### PR TITLE
remove ref to RC2

### DIFF
--- a/docs/concepts/primer.md
+++ b/docs/concepts/primer.md
@@ -61,7 +61,7 @@ Microsoft languages that .NET supports include C#, F#, and Visual Basic.
 
 > **Note**
 > 
-> In the RC2 release of .NET Core, only C# is fully supported.
+> In the current release of .NET Core, only C# is fully supported.
 >  
 
 ### Automatic memory management


### PR DESCRIPTION
Changed "RC2" to "current" in
"In the RC2 release of .NET Core, only C# is fully supported."

/cc: @mairaw 
