### PR TITLE
Because there are other package managers

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -42,7 +42,7 @@ The recommended process for porting follows the following series of steps.  Each
 
 Here's a short list of the tools you'll find helpful:
 
-* NuGet - [Nuget Client](https://dist.nuget.org/index.html) or [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer), the package manager for the .NET Platform.
+* NuGet - [Nuget Client](https://dist.nuget.org/index.html) or [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer), Microsoft's package manager for the .NET Platform.
 * Api Portability Analyzer - [command line tool](https://github.com/Microsoft/dotnet-apiport/releases) or [Visual Studio Extension](https://visualstudiogallery.msdn.microsoft.com/1177943e-cfb7-4822-a8a6-e56c7905292b), a toolchain that can generate a report of how portable your code is between .NET Framework and .NET Core, with an assembly-by-assembly breakdown of issues.  See [Tooling to help you on the process](https://github.com/Microsoft/dotnet-apiport/blob/master/docs/HowTo/Introduction.md) for more information.
 * Reverse Package Search - A [useful web service](https://packagesearch.azurewebsites.net) that allows you to search for a type and find packages containing that type.
 


### PR DESCRIPTION
# Mark nuget as a package manager
## Summary

The nuget package manager is not the only package manager for .net, use of `the` considered unhelpful.
