### PR TITLE
Add toc stubs for NuGet and Languages

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,8 @@ Topics
    porting/index
    packaging/index
    deployment/index
+   nuget/index
+   languages/index
    bcl/index
    roslyn/index
 

--- a/docs/languages/c-sharp.rst
+++ b/docs/languages/c-sharp.rst
@@ -1,0 +1,7 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| C# programming language 
+===================================
+
+.. include:: /stub-notice.txt
+

--- a/docs/languages/cli-languages.rst
+++ b/docs/languages/cli-languages.rst
@@ -1,0 +1,12 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| CLI programming languages
+=====================================
+
+Besides the ones mentioned in this section in the documents, there are many other
+languages of different types that have been implemented on top of the Common 
+Language Infrastructure (CLI). You can see them all on the official 
+`Wikipedia page <https://en.wikipedia.org/wiki/List_of_CLI_languages>`_.
+
+.. include:: /stub-notice.txt
+

--- a/docs/languages/f-sharp.rst
+++ b/docs/languages/f-sharp.rst
@@ -1,0 +1,7 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| F# programming language
+===================================
+
+.. include:: /stub-notice.txt
+

--- a/docs/languages/index.rst
+++ b/docs/languages/index.rst
@@ -9,8 +9,8 @@ Programming languages on the .NET Platform
     overview
     c-sharp
     f-sharp
-    visual-basic    
-	
+    visual-basic
+    cli-languages	
 
 .. include:: /stub-notice.txt
 

--- a/docs/languages/index.rst
+++ b/docs/languages/index.rst
@@ -1,0 +1,16 @@
+.. include:: /stub-topic.txt
+
+Programming languages on the .NET Platform
+------------------------------------------
+
+.. toctree::
+	:titlesonly:
+	
+    overview
+    c-sharp
+    f-sharp
+    visual-basic    
+	
+
+.. include:: /stub-notice.txt
+

--- a/docs/languages/overview.rst
+++ b/docs/languages/overview.rst
@@ -1,0 +1,8 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| .NET Platform & programming languages
+=================================================
+
+.. include:: /stub-notice.txt
+
+

--- a/docs/languages/visual-basic.rst
+++ b/docs/languages/visual-basic.rst
@@ -1,0 +1,7 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| VisualBasic.NET programming language 
+================================================
+
+.. include:: /stub-notice.txt
+

--- a/docs/nuget/index.rst
+++ b/docs/nuget/index.rst
@@ -1,0 +1,9 @@
+.NET Package Manager (NuGet)
+----------------------------
+
+.. toctree:: 
+  :titlesonly:
+
+  overview.rst
+  using.rst 
+  packaging.rst

--- a/docs/nuget/overview.rst
+++ b/docs/nuget/overview.rst
@@ -1,0 +1,7 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| Introduction to NuGet
+=================================
+
+.. include:: /stub-notice.txt
+

--- a/docs/nuget/packaging.rst
+++ b/docs/nuget/packaging.rst
@@ -1,0 +1,7 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| Creating your own NuGet packages 
+============================================
+
+.. include:: /stub-notice.txt
+

--- a/docs/nuget/using.rst
+++ b/docs/nuget/using.rst
@@ -1,0 +1,7 @@
+.. include:: /stub-topic.txt
+
+|stub-icon| Using NuGet 
+=======================
+
+.. include:: /stub-notice.txt
+


### PR DESCRIPTION
Add two additional parts of the docs:
- NuGet, which will explain what NuGet is, and what part of the
  ecosystem it provides for; I expect mostly links to Nuget.org
- Languages, which will explain the way .NET Platform enables
  languages as well as pointers towards the Big Three (C#, F# and
  VB.NET)

/cc @richlander @terrajobst  
