### PR TITLE
fixing metadata issue

### DIFF
--- a/docs/core/tutorials/cli-console-app-tutorial-advanced.md
+++ b/docs/core/tutorials/cli-console-app-tutorial-advanced.md
@@ -1,6 +1,6 @@
 ---
-title: Writing .NET Core console apps using the CLI tools: An advanced step-by-step guide
-description: Writing .NET Core console apps using the CLI tools: An advanced step-by-step guide
+title: Writing .NET Core console apps using the CLI tools&#58; An advanced step-by-step guide
+description: Writing .NET Core console apps using the CLI tools&#58; An advanced step-by-step guide
 keywords: .NET, .NET Core
 author: dotnet-bot
 manager: wpickett


### PR DESCRIPTION
This article, even though is still unwritten, is broken on live site because of the colon in the metadata section:
https://docs.microsoft.com/en-us/dotnet/articles/core/tutorials/cli-console-app-tutorial-advanced

I had fixed this earlier. Not sure how it came back.
