### PR TITLE
Updating TOC title to reflect article title

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -34,7 +34,7 @@
 ### [🔧 Creating single binaries with native compilation](console/single-binaries.md)
 ## [Writing libraries](libraries/index.md)
 ### [Overview](libraries/overview.md)
-### [Creating a class library on any OS](libraries/libraries-with-cli.md)
+### [Creating a class library with Cross Platform Tools](libraries/libraries-with-cli.md)
 ### [Creating a class library in Visual Studio](libraries/libraries-with-vs.md)
 ## [Understanding package management on .NET](packaging/index.md)
 ### [🔧 Introducing NuGet](packaging/overview.md)


### PR DESCRIPTION
The TOC title is different than the title of the article, which makes it a bit confusing to use.  Updated the TOC to use the title of the article.
