### PR TITLE
add appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+os: Visual Studio 2015
+
+install:
+  # .NET Core SDK binaries
+  - ps: $url = "https://go.microsoft.com/fwlink/?LinkID=798402" # v1.0.0-preview1 x64
+  # Download .NET Core SDK and add to PATH
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: $tempFile = [System.IO.Path]::GetTempFileName()
+  - ps: (New-Object System.Net.WebClient).DownloadFile($url, $tempFile)
+  - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $env:DOTNET_INSTALL_DIR)
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+
+build_script:
+  # dotnet info
+  - ps: dotnet --info
+  # Run dotnet new 
+  - ps: mkdir "test\test-dotnet-new" -Force | Push-Location
+  - ps: dotnet new --lang fsharp
+  - ps: dotnet restore
+  - ps: dotnet --verbose build
+  - ps: dotnet --verbose run a b
+  - ps: Pop-Location
+
+
+test: off 
+version: 0.0.1.{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,11 @@ os: Visual Studio 2015
 ##
 ## install:
 ##   # .NET Core SDK binaries
+##   ## 1) from direct url  
 ##   - ps: $url = "https://go.microsoft.com/fwlink/?LinkID=798402" # v1.0.0-preview1 x64
+##   ## 2) from url based on version, for example using an env var CLI_VERSION that can be a
+##   ##    a specific version `1.0.0-preview2-003118` or `Latest` (for latest dev version)
+##   - ps: $url = "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$($env:CLI_VERSION)/dotnet-dev-win-x64.$($env:CLI_VERSION.ToLower()).zip"
 ##   # Download .NET Core SDK and add to PATH
 ##   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
 ##   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,19 @@
 os: Visual Studio 2015
 
-install:
-  # .NET Core SDK binaries
-  - ps: $url = "https://go.microsoft.com/fwlink/?LinkID=798402" # v1.0.0-preview1 x64
-  # Download .NET Core SDK and add to PATH
-  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
-  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
-  - ps: $tempFile = [System.IO.Path]::GetTempFileName()
-  - ps: (New-Object System.Net.WebClient).DownloadFile($url, $tempFile)
-  - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $env:DOTNET_INSTALL_DIR)
-  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+## .NET Core SDK preview1 is already installed in the build worker image Visual Studio 2015
+##
+## To install a specific version:
+##
+## install:
+##   # .NET Core SDK binaries
+##   - ps: $url = "https://go.microsoft.com/fwlink/?LinkID=798402" # v1.0.0-preview1 x64
+##   # Download .NET Core SDK and add to PATH
+##   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+##   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+##   - ps: $tempFile = [System.IO.Path]::GetTempFileName()
+##   - ps: (New-Object System.Net.WebClient).DownloadFile($url, $tempFile)
+##   - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $env:DOTNET_INSTALL_DIR)
+##   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 
 build_script:
   # dotnet info

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -67,6 +67,33 @@ The below sections show examples of configurations using the mentioned CI SaaS o
 **TODO**
 
 ### AppVeyor
-**TODO**
 
+The [appveyor.com ci](https://www.appveyor.com/) has .NET Core SDK preview1 already installed 
+in the build worker image `Visual Studio 2015`
+
+Just use:
+
+```yaml
+os: Visual Studio 2015
+```
+
+It's possibile to install a specific version of .NET Core SDK, see [example appveyor.yml](https://github.com/dotnet/core-docs/blob/master/appveyor.yml) 
+for more info. 
+
+In the example the .NET Core SDK binaries are downloaded, unzipped in a subdirectory and added to `PATH` env var
+
+A build matrix can be added to run integration tests with multiple version of 
+the .NET Core SDK
+
+```yaml
+environment:
+  matrix:
+    - CLI_VERSION: 1.0.0-preview2-003118
+    - CLI_VERSION: Latest
+
+install:
+  # .NET Core SDK binaries
+  - ps: $url = "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$($env:CLI_VERSION)/dotnet-dev-win-x64.$($env:CLI_VERSION.ToLower()).zip"
+  # follow normal installation from binaries
+```
 

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -29,7 +29,7 @@ usage mechanisms should be similar.
 If using installers that require administrative privileges is not something that presents a problem, native installers for 
 each platform can be used to set up the build server. This approach, especially in the case of Linux build servers, has 
 one advantage which is automatic installing of dependencies needed for the SDK to run. The native installers will also 
-install a system-wide version of the SDK, which may be desired; if its not, you should look into the 
+install a system-wide version of the SDK, which may be desired; if it's not, you should look into the 
 [installer script usage](#using-the-installer-script) outlined below. 
 
 Using this approach is simple. For Linux, there is a choice of using a feed-based package manager, such as `apt-get` for 
@@ -77,13 +77,13 @@ Just use:
 os: Visual Studio 2015
 ```
 
-It's possibile to install a specific version of .NET Core SDK, see [example appveyor.yml](https://github.com/dotnet/core-docs/blob/master/appveyor.yml) 
+It's possible to install a specific version of .NET Core SDK, see [example appveyor.yml](https://github.com/dotnet/core-docs/blob/master/appveyor.yml) 
 for more info. 
 
-In the example the .NET Core SDK binaries are downloaded, unzipped in a subdirectory and added to `PATH` env var
+In the example, the .NET Core SDK binaries are downloaded, unzipped in a subdirectory and added to `PATH` env var.
 
 A build matrix can be added to run integration tests with multiple version of 
-the .NET Core SDK
+the .NET Core SDK.
 
 ```yaml
 environment:


### PR DESCRIPTION
ref https://github.com/dotnet/cli/issues/2113

Download and unzip .NET Core SDK Binaries in a subdirectory `.netcoresdk` and add that to PATH

Easy to understand what do, easy to reproduce locally.

I used powershell 3, with 5 was a bit more readable as oneliner but not every image support it (not this image from appveyor anyway)

/cc @blackdwarf 
