### PR TITLE
Add Interoperability primer document

### DIFF
--- a/docs/concepts/native-interop.rst
+++ b/docs/concepts/native-interop.rst
@@ -1,0 +1,423 @@
+Native interoperability
+=======================
+
+In this document we will dive a little bit deeper into all three ways of doing 
+"native interoperability" that are available on the .NET platform. 
+
+There are a few of reasons why you would want to call into native code:
+
+* Operating Systems come with a large volume of APIs that are 
+  not present in the managed class libraries. A prime example for this would be 
+  access to hardware or operating system management functions.
+* Communicating with other components that have or can produce C-style ABIs 
+  (native ABIs). This covers, for example, Java code that is exposed via 
+  `Java Native Interface (JNI) <http://docs.oracle.com/javase/8/docs/technotes/guides/jni/>`_ 
+  or any other managed language that could produce a native component. 
+* On Windows, most of the software that gets installed, such as Microsoft Office
+  suite, registers COM components that represent their programs and allow developers 
+  to automate them or use them. This also requires native interoperability.
+
+Of course, the list above does not cover all of the potential situations and 
+scenarios in which the developer would want/like/need to interface with native 
+components. .NET class library, for instance, uses the native interoperability 
+support to implement a fair number of its APIs, like console support and 
+manipulation, file system access and others. However, it is important to note 
+that there is an option, should one need it.
+
+.. note::
+    Most of the examples in this document will be presented for all three 
+    supported platforms for .NET Core (Windows, Linux, OS X). However, for some 
+    short and illustrative examples, I have decided to leave just one sample 
+    that will use Windows filenames and extensions (i.e. "dll" for libraries). 
+    This does not mean that those features are not available on Linux or OS X, 
+    it was done merely for conveince sake. 
+    
+Platform Invoke (P/Invoke)
+--------------------------
+P/Invoke is a technology that allows you to access structs, callbacks and functions
+in unmanaged libraries from your managed code. Most of the P/Invoke API is contained 
+in two namespaces: ``System`` and ``System.Runtime.InteropServices``. Using these 
+two namespaces will allow you access to the attributes that describe how you 
+want to communicate with the native component. 
+
+Let's start from the most common example, and that is calling unmanaged functions 
+in your managed code. Let's show a message box from a command-line application:
+
+.. code-block:: c#
+    :linenos:
+    
+    using System.Runtime.InteropServices;
+
+    public class Program {
+    
+        // Import user32.dll (containing the function we need) and define 
+        // the method corresponding to the native function. 
+        [DllImport("user32.dll")]
+        public static extrn int MessageBox(IntPtr hWnd, String text, String caption, int options);
+
+        public static void Main(string[] args) {
+            // Invoke the function as a regular managed method. 
+            MessageBox(IntPtr.Zero, "Command-line message box", "Attention!", 0);
+        }
+    }
+
+The example above is pretty simple, but it does show off what is needed to 
+invoke unmanaged functions from managed code. Let's step through the example:
+
+* Line #1 shows the using statement for the ``System.Runtime.InteropServices`` 
+  which is the namespace that holds all of the items we need. 
+* Line #5 introduces the ``DllImport`` attribute. This attribute is crucial, as 
+  it tells the runtime that it should load the unmanaged DLL. This is the DLL 
+  into which we wish to invoke.
+* Line #6 is the crux of the P/Invoke work. It defines a managed method that has
+  the **exact same signature** as the unmanaged one. The declaration has a new 
+  keyword that you can notice, ``extern``, which tells the runtime this is an 
+  external method, and that when you invoke it, the runtime should find it in the 
+  DLL specified in ``DllImport`` attribute.
+
+The rest of the example is just invoking the method as you would any other managed 
+method. 
+
+The sample is similar for OS X. One thing that needs to change is, of course, 
+the name of the library in the ``DllImport`` attribute, as OS X has a different 
+scheme of naming dynamic libraries. The sample below uses the ``getpid(2)`` 
+function to get the process ID of the application and print it out to the console. 
+
+.. code-block:: c#
+    :linenos: 
+
+    using System;
+    using System.Runtime.InteropServices;
+
+    namespace PInvokeSamples {
+        public static class Program {
+            
+            // Import the libc and define the method corresponding to the native function. 
+            [DllImport("libSystem.dylib")]
+            private static extern int getpid();
+
+            public static void Main(string[] args){
+                // Invoke the function and get the process ID. 
+                int pid = getpid();
+                Console.WriteLine(pid);
+            }
+        }
+    }
+
+It is similar on Linux, of course. The function name is same, since ``getpid(2)`` 
+is `POSIX <https://en.wikipedia.org/wiki/POSIX>`_ system call. 
+
+.. code-block:: c#
+    :linenos:
+
+    using System;
+    using System.Runtime.InteropServices;
+
+    namespace PInvokeSamples {
+        public static class Program {
+            
+            // Import the libc and define the method corresponding to the native function. 
+            [DllImport("libc.so.6")]
+            private static extern int getpid();
+
+            public static void Main(string[] args){
+                // Invoke the function and get the process ID. 
+                int pid = getpid();
+                Console.WriteLine(pid);
+            }
+        }
+    }
+
+Invoking managed code from unmanaged code
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Of course, the runtime allows communication to flow both ways 
+which enables you to call into managed artifacts from native functions, using 
+function pointers. The closest thing to a function pointer in managed code is a 
+**delegate**, so this is what is used to allow callbacks from native code into 
+managed code. 
+
+The way to use this feature is similar to managed to native process described 
+above. For a given callback, you define a delegate that matches the signature, 
+and pass that into the external method. The runtime will take care of everything 
+else.
+
+.. code-block:: c#
+    :linenos:
+
+    using System;
+    using System.Runtime.InteropServices;
+
+    namespace ConsoleApplication1 {
+
+        class Program {
+
+            // Define a delegate that corresponds to the unmanaged function.
+            delegate bool EnumWC(IntPtr hwnd, IntPtr lParam);
+
+            // Import user32.dll (containing the function we need) and define 
+            // the method corresponding to the native function. 
+            [DllImport("user32.dll")]
+            static extern int EnumWindows(EnumWC hWnd, IntPtr lParam);
+
+            // Define the implementation of the delegate; here, we simply output the window handle.
+            static bool OutputWindow(IntPtr hwnd, IntPtr lParam) {
+                Console.WriteLine(hwnd.ToInt64());
+                return true;
+            }
+
+            static void Main(string[] args) {
+                // Invoke the method; note the delegate as a first parameter. 
+                EnumWindows(OutputWindow, IntPtr.Zero);
+            }
+        }
+    }
+    
+
+Before we walk through our example, it is good to go over the signatures of the 
+unmanaged functions we need to work with. The function we want to call to 
+enumerate all of the windows has the following signature:
+``BOOL EnumWindows (WNDENUMPROC lpEnumFunc, LPARAM lParam);``
+
+The first parameter is a callback. The said callback has the following signature: 
+``BOOL CALLBACK EnumWindowsProc (HWND hwnd, LPARAM lParam);``
+
+With this in mind, let's walk through the example:
+
+* Line #8 in the example defines a delegate that matches the signature of the 
+  callback from unmanaged code. Notice how the LPARAM and HWND types are 
+  represented using ``IntPtr`` in the managed code. 
+* Lines #10 and #11 introduce the ``EnumWindows`` function from the user32.dll 
+  library. 
+* Lines #13 - 16 implement the delegate. For this simple example, we just want 
+  to output the handle to the console.
+* Finally, in line #19 we invoke the external method and pass in the delegate.
+
+The Linux and OS X examples are shown below. For them, we use the ``ftw`` function 
+that can be found in ``libc``, the C library. This function is used to traverse 
+directory hierarchies and it takes a pointer to a function as one of its parameters. 
+The said function has the following signature: 
+``int (*fn) (const char *fpath, const struct stat *sb, int typeflag)``. 
+
+.. code-block:: c#
+    :linenos:
+
+    using System;
+    using System.Runtime.InteropServices;
+
+    namespace PInvokeSamples {
+        public static class Program {
+                
+                // Define a delegate that has the same signature as the native function.
+                delegate int DirClbk(string fName, StatClass stat, int typeFlag);
+                
+                // Import the libc and define the method to represent the native function.
+                [DllImport("libc.so.6")]
+                static extern int ftw(string dirpath, DirClbk cl, int descriptors);
+                
+                // Implement the above DirClbk delegate; 
+                // this one just prints out the filename that is passed to it. 
+                static int DisplayEntry(string fName, StatClass stat, int typeFlag) {
+                        Console.WriteLine(fName);
+                        return 0;
+                }
+                
+                public static void Main(string[] args){
+                        // Call the native function. 
+                        // Note the second parameter which represents the delegate (callback). 
+                        ftw(".", DisplayEntry, 10);
+                }
+        }
+        
+        // The native callback takes a pointer to a struct. The below class 
+        // represents that struct in managed code. You can find more information 
+        // about this in the section on marshalling below. 
+        [StructLayout(LayoutKind.Sequential)]
+        public class StatClass {
+                public uint DeviceID;
+                public uint InodeNumber;
+                public uint Mode;
+                public uint HardLinks;
+                public uint UserID;
+                public uint GroupID;
+                public uint SpecialDeviceID;
+                public ulong Size;
+                public ulong BlockSize;
+                public uint Blocks;
+                public long TimeLastAccess;
+                public long TimeLastModification;
+                public long TimeLastStatusChange;
+        }
+    }
+
+
+OS X example uses the same function, and the only difference is the argument 
+to the ``DllImport`` attribute, as OS X keeps ``libc`` in a different place. 
+
+.. code-block:: c#
+    :linenos:
+
+    using System;
+    using System.Runtime.InteropServices;
+
+    namespace PInvokeSamples {
+            public static class Program {
+                    
+                    // Define a delegate that has the same signature as the native function.
+                    delegate int DirClbk(string fName, StatClass stat, int typeFlag);
+                    
+                    // Import the libc and define the method to represent the native function.
+                    [DllImport("libSystem.dylib")]
+                    static extern int ftw(string dirpath, DirClbk cl, int descriptors);
+                    
+                    // Implement the above DirClbk delegate; 
+                    // this one just prints out the filename that is passed to it. 
+                    static int DisplayEntry(string fName, StatClass stat, int typeFlag) {
+                            Console.WriteLine(fName);
+                            return 0;
+                    }
+                    
+                    public static void Main(string[] args){
+                            // Call the native function. 
+                            // Note the second parameter which represents the delegate (callback). 
+                            ftw(".", DisplayEntry, 10);
+                    }
+            }
+            
+            // The native callback takes a pointer to a struct. The below class 
+            // represents that struct in managed code. You can find more information 
+            // about this in the section on marshalling below. 
+            [StructLayout(LayoutKind.Sequential)]
+            public class StatClass {
+                    public uint DeviceID;
+                    public uint InodeNumber;
+                    public uint Mode;
+                    public uint HardLinks;
+                    public uint UserID;
+                    public uint GroupID;
+                    public uint SpecialDeviceID;
+                    public ulong Size;
+                    public ulong BlockSize;
+                    public uint Blocks;
+                    public long TimeLastAccess;
+                    public long TimeLastModification;
+                    public long TimeLastStatusChange;
+            }
+    }
+
+Both of the above examples depend on parameters, and in both cases, the parameters 
+are given as managed types. Runtime does the "right thing" and processes these 
+into its equivalents on the other side. Since this process is really important 
+to writing quality native interop code, let's take a look at what happens when 
+the runtime *marshals* the types. 
+
+Type marshalling
+----------------
+**Marshalling** is the process of transforming types when they need to cross the 
+managed boundary into native and vice versa. 
+
+The reason marshalling is needed is because the types in the managed and unmanaged 
+code are different. In managed code, for instance, you have a ``String``, while in 
+the unmanaged world strings can be Unicode ("wide"), non-Unicode, null-terminated, 
+ASCII, etc. By default, the P/Invoke subsystem will try to do the Right Thing 
+based on the default behavior which you can see on `MSDN <https://msdn.microsoft.com/en-us/library/zah6xy75.aspx>`_.
+However, for those situations where you need extra control, you can employ the 
+``MarshalAs`` attribute to specify what is the expected type on the unmanaged 
+side. For instance, if we want the string to be sent as a null-terminated 
+ANSI string, we could do it like this:
+
+.. code-block:: c#
+    
+    [DllImport("somenativelibrary.dll"]
+    static extern int MethodA([MarshalAs(UnmanagedType.LPStr) string parameter);
+
+
+Marshalling classes and structs    
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Another aspect of type marshalling is how to pass in a struct to an unmanaged method.
+For instance, some of the unmanaged methods require a struct as a parameter. 
+In these cases, we need to create a corresponding struct or a class in managed 
+part of the world to use it as a parameter. However, just defining the class is 
+not enough, we also need to instruct the marshaler how to map fields in the class 
+to the unmanaged struct. This is where the ``StructLayout`` attribute comes into 
+play. 
+
+.. code-block:: c#
+    :linenos:
+
+    [DllImport("kernel32.dll")]
+    static extern void GetSystemTime(SystemTime systemTime);
+
+    [StructLayout(LayoutKind.Sequential)]
+    class SystemTime {
+        public ushort Year;
+        public ushort Month;
+        public ushort DayOfWeek;
+        public ushort Day;
+        public ushort Hour;
+        public ushort Minute;
+        public ushort Second;
+        public ushort Milsecond;
+    }
+
+    public static void Main(string[] args) {
+        SystemTime st = new SystemTime();
+        GetSystemTime(st);
+        Console.WriteLine(st.Year);
+    }
+
+The example above shows off a simple example of calling into ``GetSystemTime()`` 
+function. The interesting bit is on line 4. The attribute specifies that the 
+fields of the class should be mapped sequentially to the struct on the other 
+(unmanaged) side. This means that the naming of the fields is not important, 
+only their order is important, as it needs to correspond to the unmanaged struct, 
+shown below: 
+
+.. code-block:: c
+
+    typedef struct _SYSTEMTIME {
+      WORD wYear;
+      WORD wMonth;
+      WORD wDayOfWeek;
+      WORD wDay;
+      WORD wHour;
+      WORD wMinute;
+      WORD wSecond;
+      WORD wMilliseconds;
+    } SYSTEMTIME, *PSYSTEMTIME*;
+
+We already saw the Linux and OS X example for this in the previous example. It is 
+shown again below. 
+
+.. code-block:: c#
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class StatClass {
+                public uint DeviceID;
+                public uint InodeNumber;
+                public uint Mode;
+                public uint HardLinks;
+                public uint UserID;
+                public uint GroupID;
+                public uint SpecialDeviceID;
+                public ulong Size;
+                public ulong BlockSize;
+                public uint Blocks;
+                public long TimeLastAccess;
+                public long TimeLastModification;
+                public long TimeLastStatusChange;
+        }
+
+The ``StatClass`` class represents a structure that is returned by the ``stat`` 
+system call on UNIX systems. It represents information about a given file. The 
+class above is the stat struct representation in managed code. Again, the fields 
+in the class have to be in the same order as the native struct (you can find these 
+by perusing man pages on your favorite UNIX implementation) and they have to be 
+of the same underlying type. 
+    
+More resources
+--------------
+
+* `PInvoke.net wiki <http://www.pinvoke.net>`_ an excellent Wiki with information 
+  on common Win32 APIs and how to call them.
+* `P/Invoke on MSDN <https://msdn.microsoft.com/en-us/library/zbz07712.aspx>`_
+* `Mono documentation on P/Invoke <http://www.mono-project.com/docs/advanced/pinvoke/>`_ 

--- a/docs/concepts/primer.rst
+++ b/docs/concepts/primer.rst
@@ -46,7 +46,7 @@ As any mature and advanced application development framework, .NET has many powe
 * Asynchronous support
 * Dynamic language features
 * Code contracts
-* Native interoperability
+* `Native interoperability`_
 
 
 Automatic memory management
@@ -243,29 +243,24 @@ TODO: finish section
 Native Interoperability
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.NET provides low-level access to native APIs via the platform invoke or
-P/Invoke facility. It enables a mapping of .NET types to native types,
-which the .NET runtime marshalls before calling the native API.
+Every operating system in current use provides a lot of platform support for 
+various programming tasks. .NET provides several ways to tap into those APIs. 
+Collectively, this support is called "native interoperability" and in this 
+section we will take a look at how to access native APIs from managed, .NET 
+code. 
 
-TODO: Examples.
+The main way to do native interoperability is via "platform invoke" or P/Invoke 
+for short. This support in .NET Core is available across Linux and Windows 
+platforms. Another, Windows-only way of doing native interoperability is known 
+as "COM interop". It's main goal is to allow using 
+`COM components <https://msdn.microsoft.com/en-us/library/bwa2bx93.aspx>`_
+in managed code. It is built on top of P/Invoke infrastructure, but it works in 
+subtly different ways. 
 
-Higher-level native interop can be established with P/Invoke. The COM
-and WinRT interop systems in the CLR are both built on top of P/Invoke.
-The Java and Objective-C interop systems provided by Xamarin on top of
-Mono are fundamentally the same.
+Most of Mono's (and thus Xamarin's) interoperability support for Java and 
+Objective-C are built similarly, that is, they use the same principles. 
 
-Unsafe Code
-~~~~~~~~~~~
-
-The CLR enables the ability to acccess native memory and do pointer
-arithmetic. These operations are needed for some algortithms and for
-calling some native APIs. The use of these capabilities is discouraged,
-since you no longer get the benefit of verifiability, nor will your code
-be allowed to run in all environments. The best practice is to confine
-unsafe code as much as possible and that the vast majority of code is
-type-safe.
-
-TODO: Examples.
+Read more about it in the :doc:`native-interop` document. 
 
 Notes
 -----


### PR DESCRIPTION
Blurb added to the Primer main document. Add more detailed document
in the documents. The document covers both P/Invoke and COM interop. The COM interop doesn't have an example, which I left out intentionally, because I couldn't find a good one that would not branch off into other points like using dynamic etc. 

/cc @richlander @terrajobst 
