### PR TITLE
Fix up HTML escaping in Reference Cells table

### DIFF
--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -56,10 +56,10 @@ The following table shows the features that are available on the reference cell.
 
 |Operator, member, or field|Description|Type|Definition|
 |--------------------------|-----------|----|----------|
-|`!` (dereference operator)|Returns the underlying value.|`'a ref -&gt; 'a`|`let (!) r = r.contents`|
-|`:=` (assignment operator)|Changes the underlying value.|`'a ref -&gt; 'a -&gt; unit`|`let (:=) r x = r.contents &lt;- x`|
-|`ref` (operator)|Encapsulates a value into a new reference cell.|`'a -&gt; 'a ref`|`let ref x = { contents = x }`|
-|`Value` (property)|Gets or sets the underlying value.|`unit -&gt; 'a`|`member x.Value = x.contents`|
+|`!` (dereference operator)|Returns the underlying value.|`'a ref -> 'a`|`let (!) r = r.contents`|
+|`:=` (assignment operator)|Changes the underlying value.|`'a ref -> 'a -> unit`|`let (:=) r x = r.contents <- x`|
+|`ref` (operator)|Encapsulates a value into a new reference cell.|`'a -> 'a ref`|`let ref x = { contents = x }`|
+|`Value` (property)|Gets or sets the underlying value.|`unit -> 'a`|`member x.Value = x.contents`|
 |`contents` (record field)|Gets or sets the underlying value.|`'a`|`let ref x = { contents = x }`|
 There are several ways to access the underlying value. The value returned by the dereference operator (`!`) is not an assignable value. Therefore, if you are modifying the underlying value, you must use the assignment operator (`:=`) instead.
 


### PR DESCRIPTION
This removes some of the HTML escaping in the Reference Cells features table and replaces it with code.
