### PR TITLE
Fixing documentation on dotnet test

### DIFF
--- a/docs/core-concepts/core-sdk/cli/dotnet-pack.md
+++ b/docs/core-concepts/core-sdk/cli/dotnet-pack.md
@@ -62,19 +62,19 @@ Configuration to use when building the project. If not specified, will default t
 
 ## EXAMPLES
 
-`dotnet-pack`
+`dotnet pack`
 
     Pack the current project.
 
-`dotnet-pack ~/projects/app1/project.json`
+`dotnet pack ~/projects/app1/project.json`
     
     Pack the app1 project.
 	
-`dotnet-pack --output nupkgs`
+`dotnet pack --output nupkgs`
     
     Pack the current application and place the resulting packages into the specified folder.
 
-`dotnet-pack --no-build --output nupkgs`
+`dotnet pack --no-build --output nupkgs`
 
     Pack the current project into the specified folder and skip the build step.
 	

--- a/docs/core-concepts/core-sdk/cli/dotnet-publish.md
+++ b/docs/core-concepts/core-sdk/cli/dotnet-publish.md
@@ -14,7 +14,7 @@ dotnet-publish [--framework]
 
 ## DESCRIPTION
 
-`dotnet-publish` compiles the application, reads through its dependencies specified in `project.json` and publishes the resulting set of files to a directory. 
+`dotnet publish` compiles the application, reads through its dependencies specified in `project.json` and publishes the resulting set of files to a directory. 
 
 Depending on the type of portable app, the directory contains the following:
 

--- a/docs/core-concepts/core-sdk/cli/dotnet-restore.md
+++ b/docs/core-concepts/core-sdk/cli/dotnet-restore.md
@@ -61,19 +61,19 @@ The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Mi
 
 ## EXAMPLES
 
-`dotnet-restore`
+`dotnet restore`
 
 Restore dependencies and tools for the project in the current directory. 
 
-`dotnet-restore ~/projects/app1/project.json`
+`dotnet restore ~/projects/app1/project.json`
     
 Restore dependencies and tools for the `app1` project found in the given path.
 	
-`dotnet-restore --f c:\packages\mypackages`
+`dotnet restore --f c:\packages\mypackages`
     
 Restore the dependencies and tools for the project in the current directory using the file path provided as the fall-back source. 
 	
-`dotnet-restore --verbosity Error`
+`dotnet restore --verbosity Error`
     
 Show only errors in the output.
 

--- a/docs/core-concepts/core-sdk/cli/dotnet-test.md
+++ b/docs/core-concepts/core-sdk/cli/dotnet-test.md
@@ -7,7 +7,7 @@ dotnet-test
 
 ## SYNOPSIS
 
-dotnet-test [--configuration]  
+dotnet test [--configuration]  
     [--output] [--build-base-path] [--framework] [--runtime]
     [--no-build]
     [--parentProcessId] [--port]  
@@ -15,7 +15,7 @@ dotnet-test [--configuration]
 
 ## DESCRIPTION
 
-`dotnet-test` is used to execute unit tests in a given project. Unit tests are class library 
+`dotnet test` is used to execute unit tests in a given project. Unit tests are class library 
 projects that have dependencies on the unit test framework (for example, NUnit or xUnit) and the 
 dotnet test runner for that unit testing framework. These are packaged as NuGet packages and are 
 restored as ordinary dependencies for the project.
@@ -30,14 +30,21 @@ Below is a sample project.json that shows the needed properties:
     "version": "1.0.0-*",
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-*",
-        "xunit": "2.1.0-*",
-        "dotnet-test-xunit": "1.0.0-*"
+        "Microsoft.NETCore.App": {
+            "version": "1.0.0-rc2-3002702",
+            "type": "platform"
+        }
+        "xunit": "2.1.0",
+        "dotnet-test-xunit": "1.0.0-rc2-build10015"
     },
     "testRunner": "xunit",
 
     "frameworks": {
-        "netstandard1.5": {
+        "netcoreapp1.0": {
+                "imports": [
+                    "dnxcore50",
+                    "portable-net45+win8"
+                ]
         }
     }
 }
@@ -89,11 +96,11 @@ Used by IDEs to specify a port number to listen for a connection.
 
 ## EXAMPLES
 
-`dotnet-test`
+`dotnet test`
 
 Run the tests in the project in the current directory. 
 
-`dotnet-test /projects/test1/project.json`
+`dotnet test /projects/test1/project.json`
 
 Run the tests in the test1 project. 
 


### PR DESCRIPTION
Fixing the broken `project.json`sample in the `dotnet test` document. Not really broken, but the implementation changed since the docs were written. Also fixing the "Examples" section in commands to all use `dotnet <verb>` syntax and not `dotnet-<verb>`. 

Fixes #446, dotnet/cli#3077
