### PR TITLE
Fixed various indentation problems in the original file.

### DIFF
--- a/docs/fsharp/language-reference/computation-expressions.md
+++ b/docs/fsharp/language-reference/computation-expressions.md
@@ -97,80 +97,82 @@ type Eventually<'T> =
     | NotYetDone of (unit -> Eventually<'T>)
 
 module Eventually =
-// The bind for the computations. Append 'func' to the
-// computation.
-let rec bind func expr =
-    match expr with
-    | Done value -> NotYetDone (fun () -> func value)
-    | NotYetDone work -> NotYetDone (fun () -> bind func (work()))
+    // The bind for the computations. Append 'func' to the
+    // computation.
+    let rec bind func expr =
+        match expr with
+        | Done value -> NotYetDone (fun () -> func value)
+        | NotYetDone work -> NotYetDone (fun () -> bind func (work()))
 
-// Return the final value wrapped in the Eventually type.
-let result value = Done value
+    // Return the final value wrapped in the Eventually type.
+    let result value = Done value
 
-type OkOrException<'T> =
-    | Ok of 'T
-    | Exception of System.Exception
+    type OkOrException<'T> =
+        | Ok of 'T
+        | Exception of System.Exception
 
-// The catch for the computations. Stitch try/with throughout
-// the computation, and return the overall result as an OkOrException.
-let rec catch expr =
-    match expr with
-    | Done value -> result (Ok value)
-    | NotYetDone work ->
-        NotYetDone (fun () ->
-            let res = try Ok(work()) with | exn -> Exception exn
+    // The catch for the computations. Stitch try/with throughout
+    // the computation, and return the overall result as an OkOrException.
+    let rec catch expr =
+        match expr with
+        | Done value -> result (Ok value)
+        | NotYetDone work ->
+            NotYetDone (fun () ->
+                let res = try Ok(work()) with | exn -> Exception exn
+                match res with
+                | Ok cont -> catch cont // note, a tailcall
+                | Exception exn -> result (Exception exn))
+
+    // The delay operator.
+    let delay func = NotYetDone (fun () -> func())
+
+    // The stepping action for the computations.
+    let step expr =
+        match expr with
+        | Done _ -> expr
+        | NotYetDone func -> func ()
+
+    // The rest of the operations are boilerplate.
+    // The tryFinally operator.
+    // This is boilerplate in terms of "result", "catch", and "bind".
+    let tryFinally expr compensation =
+        catch (expr)
+        |> bind (fun res -> 
+            compensation();
             match res with
-            | Ok cont -> catch cont // note, a tailcall
-            | Exception exn -> result (Exception exn))
+            | Ok value -> result value
+            | Exception exn -> raise exn)
 
-// The delay operator.
-let delay func = NotYetDone (fun () -> func())
+    // The tryWith operator.
+    // This is boilerplate in terms of "result", "catch", and "bind".
+    let tryWith exn handler =
+        catch exn
+        |> bind (function Ok value -> result value | Exception exn -> handler exn)
 
-// The stepping action for the computations.
-let step expr =
-    match expr with
-    | Done _ -> expr
-    | NotYetDone func -> func ()
+    // The whileLoop operator.
+    // This is boilerplate in terms of "result" and "bind".
+    let rec whileLoop pred body =
+        if pred() then body |> bind (fun _ -> whileLoop pred body)
+        else result ()
 
-// The rest of the operations are boilerplate.
-// The tryFinally operator.
-// This is boilerplate in terms of "result", "catch", and "bind".
-let tryFinally expr compensation =
-    catch (expr)
-    |> bind (fun res -> 
-        compensation();
-        match res with
-        | Ok value -> result value
-        | Exception exn -> raise exn)
+    // The sequential composition operator.
+    // This is boilerplate in terms of "result" and "bind".
+    let combine expr1 expr2 =
+        expr1 |> bind (fun () -> expr2)
 
-// The tryWith operator.
-// This is boilerplate in terms of "result", "catch", and "bind".
-let tryWith exn handler =
-    catch exn
-    |> bind (function Ok value -> result value | Exception exn -> handler exn)
+    // The using operator.
+    let using (resource: #System.IDisposable) func =
+        tryFinally (func resource) (fun () -> resource.Dispose())
 
-// The whileLoop operator.
-// This is boilerplate in terms of "result" and "bind".
-let rec whileLoop pred body =
-    if pred() then body |> bind (fun _ -> whileLoop pred body)
-    else result ()
-
-// The sequential composition operator.
-// This is boilerplate in terms of "result" and "bind".
-let combine expr1 expr2 =
-    expr1 |> bind (fun () -> expr2)
-
-// The using operator.
-let using (resource: #System.IDisposable) func =
-    tryFinally (func resource) (fun () -> resource.Dispose())
-
-// The forLoop operator.
-// This is boilerplate in terms of "catch", "result", and "bind".
-let forLoop (collection:seq<_>) func =
-    let ie = collection.GetEnumerator()
-    tryFinally (whileLoop (fun () -> ie.MoveNext())
-        (delay (fun () -> let value = ie.Current in func value)))
-    (fun () -> ie.Dispose())
+    // The forLoop operator.
+    // This is boilerplate in terms of "catch", "result", and "bind".
+    let forLoop (collection:seq<_>) func =
+        let ie = collection.GetEnumerator()
+        tryFinally 
+            (whileLoop 
+                (fun () -> ie.MoveNext()) 
+                (delay (fun () -> let value = ie.Current in func value)))
+            (fun () -> ie.Dispose())
 
 // The builder class.
 type EventuallyBuilder() =
@@ -188,8 +190,8 @@ type EventuallyBuilder() =
 let eventually = new EventuallyBuilder()
 
 let comp = eventually {
-    for x in 1 .. 2 do
-    printfn " x = %d" x
+    for x in 1..2 do
+        printfn " x = %d" x
     return 3 + 4 }
 
 // Try the remaining lines in F# interactive to see how this 


### PR DESCRIPTION
1) Indented the module part
2) Realigned the misleadingly placed expressions in the forLoop function.
3) In `let comp` moved the `printfn " x = %d" x` one tab to the right.
