### PR TITLE
Update samples still usring rc2

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -120,7 +120,7 @@ get xUnit.net to work with .NET Core RTM:
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "dnxcore54",
+        "dotnet54",
         "portable-net45+win8" 
       ]
     }

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -97,43 +97,11 @@ namespace Prime.Services
 ### Creating the test project
 
 Next, cd into the 'test' directory, and create the `PrimeServices.Tests` directory.
-CD into the `PrimeServices.Tests` directory and create a new project using `dotnet new`.
-Once again, `dotnet new` creates a console application. Your unit test project is
-a console application, but the unit test assembly should not contain the application
-entry point. The xunit testrunner contains the entry point to run the console application.
-Therefore, you need to modify
-`project.json` by removing the `buildOptions` node.
- 
-```json
-"buildOptions" : {
-    "emitEntryPoint": true
-}
-```
+CD into the `PrimeServices.Tests` directory and create a new project using
+`dotnet new -t xunittest`. `dotnet new -t xunittest` creates a test project
+that uses xunit as the test library. 
 
-The test project requires other packages to create and run unit tests.
-You'll need to add xunit, the xunit runner, and the PrimeService
-package as dependencies to the project:
-
-```json
-"dependencies": {
-    "Microsoft.NETCore.App": {
-        "type": "platform",
-        "version": "1.0.0-rc2-3002702"
-    },
-    "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-build10025",
-    "PrimeService": "1.0.0"
-}
-```
-
-Notice that the `PrimeService` project does not include
-any directory path information. Because you created the
-project structure to match the expected organization of
-`src` and `test`, and the `global.json` file indicates
-that, the build system will find the correct location
-for the project.
-
-You'll also need to add a node to specify the test runner
+The generated template configured the test runner
 at the root of `project.json`:
 
 ```json
@@ -144,20 +112,49 @@ at the root of `project.json`:
 }
 ```
 
-Finally, you need to set the framework node to use
+The template also sets the framework node to use
 `netcoreapp1.0`, and include the required imports to
-get xUnit.net to work with RC2:
+get xUnit.net to work with .NET Core RTM:
 
 ```json
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "dnxcore50",
+        "dnxcore54",
         "portable-net45+win8" 
       ]
     }
   }
 ```
+
+
+The test project requires other packages to create and run unit tests.
+`dotnet new` added xunit, and the xunit runner. You need to add the PrimeService
+package as another dependency to the project:
+
+```json
+"dependencies": {
+  "Microsoft.NETCore.App": {
+    "type":"platform",
+    "version": "1.0.0"
+  },
+  "xunit":"2.1.0",
+  "dotnet-test-xunit": "1.0.0-rc2-192208-24",
+  "PrimeService": {
+    "target": "project"
+  }
+}
+```
+
+Notice that the `PrimeService` project does not include
+any directory path information. Because you created the
+project structure to match the expected organization of
+`src` and `test`, and the `global.json` file indicates
+that, the build system will find the correct location
+for the project. You add the `"target": "project"` element
+to inform NuGet that it should look in project directories,
+not in the NuGet feed. Without this key, you might download
+a package with the same name as your internal library.
 
 You can see the entire file in the [samples repository](https://github.com/dotnet/core-docs/blob/master/samples/unit-testing/using-dotnet-test/test/PrimeService.Tests/project.json)
 on GitHub.

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -301,20 +301,22 @@ running `dotnet publish` and examining the files that are part of the installed
 package. You'll see `System.Collections.dll` in the list. 
 
 ```json
-{
-  "version": "1.0.0-*",
-  "buildOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702"
-    }
-  },
-  "frameworks": {
-    "netcoreapp1.0": {
-      "imports": "dnxcore50"
-    }
+{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
   },
   "runtimes": {
     "win10-x64": {},

--- a/samples/core-projects/console-apps/Fibonacci/project.json
+++ b/samples/core-projects/console-apps/Fibonacci/project.json
@@ -1,17 +1,19 @@
-﻿{
-  "version": "1.0.0-*",
-  "buildOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702"
-    }
-  },
-  "frameworks": {
-    "netcoreapp1.0": {
-      "imports": "dnxcore50"
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
   },
   "runtimes": {
     "win10-x64": {},

--- a/samples/core-projects/console-apps/FibonacciBetter/project.json
+++ b/samples/core-projects/console-apps/FibonacciBetter/project.json
@@ -1,17 +1,19 @@
-﻿{
-  "version": "1.0.0-*",
-  "buildOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702"
-    }
-  },
-  "frameworks": {
-    "netcoreapp1.0": {
-      "imports": "dnxcore50"
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
   },
   "runtimes": {
     "win10-x64": {},

--- a/samples/core-projects/console-apps/Hello/project.json
+++ b/samples/core-projects/console-apps/Hello/project.json
@@ -1,17 +1,19 @@
-{
-  "version": "1.0.0-*",
-  "buildOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc2-3002702"
-    }
-  },
-  "frameworks": {
-    "netcoreapp1.0": {
-      "imports": "dnxcore50"
-    }
-  }
+{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/core-projects/console-apps/HelloNative/project.json
+++ b/samples/core-projects/console-apps/HelloNative/project.json
@@ -1,21 +1,22 @@
-{
-  "version": "1.0.0-*",
-  "buildOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702"
-    }
-  },
-  "frameworks": {
-    "netcoreapp1.0": {
-      "imports": "dnxcore50"
-    }
-  },
+{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  }, 
   "runtimes": {
     "win10-x64": {},
     "osx.10.11-x64": {}
   }
-
 }
+

--- a/samples/core-projects/console-apps/NewTypes/test/NewTypesTests/project.json
+++ b/samples/core-projects/console-apps/NewTypes/test/NewTypesTests/project.json
@@ -1,22 +1,28 @@
 {
   "version": "1.0.0-*",
-  "testRunner": "xunit",
-
-  "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type":"platform",
-      "version": "1.0.0"
-    },
-    "xunit":"2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "NewTypes": "1.0.0"
+  "buildOptions": {
+    "debugType": "portable"
   },
+  "dependencies": {
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
+    "NewTypes": {"target": "project"}
+  },
+  "testRunner": "xunit",
   "frameworks": {
     "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
       "imports": [
-        "dnxcore50",
-        "portable-net45+win8" 
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   }
 }
+

--- a/samples/csharp-language/WeatherMicroservice/project.json
+++ b/samples/csharp-language/WeatherMicroservice/project.json
@@ -9,11 +9,11 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002702",
+      "version": "1.0.0",
       "type": "platform"
     },
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Newtonsoft.Json": "8.0.4-beta1"
   },
 

--- a/samples/csharp-language/console-linq/project.json
+++ b/samples/csharp-language/console-linq/project.json
@@ -1,17 +1,19 @@
-﻿{
-    "version": "1.0.0-*",
-    "buildOptions": {
-        "emitEntryPoint": true
-    },
-    "dependencies": {
-        "Microsoft.NETCore.App": {
-            "version": "1.0.0-rc2-3002702",
-            "type": "platform"
-        }
-    },
-    "frameworks": {
-        "netcoreapp1.0": {
-            "imports":"dnxcore50"
-        }
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/csharp-language/console-teleprompter/project.json
+++ b/samples/csharp-language/console-teleprompter/project.json
@@ -1,18 +1,19 @@
-﻿{
-    "version": "1.0.0-*",
-    "buildOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "Microsoft.NETCore.App": {
-            "version": "1.0.0-rc2-3002702",
-            "type": "platform"
-        }
-    },
-    "frameworks": {
-        "netcoreapp1.0": {
-            "imports":"dnxcore50"
-        }
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/csharp-language/console-webapiclient/console-webapiclient.xproj
+++ b/samples/csharp-language/console-webapiclient/console-webapiclient.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>6e6c633f-2d95-4af1-aa07-830c5553c4cd</ProjectGuid>
+    <RootNamespace>console-webapiclient</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/samples/csharp-language/console-webapiclient/project.json
+++ b/samples/csharp-language/console-webapiclient/project.json
@@ -1,21 +1,22 @@
-﻿{
-    "version": "1.0.0-*",
-    "buildOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-       "Microsoft.NETCore.App": {
-            "version": "1.0.0-rc2-3002702",
-            "type": "platform"
-        },
-        "System.Runtime.Serialization.Json": "4.0.2-rc2-24027",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027"
-    },
-
-    "frameworks": {
-        "netcoreapp1.0": {
-            "imports":"dnxcore50"
-        }
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {
+    "System.Runtime.Serialization.Json": "4.0.2",
+    "System.Runtime.Serialization.Primitives": "4.1.1"
+  }, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/csharp-language/delegates-and-events/log.txt
+++ b/samples/csharp-language/delegates-and-events/log.txt
@@ -1,0 +1,4 @@
+7/14/2016 12:46:32 PM	Warning	Console	This is a warning message
+7/14/2016 12:46:32 PM	Warning	Console	This is a warning message
+7/14/2016 12:46:32 PM	Information	Console	Information message two
+7/14/2016 12:46:32 PM	Information	Console	Information message two

--- a/samples/csharp-language/delegates-and-events/project.json
+++ b/samples/csharp-language/delegates-and-events/project.json
@@ -1,14 +1,19 @@
-﻿{
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704"
-    },
-
-    "frameworks": {
-        "dnxcore50": { }
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/csharp-language/events/project.json
+++ b/samples/csharp-language/events/project.json
@@ -1,14 +1,19 @@
-﻿{
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704"
-    },
-
-    "frameworks": {
-        "dnxcore50": { }
-    }
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
+  "dependencies": {}, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/csharp-language/expression-trees/project.json
+++ b/samples/csharp-language/expression-trees/project.json
@@ -1,18 +1,21 @@
-﻿{
-  "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
-
+﻿{ 
+  "version": "1.0.0-*", 
+  "buildOptions": { 
+    "debugType": "portable", 
+    "emitEntryPoint": true 
+  }, 
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Dynamic.Runtime": "4.0.11-beta-23516"
-  },
-
-  "frameworks": {
-    "dnxcore50": {
-      "dependencies": {
-      }
-    }
-  }
+        "System.Dynamic.Runtime": "4.0.11"
+  }, 
+  "frameworks": { 
+    "netcoreapp1.0": { 
+      "dependencies": { 
+        "Microsoft.NETCore.App": { 
+          "type": "platform", 
+          "version": "1.0.0" 
+        } 
+      }, 
+      "imports": "dnxcore50" 
+    } 
+  } 
 }

--- a/samples/csharp-language/indexers/project.json
+++ b/samples/csharp-language/indexers/project.json
@@ -1,14 +1,19 @@
 ﻿{
     "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
+    "buildOptions": {
+        "emitEntryPoint": true,
+        "debugType": "portable"
     },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704"
-    },
-
+    "dependencies": {},
     "frameworks": {
-        "dnxcore50": { }
+        "netcoreapp1.0": { 
+            "dependencies": {
+                "Microsoft.NETCore.App" :{
+                    "type":"platform",
+                    "version": "1.0.0"
+                }
+            },
+            "imports":"dnxcore50"
+        }
     }
 }

--- a/samples/unit-testing/using-dotnet-test/src/PrimeService/project.json
+++ b/samples/unit-testing/using-dotnet-test/src/PrimeService/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     }
   },
   "frameworks": {

--- a/samples/unit-testing/using-dotnet-test/test/PrimeService.Tests/project.json
+++ b/samples/unit-testing/using-dotnet-test/test/PrimeService.Tests/project.json
@@ -5,10 +5,10 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type":"platform",
-      "version": "1.0.0-rc2-3002702"
+      "version": "1.0.0"
     },
     "xunit":"2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-build10015",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "PrimeService": "1.0.0"
   },
   "frameworks": {

--- a/samples/unit-testing/using-dotnet-test/test/PrimeService.Tests/project.json
+++ b/samples/unit-testing/using-dotnet-test/test/PrimeService.Tests/project.json
@@ -9,13 +9,21 @@
     },
     "xunit":"2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "PrimeService": "1.0.0"
+    "PrimeService": {
+      "target": "project"
+    }
   },
   "frameworks": {
     "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
       "imports": [
-        "dnxcore50",
-        "portable-net45+win8" 
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   }


### PR DESCRIPTION
Some samples were still using RC 2 binaries.

Update all project.json files to use the RTM bits.

Update related articles to match the code generated by the dotnet CLI templates.

/cc @dend @cartermp @blackdwarf 
