### PR TITLE
Improve `publishOptions.mappings` example

### DIFF
--- a/docs/core/tools/project-json.md
+++ b/docs/core/tools/project-json.md
@@ -721,7 +721,8 @@ String example:
 
     {
         "mappings": {
-            "dest/path": "./src/path"
+            "dest/path": "./src/path",
+            "dest/folder/": "./src/folder/**/*"
         }
     }
 
@@ -731,6 +732,9 @@ Object example:
         "mappings": {
             "dest/path":{
                 "include":"./src/path"
+            },
+            "dest/folder/":{
+                "include":"./src/folder/**/*"
             }
         }
     }
@@ -1056,8 +1060,7 @@ String example:
 
     {
         "mappings": {
-            "dest/file": "./src/file",
-            "dest/folder/": "./src/folder/**/*"
+            "dest/file": "./src/file"
         }
     }
 
@@ -1067,9 +1070,6 @@ Object example:
         "mappings": {
             "dest/file":{
                 "include":"./src/file"
-            },
-            "dest/folder/":{
-                "include":"./src/folder/**/*"
             }
         }
     }

--- a/docs/core/tools/project-json.md
+++ b/docs/core/tools/project-json.md
@@ -721,7 +721,7 @@ String example:
 
     {
         "mappings": {
-            "dest/path": "./src/path",
+            "dest/file": "./src/file",
             "dest/folder/": "./src/folder/**/*"
         }
     }
@@ -730,8 +730,8 @@ Object example:
 
     {
         "mappings": {
-            "dest/path":{
-                "include":"./src/path"
+            "dest/file":{
+                "include":"./src/file"
             },
             "dest/folder/":{
                 "include":"./src/folder/**/*"
@@ -1060,7 +1060,7 @@ String example:
 
     {
         "mappings": {
-            "dest/file": "./src/file"
+            "dest/path": "./src/path"
         }
     }
 
@@ -1068,8 +1068,8 @@ Object example:
 
     {
         "mappings": {
-            "dest/file":{
-                "include":"./src/file"
+            "dest/path":{
+                "include":"./src/path"
             }
         }
     }

--- a/docs/core/tools/project-json.md
+++ b/docs/core/tools/project-json.md
@@ -1056,7 +1056,8 @@ String example:
 
     {
         "mappings": {
-            "dest/path": "./src/path"
+            "dest/file": "./src/file",
+            "dest/folder/": "./src/folder/**/*"
         }
     }
 
@@ -1064,8 +1065,11 @@ Object example:
 
     {
         "mappings": {
-            "dest/path":{
-                "include":"./src/path"
+            "dest/file":{
+                "include":"./src/file"
+            },
+            "dest/folder/":{
+                "include":"./src/folder/**/*"
             }
         }
     }


### PR DESCRIPTION
# Title

Improve `publishOptions.mappings` example in `project.json`
## Summary

The documentation for `publishOptions.mappings` contains an example that ambiguously appears to work for both single files and folders.  However, they require different syntax. This edit improves the example to show each use case.
