### PR TITLE
Fix Tip content (remove "you can" repetition)

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -252,4 +252,4 @@ will be seamless, and you can concentrate on the problem at hand. The
 tools will run automatically.
    
    > [!TIP]
-   > On Windows platform you can you can use MSTest. You can find out more in the [Using MSTest on Windows document](./using-mstest-on-windows.md).
+   > On Windows platform you can use MSTest. Find out more in the [Using MSTest on Windows document](./using-mstest-on-windows.md).

--- a/docs/core/tutorials/using-on-windows.md
+++ b/docs/core/tutorials/using-on-windows.md
@@ -165,7 +165,7 @@ Starting from the solution obtained with the previous script, execute the follow
    The application should build and hit the breakpoint. The application output should be "The answer is 42.".
    
    > [!TIP]
-   > On Windows platform you can you can use MSTest. You can find out more in the [Using MSTest on Windows document](../testing/using-mstest-on-windows.md).
+   > On Windows platform you can use MSTest. Find out more in the [Using MSTest on Windows document](../testing/using-mstest-on-windows.md).
 
 Moving a library from netstandard 1.4 to 1.3
 --------------------------------------------


### PR DESCRIPTION
## Summary

The actual TIP content contains a repetition: "you can you can" and "You can" is also present in the beginning of the next sentence. This PR fixes it on both files that contain the Tip.
## Suggested Reviewers

@BillWagner 
