### PR TITLE
Fixed more links to open.xamarin.com

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -68,7 +68,7 @@ Projects
 - [CoreFX](https://github.com/dotnet/coreclr) - .NET class libraries, used by .NET Core and to a degree by Mono via source sharing.
 - [Roslyn](https://github.com/dotnet/roslyn) - C# and Visual Basic compilers, used by most .NET platforms and tools. Exposes APIs for reading, writing and analyzing source code.
 - [F#](https://github.com/microsoft/visualfsharp) - F# compiler.
-- [Xamarin SDK](https://open.xamarin.com) -- Tools and libraries needed to write Android, iOS and macOS in C# and F#.
+- [Xamarin SDK](http://open.xamarin.com) - Tools and libraries needed to write Android, iOS and macOS in C# and F#.
 
 Standardized
 ------------

--- a/docs/about/products.md
+++ b/docs/about/products.md
@@ -130,7 +130,7 @@ There are several components that make up Mono:
 
 ### Xamarin SDK
 
-The [Xamarin SDK](https://open.xamarin.com) is used to build native mobile and device apps, primarily for Apple and Google ecosystems. It is based on Mono and is open source using the MIT license. You can use it to build iOS and Android apps for phones, tablets and watches. [Xamarin.Forms](https://www.xamarin.com/forms) is a popular way to write reusable UIs across Apple, Google and Windows apps.
+The [Xamarin SDK](http://open.xamarin.com) is used to build native mobile and device apps, primarily for Apple and Google ecosystems. It is based on Mono and is open source using the MIT license. You can use it to build iOS and Android apps for phones, tablets and watches. [Xamarin.Forms](https://www.xamarin.com/forms) is a popular way to write reusable UIs across Apple, Google and Windows apps.
 
 - Learn about the [Xamarin SDK](https://developer.xamarin.com/)
 - [Download Xamarin](https://www.xamarin.com/platform)


### PR DESCRIPTION
Fixed two more HTTPS links to open.xamarin.com.

The link fixed in #752 wasn't the only instance of this problem, this should be all of them.
