### PR TITLE
Improve titles of some F# articles

### DIFF
--- a/docs/fsharp/language-reference/conditional-expressions-if-then-else.md
+++ b/docs/fsharp/language-reference/conditional-expressions-if-then-else.md
@@ -1,6 +1,6 @@
 ---
-title: Conditional Expressions - if... then...else (F#)
-description: Conditional Expressions - if... then...else (F#)
+title: "Conditional Expressions: if... then...else (F#)"
+description: "Conditional Expressions: if... then...else (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/exception-handling/the-failwith-function.md
+++ b/docs/fsharp/language-reference/exception-handling/the-failwith-function.md
@@ -1,6 +1,6 @@
 ---
-title: Exceptions - The failwith Function (F#)
-description: Exceptions - The failwith Function (F#)
+title: "Exceptions: The failwith Function (F#)"
+description: "Exceptions: The failwith Function (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/exception-handling/the-invalidArg-function.md
+++ b/docs/fsharp/language-reference/exception-handling/the-invalidArg-function.md
@@ -1,6 +1,6 @@
 ---
-title: Exceptions - The invalidArg Function (F#)
-description: Exceptions - The invalidArg Function (F#)
+title: "Exceptions: The invalidArg Function (F#)"
+description: "Exceptions: The invalidArg Function (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/exception-handling/the-raise-function.md
+++ b/docs/fsharp/language-reference/exception-handling/the-raise-function.md
@@ -1,6 +1,6 @@
 ---
-title: Exceptions - the raise Function (F#)
-description: Exceptions - the raise Function (F#)
+title: "Exceptions: the raise Function (F#)"
+description: "Exceptions: the raise Function (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/exception-handling/the-try-finally-expression.md
+++ b/docs/fsharp/language-reference/exception-handling/the-try-finally-expression.md
@@ -1,6 +1,6 @@
 ---
-title: Exceptions - The try...finally Expression (F#)
-description: Exceptions - The try...finally Expression (F#)
+title: "Exceptions: The try...finally Expression (F#)"
+description: "Exceptions: The try...finally Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/exception-handling/the-try-with-expression.md
+++ b/docs/fsharp/language-reference/exception-handling/the-try-with-expression.md
@@ -1,6 +1,6 @@
 ---
-title: Exceptions - The try...with Expression (F#)
-description: Exceptions - The try...with Expression (F#)
+title: "Exceptions: The try...with Expression (F#)"
+description: "Exceptions: The try...with Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -1,6 +1,6 @@
 ---
-title: Lambda Expressions - The fun Keyword (F#)
-description: Lambda Expressions - The fun Keyword (F#)
+title: "Lambda Expressions: The fun Keyword (F#)"
+description: "Lambda Expressions: The fun Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/functions/recursive-functions-the-rec-keyword.md
+++ b/docs/fsharp/language-reference/functions/recursive-functions-the-rec-keyword.md
@@ -1,6 +1,6 @@
 ---
-title: Recursive Functions: The rec Keyword (F#)
-description: Recursive Functions: The rec Keyword (F#)
+title: "Recursive Functions: The rec Keyword (F#)"
+description: "Recursive Functions: The rec Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -1,6 +1,6 @@
 ---
-title: Import Declarations: The open Keyword (F#)
-description: Import Declarations: The open Keyword (F#)
+title: "Import Declarations: The open Keyword (F#)"
+description: "Import Declarations: The open Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/loops-for-in-expression.md
+++ b/docs/fsharp/language-reference/loops-for-in-expression.md
@@ -1,6 +1,6 @@
 ---
-title: Loops - for...in Expression (F#)
-description: Loops - for...in Expression (F#)
+title: "Loops: for...in Expression (F#)"
+description: "Loops: for...in Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/loops-for-to-expression.md
+++ b/docs/fsharp/language-reference/loops-for-to-expression.md
@@ -1,6 +1,6 @@
 ---
-title: Loops - for...to Expression (F#)
-description: Loops - for...to Expression (F#)
+title: "Loops: for...to Expression (F#)"
+description: "Loops: for...to Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/loops-while-do-expression.md
+++ b/docs/fsharp/language-reference/loops-while-do-expression.md
@@ -1,6 +1,6 @@
 ---
-title: Loops - while...do Expression (F#)
-description: Loops - while...do Expression (F#)
+title: "Loops: while...do Expression (F#)"
+description: "Loops: while...do Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
+++ b/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
@@ -1,6 +1,6 @@
 ---
-title: Explicit Fields: The val Keyword (F#)
-description: Explicit Fields: The val Keyword (F#)
+title: "Explicit Fields: The val Keyword (F#)"
+description: "Explicit Fields: The val Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/language-reference/resource-management-the-use-keyword.md
+++ b/docs/fsharp/language-reference/resource-management-the-use-keyword.md
@@ -1,6 +1,6 @@
 ---
-title: Resource Management - The use Keyword (F#)
-description: Resource Management - The use Keyword (F#)
+title: "Resource Management: The use Keyword (F#)"
+description: "Resource Management: The use Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/getting-started/getting-started-visual-studio.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-visual-studio.md
@@ -1,6 +1,6 @@
 ---
-title: Walkthrough - Your First F# Program
-description: Walkthrough - Your First F# Program
+title: Getting Started with F# in Visual Studio
+description: Getting Started with F# in Visual Studio
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database-entities.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database-entities.md
@@ -1,6 +1,6 @@
 ---
-title: Walkthrough - Accessing a SQL Database by Using Type Providers and Entities (F#)
-description: Walkthrough - Accessing a SQL Database by Using Type Providers and Entities (F#)
+title: "Walkthrough: Accessing a SQL Database by Using Type Providers and Entities (F#)"
+description: "Walkthrough: Accessing a SQL Database by Using Type Providers and Entities (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
@@ -1,6 +1,6 @@
 ---
-title: Walkthrough - Accessing a SQL Database by Using Type Providers (F#)
-description: Walkthrough - Accessing a SQL Database by Using Type Providers (F#)
+title: "Walkthrough: Accessing a SQL Database by Using Type Providers (F#)"
+description: "Walkthrough: Accessing a SQL Database by Using Type Providers (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/type-providers/accessing-an-odata-service.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-an-odata-service.md
@@ -1,6 +1,6 @@
 ---
-title: Walkthrough - Accessing an OData Service by Using Type Providers (F#)
-description: Walkthrough - Accessing an OData Service by Using Type Providers (F#)
+title: "Walkthrough: Accessing an OData Service by Using Type Providers (F#)"
+description: "Walkthrough: Accessing an OData Service by Using Type Providers (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
+++ b/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
@@ -1,6 +1,6 @@
 ---
-title: Tutorial - Creating a Type Provider (F#)
-description: Tutorial - Creating a Type Provider (F#)
+title: "Tutorial: Creating a Type Provider (F#)"
+description: "Tutorial: Creating a Type Provider (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
@@ -1,6 +1,6 @@
 ---
-title: Walkthrough - Generating F# Types from a DBML File (F#)
-description: Walkthrough - Generating F# Types from a DBML File (F#)
+title: "Walkthrough: Generating F# Types from a DBML File (F#)"
+description: "Walkthrough: Generating F# Types from a DBML File (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe

--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-edmx.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-edmx.md
@@ -1,6 +1,6 @@
 ---
-title: Walkthrough - Generating F# Types from an EDMX Schema File (F#)
-description: Walkthrough - Generating F# Types from an EDMX Schema File (F#)
+title: "Walkthrough: Generating F# Types from an EDMX Schema File (F#)"
+description: "Walkthrough: Generating F# Types from an EDMX Schema File (F#)"
 keywords: visual f#, f#, functional programming
 author: dend
 manager: danielfe


### PR DESCRIPTION
1. Fix articles with `:` in `title` using `"`
2. Make `title` and first heading of articles consistent:
   - Replace `-` with `:`
   - For `getting-started-visual-studio.md`, change the `title` entirely
