### PR TITLE
add travisci example (Ubuntu 14.04 and Mac OS X 10.11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: csharp
+
+matrix:
+  include:
+    - os: linux # Ubuntu 14.04
+      dist: trusty
+      sudo: required
+      dotnet: 1.0.0-preview2-003121
+    - os: osx # OSX 10.11
+      osx_image: xcode7.2
+      dotnet: 1.0.0-preview2-003121
+
+script:
+  # dotnet info
+  - dotnet --info
+  # Run dotnet new 
+  - mkdir -p "test/test-dotnet-new" && pushd "test/test-dotnet-new"
+  - dotnet new
+  - dotnet restore
+  - dotnet --verbose run a b
+  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ matrix:
       dotnet: 1.0.0-preview2-003121
 
 script:
-  # dotnet info
-  - dotnet --info
-  # Run dotnet new 
+  # Run a new console app
   - mkdir -p "test/test-dotnet-new" && pushd "test/test-dotnet-new"
   - dotnet new
   - dotnet restore

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -65,7 +65,7 @@ The below sections show examples of configurations using the mentioned CI SaaS o
 
 ### TravisCI
 
-The [travis-ci](https://travis-ci.org/) can be configured to install the .NET Core SDK using the language `csharp` and `dotnet` key
+The [travis-ci](https://travis-ci.org/) can be configured to install the .NET Core SDK using the `csharp` language and the `dotnet` key.
 
 Just use:
 
@@ -73,8 +73,8 @@ Just use:
 dotnet: 1.0.0-preview2-003121
 ```
 
-Travis can run both `osx` (OSX 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/core-docs/blob/master/.travis.yml) 
-for more info.
+Travis can run both `osx` (OS X 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/core-docs/blob/master/.travis.yml) 
+for more information.
 
 ### AppVeyor
 

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -78,8 +78,8 @@ for more information.
 
 ### AppVeyor
 
-The [appveyor.com ci](https://www.appveyor.com/) has .NET Core SDK preview1 already installed 
-in the build worker image `Visual Studio 2015`
+The [appveyor.com ci](https://www.appveyor.com/) has .NET Core SDK preview2 already installed 
+in the build worker image `Visual Studio 2015`.
 
 Just use:
 

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -64,7 +64,17 @@ in the [CLI repo](https://github.com/dotnet/core/blob/master/Documentation/prere
 The below sections show examples of configurations using the mentioned CI SaaS offerings. 
 
 ### TravisCI
-**TODO**
+
+The [travis-ci](https://travis-ci.org/) can be configured to install the .NET Core SDK using the language `csharp` and `dotnet` key
+
+Just use:
+
+```yaml
+dotnet: 1.0.0-preview2-003121
+```
+
+Travis can run both `osx` (OSX 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/core-docs/blob/master/.travis.yml) 
+for more info.
 
 ### AppVeyor
 


### PR DESCRIPTION
ref https://github.com/dotnet/cli/issues/2113

it add an example travisci to build:
- osx 10.11
- ubuntu 14.04

It use .NET Core SDK binaries, so it's pretty much curl sdk | unzip to a subdirectory `.dotnetsdk` and add that to PATH

I used the .net core sdk binaries instead of pkg because are easier to test locally, no need for sudo etc.
The script from dotnet/cli repo is not used because it's easier to just download and unzip, and also it's easier to understand.

i am pretty sure for osx deps (because of docs about brew)

But i am not sure about ubuntu (see apt deps) because these were needed some months ago, maybe now are not.

It use `generic` as travis language, so it's possibile to copy before_install, install in any travis, not only `csharp`.

/cc @blackdwarf @akoeplinger
