### PR TITLE
update names per naming guidelines.

### DIFF
--- a/docs/csharp/distinguish-delegates-events.md
+++ b/docs/csharp/distinguish-delegates-events.md
@@ -48,7 +48,7 @@ properly sort the elements. LINQ queries must be supplied with delegates
 in order to determine what elements to return. Both used a design built
 with delegates.
 
-Consider the `OnProgress` event handler. It reports progress on a task.
+Consider the `Progress` event handler. It reports progress on a task.
 The task continues to proceed whether or not there are any listeners.
 The `FileSearcher` is another example. It would still search and find
 all the files that were sought, even with no event subscribers attached.

--- a/docs/csharp/distinguish-delegates-events.md
+++ b/docs/csharp/distinguish-delegates-events.md
@@ -48,7 +48,7 @@ properly sort the elements. LINQ queries must be supplied with delegates
 in order to determine what elements to return. Both used a design built
 with delegates.
 
-Consider the `Progress` event handler. It reports progress on a task.
+Consider the `onProgress` event handler. It reports progress on a task.
 The task continues to proceed whether or not there are any listeners.
 The `FileSearcher` is another example. It would still search and find
 all the files that were sought, even with no event subscribers attached.

--- a/docs/csharp/distinguish-delegates-events.md
+++ b/docs/csharp/distinguish-delegates-events.md
@@ -48,7 +48,7 @@ properly sort the elements. LINQ queries must be supplied with delegates
 in order to determine what elements to return. Both used a design built
 with delegates.
 
-Consider the `onProgress` event handler. It reports progress on a task.
+Consider the `Progress` event. It reports progress on a task.
 The task continues to proceed whether or not there are any listeners.
 The `FileSearcher` is another example. It would still search and find
 all the files that were sought, even with no event subscribers attached.

--- a/docs/csharp/event-pattern.md
+++ b/docs/csharp/event-pattern.md
@@ -29,7 +29,7 @@ subscribe and process standard events in your code.
 The standard signature for a .NET event delegate is:
 
 ```cs
-void Handler(object sender, EventArgs args);
+void OnEventRaised(object sender, EventArgs args);
 ```
 
 The return type is void. Events are based on delegates and are
@@ -97,13 +97,13 @@ a pattern, and raise the correct event when a match is discovered.
 ```cs
 public class FileSearcher
 {
-    public event EventHandler<FileFoundArgs> OnFoundFile;
+    public event EventHandler<FileFoundArgs> FoundFile;
 
     public void Search(string directory, string searchPattern)
     {
         foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
         {
-            OnFoundFile?.Invoke(this, new FileFoundArgs(file));
+            FoundFile?.Invoke(this, new FileFoundArgs(file));
         }
     }
 }
@@ -115,7 +115,7 @@ The simplest way to add an event to your class is to declare that
 event as a public field, as in the above example:
 
 ```cs
-public event EventHandler<FileFoundArgs> OnFoundFile;
+public event EventHandler<FileFoundArgs> FoundFile;
 ```
 
 This looks like it's declaring a public field, which would appear to
@@ -126,15 +126,15 @@ that the event objects can only be accessed in safe ways. The only
 operations available on a field-like event are add handler:
 
 ```cs
-EventHandler<FileFoundArgs> handler = (sender, eventArgs) =>
+EventHandler<FileFoundArgs> OnFoundFile = (sender, eventArgs) =>
     Console.WriteLine(eventArgs.FoundFile);
-lister.OnFoundFile += handler;
+lister.FoundFile += OnFoundFile;
 ```
 
 and remove handler:
 
 ```cs
-lister.OnFoundFile -= handler;
+lister.FoundFile -= OnFoundFile;
 ```
 
 Note that there's a local variable for the handler. If you used
@@ -205,7 +205,7 @@ public void List(string directory, string searchPattern)
     foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
     {
         var args = new FileFoundArgs(file);
-        OnFoundFile?.Invoke(this, args);
+        FoundFile?.Invoke(this, args);
         if (args.CancelRequested)
             break;
     }
@@ -221,7 +221,7 @@ Let's update the subscriber so that it requests a cancellation once
 it finds the first executable:
 
 ```cs
-EventHandler<FileFoundArgs> handler = (sender, eventArgs) =>
+EventHandler<FileFoundArgs> OnFoundFile = (sender, eventArgs) =>
 {
     Console.WriteLine(eventArgs.FoundFile);
     eventArgs.CancelRequested = true;
@@ -270,7 +270,7 @@ need extra code in those handlers in this project, but this shows how
 you would create them.
 
 ```cs
-internal event EventHandler<SearchDirectoryArgs> OnChangeDirectory
+internal event EventHandler<SearchDirectoryArgs> ChangeDirectory
 {
     add { changeDirectory += value; }
     remove { changeDirectory -= value; }
@@ -323,7 +323,7 @@ private void SearchDirectory(string directory, string searchPattern)
     foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
     {
         var args = new FileFoundArgs(file);
-        OnFoundFile?.Invoke(this, args);
+        FoundFile?.Invoke(this, args);
         if (args.CancelRequested)
             break;
     }
@@ -332,14 +332,14 @@ private void SearchDirectory(string directory, string searchPattern)
 
 At this point, you can run the application calling the overload for
 searching all sub-directories. There are no subscribers on the new
-`OnChangeDirectory` event, but using the `?.Invoke()` idiom ensures
+`ChangeDirectory` event, but using the `?.Invoke()` idiom ensures
 that this works correctly.
 
  Let's add a handler to write a line that shows the progress in the
  console window. 
 
 ```cs
-lister.OnChangeDirectory += (sender, eventArgs) =>
+lister.ChangeDirectory += (sender, eventArgs) =>
 {
     Console.Write($"Entering '{eventArgs.CurrentSearchDirectory}'.");
     Console.WriteLine($" {eventArgs.CompletedDirs} of {eventArgs.TotalDirs} completed...");

--- a/docs/csharp/event-pattern.md
+++ b/docs/csharp/event-pattern.md
@@ -126,7 +126,7 @@ that the event objects can only be accessed in safe ways. The only
 operations available on a field-like event are add handler:
 
 ```cs
-EventHandler<FileFoundArgs> OnFoundFile = (sender, eventArgs) =>
+EventHandler<FileFoundArgs> onFoundFile = (sender, eventArgs) =>
     Console.WriteLine(eventArgs.FoundFile);
 lister.FoundFile += OnFoundFile;
 ```
@@ -221,7 +221,7 @@ Let's update the subscriber so that it requests a cancellation once
 it finds the first executable:
 
 ```cs
-EventHandler<FileFoundArgs> OnFoundFile = (sender, eventArgs) =>
+EventHandler<FileFoundArgs> onFoundFile = (sender, eventArgs) =>
 {
     Console.WriteLine(eventArgs.FoundFile);
     eventArgs.CancelRequested = true;
@@ -270,12 +270,12 @@ need extra code in those handlers in this project, but this shows how
 you would create them.
 
 ```cs
-internal event EventHandler<SearchDirectoryArgs> ChangeDirectory
+internal event EventHandler<SearchDirectoryArgs> ChangedDirectory
 {
     add { changeDirectory += value; }
     remove { changeDirectory -= value; }
 }
-private event EventHandler<SearchDirectoryArgs> changeDirectory;
+private EventHandler<SearchDirectoryArgs> changedDirectory;
 ```
 
 In may ways, the code you write here mirrors the code the compiler

--- a/docs/csharp/event-pattern.md
+++ b/docs/csharp/event-pattern.md
@@ -97,13 +97,13 @@ a pattern, and raise the correct event when a match is discovered.
 ```cs
 public class FileSearcher
 {
-    public event EventHandler<FileFoundArgs> FoundFile;
+    public event EventHandler<FileFoundArgs> FileFound;
 
     public void Search(string directory, string searchPattern)
     {
         foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
         {
-            FoundFile?.Invoke(this, new FileFoundArgs(file));
+            FileFound?.Invoke(this, new FileFoundArgs(file));
         }
     }
 }
@@ -115,7 +115,7 @@ The simplest way to add an event to your class is to declare that
 event as a public field, as in the above example:
 
 ```cs
-public event EventHandler<FileFoundArgs> FoundFile;
+public event EventHandler<FileFoundArgs> FileFound;
 ```
 
 This looks like it's declaring a public field, which would appear to
@@ -126,15 +126,15 @@ that the event objects can only be accessed in safe ways. The only
 operations available on a field-like event are add handler:
 
 ```cs
-EventHandler<FileFoundArgs> onFoundFile = (sender, eventArgs) =>
+EventHandler<FileFoundArgs> onFileFound = (sender, eventArgs) =>
     Console.WriteLine(eventArgs.FoundFile);
-lister.FoundFile += OnFoundFile;
+lister.FileFound += onFIleFound;
 ```
 
 and remove handler:
 
 ```cs
-lister.FoundFile -= OnFoundFile;
+lister.FileFound -= onFileFound;
 ```
 
 Note that there's a local variable for the handler. If you used
@@ -205,7 +205,7 @@ public void List(string directory, string searchPattern)
     foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
     {
         var args = new FileFoundArgs(file);
-        FoundFile?.Invoke(this, args);
+        FileFound?.Invoke(this, args);
         if (args.CancelRequested)
             break;
     }
@@ -221,7 +221,7 @@ Let's update the subscriber so that it requests a cancellation once
 it finds the first executable:
 
 ```cs
-EventHandler<FileFoundArgs> onFoundFile = (sender, eventArgs) =>
+EventHandler<FileFoundArgs> onFileFound = (sender, eventArgs) =>
 {
     Console.WriteLine(eventArgs.FoundFile);
     eventArgs.CancelRequested = true;
@@ -270,12 +270,12 @@ need extra code in those handlers in this project, but this shows how
 you would create them.
 
 ```cs
-internal event EventHandler<SearchDirectoryArgs> ChangedDirectory
+internal event EventHandler<SearchDirectoryArgs> DirectoryChanged
 {
-    add { changeDirectory += value; }
-    remove { changeDirectory -= value; }
+    add { directoryChanged += value; }
+    remove { directoryChanged -= value; }
 }
-private EventHandler<SearchDirectoryArgs> changedDirectory;
+private EventHandler<SearchDirectoryArgs> directoryChanged;
 ```
 
 In may ways, the code you write here mirrors the code the compiler
@@ -302,13 +302,13 @@ public void Search(string directory, string searchPattern, bool searchSubDirs = 
         var totalDirs = allDirectories.Length + 1;
         foreach (var dir in allDirectories)
         {
-            changeDirectory?.Invoke(this,
+            directoryChanged?.Invoke(this,
                 new SearchDirectoryArgs(dir, totalDirs, completedDirs++));
             // Recursively search this child directory:
             SearchDirectory(dir, searchPattern);
         }
         // Include the Current Directory:
-        changeDirectory?.Invoke(this,
+        directoryChanged?.Invoke(this,
             new SearchDirectoryArgs(directory, totalDirs, completedDirs++));
         SearchDirectory(directory, searchPattern);
     }
@@ -323,7 +323,7 @@ private void SearchDirectory(string directory, string searchPattern)
     foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
     {
         var args = new FileFoundArgs(file);
-        FoundFile?.Invoke(this, args);
+        FileFound?.Invoke(this, args);
         if (args.CancelRequested)
             break;
     }
@@ -339,7 +339,7 @@ that this works correctly.
  console window. 
 
 ```cs
-lister.ChangeDirectory += (sender, eventArgs) =>
+lister.DirectoryChanged += (sender, eventArgs) =>
 {
     Console.Write($"Entering '{eventArgs.CurrentSearchDirectory}'.");
     Console.WriteLine($" {eventArgs.CompletedDirs} of {eventArgs.TotalDirs} completed...");

--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -71,15 +71,15 @@ public event EventHandler<FileListArgs> Progress;
 The type of the event (`EventHandler<FileListArgs>` in this example) must be a
 delegate type. There are a number of conventions that you should follow
 when declaring an event. Typically, the event delegate type has a void return.
-Prefix event declarations with 'On'.
-The remainder of the name is a verb. Use past tense (as in this example) when
+Event declarations should be a verb, or verb phrase.
+Use past tense (as in this example) when
 the event reports something that has happened. Use a present tense verb (for
 example, `Closing`) to report something that is about to happen. Often, using
 present tense indicates that the event supports cancellation. For example,
 an `Closing` event may include an argument that would indicate if the close
 operation should continue, or not.  
 
-When you want to raise the event, you call the event using the delegate invocation
+When you want to raise the event, you call the event handlers using the delegate invocation
 syntax:
 
 ```cs
@@ -97,6 +97,9 @@ EventHandler<FileListArgs> OnProgress = (sender, eventArgs) =>
     Console.WriteLine(eventArgs.FoundFile);
 lister.Progress += OnProgress;
 ```
+
+The handler method typically is the prefix 'On' followed
+by the event name, as shown above.
 
 You unsubscribe using the `-=` operator:
 

--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -65,7 +65,7 @@ an extension of the syntax for delegates.
 To define an event you use the `event` keyword:
 
 ```cs
-public event EventHandler<FileListArgs> OnProgress;
+public event EventHandler<FileListArgs> Progress;
 ```
 
 The type of the event (`EventHandler<FileListArgs>` in this example) must be a
@@ -74,16 +74,16 @@ when declaring an event. Typically, the event delegate type has a void return.
 Prefix event declarations with 'On'.
 The remainder of the name is a verb. Use past tense (as in this example) when
 the event reports something that has happened. Use a present tense verb (for
-example, `OnClosing`) to report something that is about to happen. Often, using
+example, `Closing`) to report something that is about to happen. Often, using
 present tense indicates that the event supports cancellation. For example,
-an `OnClosing` event may include an argument that would indicate if the close
+an `Closing` event may include an argument that would indicate if the close
 operation should continue, or not.  
 
 When you want to raise the event, you call the event using the delegate invocation
 syntax:
 
 ```cs
-OnProgress?.Invoke(this, new FileListArgs(file));
+Progress?.Invoke(this, new FileListArgs(file));
 ```
 
 As discussed in the section on [delegates](delegates-patterns.md), the ?.
@@ -93,15 +93,15 @@ when there are no subscribers to that event.
 You subscribe to an event by using the `+=` operator:
 
 ```cs
-EventHandler<FileListArgs> handler = (sender, eventArgs) => 
+EventHandler<FileListArgs> OnProgress = (sender, eventArgs) => 
     Console.WriteLine(eventArgs.FoundFile);
-lister.OnProgress += handler;
+lister.Progress += OnProgress;
 ```
 
 You unsubscribe using the `-=` operator:
 
 ```cs
-lister.OnProgress -= handler;
+lister.Progress -= OnProgress;
 ```
 
 It's important to note that I declared a local variable for the expression that

--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -93,7 +93,7 @@ when there are no subscribers to that event.
 You subscribe to an event by using the `+=` operator:
 
 ```cs
-EventHandler<FileListArgs> OnProgress = (sender, eventArgs) => 
+EventHandler<FileListArgs> onProgress = (sender, eventArgs) => 
     Console.WriteLine(eventArgs.FoundFile);
 lister.Progress += OnProgress;
 ```
@@ -104,7 +104,7 @@ by the event name, as shown above.
 You unsubscribe using the `-=` operator:
 
 ```cs
-lister.Progress -= OnProgress;
+lister.Progress -= onProgress;
 ```
 
 It's important to note that I declared a local variable for the expression that

--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -71,12 +71,12 @@ public event EventHandler<FileListArgs> Progress;
 The type of the event (`EventHandler<FileListArgs>` in this example) must be a
 delegate type. There are a number of conventions that you should follow
 when declaring an event. Typically, the event delegate type has a void return.
-Event declarations should be a verb, or verb phrase.
+Event declarations should be a verb, or a verb phrase.
 Use past tense (as in this example) when
 the event reports something that has happened. Use a present tense verb (for
 example, `Closing`) to report something that is about to happen. Often, using
 present tense indicates that the event supports cancellation. For example,
-an `Closing` event may include an argument that would indicate if the close
+a `Closing` event may include an argument that would indicate if the close
 operation should continue, or not.  
 
 When you want to raise the event, you call the event handlers using the delegate invocation

--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -75,9 +75,14 @@ Event declarations should be a verb, or a verb phrase.
 Use past tense (as in this example) when
 the event reports something that has happened. Use a present tense verb (for
 example, `Closing`) to report something that is about to happen. Often, using
-present tense indicates that the event supports cancellation. For example,
+present tense indicates that your class supports some kind of customization
+behavior. One of the most common scenarios is to support cancellation. For example,
 a `Closing` event may include an argument that would indicate if the close
-operation should continue, or not.  
+operation should continue, or not.  Other scenarios may enable callers to modify
+behavior by updating properties of the event arguments. You may raise an
+event to indicate a proposed next action an algorithm will take. The event
+handler may mandate a different action by modifying  properties of the event
+argument.
 
 When you want to raise the event, you call the event handlers using the delegate invocation
 syntax:

--- a/docs/csharp/modern-events.md
+++ b/docs/csharp/modern-events.md
@@ -93,7 +93,7 @@ create a safe `async void` method. The basics of the pattern you need
 to implement are below:
 
 ```cs
-worker.OnStartWorking += async (sender, eventArgs) =>
+worker.StartWorking += async (sender, eventArgs) =>
 {
     try 
     {

--- a/samples/csharp/events/Program.cs
+++ b/samples/csharp/events/Program.cs
@@ -15,16 +15,16 @@ namespace EventSampleCode
             var lister = new FileSearcher();
             int filesFound = 0;
 
-            EventHandler<FileFoundArgs> onFoundFile = (sender, eventArgs) =>
+            EventHandler<FileFoundArgs> onFileFound = (sender, eventArgs) =>
             {
                 Console.WriteLine(eventArgs.FoundFile);
                 filesFound++;
                 //eventArgs.CancelRequested = true;
             };
 
-            lister.FoundFile += onFoundFile;
+            lister.FileFound += onFileFound;
 
-            lister.ChangedDirectory += (sender, eventArgs) =>
+            lister.DirectoryChanged += (sender, eventArgs) =>
             {
                 Console.Write($"Entering '{eventArgs.CurrentSearchDirectory}'.");
                 Console.WriteLine($" {eventArgs.CompletedDirs} of {eventArgs.TotalDirs} completed...");
@@ -32,7 +32,7 @@ namespace EventSampleCode
 
             lister.Search(".", "*.dll", true);
 
-            lister.FoundFile -= onFoundFile;
+            lister.FileFound -= onFileFound;
         }
     }
 
@@ -62,13 +62,13 @@ namespace EventSampleCode
     }
     public class FileSearcher
     {
-        public event EventHandler<FileFoundArgs> FoundFile;
-        internal event EventHandler<SearchDirectoryArgs> ChangedDirectory
+        public event EventHandler<FileFoundArgs> FileFound;
+        internal event EventHandler<SearchDirectoryArgs> DirectoryChanged
         {
-            add { changeDirectory += value; }
-            remove { changeDirectory -= value; }
+            add { directoryChanged += value; }
+            remove { directoryChanged -= value; }
         }
-        private EventHandler<SearchDirectoryArgs> changeDirectory;
+        private EventHandler<SearchDirectoryArgs> directoryChanged;
 
         public void Search(string directory, string searchPattern, bool searchSubDirs = false)
         {
@@ -79,13 +79,13 @@ namespace EventSampleCode
                 var totalDirs = allDirectories.Length + 1;
                 foreach (var dir in allDirectories)
                 {
-                    changeDirectory?.Invoke(this,
+                    directoryChanged?.Invoke(this,
                         new SearchDirectoryArgs(dir, totalDirs, completedDirs++));
                     // Recursively search this child directory:
                     SearchDirectory(dir, searchPattern);
                 }
                 // Include the Current Directory:
-                changeDirectory?.Invoke(this,
+                directoryChanged?.Invoke(this,
                     new SearchDirectoryArgs(directory, totalDirs, completedDirs++));
                 SearchDirectory(directory, searchPattern);
             }
@@ -100,7 +100,7 @@ namespace EventSampleCode
             foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
             {
                 var args = new FileFoundArgs(file);
-                FoundFile?.Invoke(this, args);
+                FileFound?.Invoke(this, args);
                 if (args.CancelRequested)
                     break;
             }

--- a/samples/csharp/events/Program.cs
+++ b/samples/csharp/events/Program.cs
@@ -15,16 +15,16 @@ namespace EventSampleCode
             var lister = new FileSearcher();
             int filesFound = 0;
 
-            EventHandler<FileFoundArgs> OnFoundFile = (sender, eventArgs) =>
+            EventHandler<FileFoundArgs> onFoundFile = (sender, eventArgs) =>
             {
                 Console.WriteLine(eventArgs.FoundFile);
                 filesFound++;
                 //eventArgs.CancelRequested = true;
             };
 
-            lister.FoundFile += OnFoundFile;
+            lister.FoundFile += onFoundFile;
 
-            lister.ChangeDirectory += (sender, eventArgs) =>
+            lister.ChangedDirectory += (sender, eventArgs) =>
             {
                 Console.Write($"Entering '{eventArgs.CurrentSearchDirectory}'.");
                 Console.WriteLine($" {eventArgs.CompletedDirs} of {eventArgs.TotalDirs} completed...");
@@ -32,7 +32,7 @@ namespace EventSampleCode
 
             lister.Search(".", "*.dll", true);
 
-            lister.FoundFile -= OnFoundFile;
+            lister.FoundFile -= onFoundFile;
         }
     }
 
@@ -63,12 +63,12 @@ namespace EventSampleCode
     public class FileSearcher
     {
         public event EventHandler<FileFoundArgs> FoundFile;
-        internal event EventHandler<SearchDirectoryArgs> ChangeDirectory
+        internal event EventHandler<SearchDirectoryArgs> ChangedDirectory
         {
             add { changeDirectory += value; }
             remove { changeDirectory -= value; }
         }
-        private event EventHandler<SearchDirectoryArgs> changeDirectory;
+        private EventHandler<SearchDirectoryArgs> changeDirectory;
 
         public void Search(string directory, string searchPattern, bool searchSubDirs = false)
         {

--- a/samples/csharp/events/Program.cs
+++ b/samples/csharp/events/Program.cs
@@ -15,24 +15,24 @@ namespace EventSampleCode
             var lister = new FileSearcher();
             int filesFound = 0;
 
-            EventHandler<FileFoundArgs> handler = (sender, eventArgs) =>
+            EventHandler<FileFoundArgs> OnFoundFile = (sender, eventArgs) =>
             {
                 Console.WriteLine(eventArgs.FoundFile);
                 filesFound++;
                 //eventArgs.CancelRequested = true;
             };
 
-            lister.OnFoundFile += handler;
+            lister.FoundFile += OnFoundFile;
 
-            lister.OnChangeDirectory += (sender, eventArgs) =>
+            lister.ChangeDirectory += (sender, eventArgs) =>
             {
                 Console.Write($"Entering '{eventArgs.CurrentSearchDirectory}'.");
                 Console.WriteLine($" {eventArgs.CompletedDirs} of {eventArgs.TotalDirs} completed...");
             };
 
-            lister.Search(".", "*.exe", true);
+            lister.Search(".", "*.dll", true);
 
-            lister.OnFoundFile -= handler;
+            lister.FoundFile -= OnFoundFile;
         }
     }
 
@@ -62,8 +62,8 @@ namespace EventSampleCode
     }
     public class FileSearcher
     {
-        public event EventHandler<FileFoundArgs> OnFoundFile;
-        internal event EventHandler<SearchDirectoryArgs> OnChangeDirectory
+        public event EventHandler<FileFoundArgs> FoundFile;
+        internal event EventHandler<SearchDirectoryArgs> ChangeDirectory
         {
             add { changeDirectory += value; }
             remove { changeDirectory -= value; }
@@ -100,7 +100,7 @@ namespace EventSampleCode
             foreach (var file in Directory.EnumerateFiles(directory, searchPattern))
             {
                 var args = new FileFoundArgs(file);
-                OnFoundFile?.Invoke(this, args);
+                FoundFile?.Invoke(this, args);
                 if (args.CancelRequested)
                     break;
             }

--- a/samples/csharp/events/events.xproj
+++ b/samples/csharp/events/events.xproj
@@ -9,9 +9,8 @@
     <ProjectGuid>fd45fa0a-8e95-4daa-aec9-63719b4e3fc9</ProjectGuid>
     <RootNamespace>events</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #1011

The section on "events" incorrectly recommended naming events with the "On" prefix. Events should be the verb or verb phrase, and the handlers should have the "On" prefix.
