### PR TITLE
fixed warnings from docfx build

### DIFF
--- a/docs/core-concepts/dotnet-core.md
+++ b/docs/core-concepts/dotnet-core.md
@@ -16,7 +16,7 @@ Composition
 .NET Core is composed of the following parts:
 
 - A [.NET runtime](https://github.com/dotnet/coreclr), which provides a type system, assembly loading, a garbage collector, native interop and other basic services. 
-- A set of [framework libraries]((https://github.com/dotnet/corefx)), which provide primitive data types, app composition types and fundamental utilities. 
+- A set of [framework libraries](https://github.com/dotnet/corefx), which provide primitive data types, app composition types and fundamental utilities. 
 - The 'dotnet' app host, which is used to launch .NET Core apps. It selects the runtime and hosts the runtime, provides an assembly loading policy and launches the app. The same host is also used to launch SDK tools in much the same way.
 - A [set of SDK tools](https://github.com/dotnet/cli) and language compilers that enable the base developer experience, available in the [.NET Core SDK](http://dotnet.github.io/docs/core-concepts/core-sdk).
 

--- a/docs/core-concepts/packages.md
+++ b/docs/core-concepts/packages.md
@@ -120,7 +120,7 @@ There is a two-way relationship between frameworks and packages. The first part 
 
 The second part of the relationship is asset selection. Packages can contain assets for multiple frameworks. Given a reference to a set of packages and/or metapackages, the framework is needed to determine which asset should be selected, for example `net46` or `netstandard1.3`. It is important to select the correct asset. For example, a `net46` asset is not likely to be compatible with .NET Framework 4.0 or .NET Core 1.0.
 
-[Package-based Framework Composition](!../images/package-framework.png)
+![Package-based Framework Composition](../../images/package-framework.png)
 
 You can see this relationship in the image above. The *API* targets and defines the *framework*. The *framework* is used for *asset selection*. The *asset* gives you the API.
 

--- a/docs/getting-started/cli-console-app-tutorial.md
+++ b/docs/getting-started/cli-console-app-tutorial.md
@@ -111,7 +111,7 @@ you'll build a Windows executable. If you are following these steps on a Mac, yo
 }
 ```
 
-See the full list of supported runtimes in the [RID catalog](../core-concepts/rid-catalog.html). 
+See the full list of supported runtimes in the [RID catalog](../core-concepts/rid-catalog.md). 
  
 After making those two changes you execute `dotnet restore`, followed by `dotnet build` to create the native executable. Then, you can run the generated
 native executable. 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,7 +6,7 @@
     *  [Installing .NET Core on Windows](installing/installing-core-windows.md)
     *  [Installing .NET Core on Linux](installing/installing-core-linux.md)
     *  [Installing .NET Core on OS X](installing/installing-core-osx.md)    
-*  [Using the CLI tools to write console apps: A step-by-step guide](getting-started/cli-console-app-tutorial.md)
+*  [Using the CLI tools to write console apps: A step-by-step guide](cli-console-app-tutorial.md)
 *  [Setting up your integrated development environment (IDE)](devenv/index.md)
     *  [🔧 Development using Visual Studio 2015](devenv/using-visual-studio.md)
     *  [🔧 Development using Visual Studio Code](devenv/using-visual-studio-code.md)


### PR DESCRIPTION
There are a couple of broken links being flagged when you build the content with docfx. Purposely ignored the TOC file since a lot of people are touching that at the moment. 

Fixes #525 

/cc @richlander @blackdwarf 
