### PR TITLE
Most types on .NET are uppercase - even in F# type abbreviations

### DIFF
--- a/docs/fsharp/language-reference/type-abbreviations.md
+++ b/docs/fsharp/language-reference/type-abbreviations.md
@@ -30,7 +30,7 @@ Type abbreviations can include generic parameters, as in the following code.
 
 [!code-fsharp[Main](../../../samples/snippets/fsharp/lang-ref-1/snippet2302.fs)]
 
-In the previous code, `transform` is a type abbreviation that represents a function that takes a single argument of any type and that returns a single value of that same type.
+In the previous code, `Transform` is a type abbreviation that represents a function that takes a single argument of any type and that returns a single value of that same type.
 
 Type abbreviations are not preserved in the .NET Framework MSIL code. Therefore, when you use an F# assembly from another .NET Framework language, you must use the underlying type name for a type abbreviation.
 

--- a/samples/snippets/fsharp/lang-ref-1/snippet2301.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet2301.fs
@@ -1,2 +1,2 @@
 
-type sizeType = uint32
+type SizeType = uint32

--- a/samples/snippets/fsharp/lang-ref-1/snippet2302.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet2302.fs
@@ -1,2 +1,2 @@
 
-type transform<'a> = 'a -> 'a
+type Transform<'a> = 'a -> 'a


### PR DESCRIPTION
Most types on .NET are uppercase - even in F# type abbreviations
