### PR TITLE
Change Library to library

### DIFF
--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -219,7 +219,7 @@ to create a new console application.
 
 Your console application depends on the library you built and tested
 in the previous steps. You need to indicate that by editing `project.json`
-to add this dependency.  In the `dependencies` node, add the `Library`
+to add this dependency.  In the `dependencies` node, add the `library`
 node as follows:
 
 ```js

--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -241,7 +241,7 @@ and replace the contents of the `Main` method with this line:
 WriteLine($"The answer is {new Thing().Get(19, 23)}");
 ```
 
-You'll need to add a couple using directives to the top of the file:
+You'll need to add a couple `using` directives to the top of the file:
 
 ```cs
 using static System.Console;
@@ -255,7 +255,7 @@ can type `dotnet run` to run the executable.
 
 You can debug your code in VS Code using the C# extension.
 You install this extension by pressing `F1` to open the VS Code
-palette. Type `ext install` to see the list of extensions. Select the `C#`
+palette. Type `ext install` to see the list of extensions. Select the C#
 extension. (More details are available on the [Visual Studio
 Code C# Extension documentation](https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger.md)
 page.)


### PR DESCRIPTION
Above **Debugging your application** section, there is:

> You'll need to add a couple using directives to the top of the file:
> 
> ``` c#
> using static System.Console;
> using Library;
> ```

Maybe using should be formatted: `using`?

And inside the section:

> You can debug your code in VS Code using the C# extension. You install this extension by pressing `F1` to open the VS Code palette. Type `ext install` to see the list of extensions. Select the `C#` extension.

Maybe the 2<sup>nd</sup> C# shouldn't be formatted?

cc: @bleroy 
