### PR TITLE
Change 'Getting Started' links to target the right page

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -15,7 +15,7 @@ ms.assetid: 2e38e9d9-8284-46ee-a15f-199adc4f26f4
 About .NET
 ==========
 
-> Check out the ["Getting Started with .NET Core" tutorials](../core/tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started with .NET Core" tutorials](../core/tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 .NET is a general purpose development platform. It can be used for any kind of app type or workload where general purpose solutions are used. It has several key features that are attractive to many developers, including automatic memory management and modern programming languages, that make it easier to efficiently build high-quality applications. .NET enables a high-level programming environment with many convenience features, while providing low-level access to native memory and APIs.
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -15,7 +15,7 @@ ms.assetid: 2e38e9d9-8284-46ee-a15f-199adc4f26f4
 About .NET
 ==========
 
-> Check out the ["Getting Started with .NET Core" tutorials](../core/tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started with .NET Core" tutorials](../core/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 .NET is a general purpose development platform. It can be used for any kind of app type or workload where general purpose solutions are used. It has several key features that are attractive to many developers, including automatic memory management and modern programming languages, that make it easier to efficiently build high-quality applications. .NET enables a high-level programming environment with many convenience features, while providing low-level access to native memory and APIs.
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -14,7 +14,7 @@ ms.assetid: f2b312cb-f80c-4b0d-9101-93908f06a6fa
 
 # .NET Core
 
-> Check out the ["Getting Started" tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started" tutorials](tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 .NET Core is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios. 
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -14,7 +14,7 @@ ms.assetid: f2b312cb-f80c-4b0d-9101-93908f06a6fa
 
 # .NET Core
 
-> Check out the ["Getting Started" tutorials](tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started" tutorials](getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 .NET Core is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios. 
 

--- a/docs/standard/index.md
+++ b/docs/standard/index.md
@@ -14,7 +14,7 @@ ms.assetid: bbfe6465-329d-4982-869d-472e7ef85d93
 
 # .NET Primer
 
-> Check out the ["Getting Started with .NET Core" tutorials](../core/tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started with .NET Core" tutorials](../core/tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 .NET is a general purpose development platform. It can be used for any kind of app type or workload where general purpose solutions are used. It has several key features that are attractive to many developers, including automatic memory management and modern programming languages, that make it easier to efficiently build high-quality applications. .NET enables a high-level programming environment with many convenience features, while providing low-level access to native memory and APIs.
 

--- a/docs/standard/index.md
+++ b/docs/standard/index.md
@@ -14,7 +14,7 @@ ms.assetid: bbfe6465-329d-4982-869d-472e7ef85d93
 
 # .NET Primer
 
-> Check out the ["Getting Started with .NET Core" tutorials](../core/tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started with .NET Core" tutorials](../core/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 .NET is a general purpose development platform. It can be used for any kind of app type or workload where general purpose solutions are used. It has several key features that are attractive to many developers, including automatic memory management and modern programming languages, that make it easier to efficiently build high-quality applications. .NET enables a high-level programming environment with many convenience features, while providing low-level access to native memory and APIs.
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -15,7 +15,7 @@ ms.assetid: cb788dcf-2120-467f-9c34-c02a90e1f68f
 Welcome to .NET
 ===============
 
-> Check out the ["Getting Started with .NET Core" tutorials](core/tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started with .NET Core" tutorials](core/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 Welcome to .NET! You can build any kind of application you want with .NET, from cloud to IoT to games. You can start building your next application today, for Windows, Linux, Android, macOS, and iOS. There are millions of developers that use .NET to power mission critical applications, personal apps and immersive games. You can write the next one.
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -15,7 +15,7 @@ ms.assetid: cb788dcf-2120-467f-9c34-c02a90e1f68f
 Welcome to .NET
 ===============
 
-> Check out the ["Getting Started with .NET Core" tutorials](core/tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+> Check out the ["Getting Started with .NET Core" tutorials](core/tutorials/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
 Welcome to .NET! You can build any kind of application you want with .NET, from cloud to IoT to games. You can start building your next application today, for Windows, Linux, Android, macOS, and iOS. There are millions of developers that use .NET to power mission critical applications, personal apps and immersive games. You can write the next one.
 


### PR DESCRIPTION
We should focus all "Getting Started" readers at the one location.
