### PR TITLE
removed asset_id

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,4 @@
 ---
-asset_id: 
 layout: HubPage
 
 title: .NET Core Documentation 


### PR DESCRIPTION
Sorry for smallish commit message - this is a small change that will mitigate a series of build errors we're seeing related to an un-needed metadata element on hub pages. 
