### PR TITLE
Fix dnx syntax in installing-core-windows.rst #83

### DIFF
--- a/docs/getting-started/installing-core-windows.rst
+++ b/docs/getting-started/installing-core-windows.rst
@@ -125,7 +125,7 @@ You can run your app with the DNX command.
 
 .. code-block:: console
 
-    dnx . run
+    dnx run
 
 This will instruct the currently active DNX to run your app. Note that you didn't need to actually build the code; DNX will take care of this for you.
 


### PR DESCRIPTION
See "Run your App" section in http://dotnet.readthedocs.org/en/latest/getting-started/installing-core-windows.html
