### PR TITLE
Fixes project.json dependencies node mistake

### DIFF
--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -220,7 +220,7 @@ to create a new console application.
 Your console application depends on the library you built and tested
 in the previous steps. You need to indicate that by editing `project.json`
 to add this dependency.  In the `dependencies` node, add the `Library`
-node below the `Microsoft.NetCore.App` node as follows:
+node as follows:
 
 ```js
 "dependencies": {


### PR DESCRIPTION
The documentation incorrectly stated to add the 'Library' node to the frameworks section of the project.json.
