### PR TITLE
Finalize hub page

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,7 +20,6 @@ ms.assetid:
     <section id="hero-content" class="graph">
         <h1>.NET Documentation</h1>
         <h2>Welcome to .NET! This is the home of the technical documentation for .NET, C#, F# and Visual Basic, including basic concepts, getting started instructions, tutorials and samples. Start reading and exploring, to learn .NET for the first time or to find an answer to today's challenge.</h2>
-        <h3>New to .NET? Visit the <a href="">.NET Products page</a> &rarr;</h3>
     </section>
     <aside class="alert section-border">
         <p>Download .NET Core today</p>
@@ -64,12 +63,6 @@ ms.assetid:
                                 <a href="core/api/index">
                                     <h3>API Reference</h3>
                                     <p>Browse the .NET API, organized by namespace.</p>
-                                </a>
-                            </li>
-                            <li class="column column-third">
-                                <a href="dotnet/primer">
-                                    <h3>.NET and C# Primers</h3>
-                                    <p>Learn about the fundamentals of the .NET platform by reading the .NET and C# Primers.</p>
                                 </a>
                             </li>
                         </ul>
@@ -121,13 +114,13 @@ ms.assetid:
                     <section class="journey-step-elements content">
                         <ul class="row">
                             <li class="column column-third">
-                                <a href="">
+                                <a href="https://developer.xamarin.com/guides/ios/getting_started/">
                                     <h3>Android and iOS apps</h3>
                                     <p>Learn how to build native iOS and Android applications with Xamarin</p>
                                 </a>
                             </li>
                             <li class="column column-third">
-                                <a href="">
+                                <a href="https://developer.microsoft.com/en-us/windows/getstarted">
                                     <h3>Universal Windows Platform</h3>
                                     <p>Learn how to build Windows 10 UWP apps, which can run on all Windows 10 devices.</p>
                                 </a>
@@ -175,13 +168,13 @@ ms.assetid:
                     <section class="journey-step-elements content">
                         <ul class="row">
                             <li class="column column-third">
-                                <a href="http://unity3d.com/unity">
+                                <a href="http://docs.unity3d.com/Manual/index.html">
                                     <h3>Unity</h3>
                                     <p>Build games for desktop, console and mobile in C# with Unity.</p>
                                 </a>
                             </li>
                             <li class="column column-third">
-                                <a href="http://www.monogame.net">
+                                <a href="http://www.monogame.net/documentation/?page=main">
                                     <h3>MonoGame</h3>
                                     <p>Build games for desktop, console and mobile in C# with MonoGame.</p>
                                 </a>


### PR DESCRIPTION
Details of change:
- Removed Primers link as it wasn't going anywhere and I couldn't find anything in the TOC that looked like the Primers section. I re-read the thread on the topic but didn't take note of any PRs mentioned. 
- Removed the "new to .net" link between masthead and "download" call to action, it wasn't going anywhere and seemed extraneous
- Fixed the UWP and IOS links
- Redirected the gaming links. They'd been linking to the Unity/MonoGame home pages. That seems appropriate as outbound links from the marketing page, but for the dotnet docs site, it felt like a better idea to use the project's documentation pages. So I changed these two as well.

Please don't merge until @richlander provides a confirmation in the comments
