### PR TITLE
C# Xml doc

### DIFF
--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -777,7 +777,7 @@ public class SomeClass
 
 ### Putting it all together
 
-If you've followed this tutorial and applied the tags to your code where necessary your code should look like the following:
+If you've followed this tutorial and applied the tags to your code where necessary your code should look similar to the following:
 
 ```csharp
 /*
@@ -1025,8 +1025,8 @@ public class Math
 }
 ```
 
-From our sample code above we can generate a well detailed documentation website complete with clickable cross-references but we've introduced another problem, our code has become had to read.
-This is going to be a nightmare for any developers who want to contribute to this code, so much information to sift through. 
+From our sample code above we can generate a well detailed documentation website complete with clickable cross-references but we've introduced another problem, our code has become hard to read.
+This is going to be a nightmare for any developer who wants to contribute to this code, so much information to sift through. 
 Thankfully there's an XML tag that helps us deal with this:
 
 ### &lt;include&gt;

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -36,7 +36,7 @@ public class SomeClass
 
 ## Walkthrough
 
-In this section you're going to be walked through documenting a very basic math library to make it easy for new developers to understand/contribute and for third party developers to use.
+Let's walk through documenting a very basic math library to make it easy for new developers to understand/contribute and for third party developers to use.
 
 Here's code for the simple math library:
 
@@ -105,7 +105,7 @@ public class Math
 }
 ```
 
-The sample library above doesn't do much, it supports four major arithmetic operations `add`, `subtract`, `multiply` and `divide` on `int` and `double` datatypes.
+The sample library supports four major arithmetic operations `add`, `subtract`, `multiply` and `divide` on `int` and `double` datatypes.
 
 Now you want to be able to create an API reference document from your code for third party developers who use your library but don't have access to the source code.
 As mentioned earlier XML documentation tags can be used to achieve this, You will now be introduced to the standard XML tags the C# compiler supports.
@@ -142,7 +142,7 @@ public class Math
 }
 ```
 
-The `<summary>` tag is super important and you are strongly advised to include it because its content is the primary source of type or member description in the resulting API reference document. 
+The `<summary>` tag is super important and you are strongly advised to include it because its content is the primary source of type or member description in intellisense and the resulting API reference document.
 
 ### &lt;remarks&gt;
 
@@ -174,21 +174,21 @@ Like before this will be illustrated on the first `Add` method go ahead an imple
 
 ```csharp
 // Adds two integers and returns the result
-    /// <summary>
-    /// Adds two integers and returns the result.
-    /// </summary>
-    /// <returns>
-    /// The sum of two integers.
-    /// </returns>
-    public static int Add(int a, int b)
-    {
-        // If any parameter is equal to the max value of an integer
-        // and the other is greater than zero
-        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
-            throw new System.OverflowException();
+/// <summary>
+/// Adds two integers and returns the result.
+/// </summary>
+/// <returns>
+/// The sum of two integers.
+/// </returns>
+public static int Add(int a, int b)
+{
+    // If any parameter is equal to the max value of an integer
+    // and the other is greater than zero
+    if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+        throw new System.OverflowException();
 
-        return a + b;
-    }
+    return a + b;
+}
 ```
 
 ### &lt;value&gt;
@@ -207,6 +207,7 @@ Assuming your `Math` library had a static property called `PI` here's how you'll
 /// </summary>
 /// <remarks>
 /// This class can add, subtract, multiply and divide.
+/// These operations can be performed on both integers and doubles
 /// </remarks>
 public class Math
 {
@@ -222,30 +223,30 @@ This involves using the child `<code>` tag.
 
 ```csharp
 // Adds two integers and returns the result
-    /// <summary>
-    /// Adds two integers and returns the result.
-    /// </summary>
-    /// <returns>
-    /// The sum of two integers.
-    /// </returns>
-    /// <example>
-    /// <code>
-    /// int c = Math.Add(4, 5);
-    /// if (c > 10)
-    /// {
-    ///     Console.WriteLine(c);
-    /// }
-    /// </code>
-    /// </example>
-    public static int Add(int a, int b)
-    {
-        // If any parameter is equal to the max value of an integer
-        // and the other is greater than zero
-        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
-            throw new System.OverflowException();
+/// <summary>
+/// Adds two integers and returns the result.
+/// </summary>
+/// <returns>
+/// The sum of two integers.
+/// </returns>
+/// <example>
+/// <code>
+/// int c = Math.Add(4, 5);
+/// if (c > 10)
+/// {
+///     Console.WriteLine(c);
+/// }
+/// </code>
+/// </example>
+public static int Add(int a, int b)
+{
+    // If any parameter is equal to the max value of an integer
+    // and the other is greater than zero
+    if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+        throw new System.OverflowException();
 
-        return a + b;
-    }
+    return a + b;
+}
 ```
 
 The `code` tag preserves line breaks and indentation for longer examples.
@@ -253,8 +254,8 @@ The `code` tag preserves line breaks and indentation for longer examples.
 ### &lt;para&gt;
 
 You may find you need to format the content of certain tags and that's where the `<para>` tag comes in.
-You usually use it inside a tag, such as `<summary>`, `<remarks>`, or `<returns>`, and lets you divide text into paragraphs.
-You can go ahead and format the contents of the `<summary>` tag for your class definition.
+You usually use it inside a tag, such as `<remarks>`, or `<returns>`, and lets you divide text into paragraphs.
+You can go ahead and format the contents of the `<remarks>` tag for your class definition.
 
 ```csharp
 /*
@@ -262,9 +263,13 @@ You can go ahead and format the contents of the `<summary>` tag for your class d
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main Math class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main Math class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
+/// <remarks>
+/// <para>This class can add, subtract, multiply and divide.</para>
+/// <para>These operations can be performed on both integers and doubles.</para>
+/// </remarks>
 public class Math
 {
 
@@ -283,8 +288,8 @@ Let's update the documentation for the `Math` class.
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -305,8 +310,8 @@ is that both `Divide` methods will throw as well if the parameter `b` is zero. N
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -325,7 +330,8 @@ public class Math
     /// }
     /// </code>
     /// </example>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than 0.</exception>
     public static int Add(int a, int b)
     {
         if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
@@ -340,7 +346,8 @@ public class Math
     /// <returns>
     /// The sum of two doubles.
     /// </returns>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than zero.</exception>
     public static double Add(double a, double b)
     {
         if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
@@ -389,8 +396,8 @@ The `<see>` tag is one that let's you create clickable links to documentation pa
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -409,7 +416,8 @@ public class Math
     /// }
     /// </code>
     /// </example>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than 0.</exception>
     /// See <see cref="Math.Add(double, double)"/> to add doubles.
     public static int Add(int a, int b)
     {
@@ -425,7 +433,8 @@ public class Math
     /// <returns>
     /// The sum of two doubles.
     /// </returns>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than zero.</exception>
     /// See <see cref="Math.Add(int, int)"/> to add integers.
     public static double Add(double a, double b)
     {
@@ -451,8 +460,8 @@ the one you sometimes see on the MSDN documentation pages. Here we'll add a `see
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -471,7 +480,8 @@ public class Math
     /// }
     /// </code>
     /// </example>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than 0.</exception>
     /// See <see cref="Math.Add(double, double)"/> to add doubles.
     /// <seealso cref="Math.Subtract(int, int)"/>
     /// <seealso cref="Math.Multiply(int, int)"/>
@@ -500,8 +510,8 @@ The parameter the tag describes is specified in the **required** `name` attribut
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -511,7 +521,8 @@ public class Math
     /// <returns>
     /// The sum of two doubles.
     /// </returns>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than zero.</exception>
     /// See <see cref="Math.Add(int, int)"/> to add integers.
     /// <param name="a">A double precision number.</param>
     /// <param name="b">A double precision number.</param>
@@ -528,7 +539,7 @@ public class Math
 ### &lt;typeparam&gt;
 
 You use `<typeparam>` tag just like the `<param>` tag but for generic type or method declarations to describe a generic parameter.
-Go ahead and add a quick generic method to your `Math` class to check if 
+Go ahead and add a quick generic method to your `Math` class to check if one quantity is greater than another.
 
 ```csharp
 /*
@@ -536,8 +547,8 @@ Go ahead and add a quick generic method to your `Math` class to check if
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -564,8 +575,8 @@ the parameter name is specified in the **required** `name` attribute.
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -575,7 +586,8 @@ public class Math
     /// <returns>
     /// The sum of two doubles.
     /// </returns>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than zero.</exception>
     /// See <see cref="Math.Add(int, int)"/> to add integers.
     /// <param name="a">A double precision number.</param>
     /// <param name="b">A double precision number.</param>
@@ -600,8 +612,8 @@ You can use the same generic method you previously created.
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 public class Math
 {
@@ -619,7 +631,7 @@ public class Math
 ### &lt;list&gt;
 
 You use the `<list>` tag to format documentation information as an ordered list, unordered list or table.
-You'll make an unordered list of every math operation your `Math` library supports, you also get stub samples for ordered list and table.
+You'll make an unordered list of every math operation your `Math` library supports.
 
 ```csharp
 /*
@@ -627,8 +639,8 @@ You'll make an unordered list of every math operation your `Math` library suppor
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// <list type="bullet">
 /// <item>
 /// <term>Add</term>
@@ -648,46 +660,13 @@ You'll make an unordered list of every math operation your `Math` library suppor
 /// </item>
 /// </list>
 /// </summary>
-
-/// <summary>
-/// An example of an ordered list.
-/// <list type="number">
-/// <item>
-/// <term>Some term</term>
-/// <description>Some description</description>
-/// </item>
-/// <item>
-/// <term>Some term</term>
-/// <description>Some description</description>
-/// </item>
-/// </list>
-/// </summary>
-
-/// <summary>
-/// An example of a table.
-/// <list type="table">
-/// <listheader>
-/// <term>Table Heading Col 1</term>
-/// <term>Table Heading Col 2</term>
-/// <term>Table Heading Col 3</term>
-/// </listheader>
-/// <item>
-/// <term>Col 1 Row 1</term>
-/// <term>Col 2 Row 1</term>
-/// <term>Col 3 Row 1</term>
-/// </item>
-/// <item>
-/// <term>Col 1 Row 2</term>
-/// <term>Col 2 Row 2</term>
-/// <term>Col 3 Row 2</term>
-/// </item>
-/// </list>
-/// </summary>
 public class Math
 {
 
 }
 ```
+
+You can make an ordered list or table by changing the `type` attribute to `number` or `table` respectively.
 
 ### Putting it all together
 
@@ -699,8 +678,8 @@ You've followed this tutorial and applied the tags to your code where necessary,
     Contains all methods for performing basic math functions
 */
 /// <summary>
-/// <para>The main <c>Math</c> class.</para>
-/// <para>Contains all methods for performing basic math functions.</para>
+/// The main <c>Math</c> class.
+/// Contains all methods for performing basic math functions.
 /// <list type="bullet">
 /// <item>
 /// <term>Add</term>
@@ -721,7 +700,8 @@ You've followed this tutorial and applied the tags to your code where necessary,
 /// </list>
 /// </summary>
 /// <remarks>
-/// This class can add, subtract, multiply and divide.
+/// <para>This class can add, subtract, multiply and divide.</para>
+/// <para>These operations can be performed on both integers and doubles.</para>
 /// </remarks>
 public class Math
 {
@@ -741,7 +721,8 @@ public class Math
     /// }
     /// </code>
     /// </example>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than 0.</exception>
     /// See <see cref="Math.Add(double, double)"/> to add doubles.
     /// <seealso cref="Math.Subtract(int, int)"/>
     /// <seealso cref="Math.Multiply(int, int)"/>
@@ -774,7 +755,8 @@ public class Math
     /// }
     /// </code>
     /// </example>
-    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max 
+    /// and the other is greater than 0.</exception>
     /// See <see cref="Math.Add(int, int)"/> to add integers.
     /// <seealso cref="Math.Subtract(double, double)"/>
     /// <seealso cref="Math.Multiply(double, double)"/>
@@ -972,11 +954,12 @@ Now you're going to move all your XML tags into a separate XML file named `docs.
     <members name="math">
         <Math>
             <summary>
-            <para>The main <c>Math</c> class.</para>
-            <para>Contains all methods for performing basic math functions.</para>
+            The main <c>Math</c> class.
+            Contains all methods for performing basic math functions.
             </summary>
             <remarks>
-            This class can add, subtract, multiply and divide.
+            <para>This class can add, subtract, multiply and divide.</para>
+            <para>These operations can be performed on both integers and doubles.</para>
             </remarks>
         </Math>
         <AddInt>
@@ -1171,7 +1154,7 @@ Now you're going to move all your XML tags into a separate XML file named `docs.
 </docs>
 ```
 
-In the above XML each member's documentation comments appears directly inside a tag named after what they do, you can choose your own strategy. 
+In the above XML each member's documentation comments appears directly inside a tag named after what they do; you can choose your own strategy. 
 Now that you have your XML comments in a separate file let's see how your code can be made more readable using the `<include>` tag:
 
 ```csharp
@@ -1274,7 +1257,7 @@ that need to be taken into consideration when using XML documentation tags in yo
 
 * For the sake of consistency all publicly visible types and their members should be documented. If you must do it, do it all.
 * Private members can also be documented using XML comments, however this exposes the inner (potentially confidential) workings of your library.
-* In addition to other tags, types and their members should have at the very least a `<summary>` tag.
+* In addition to other tags, types and their members should have at the very least a `<summary>` tag because its content is needed for intellisense.
 * Documentation text should be written using complete sentences ending with full stops.
 * Partial classes are fully supported and documentation information will be concatenated into one.
 * The compiler verifies the syntax of `<exception>`, `<include>`, `<param>`, `<see>`, `<seealso>` and `<typeparam>` tags.

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -4,7 +4,7 @@ description: Documenting your code
 keywords: .NET, .NET Core
 author: tsolarin
 manager: wpickett
-ms.date: 07/24/2016
+ms.date: 07/29/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -19,14 +19,14 @@ Unlike regular C# comments documentation comments are not ignored by the compile
 by adding `"xmlDoc": true` under `buildOptions` in your `project.json` when using .NET Core or use the `/doc` compiler option for the .NET framework.
 Go [here](https://msdn.microsoft.com/en-us/library/3260k4x7.aspx) to learn how to enable XML documentation generation in Visual Studio.
 
-Documentation tags are commented using three forward slashes (`///`) as opposed to two forward slashes (`//`) used for single line comments.
+Documentation tags are commented using three forward slashes (`///`) as opposed to two forward slashes (`//`) used for single line comments and `/** **/` for multiline comments.
 There are tools tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) that help you generate documentation websites from your documentation tags,
 also, distributing the compiler generated XML file along with your library allows Visual Studio and other IDEs to show quick information about types or members when performing intellisense. 
 
 <a name="summary"></a>
 ## &lt;summary&gt;
 
-The &lt;summary&gt; tag contains the primary information of a class or method.
+The `<summary>` tag contains the primary information of a class or method.
 
 ```csharp
 /// <summary>
@@ -55,8 +55,8 @@ public class SomeClass
 <a name="remarks"></a>
 ## &lt;remarks&gt;
 
-The &lt;remarks&gt; tag is used to add information about a type or type members, 
-supplementing the information specified with &lt;summary&gt;.
+The `<remarks>` tag is used to add information about a type or type members, 
+supplementing the information specified with `<summary>`.
 
 ```csharp
 /// <summary>
@@ -74,7 +74,7 @@ public class SomeClass
 <a name="returns"></a>
 ## &lt;returns&gt;
 
-The &lt;returns&gt; tag should be used in the comment for a method declaration to describe the return value.
+The `<returns>` tag should be used in the comment for a method declaration to describe the return value.
 
 ```csharp
 /// <summary>
@@ -96,8 +96,8 @@ public class SomeClass
 <a name="example"></a>
 ## &lt;example&gt;
 
-The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
-This commonly involves using the [&lt;code&gt;](#code) and sometimes the [&lt;c&gt;](#c) tag.
+The `<example>` tag lets you specify an example of how to use a method or other library member. 
+This commonly involves using the [`<code>`](#code) and sometimes the [`<c>`](#c) tag.
 
 ```csharp
 /// <summary>
@@ -111,7 +111,11 @@ public class SomeClass
     /// <example>
     /// <code>
     /// SomeClass someClass = new SomeClass();
-    /// someClass.DoStuff();
+    /// bool somethingToDo = true;
+    /// if (somethingToDo)
+    /// {
+    ///     someClass.DoStuff();
+    /// }
     /// </code>
     /// </example>
     public void DoStuff()
@@ -124,7 +128,7 @@ public class SomeClass
 <a name="value"></a>
 ## &lt;value&gt;
 
-The &lt;value&gt; lets you describe the value that a property represents.
+The `<value>` lets you describe the value that a property represents.
 
 ```csharp
 /// <summary>
@@ -143,7 +147,7 @@ public class SomeClass
 <a name="exception"></a>
 ## &lt;exception&gt;
 
-The &lt;exception&gt; tag lets you specify possible exceptions that can be thrown. 
+The `<exception>` tag lets you specify possible exceptions that can be thrown. 
 It's applicable to methods, properties, events, and indexers.
 
 ```csharp
@@ -169,11 +173,12 @@ public class SomeClass
 ```
 
 The `cref` attribute represents a reference to an exception that is available from the current compilation environment.
+This can be any type defined in the project or a referenced assembly.
 
 <a name="c"></a>
 ## &lt;c&gt;
 
-The &lt;c&gt; tag is used to indicate inline code.
+The `<c>` tag is used to indicate inline code.
 
 ```csharp
 /// <summary>
@@ -194,15 +199,15 @@ public class SomeClass
 <a name="code"></a>
 ## &lt;code&gt;
 
-The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code.
-See the [&lt;example&gt;](#example) tag for sample usage.
+The `<code>` tag is used to indicate that multiple lines of text should be marked as code.
+See the [`<example>`](#example) tag for sample usage.
 The tag preserves line breaks and indentation for longer examples.
 
 <a name="para"></a>
 ## &lt;para&gt;
 
-The &lt;para&gt; tag is for use inside a tag, such as &lt;summary&gt;, &lt;remarks&gt;, 
-or &lt;returns&gt;, and lets you add paragraphs to text.
+The `<para>` tag is for use inside a tag, such as `<summary>`, `<remarks>`, 
+or `<returns>`, and lets you add paragraphs to text.
 
 ```csharp
 /// <summary>
@@ -225,7 +230,7 @@ public class SomeClass
 <a name="list"></a>
 ## &lt;list&gt;
 
-The &lt;list&gt; tag lets you format documentation information as an ordered list, unordered list or table.
+The `<list>` tag lets you format documentation information as an ordered list, unordered list or table.
 
 ```csharp
 /// <summary>
@@ -299,10 +304,11 @@ public class SomeClass
 <a name="see"></a>
 ## &lt;see&gt;
 
-The &lt;see&gt; tag lets you specify a link from within text. 
-Use the `cref` attribute to create internal hyperlinks to documentation pages for code elements.
+The `<see>` tag lets you specify a link from within text, 
+it creates internal hyperlinks to documentation pages for code elements. The `cref` attribute **must** be specified.
 
 The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
+This can be any type defined in the project or a referenced assembly.
 
 ```csharp
 /// <summary>
@@ -362,12 +368,13 @@ public class SomeClass
 ```
 
 The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
+This can be any type defined in the project or a referenced assembly.
 
 <a name="param"></a>
 ## &lt;param&gt;
 
-The &lt;param&gt; tag should be used in the comment for a method declaration to describe one of the parameters for the method.
-To document multiple parameters, use multiple &lt;param&gt; tags.
+The `<param>` tag should be used in the comment for a method declaration to describe one of the parameters for the method.
+To document multiple parameters, use multiple `<param>` tags. This tag is also applicable to indexers.
 
 ```csharp
 /// <summary>
@@ -401,8 +408,8 @@ The `name` attribute represents the name of a method parameter
 <a name="paramref"></a>
 ## &lt;paramref&gt;
 
-The &lt;paramref&gt; tag gives you a way to indicate that a word in the code comments, 
-for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
+The `<paramref>` tag gives you a way to indicate that a word in the code comments, 
+for example in a `<summary>` or `<remarks>` block refers to a parameter.
 
 ```csharp
 /// <summary>
@@ -425,7 +432,7 @@ public class SomeClass
 <a name="typeparam"></a>
 ## &lt;typeparam&gt;
 
-The &lt;typeparam&gt; tag should be used in the comment for a generic type or method declaration to describe a type parameter. 
+The `<typeparam>` tag should be used in the comment for a generic type or method declaration to describe a type parameter. 
 Add a tag for each type parameter of the generic type or method.
 
 ```csharp
@@ -448,8 +455,8 @@ public class SomeClass
 <a name="typeparamref"></a>
 ## &lt;typeparamref&gt;
 
-The &lt;typeparamref&gt; tag gives you a way to indicate that a word in the code comments, 
-for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type parameter.
+The `<typeparamref>` tag gives you a way to indicate that a word in the code comments, 
+for example in a `<summary>` or `<remarks>` block refers to a type parameter.
 
 ```csharp
 /// <summary>
@@ -471,7 +478,7 @@ public class SomeClass
 <a name="include"></a>
 ## &lt;include&gt;
 
-The &lt;include&gt; tag lets you refer to comments in a separate XML file that describe the types and members 
+The `<include>` tag lets you refer to comments in a separate XML file that describe the types and members 
 in your source code as opposed to placing documentation comments directly in your source code file.
 
 ```csharp
@@ -531,7 +538,8 @@ The `id` attribute represents the ID for the tag that precedes the comments
 ## User Defined Tags
 
 All the tags outlined above represent those that are recognized by the C# compiler. However, a user is free to define their own tags.
-Tools like Sandcastle bring support for extra tags like &lt;event&gt;, &lt;note&gt; and even support documenting namespaces.
+Tools like Sandcastle bring support for extra tags like [`<event>`](http://ewsoftware.github.io/XMLCommentsGuide/html/81bf7ad3-45dc-452f-90d5-87ce2494a182.htm), [`<note>`](http://ewsoftware.github.io/XMLCommentsGuide/html/4302a60f-e4f4-4b8d-a451-5f453c4ebd46.htm)
+and even support [documenting namespaces](http://ewsoftware.github.io/XMLCommentsGuide/html/BD91FAD4-188D-4697-A654-7C07FD47EF31.htm).
 Custom or in-house documentation generation tools can also be used with the standard tags and multiple output formats from HTML to PDF can be supported.
 
 <a name="recommendations"></a>
@@ -541,8 +549,8 @@ Documenting code is definitely a recommended practice for lots of reasons. Howev
 that need to be taken into consideration when using XML documentation tags in your C# code.
 
 * For the sake of consistency all publicly visible types and their members should be documented. If you must do it, do it all.
-* In addition to other tags, types and their members should have a &lt;summary&gt; tag.
+* In addition to other tags, types and their members should have a `<summary>` tag.
 * Documentation text should be written using complete sentences ending with full stops.
 * Partial classes are fully supported and documentation information will be concatenated into one.
-* The compiler verifies the syntax of &lt;exception&gt;, &lt;include&gt;, &lt;param&gt;, &lt;see&gt;, &lt;seealso&gt; and &lt;typeparam&gt; tags.
+* The compiler verifies the syntax of `<exception>`, `<include>`, `<param>`, `<see>`, `<seealso>` and `<typeparam>` tags.
 It validates the parameters that contain file paths and references to other parts of the code.

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -2,9 +2,9 @@
 title: Documenting your code
 description: Documenting your code
 keywords: .NET, .NET Core
-author: dotnet-bot
+author: tsolarin
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 07/19/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -14,89 +14,84 @@ ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 
 # XML Documentation
 
-by [Toni Solarin-Sodara](https://github.com/tsolarin)
+XML documentation tags are specially formatted comments, added above the definition of any user defined type or member, used to document your code.
+Unlike regular C# comments documentation comments are not ignored by the compiler and you can generate the XML documentation file at compile time
+by adding `"xmlDoc": true` under `buildOptions` in your `project.json` when using .NET Core or use the `/doc` compiler option for the .NET framework.
+Go [here](https://msdn.microsoft.com/en-us/library/3260k4x7.aspx) to learn how to enable XML documentation generation in Visual Studio.
 
-XML documentation tags are specially formatted comments, added above the definition of a class 
-or its members, used to document your code. You can generate the XML documentation file at compile time 
-by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
-
-* [&lt;summary&gt;](#summary)
-* [&lt;remarks&gt;](#remarks)
-* [&lt;returns&gt;](#returns)
-* [&lt;example&gt;](#example)
-* [&lt;value&gt;](#value)
-* [&lt;exception&gt;](#exception)
-* [&lt;c&gt;](#c)
-* [&lt;code&gt;](#code)
-* [&lt;para&gt;](#para)
-* [&lt;list&gt;](#list)
-* [&lt;see&gt;](#see)
-* [&lt;seealso&gt;](#seealso)
-* [&lt;param&gt;](#param)
-* [&lt;paramref&gt;](#paramref)
-* [&lt;typeparam&gt;](#typeparam)
-* [&lt;typeparamref&gt;](#typeparamref)
-* [&lt;include&gt;](#include)
+Documentation tags are commented using three forward slashes (`///`) as opposed to two forward slashes (`//`) used for single line comments.
+There are tools tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) that help you generate documentation websites from your documentation tags,
+also, distributing the compiler generated XML file along with your library allows Visual Studio and other IDEs to show quick information about types or members when performing intellisense. 
 
 <a name="summary"></a>
 ## &lt;summary&gt;
 
 The &lt;summary&gt; tag contains the primary information of a class or method.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// This method does stuff.
     /// </summary>
-    public class SomeClass
+    public void DoStuff(int a)
     {
-        /// <summary>
-        /// This method does stuff
-        /// </summary>
-        public void DoStuff(int a)
-        {
 
-        }
-
-        /// <summary>
-        /// This method does more stuff
-        /// </summary>
-        public void DoMoreStuff(int a, string b)
-        {
-
-        }
     }
+
+    /// <summary>
+    /// This method does more stuff.
+    /// </summary>
+    public void DoMoreStuff(int a, string b)
+    {
+
+    }
+}
+```
 
 <a name="remarks"></a>
 ## &lt;remarks&gt;
 
-The &lt;remarks&gt; tag is used to add information about a type, supplementing the information specified with &lt;summary&gt;.
+The &lt;remarks&gt; tag is used to add information about a type or type members, 
+supplementing the information specified with &lt;summary&gt;.
 
-    /// <summary>
-    /// This class primarily does something
-    /// </summary>
-    /// <remarks>
-    /// It can also do everything
-    /// </remarks>
-    public class SomeClass
-    {
-        
-    }
+```csharp
+/// <summary>
+/// This class primarily does something.
+/// </summary>
+/// <remarks>
+/// This class can also do everything.
+/// </remarks>
+public class SomeClass
+{
+    
+}
+```
 
 <a name="returns"></a>
 ## &lt;returns&gt;
 
 The &lt;returns&gt; tag should be used in the comment for a method declaration to describe the return value.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// This method does stuff.
     /// </summary>
-    public class SomeClass
+    /// <returns>Stuff it has done</returns>
+    public int DoStuff(int a)
     {
-        /// <returns>Stuff it has done</returns>
-        public int DoStuff(int a)
-        {
-            return a;
-        }
+        return a;
     }
+}
+```
 
 <a name="example"></a>
 ## &lt;example&gt;
@@ -104,36 +99,40 @@ The &lt;returns&gt; tag should be used in the comment for a method declaration t
 The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
 This commonly involves using the [&lt;code&gt;](#code) tag.
 
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
+    /// <example>
+    /// <code>
+    /// SomeClass someClass = new SomeClass();
+    /// someClass.DoStuff();
+    /// </code>
+    /// </example>
+    public void DoStuff()
     {
-        /// <example>
-        /// <code>
-        /// SomeClass someClass = new SomeClass();
-        /// someClass.DoStuff();
-        /// </code>
-        /// </example>
-        public void DoStuff()
-        {
 
-        }
     }
+}
+```
 
 <a name="value"></a>
 ## &lt;value&gt;
 
 The &lt;value&gt; lets you describe the value that a property represents.
 
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
-    {
-        /// <value>The Name property gets/sets the name value of something</value>
-        public string Name { get; set; }
-    }
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
+    /// <value>The Name property gets/sets the name value of something.</value>
+    public string Name { get; set; }
+}
+```
 
 <a name="exception"></a>
 ## &lt;exception&gt;
@@ -141,189 +140,204 @@ The &lt;value&gt; lets you describe the value that a property represents.
 The &lt;exception&gt; tag lets you specify possible exceptions that can be thrown. 
 It's applicable to methods, properties, events, and indexers.
 
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
+    /// <exception cref="System.ArgumentNullException">Thrown when there's no stuff to do</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when it tries to do the wrong stuff</exception>
+    public void DoStuff()
     {
-        /// <exception cref="System.Exception">Thrown when there's no stuff to do</exception>
-        public void DoStuff()
-        {
 
-        }
     }
+}
+```
 
-The `cref` parameter represents a reference to an exception that is available from the current compilation environment.
+The `cref` attribute represents a reference to an exception that is available from the current compilation environment.
 
 <a name="c"></a>
 ## &lt;c&gt;
 
-The &lt;c&gt; tag is used to indicate that a single line of text should be marked as code
+The &lt;c&gt; tag is used to indicate inline code
 
+```csharp
+/// <summary>
+/// <c>SomeClass</c> does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// <c>SomeClass</c> does something
+    /// <c>DoStuff</c> does stuff on an instance of <c>SomeClass</c>
     /// </summary>
-    public class SomeClass
+    public void DoStuff()
     {
-        /// <summary>
-        /// <c>DoStuff</c> does stuff on an instance of <c>SomeClass</c>
-        /// </summary>
-        public void DoStuff()
-        {
 
-        }
     }
+}
+```
 
 <a name="code"></a>
 ## &lt;code&gt;
 
 The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code.
 See the [&lt;example&gt;](#example) tag for sample usage.
+The tag preserves line breaks and indentation for longer examples.
 
 <a name="para"></a>
 ## &lt;para&gt;
 
 The &lt;para&gt; tag is for use inside a tag, such as &lt;summary&gt;, &lt;remarks&gt;, 
-or &lt;returns&gt;, and lets you add structure to the text.
+or &lt;returns&gt;, and lets you add paragraphs to text.
 
-    /// <summary>
-    /// <para>This class does something</para>
-    /// </summary>
-    public class SomeClass
+```csharp
+/// <summary>
+/// <para>This class does something</para>
+/// <para>This is a new paragraph</para>
+/// </summary>
+public class SomeClass
+{
+    public void DoStuff()
     {
-        public void DoStuff()
-        {
 
-        }
     }
+}
+```
 
 <a name="list"></a>
 ## &lt;list&gt;
 
 The &lt;list&gt; tag lets you format documentation information as an ordered list, unordered list or table.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// An example of an unordered list.
+    /// <list type="bullet">
+    /// <item>
+    /// <term>Some term</term>
+    /// <description>Some description</description>
+    /// </item>
+    /// <item>
+    /// <term>Some term</term>
+    /// <description>Some description</description>
+    /// </item>
+    /// </list>
     /// </summary>
-    public class SomeClass
+    public void DoStuff(int a)
     {
-        /// <summary>
-        /// An example of an unordered list
-        /// <list type="bullet">
-        /// <item>
-        /// <term>Some term</term>
-        /// <description>Some description</description>
-        /// </item>
-        /// <item>
-        /// <term>Some term</term>
-        /// <description>Some description</description>
-        /// </item>
-        /// </list>
-        /// </summary>
-        public void DoStuff(int a)
-        {
 
-        }
-
-        /// <summary>
-        /// An example of an ordered list
-        /// <list type="number">
-        /// <item>
-        /// <term>Some term</term>
-        /// <description>Some description</description>
-        /// </item>
-        /// <item>
-        /// <term>Some term</term>
-        /// <description>Some description</description>
-        /// </item>
-        /// </list>
-        /// </summary>
-        public void DoMoreStuff(int a, string b)
-        {
-
-        }
-
-        /// <summary>
-        /// An example of a table
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Table Heading Col 1</term>
-        /// <term>Table Heading Col 2</term>
-        /// <term>Table Heading Col 3</term>
-        /// </listheader>
-        /// <item>
-        /// <term>Col 1 Row 1</term>
-        /// <term>Col 2 Row 1</term>
-        /// <term>Col 3 Row 1</term>
-        /// </item>
-        /// <item>
-        /// <term>Col 1 Row 2</term>
-        /// <term>Col 2 Row 2</term>
-        /// <term>Col 3 Row 2</term>
-        /// </item>
-        /// </list>
-        /// </summary>
-        public void DoALotMoreStuff(params string[] args)
-        {
-
-        }
     }
+
+    /// <summary>
+    /// An example of an ordered list.
+    /// <list type="number">
+    /// <item>
+    /// <term>Some term</term>
+    /// <description>Some description</description>
+    /// </item>
+    /// <item>
+    /// <term>Some term</term>
+    /// <description>Some description</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    public void DoMoreStuff(int a, string b)
+    {
+
+    }
+
+    /// <summary>
+    /// An example of a table.
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Table Heading Col 1</term>
+    /// <term>Table Heading Col 2</term>
+    /// <term>Table Heading Col 3</term>
+    /// </listheader>
+    /// <item>
+    /// <term>Col 1 Row 1</term>
+    /// <term>Col 2 Row 1</term>
+    /// <term>Col 3 Row 1</term>
+    /// </item>
+    /// <item>
+    /// <term>Col 1 Row 2</term>
+    /// <term>Col 2 Row 2</term>
+    /// <term>Col 3 Row 2</term>
+    /// </item>
+    /// </list>
+    /// </summary>
+    public void DoALotMoreStuff(params string[] args)
+    {
+
+    }
+}
+```
 
 <a name="see"></a>
 ## &lt;see&gt;
 
 The &lt;see&gt; tag lets you specify a link from within text. Use the `cref` attribute to create internal hyperlinks to documentation pages for code elements.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// This method does stuff.
+    /// See <see cref="SomeClass.DoMoreStuff"/> to do more stuff
     /// </summary>
-    public class SomeClass
+    public void DoStuff(int a)
     {
-        /// <summary>
-        /// This method does stuff
-        /// See <see cref="SomeClass.DoMoreStuff" /> to do more stuff
-        /// </summary>
-        public void DoStuff(int a)
-        {
 
-        }
-
-        /// <summary>
-        /// This method does more stuff
-        /// </summary>
-        public void DoMoreStuff(int a, string b)
-        {
-
-        }
     }
+
+    /// <summary>
+    /// This method does more stuff.
+    /// </summary>
+    public void DoMoreStuff(int a, string b)
+    {
+
+    }
+}
+```
 
 <a name="seealso"></a>
 ## &lt;seealso&gt;
 
 The &lt;seealso&gt; tag lets you specify the text that you might want to appear in a See Also section.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// This method does stuff.
+    /// <seealso cref="SomeClass.DoMoreStuff"/>
     /// </summary>
-    public class SomeClass
+    public void DoStuff(int a)
     {
-        /// <summary>
-        /// This method does stuff
-        /// <seealso cref="SomeClass.DoMoreStuff" />
-        /// </summary>
-        public void DoStuff(int a)
-        {
 
-        }
-
-        /// <summary>
-        /// This method does more stuff
-        /// </summary>
-        public void DoMoreStuff(int a, string b)
-        {
-
-        }
     }
+
+    /// <summary>
+    /// This method does more stuff.
+    /// </summary>
+    public void DoMoreStuff(int a, string b)
+    {
+
+    }
+}
+```
 
 <a name="param"></a>
 ## &lt;param&gt;
@@ -331,26 +345,28 @@ The &lt;seealso&gt; tag lets you specify the text that you might want to appear 
 The &lt;param&gt; tag should be used in the comment for a method declaration to describe one of the parameters for the method.
 To document multiple parameters, use multiple &lt;param&gt; tags.
 
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
+    /// <param name="a">The stuff to do</param>
+    public void DoStuff(int a)
     {
-        /// <param name="a">The stuff to do</param>
-        public void DoStuff(int a)
-        {
 
-        }
-
-        /// <param name="a">A stuff to do</param>
-        /// <param name="b">Another stuff to do</param>
-        public void DoMoreStuff(int a, string b)
-        {
-
-        }
     }
 
-The `name` parameter represents the name of a method parameter
+    /// <param name="a">A stuff to do</param>
+    /// <param name="b">Another stuff to do</param>
+    public void DoMoreStuff(int a, string b)
+    {
+
+    }
+}
+```
+
+The `name` attribute represents the name of a method parameter
 
 <a name="paramref"></a>
 ## &lt;paramref&gt;
@@ -358,21 +374,23 @@ The `name` parameter represents the name of a method parameter
 The &lt;paramref&gt; tag gives you a way to indicate that a word in the code comments, 
 for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// This method does stuff.
+    /// The parameter <paramref name="a"/> takes a number
     /// </summary>
-    public class SomeClass
+    /// <param name="a">The stuff to do</param>
+    public void DoStuff(int a)
     {
-        /// <summary>
-        /// This method does stuff.
-        /// The <paramref name="a"/> takes a number
-        /// </summary>
-        /// <param name="a">The stuff to do</param>
-        public void DoStuff(int a)
-        {
 
-        }
     }
+}
+```
 
 <a name="typeparam"></a>
 ## &lt;typeparam&gt;
@@ -380,20 +398,22 @@ for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
 The &lt;typeparam&gt; tag should be used in the comment for a generic type or method declaration to describe a type parameter. 
 Add a tag for each type parameter of the generic type or method.
 
+```csharp
+/// <summary>
+/// This class does something.
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// Does generic stuff.
     /// </summary>
-    public class SomeClass
+    /// <typeparam name="T">The generic stuff to do</typeparam>
+    public void DoGenericStuff<T>()
     {
-        /// <summary>
-        /// Does generic stuff
-        /// </summary>
-        /// <typeparam name="T">The generic stuff to do</param>
-        public void DoGenericStuff<T>()
-        {
 
-        }
     }
+}
+```
 
 <a name="typeparamref"></a>
 ## &lt;typeparamref&gt;
@@ -401,20 +421,22 @@ Add a tag for each type parameter of the generic type or method.
 The &lt;typeparamref&gt; tag gives you a way to indicate that a word in the code comments, 
 for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type parameter.
 
+```csharp
+/// <summary>
+/// This class does something
+/// </summary>
+public class SomeClass
+{
     /// <summary>
-    /// This class does something
+    /// Does generic stuff <typeparamref name="T"/>
     /// </summary>
-    public class SomeClass
+    /// <typeparam name="T">The generic stuff to do</typeparam>
+    public void DoGenericStuff<T>()
     {
-        /// <summary>
-        /// Does generic stuff <typeparamref name="T"/>
-        /// </summary>
-        /// <typeparam name="T">The generic stuff to do</param>
-        public void DoGenericStuff<T>()
-        {
 
-        }
     }
+}
+```
 
 <a name="include"></a>
 ## &lt;include&gt;
@@ -422,53 +444,54 @@ for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type param
 The &lt;include&gt; tag lets you refer to comments in a separate XML file that describe the types and members 
 in your source code as opposed to placing documentation comments directly in your source code file.
 
-    
-    /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/SomeClass/*' />
-    public class SomeClass
-    {
-        /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/DoStuff/*' />
-        public void DoStuff(int a)
-        {
-
-        }
-    }
-
-    /// <include file='docs.xml' path='Docs/Members[@name="someotherclass"]/SomeOtherClass/*' />
-    public class SomeOtherClass
+```csharp
+/// <include file='docs.xml' path='Docs/Members[@name="someclass"]/SomeClass/*'/>
+public class SomeClass
+{
+    /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/DoStuff/*'/>
+    public void DoStuff(int a)
     {
 
     }
+}
 
-    /*
-        Contents of docs.xml
-        --------------------
+/// <include file='docs.xml' path='Docs/Members[@name="someotherclass"]/SomeOtherClass/*'/>
+public class SomeOtherClass
+{
 
-        <Docs>
-            <Members name="someclass">
-                <SomeClass>
-                    <summary>
-                    This class does something
-                    </summary>
-                </SomeClass>
-                <DoStuff>
-                    <summary>
-                    This method does stuff
-                    </summary>
-                </DoStuff>
-            </Members>
-            <Members name="someotherclass">
-                <SomeOtherClass>
-                    <summary>
-                    This class does some other thing
-                    </summary>
-                </SomeOtherClass>
-            </Members>
-        </Docs>
-    */
+}
+
+/*
+    Contents of docs.xml
+    --------------------
+
+    <Docs>
+        <Members name="someclass">
+            <SomeClass>
+                <summary>
+                This class does something
+                </summary>
+            </SomeClass>
+            <DoStuff>
+                <summary>
+                This method does stuff
+                </summary>
+            </DoStuff>
+        </Members>
+        <Members name="someotherclass">
+            <SomeOtherClass>
+                <summary>
+                This class does some other thing
+                </summary>
+            </SomeOtherClass>
+        </Members>
+    </Docs>
+*/
+```
 
 The `filename` attribute represents the name of the XML file containing the documentation.
 
-The `tagpath` attribute represents the path of the tags in `filename` that leads to the `tag name`.
+The `path` attribute represents an [XPath](https://msdn.microsoft.com/en-us/library/ms256115(v=vs.110).aspx) query to the `tag name` present in the specified `filename`
 
 The `name` attribute represents the name specifier in the tag that precedes the comments
 

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -4,7 +4,7 @@ description: Documenting your code
 keywords: .NET, .NET Core
 author: tsolarin
 manager: wpickett
-ms.date: 08/18/2016
+ms.date: 08/24/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -13,42 +13,6 @@ ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 ---
 
 # Documenting your code
-
-Documenting C# code is recommended practice as it helps make code easy to understand and maintain.
-Comments are a great way to add documentation to your C# code, they can help explain parts of your code and the great thing is,
-they do not add any overhead to your workflow because they usually are completely ignored by the compiler.
-
-## Single Line Comments
-
-Single line comments are a great way to explain C# code. They can be on a separate line or inline with your code.
-The comment body is prefixed by double forward slashes (`//`).
-
-```csharp
-// This comment describes variable i
-// Multiple lines could be a hassle
-int i = 0;
-int j = 1; // This comment describes variable j
-```
-
-## Multiline Comments
-
-Multiline comments function just like single line comments except that they make it easier to have comments that span multiple lines.
-The comment body starts with (`/*`) and ends with (`*/`).
-
-```csharp
-/*
-This describes variables i and j
-Multiline is less of a hassle
-*/
-int i = 0, j = 1;
-```
-
-Single line and Multiline comments are very useful for explaining code and getting new contributors up to speed with the codebase. They however 
-do not account for situations where the .NET assembly is distributed as a binary to third party developers with no available source code.
-This is where XML documentation comments come in handy.
-
-
-## XML Documentation Comments
 
 XML documentation comments are a special kind of comment, added above the definition of any user defined type or member. 
 They are special because they can be processed by the compiler to generate an XML documentation file at compile time.
@@ -72,68 +36,9 @@ public class SomeClass
 
 ## Walkthrough
 
-In this section I'm going to walk you through documenting a very basic math library to make it easy for new developers to understand/contribute and for third party developers to use.
-We're going to use a combination of single line comments, multiline comments and XML documentation tags.
+In this section you're going to be walked through documenting a very basic math library to make it easy for new developers to understand/contribute and for third party developers to use.
 
 Here's code for the simple math library:
-
-```csharp
-public class Math
-{
-    public static int Add(int a, int b)
-    {
-        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
-            throw new System.OverflowException();
-
-        return a + b;
-    }
-
-    public static double Add(double a, double b)
-    {
-        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
-            throw new System.OverflowException();
-
-        return a + b;
-    }
-
-    public static int Subtract(int a, int b)
-    {
-        return a - b;
-    }
-
-    public static double Subtract(double a, double b)
-    {
-        return a - b;
-    }
-
-    public static int Multiply(int a, int b)
-    {
-        return a * b;
-    }
-
-    public static double Multiply(double a, double b)
-    {
-        return a * b;
-    }
-
-    public static int Divide(int a, int b)
-    {
-        return a / b;
-    }
-
-    public static double Divide(double a, double b)
-    {
-        return a / b;
-    }
-}
-```
-
-The sample library above doesn't do much, it supports four major arithmetic operations `add`, `subtract`, `multiply` and `divide` on `int` and `double` datatypes.
-Now let's assume this is one huge library that is going to have a ton of developers, we'll need to add some comments to make it easier to understand.
-In this sample we'll use multiline comments for class definitions and single line comments otherwise, these are not imposed conventions however,
-so feel free to use the kind of comment the situation requires.
-
-Here's the updated library code with comments added:
 
 ```csharp
 /*
@@ -200,15 +105,15 @@ public class Math
 }
 ```
 
-And there you have it! now any new developer can easily get quick insight into what each method and the overall class does.
+The sample library above doesn't do much, it supports four major arithmetic operations `add`, `subtract`, `multiply` and `divide` on `int` and `double` datatypes.
 
-Next we want to be able to create an API reference document from our code for third party developers who use our library but don't have access to the source code.
-As mentioned earlier XML documentation tags can be used to achieve this, I will now introduce you to the standard XML tags the C# compiler supports.
+Now you want to be able to create an API reference document from your code for third party developers who use your library but don't have access to the source code.
+As mentioned earlier XML documentation tags can be used to achieve this, You will now be introduced to the standard XML tags the C# compiler supports.
 
 ### &lt;summary&gt;
 
-First off is the `<summary>` tag and as the name suggests it is used to add brief information about a type or member.
-I'll demonstrate its use by adding it to the `Math` class definition and the first `Add` method, feel free to apply it to the rest of the code.
+First off is the `<summary>` tag and as the name suggests you use it to add brief information about a type or member.
+I'll demonstrate its use by adding it to the `Math` class definition and the first `Add` method, feel free to apply it to the rest of your code.
 
 ```csharp
 /*
@@ -237,12 +142,12 @@ public class Math
 }
 ```
 
-The `<summary>` tag is super important and I strongly advice it be included because its content is the primary source of type or member description in the resulting API reference document. 
+The `<summary>` tag is super important and you are strongly advised to include it because its content is the primary source of type or member description in the resulting API reference document. 
 
 ### &lt;remarks&gt;
 
-The `<remarks>` tag is used to add information about types or members, supplementing the information specified with `<summary>`.
-In this example I'll just add it to the class.
+You use the `<remarks>` tag to add information about types or members, supplementing the information specified with `<summary>`.
+In this example you'll just add it to the class.
 
 ```csharp
 /*
@@ -264,7 +169,7 @@ public class Math
 
 ### &lt;returns&gt;
 
-As the name suggests the `<returns>` tag is used in the comment for a method declaration to describe its return value.
+As the name suggests you use the `<returns>` tag in the comment for a method declaration to describe its return value.
 Like before this will be illustrated on the first `Add` method go ahead an implement it on other methods.
 
 ```csharp
@@ -288,8 +193,8 @@ Like before this will be illustrated on the first `Add` method go ahead an imple
 
 ### &lt;value&gt;
 
-The `<value>` works similarly to the `<returns>` tag except that it is used for properties.
-Let's assume our `Math` library had a static property called `PI` here's how we'll use this tag:
+The `<value>` works similarly to the `<returns>` tag except that you use it for properties.
+Assuming your `Math` library had a static property called `PI` here's how you'll use this tag:
 
 ```csharp
 /*
@@ -312,7 +217,7 @@ public class Math
 
 ### &lt;example&gt;
 
-The `<example>` tag lets you specify an example of how to use a class, method or other member. 
+You use the `<example>` tag to include an example in your XML documentation.
 This involves using the child `<code>` tag.
 
 ```csharp
@@ -347,9 +252,9 @@ The `code` tag preserves line breaks and indentation for longer examples.
 
 ### &lt;para&gt;
 
-Sometimes there is need to format the content of certain tags and that's where the `<para>` tag comes in.
-It is for use inside a tag, such as `<summary>`, `<remarks>`, or `<returns>`, and lets divide text into paragraphs.
-We'll go ahead and format the contents of the `<summary>` tag for our class definition.
+You may find you need to format the content of certain tags and that's where the `<para>` tag comes in.
+You usually use it inside a tag, such as `<summary>`, `<remarks>`, or `<returns>`, and lets you divide text into paragraphs.
+You can go ahead and format the contents of the `<summary>` tag for your class definition.
 
 ```csharp
 /*
@@ -368,7 +273,7 @@ public class Math
 
 ### &lt;c&gt;
 
-Still on the topic of formatting, let me introduce the `<c>` tag which is used for marking part of text as code.
+Still on the topic of formatting, you use the `<c>` tag for marking part of text as code.
 It's like the `<code>` tag but inline and is great when you want to show a quick code example as part of a tag's content.
 Let's update the documentation for the `Math` class.
 
@@ -391,8 +296,8 @@ public class Math
 
 There's no getting rid of exceptions, there will always be exceptional situations your code is not built to handle.
 Good news is there's a way to let your developers know that certain methods can throw certain exceptions and that's by using the `<exception>` tag.
-Looking at our little Math library we can see that both `Add` methods throw an exception if a certain condition is met not so obvious though
-is that both `Divide` methods will throw as well if the parameter `b` is zero. Let's go ahead to add exception documentation these methods.
+Looking at your little Math library you can see that both `Add` methods throw an exception if a certain condition is met, not so obvious though
+is that both `Divide` methods will throw as well if the parameter `b` is zero. Now go ahead to add exception documentation to these methods.
 
 ```csharp
 /*
@@ -537,7 +442,7 @@ This can be any type defined in the project or a referenced assembly.
 
 ## &lt;seealso&gt;
 
-The `<seealso>` tag works similarly to the `<see>` tag, the only difference is that it's content is typically broken into a "See Also" section not that different from
+You use the `<seealso>` tag in the same way you do the `<see>` tag, the only difference is that it's content is typically broken into a "See Also" section not that different from
 the one you sometimes see on the MSDN documentation pages. Here we'll add a `seealso` tag on the integer `Add` method to reference other methods in the class that accept interger parameters:
 
 ```csharp
@@ -586,7 +491,7 @@ This can be any type defined in the project or a referenced assembly.
 
 ### &lt;param&gt;
 
-The `<param>` tag is used for describing the parameters a method takes. Here's an example on the double `Add` method:
+You use the `<param>` tag for describing the parameters a method takes. Here's an example on the double `Add` method:
 The parameter the tag describes is specified in the **required** `name` attribute.
 
 ```csharp
@@ -622,22 +527,27 @@ public class Math
 
 ### &lt;typeparam&gt;
 
-The `<typeparam>` tag functions just like the `<param>` tag but for generic type or method declarations to describe a generic parameter.
-Since our math library doesn't have a generic method I'll just bring in `SomeClass` to demonstrate it.
+You use `<typeparam>` tag just like the `<param>` tag but for generic type or method declarations to describe a generic parameter.
+Go ahead and add a quick generic method to your `Math` class to check if 
 
 ```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
 /// <summary>
-/// This class does something.
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
 /// </summary>
-public class SomeClass
+public class Math
 {
     /// <summary>
-    /// Does generic stuff.
+    /// Checks if an IComparable is greater than another.
     /// </summary>
-    /// <typeparam name="T">The generic stuff to do.</typeparam>
-    public void DoGenericStuff<T>()
+    /// <typeparam name="T">A type that inherits from the IComparable interface.</typeparam>
+    public static bool GreaterThan<T>(T a, T b) where T : IComparable
     {
-
+        return a.CompareTo(b) > 0;
     }
 }
 ```
@@ -681,103 +591,8 @@ public class Math
 
 ### &lt;typeparamref&gt;
 
-The `<typeparamref>` tag functions just like the `<paramref>` tag but for generic type or method declarations to describe a generic parameter.
-Since our math library doesn't have a generic method I'll just bring in `SomeClass` to demonstrate it.
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// Does generic stuff <typeparamref name="T"/>.
-    /// </summary>
-    /// <typeparam name="T">The generic stuff to do.</typeparam>
-    public void DoGenericStuff<T>()
-    {
-
-    }
-}
-```
-
-### &lt;list&gt;
-
-Although we don't get to use it with our math library the `<list>` tag is a very useful tag because it lets you format documentation information as an ordered list, unordered list or table.
-Here's a quick example with `SomeClass`:
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// An example of an unordered list.
-    /// <list type="bullet">
-    /// <item>
-    /// <term>Some term</term>
-    /// <description>Some description</description>
-    /// </item>
-    /// <item>
-    /// <term>Some term</term>
-    /// <description>Some description</description>
-    /// </item>
-    /// </list>
-    /// </summary>
-    public void DoStuff(int a)
-    {
-
-    }
-
-    /// <summary>
-    /// An example of an ordered list.
-    /// <list type="number">
-    /// <item>
-    /// <term>Some term</term>
-    /// <description>Some description</description>
-    /// </item>
-    /// <item>
-    /// <term>Some term</term>
-    /// <description>Some description</description>
-    /// </item>
-    /// </list>
-    /// </summary>
-    public void DoMoreStuff(int a, string b)
-    {
-
-    }
-
-    /// <summary>
-    /// An example of a table.
-    /// <list type="table">
-    /// <listheader>
-    /// <term>Table Heading Col 1</term>
-    /// <term>Table Heading Col 2</term>
-    /// <term>Table Heading Col 3</term>
-    /// </listheader>
-    /// <item>
-    /// <term>Col 1 Row 1</term>
-    /// <term>Col 2 Row 1</term>
-    /// <term>Col 3 Row 1</term>
-    /// </item>
-    /// <item>
-    /// <term>Col 1 Row 2</term>
-    /// <term>Col 2 Row 2</term>
-    /// <term>Col 3 Row 2</term>
-    /// </item>
-    /// </list>
-    /// </summary>
-    public void DoALotMoreStuff(params string[] args)
-    {
-
-    }
-}
-```
-
-### Putting it all together
-
-If you've followed this tutorial and applied the tags to your code where necessary your code should look similar to the following:
+You use `<typeparamref>` tag just like the `<paramref>` tag but for generic type or method declarations to describe a generic parameter.
+You can use the same generic method you previously created.
 
 ```csharp
 /*
@@ -787,6 +602,123 @@ If you've followed this tutorial and applied the tags to your code where necessa
 /// <summary>
 /// <para>The main <c>Math</c> class.</para>
 /// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+public class Math
+{
+    /// <summary>
+    /// Checks if an IComparable <typeparamref name="T"/> is greater than another.
+    /// </summary>
+    /// <typeparam name="T">A type that inherits from the IComparable interface.</typeparam>
+    public static bool GreaterThan<T>(T a, T b) where T : IComparable
+    {
+        return a.CompareTo(b) > 0;
+    }
+}
+```
+
+### &lt;list&gt;
+
+You use the `<list>` tag to format documentation information as an ordered list, unordered list or table.
+You'll make an unordered list of every math operation your `Math` library supports, you also get stub samples for ordered list and table.
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// <list type="bullet">
+/// <item>
+/// <term>Add</term>
+/// <description>Addition Operation</description>
+/// </item>
+/// <item>
+/// <term>Subtract</term>
+/// <description>Subtraction Operation</description>
+/// </item>
+/// <item>
+/// <term>Multiply</term>
+/// <description>Multiplication Operation</description>
+/// </item>
+/// <item>
+/// <term>Divide</term>
+/// <description>Division Operation</description>
+/// </item>
+/// </list>
+/// </summary>
+
+/// <summary>
+/// An example of an ordered list.
+/// <list type="number">
+/// <item>
+/// <term>Some term</term>
+/// <description>Some description</description>
+/// </item>
+/// <item>
+/// <term>Some term</term>
+/// <description>Some description</description>
+/// </item>
+/// </list>
+/// </summary>
+
+/// <summary>
+/// An example of a table.
+/// <list type="table">
+/// <listheader>
+/// <term>Table Heading Col 1</term>
+/// <term>Table Heading Col 2</term>
+/// <term>Table Heading Col 3</term>
+/// </listheader>
+/// <item>
+/// <term>Col 1 Row 1</term>
+/// <term>Col 2 Row 1</term>
+/// <term>Col 3 Row 1</term>
+/// </item>
+/// <item>
+/// <term>Col 1 Row 2</term>
+/// <term>Col 2 Row 2</term>
+/// <term>Col 3 Row 2</term>
+/// </item>
+/// </list>
+/// </summary>
+public class Math
+{
+
+}
+```
+
+### Putting it all together
+
+You've followed this tutorial and applied the tags to your code where necessary, your code should now look similar to the following:
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// <list type="bullet">
+/// <item>
+/// <term>Add</term>
+/// <description>Addition Operation</description>
+/// </item>
+/// <item>
+/// <term>Subtract</term>
+/// <description>Subtraction Operation</description>
+/// </item>
+/// <item>
+/// <term>Multiply</term>
+/// <description>Multiplication Operation</description>
+/// </item>
+/// <item>
+/// <term>Divide</term>
+/// <description>Division Operation</description>
+/// </item>
+/// </list>
 /// </summary>
 /// <remarks>
 /// This class can add, subtract, multiply and divide.
@@ -1025,15 +957,15 @@ public class Math
 }
 ```
 
-From our sample code above we can generate a well detailed documentation website complete with clickable cross-references but we've introduced another problem, our code has become hard to read.
+From your code you can generate a well detailed documentation website complete with clickable cross-references but then you're faced with another problem, your code has become hard to read.
 This is going to be a nightmare for any developer who wants to contribute to this code, so much information to sift through. 
-Thankfully there's an XML tag that helps us deal with this:
+Thankfully there's an XML tag that can help you deal with this:
 
 ### &lt;include&gt;
 
 The `<include>` tag lets you refer to comments in a separate XML file that describe the types and members in your source code as opposed to placing documentation comments directly in your source code file.
 
-Now we're going to move all our XML tags into a separate XML file named `docs.xml`, feel free to name the file whatever you want.
+Now you're going to move all your XML tags into a separate XML file named `docs.xml`, feel free to name the file whatever you want.
 
 ```xml
 <docs>
@@ -1239,8 +1171,8 @@ Now we're going to move all our XML tags into a separate XML file named `docs.xm
 </docs>
 ```
 
-In our XML I basically put each member's documentation comments directly inside a tag named after what they do, you can choose your own strategy. 
-Now that we have our XML comments in a separate file let's see how our code can be made more readable using the `<include>` tag:
+In the above XML each member's documentation comments appears directly inside a tag named after what they do, you can choose your own strategy. 
+Now that you have your XML comments in a separate file let's see how your code can be made more readable using the `<include>` tag:
 
 ```csharp
 /*
@@ -1342,7 +1274,7 @@ that need to be taken into consideration when using XML documentation tags in yo
 
 * For the sake of consistency all publicly visible types and their members should be documented. If you must do it, do it all.
 * Private members can also be documented using XML comments, however this exposes the inner (potentially confidential) workings of your library.
-* In addition to other tags, types and their members should have at the very list `<summary>` tag.
+* In addition to other tags, types and their members should have at the very least a `<summary>` tag.
 * Documentation text should be written using complete sentences ending with full stops.
 * Partial classes are fully supported and documentation information will be concatenated into one.
 * The compiler verifies the syntax of `<exception>`, `<include>`, `<param>`, `<see>`, `<seealso>` and `<typeparam>` tags.

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -14,6 +14,8 @@ ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 
 # XML Documentation
 
+by [Toni Solarin-Sodara](https://github.com/tsolarin)
+
 XML documentation tags are specially formatted comments, added above class and method 
 definitions, used to document your code. You can generate the XML doc file at compile time 
 by adding `"xmlDoc": true` under `buildOptions` in your `project.json`

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -4,7 +4,7 @@ description: Documenting your code
 keywords: .NET, .NET Core
 author: tsolarin
 manager: wpickett
-ms.date: 07/19/2016
+ms.date: 07/24/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -85,7 +85,7 @@ public class SomeClass
     /// <summary>
     /// This method does stuff.
     /// </summary>
-    /// <returns>Stuff it has done</returns>
+    /// <returns>Stuff it has done.</returns>
     public int DoStuff(int a)
     {
         return a;
@@ -97,7 +97,7 @@ public class SomeClass
 ## &lt;example&gt;
 
 The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
-This commonly involves using the [&lt;code&gt;](#code) tag.
+This commonly involves using the [&lt;code&gt;](#code) and sometimes the [&lt;c&gt;](#c) tag.
 
 ```csharp
 /// <summary>
@@ -105,6 +105,9 @@ This commonly involves using the [&lt;code&gt;](#code) tag.
 /// </summary>
 public class SomeClass
 {
+    /// <summary>
+    /// This method does stuff.
+    /// </summary>
     /// <example>
     /// <code>
     /// SomeClass someClass = new SomeClass();
@@ -129,7 +132,10 @@ The &lt;value&gt; lets you describe the value that a property represents.
 /// </summary>
 public class SomeClass
 {
-    /// <value>The Name property gets/sets the name value of something.</value>
+    /// <summary>
+    /// This is the Name property.
+    /// </summary>
+    /// <value>Gets or sets the name value of something.</value>
     public string Name { get; set; }
 }
 ```
@@ -146,11 +152,18 @@ It's applicable to methods, properties, events, and indexers.
 /// </summary>
 public class SomeClass
 {
-    /// <exception cref="System.ArgumentNullException">Thrown when there's no stuff to do</exception>
-    /// <exception cref="System.InvalidOperationException">Thrown when it tries to do the wrong stuff</exception>
-    public void DoStuff()
+    /// <summary>
+    /// This method does stuff.
+    /// </summary>
+    /// <exception cref="System.ArgumentNullException">Thrown when there's no stuff to do.</exception>
+    /// <exception cref="System.InvalidOperationException">Thrown when it tries to do the wrong stuff.</exception>
+    public void DoStuff(string a)
     {
+        if (a == null)
+            throw new System.ArgumentNullException();
 
+        if (a == "wrong stuff")
+            throw new System.InvalidOperationException();
     }
 }
 ```
@@ -160,7 +173,7 @@ The `cref` attribute represents a reference to an exception that is available fr
 <a name="c"></a>
 ## &lt;c&gt;
 
-The &lt;c&gt; tag is used to indicate inline code
+The &lt;c&gt; tag is used to indicate inline code.
 
 ```csharp
 /// <summary>
@@ -169,7 +182,7 @@ The &lt;c&gt; tag is used to indicate inline code
 public class SomeClass
 {
     /// <summary>
-    /// <c>DoStuff</c> does stuff on an instance of <c>SomeClass</c>
+    /// <c>DoStuff</c> does stuff on an instance of <c>SomeClass</c>.
     /// </summary>
     public void DoStuff()
     {
@@ -193,11 +206,15 @@ or &lt;returns&gt;, and lets you add paragraphs to text.
 
 ```csharp
 /// <summary>
-/// <para>This class does something</para>
-/// <para>This is a new paragraph</para>
+/// <para>This class does something.</para>
+/// <para>This is a new paragraph.</para>
 /// </summary>
 public class SomeClass
 {
+    /// <summary>
+    /// This method does stuff.
+    /// <para>This is a paragraph</para>
+    /// </summary>
     public void DoStuff()
     {
 
@@ -282,7 +299,10 @@ public class SomeClass
 <a name="see"></a>
 ## &lt;see&gt;
 
-The &lt;see&gt; tag lets you specify a link from within text. Use the `cref` attribute to create internal hyperlinks to documentation pages for code elements.
+The &lt;see&gt; tag lets you specify a link from within text. 
+Use the `cref` attribute to create internal hyperlinks to documentation pages for code elements.
+
+The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
 
 ```csharp
 /// <summary>
@@ -292,7 +312,7 @@ public class SomeClass
 {
     /// <summary>
     /// This method does stuff.
-    /// See <see cref="SomeClass.DoMoreStuff"/> to do more stuff
+    /// See <see cref="SomeClass.DoMoreStuff"/> to do more stuff.
     /// </summary>
     public void DoStuff(int a)
     {
@@ -312,7 +332,9 @@ public class SomeClass
 <a name="seealso"></a>
 ## &lt;seealso&gt;
 
-The &lt;seealso&gt; tag lets you specify the text that you might want to appear in a See Also section.
+This tag identifies cross-references in the documentation to other types or members.
+The tags are typically broken out into a separate "See Also" section.
+This tag is useful because it allows tools to generate cross-references, indexes, and hyperlinked views of the documentation.
 
 ```csharp
 /// <summary>
@@ -339,6 +361,8 @@ public class SomeClass
 }
 ```
 
+The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
+
 <a name="param"></a>
 ## &lt;param&gt;
 
@@ -351,14 +375,20 @@ To document multiple parameters, use multiple &lt;param&gt; tags.
 /// </summary>
 public class SomeClass
 {
-    /// <param name="a">The stuff to do</param>
+    /// <summary>
+    /// This method does stuff.
+    /// </summary>
+    /// <param name="a">The stuff to do.</param>
     public void DoStuff(int a)
     {
 
     }
 
-    /// <param name="a">A stuff to do</param>
-    /// <param name="b">Another stuff to do</param>
+    /// <summary>
+    /// This method does more stuff.
+    /// </summary>
+    /// <param name="a">A stuff to do.</param>
+    /// <param name="b">Another stuff to do.</param>
     public void DoMoreStuff(int a, string b)
     {
 
@@ -382,9 +412,9 @@ public class SomeClass
 {
     /// <summary>
     /// This method does stuff.
-    /// The parameter <paramref name="a"/> takes a number
+    /// The parameter <paramref name="a"/> takes a number.
     /// </summary>
-    /// <param name="a">The stuff to do</param>
+    /// <param name="a">The stuff to do.</param>
     public void DoStuff(int a)
     {
 
@@ -407,7 +437,7 @@ public class SomeClass
     /// <summary>
     /// Does generic stuff.
     /// </summary>
-    /// <typeparam name="T">The generic stuff to do</typeparam>
+    /// <typeparam name="T">The generic stuff to do.</typeparam>
     public void DoGenericStuff<T>()
     {
 
@@ -423,14 +453,14 @@ for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type param
 
 ```csharp
 /// <summary>
-/// This class does something
+/// This class does something.
 /// </summary>
 public class SomeClass
 {
     /// <summary>
-    /// Does generic stuff <typeparamref name="T"/>
+    /// Does generic stuff <typeparamref name="T"/>.
     /// </summary>
-    /// <typeparam name="T">The generic stuff to do</typeparam>
+    /// <typeparam name="T">The generic stuff to do.</typeparam>
     public void DoGenericStuff<T>()
     {
 
@@ -469,19 +499,19 @@ public class SomeOtherClass
         <Members name="someclass">
             <SomeClass>
                 <summary>
-                This class does something
+                This class does something.
                 </summary>
             </SomeClass>
             <DoStuff>
                 <summary>
-                This method does stuff
+                This method does stuff.
                 </summary>
             </DoStuff>
         </Members>
         <Members name="someotherclass">
             <SomeOtherClass>
                 <summary>
-                This class does some other thing
+                This class does some other thing.
                 </summary>
             </SomeOtherClass>
         </Members>
@@ -496,3 +526,23 @@ The `path` attribute represents an [XPath](https://msdn.microsoft.com/en-us/libr
 The `name` attribute represents the name specifier in the tag that precedes the comments
 
 The `id` attribute represents the ID for the tag that precedes the comments
+
+<a name="user-defined"></a>
+## User Defined Tags
+
+All the tags outlined above represent those that are recognized by the C# compiler. However, a user is free to define their own tags.
+Tools like Sandcastle bring support for extra tags like &lt;event&gt;, &lt;note&gt; and even support documenting namespaces.
+Custom or in-house documentation generation tools can also be used with the standard tags and multiple output formats from HTML to PDF can be supported.
+
+<a name="recommendations"></a>
+## Recommendations
+
+Documenting code is definitely a recommended practice for lots of reasons. However, there are some best practices and general use case scenarios
+that need to be taken into consideration when using XML documentation tags in your C# code.
+
+* For the sake of consistency all publicly visible types and their members should be documented. If you must do it, do it all.
+* In addition to other tags, types and their members should have a &lt;summary&gt; tag.
+* Documentation text should be written using complete sentences ending with full stops.
+* Partial classes are fully supported and documentation information will be concatenated into one.
+* The compiler verifies the syntax of &lt;exception&gt;, &lt;include&gt;, &lt;param&gt;, &lt;see&gt;, &lt;seealso&gt; and &lt;typeparam&gt; tags.
+It validates the parameters that contain file paths and references to other parts of the code.

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -43,10 +43,25 @@ by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
 
 The &lt;c&gt; tag is used to indicate that a single line of text should be marked as code
 
+    /// <summary>
+    /// <c>SomeClass</c> does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// <c>DoStuff</c> does stuff on an instance of <c>SomeClass</c>
+        /// </summary>
+        public void DoStuff()
+        {
+
+        }
+    }
+
 <a name="code"></a>
 ## &lt;code&gt;
 
-The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code
+The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code.
+It is used within the &lt;example&gt; tag
 
 <a name="example"></a>
 ## &lt;example&gt;
@@ -54,11 +69,42 @@ The &lt;code&gt; tag is used to indicate that multiple lines of text should be m
 The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
 This commonly involves using the &lt;code&gt; tag.
 
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <example>
+        /// <code>
+        /// SomeClass someClass = new SomeClass();
+        /// someClass.DoStuff();
+        /// </code>
+        /// </example>
+        public void DoStuff()
+        {
+
+        }
+    }
+
 <a name="exception"></a>
 ## &lt;exception&gt;
 
 The &lt;exception&gt; tag lets you specify possible exceptions that can be thrown. 
 It's applicable to methods, properties, events, and indexers.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <exception cref="System.Exception">Thrown when there's no stuff to do</exception>
+        public void DoStuff()
+        {
+
+        }
+    }
+
+The `cref` parameter represents a reference to an exception that is available from the current compilation environment.
 
 <a name="include"></a>
 ## &lt;include&gt;
@@ -77,11 +123,43 @@ The &lt;list&gt; tag lets you format documentation information as an ordered lis
 The &lt;para&gt; tag is for use inside a tag, such as &lt;summary&gt;, &lt;remarks&gt;, 
 or &lt;returns&gt;, and lets you add structure to the text.
 
+    /// <summary>
+    /// <para>This class does something</para>
+    /// </summary>
+    public class SomeClass
+    {
+        public void DoStuff()
+        {
+
+        }
+    }
+
 <a name="param"></a>
 ## &lt;param&gt;
 
 The &lt;param&gt; tag should be used in the comment for a method declaration to describe one of the parameters for the method.
 To document multiple parameters, use multiple &lt;param&gt; tags.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <param name="a">The stuff to do</param>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <param name="a">A stuff to do</param>
+        /// <param name="b">Another stuff to do</param>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+    }
+
+The `name` parameter represents the name of a method parameter
 
 <a name="paramref"></a>
 ## &lt;paramref&gt;
@@ -89,30 +167,137 @@ To document multiple parameters, use multiple &lt;param&gt; tags.
 The &lt;paramref&gt; tag gives you a way to indicate that a word in the code comments, 
 for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
 
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// This method does stuff.
+        /// The <paramref name="a"/> takes a number
+        /// </summary>
+        /// <param name="a">The stuff to do</param>
+        public void DoStuff(int a)
+        {
+
+        }
+    }
+
 <a name="remarks"></a>
 ## &lt;remarks&gt;
 
 The &lt;remarks&gt; tag is used to add information about a type, supplementing the information specified with &lt;summary&gt;.
+
+    /// <summary>
+    /// This class primarily does something
+    /// </summary>
+    /// <remarks>
+    /// It can also do everything
+    /// </remarks>
+    public class SomeClass
+    {
+        
+    }
 
 <a name="returns"></a>
 ## &lt;returns&gt;
 
 The &lt;returns&gt; tag should be used in the comment for a method declaration to describe the return value.
 
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <returns>Stuff it has done</returns>
+        public int DoStuff(int a)
+        {
+            return a;
+        }
+    }
+
 <a name="see"></a>
 ## &lt;see&gt;
 
-The &lt;see&gt; tag lets you specify a link from within text. Use the `cref` Attribute to create internal hyperlinks to documentation pages for code elements.
+The &lt;see&gt; tag lets you specify a link from within text. Use the `cref` attribute to create internal hyperlinks to documentation pages for code elements.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// This method does stuff
+        /// See <see cref="SomeClass.DoMoreStuff" /> to do more stuff
+        /// </summary>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <summary>
+        /// This method does more stuff
+        /// </summary>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+    }
 
 <a name="seealso"></a>
 ## &lt;seealso&gt;
 
-The &lt;seealso&gt; tag lets you specify the text that you might want to appear in a See Also section. 
+The &lt;seealso&gt; tag lets you specify the text that you might want to appear in a See Also section.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// This method does stuff
+        /// <seealso cref="SomeClass.DoMoreStuff" />
+        /// </summary>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <summary>
+        /// This method does more stuff
+        /// </summary>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+    }
 
 <a name="summary"></a>
 ## &lt;summary&gt;
 
 The &lt;summary&gt; tag contains the primary information of a class or method
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// This method does stuff
+        /// </summary>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <summary>
+        /// This method does more stuff
+        /// </summary>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+    }
 
 <a name="typeparam"></a>
 ## &lt;typeparam&gt;
@@ -120,13 +305,52 @@ The &lt;summary&gt; tag contains the primary information of a class or method
 The &lt;typeparam&gt; tag should be used in the comment for a generic type or method declaration to describe a type parameter. 
 Add a tag for each type parameter of the generic type or method.
 
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// Does generic stuff
+        /// </summary>
+        /// <typeparam name="T">The generic stuff to do</param>
+        public void DoGenericStuff<T>()
+        {
+
+        }
+    }
+
 <a name="typeparamref"></a>
 ## &lt;typeparamref&gt;
 
 The &lt;typeparamref&gt; tag gives you a way to indicate that a word in the code comments, 
 for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type parameter.
 
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// Does generic stuff <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">The generic stuff to do</param>
+        public void DoGenericStuff<T>()
+        {
+
+        }
+    }
+
 <a name="value"></a>
 ## &lt;value&gt;
 
 The &lt;value&gt; lets you describe the value that a property represents.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <value>The Name property gets/sets the name value of something</value>
+        public string Name { get; set; }
+    }

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -29,7 +29,6 @@ by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
 * [&lt;para&gt;](#para)
 * [&lt;param&gt;](#param)
 * [&lt;paramref&gt;](#paramref)
-* [&lt;permission&gt;](#permission)
 * [&lt;remarks&gt;](#remarks)
 * [&lt;returns&gt;](#returns)
 * [&lt;see&gt;](#see)
@@ -38,3 +37,96 @@ by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
 * [&lt;typeparam&gt;](#typeparam)
 * [&lt;typeparamref&gt;](#typeparamref)
 * [&lt;value&gt;](#value)
+
+<a name="c"></a>
+## &lt;c&gt;
+
+The &lt;c&gt; tag is used to indicate that a single line of text should be marked as code
+
+<a name="code"></a>
+## &lt;code&gt;
+
+The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code
+
+<a name="example"></a>
+## &lt;example&gt;
+
+The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
+This commonly involves using the &lt;code&gt; tag.
+
+<a name="exception"></a>
+## &lt;exception&gt;
+
+The &lt;exception&gt; tag lets you specify possible exceptions that can be thrown. 
+It's applicable to methods, properties, events, and indexers.
+
+<a name="include"></a>
+## &lt;include&gt;
+
+The &lt;include&gt; tag lets you refer to comments in a separate XML file that describe the types and members 
+in your source code as opposed to placing documentation comments directly in your source code file.
+
+<a name="list"></a>
+## &lt;list&gt;
+
+The &lt;list&gt; tag lets you format documentation information as an ordered list, unordered list or table.
+
+<a name="para"></a>
+## &lt;para&gt;
+
+The &lt;para&gt; tag is for use inside a tag, such as &lt;summary&gt;, &lt;remarks&gt;, 
+or &lt;returns&gt;, and lets you add structure to the text.
+
+<a name="param"></a>
+## &lt;param&gt;
+
+The &lt;param&gt; tag should be used in the comment for a method declaration to describe one of the parameters for the method.
+To document multiple parameters, use multiple &lt;param&gt; tags.
+
+<a name="paramref"></a>
+## &lt;paramref&gt;
+
+The &lt;paramref&gt; tag gives you a way to indicate that a word in the code comments, 
+for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
+
+<a name="remarks"></a>
+## &lt;remarks&gt;
+
+The &lt;remarks&gt; tag is used to add information about a type, supplementing the information specified with &lt;summary&gt;.
+
+<a name="returns"></a>
+## &lt;returns&gt;
+
+The &lt;returns&gt; tag should be used in the comment for a method declaration to describe the return value.
+
+<a name="see"></a>
+## &lt;see&gt;
+
+The &lt;see&gt; tag lets you specify a link from within text. Use the `cref` Attribute to create internal hyperlinks to documentation pages for code elements.
+
+<a name="seealso"></a>
+## &lt;seealso&gt;
+
+The &lt;seealso&gt; tag lets you specify the text that you might want to appear in a See Also section. 
+
+<a name="summary"></a>
+## &lt;summary&gt;
+
+The &lt;summary&gt; tag contains the primary information of a class or method
+
+<a name="typeparam"></a>
+## &lt;typeparam&gt;
+
+The &lt;typeparam&gt; tag should be used in the comment for a generic type or method declaration to describe a type parameter. 
+Add a tag for each type parameter of the generic type or method.
+
+<a name="typeparamref"></a>
+## &lt;typeparamref&gt;
+
+The &lt;typeparamref&gt; tag gives you a way to indicate that a word in the code comments, 
+for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type parameter.
+
+<a name="value"></a>
+## &lt;value&gt;
+
+The &lt;value&gt; lets you describe the value that a property represents.

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -20,23 +20,140 @@ XML documentation tags are specially formatted comments, added above the definit
 or its members, used to document your code. You can generate the XML documentation file at compile time 
 by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
 
-* [&lt;c&gt;](#c)
-* [&lt;code&gt;](#code)
-* [&lt;example&gt;](#example)
-* [&lt;exception&gt;](#exception)
-* [&lt;include&gt;](#include)
-* [&lt;list&gt;](#list)
-* [&lt;para&gt;](#para)
-* [&lt;param&gt;](#param)
-* [&lt;paramref&gt;](#paramref)
+* [&lt;summary&gt;](#summary)
 * [&lt;remarks&gt;](#remarks)
 * [&lt;returns&gt;](#returns)
+* [&lt;example&gt;](#example)
+* [&lt;value&gt;](#value)
+* [&lt;exception&gt;](#exception)
+* [&lt;c&gt;](#c)
+* [&lt;code&gt;](#code)
+* [&lt;para&gt;](#para)
+* [&lt;list&gt;](#list)
 * [&lt;see&gt;](#see)
 * [&lt;seealso&gt;](#seealso)
-* [&lt;summary&gt;](#summary)
+* [&lt;param&gt;](#param)
+* [&lt;paramref&gt;](#paramref)
 * [&lt;typeparam&gt;](#typeparam)
 * [&lt;typeparamref&gt;](#typeparamref)
-* [&lt;value&gt;](#value)
+* [&lt;include&gt;](#include)
+
+<a name="summary"></a>
+## &lt;summary&gt;
+
+The &lt;summary&gt; tag contains the primary information of a class or method.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// This method does stuff
+        /// </summary>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <summary>
+        /// This method does more stuff
+        /// </summary>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+    }
+
+<a name="remarks"></a>
+## &lt;remarks&gt;
+
+The &lt;remarks&gt; tag is used to add information about a type, supplementing the information specified with &lt;summary&gt;.
+
+    /// <summary>
+    /// This class primarily does something
+    /// </summary>
+    /// <remarks>
+    /// It can also do everything
+    /// </remarks>
+    public class SomeClass
+    {
+        
+    }
+
+<a name="returns"></a>
+## &lt;returns&gt;
+
+The &lt;returns&gt; tag should be used in the comment for a method declaration to describe the return value.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <returns>Stuff it has done</returns>
+        public int DoStuff(int a)
+        {
+            return a;
+        }
+    }
+
+<a name="example"></a>
+## &lt;example&gt;
+
+The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
+This commonly involves using the [&lt;code&gt;](#code) tag.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <example>
+        /// <code>
+        /// SomeClass someClass = new SomeClass();
+        /// someClass.DoStuff();
+        /// </code>
+        /// </example>
+        public void DoStuff()
+        {
+
+        }
+    }
+
+<a name="value"></a>
+## &lt;value&gt;
+
+The &lt;value&gt; lets you describe the value that a property represents.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <value>The Name property gets/sets the name value of something</value>
+        public string Name { get; set; }
+    }
+
+<a name="exception"></a>
+## &lt;exception&gt;
+
+The &lt;exception&gt; tag lets you specify possible exceptions that can be thrown. 
+It's applicable to methods, properties, events, and indexers.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <exception cref="System.Exception">Thrown when there's no stuff to do</exception>
+        public void DoStuff()
+        {
+
+        }
+    }
+
+The `cref` parameter represents a reference to an exception that is available from the current compilation environment.
 
 <a name="c"></a>
 ## &lt;c&gt;
@@ -61,108 +178,24 @@ The &lt;c&gt; tag is used to indicate that a single line of text should be marke
 ## &lt;code&gt;
 
 The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code.
-See the &lt;example&gt; tag for sample usage.
+See the [&lt;example&gt;](#example) tag for sample usage.
 
-<a name="example"></a>
-## &lt;example&gt;
+<a name="para"></a>
+## &lt;para&gt;
 
-The &lt;example&gt; tag lets you specify an example of how to use a method or other library member. 
-This commonly involves using the &lt;code&gt; tag.
+The &lt;para&gt; tag is for use inside a tag, such as &lt;summary&gt;, &lt;remarks&gt;, 
+or &lt;returns&gt;, and lets you add structure to the text.
 
     /// <summary>
-    /// This class does something
+    /// <para>This class does something</para>
     /// </summary>
     public class SomeClass
     {
-        /// <example>
-        /// <code>
-        /// SomeClass someClass = new SomeClass();
-        /// someClass.DoStuff();
-        /// </code>
-        /// </example>
         public void DoStuff()
         {
 
         }
     }
-
-<a name="exception"></a>
-## &lt;exception&gt;
-
-The &lt;exception&gt; tag lets you specify possible exceptions that can be thrown. 
-It's applicable to methods, properties, events, and indexers.
-
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
-    {
-        /// <exception cref="System.Exception">Thrown when there's no stuff to do</exception>
-        public void DoStuff()
-        {
-
-        }
-    }
-
-The `cref` parameter represents a reference to an exception that is available from the current compilation environment.
-
-<a name="include"></a>
-## &lt;include&gt;
-
-The &lt;include&gt; tag lets you refer to comments in a separate XML file that describe the types and members 
-in your source code as opposed to placing documentation comments directly in your source code file.
-
-    
-    /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/SomeClass/*' />
-    public class SomeClass
-    {
-        /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/DoStuff/*' />
-        public void DoStuff(int a)
-        {
-
-        }
-    }
-
-    /// <include file='docs.xml' path='Docs/Members[@name="someotherclass"]/SomeOtherClass/*' />
-    public class SomeOtherClass
-    {
-
-    }
-
-    /*
-        Contents of docs.xml
-        --------------------
-
-        <Docs>
-            <Members name="someclass">
-                <SomeClass>
-                    <summary>
-                    This class does something
-                    </summary>
-                </SomeClass>
-                <DoStuff>
-                    <summary>
-                    This method does stuff
-                    </summary>
-                </DoStuff>
-            </Members>
-            <Members name="someotherclass">
-                <SomeOtherClass>
-                    <summary>
-                    This class does some other thing
-                    </summary>
-                </SomeOtherClass>
-            </Members>
-        </Docs>
-    */
-
-The `filename` attribute represents the name of the XML file containing the documentation.
-
-The `tagpath` attribute represents the path of the tags in `filename` that leads to the `tag name`.
-
-The `name` attribute represents the name specifier in the tag that precedes the comments
-
-The `id` attribute represents the ID for the tag that precedes the comments
 
 <a name="list"></a>
 ## &lt;list&gt;
@@ -236,105 +269,6 @@ The &lt;list&gt; tag lets you format documentation information as an ordered lis
         }
     }
 
-<a name="para"></a>
-## &lt;para&gt;
-
-The &lt;para&gt; tag is for use inside a tag, such as &lt;summary&gt;, &lt;remarks&gt;, 
-or &lt;returns&gt;, and lets you add structure to the text.
-
-    /// <summary>
-    /// <para>This class does something</para>
-    /// </summary>
-    public class SomeClass
-    {
-        public void DoStuff()
-        {
-
-        }
-    }
-
-<a name="param"></a>
-## &lt;param&gt;
-
-The &lt;param&gt; tag should be used in the comment for a method declaration to describe one of the parameters for the method.
-To document multiple parameters, use multiple &lt;param&gt; tags.
-
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
-    {
-        /// <param name="a">The stuff to do</param>
-        public void DoStuff(int a)
-        {
-
-        }
-
-        /// <param name="a">A stuff to do</param>
-        /// <param name="b">Another stuff to do</param>
-        public void DoMoreStuff(int a, string b)
-        {
-
-        }
-    }
-
-The `name` parameter represents the name of a method parameter
-
-<a name="paramref"></a>
-## &lt;paramref&gt;
-
-The &lt;paramref&gt; tag gives you a way to indicate that a word in the code comments, 
-for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
-
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
-    {
-        /// <summary>
-        /// This method does stuff.
-        /// The <paramref name="a"/> takes a number
-        /// </summary>
-        /// <param name="a">The stuff to do</param>
-        public void DoStuff(int a)
-        {
-
-        }
-    }
-
-<a name="remarks"></a>
-## &lt;remarks&gt;
-
-The &lt;remarks&gt; tag is used to add information about a type, supplementing the information specified with &lt;summary&gt;.
-
-    /// <summary>
-    /// This class primarily does something
-    /// </summary>
-    /// <remarks>
-    /// It can also do everything
-    /// </remarks>
-    public class SomeClass
-    {
-        
-    }
-
-<a name="returns"></a>
-## &lt;returns&gt;
-
-The &lt;returns&gt; tag should be used in the comment for a method declaration to describe the return value.
-
-    /// <summary>
-    /// This class does something
-    /// </summary>
-    public class SomeClass
-    {
-        /// <returns>Stuff it has done</returns>
-        public int DoStuff(int a)
-        {
-            return a;
-        }
-    }
-
 <a name="see"></a>
 ## &lt;see&gt;
 
@@ -391,10 +325,38 @@ The &lt;seealso&gt; tag lets you specify the text that you might want to appear 
         }
     }
 
-<a name="summary"></a>
-## &lt;summary&gt;
+<a name="param"></a>
+## &lt;param&gt;
 
-The &lt;summary&gt; tag contains the primary information of a class or method.
+The &lt;param&gt; tag should be used in the comment for a method declaration to describe one of the parameters for the method.
+To document multiple parameters, use multiple &lt;param&gt; tags.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <param name="a">The stuff to do</param>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <param name="a">A stuff to do</param>
+        /// <param name="b">Another stuff to do</param>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+    }
+
+The `name` parameter represents the name of a method parameter
+
+<a name="paramref"></a>
+## &lt;paramref&gt;
+
+The &lt;paramref&gt; tag gives you a way to indicate that a word in the code comments, 
+for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a parameter.
 
     /// <summary>
     /// This class does something
@@ -402,17 +364,11 @@ The &lt;summary&gt; tag contains the primary information of a class or method.
     public class SomeClass
     {
         /// <summary>
-        /// This method does stuff
+        /// This method does stuff.
+        /// The <paramref name="a"/> takes a number
         /// </summary>
+        /// <param name="a">The stuff to do</param>
         public void DoStuff(int a)
-        {
-
-        }
-
-        /// <summary>
-        /// This method does more stuff
-        /// </summary>
-        public void DoMoreStuff(int a, string b)
         {
 
         }
@@ -460,16 +416,60 @@ for example in a &lt;summary&gt; or &lt;remarks&gt; block refers to a type param
         }
     }
 
-<a name="value"></a>
-## &lt;value&gt;
+<a name="include"></a>
+## &lt;include&gt;
 
-The &lt;value&gt; lets you describe the value that a property represents.
+The &lt;include&gt; tag lets you refer to comments in a separate XML file that describe the types and members 
+in your source code as opposed to placing documentation comments directly in your source code file.
 
-    /// <summary>
-    /// This class does something
-    /// </summary>
+    
+    /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/SomeClass/*' />
     public class SomeClass
     {
-        /// <value>The Name property gets/sets the name value of something</value>
-        public string Name { get; set; }
+        /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/DoStuff/*' />
+        public void DoStuff(int a)
+        {
+
+        }
     }
+
+    /// <include file='docs.xml' path='Docs/Members[@name="someotherclass"]/SomeOtherClass/*' />
+    public class SomeOtherClass
+    {
+
+    }
+
+    /*
+        Contents of docs.xml
+        --------------------
+
+        <Docs>
+            <Members name="someclass">
+                <SomeClass>
+                    <summary>
+                    This class does something
+                    </summary>
+                </SomeClass>
+                <DoStuff>
+                    <summary>
+                    This method does stuff
+                    </summary>
+                </DoStuff>
+            </Members>
+            <Members name="someotherclass">
+                <SomeOtherClass>
+                    <summary>
+                    This class does some other thing
+                    </summary>
+                </SomeOtherClass>
+            </Members>
+        </Docs>
+    */
+
+The `filename` attribute represents the name of the XML file containing the documentation.
+
+The `tagpath` attribute represents the path of the tags in `filename` that leads to the `tag name`.
+
+The `name` attribute represents the name specifier in the tag that precedes the comments
+
+The `id` attribute represents the ID for the tag that precedes the comments

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -4,7 +4,7 @@ description: Documenting your code
 keywords: .NET, .NET Core
 author: tsolarin
 manager: wpickett
-ms.date: 08/02/2016
+ms.date: 08/18/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,23 +12,53 @@ ms.devlang: dotnet
 ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 ---
 
-# XML Documentation
+# Documenting your code
 
-XML documentation tags are specially formatted comments, added above the definition of any user defined type or member, used to document your code.
-Unlike regular C# comments documentation comments are not ignored by the compiler and you can generate the XML documentation file at compile time
-by adding `"xmlDoc": true` under `buildOptions` in your `project.json` when using .NET Core or use the `/doc` compiler option for the .NET framework.
+Documenting C# code is recommended practice as it helps make code easy to understand and maintain.
+Comments are a great way to add documentation to your C# code, they can help explain parts of your code and the great thing is,
+they do not add any overhead to your workflow because they usually are completely ignored by the compiler.
+
+## Single Line Comments
+
+Single line comments are a great way to explain C# code. They can be on a separate line or inline with your code.
+The comment body is prefixed by double forward slashes (`//`).
+
+```csharp
+// This comment describes variable i
+// Multiple lines could be a hassle
+int i = 0;
+int j = 1; // This comment describes variable j
+```
+
+## Multiline Comments
+
+Multiline comments function just like single line comments except that they make it easier to have comments that span multiple lines.
+The comment body starts with (`/*`) and ends with (`*/`).
+
+```csharp
+/*
+This describes variables i and j
+Multiline is less of a hassle
+*/
+int i = 0, j = 1;
+```
+
+Single line and Multiline comments are very useful for explaining code and getting new contributors up to speed with the codebase. They however 
+do not account for situations where the .NET assembly is distributed as a binary to third party developers with no available source code.
+This is where XML documentation comments come in handy.
+
+
+## XML Documentation Comments
+
+XML documentation comments are a special kind of comment, added above the definition of any user defined type or member. 
+They are special because they can be processed by the compiler to generate an XML documentation file at compile time.
+The compiler generated XML file can be distributed alongside your .NET assembly so that Visual Studio and other IDEs can show quick information about types or members when performing intellisense.
+Additionally the XML file can be run through tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) to generate full on API reference websites.
+
+XML documentation comments like all other comments are ignored by the compiler, to enable generation of the XML file add `"xmlDoc":true` under `buildOptions` in your `project.json` when using .NET Core or use the `/doc` compiler option for the .NET framework.
 Go [here](https://msdn.microsoft.com/en-us/library/3260k4x7.aspx) to learn how to enable XML documentation generation in Visual Studio.
 
-Comments are used to add documentation to your C# code. Single line comments start with double forward slashes `//` while multiline comments start with `/*` and terminates with `*/`,
-XML documentation comments span multiple lines but each must begin with triple forward slashes `///`.
-
-There are tools tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) that help you generate documentation websites from your documentation tags,
-also, distributing the compiler generated XML file along with your library allows Visual Studio and other IDEs to show quick information about types or members when performing intellisense. 
-
-<a name="summary"></a>
-## &lt;summary&gt;
-
-The `<summary>` tag contains the primary information of a class or method.
+XML documentation comments are characterized by triple forward slashes (`///`) and an XML formatted comment body.
 
 ```csharp
 /// <summary>
@@ -36,203 +66,645 @@ The `<summary>` tag contains the primary information of a class or method.
 /// </summary>
 public class SomeClass
 {
-    /// <summary>
-    /// This method does stuff.
-    /// </summary>
-    public void DoStuff(int a)
-    {
 
+}
+```
+
+## Walkthrough
+
+In this section I'm going to walk you through documenting a very basic math library to make it easy for new developers to understand/contribute and for third party developers to use.
+We're going to use a combination of single line comments, multiline comments and XML documentation tags.
+
+Here's code for the simple math library:
+
+```csharp
+public class Math
+{
+    public static int Add(int a, int b)
+    {
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
     }
 
-    /// <summary>
-    /// This method does more stuff.
-    /// </summary>
-    public void DoMoreStuff(int a, string b)
+    public static double Add(double a, double b)
     {
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
 
+        return a + b;
+    }
+
+    public static int Subtract(int a, int b)
+    {
+        return a - b;
+    }
+
+    public static double Subtract(double a, double b)
+    {
+        return a - b;
+    }
+
+    public static int Multiply(int a, int b)
+    {
+        return a * b;
+    }
+
+    public static double Multiply(double a, double b)
+    {
+        return a * b;
+    }
+
+    public static int Divide(int a, int b)
+    {
+        return a / b;
+    }
+
+    public static double Divide(double a, double b)
+    {
+        return a / b;
     }
 }
 ```
 
-<a name="remarks"></a>
-## &lt;remarks&gt;
+The sample library above doesn't do much, it supports four major arithmetic operations `add`, `subtract`, `multiply` and `divide` on `int` and `double` datatypes.
+Now let's assume this is one huge library that is going to have a ton of developers, we'll need to add some comments to make it easier to understand.
+In this sample we'll use multiline comments for class definitions and single line comments otherwise, these are not imposed conventions however,
+so feel free to use the kind of comment the situation requires.
 
-The `<remarks>` tag is used to add information about a type or type members, 
-supplementing the information specified with `<summary>`.
+Here's the updated library code with comments added:
 
 ```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+public class Math
+{
+    // Adds two integers and returns the result
+    public static int Add(int a, int b)
+    {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    // Adds two doubles and returns the result
+    public static double Add(double a, double b)
+    {
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    // Subtracts an integer from another and returns the result
+    public static int Subtract(int a, int b)
+    {
+        return a - b;
+    }
+
+    // Subtracts a double from another and returns the result
+    public static double Subtract(double a, double b)
+    {
+        return a - b;
+    }
+
+    // Multiplies two intergers and returns the result
+    public static int Multiply(int a, int b)
+    {
+        return a * b;
+    }
+
+    // Multiplies two doubles and returns the result
+    public static double Multiply(double a, double b)
+    {
+        return a * b;
+    }
+
+    // Divides an integer by another and returns the result
+    public static int Divide(int a, int b)
+    {
+        return a / b;
+    }
+
+    // Divides a double by another and returns the result
+    public static double Divide(double a, double b)
+    {
+        return a / b;
+    }
+}
+```
+
+And there you have it! now any new developer can easily get quick insight into what each method and the overall class does.
+
+Next we want to be able to create an API reference document from our code for third party developers who use our library but don't have access to the source code.
+As mentioned earlier XML documentation tags can be used to achieve this, I will now introduce you to the standard XML tags the C# compiler supports.
+
+### &lt;summary&gt;
+
+First off is the `<summary>` tag and as the name suggests it is used to add brief information about a type or member.
+I'll demonstrate its use by adding it to the `Math` class definition and the first `Add` method, feel free to apply it to the rest of the code.
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
 /// <summary>
-/// This class primarily does something.
+/// The main Math class.
+/// Contains all methods for performing basic math functions.
+/// </summary>
+public class Math
+{
+    // Adds two integers and returns the result
+    /// <summary>
+    /// Adds two integers and returns the result.
+    /// </summary>
+    public static int Add(int a, int b)
+    {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+}
+```
+
+The `<summary>` tag is super important and I strongly advice it be included because its content is the primary source of type or member description in the resulting API reference document. 
+
+### &lt;remarks&gt;
+
+The `<remarks>` tag is used to add information about types or members, supplementing the information specified with `<summary>`.
+In this example I'll just add it to the class.
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// The main Math class.
+/// Contains all methods for performing basic math functions.
 /// </summary>
 /// <remarks>
-/// This class can also do everything.
+/// This class can add, subtract, multiply and divide.
 /// </remarks>
-public class SomeClass
+public class Math
 {
-    
+
 }
 ```
 
-<a name="returns"></a>
-## &lt;returns&gt;
+### &lt;returns&gt;
 
-The `<returns>` tag should be used in the comment for a method declaration to describe the return value.
+As the name suggests the `<returns>` tag is used in the comment for a method declaration to describe its return value.
+Like before this will be illustrated on the first `Add` method go ahead an implement it on other methods.
 
 ```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
+// Adds two integers and returns the result
     /// <summary>
-    /// This method does stuff.
+    /// Adds two integers and returns the result.
     /// </summary>
-    /// <returns>Stuff it has done.</returns>
-    public int DoStuff(int a)
+    /// <returns>
+    /// The sum of two integers.
+    /// </returns>
+    public static int Add(int a, int b)
     {
-        return a;
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
     }
+```
+
+### &lt;value&gt;
+
+The `<value>` works similarly to the `<returns>` tag except that it is used for properties.
+Let's assume our `Math` library had a static property called `PI` here's how we'll use this tag:
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// The main Math class.
+/// Contains all methods for performing basic math functions.
+/// </summary>
+/// <remarks>
+/// This class can add, subtract, multiply and divide.
+/// </remarks>
+public class Math
+{
+    /// <value>Gets the value of PI.</value>
+    public static double PI { get; }
 }
 ```
 
-<a name="example"></a>
-## &lt;example&gt;
+### &lt;example&gt;
 
-The `<example>` tag lets you specify an example of how to use a method or other library member. 
-This commonly involves using the [`<code>`](#code) and sometimes the [`<c>`](#c) tag.
+The `<example>` tag lets you specify an example of how to use a class, method or other member. 
+This involves using the child `<code>` tag.
 
 ```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
+// Adds two integers and returns the result
     /// <summary>
-    /// This method does stuff.
+    /// Adds two integers and returns the result.
     /// </summary>
+    /// <returns>
+    /// The sum of two integers.
+    /// </returns>
     /// <example>
     /// <code>
-    /// SomeClass someClass = new SomeClass();
-    /// bool somethingToDo = true;
-    /// if (somethingToDo)
+    /// int c = Math.Add(4, 5);
+    /// if (c > 10)
     /// {
-    ///     someClass.DoStuff();
+    ///     Console.WriteLine(c);
     /// }
     /// </code>
     /// </example>
-    public void DoStuff()
+    public static int Add(int a, int b)
     {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
 
+        return a + b;
     }
+```
+
+The `code` tag preserves line breaks and indentation for longer examples.
+
+### &lt;para&gt;
+
+Sometimes there is need to format the content of certain tags and that's where the `<para>` tag comes in.
+It is for use inside a tag, such as `<summary>`, `<remarks>`, or `<returns>`, and lets divide text into paragraphs.
+We'll go ahead and format the contents of the `<summary>` tag for our class definition.
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main Math class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+public class Math
+{
+
 }
 ```
 
-<a name="value"></a>
-## &lt;value&gt;
+### &lt;c&gt;
 
-The `<value>` lets you describe the value that a property represents.
+Still on the topic of formatting, let me introduce the `<c>` tag which is used for marking part of text as code.
+It's like the `<code>` tag but inline and is great when you want to show a quick code example as part of a tag's content.
+Let's update the documentation for the `Math` class.
 
 ```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
 /// <summary>
-/// This class does something.
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
 /// </summary>
-public class SomeClass
+public class Math
 {
-    /// <summary>
-    /// This is the Name property.
-    /// </summary>
-    /// <value>Gets or sets the name value of something.</value>
-    public string Name { get; set; }
+
 }
 ```
 
-<a name="exception"></a>
-## &lt;exception&gt;
+### &lt;exception&gt;
 
-The `<exception>` tag lets you specify possible exceptions that can be thrown. 
-It's applicable to methods, properties, events, and indexers.
+There's no getting rid of exceptions, there will always be exceptional situations your code is not built to handle.
+Good news is there's a way to let your developers know that certain methods can throw certain exceptions and that's by using the `<exception>` tag.
+Looking at our little Math library we can see that both `Add` methods throw an exception if a certain condition is met not so obvious though
+is that both `Divide` methods will throw as well if the parameter `b` is zero. Let's go ahead to add exception documentation these methods.
 
 ```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
 /// <summary>
-/// This class does something.
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
 /// </summary>
-public class SomeClass
+public class Math
 {
     /// <summary>
-    /// This method does stuff.
+    /// Adds two integers and returns the result.
     /// </summary>
-    /// <exception cref="System.ArgumentNullException">Thrown when there's no stuff to do.</exception>
-    /// <exception cref="System.InvalidOperationException">Thrown when it tries to do the wrong stuff.</exception>
-    public void DoStuff(string a)
+    /// <returns>
+    /// The sum of two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Add(4, 5);
+    /// if (c > 10)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    public static int Add(int a, int b)
     {
-        if (a == null)
-            throw new System.ArgumentNullException();
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
 
-        if (a == "wrong stuff")
-            throw new System.InvalidOperationException();
+        return a + b;
+    }
+
+    /// <summary>
+    /// Adds two doubles and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two doubles.
+    /// </returns>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    public static double Add(double a, double b)
+    {
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    /// <summary>
+    /// Divides an integer by another and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The division of two integers.
+    /// </returns>
+    /// <exception cref="System.DivideByZeroException">Thrown when a division by zero occurs.</exception>
+    public static int Divide(int a, int b)
+    {
+        return a / b;
+    }
+
+    /// <summary>
+    /// Divides a double by another and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The division of two doubles.
+    /// </returns>
+    /// <exception cref="System.DivideByZeroException">Thrown when a division by zero occurs.</exception>
+    public static double Divide(double a, double b)
+    {
+        return a / b;
     }
 }
 ```
 
 The `cref` attribute represents a reference to an exception that is available from the current compilation environment.
+This can be any type defined in the project or a referenced assembly, the compiler will issue a warning if its value cannot be resolved.
+
+### &lt;see&gt;
+
+While documenting your code with XML tags you might reach a point where you need to add some sort of reference to another part of the code to make your reader understand it better.
+The `<see>` tag is one that let's you create clickable links to documentation pages for other code elements. In our next example we'll create a clickable link between the two `Add` methods.
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+public class Math
+{
+    /// <summary>
+    /// Adds two integers and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Add(4, 5);
+    /// if (c > 10)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// See <see cref="Math.Add(double, double)"/> to add doubles.
+    public static int Add(int a, int b)
+    {
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    /// <summary>
+    /// Adds two doubles and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two doubles.
+    /// </returns>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// See <see cref="Math.Add(int, int)"/> to add integers.
+    public static double Add(double a, double b)
+    {
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+}
+```
+
+The `cref` is a **required** attribute that represents a reference to a type or its member that is available from the current compilation environment. 
 This can be any type defined in the project or a referenced assembly.
 
-<a name="c"></a>
-## &lt;c&gt;
+## &lt;seealso&gt;
 
-The `<c>` tag is used to indicate inline code.
+The `<seealso>` tag works similarly to the `<see>` tag, the only difference is that it's content is typically broken into a "See Also" section not that different from
+the one you sometimes see on the MSDN documentation pages. Here we'll add a `seealso` tag on the integer `Add` method to reference other methods in the class that accept interger parameters:
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+public class Math
+{
+    /// <summary>
+    /// Adds two integers and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Add(4, 5);
+    /// if (c > 10)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// See <see cref="Math.Add(double, double)"/> to add doubles.
+    /// <seealso cref="Math.Subtract(int, int)"/>
+    /// <seealso cref="Math.Multiply(int, int)"/>
+    /// <seealso cref="Math.Divide(int, int)"/>
+    public static int Add(int a, int b)
+    {
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+}
+```
+
+The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
+This can be any type defined in the project or a referenced assembly.
+
+### &lt;param&gt;
+
+The `<param>` tag is used for describing the parameters a method takes. Here's an example on the double `Add` method:
+The parameter the tag describes is specified in the **required** `name` attribute.
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+public class Math
+{
+    /// <summary>
+    /// Adds two doubles and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two doubles.
+    /// </returns>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// See <see cref="Math.Add(int, int)"/> to add integers.
+    /// <param name="a">A double precision number.</param>
+    /// <param name="b">A double precision number.</param>
+    public static double Add(double a, double b)
+    {
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+}
+```
+
+### &lt;typeparam&gt;
+
+The `<typeparam>` tag functions just like the `<param>` tag but for generic type or method declarations to describe a generic parameter.
+Since our math library doesn't have a generic method I'll just bring in `SomeClass` to demonstrate it.
 
 ```csharp
 /// <summary>
-/// <c>SomeClass</c> does something.
+/// This class does something.
 /// </summary>
 public class SomeClass
 {
     /// <summary>
-    /// <c>DoStuff</c> does stuff on an instance of <c>SomeClass</c>.
+    /// Does generic stuff.
     /// </summary>
-    public void DoStuff()
+    /// <typeparam name="T">The generic stuff to do.</typeparam>
+    public void DoGenericStuff<T>()
     {
 
     }
 }
 ```
 
-<a name="code"></a>
-## &lt;code&gt;
+### &lt;paramref&gt;
 
-The `<code>` tag is used to indicate that multiple lines of text should be marked as code.
-See the [`<example>`](#example) tag for sample usage.
-The tag preserves line breaks and indentation for longer examples.
+Sometimes you might be in the middle of describing what a method does in what could be a `<summary>` tag and you might want to make a reference
+to a parameter, the `<paramref>` tag is great for just this. Let's update the summary of our double based `Add` method. Like the `<param>` tag
+the parameter name is specified in the **required** `name` attribute.
 
-<a name="para"></a>
-## &lt;para&gt;
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+public class Math
+{
+    /// <summary>
+    /// Adds two doubles <paramref name="a"/> and <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two doubles.
+    /// </returns>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than zero.</exception>
+    /// See <see cref="Math.Add(int, int)"/> to add integers.
+    /// <param name="a">A double precision number.</param>
+    /// <param name="b">A double precision number.</param>
+    public static double Add(double a, double b)
+    {
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
 
-The `<para>` tag is for use inside a tag, such as `<summary>`, `<remarks>`, 
-or `<returns>`, and lets you add paragraphs to text.
+        return a + b;
+    }
+}
+```
+
+### &lt;typeparamref&gt;
+
+The `<typeparamref>` tag functions just like the `<paramref>` tag but for generic type or method declarations to describe a generic parameter.
+Since our math library doesn't have a generic method I'll just bring in `SomeClass` to demonstrate it.
 
 ```csharp
 /// <summary>
-/// <para>This class does something.</para>
-/// <para>This is a new paragraph.</para>
+/// This class does something.
 /// </summary>
 public class SomeClass
 {
     /// <summary>
-    /// This method does stuff.
-    /// <para>This is a paragraph</para>
+    /// Does generic stuff <typeparamref name="T"/>.
     /// </summary>
-    public void DoStuff()
+    /// <typeparam name="T">The generic stuff to do.</typeparam>
+    public void DoGenericStuff<T>()
     {
 
     }
 }
 ```
 
-<a name="list"></a>
-## &lt;list&gt;
+### &lt;list&gt;
 
-The `<list>` tag lets you format documentation information as an ordered list, unordered list or table.
+Although we don't get to use it with our math library the `<list>` tag is a very useful tag because it lets you format documentation information as an ordered list, unordered list or table.
+Here's a quick example with `SomeClass`:
 
 ```csharp
 /// <summary>
@@ -303,230 +775,550 @@ public class SomeClass
 }
 ```
 
-<a name="see"></a>
-## &lt;see&gt;
+### Putting it all together
 
-The `<see>` tag lets you specify a link from within text, 
-it creates internal hyperlinks to documentation pages for code elements. The `cref` attribute **must** be specified.
-
-The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
-This can be any type defined in the project or a referenced assembly.
+If you've followed this tutorial and applied the tags to your code where necessary your code should look like the following:
 
 ```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// This method does stuff.
-    /// See <see cref="SomeClass.DoMoreStuff"/> to do more stuff.
-    /// </summary>
-    public void DoStuff(int a)
-    {
-
-    }
-
-    /// <summary>
-    /// This method does more stuff.
-    /// </summary>
-    public void DoMoreStuff(int a, string b)
-    {
-
-    }
-}
-```
-
-<a name="seealso"></a>
-## &lt;seealso&gt;
-
-This tag identifies cross-references in the documentation to other types or members.
-The tags are typically broken out into a separate "See Also" section.
-This tag is useful because it allows tools to generate cross-references, indexes, and hyperlinked views of the documentation.
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// This method does stuff.
-    /// <seealso cref="SomeClass.DoMoreStuff"/>
-    /// </summary>
-    public void DoStuff(int a)
-    {
-
-    }
-
-    /// <summary>
-    /// This method does more stuff.
-    /// </summary>
-    public void DoMoreStuff(int a, string b)
-    {
-
-    }
-}
-```
-
-The `cref` attribute represents a reference to a type or its member that is available from the current compilation environment.
-This can be any type defined in the project or a referenced assembly.
-
-<a name="param"></a>
-## &lt;param&gt;
-
-The `<param>` tag should be used in the comment for a method declaration to describe one of the parameters for the method.
-To document multiple parameters, use multiple `<param>` tags. This tag is also applicable to indexers.
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// This method does stuff.
-    /// </summary>
-    /// <param name="a">The stuff to do.</param>
-    public void DoStuff(int a)
-    {
-
-    }
-
-    /// <summary>
-    /// This method does more stuff.
-    /// </summary>
-    /// <param name="a">A stuff to do.</param>
-    /// <param name="b">Another stuff to do.</param>
-    public void DoMoreStuff(int a, string b)
-    {
-
-    }
-}
-```
-
-The `name` attribute represents the name of a method parameter
-
-<a name="paramref"></a>
-## &lt;paramref&gt;
-
-The `<paramref>` tag gives you a way to indicate that a word in the code comments, 
-for example in a `<summary>` or `<remarks>` block refers to a parameter.
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// This method does stuff.
-    /// The parameter <paramref name="a"/> takes a number.
-    /// </summary>
-    /// <param name="a">The stuff to do.</param>
-    public void DoStuff(int a)
-    {
-
-    }
-}
-```
-
-<a name="typeparam"></a>
-## &lt;typeparam&gt;
-
-The `<typeparam>` tag should be used in the comment for a generic type or method declaration to describe a type parameter. 
-Add a tag for each type parameter of the generic type or method.
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// Does generic stuff.
-    /// </summary>
-    /// <typeparam name="T">The generic stuff to do.</typeparam>
-    public void DoGenericStuff<T>()
-    {
-
-    }
-}
-```
-
-<a name="typeparamref"></a>
-## &lt;typeparamref&gt;
-
-The `<typeparamref>` tag gives you a way to indicate that a word in the code comments, 
-for example in a `<summary>` or `<remarks>` block refers to a type parameter.
-
-```csharp
-/// <summary>
-/// This class does something.
-/// </summary>
-public class SomeClass
-{
-    /// <summary>
-    /// Does generic stuff <typeparamref name="T"/>.
-    /// </summary>
-    /// <typeparam name="T">The generic stuff to do.</typeparam>
-    public void DoGenericStuff<T>()
-    {
-
-    }
-}
-```
-
-<a name="include"></a>
-## &lt;include&gt;
-
-The `<include>` tag lets you refer to comments in a separate XML file that describe the types and members 
-in your source code as opposed to placing documentation comments directly in your source code file.
-
-```csharp
-/// <include file='docs.xml' path='Docs/Members[@name="someclass"]/SomeClass/*'/>
-public class SomeClass
-{
-    /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/DoStuff/*'/>
-    public void DoStuff(int a)
-    {
-
-    }
-}
-
-/// <include file='docs.xml' path='Docs/Members[@name="someotherclass"]/SomeOtherClass/*'/>
-public class SomeOtherClass
-{
-
-}
-
 /*
-    Contents of docs.xml
-    --------------------
-
-    <Docs>
-        <Members name="someclass">
-            <SomeClass>
-                <summary>
-                This class does something.
-                </summary>
-            </SomeClass>
-            <DoStuff>
-                <summary>
-                This method does stuff.
-                </summary>
-            </DoStuff>
-        </Members>
-        <Members name="someotherclass">
-            <SomeOtherClass>
-                <summary>
-                This class does some other thing.
-                </summary>
-            </SomeOtherClass>
-        </Members>
-    </Docs>
+    The main Math class
+    Contains all methods for performing basic math functions
 */
+/// <summary>
+/// <para>The main <c>Math</c> class.</para>
+/// <para>Contains all methods for performing basic math functions.</para>
+/// </summary>
+/// <remarks>
+/// This class can add, subtract, multiply and divide.
+/// </remarks>
+public class Math
+{
+    // Adds two integers and returns the result
+    /// <summary>
+    /// Adds two integers <paramref name="a"/> and <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Add(4, 5);
+    /// if (c > 10)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// See <see cref="Math.Add(double, double)"/> to add doubles.
+    /// <seealso cref="Math.Subtract(int, int)"/>
+    /// <seealso cref="Math.Multiply(int, int)"/>
+    /// <seealso cref="Math.Divide(int, int)"/>
+    /// <param name="a">An integer.</param>
+    /// <param name="b">An integer.</param>
+    public static int Add(int a, int b)
+    {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    // Adds two doubles and returns the result
+    /// <summary>
+    /// Adds two doubles <paramref name="a"/> and <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The sum of two doubles.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// double c = Math.Add(4.5, 5.4);
+    /// if (c > 10)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+    /// See <see cref="Math.Add(int, int)"/> to add integers.
+    /// <seealso cref="Math.Subtract(double, double)"/>
+    /// <seealso cref="Math.Multiply(double, double)"/>
+    /// <seealso cref="Math.Divide(double, double)"/>
+    /// <param name="a">A double precision number.</param>
+    /// <param name="b">A double precision number.</param>
+    public static double Add(double a, double b)
+    {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    // Subtracts an integer from another and returns the result
+    /// <summary>
+    /// Subtracts <paramref name="b"/> from <paramref name="a"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The difference between two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Subtract(4, 5);
+    /// if (c > 1)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// See <see cref="Math.Subtract(double, double)"/> to subtract doubles.
+    /// <seealso cref="Math.Add(int, int)"/>
+    /// <seealso cref="Math.Multiply(int, int)"/>
+    /// <seealso cref="Math.Divide(int, int)"/>
+    /// <param name="a">An integer.</param>
+    /// <param name="b">An integer.</param>
+    public static int Subtract(int a, int b)
+    {
+        return a - b;
+    }
+
+    // Subtracts a double from another and returns the result
+    /// <summary>
+    /// Subtracts a double <paramref name="b"/> from another double <paramref name="a"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The difference between two doubles.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// double c = Math.Subtract(4.5, 5.4);
+    /// if (c > 1)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// See <see cref="Math.Subtract(int, int)"/> to subtract integers.
+    /// <seealso cref="Math.Add(double, double)"/>
+    /// <seealso cref="Math.Multiply(double, double)"/>
+    /// <seealso cref="Math.Divide(double, double)"/>
+    /// <param name="a">A double precision number.</param>
+    /// <param name="b">A double precision number.</param>
+    public static double Subtract(double a, double b)
+    {
+        return a - b;
+    }
+
+    // Multiplies two intergers and returns the result
+    /// <summary>
+    /// Multiplies two integers <paramref name="a"/> and <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The product of two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Multiply(4, 5);
+    /// if (c > 100)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// See <see cref="Math.Multiply(double, double)"/> to multiply doubles.
+    /// <seealso cref="Math.Add(int, int)"/>
+    /// <seealso cref="Math.Subtract(int, int)"/>
+    /// <seealso cref="Math.Divide(int, int)"/>
+    /// <param name="a">An integer.</param>
+    /// <param name="b">An integer.</param>
+    public static int Multiply(int a, int b)
+    {
+        return a * b;
+    }
+
+    // Multiplies two doubles and returns the result
+    /// <summary>
+    /// Multiplies two doubles <paramref name="a"/> and <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The product of two doubles.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// double c = Math.Multiply(4.5, 5.4);
+    /// if (c > 100.0)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// See <see cref="Math.Multiply(int, int)"/> to multiply integers.
+    /// <seealso cref="Math.Add(double, double)"/>
+    /// <seealso cref="Math.Subtract(double, double)"/>
+    /// <seealso cref="Math.Divide(double, double)"/>
+    /// <param name="a">A double precision number.</param>
+    /// <param name="b">A double precision number.</param>
+    public static double Multiply(double a, double b)
+    {
+        return a * b;
+    }
+
+    // Divides an integer by another and returns the result
+    /// <summary>
+    /// Divides an integer <paramref name="a"/> by another integer <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The quotient of two integers.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// int c = Math.Divide(4, 5);
+    /// if (c > 1)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.DivideByZeroException">Thrown when <paramref name="b"/> is equal to 0.</exception>
+    /// See <see cref="Math.Divide(double, double)"/> to divide doubles.
+    /// <seealso cref="Math.Add(int, int)"/>
+    /// <seealso cref="Math.Subtract(int, int)"/>
+    /// <seealso cref="Math.Multiply(int, int)"/>
+    /// <param name="a">An integer dividend.</param>
+    /// <param name="b">An integer divisor.</param>
+    public static int Divide(int a, int b)
+    {
+        return a / b;
+    }
+
+    // Divides a double by another and returns the result
+    /// <summary>
+    /// Divides a double <paramref name="a"/> by another double <paramref name="b"/> and returns the result.
+    /// </summary>
+    /// <returns>
+    /// The quotient of two doubles.
+    /// </returns>
+    /// <example>
+    /// <code>
+    /// double c = Math.Divide(4.5, 5.4);
+    /// if (c > 1.0)
+    /// {
+    ///     Console.WriteLine(c);
+    /// }
+    /// </code>
+    /// </example>
+    /// <exception cref="System.DivideByZeroException">Thrown when <paramref name="b"/> is equal to 0.</exception>
+    /// See <see cref="Math.Divide(int, int)"/> to divide integers.
+    /// <seealso cref="Math.Add(double, double)"/>
+    /// <seealso cref="Math.Subtract(double, double)"/>
+    /// <seealso cref="Math.Multiply(double, double)"/>
+    /// <param name="a">A double precision dividend.</param>
+    /// <param name="b">A double precision divisor.</param>
+    public static double Divide(double a, double b)
+    {
+        return a / b;
+    }
+}
 ```
+
+From our sample code above we can generate a well detailed documentation website complete with clickable cross-references but we've introduced another problem, our code has become had to read.
+This is going to be a nightmare for any developers who want to contribute to this code, so much information to sift through. 
+Thankfully there's an XML tag that helps us deal with this:
+
+### &lt;include&gt;
+
+The `<include>` tag lets you refer to comments in a separate XML file that describe the types and members in your source code as opposed to placing documentation comments directly in your source code file.
+
+Now we're going to move all our XML tags into a separate XML file named `docs.xml`, feel free to name the file whatever you want.
+
+```xml
+<docs>
+    <members name="math">
+        <Math>
+            <summary>
+            <para>The main <c>Math</c> class.</para>
+            <para>Contains all methods for performing basic math functions.</para>
+            </summary>
+            <remarks>
+            This class can add, subtract, multiply and divide.
+            </remarks>
+        </Math>
+        <AddInt>
+            <summary>
+            Adds two integers <paramref name="a"/> and <paramref name="b"/> and returns the result.
+            </summary>
+            <returns>
+            The sum of two integers.
+            </returns>
+            <example>
+            <code>
+            int c = Math.Add(4, 5);
+            if (c > 10)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+            See <see cref="Math.Add(double, double)"/> to add doubles.
+            <seealso cref="Math.Subtract(int, int)"/>
+            <seealso cref="Math.Multiply(int, int)"/>
+            <seealso cref="Math.Divide(int, int)"/>
+            <param name="a">An integer.</param>
+            <param name="b">An integer.</param>
+        </AddInt>
+        <AddDouble>
+            <summary>
+            Adds two doubles <paramref name="a"/> and <paramref name="b"/> and returns the result.
+            </summary>
+            <returns>
+            The sum of two doubles.
+            </returns>
+            <example>
+            <code>
+            double c = Math.Add(4.5, 5.4);
+            if (c > 10)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+            See <see cref="Math.Add(int, int)"/> to add integers.
+            <seealso cref="Math.Subtract(double, double)"/>
+            <seealso cref="Math.Multiply(double, double)"/>
+            <seealso cref="Math.Divide(double, double)"/>
+            <param name="a">A double precision number.</param>
+            <param name="b">A double precision number.</param>
+        </AddDouble>
+        <SubtractInt>
+            <summary>
+            Subtracts <paramref name="b"/> from <paramref name="a"/> and returns the result.
+            </summary>
+            <returns>
+            The difference between two integers.
+            </returns>
+            <example>
+            <code>
+            int c = Math.Subtract(4, 5);
+            if (c > 1)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            See <see cref="Math.Subtract(double, double)"/> to subtract doubles.
+            <seealso cref="Math.Add(int, int)"/>
+            <seealso cref="Math.Multiply(int, int)"/>
+            <seealso cref="Math.Divide(int, int)"/>
+            <param name="a">An integer.</param>
+            <param name="b">An integer.</param>
+        </SubtractInt>
+        <SubtractDouble>
+            <summary>
+            Subtracts a double <paramref name="b"/> from another double <paramref name="a"/> and returns the result.
+            </summary>
+            <returns>
+            The difference between two doubles.
+            </returns>
+            <example>
+            <code>
+            double c = Math.Subtract(4.5, 5.4);
+            if (c > 1)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            See <see cref="Math.Subtract(int, int)"/> to subtract integers.
+            <seealso cref="Math.Add(double, double)"/>
+            <seealso cref="Math.Multiply(double, double)"/>
+            <seealso cref="Math.Divide(double, double)"/>
+            <param name="a">A double precision number.</param>
+            <param name="b">A double precision number.</param>
+        </SubtractDouble>
+        <MultiplyInt>
+            <summary>
+            Multiplies two integers <paramref name="a"/> and <paramref name="b"/> and returns the result.
+            </summary>
+            <returns>
+            The product of two integers.
+            </returns>
+            <example>
+            <code>
+            int c = Math.Multiply(4, 5);
+            if (c > 100)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            See <see cref="Math.Multiply(double, double)"/> to multiply doubles.
+            <seealso cref="Math.Add(int, int)"/>
+            <seealso cref="Math.Subtract(int, int)"/>
+            <seealso cref="Math.Divide(int, int)"/>
+            <param name="a">An integer.</param>
+            <param name="b">An integer.</param>
+        </MultiplyInt>
+        <MultiplyDouble>
+            <summary>
+            Multiplies two doubles <paramref name="a"/> and <paramref name="b"/> and returns the result.
+            </summary>
+            <returns>
+            The product of two doubles.
+            </returns>
+            <example>
+            <code>
+            double c = Math.Multiply(4.5, 5.4);
+            if (c > 100.0)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            See <see cref="Math.Multiply(int, int)"/> to multiply integers.
+            <seealso cref="Math.Add(double, double)"/>
+            <seealso cref="Math.Subtract(double, double)"/>
+            <seealso cref="Math.Divide(double, double)"/>
+            <param name="a">A double precision number.</param>
+            <param name="b">A double precision number.</param>
+        </MultiplyDouble>
+        <DivideInt>
+            <summary>
+            Divides an integer <paramref name="a"/> by another integer <paramref name="b"/> and returns the result.
+            </summary>
+            <returns>
+            The quotient of two integers.
+            </returns>
+            <example>
+            <code>
+            int c = Math.Divide(4, 5);
+            if (c > 1)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            <exception cref="System.DivideByZeroException">Thrown when <paramref name="b"/> is equal to 0.</exception>
+            See <see cref="Math.Divide(double, double)"/> to divide doubles.
+            <seealso cref="Math.Add(int, int)"/>
+            <seealso cref="Math.Subtract(int, int)"/>
+            <seealso cref="Math.Multiply(int, int)"/>
+            <param name="a">An integer dividend.</param>
+            <param name="b">An integer divisor.</param>
+        </DivideInt>
+        <DivideDouble>
+            <summary>
+            Divides a double <paramref name="a"/> by another double <paramref name="b"/> and returns the result.
+            </summary>
+            <returns>
+            The quotient of two doubles.
+            </returns>
+            <example>
+            <code>
+            double c = Math.Divide(4.5, 5.4);
+            if (c > 1.0)
+            {
+                Console.WriteLine(c);
+            }
+            </code>
+            </example>
+            <exception cref="System.DivideByZeroException">Thrown when <paramref name="b"/> is equal to 0.</exception>
+            See <see cref="Math.Divide(int, int)"/> to divide integers.
+            <seealso cref="Math.Add(double, double)"/>
+            <seealso cref="Math.Subtract(double, double)"/>
+            <seealso cref="Math.Multiply(double, double)"/>
+            <param name="a">A double precision dividend.</param>
+            <param name="b">A double precision divisor.</param>
+        </DivideDouble>
+    </members>
+</docs>
+```
+
+In our XML I basically put each member's documentation comments directly inside a tag named after what they do, you can choose your own strategy. 
+Now that we have our XML comments in a separate file let's see how our code can be made more readable using the `<include>` tag:
+
+```csharp
+/*
+    The main Math class
+    Contains all methods for performing basic math functions
+*/
+/// <include file='docs.xml' path='docs/members[@name="math"]/Math/*'/>
+public class Math
+{
+    // Adds two integers and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/AddInt/*'/>
+    public static int Add(int a, int b)
+    {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == int.MaxValue && b > 0) || (b == int.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    // Adds two doubles and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/AddDouble/*'/>
+    public static double Add(double a, double b)
+    {
+        // If any parameter is equal to the max value of an integer
+        // and the other is greater than zero
+        if ((a == double.MaxValue && b > 0) || (b == double.MaxValue && a > 0))
+            throw new System.OverflowException();
+
+        return a + b;
+    }
+
+    // Subtracts an integer from another and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/SubtractInt/*'/>
+    public static int Subtract(int a, int b)
+    {
+        return a - b;
+    }
+
+    // Subtracts a double from another and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/SubtractDouble/*'/>
+    public static double Subtract(double a, double b)
+    {
+        return a - b;
+    }
+
+    // Multiplies two intergers and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/MultiplyInt/*'/>
+    public static int Multiply(int a, int b)
+    {
+        return a * b;
+    }
+
+    // Multiplies two doubles and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/MultiplyDouble/*'/>
+    public static double Multiply(double a, double b)
+    {
+        return a * b;
+    }
+
+    // Divides an integer by another and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/DivideInt/*'/>
+    public static int Divide(int a, int b)
+    {
+        return a / b;
+    }
+
+    // Divides a double by another and returns the result
+    /// <include file='docs.xml' path='docs/members[@name="math"]/DivideDouble/*'/>
+    public static double Divide(double a, double b)
+    {
+        return a / b;
+    }
+}
+```
+
+An there you have it, our code is back to being readable and no documentation information has been lost. 
 
 The `filename` attribute represents the name of the XML file containing the documentation.
 
@@ -534,24 +1326,23 @@ The `path` attribute represents an [XPath](https://msdn.microsoft.com/en-us/libr
 
 The `name` attribute represents the name specifier in the tag that precedes the comments
 
-The `id` attribute represents the ID for the tag that precedes the comments
+The `id` attribute which can be used in place of `name` represents the ID for the tag that precedes the comments
 
-<a name="user-defined"></a>
-## User Defined Tags
+### User Defined Tags
 
 All the tags outlined above represent those that are recognized by the C# compiler. However, a user is free to define their own tags.
 Tools like Sandcastle bring support for extra tags like [`<event>`](http://ewsoftware.github.io/XMLCommentsGuide/html/81bf7ad3-45dc-452f-90d5-87ce2494a182.htm), [`<note>`](http://ewsoftware.github.io/XMLCommentsGuide/html/4302a60f-e4f4-4b8d-a451-5f453c4ebd46.htm)
 and even support [documenting namespaces](http://ewsoftware.github.io/XMLCommentsGuide/html/BD91FAD4-188D-4697-A654-7C07FD47EF31.htm).
 Custom or in-house documentation generation tools can also be used with the standard tags and multiple output formats from HTML to PDF can be supported.
 
-<a name="recommendations"></a>
 ## Recommendations
 
 Documenting code is definitely a recommended practice for lots of reasons. However, there are some best practices and general use case scenarios
 that need to be taken into consideration when using XML documentation tags in your C# code.
 
 * For the sake of consistency all publicly visible types and their members should be documented. If you must do it, do it all.
-* In addition to other tags, types and their members should have a `<summary>` tag.
+* Private members can also be documented using XML comments, however this exposes the inner (potentially confidential) workings of your library.
+* In addition to other tags, types and their members should have at the very list `<summary>` tag.
 * Documentation text should be written using complete sentences ending with full stops.
 * Partial classes are fully supported and documentation information will be concatenated into one.
 * The compiler verifies the syntax of `<exception>`, `<include>`, `<param>`, `<see>`, `<seealso>` and `<typeparam>` tags.

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -14,6 +14,10 @@ ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 
 # XML Documentation
 
+XML documentation tags are specially formatted comments, added above class and method 
+definitions, used to document your code. You can generate the XML doc file at compile time 
+by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
+
 * [&lt;c&gt;](#c)
 * [&lt;code&gt;](#code)
 * [&lt;example&gt;](#example)

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -4,7 +4,7 @@ description: Documenting your code
 keywords: .NET, .NET Core
 author: tsolarin
 manager: wpickett
-ms.date: 07/29/2016
+ms.date: 08/02/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -19,7 +19,9 @@ Unlike regular C# comments documentation comments are not ignored by the compile
 by adding `"xmlDoc": true` under `buildOptions` in your `project.json` when using .NET Core or use the `/doc` compiler option for the .NET framework.
 Go [here](https://msdn.microsoft.com/en-us/library/3260k4x7.aspx) to learn how to enable XML documentation generation in Visual Studio.
 
-Documentation tags are commented using three forward slashes (`///`) as opposed to two forward slashes (`//`) used for single line comments and `/** **/` for multiline comments.
+Comments are used to add documentation to your C# code. Single line comments start with double forward slashes `//` while multiline comments start with `/*` and terminates with `*/`,
+XML documentation comments span multiple lines but each must begin with triple forward slashes `///`.
+
 There are tools tools like [DocFX](https://dotnet.github.io/docfx/) and [Sandcastle](https://github.com/EWSoftware/SHFB) that help you generate documentation websites from your documentation tags,
 also, distributing the compiler generated XML file along with your library allows Visual Studio and other IDEs to show quick information about types or members when performing intellisense. 
 

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -978,7 +978,8 @@ Now you're going to move all your XML tags into a separate XML file named `docs.
             }
             </code>
             </example>
-            <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+            <exception cref="System.OverflowException">Thrown when one parameter is max 
+            and the other is greater than 0.</exception>
             See <see cref="Math.Add(double, double)"/> to add doubles.
             <seealso cref="Math.Subtract(int, int)"/>
             <seealso cref="Math.Multiply(int, int)"/>
@@ -1002,7 +1003,8 @@ Now you're going to move all your XML tags into a separate XML file named `docs.
             }
             </code>
             </example>
-            <exception cref="System.OverflowException">Thrown when one parameter is max and the other is greater than 0.</exception>
+            <exception cref="System.OverflowException">Thrown when one parameter is max 
+            and the other is greater than 0.</exception>
             See <see cref="Math.Add(int, int)"/> to add integers.
             <seealso cref="Math.Subtract(double, double)"/>
             <seealso cref="Math.Multiply(double, double)"/>

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -12,16 +12,23 @@ ms.devlang: dotnet
 ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 ---
 
-# 🔧 Documenting your code
+# XML Documentation
 
-> **Note**
-> 
-> This topic hasn’t been written yet! 
->
-> We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/494) at GitHub.
-> 
-> If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
->
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
->
+* [&lt;c&gt;](#c)
+* [&lt;code&gt;](#code)
+* [&lt;example&gt;](#example)
+* [&lt;exception&gt;](#exception)
+* [&lt;include&gt;](#include)
+* [&lt;list&gt;](#list)
+* [&lt;para&gt;](#para)
+* [&lt;param&gt;](#param)
+* [&lt;paramref&gt;](#paramref)
+* [&lt;permission&gt;](#permission)
+* [&lt;remarks&gt;](#remarks)
+* [&lt;returns&gt;](#returns)
+* [&lt;see&gt;](#see)
+* [&lt;seealso&gt;](#seealso)
+* [&lt;summary&gt;](#summary)
+* [&lt;typeparam&gt;](#typeparam)
+* [&lt;typeparamref&gt;](#typeparamref)
+* [&lt;value&gt;](#value)

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -61,7 +61,7 @@ The &lt;c&gt; tag is used to indicate that a single line of text should be marke
 ## &lt;code&gt;
 
 The &lt;code&gt; tag is used to indicate that multiple lines of text should be marked as code.
-It is used within the &lt;example&gt; tag
+See the &lt;example&gt; tag for sample usage.
 
 <a name="example"></a>
 ## &lt;example&gt;
@@ -112,10 +112,129 @@ The `cref` parameter represents a reference to an exception that is available fr
 The &lt;include&gt; tag lets you refer to comments in a separate XML file that describe the types and members 
 in your source code as opposed to placing documentation comments directly in your source code file.
 
+    
+    /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/SomeClass/*' />
+    public class SomeClass
+    {
+        /// <include file='docs.xml' path='Docs/Members[@name="someclass"]/DoStuff/*' />
+        public void DoStuff(int a)
+        {
+
+        }
+    }
+
+    /// <include file='docs.xml' path='Docs/Members[@name="someotherclass"]/SomeOtherClass/*' />
+    public class SomeOtherClass
+    {
+
+    }
+
+    /*
+        Contents of docs.xml
+        --------------------
+
+        <Docs>
+            <Members name="someclass">
+                <SomeClass>
+                    <summary>
+                    This class does something
+                    </summary>
+                </SomeClass>
+                <DoStuff>
+                    <summary>
+                    This method does stuff
+                    </summary>
+                </DoStuff>
+            </Members>
+            <Members name="someotherclass">
+                <SomeOtherClass>
+                    <summary>
+                    This class does some other thing
+                    </summary>
+                </SomeOtherClass>
+            </Members>
+        </Docs>
+    */
+
+The `filename` attribute represents the name of the XML file containing the documentation.
+
+The `tagpath` attribute represents the path of the tags in `filename` that leads to the `tag name`.
+
+The `name` attribute represents the name specifier in the tag that precedes the comments
+
+The `id` attribute represents the ID for the tag that precedes the comments
+
 <a name="list"></a>
 ## &lt;list&gt;
 
 The &lt;list&gt; tag lets you format documentation information as an ordered list, unordered list or table.
+
+    /// <summary>
+    /// This class does something
+    /// </summary>
+    public class SomeClass
+    {
+        /// <summary>
+        /// An example of an unordered list
+        /// <list type="bullet">
+        /// <item>
+        /// <term>Some term</term>
+        /// <description>Some description</description>
+        /// </item>
+        /// <item>
+        /// <term>Some term</term>
+        /// <description>Some description</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public void DoStuff(int a)
+        {
+
+        }
+
+        /// <summary>
+        /// An example of an ordered list
+        /// <list type="number">
+        /// <item>
+        /// <term>Some term</term>
+        /// <description>Some description</description>
+        /// </item>
+        /// <item>
+        /// <term>Some term</term>
+        /// <description>Some description</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public void DoMoreStuff(int a, string b)
+        {
+
+        }
+
+        /// <summary>
+        /// An example of a table
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Table Heading Col 1</term>
+        /// <term>Table Heading Col 2</term>
+        /// <term>Table Heading Col 3</term>
+        /// </listheader>
+        /// <item>
+        /// <term>Col 1 Row 1</term>
+        /// <term>Col 2 Row 1</term>
+        /// <term>Col 3 Row 1</term>
+        /// </item>
+        /// <item>
+        /// <term>Col 1 Row 2</term>
+        /// <term>Col 2 Row 2</term>
+        /// <term>Col 3 Row 2</term>
+        /// </item>
+        /// </list>
+        /// </summary>
+        public void DoALotMoreStuff(params string[] args)
+        {
+
+        }
+    }
 
 <a name="para"></a>
 ## &lt;para&gt;
@@ -275,7 +394,7 @@ The &lt;seealso&gt; tag lets you specify the text that you might want to appear 
 <a name="summary"></a>
 ## &lt;summary&gt;
 
-The &lt;summary&gt; tag contains the primary information of a class or method
+The &lt;summary&gt; tag contains the primary information of a class or method.
 
     /// <summary>
     /// This class does something

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -16,8 +16,8 @@ ms.assetid: 8e75e317-4a55-45f2-a866-e76124171838
 
 by [Toni Solarin-Sodara](https://github.com/tsolarin)
 
-XML documentation tags are specially formatted comments, added above class and method 
-definitions, used to document your code. You can generate the XML doc file at compile time 
+XML documentation tags are specially formatted comments, added above the definition of a class 
+or its members, used to document your code. You can generate the XML documentation file at compile time 
 by adding `"xmlDoc": true` under `buildOptions` in your `project.json`
 
 * [&lt;c&gt;](#c)

--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -33,4 +33,3 @@ Or, check out the [C# Concepts](concepts.md) to learn the features of the C# lan
 ## Experienced C# developers
 
 If you've used C# before, you should start by reading what's in the latest version of the language. Check out [What's new in C# 6](csharp-6.md) for the new features in the current version. Then, explore the [C# Concepts](concepts.md) where you want more depth.
- 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -55,7 +55,7 @@
 #### [Summary](csharp/expression-trees-summary.md)
 ### [🔧 Native interoperability](csharp/interop.md)
 ### [🔧 Reflection & code generation](csharp/reflection.md)
-### [🔧 Documenting your code](csharp/codedoc.md) 
+### [Documenting your code](csharp/codedoc.md) 
 ## [🔧 Syntax Reference](csharp/syntax.md)
 
 <!-- Note to self: update languages/csharp/index.md to match this file


### PR DESCRIPTION
This PR adds content for C# Code documentation.

Changes include
- Brief description of XML documentation tags and how to enable it in `project.json`
- Reference to XML documentation tags 
- Example usage of each tag

Fixes #67 

/cc @BillWagner 
