### PR TITLE
Updated samples\readme.md with correct version of system.console

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -21,7 +21,7 @@ To create a sample:
 		"dependencies": {
 		    "System.Runtime":"4.0.0-rc1-*",
 		    "System.Linq":"4.0.0-rc1-*",
-		    "System.Console": "4.0.0-rc1-*"
+		    "System.Console": "4.0.0-beta-*"
 	    },
 	    "frameworks": {
 		    "dnxcore50":{}


### PR DESCRIPTION
The rc1 version of System.Console is not available from nuget and throws and exception when performing a dnu restore. Updated the version in the readme.md to use the 4.0.0-Beta version.

For #101 
