### PR TITLE
Consolidate Installing into a single document

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -2,9 +2,6 @@
 
 *  [🔧 What is the .NET Platform?](what-is-dotnet.md)
 *  [Installing .NET Core](installing/index.md)
-    *  [Installing .NET Core on Windows](installing/installing-core-windows.md)
-    *  [Installing .NET Core on Ubuntu](installing/installing-core-ubuntu.md)
-    *  [Installing .NET Core on OS X](installing/installing-core-osx.md)
 *  [Setting up your development environment](devenv/index.md)
     *  [🔧 Development using Visual Studio 2015](devenv/using-visual-studio.md)
     *  [🔧 Development using Visual Studio Code](devenv/using-visual-studio-code.md)

--- a/docs/getting-started/installing/index.md
+++ b/docs/getting-started/installing/index.md
@@ -1,6 +1,5 @@
-# Understanding package management on .NET
+# Installing .NET Core
 
-*  [Installing .NET Core on Windows](installing-core-windows.md)
-*  [Installing .NET Core on Linux](installing-core-ubuntu.md)
-*  [Installing .NET Core on OS X](installing-core-osx.md)
+By [Zlatko Knezevic](https://github.com/blackdwarf)
 
+The best way to get started is to follow our interactive guide on [.NET Core website](http://go.microsoft.com/fwlink/p/?LinkID=798306&clcid=0x409). 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1,8 +1,5 @@
 # [Getting started](getting-started/index.md)
 ## [Installing .NET Core](getting-started/installing/index.md)
-### [Installing .NET Core on Windows](getting-started/installing/installing-core-windows.md)
-### [Installing .NET Core on Ubuntu](getting-started/installing/installing-core-ubuntu.md)
-### [Installing .NET Core on OS X](getting-started/installing/installing-core-osx.md)
 ## [Setting up your development environment](getting-started/devenv/index.md)
 ### [🔧 Development using Visual Studio 2015](getting-started/devenv/using-visual-studio.md)
 ### [🔧 Development using Visual Studio Code](getting-started/devenv/using-visual-studio-code.md)


### PR DESCRIPTION
Currently, _Installing .NET Core_ links to the three _Installing .NET Core on …_ pages. But all three of them contain exactly the same content: a link to https://www.microsoft.com/net/core. I don't see much reason to keep the OS-specific pages, so I removed them from TOCs and included their content in _Installing .NET Core_.

I didn't delete the OS-specific pages, so that old links pointing to them still work. (It would be nice to redirect those to the generic _Installing .NET Core_ page, but I don't know how to do redirects in docfx.)

I also fixed the heading of _Installing .NET Core_ (it certainly doesn't have anything to do with package management).
