### PR TITLE
Add Placeholders for .NET Core Testing articles

### DIFF
--- a/docs/core-concepts/development.md
+++ b/docs/core-concepts/development.md
@@ -6,3 +6,4 @@
     * [Overview](libraries/overview.md)
     * [Creating a class library with Cross Platform Tools](libraries/libraries-with-cli.md)
     * [Creating a class library in Visual Studio](libraries/libraries-with-vs.md)
+* [Testing](testing/unit-testing.md)

--- a/docs/core-concepts/testing/unit-testing-in-visual-studio.md
+++ b/docs/core-concepts/testing/unit-testing-in-visual-studio.md
@@ -1,0 +1,17 @@
+# 🔧 Unit Testing in .NET Core Using Visual Studio
+
+> **Note**
+> 
+> We are currently working on this topic.
+>
+> We welcome your input to help shape the scope and approach. You can
+> track the 
+> status and provide input on this [issue](https://github.com/dotnet/core-docs/issues/401)
+> on GitHub.
+>
+> If you would like to review early drafts and outlines of this topic,
+> please leave a note with your contact information in the
+> [issue](https://github.com/dotnet/core-docs/issues/401).
+>
+> Learn more about how you can [contribute](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md)
+> on GitHub.

--- a/docs/core-concepts/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core-concepts/testing/unit-testing-with-dotnet-test.md
@@ -1,0 +1,17 @@
+# 🔧 Unit Testing in .NET Core using dotnet test
+
+> **Note**
+> 
+> We are currently working on this topic.
+>
+> We welcome your input to help shape the scope and approach. You can
+> track the 
+> status and provide input on this [issue](https://github.com/dotnet/core-docs/issues/401)
+> on GitHub.
+>
+> If you would like to review early drafts and outlines of this topic,
+> please leave a note with your contact information in the
+> [issue](https://github.com/dotnet/core-docs/issues/401).
+>
+> Learn more about how you can [contribute](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md)
+> on GitHub.

--- a/docs/core-concepts/testing/unit-testing-with-xunit.md
+++ b/docs/core-concepts/testing/unit-testing-with-xunit.md
@@ -1,0 +1,17 @@
+# 🔧 Unit Testing in .NET Core using xUnit
+
+> **Note**
+> 
+> We are currently working on this topic.
+>
+> We welcome your input to help shape the scope and approach. You can
+> track the 
+> status and provide input on this [issue](https://github.com/dotnet/core-docs/issues/401)
+> on GitHub.
+>
+> If you would like to review early drafts and outlines of this topic,
+> please leave a note with your contact information in the
+> [issue](https://github.com/dotnet/core-docs/issues/401).
+>
+> Learn more about how you can [contribute](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md)
+> on GitHub.

--- a/docs/core-concepts/testing/unit-testing.md
+++ b/docs/core-concepts/testing/unit-testing.md
@@ -1,0 +1,17 @@
+# 🔧 Unit Testing in .NET Core
+
+> **Note**
+> 
+> We are currently working on this topic.
+>
+> We welcome your input to help shape the scope and approach. You can
+> track the 
+> status and provide input on this [issue](https://github.com/dotnet/core-docs/issues/401)
+> on GitHub.
+>
+> If you would like to review early drafts and outlines of this topic,
+> please leave a note with your contact information in the
+> [issue](https://github.com/dotnet/core-docs/issues/401).
+>
+> Learn more about how you can [contribute](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md)
+> on GitHub.

--- a/docs/core-concepts/testing/unit-testing.md
+++ b/docs/core-concepts/testing/unit-testing.md
@@ -15,3 +15,22 @@
 >
 > Learn more about how you can [contribute](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md)
 > on GitHub.
+
+This topic will have the following sections:
+<style type="text/css">
+ol {
+  list-style-type: upper-roman;
+}
+</style>
+1. [Creating unit tests using dotnet test](unit-testing-with-dotnet-test.md)
+
+    This article describes setting up test projects with the Command Line Interface (CLI).
+        
+2. [Creating unit tests using xUnit (or your favorite test framework)](unit-testing-with-xunit.md)
+
+    This article describes creating and running unit tests using xUnit
+    (or NUnit, or other unit testing frameworks).
+
+3. [.NET Testing integration with Visual Studio](unit-testing-in-visual-studio.md)
+
+    This article describes Visual Studio Integration with .NET unit test projects.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -42,6 +42,7 @@
 #### [Overview](core-concepts/libraries/overview.md)
 #### [Creating a class library with Cross Platform Tools](core-concepts/libraries/libraries-with-cli.md)
 #### [Creating a class library in Visual Studio](core-concepts/libraries/libraries-with-vs.md)
+### [Testing](core-concepts/testing/unit-testing.md)
 ## [.NET Core Application Deployment](core-concepts/app-deployment.md)
 ## [Migrating from DNX](core-concepts/dnx-migration.md)
 ## [Porting applications between editions of .NET Platform](porting/index.md)


### PR DESCRIPTION
This adds the TOC and placeholder for articles on Unit Testing.

The content will be flushed out for Issue #401

/cc @blackdwarf

I'll start a new branch for the content. I'll move this to a different location, if it should go under a different heading.
