### PR TITLE
insert step 4 in "Writing the consoling app" section

### DIFF
--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -113,7 +113,7 @@ Deploying a portable app with one or more third-party dependencies involves thre
         "type": "platform",
         "version": "1.0.0"
       },
-      "Newtonsoft.Json": "8.0.3"
+      "Newtonsoft.Json": "9.0.1"
     },
     ```
 
@@ -261,7 +261,7 @@ Deploying a self-contained app with one or more third-party dependencies involve
       "NETStandard.Library": "1.6.0",
       "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2",
       "Microsoft.NETCore.DotNetHostPolicy":  "1.0.1",
-      "Newtonsoft.Json": "8.0.3"
+      "Newtonsoft.Json": "9.0.1"
     },
     ```
 

--- a/docs/core/tutorials/using-on-windows.md
+++ b/docs/core/tutorials/using-on-windows.md
@@ -150,33 +150,35 @@ Starting from the solution obtained with the previous script, execute the follow
 
    The solution should still build and function exactly like it did before: the test should pass, and the console application should run and be debuggable.
 
-3. In Solution Explorer, open the context menu for the `src` folder, and choose **Add**. , **New Project**.
+3. In the **Library"" Project, open the context menu and choose **Build**.
 
-4. In the **New Project** dialog, choose the **Visual C#** node, and then choose **Console Application**.
+4. In Solution Explorer, open the context menu for the `src` folder, and choose **Add**. , **New Project**.
+
+5. In the **New Project** dialog, choose the **Visual C#** node, and then choose **Console Application**.
 
    > **Important**
    >
    > Make sure you choose a standard console application, not the .NET Core version. In this section, you'll be  consuming the library from a .NET Framework application
 
-5. Name the project "FxApp", and set the location to `Golden\src`.
+6. Name the project "FxApp", and set the location to `Golden\src`.
 
-6. In the **FxApp** project, open the context menu for the **References** node and choose **Add Reference**.
+7. In the **FxApp** project, open the context menu for the **References** node and choose **Add Reference**.
 
-7. In the **Reference Manager** dialog, choose **Browse** and browse to the location of the built `Library.dll` (under the ..Golden\src\Library\bin\Debug\netstandard1.4 path), and then click **Add**. 
+8. In the **Reference Manager** dialog, choose **Browse** and browse to the location of the built `Library.dll` (under the ..Golden\src\Library\bin\Debug\netstandard1.4 path), and then click **Add**. 
 
    You could also package the library and reference the package, as another way to reference .NET Core code from the .NET Framework.
 
-8. Open the context menu for the **References** node and choose **Manage NuGet Packages**.
+9. Open the context menu for the **References** node and choose **Manage NuGet Packages**.
 
-9. Choose "nuget.org" as the **Package source**, and choose the **Browse** tab. Check the **Include prerelease** checkbox, and then browse for **Newtonsoft.Json**. Click **Install**. 
+10. Choose "nuget.org" as the **Package source**, and choose the **Browse** tab. Check the **Include prerelease** checkbox, and then browse for **Newtonsoft.Json**. Click **Install**. 
 
-10. In the **FxApp** project, open the `Program.cs` file and add a `using Library;` directive to the top of the file, and add `Console.WriteLine($"The answer is {new Thing().Get(42)}.");` to the `Main` method of the program.
+11. In the **FxApp** project, open the `Program.cs` file and add a `using Library;` directive to the top of the file, and add `Console.WriteLine($"The answer is {new Thing().Get(42)}.");` to the `Main` method of the program.
 
-11. Set a breakpoint after the line that you just added.
+12. Set a breakpoint after the line that you just added.
 
-12. Make **FxApp** the startup application for the solution.
+13. Make **FxApp** the startup application for the solution.
 
-13. Press F5 to run the app.
+14. Press F5 to run the app.
 
    The application should build and hit the breakpoint. The application output should be "The answer is 42.".
 

--- a/docs/core/tutorials/using-on-windows.md
+++ b/docs/core/tutorials/using-on-windows.md
@@ -123,7 +123,7 @@ A solution using only .NET Core projects
 
 3. In the **Reference Manager** dialog, check **Library** under the **Projects**, **Solution** node, and then click **OK**
 
-4. In the **App** project, open the `project.json` file, and replace `"Library": "1.0.0-*"` with `"Library": {"target": "project", "version": "1.0.0-*"}`.
+4. In the **App** project, open the `project.json` file, and replace `"Library": "1.0.0-*"` with `"Library": {"target": "project"}`.
 
 5. Open the context menu for the **References** node and choose **Restore Packages**.
 

--- a/docs/core/tutorials/using-on-windows.md
+++ b/docs/core/tutorials/using-on-windows.md
@@ -121,17 +121,19 @@ A solution using only .NET Core projects
 
 2. In the **App** project, open the context menu for the **References** node and choose **Add**,  **Reference**. 
 
-3. In the **Reference Manager** dialog, check **Library** under the **Projects**, **Solution** node, and then click **OK** 
+3. In the **Reference Manager** dialog, check **Library** under the **Projects**, **Solution** node, and then click **OK**
 
-4. Open the context menu for the **References** node and choose **Restore Packages**.
+4. In the **App** project, open the `project.json` file, and replace `"Library": "1.0.0-*"` with `"Library": {"target": "project", "version": "1.0.0-*"}`.
 
-5. Open the context menu for the **App** node and choose **Set as StartUp Project**.
+5. Open the context menu for the **References** node and choose **Restore Packages**.
 
-6. Open the `Program.cs` file, add a `using Library;` directive to the top of the file, and then add `Console.WriteLine($"The answer is {new Thing().Get(42)}");` to the `Main` method.
+6. Open the context menu for the **App** node and choose **Set as StartUp Project**.
 
-7. Set a breakpoint after the line that you just added.
+7. Open the `Program.cs` file, add a `using Library;` directive to the top of the file, and then add `Console.WriteLine($"The answer is {new Thing().Get(42)}");` to the `Main` method.
 
-8. Press F5 to run the application..
+8. Set a breakpoint after the line that you just added.
+
+9. Press F5 to run the application..
 
    The application should build without error, and should hit the breakpoint. You should also be able to check that the application output "The answer is 42.".
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -487,7 +487,7 @@ namespace ConsoleApplication
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
   "frameworks": {


### PR DESCRIPTION
Add step 4 to avoid resolution of the library poroject to nuget package with the same name and keep consistency with "Writing the test project" section
