### PR TITLE
Add missing indefinite article

### DIFF
--- a/docs/roslyn/roslyn-overview.rst
+++ b/docs/roslyn/roslyn-overview.rst
@@ -176,7 +176,7 @@ Workspaces APIs
 The Workspaces layer contains the Workspace API, which is the starting
 point for doing code analysis and refactoring over entire solutions. It
 assists you in organizing all the information about the projects in a
-solution into single object model, offering you direct access to the
+solution into a single object model, offering you direct access to the
 compiler layer object models without needing to parse files, configure
 options or manage project to project dependencies.
 


### PR DESCRIPTION
This sentence was previously grammatically incorrect due to a missing article.
