### PR TITLE
Fixed heading levels in C# tutorials

### DIFF
--- a/docs/tutorials/getting-started-with-csharp/console-teleprompter.md
+++ b/docs/tutorials/getting-started-with-csharp/console-teleprompter.md
@@ -1,4 +1,6 @@
-# Introduction
+# Console Application
+
+## Introduction
 This tutorial teaches you a number of features in .NET Core and the C# language. You’ll learn:
 *	The basics of the .NET Core Command Line Interface (CLI).
 *	The structure of a C# Console Application.
@@ -12,13 +14,13 @@ be paced to match reading it aloud. You can speed up or slow down the pace
 by pressing the ‘<’ or ‘>’ keys.
 
 There are a lot of features in this tutorial. Let’s build them one by one. 
-# Prerequisites
+## Prerequisites
 You’ll need to setup your machine to run .NET core. You can find the
 installation instructions on the [Getting Started](http://dotnet.github.io/getting-started/)
 page. You can run this
 application on Windows, Ubuntu Linux, OS X or in a Docker container. 
 You’ll need to install your favorite code editor. 
-# Create the Application
+## Create the Application
 The first step is to create a new application. Open a command prompt and
 create a new directory for your application. Make that the current
 directory. Type the command "dotnet new" at the command prompt. This
@@ -61,7 +63,7 @@ change it to `TeleprompterConsole`.
 namespace TeleprompterConsole
 ```
 
-# Reading and Echoing the File
+## Reading and Echoing the File
 The first feature to add is to read a text file, and display all that text
 to the console. First, let’s add a text file. Copy the 
 [sampleQuotes.txt](https://github.com/dotnet/core-docs/blob/master/docs/tutorials/getting-started-with-csharp/console-teleprompter/sampleQuotes.txt)
@@ -140,7 +142,7 @@ foreach (var line in lines)
 Run the program (using "dotnet run" and you can see every line printed out
 to the console.  
 
-# Adding Delays and Formatting output
+## Adding Delays and Formatting output
 What you have is being displayed far too fast to read aloud. Now you need
 to add the delays in the output. As you start, you’ll be building some of
 the core code that enables asynchronous processing. However, these first
@@ -222,7 +224,7 @@ if (lineLength > 70)
 Run the sample, and you’ll be able to read aloud at its pre-configured
 pace.
 
-# Async Tasks
+## Async Tasks
 In this final step, you’ll add the code to write the output asynchronously
 in one task, while also running another task to read input from the user
 if they want to speed up or slow down the text display. This has a few
@@ -420,7 +422,7 @@ public void SetDone()
 }
 ```
 
-# Conclusion
+## Conclusion
 This tutorial showed you a number of the features around the C# language
 and the .NET Core libraries related to working in Console applications.
 You can build on this knowledge to explore more about the language, and

--- a/docs/tutorials/getting-started-with-csharp/console-webapiclient.md
+++ b/docs/tutorials/getting-started-with-csharp/console-webapiclient.md
@@ -1,4 +1,6 @@
-# Introduction
+# REST client
+
+## Introduction
 This tutorial teaches you a number of features in .NET Core and the C# language. You’ll learn:
 *	The basics of the .NET Core Command Line Interface (CLI).
 *   An overview of C# Language features.
@@ -13,7 +15,7 @@ that JSON packet into C# objects. Finally, you'll see how to work with
 C# objects.
 
 There are a lot of features in this tutorial. Let’s build them one by one. 
-# Prerequisites
+## Prerequisites
 You’ll need to setup your machine to run .NET core. Instructions are
 [here](http://dotnet.github.io/getting-started/). You can run this
 application on Windows, Ubuntu Linux, OS X or in a Docker container. 
@@ -21,7 +23,7 @@ You’ll need to install your favorite code editor. The descriptions below
 use [Visual Studio Code](https://code.visualstudio.com/) which is an open
 source, cross platform editor. However, you can use whatever tools you are
 comfortable with.
-# Create the Application
+## Create the Application
 The first step is to create a new application. Open a command prompt and
 create a new directory for your application. Make that the current
 directory. Type the command "dotnet new" at the command prompt. This
@@ -45,7 +47,7 @@ After restoring packages, you run “dotnet build”. This executes the build
 engine and creates your application. Finally, you execute “dotnet run” to
 run your application.
 
-# Adding New Dependencies
+## Adding New Dependencies
 One of the key design goals for .NET Core is to minimize the size of
 the .NET framework installation. The .NET Core Application framework contains
 only the most common elements of the .NET full framework. This application
@@ -89,7 +91,7 @@ Core Application framework.
 After you've made these changes, you should run "dotnet restore" again so
 that those packages are installed on your system.
 
-# Making Web Requests
+## Making Web Requests
 Now you're ready to start retrieving data from the web. In this
 application, you'll read information from the 
 [GitHub API](https://developer.github.com/v3/). Let's read information
@@ -181,7 +183,7 @@ The final two lines of this method await that task, and then print the response 
 Build the app, and run it. The build warning is gone now, because the `ProcessRepositories` now
 does contain an `await` operator. You'll see a long display of JSON formatted text.   
 
-# Processing the JSON Result
+## Processing the JSON Result
 
 At this point, you've written the code to retrieve a response from a web server, and display
 the text that is contained in that response. Next, let's convert that JSON response into C#
@@ -257,7 +259,7 @@ foreach (var repo in repositories)
 Compile and run the application. It will print out the names of the repositories that are part of the
 .NET Foundation.
 
-# Controlling Serialization
+## Controlling Serialization
 
 Before you add more features, let's address the `repo` type and make it follow more standard
 C# conventions. You'll do this by annotating the `repo` type with *Attributes* that control how
@@ -380,7 +382,7 @@ Accessing the `Result` property of a Task blocks until the task has completed. N
 to `await` the completion of the task as in the `ProcessRepositories` method, but that isn't allowed in the
 `Main` method.
 
-# Reading More Information
+## Reading More Information
 
 Let's finish this by processing a few more of the properties in the JSON packet that gets sent from the
 GitHub API. You won't want to grab everything, but adding a few properties will demonstrate a few more
@@ -470,7 +472,7 @@ Console.WriteLine(repo.LastPush);
 Your version should now match the finished version located
 [here](https://github.com/dotnet/core-docs/tree/master/docs/tutorials/getting-started-with-csharp/console-webapiclient).
  
-# Conclusion
+## Conclusion
 
 This tutorial showed you how to make web requests, parse the result, and display properties of
 those results. You've also added new packages as dependencies in your project. You've seen some of

--- a/docs/tutorials/getting-started-with-csharp/microservices.md
+++ b/docs/tutorials/getting-started-with-csharp/microservices.md
@@ -1,4 +1,6 @@
-#Introduction
+# Microservices hosted in Docker
+
+##Introduction
 
 This tutorial details the tasks necessary to build and deploy
 an ASP.NET Core microservice in a Docker container. During the course
@@ -16,7 +18,7 @@ Along the way, you'll also see some C# language features:
 * How to process incoming HTTP Requests and generate the HTTP Response
 * How to work with nullable value types
 
-## Why Docker?
+### Why Docker?
 
 Docker makes it easy to create standard machine images to
 host your services in a data center, or the public cloud. Docker
@@ -27,7 +29,7 @@ All the code in this tutorial will work in any .NET Core environment.
 The additional tasks for a Docker installation will work for an ASP.NET
 Core application. 
 
-# Prerequisites
+## Prerequisites
 You’ll need to setup your machine to run .NET core. See the 
 [.NET Core Getting Started page](http://dotnet.github.io/getting-started/)
 for instructions on installing .NET core on your machine.
@@ -58,7 +60,7 @@ the yeoman asp.net template generators:
 
 `npm install -g generator-aspnet`
 
-# Create the Application
+## Create the Application
 
 Now that you've installed all the tools, create a new asp.net core
 application. To use the command line generator, execute the following
@@ -104,7 +106,7 @@ And once you build the application, you run it from the command line:
 The default configuration listens to http://localhost:5000. You can open a
 browser and navigate to that page and see a "Hello World!" message.
 
-## Anatomy of an ASP.NET Core application
+### Anatomy of an ASP.NET Core application
 
 Now that you've built the application, let's look at how this functionality
 is implemented. There are two of the generated files that are particularly
@@ -129,7 +131,7 @@ need to configure any dependencies. The `Configure` method configures the handle
 for incoming HTTP Requests. The template generates a simple handler that responds
 to any request with the text 'Hello World!'.
 
-# Build a microservice
+## Build a microservice
 
 The service you're going to build will deliver weather reports from anywhere
 around the globe. In a production application, you'd call some service
@@ -147,7 +149,7 @@ our random weather service:
 
 The next sections walk you through each of these steps.
 
-## Parsing the Query String.
+### Parsing the Query String.
 
 You'll begin by parsing the query string. The service will accept 
 'lat' and 'long' arguments on the query string in this form:
@@ -233,7 +235,7 @@ At this point, you can run the web application and see if your parsing
 code is working. Add values to the web request in a browser, and you should see
 the updated results.
 
-## Build a random weather forecast
+### Build a random weather forecast
 
 Your next task is to build a random weather forecast. Let's start with a data
 container that holds the values you'd want for a weather forecast:
@@ -285,7 +287,7 @@ if (latitude.HasValue && longitude.HasValue)
 }
 ``` 
 
-## Build the JSON response.
+### Build the JSON response.
 
 The final code task on the server is to convert the WeatherReport array
 into a JSON packet, and send that back to the client. Let's start by creating
@@ -319,7 +321,7 @@ you set the content type to 'application/json', and write the string.
 
 The application now runs and returns random forecasts.
 
-# Load into Docker
+## Load into Docker
 
 The Dockerfile created by the asp.net template will serve
 for our purposes. Let's go over its contents.
@@ -450,7 +452,7 @@ docker-machine ip weather-service
 Open a browser on the docker host and navigate to that site, and you should see your 
 weather service running. 
 
-# Conclusion 
+## Conclusion 
 
 In this tutorial, you built an asp.net core microservice, and added a few
 features.

--- a/docs/tutorials/getting-started-with-csharp/working-with-linq.md
+++ b/docs/tutorials/getting-started-with-csharp/working-with-linq.md
@@ -1,4 +1,6 @@
-# Introduction
+# Working with LINQ
+
+## Introduction
 This tutorial teaches you a number of features in .NET Core and the C# language. You’ll learn:
 
 *	How to generate sequences with LINQ
@@ -24,7 +26,7 @@ This tutorial has multiple steps. After each step, you can run the
 application and see the progress.
 
 
-# Prerequisites
+## Prerequisites
 You’ll need to setup your machine to run .NET core. Instructions are
 [here](http://dotnet.github.io/getting-started/). You can run this
 application on Windows, Ubuntu Linux, OS X or in a Docker container. 
@@ -33,7 +35,7 @@ use [Visual Studio Code](https://code.visualstudio.com/) which is an open
 source, cross platform editor. However, you can use whatever tools you are
 comfortable with.
 
-# Create the Application
+## Create the Application
 
 The first step is to create a new application. Open a command prompt and
 create a new directory for your application. Make that the current
@@ -44,7 +46,7 @@ If you've never used C# before, [this tutorial](console-teleprompter.md)
 explains the structure of a C# program. You can read that and then
 return here to learn more about LINQ. 
 
-# Creating the Data Set
+## Creating the Data Set
 
 Let's start by creating a deck of cards. You'll do this using a LINQ
 query that has two sources (one for the four suits, one for the
@@ -108,7 +110,7 @@ under a debugger to observe how the `Suits()` and `Values()` methods
 execute. You can clearly see that each string in each sequence is generated
 only as it is needed.
 
-# Manipulating the Order
+## Manipulating the Order
 
 Next, let's build a utility method that can perform the shuffle. The first step
 is to split the deck in two. The `Take()` and `Skip()` methods that are
@@ -210,7 +212,7 @@ public static void Main(string[] args)
 }
 ```
 
-# Comparisons
+## Comparisons
 
 Let's see how many shuffles it takes to set the deck back to its
 original order. You'll need to write a method that determines if
@@ -268,7 +270,7 @@ Console.WriteLine(times);
 Run the sample, and see how the deck rearranges on each shuffle, until
 it returns to its original configuration after 8 iterations.
 
-# Optimizations
+## Optimizations
 
 The sample you've built so far executes an *in shuffle*, where the
 top and bottom cards stay the same on each run. Let's make one change,
@@ -403,7 +405,7 @@ lazy evaluation enables more complex queries to execute only one round trip to t
 database process.) LINQ enables both lazy and eager evaluation. Measure, and pick
 the best choice.
 
-# Preparing for New Features
+## Preparing for New Features
 
 The code you've written for this sample is an example of creating a simple prototype that does the
 job. This is a great way to explore a problem space, and for many features, it may be
@@ -535,7 +537,7 @@ var startingDeck = (from s in Suits().LogQuery("Suit Generation")
 Compile and run again. The output is a little cleaner, and the code is a bit
 more clear and can be extended more easily.
 
-# Conclusion
+## Conclusion
 
 This sample should you some of the methods used in LINQ, how to create your
 own methods that will be easily used with LINQ enabled code. It also showed

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,3 +1,5 @@
+# C# Tutorials
+
 These exercises enable you to build C# programs using core CLR.
 
 * [Console Application](getting-started-with-csharp/console-teleprompter.md). This tutorial


### PR DESCRIPTION
Articles now have H1 containing article title, sub-headings start at H2.
