### PR TITLE
remove excess braces

### DIFF
--- a/docs/standard/collections/threadsafe/how-to-create-an-object-pool.md
+++ b/docs/standard/collections/threadsafe/how-to-create-an-object-pool.md
@@ -45,10 +45,7 @@ namespace ObjectPoolExample
         public T GetObject()
         {
             T item;
-            if (_objects.TryTake(out item)) return item;
-            {
-                return _objectGenerator();
-            }
+            return _objects.TryTake(out item) ? item : _objectGenerator();
         }
 
         public void PutObject(T item)


### PR DESCRIPTION
# Title

remove excess braces 
## Summary

The braces are a bit confusing as to their relationship with the `if` statement.
## Details

In some ways, I "like" this pattern.

In this case however, it initially reads as "if I successfully find an item in the collection, return an instance from the generator function"...until you notice the return to the right of the if statement.

There's a few ways to do this...I saw the ternary approach on someone else's article about object pooling in the same google results I found this post.
## Suggested Reviewers

If you know who should review this, use '@' to request a review.
