### PR TITLE
update broken links where samples moved.

### DIFF
--- a/docs/tutorials/getting-started-with-csharp/console-teleprompter.md
+++ b/docs/tutorials/getting-started-with-csharp/console-teleprompter.md
@@ -80,8 +80,8 @@ namespace TeleprompterConsole
 ## Reading and Echoing the File
 The first feature to add is to read a text file, and display all that text
 to the console. First, let’s add a text file. Copy the 
-[sampleQuotes.txt](https://github.com/dotnet/core-docs/blob/master/docs/tutorials/getting-started-with-csharp/console-teleprompter/sampleQuotes.txt)
-file from the GitHub repository for this [sample](https://github.com/dotnet/core-docs/tree/master/docs/tutorials/getting-started-with-csharp/console-teleprompter) into your project directory. 
+[sampleQuotes.txt](https://github.com/dotnet/core-docs/blob/master/samples/csharp-language/console-teleprompter/sampleQuotes.txt)
+file from the GitHub repository for this [sample](https://github.com/dotnet/core-docs/tree/master/samples/csharp-language/console-teleprompter) into your project directory. 
 This will serve as the script for your
 application.
 

--- a/docs/tutorials/getting-started-with-csharp/console-webapiclient.md
+++ b/docs/tutorials/getting-started-with-csharp/console-webapiclient.md
@@ -485,7 +485,7 @@ Console.WriteLine(repo.LastPush);
 ```
 
 Your version should now match the finished version located
-[here](https://github.com/dotnet/core-docs/tree/master/docs/tutorials/getting-started-with-csharp/console-webapiclient).
+[here](https://github.com/dotnet/core-docs/tree/master/samples/csharp-language/console-webapiclient).
  
 ## Conclusion
 


### PR DESCRIPTION
They are now all under /samples in the repo.
