### PR TITLE
Adding default values

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -77,7 +77,8 @@
       "author": "dotnet-bot",
       "manager": "wpickett",
       "ms.date": "06/27/2016",
-      "ms.topic": "managed-reference"
+      "ms.topic": "managed-reference",
+      "ms.prod": ".net-core"
     },
     "dest": "_site",
     "template": [ "docs.html" ]

--- a/docfx.json
+++ b/docfx.json
@@ -74,7 +74,10 @@
     "globalMetadata": {
       "breadcrumb_path": "/dotnet/toc.json",
       "_displayLangs": ["csharp"],
-      "author": "dotnet-bot"
+      "author": "dotnet-bot",
+      "manager": "wpickett",
+      "ms.date": "06/27/2016",
+      "ms.topic": "managed-reference"
     },
     "dest": "_site",
     "template": [ "docs.html" ]


### PR DESCRIPTION
Managed reference has no metadata. Adding this workaround until we have a better solution to add values only to the API pages.
