### PR TITLE
Change Azure link

### DIFF
--- a/index.md
+++ b/index.md
@@ -100,7 +100,7 @@ ms.assetid:
                                 </a>
                             </li>
                             <li class="column column-third">
-                                <a href="https://azure.microsoft.com/develop/net/">
+                                <a href="https://www.visualstudio.com/features/azure-tools-vs">
                                     <h3>Microsoft Azure</h3>
                                     <p>Get Started developing applications using Microsoft Azure</p>
                                 </a>


### PR DESCRIPTION
Updates the Azure hub page link to point to the VS.com Azure tools page, as the .NET page on ACOM is no longer maintained.
