### PR TITLE
fixing small mistake in the directory tree layout

### DIFF
--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -88,7 +88,7 @@ At this point, your directory tree should look like this:
 |__/src
    |__/app
    |__/library
-/test
+|__/test
    |__/test-library
 ```
 


### PR DESCRIPTION
Schema now follows instructions: "...create a 'golden' directory. Under that directory create `src` and `test` directories."
