### PR TITLE
Escape the trailing `#` in title

### DIFF
--- a/docs/fsharp/index.md
+++ b/docs/fsharp/index.md
@@ -1,6 +1,6 @@
 ---
-title: Learn F# 
-description: Learn F# 
+title: F# Guide
+description: F# Guide 
 keywords: .NET, .NET Core
 author: jackfoxy
 manager: wpickett
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: ea27fb37-dad1-4bd4-a3cc-4f5c70767ae9
 ---
 
-# Learn F\# 
+# F# Guide 
 
 * [F# Learning Resources](http://fsharp.org/learn.html)
 * [F# Language Reference](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/fsharp-language-reference)

--- a/docs/fsharp/index.md
+++ b/docs/fsharp/index.md
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: ea27fb37-dad1-4bd4-a3cc-4f5c70767ae9
 ---
 
-# Learn F# 
+# Learn F\# 
 
 * [F# Learning Resources](http://fsharp.org/learn.html)
 * [F# Language Reference](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/fsharp-language-reference)


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/articles/fsharp/index is dropping the trailing `#`.
