### PR TITLE
Missing option --version-suffix description and example added

### DIFF
--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -70,6 +70,10 @@ Places the temporary build artifacts in the specified directory. By default, the
 
 Configuration to use when building the project. If not specified, will default to "Debug".
 
+`--version-suffix`
+
+Updates the star in `-*` package version suffix with a specified one.
+
 ## EXAMPLES
 
 `dotnet pack`
@@ -87,3 +91,7 @@ Packs the current application and place the resulting packages into the specifie
 `dotnet pack --no-build --output nupkgs`
 
 Packs the current project into the specified folder and skips the build step.
+
+`dotnet pack --version-suffix "ci-1234"`
+
+Packs the current application and updates the resulting packages version with the given suffix. E.g. version `1.0.0-*` will be updated to `1.0.0-ci-1234`.

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -86,7 +86,7 @@ Packs the app1 project.
 	
 `dotnet pack --output nupkgs`
     
-Packs the current application and place the resulting packages into the specified folder.
+Packs the current project and place the resulting packages into the specified folder.
 
 `dotnet pack --no-build --output nupkgs`
 
@@ -94,4 +94,4 @@ Packs the current project into the specified folder and skips the build step.
 
 `dotnet pack --version-suffix "ci-1234"`
 
-Packs the current application and updates the resulting packages version with the given suffix. E.g. version `1.0.0-*` will be updated to `1.0.0-ci-1234`.
+Packs the current project and updates the resulting packages version with the given suffix. E.g. version `1.0.0-*` will be updated to `1.0.0-ci-1234`.

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -72,7 +72,7 @@ Configuration to use when building the project. If not specified, will default t
 
 `--version-suffix`
 
-Updates the star in `-*` package version suffix with a specified one.
+Updates the star in `-*` package version suffix with a specified string.
 
 ## EXAMPLES
 


### PR DESCRIPTION
Missing option `--version-suffix` description and example added.

https://github.com/dotnet/cli/issues/3912#issuecomment-234730918
