### PR TITLE
Update installing-core-osx.md

### DIFF
--- a/docs/getting-started/installing/installing-core-osx.md
+++ b/docs/getting-started/installing/installing-core-osx.md
@@ -122,7 +122,7 @@ The next thing you will need is a `project.json` file that will outline the depe
 
 ## Run your App
 
-You need to restore packages for your app, based on your project.json, with `dnu restore`. You will need to run this command under the Mono DNX. The first command switches the active runtime to the Mono one.
+You need to restore packages for your app, based on your project.json, with `dnu restore`. You will need to run this command under the Mono DNX. The first command switches the active runtime to the Mono one. Note that the second line is `dnu restore` and **not** `dnvm`. It's easy to miss.
 
 ```console
 dnvm use 1.0.0-beta5-11649 -r mono


### PR DESCRIPTION
Note the for the lines:

> You are now ready to run your app under .NET Core. As you can guess, however, before you do that you first need to switch to the .NET Core runtime. The first command below does exactly that.

it's mistaken. If I followed your exact commands, as I did, I don't need to switch to coreclr at all. Runs fine on mono. I think what you mean is that you need to switch IFF you want to have the coreclr be used as the osx runtime. Yes?
