### PR TITLE
updating core links

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,13 +54,13 @@ ms.assetid:
                     <section class="journey-step-elements content">
                         <ul class="row">
                             <li class="column column-third">
-                                <a href="core/">
+                                <a href="core/index">
                                     <h3>Getting Started with .NET Core</h3>
                                     <p>Learn how to build .NET Core console apps at the command-line or in Visual Studio.</p>
                                 </a>
                             </li>
                             <li class="column column-third">
-                                <a href="api/">
+                                <a href="core/api/index">
                                     <h3>API Reference</h3>
                                     <p>Browse the .NET API, organized by namespace.</p>
                                 </a>


### PR DESCRIPTION
The core conceptual and api links were broken in the last commit. @richlander can you confirm these URLs are okay? @richlander your last commit omitted **core** from the URLs. 
