### PR TITLE
Update global-json.md

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -4,7 +4,7 @@ description: Global.json reference
 keywords: .NET, .NET Core
 author: aL3891
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 09/01/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -14,30 +14,75 @@ ms.assetid: e1ac9659-425f-4486-a376-c12ca942ead8
 
 # Global.json reference
 
-* [projects/sources](#projects)
-* [packages](#packages)
-
-<a name="projects"></a>
 ## projects
 Type: String[]
 
-Specifies what folders the build system should search for projects when resolving dependencies.  The build system will only search top level child folders.
+Specifies which folders the build system should search for projects when resolving dependencies. The build system will only search top-level child folders.
 
-<a name="packages"></a>
+For example:
+
+```json
+{
+    "projects": [ "src", "test" ]
+}
+```
+
 ## packages
-Type: String[]
+Type: String
 
-The folder to store packages.
+The location to store packages.
 
+For example:
+```json
+{
+    "packages": "packages-dir"
+}
+```
 
+## sdk
+Type: Object
 
+Specifies information about the SDK.
 
+### version
+Type: String
 
+The version of the SDK to use.
 
+For example:
 
+```json
+{
+    "sdk": {
+        "version": "1.0.0-preview2-003121"
+    }
+}
+```
 
+### architecture
+Type: String
 
+Specifies which processor architecture to target. Supported values: `x86` or `x64`.
 
+For example:
+```json
+{
+    "sdk": {
+        "architecture": "x86"
+    }
+}
+```
 
+### runtime
+Type: String
 
+Determines which runtime to target. Supported values: `clr` or `coreclr`.
 
+For example:
+```json
+{
+    "sdk": {
+        "runtime": "clr"
+    }
+}
+```

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -58,31 +58,3 @@ For example:
     }
 }
 ```
-
-### architecture
-Type: String
-
-Specifies which processor architecture to target. Supported values: `x86` or `x64`.
-
-For example:
-```json
-{
-    "sdk": {
-        "architecture": "x86"
-    }
-}
-```
-
-### runtime
-Type: String
-
-Determines which runtime to target. Supported values: `clr` or `coreclr`.
-
-For example:
-```json
-{
-    "sdk": {
-        "runtime": "clr"
-    }
-}
-```

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -1,10 +1,11 @@
 ---
-title: Global.json reference
-description: Global.json reference
+title: global.json reference | .NET Core
+description: global.json reference
 keywords: .NET, .NET Core
 author: aL3891
+ms.author: mairaw
 manager: wpickett
-ms.date: 09/01/2016
+ms.date: 11/02/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,7 +13,10 @@ ms.devlang: dotnet
 ms.assetid: e1ac9659-425f-4486-a376-c12ca942ead8
 ---
 
-# Global.json reference
+# global.json reference
+
+The global.json file is used on .NET Core projects to define the solution metadata. This file is used when the [dotnet-restore](dotnet-restore.md) command is invoked to restore the dependencies of a .NET Core project.
+In this reference topic, you'll see the list of the properties you can define in your global.json file.
 
 ## projects
 Type: String[]


### PR DESCRIPTION
global.json reference was missing entries and examples.

Pending questions:

Does the packages property work? Or should we add a note about this dotnet/cli#3816?
What happens if runtime is not specified?
What happens if architecture is not specified?

/cc @blackdwarf @livarcocc
