### PR TITLE
Update toc.md with F# link

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -74,6 +74,7 @@
 ## [🔧 Reflection & code generation](languages/csharp/reflection.md)
 ## [🔧 Documenting your code](languages/csharp/codedoc.md)
 ## [C# Tutorials](tutorials/index.md)
+# [Learn F#](https://msdn.microsoft.com/visualfsharpdocs/conceptual/fsharp-language-reference)
 # [Learn .NET](concepts/index.md)
 ## [The .NET Primer](concepts/primer.md)
 ## [.NET Standard](concepts/net-standard.md)


### PR DESCRIPTION
In the absence of proper documentation for F# here, I've added a single link for Learn F# which directs to the new F# documentation site.
