### PR TITLE
Fixing build warning

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -2,6 +2,7 @@
   "need_generate_pdf": false,
   "need_generate_intellisense": false,
   "git_repository_branch_open_to_public_contributors": "master",
+  "git_repository_url_open_to_public_contributors": "https://github.com/dotnet/core-docs",
   "docsets_to_publish": [
     {
       "docset_name": "core-docs",


### PR DESCRIPTION
We're getting the following warning on build logs:
git_repository_url_open_to_public_contributors 'null' is not a valid absolute url. Use https://github.com/dotnet/core-docs to generate remote Git url.

This change is supposed to fix this.
