### PR TITLE
Correcting the version reference

### DIFF
--- a/docs/standard/library.md
+++ b/docs/standard/library.md
@@ -32,7 +32,7 @@ You can see the complete set of .NET runtimes that support the .NET Standard Lib
 | :---------- | :--------- |:--------- |:--------- |:--------- |:--------- |:--------- |:--------- |:--------- |
 |.NET Standard | netstandard | 1.0 | 1.1 | 1.2 | 1.3 | 1.4 | 1.5 | 1.6 |
 |.NET Core|netcoreapp|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|1.0|
-|.NET Framework|net|&rarr;|4.5|4.5.1|4.6|4.6.1|4.6.2|4.6.3|
+|.NET Framework|net|&rarr;|4.5|4.5.1|4.6|4.6.1|4.6.2|vNext|
 |Mono/Xamarin Platforms||&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|*|
 |Universal Windows Platform|uap|&rarr;|&rarr;|&rarr;|&rarr;|10.0|||
 |Windows|win|&rarr;|8.0|8.1|||||


### PR DESCRIPTION
# Correcting the version number for .NET Framework on the .NET Standards Library file
## Summary

Updated the version number for the next version of the .NET Framework, as it has not been officially deemed 4.6.3. 
## Suggested Reviewers

@richlander 
