### PR TITLE
Change .NET implementations overview document

### DIFF
--- a/docs/concepts/editions-overview.md
+++ b/docs/concepts/editions-overview.md
@@ -1,20 +1,23 @@
 # Overview of .NET implementations
 
-.NET Platform is, at its very core, a set of standards that can be implemented. There are various implementations, some coming from Microsoft, some coming from other companies and groups.
+.NET Platform is, at its very core, a set of standards that proscribe how the platform should behave. 
+There are various implementations of said standard, some by Microsoft and some by other companies. 
+On this page, we will go through three main implementations that are currently available from Microsoft and outline what are their 
+main features and how do they differ amongst themselves. 
 
 ## .NET Core
 
 .NET Core is a cloud-optimized, cross-platform implementation of the .NET Platform. It currently supports three main operating systems: Linux, Windows and OS X.
 
-The following are main characteristics of .NET Core:
+The following are the main characteristics of .NET Core:
 
-**Cross-platform support** is the first important feature. For applications, it is important to use those platforms that will provide the best environment for their execution. Thus, having an application platform that can enable the app to be ran on different operating systems with minimal or no changes provides a significant gain.
+**Cross-platform support** - for applications, it is important to use those platforms that will provide the best environment for their execution. Thus, having an application platform that can enable the app to be ran on different operating systems with minimal or no changes provides a significant gain.
 
-**Open Source** because it is proven to be a great way to enable a larger set of platforms, supported by community contribution. It is also a very open way of developing software which enables better community inclusion in the overall process of designing .NET Platform. 
+**Open Source** - it has been proven to be a great way to enable a larger set of platforms, supported by community contribution. It is also a very open way of developing software which enables better community inclusion in the overall process of designing the .NET Platform. 
 
 **Better packaging story** - the framework is distributed as a set of packages that developers can pick and choose from, rather than a single, monolithic platform. .NET Core is the first implementation of .NET Platform that is distributed via [NuGet](http://www.nuget.org/) package manager.
 
-**Better application isolation** as one of the scenarios for .NET Core is to enable applications to “take” the needed runtime for their execution and deploy it with the application, not depending on shared components on the targeted machine. This plays well with the current trends of developing software and using container technologies like Docker for consolidation.
+**Better application isolation** - one of the scenarios for .NET Core is to enable applications to “take” the needed runtime for their execution and deploy it with the application, not depending on shared components on the targeted machine. This plays well with the current trends of developing software and using container technologies like Docker for consolidation.
 
 ## .NET Framework
 
@@ -30,7 +33,7 @@ There are additional stacks built on top the .NET Framework that allow developer
 
 ## .NET Native
 
-.NET Native is not so much an"edition" of the .NET platform as it is a set of tools that allow developers to have different build outputs. The normal .NET source compilation process takes the source code written in one of the .NET languages (such as C#, Visual Basic, F# etc.) and produces something called "Intermediate Language" (IL). At run-time, a just-in-time (JIT) compiler compiles the IL into machine code.
+.NET Native is not so much an "edition" of the .NET platform as it is a set of tools that allow developers to have different build outputs. The normal .NET source compilation process takes the source code written in one of the .NET languages (such as C#, Visual Basic, F#, etc.) and produces something called "Intermediate Language" (IL). At run-time, a just-in-time (JIT) compiler compiles the IL into machine code.
 
 .NET Native is an Ahead-of-Time (AOT) toolchain that compiles IL byte code to native machine code, so that when the code is executed, there is only “native” code running. This means that the resulting binary is what the OS executes; there is no JIT-ing, no runtime compilation. This leads to better performance, as well as some security benefits.
 

--- a/docs/concepts/editions-overview.md
+++ b/docs/concepts/editions-overview.md
@@ -6,11 +6,11 @@
 
 .NET Core is a cloud-optimized, cross-platform implementation of the .NET Platform. It currently supports three main operating systems: Linux, Windows and OS X.
 
-There are several characteristics of .NET Core:
+The following are main characteristics of .NET Core:
 
-**Cross-platform support** is the first important feature. For applications, it is important to use those platforms that will provide the best environment for their execution. Thus, having an application platform that can enable the app to be ran on different operating systems with minimal or no changes provides a significant boon.
+**Cross-platform support** is the first important feature. For applications, it is important to use those platforms that will provide the best environment for their execution. Thus, having an application platform that can enable the app to be ran on different operating systems with minimal or no changes provides a significant gain.
 
-**Open Source** because it is proven to be a great way to enable a larger set of platforms, supported by community contribution.
+**Open Source** because it is proven to be a great way to enable a larger set of platforms, supported by community contribution. It is also a very open way of developing software which enables better community inclusion in the overall process of designing .NET Platform. 
 
 **Better packaging story** - the framework is distributed as a set of packages that developers can pick and choose from, rather than a single, monolithic platform. .NET Core is the first implementation of .NET Platform that is distributed via [NuGet](http://www.nuget.org/) package manager.
 
@@ -18,11 +18,11 @@ There are several characteristics of .NET Core:
 
 ## .NET Framework
 
-The .NET Framework is the premier implementation of the .NET Platform available for Windows server and client developers. It is a very powerful, very mature framework, with a huge class library (known as the **Framework Class Libraries**) that supports a wide variety of applications and solutions on Windows.
+The .NET Framework is the premier implementation of the .NET Platform available for Windows server and client developers. It is a very powerful, very mature framework, with a huge class library (known as the **.NET Framework Class Library**) that supports a wide variety of applications and solutions on Windows.
 
 There are additional stacks built on top the .NET Framework that allow developers to build applications ranging from console applications, across rich client (WPF) applications to scalable web applications.
 
-[Windows Forms](https://msdn.microsoft.com/en-us/library/dd30h2yb%28v=vs.110%29.aspx) and [Windows Presentation Foundation (WPF)](https://msdn.microsoft.com/en-us/library/ms754130%28v=vs.110%29.aspx) are User Interface (UI) stacks that enable you to build desktop applications for Windows. Windows Forms’ strength is in its rich support for common databinding scenarios as well as access to Windows’ native user interface controls. WPF, on the other hand, allows you to exercise much more control over the look and feel of your application. Both of them allow for building very rich desktop applications that run on Windows, and you should pick the one that is suited for your use case.
+[Windows Forms](https://msdn.microsoft.com/en-us/library/dd30h2yb%28v=vs.110%29.aspx) and [Windows Presentation Foundation (WPF)](https://msdn.microsoft.com/en-us/library/ms754130%28v=vs.110%29.aspx) are User Interface (UI) stacks that enable you to build desktop applications for Windows. The strength of Windows Forms lies in its rich support for common databinding scenarios as well as access to Windows’ native user interface controls. WPF, on the other hand, allows you to exercise much more control over the look and feel of your application. Both of them allow for building very rich desktop applications that run on Windows, and you should pick the one that is best suited for your use case.
 
 [Windows Communication Foundation (WCF)](https://msdn.microsoft.com/en-us/library/ms731082%28v=vs.110%29.aspx) is a set of libraries that comprise the middleware services stack on .NET Framework. It allows you to create services that can communicate through various supported protocols using various data formats, and that can be hosted in any process you choose. This leads to one of the major features of WCF: your services are not tied to any particular hosting strategy or approach.
 
@@ -30,11 +30,11 @@ There are additional stacks built on top the .NET Framework that allow developer
 
 ## .NET Native
 
-.NET Native is not so much an “edition” of the .NET platform as it is a set of tools that allow developers to have different build outputs. The normal .NET source compilation process takes the source code written in one of the .NET languages (such as C#, Visual Basic, F# etc.) and produces something called “Intermediate Language”. IL is then picked up by the runtime, and Just-In-Time compiled at run-time to machine code.
+.NET Native is not so much an"edition" of the .NET platform as it is a set of tools that allow developers to have different build outputs. The normal .NET source compilation process takes the source code written in one of the .NET languages (such as C#, Visual Basic, F# etc.) and produces something called "Intermediate Language" (IL). At run-time, a just-in-time (JIT) compiler compiles the IL into machine code.
 
-.NET Native NET Native is an Ahead-of-Time (AOT) toolchain that compiles IL byte code to native machine code, so that when the code is executed, there is only “native” code running. This means that the resulting binary is what the OS executes; there is no JIT-ing, no runtime compilation. This leads to better performance, as well as some security benefits.
+.NET Native is an Ahead-of-Time (AOT) toolchain that compiles IL byte code to native machine code, so that when the code is executed, there is only “native” code running. This means that the resulting binary is what the OS executes; there is no JIT-ing, no runtime compilation. This leads to better performance, as well as some security benefits.
 
-.NET Native is the set of tools used to build .NET **Universal Windows Platform (UWP)** applications.
+.NET Native is the set of tools used to build .NET **[Universal Windows Platform (UWP)](https://msdn.microsoft.com/en-us/library/windows/apps/dn726767.aspx)** applications.
 
 ## Supported operating systems
 

--- a/docs/concepts/primer.md
+++ b/docs/concepts/primer.md
@@ -6,7 +6,7 @@ By [Rich Lander](https://github.com/richlander), [Zlatko Knezevic](https://githu
 
 Multiple implementations of .NET are available, based on open [.NET Standards](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/dotnet-standards.md) that specify the fundamentals of the platform. They are separately optimized for different app types (e.g. desktop, mobile, gaming, cloud) and support many chips (e.g. x86/x64, ARM) and operating systems (e.g. Windows, Linux, iOS, Android, OS X). Open source is also an important part of the .NET ecosystem, with multiple .NET implementations and many libraries available under OSI-approved licenses.
 
-You can take a look at the [Overview of .NET implementations](editions-overview.md) document to figure out all of the different editions of .NET Framework that are available, both Microsoft’s and others.
+You can take a look at the [Overview of .NET implementations](editions-overview.md) document to figure out all of the different editions of the .NET Framework that are available, both Microsoft’s and others.
 
 ## Key .NET Concepts
 

--- a/docs/concepts/primer.md
+++ b/docs/concepts/primer.md
@@ -6,7 +6,7 @@ By [Rich Lander](https://github.com/richlander), [Zlatko Knezevic](https://githu
 
 Multiple implementations of .NET are available, based on open [.NET Standards](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/dotnet-standards.md) that specify the fundamentals of the platform. They are separately optimized for different app types (e.g. desktop, mobile, gaming, cloud) and support many chips (e.g. x86/x64, ARM) and operating systems (e.g. Windows, Linux, iOS, Android, OS X). Open source is also an important part of the .NET ecosystem, with multiple .NET implementations and many libraries available under OSI-approved licenses.
 
-You can take a look at the [Overview of .NET implementations](../getting-started/overview.md) document to figure out all of the different editions of .NET Framework that are available, both Microsoft’s and others.
+You can take a look at the [Overview of .NET implementations](editions-overview.md) document to figure out all of the different editions of .NET Framework that are available, both Microsoft’s and others.
 
 ## Key .NET Concepts
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -25,6 +25,7 @@
 ## [🔧 Documenting your code](languages/csharp/codedoc.md)
 # [Understanding the .NET Core Platform](index.md)
 ## [The .NET Primer](concepts/primer.md)
+## [Overview of .NET implementations](concepts/editions-overview.md) 
 ## [Programming Languages on .NET Platform](languages/index.md)
 ### [🔧 .NET - a multi-language platform](languages/overview.md)
 ### [🔧 The main trio: C#, F# and Visual Basic](languages/main-trio.md)


### PR DESCRIPTION
Change the things suggested in #105. Also add the document to the new TOC.
Move and rename the document from getting-started/overview.md to
concepts/editions-overview.md for more clarity.

Fix #105 

/cc @mairaw 
