### PR TITLE
Fix API Reference table style

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -20,7 +20,7 @@ In the .NET Core library, the namespace name serves to identify a type's functio
  
 The .NET Core class library includes the following namespaces:
 
-<table>
+<table class="table table-bordered table-striped table-condensed">
 <thead>
    <tr>
       <th>Namespace</th>


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/3997851/16367179/725bae98-3c53-11e6-94c0-551d268adf28.png)

After:
![after](https://cloud.githubusercontent.com/assets/3997851/16367181/7b0cc8a6-3c53-11e6-9caa-445fa280bcbc.png)
