### PR TITLE
Update using-on-windows.md

### DIFF
--- a/docs/core/tutorials/using-on-windows.md
+++ b/docs/core/tutorials/using-on-windows.md
@@ -41,7 +41,7 @@ A solution using only .NET Core projects
 
 3. In Solution Explorer, open the context menu for the **References** node and choose **Manage NuGet Packages**.
 
-4. Choose "nuget.org" as the **Package source**, and choose the **Browse** tab. Check the **Include prerelease** checkbox, and then browse for **Newtonsoft.Json**. Click **Install**. 
+4. Choose "nuget.org" as the **Package source**, and choose the **Browse** tab. Browse for **Newtonsoft.Json**. Click **Install**. 
 
 5. Open the context menu for the **References** node and choose  **Restore packages**.
 


### PR DESCRIPTION
# Remove "Check the Include prerelease checkbox"
## Summary

No need to include prerelease checkbox, as the latest release of Newtonsoft.Json (9.0.1 at the time of writing) is ok for NetStandard 1.6.0
