### PR TITLE
Better example for ArgumentOutOfRangeException

### DIFF
--- a/docs/standard/exceptions.md
+++ b/docs/standard/exceptions.md
@@ -74,7 +74,7 @@ The following table lists some common exceptions with examples of what can cause
 | @System.InvalidOperationException | @System.Exception | Thrown by methods when in an invalid state. | Calling `Enumerator.GetNext()` after removing an Item from the underlying collection. |
 | @System.ArgumentException | @System.Exception | Base class for all argument exceptions. | None (use a derived class of this exception). |
 | @System.ArgumentNullException | @System.Exception | Thrown by methods that do not allow an argument to be null. | `String s = null; "Calculate".IndexOf (s);` |
-| @System.ArgumentOutOfRangeException | @System.Exception | Thrown by methods that verify that arguments are in a given range. | `String s = "string"; s.Chars[9];` |
+| @System.ArgumentOutOfRangeException | @System.Exception | Thrown by methods that verify that arguments are in a given range. | `String s = "string"; s.Substring(s.Length+1);` |
 
 ## How to use the try/catch block to catch exceptions
 


### PR DESCRIPTION
The example snippet for `ArgumentOutOfRangeException` looks no different than the example for `IndexOutOfRangeException`. I think using an explicit method call with an invalid argument is less irritating.
