### PR TITLE
Fix spacing in if...then...else.

### DIFF
--- a/docs/fsharp/language-reference/conditional-expressions-if-then-else.md
+++ b/docs/fsharp/language-reference/conditional-expressions-if-then-else.md
@@ -25,7 +25,7 @@ if boolean-expression then expression1 [ else expression2 ]
 ## Remarks
 In the previous syntax, *expression1* runs when the Boolean expression evaluates to `true`; otherwise, *expression2* runs.
 
-Unlike in other languages, the `if...then...else` construct is an expression, not a statement. That means that it produces a value, which is the value of the last expression in the branch that executes. The types of the values produced in each branch must match. If there is no explicit `else` branch, its type is `unit`. Therefore, if the type of the `then` branch is any type other than `unit`, there must be an `else` branch with the same return type. When chaining `if...then...else` expressions together, you can use the keyword `elif` instead of `else``if`; they are equivalent.
+Unlike in other languages, the `if...then...else` construct is an expression, not a statement. That means that it produces a value, which is the value of the last expression in the branch that executes. The types of the values produced in each branch must match. If there is no explicit `else` branch, its type is `unit`. Therefore, if the type of the `then` branch is any type other than `unit`, there must be an `else` branch with the same return type. When chaining `if...then...else` expressions together, you can use the keyword `elif` instead of `else if`; they are equivalent.
 
 ## Example
 The following example illustrates how to use the `if...then...else` expression.


### PR DESCRIPTION
# Fix spacing in Conditional Expressions: if...then...else
## Summary

The `else if` example in the last sentence of the paragraph renders incorrectly:

![elseif](https://cloud.githubusercontent.com/assets/1612952/17979368/0fa6ed32-6aaf-11e6-9c3b-b8444024906e.png)
