### PR TITLE
added an anchor

### DIFF
--- a/docs/core/getting-started.md
+++ b/docs/core/getting-started.md
@@ -54,6 +54,7 @@ You can get started developing .NET Core apps by following these step-by-step tu
 
 .NET Core is supported by the Linux distributions and versions listed above in the installation links.
 
+<a name="macos"></a>
 ## OS X / macOS
 
 Install .NET Core for [Mac OS X 10.11](https://www.microsoft.com/net/core#macos).


### PR DESCRIPTION
There was a broken link on the top of the article linking to an undefined macos anchor. The only reason why I haven't use the automatically generated one is because GitHub and OPS are generating different ones in this case, so I'll open a bug to get this fixed.
