### PR TITLE
Linking to docs contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 .NET Core Documentation
 =======================
 
-This repo contains work-in-progress documentation for .NET Core. Please see the [Contributing Guide](CONTRIBUTING.md) to get set up and take a look at our [issues list](https://github.com/dotnet/core-docs/issues). 
+This repo contains work-in-progress documentation for .NET Core. Please see the [Contributing Guide](https://github.com/Microsoft/Docs/blob/master/readme.md) to get set up and take a look at our [issues list](https://github.com/dotnet/core-docs/issues). 
 
 We very much welcome contributions to help us provide a complete set of .NET Core docs sooner. Feel free to use (copy/paste) documentation from [.NET Framework docs](https://msdn.microsoft.com/library/w0x726c2.aspx) as a starting point for .NET Core docs. We will likely port higher-quality .NET Core content to the .NET Framework docs, such that investments in this repo have a broader impact than .NET Core users. We expect that [Xamarin](http://developer.xamarin.com/api/root/classlib/), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib) and [Unity](http://docs.unity3d.com/Manual/index.html) will also use this documentation.


### PR DESCRIPTION
Changing the link of the contributing guide to the one in the microsoft/docs repo. Should I also add a link from the contributing.md file? I didn't want to delete that one yet since we need to make sure the docs one covers everything we need.

/cc @richlander @blackdwarf @bradygaster 
