### PR TITLE
Update .net versions to 1.0.0, update donet-test-xunit to 1.0.0-*

### DIFF
--- a/samples/core-projects/console-apps/NewTypes/src/NewTypes/project.json
+++ b/samples/core-projects/console-apps/NewTypes/src/NewTypes/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
   "frameworks": {

--- a/samples/core-projects/console-apps/NewTypes/test/NewTypesTests/project.json
+++ b/samples/core-projects/console-apps/NewTypes/test/NewTypesTests/project.json
@@ -7,8 +7,8 @@
       "type":"platform",
       "version": "1.0.0"
     },
-    "xunit":"2.1.0",
-    "dotnet-test-xunit": "1.0.0-*",
+    "xunit":"2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "NewTypes": "1.0.0"
   },
   "frameworks": {

--- a/samples/core-projects/console-apps/NewTypes/test/NewTypesTests/project.json
+++ b/samples/core-projects/console-apps/NewTypes/test/NewTypesTests/project.json
@@ -5,10 +5,10 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type":"platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     },
     "xunit":"2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-build10015",
+    "dotnet-test-xunit": "1.0.0-*",
     "NewTypes": "1.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
I was trying to follow along with the bottom half of this tutorial:
https://docs.microsoft.com/en-us/dotnet/articles/core/tutorials/using-with-xplat-cli

After running `dotnet restore` and then `dotnet test` in the `test/NewTypesTests` directory as suggested I received following error:

```
The specified framework 'Microsoft.NETCore.App', version '1.0.0-rc2-3002702' was not found.
  - Check application dependencies and target a framework version installed at:
      C:\Program Files\dotnet\shared\Microsoft.NETCore.App
  - The following versions are installed:
      1.0.0
  - Alternatively, install the framework version '1.0.0-rc2-3002702'.
SUMMARY: Total: 1 targets, Passed: 0, Failed: 1.
```

The project.json is looking for specific version of dotnet framework that I didn't have.  This is expected, but I was thinking that with the recent announcement of 1.0.0, I assume many other people are going to be downloading the latest version and trying things out and it would be nice if this tutorial worked without any manual modification which could cause some people to get stuck.

dotnet --info:

```
.NET Command Line Tools (1.0.0-preview2-003121)

Product Information:
 Version:            1.0.0-preview2-003121
 Commit SHA-1 hash:  1e9d529bc5

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.14366
 OS Platform: Windows
 RID:         win10-x64
```
