### PR TITLE
Clarified behavior of project dep. resolution

### DIFF
--- a/docs/project-model/global-json-reference.md
+++ b/docs/project-model/global-json-reference.md
@@ -7,7 +7,7 @@
 ## projects
 Type: String[]
 
-Specifies what folders the build system should search for projects when resolving dependencies
+Specifies what folders the build system should search for projects when resolving dependencies.  The build system will only search top level child folders.
 
 <a name="packages"></a>
 ## packages


### PR DESCRIPTION
Spent an extended amount of time trying to debug an issue where we had projects in a subfolder of the 'src' that were not being resolved because dotnet restore does not go beyond one subdirectory of the specified project folder.  In other words, if I have 'src' as my only specified value for 'projects' in global.json, but have projects in 'src/itsOk,', 'src/ItsOk2', 'src/Platforms/ItsNotOk', the ItsNotOk project will never be resolved, furthermore the dotnet restore command does not provide any insight into its search behavior (even with debug verbosity.)
