### PR TITLE
Fix dnx syntax in installing-core-osx.rst #82

### DIFF
--- a/docs/getting-started/installing-core-osx.rst
+++ b/docs/getting-started/installing-core-osx.rst
@@ -142,7 +142,7 @@ You are now ready to run your app under .NET Core. As you can guess, however, be
 .. code-block:: console
 
     dnvm use 1.0.0-beta5-11649 -r coreclr
-    dnx . run
+    dnx run
 
     Hello, OSX
     Love from CoreCLR.


### PR DESCRIPTION
See "Run your App" section in http://dotnet.readthedocs.org/en/latest/getting-started/installing-core-osx.html
