### PR TITLE
Add samples structure with LINQ stub in place

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,12 @@
+# .NET Core Samples
+
+The code samples here are simple, buildable projects which augment the .NET Core Documentation with demonstrative code snippets.  These samples are directly embedded into documentation.
+
+If you wish to add a code sample:
+
+1. Your sample **must be part of a buildable project**
+2. Your sample **cannot be a Visual Studio Project**
+
+	- We do not want Windows and Visual Studio to be a dependency for people building these on their own.
+
+We will eventually have a CI system in place to build these projects.

--- a/samples/linq/csharp/project.json
+++ b/samples/linq/csharp/project.json
@@ -1,9 +1,0 @@
-{
-	"dependencies": {
-		"System.Linq": "4.0.0-rc1-*",
-		"System.Runtime": "4.0.0-rc1-*"
-	},
-	"frameworks": {
-		"dotnet51":{}
-	}
-}

--- a/samples/linq/csharp/project.json
+++ b/samples/linq/csharp/project.json
@@ -1,0 +1,9 @@
+{
+	"dependencies": {
+		"System.Linq": "4.0.0-rc1-*",
+		"System.Runtime": "4.0.0-rc1-*"
+	},
+	"frameworks": {
+		"dotnet51":{}
+	}
+}

--- a/samples/linq/csharp/restriction/Where-Sample-1.cs
+++ b/samples/linq/csharp/restriction/Where-Sample-1.cs
@@ -1,0 +1,7 @@
+using System;
+using System.Linq;
+
+namespace Restriction
+{
+	// TODO write some code
+}

--- a/samples/linq/csharp/restriction/project.json
+++ b/samples/linq/csharp/restriction/project.json
@@ -1,0 +1,9 @@
+{
+	"dependencies": {
+		"System.Runtime":"4.0.0-rc1-*",
+		"System.Linq":"4.0.0-rc1-*"
+	},
+	"frameworks": {
+		"dotnet":{}
+	}
+}


### PR DESCRIPTION
This addresses #91.  This adds the samples structure with a stub for LINQ, showing what other samples should look like moving forward.

As mentioned in #91, samples here are not dependent on Windows or Visual Studio.  They should be project.json-based, and be made up of only folders and files.
