### PR TITLE
Added missing return type to FindAllElementsWithAttribute

### DIFF
--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -69,7 +69,7 @@ For a significant chunk of software out in the wild, everything revolves around 
 Consider the following: finding all XML elements with a specific attribute value.
 
 ```cs
-public static FindAllElementsWithAttribute(XElement documentRoot, string elementName,
+public static IEnumerable<XElement> FindAllElementsWithAttribute(XElement documentRoot, string elementName,
                                            string attributeName, string value)
 {
     return from el in documentRoot.Elements(elementName)


### PR DESCRIPTION
# Added missing return type to FindAllElementsWithAttribute
## Summary

Method `FindAllElementsWithAttribute` was missing `IEnumerable<XElement>` as return type
## Details

No return type was specified in the signature of the method. The correct return type should be `IEnumerable<XElement>`
