### PR TITLE
Fix Aggregate example

### DIFF
--- a/docs/concepts/linq.rst
+++ b/docs/concepts/linq.rst
@@ -130,7 +130,8 @@ The following is a quick demonstration of some of the essential pieces of LINQ. 
 	                select dog.TurnIntoACat();
 
 	// Summing then lengths of a set of strings
-	int sumOfStrings = strings.Aggregate((s1, s2) => s1.Length + s2.Length);
+	int seed = 0;
+	int sumOfStrings = strings.Aggregate(seed, (s1, s2) => s1.Length + s2.Length);
 
 * Flattening a list of lists:
 


### PR DESCRIPTION
The code sample for `Aggregate` used the overload which required a seed value to make a `T -> U` transformation.  This is now fixed by including a seed value.
