### PR TITLE
Update toc.yml

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -1,4 +1,4 @@
-﻿- name: .Net Core
+﻿- name: .NET Home
   href: /dotnet
   homepage: /dotnet/index
   items:


### PR DESCRIPTION
Since the docset will surface at /dotnet/index and since the hub page for the dotnet home will contain more than just .NET Core, this seemed like a good change to the TOC.
