### PR TITLE
Fix typo in DogHairLenghtComparer

### DIFF
--- a/docs/concepts/linq.md
+++ b/docs/concepts/linq.md
@@ -150,7 +150,7 @@ public class DogHairLengthComparer : IEqualityComparer<Dog>
 {
     public bool Equals(Dog a, Dog b)
     {
-        if (a == null && a == null)
+        if (a == null && b == null)
         {
             return true;
         }


### PR DESCRIPTION
typo in Equals when validating objects on null
