### PR TITLE
Use HTTPS URL to avoid mixed content warning

### DIFF
--- a/template/partials/head.tmpl.partial
+++ b/template/partials/head.tmpl.partial
@@ -8,7 +8,7 @@
   <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
   {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
   <link rel="shortcut icon" href="{{_rel}}images/Logo_DotNet.png" type="image/x-icon">
-  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="{{_rel}}styles/docfx.vendor.css">
   <link rel="stylesheet" href="{{_rel}}styles/main.css">
   <link rel="stylesheet" href="{{_rel}}styles/docfx.css">


### PR DESCRIPTION
This was causing the following errors for me in FF:

> Firefox has blocked parts of this page that are not secure.

<!-- -->

> Blocked loading mixed active content "http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"

Since dotnet.github.io only seems to exist as HTTPS (HTTP redirects to HTTPS), using the HTTPS URL here should be fine (instead of protocol relative URL).
