### PR TITLE
Add constructors-and-inheritance link in F# constructor doc.

### DIFF
--- a/docs/fsharp/language-reference/members/constructors.md
+++ b/docs/fsharp/language-reference/members/constructors.md
@@ -82,9 +82,11 @@ The following version of the previous code illustrates the combination of ordina
 
 [!code-fsharp[Main](../../../../samples/snippets/fsharp/lang-ref-2/snippet3507.fs)]
     
+## Constructors in inherited class
+You can definition constructors combined inherited class. For more information, see [Constructors and inheritance](../inheritance.md#constructors-and-inheritance).
+
 ## Static Constructors or Type Constructors
 In addition to specifying code for creating objects, static `let` and `do` bindings can be authored in class types that execute before the type is first used to perform initialization at the type level. For more information, see [`let` Bindings in Classes](let-bindings-in-classes.md) and [`do` Bindings in Classes](do-bindings-in-classes.md).
-
 
 ## See Also
 [Members](index.md)

--- a/docs/fsharp/language-reference/members/constructors.md
+++ b/docs/fsharp/language-reference/members/constructors.md
@@ -83,7 +83,7 @@ The following version of the previous code illustrates the combination of ordina
 [!code-fsharp[Main](../../../../samples/snippets/fsharp/lang-ref-2/snippet3507.fs)]
     
 ## Constructors in inherited class
-You can definition constructors combined inherited class. For more information, see [Constructors and inheritance](../inheritance.md#constructors-and-inheritance).
+When inheriting from a base class that has a constructor, you must specify its arguments in the inherit clause. For more information, see [Constructors and inheritance](../inheritance.md#constructors-and-inheritance).
 
 ## Static Constructors or Type Constructors
 In addition to specifying code for creating objects, static `let` and `do` bindings can be authored in class types that execute before the type is first used to perform initialization at the type level. For more information, see [`let` Bindings in Classes](let-bindings-in-classes.md) and [`do` Bindings in Classes](do-bindings-in-classes.md).


### PR DESCRIPTION
# Add constructors-and-inheritance link in F# constructor doc.

Add link F#'s constructor in inherited class.
## Summary

F#'s constructor doc lacks how to define constructor in inherited class.
## Details

I understand this docs in inheritance.md, so add link.
## Suggested Reviewers

I'm first time core-docs PR, please review @cartermp , thx.
