### PR TITLE
Update local build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,10 +94,10 @@ If you are comfortable with other ways listed on the link above, feel free to us
 You can build and preview the resulting site locally using a built-in web server. Navigate to the core-docs folder on your machine and type the following command:
 
 ```
-docfx .\docfx.json --serve
+docfx -t default --serve
 ```
 	
-This starts the local preview on [localhost:8080](http://localhost:8080). You can then view the changes by going to `http://localhost:8080/docs/[path]`, such as http://localhost:8080/docs/articles/.
+This starts the local preview on [localhost:8080](http://localhost:8080). You can then view the changes by going to `http://localhost:8080/[path]`, such as http://localhost:8080/articles/welcome.html.
 
 **Note:** the local preview currently doesn't contain any themes at the moment so the look and feel won't be the same as in the documentation site. We're working towards fixing that experience.
 


### PR DESCRIPTION
Update docfx build instructions based on https://github.com/dotnet/core-docs/issues/849#issuecomment-237763927.

cc: @chenkennt @mairaw 
