### PR TITLE
Add .. code-block on all code samples

### DIFF
--- a/docs/dnx/overview.rst
+++ b/docs/dnx/overview.rst
@@ -91,6 +91,8 @@ Packages and feeds
 
 For package dependencies to resolve they must first be installed. You can use DNU to install a new package into an existing project or to restore all package dependencies for an existing project, like this::
 
+.. code-block:: console
+
     dnu restore
 
 Packages are restored using the configured set of package feeds. You configure the available package feeds using `NuGet configuration files (NuGet.config) <http://docs.nuget.org/consume/nuget-config-file>`_.
@@ -130,9 +132,13 @@ A command is a named execution of a .NET entry point with specific arguments. Yo
 
 You can then use DNX to execute the commands defined by your project, like this::
 
+.. code-block:: console
+
     dnx . web
 
 Commands can  be built and distributed as NuGet packages. You can then use DNU to install commands globally on a machine::
+
+.. code-block:: console
 
     dnu commands install MyCommand
 

--- a/docs/getting-started/installing-core-linux.rst
+++ b/docs/getting-started/installing-core-linux.rst
@@ -22,13 +22,13 @@ Installing the required packages
 
 Install the ``libunwind8``, ``libssl-dev`` and ``unzip`` packages:
 
-::
+.. code-block:: console
 
     sudo apt-get install libunwind8 libssl-dev unzip
 
 You also need a latest version of Mono, which is required for DNX tooling. This is a temporary requirement, and will not be required in the future.
 
-::
+.. code-block:: console
 
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
     echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
@@ -40,7 +40,7 @@ Certificates
 
 You need to import trusted root certificates in order to restore NuGet packages. You can do that with the ``mozroots`` tool.
 
-::
+.. code-block:: console
 
     mozroots --import --sync
 
@@ -49,7 +49,7 @@ Installing DNVM
 
 You need DNVM as a starting point. DNVM enables you to acquire one or multiple .NET Execution Environments (DNX). DNVM is a shell script and does not require .NET. You can use the below command to install it.
 
-::
+.. code-block:: console
 
     curl -sSL https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.sh | DNX_BRANCH=dev sh && source ~/.dnx/dnvm/dnvm.sh
 
@@ -62,23 +62,23 @@ command is not yet supported on .NET Core, requiring us to use Mono for
 this purpose (until DNU runs on .NET Core). Mono is the default DNX, so
 you can acquire it via ``dnvnm upgrade``.
 
-::
+.. code-block:: console
 
     dnvm upgrade -u
 
 Next, acquire the .NET Core DNX SDK.
 
-::
+.. code-block:: console
 
     dnvm install latest -r coreclr -u
 
 You can see the currently installed DNX versions with ``dnvm list``.
 
-::
+.. code-block:: console
 
     dnvm list
 
-::
+.. code-block:: console
 
     Active Version              Runtime Arch Location             Alias
     ------ -------              ------- ---- --------             -----
@@ -90,7 +90,7 @@ Using a specific runtime
 
 You can choose which of the installed DNXs you want to use with ``dnvm use``, specifying arguments that are similar to the ones used when installing a runtime.
 
-::
+.. code-block:: console
 
     dnvm use -r coreclr -arch x86 1.0.0-beta5-11649
     Adding ~/.dnx/runtimes/dnx-coreclr-win-x86.1.0.0-beta5-11649/bin
@@ -112,7 +112,7 @@ Write your App
 
 his being an introduction-level document, it seems fitting to start with a "Hello World" app.  Here's a very simple one you can copy and paste into a CS file in a directory.
 
-.. code:: csharp
+.. code-block:: c#
 
     using System;
 
@@ -129,7 +129,7 @@ A more ambitious example is available on the `corefxlab repo <https://www.github
 
 The next thing you will need is a ``project.json`` file that will outline the dependencies of an app, so you can **actually** run it. Use the contents below, it will work for both examples above. Save this file in a directory next to the CS file that contains your code.
 
-::
+.. code-blocl:: json
 
     {
         "version": "1.0.0-*",
@@ -152,14 +152,14 @@ You need to restore packages for your app, based on your project.json,
 with ``dnu restore``. You will need to run this command under the Mono
 DNX. The first command switches the active runtime to the Mono one.
 
-::
+.. code-block:: console
 
     dnvm use 1.0.0-beta5-11649 -r mono
     dnu restore
 
 You are now ready to run your app under .NET Core. As you can guess, however, before you do that you first need to switch to the .NET Core runtime. The first command below does exactly that.
 
-::
+.. code-block:: console
 
     dnvm use 1.0.0-beta5-11649 -r coreclr
     dnx . run

--- a/docs/getting-started/installing-core-osx.rst
+++ b/docs/getting-started/installing-core-osx.rst
@@ -21,7 +21,7 @@ which doesn't depend on .NET. On OS X the best way to get DNVM is to use `Homebr
 you don't have Homebrew installed then follow the `Homebrew installation
 instructions <http://www.brew.sh>`__. Once you have Homebrew up and running you can use the the following commands:
 
-::
+.. code-block:: console
 
     brew tap aspnet/dnx
     brew update
@@ -29,7 +29,7 @@ instructions <http://www.brew.sh>`__. Once you have Homebrew up and running you 
 
 You will likely need to register the dnvm command:
 
-::
+.. code-block:: console
 
     source dnvm.sh
 
@@ -38,23 +38,23 @@ Installing the .NET Core DNX
 
 Since .NET Core is still a work in progress, you will need to make use of `Mono <http://www.mono-project.com>`_ to run certain parts of the DNX tooling. On non-Windows operating systems, Mono is the default DNX, so you can use a simple ``dnvm upgrade`` command to install it.
 
-::
+.. code-block:: console
 
     dnvm upgrade -u
 
 Next, acquire the .NET Core DNX SDK.
 
-::
+.. code-block:: console
 
     dnvm install latest -r coreclr -u
 
 You can see the currently installed DNX versions with ``dnvm list``.
 
-::
+.. code-block:: console
 
     dnvm list
 
-::
+.. code-block:: console
 
     Active Version              Runtime Arch Location             Alias
     ------ -------              ------- ---- --------             -----
@@ -69,7 +69,7 @@ Using a specific runtime
 
 You can choose which of the installed DNXs you want to use with ``dnvm use``, specifying arguments that are similar to the ones used when installing a runtime.
 
-::
+.. code-block:: console
 
     dnvm use -r coreclr -arch x64 1.0.0-beta5-11649
     Adding ~/.dnx/runtimes/dnx-coreclr-win-x86.1.0.0-beta5-11649/bin
@@ -92,7 +92,7 @@ Write your App
 
 This being an introduction-level document, it seems fitting to start with a "Hello World" app.  Here's a very simple one you can copy and paste into a CS file in a directory.
 
-.. code:: csharp
+.. code-block:: c#
 
     using System;
 
@@ -109,7 +109,7 @@ A more ambitious example is available on the `corefxlab repo <https://www.github
 
 The next thing you will need is a ``project.json`` file that will outline the dependencies of an app, so you can **actually** run it. Use the contents below, it will work for both examples above. Save this file in a directory next to the CS file that contains your code.
 
-::
+.. code-block:: json
 
     {
         "version": "1.0.0-*",
@@ -132,14 +132,14 @@ You need to restore packages for your app, based on your project.json,
 with ``dnu restore``. You will need to run this command under the Mono
 DNX. The first command switches the active runtime to the Mono one.
 
-::
+.. code-block:: console
 
     dnvm use 1.0.0-beta5-11649 -r mono
     dnu restore
 
 You are now ready to run your app under .NET Core. As you can guess, however, before you do that you first need to switch to the .NET Core runtime. The first command below does exactly that.
 
-::
+.. code-block:: console
 
     dnvm use 1.0.0-beta5-11649 -r coreclr
     dnx . run

--- a/docs/getting-started/installing-core-windows.rst
+++ b/docs/getting-started/installing-core-windows.rst
@@ -15,7 +15,7 @@ which doesn't depend on .NET. You can install it via a PowerShell
 command from a command prompt window. You can find alternate DNVM install instructions at the
 `ASP.NET Home repo <https://github.com/aspnet/home>`__.
 
-::
+.. code-block:: console
 
     @powershell -NoProfile -ExecutionPolicy unrestricted -Command "&{$Branch='dev';iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/aspnet/Home/dev/dnvminstall.ps1'))}"
 
@@ -26,19 +26,19 @@ Installing a .NET Core DNX
 
 It's easy to install the latest .NET Core-based DNX, using the ``dnvm install`` command.
 
-::
+.. code-block:: console
 
     dnvm install -r coreclr latest -u
 
 This will install the 32-bit version of .NET Core. If you want the 64-bit version, you can specify processor architecture.
 
-::
+.. code-block:: console
 
     dnvm install -r coreclr -arch x64 latest -u
 
 You can see the currently installed DNX versions with ``dnvm list``.
 
-::
+.. code-block:: console
 
     dnvm list
 
@@ -56,7 +56,7 @@ Using a specific runtime
 
 You can choose which of the installed DNXs you want to use with ``dnvm use``, specifying arguments that are similar to the ones used when installing a runtime.
 
-::
+.. code-block:: console
 
     dnvm use -r coreclr -arch x86 1.0.0-beta5-11649
     Adding C:\Users\[user]\.dnx\runtimes\dnx-coreclr-win-x86.1.0.0-beta5-11649\bin
@@ -78,7 +78,7 @@ Write your App
 
 This being an introduction-level document, it seems fitting to start with a "Hello World" app.  Here's a very simple one you can copy and paste into a CS file in a directory.
 
-.. code:: csharp
+.. code-block:: c#
 
     using System;
 
@@ -95,7 +95,7 @@ A more ambitious example is available on the `corefxlab repo <https://www.github
 
 The next thing you will need is a ``project.json`` file that will outline the dependencies of an app, so you can **actually** run it. Use the contents below, it will work for both examples above. Save this file in a directory next to the CS file that contains your code.
 
-::
+.. code-block:: c#
 
     {
         "version": "1.0.0-*",
@@ -117,13 +117,13 @@ Run your App
 You need to restore packages for your app, based on your project.json,
 with ``dnu restore``.
 
-::
+.. code-block:: console
 
     dnu restore
 
 You can run your app with the DNX command.
 
-::
+.. code-block:: console
 
     dnx . run
 

--- a/docs/roslyn/roslyn-overview.rst
+++ b/docs/roslyn/roslyn-overview.rst
@@ -355,7 +355,7 @@ span, plus the span of any leading or trailing trivia.
 
 For example:
 
-.. code::
+.. code-block:: c#
 
           if (x > 3)
           {


### PR DESCRIPTION
Adding proper way to do code blocks on RTD, using .. code-block:: directive with appropriate language moniker (i.e. c#, json, console etc.)
