### PR TITLE
Use .NET Core SDK branding

### DIFF
--- a/docs/core-concepts/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core-concepts/testing/unit-testing-with-dotnet-test.md
@@ -48,7 +48,7 @@ make a modification to `project.json` so that you build a class library
 project. 
 
 * note: You can track [this issue](https://github.com/dotnet/cli/issues/2052)
-for other project types coming for the dotnet CLI, including class libraries.
+for other project types coming for the .NET Core SDK, including class libraries.
 Once this issue is addressed, you won't need to make these changes.
 
 Simply remove the `buildOptions` node that instructs the compiler
@@ -94,7 +94,7 @@ Once again, `dotnet new` creates a console application, and you'll need to modif
 ```
 
 * note: You can track [this issue](https://github.com/dotnet/cli/issues/2052)
-for other project types coming for the dotnet CLI, including class libraries.
+for other project types coming for the .NET Core SDK, including class libraries.
 Once this issue is addressed, you won't need to make these changes.
 
 The test project requires other packages to create and run unit tests.


### PR DESCRIPTION
We should use .NET instead of "dotnet" except when referring directly to dotnet.exe.
