### PR TITLE
Improved formatting of SQL Database Type Providers walkthrough

### DIFF
--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
@@ -25,46 +25,34 @@ This walkthrough illustrates the following tasks. These tasks must be performed 
 
 
 - Preparing a test database
-<br />
 
 - Creating the project
-<br />
 
 - Setting up a type provider
-<br />
 
 - Querying the data
-<br />
 
 - Working with nullable fields
-<br />
 
 - Calling a stored procedure
-<br />
 
 - Updating the database
-<br />
 
 - Executing Transact-SQL code
-<br />
 
 - Using the full data context
-<br />
 
 - Deleting data
-<br />
 
 - Create a test database (as needed)
-<br />
 
 ## Preparing a Test Database
-On a server that's running SQL Server, create a database for testing purposes. You can use the database create script at the bottom of this page in the section [MyDatabase Create Script]: #BKMK_MyDBCreateScript to do this.
+On a server that's running SQL Server, create a database for testing purposes. You can use the database create script at the bottom of this page in the section [Creating a test database](#creating-a-test-database) to do this.
 
 
 #### To prepare a test database
 
-- To run the MyDatabase Create Script, open the **View** menu, and then choose **SQL Server Object Explorer** or choose the Ctrl+\, Ctrl+S keys. In **SQL Server Object Explorer** window, open the shortcut menu for the appropriate instance, choose **New Query**, copy the script at the bottom of this page, and then paste the script into the editor. To run the SQL script, choose the toolbar icon with the triangular symbol, or choose the Ctrl+Q keys. For more information about **SQL Server Object Explorer**, see [Connected Database Development](http://go.microsoft.com/fwlink/?LinkId=237128).
-<br />
+To run the MyDatabase Create Script, open the **View** menu, and then choose **SQL Server Object Explorer** or choose the Ctrl+\, Ctrl+S keys. In **SQL Server Object Explorer** window, open the shortcut menu for the appropriate instance, choose **New Query**, copy the script at the bottom of this page, and then paste the script into the editor. To run the SQL script, choose the toolbar icon with the triangular symbol, or choose the Ctrl+Q keys. For more information about **SQL Server Object Explorer**, see [Connected Database Development](http://go.microsoft.com/fwlink/?LinkId=237128).
 
 
 ## Creating the project
@@ -74,15 +62,12 @@ Next, you create an F# application project.
 #### To create and set up the project
 
 1. Create a new F# Application project.
-<br />
 
 2. Add references to [FSharp.Data.TypeProviders](https://msdn.microsoft.com/library/a858f859-047a-44ab-945b-8731d7a0e6e3), as well as `System.Data`, and `System.Data.Linq`.
-<br />
 
 3. Open the appropriate namespaces by adding the following lines of code to the top of your F# code file Program.fs.
-<br />
 
-```fsharp
+  ```fsharp
 open System
 open System.Data
 open System.Data.Linq
@@ -91,16 +76,14 @@ open Microsoft.FSharp.Linq
 ```
 
 4. As with most F# programs, you can execute the code in this walkthrough as a compiled program, or you can run it interactively as a script. If you prefer to use scripts, open the shortcut menu for the project node, select **Add New Item**, add an F# script file, and add the code in each step to the script. You will need to add the following lines at the top of the file to load the assembly references.
-<br />
 
-```fsharp
+  ```fsharp
 #r "System.Data.dll"
 #r "FSharp.Data.TypeProviders.dll"
 #r "System.Data.Linq.dll"
 ```
 
   You can then select each block of code as you add it and press Alt+Enter to run it in F# Interactive.
-<br />
 
 ## Setting up a type provider
 In this step, you create a type provider for your database schema.
@@ -108,8 +91,7 @@ In this step, you create a type provider for your database schema.
 
 #### To set up the type provider from a direct database connection
 
-- There are two critical lines of code that you need in order to create the types that you can use to query a SQL database using the type provider. First, you instantiate the type provider. To do this, create what looks like a type abbreviation for a `SqlDataConnection` with a static generic parameter. `SqlDataConnection` is a SQL type provider, and should not be confused with `SqlConnection` type that is used in ADO.NET programming. If you have a database that you want to connect to, and have a connection string, use the following code to invoke the type provider. Substitute your own connection string for the example string given. For example, if your server is MYSERVER and the database instance is INSTANCE, the database name is MyDatabase, and you want to use Windows Authentication to access the database, then the connection string would be as given in the following example code.
-<br />
+There are two critical lines of code that you need in order to create the types that you can use to query a SQL database using the type provider. First, you instantiate the type provider. To do this, create what looks like a type abbreviation for a `SqlDataConnection` with a static generic parameter. `SqlDataConnection` is a SQL type provider, and should not be confused with `SqlConnection` type that is used in ADO.NET programming. If you have a database that you want to connect to, and have a connection string, use the following code to invoke the type provider. Substitute your own connection string for the example string given. For example, if your server is MYSERVER and the database instance is INSTANCE, the database name is MyDatabase, and you want to use Windows Authentication to access the database, then the connection string would be as given in the following example code.
 
 ```fsharp
 type dbSchema = SqlDataConnection<"Data Source=MYSERVER\INSTANCE;Initial Catalog=MyDatabase;Integrated Security=SSPI;">
@@ -120,16 +102,16 @@ db.DataContext.Log <- System.Console.Out
 ```
 
 Now you have a type, `dbSchema`, which is a parent type that contains all the generated types that represent database tables. You also have an object, `db`, which has as its members all the tables in the database. The table names are properties, and the type of these properties is generated by the F# compiler. The types themselves appear as nested types under `dbSchema.ServiceTypes`. Therefore, any data retrieved for rows of these tables is an instance of the appropriate type that was generated for that table. The name of the type is `ServiceTypes.Table1`.
-<br />  To familiarize yourself with how the F# language interprets queries into SQL queries, review the line that sets the `Log` property on the data context.
-<br />  To further explore the types created by the type provider, add the following code.
-<br />
+
+To familiarize yourself with how the F# language interprets queries into SQL queries, review the line that sets the `Log` property on the data context.
+
+To further explore the types created by the type provider, add the following code.
 
 ```fsharp
 let table1 = db.Table1
 ```
 
-Hover over `table1` to see its type. Its type is`System.Data.Linq.Table<dbSchema.ServiceTypes.Table1>` and the generic argument implies that the type of each row is the generated type, `dbSchema.ServiceTypes.Table1`. The compiler creates a similar type for each table in the database.
-<br />
+Hover over `table1` to see its type. Its type is `System.Data.Linq.Table<dbSchema.ServiceTypes.Table1>` and the generic argument implies that the type of each row is the generated type, `dbSchema.ServiceTypes.Table1`. The compiler creates a similar type for each table in the database.
 
 ## Querying the data
 In this step, you write a query using F# query expressions.
@@ -138,58 +120,52 @@ In this step, you write a query using F# query expressions.
 #### To query the data
 
 1. Now create a query for that table in the database. Add the following code.
-<br />
 
-```fsharp
-let query1 =
-  query {
-    for row in db.Table1 do
-    select row
-  }
-query1 |> Seq.iter (fun row -> printfn "%s %d" row.Name row.TestData1)
+  ```fsharp
+   let query1 =
+     query {
+       for row in db.Table1 do
+       select row
+     }
+   query1 |> Seq.iter (fun row -> printfn "%s %d" row.Name row.TestData1)
 ```
 
-The appearance of the word `query` indicates that this is a query expression, a type of computation expression that generates a collection of results similar of a typical database query. If you hover over query, you will see that it is an instance of [Linq.QueryBuilder Class](https://msdn.microsoft.com/visualfsharpdocs/conceptual/linq.querybuilder-class-%5bfsharp%5d), a type that defines the query computation expression. If you hover over `query1`, you will see that it is an instance of `System.Linq.IQueryable`. As the name suggests, `System.Linq.IQueryable` represents data that may be queried, not the result of a query. A query is subject to lazy evaluation, which means that the database is only queried when the query is evaluated. The final line passes the query through `Seq.iter`. Queries are enumerable and may be iterated like sequences. For more information, see [Query Expressions](../../language-reference/query-expressions.md).
-
-<br />
+  The appearance of the word `query` indicates that this is a query expression, a type of computation expression that generates a collection of results similar of a typical database query. If you hover over query, you will see that it is an instance of [Linq.QueryBuilder Class](https://msdn.microsoft.com/visualfsharpdocs/conceptual/linq.querybuilder-class-%5bfsharp%5d), a type that defines the query computation expression. If you hover over `query1`, you will see that it is an instance of `System.Linq.IQueryable`. As the name suggests, `System.Linq.IQueryable` represents data that may be queried, not the result of a query. A query is subject to lazy evaluation, which means that the database is only queried when the query is evaluated. The final line passes the query through `Seq.iter`. Queries are enumerable and may be iterated like sequences. For more information, see [Query Expressions](../../language-reference/query-expressions.md).
 
 2. Now add a query operator to the query. There are a number of query operators available that you can use to construct more complex queries. This example also shows that you can eliminate the query variable and use a pipeline operator instead.
-<br />
 
-```fsharp
-query {
-  for row in db.Table1 do
-  where (row.TestData1 > 2)
-  select row
-} |> Seq.iter (fun row -> printfn "%d %s" row.TestData1 row.Name)
+  ```fsharp
+   query {
+     for row in db.Table1 do
+     where (row.TestData1 > 2)
+     select row
+   } |> Seq.iter (fun row -> printfn "%d %s" row.TestData1 row.Name)
 ```
 
 3. Add a more complex query with a join of two tables.
-<br />
 
-```fsharp
-query {
-  for row1 in db.Table1 do
-  join row2 in db.Table2 on (row1.Id = row2.Id)
-  select (row1, row2)
-} |> Seq.iteri (fun index (row1, row2) ->
-                if (index = 0) then printfn "Table1.Id TestData1 TestData2 Name Table2.Id TestData1 TestData2 Name"
-printfn "%d %d %f %s %d %d %f %s" row1.Id row1.TestData1 row1.TestData2 row1.Name
-row2.Id (row2.TestData1.GetValueOrDefault()) (row2.TestData2.GetValueOrDefault()) row2.Name)
+  ```fsharp
+   query {
+     for row1 in db.Table1 do
+     join row2 in db.Table2 on (row1.Id = row2.Id)
+     select (row1, row2)
+   } |> Seq.iteri (fun index (row1, row2) ->
+                   if (index = 0) then printfn "Table1.Id TestData1 TestData2 Name Table2.Id TestData1 TestData2 Name"
+                   printfn "%d %d %f %s %d %d %f %s" row1.Id row1.TestData1 row1.TestData2 row1.Name
+                     row2.Id (row2.TestData1.GetValueOrDefault()) (row2.TestData2.GetValueOrDefault()) row2.Name)
 ```
 
 4. In real-world code, the parameters in your query are usually values or variables, not compile-time constants. Add the following code that wraps a query in a function that takes a parameter, and then calls that function with the value 10.
-<br />
 
-```fsharp
-let findData param =
-  query {
-    for row in db.Table1 do
-    where (row.TestData1 = param)
-    select row
-}
+  ```fsharp
+   let findData param =
+     query {
+       for row in db.Table1 do
+       where (row.TestData1 = param)
+       select row
+     }
 
-findData 10 |> Seq.iter (fun row -> printfn "Found row: %d %d %f %s" row.Id row.TestData1 row.TestData2 row.Name)
+   findData 10 |> Seq.iter (fun row -> printfn "Found row: %d %d %f %s" row.Id row.TestData1 row.TestData2 row.Name)
 ```
 
 ## Working with nullable fields
@@ -200,8 +176,7 @@ When you need to perform equality tests or comparisons on nullable values in a `
 
 #### To work with nullable fields
 
-1. The following code shows working with nullable values; assume that **TestData1** is an integer field that allows nulls.
-<br />
+The following code shows working with nullable values; assume that **TestData1** is an integer field that allows nulls.
 
 ```fsharp
 query {
@@ -224,9 +199,9 @@ Any stored procedures on the database can be called from F#. You must set the st
 
 #### To call a stored procedure
 
-- If the stored procedures takes parameters that are nullable, you need to pass an appropriate `System.Nullable` value. The return value of a stored procedure method that returns a scalar or a table is `System.Data.Linq.ISingleResult`, which contains properties that enable you to access the returned data. The type argument for `System.Data.Linq.ISingleResult` depends on the specific procedure and is also one of the types that the type provider generates. For a stored procedure named `Procedure1`, the type is `Procedure1Result`. The type `Procedure1Result` contains the names of the columns in a returned table, or, for a stored procedure that returns a scalar value, it represents the return value.
-<br />  The following code assumes that there is a procedure `Procedure1` on the database that takes two nullable integers as parameters, runs a query that returns a column named `TestData1`, and returns an integer.
-<br />
+If the stored procedures takes parameters that are nullable, you need to pass an appropriate `System.Nullable` value. The return value of a stored procedure method that returns a scalar or a table is `System.Data.Linq.ISingleResult`, which contains properties that enable you to access the returned data. The type argument for `System.Data.Linq.ISingleResult` depends on the specific procedure and is also one of the types that the type provider generates. For a stored procedure named `Procedure1`, the type is `Procedure1Result`. The type `Procedure1Result` contains the names of the columns in a returned table, or, for a stored procedure that returns a scalar value, it represents the return value.
+
+The following code assumes that there is a procedure `Procedure1` on the database that takes two nullable integers as parameters, runs a query that returns a column named `TestData1`, and returns an integer.
 
 ```fsharp
 type schema = SqlDataConnection<"Data Source=MYSERVER\INSTANCE;Initial Catalog=MyDatabase;Integrated Security=SSPI;", StoredProcedures = true>
@@ -251,44 +226,42 @@ The LINQ DataContext type contains methods that make it easier to perform transa
 #### To update the database
 
 1. In the following code, several rows are added to the database. If you are only adding a row, you can use `System.Data.Linq.Table.InsertOnSubmit()` to specify the new row to add. If you are inserting multiple rows, you should put them into a collection and call `System.Data.Linq.Table.InsertAllOnSubmit(System.Collections.Generic.IEnumerable)`. When you call either of these methods, the database is not immediately changed. You must call `System.Data.Linq.DataContext.SubmitChanges` to actually commit the changes. By default, everything that you do before you call `System.Data.Linq.DataContext.SubmitChanges` is implicitly part of the same transaction.
-<br />
 
-```fsharp
-let newRecord = new dbSchema.ServiceTypes.Table1(Id = 100,
-                                                 TestData1 = 35, 
-                                                 TestData2 = 2.0,
-                                                 Name = "Testing123")
+ ```fsharp
+   let newRecord = new dbSchema.ServiceTypes.Table1(Id = 100,
+                                                    TestData1 = 35, 
+                                                    TestData2 = 2.0,
+                                                    Name = "Testing123")
 
-let newValues =
-  [ for i in [1 .. 10] ->
-    new dbSchema.ServiceTypes.Table3(Id = 700 + i,
-      Name = "Testing" + i.ToString(),
-      Data = i) ]
+   let newValues =
+     [ for i in [1 .. 10] ->
+       new dbSchema.ServiceTypes.Table3(Id = 700 + i,
+         Name = "Testing" + i.ToString(),
+         Data = i) ]
 
-// Insert the new data into the database.
-db.Table1.InsertOnSubmit(newRecord)
-db.Table3.InsertAllOnSubmit(newValues)
+   // Insert the new data into the database.
+   db.Table1.InsertOnSubmit(newRecord)
+   db.Table3.InsertAllOnSubmit(newValues)
 
-try
-  db.DataContext.SubmitChanges()
-  printfn "Successfully inserted new rows."
-with
-| exn -> printfn "Exception:\n%s" exn.Message
+   try
+     db.DataContext.SubmitChanges()
+     printfn "Successfully inserted new rows."
+   with
+   | exn -> printfn "Exception:\n%s" exn.Message
 ```
 
 2. Now clean up the rows by calling a delete operation.
-<br />
 
-```fsharp
-// Now delete what was added.
-db.Table1.DeleteOnSubmit(newRecord)
-db.Table3.DeleteAllOnSubmit(newValues)
+  ```fsharp
+   // Now delete what was added.
+   db.Table1.DeleteOnSubmit(newRecord)
+   db.Table3.DeleteAllOnSubmit(newValues)
 
-try
-  db.DataContext.SubmitChanges()
-  printfn "Successfully deleted all pending rows."
-with
-| exn -> printfn "Exception:\n%s" exn.Message
+   try
+     db.DataContext.SubmitChanges()
+     printfn "Successfully deleted all pending rows."
+   with
+   | exn -> printfn "Exception:\n%s" exn.Message
 ```
 
 ## Executing Transact-SQL code
@@ -297,8 +270,7 @@ You can also specify Transact-SQL directly by using the `System.Data.Linq.DataCo
 
 #### To execute custom SQL commands
 
-- The following code shows how to send SQL commands to insert a record into a table and also to delete a record from a table.
-<br />
+The following code shows how to send SQL commands to insert a record into a table and also to delete a record from a table.
 
 ```fsharp
 try
@@ -318,8 +290,7 @@ In the previous examples, the `GetDataContext` method was used to get what is ca
 
 #### To use the full data context
 
-- The following code demonstrates getting a full data context object and using it to execute commands directly against the database. In this case, two commands are executed as part of the same transaction.
-<br />
+The following code demonstrates getting a full data context object and using it to execute commands directly against the database. In this case, two commands are executed as part of the same transaction.
 
 ```fsharp
 let dbConnection = testdb.Connection
@@ -355,12 +326,11 @@ This step shows you how to delete rows from a data table.
 
 #### To delete rows from the database
 
-- Now, clean up any added rows by writing a function that deletes rows from a specified table, an instance of the `System.Data.Linq.Table` class. Then write a query to find all the rows that you want to delete, and pipe the results of the query into the `deleteRows` function. This code takes advantage of the ability to provide partial application of function arguments.
-<br />
+Now, clean up any added rows by writing a function that deletes rows from a specified table, an instance of the `System.Data.Linq.Table` class. Then write a query to find all the rows that you want to delete, and pipe the results of the query into the `deleteRows` function. This code takes advantage of the ability to provide partial application of function arguments.
 
 ```fsharp
 let deleteRowsFrom (table:Table<_>) rows =
-table.DeleteAllOnSubmit(rows)
+  table.DeleteAllOnSubmit(rows)
 
 query {
   for rows in db.Table3 do
@@ -381,17 +351,12 @@ Note that if you alter the database in some way, you will have to reset the type
 #### To create the test database
 
 1. In **Server Explorer**, open the shortcut menu for the **Data Connections** node, and choose **Add Connection**. The **Add Connection** dialog box appears.
-<br />
 
 2. In the **Server name** box, specify the name of an instance of SQL Server that you have administrative access to, or if you do not have access to a server, specify (localdb\v11.0). SQL Express LocalDB provides a lightweight database server for development and testing on your machine. A new node is created in **Server Explorer** under **Data Connections**. For more information about LocalDB, see [Walkthrough: Creating a Local Database File in Visual Studio](https://msdn.microsoft.com/library/ms233763.aspx).
-<br />
 
 3. Open the shortcut menu for the new connection node, and select **New Query**.
-<br />
-
 
 4. Copy the following SQL script, paste it into the query editor, and then choose the **Execute** button on the toolbar or choose the Ctrl+Shift+E keys.
-<br />
 
 ```sql
 SET ANSI_NULLS ON
@@ -428,7 +393,7 @@ CREATE TABLE [dbo].[Table1] (
   PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 
---Create Table2.
+-- Create the Table3 table.
 CREATE TABLE [dbo].[Table2] (
   [Id]        INT        NOT NULL,
   [TestData1] INT        NULL,
@@ -438,7 +403,7 @@ CREATE TABLE [dbo].[Table2] (
 );
 
 
---     Create Table3.
+-- Create the Table3 table.
 CREATE TABLE [dbo].[Table3] (
   [Id]   INT           NOT NULL,
   [Name] NVARCHAR (50) NOT NULL,
@@ -463,7 +428,7 @@ INSERT INTO Table1 (Id, TestData1, TestData2, Name)
 INSERT INTO Table1 (Id, TestData1, TestData2, Name)
   VALUES(2, 20, -1.2, 'Testing2');
 
---Insert data into the Table2 table.
+-- Insert data into the Table2 table.
 INSERT INTO Table2 (Id, TestData1, TestData2, Name)
   VALUES(1, 10, 5.5, 'Testing1');
 INSERT INTO Table2 (Id, TestData1, TestData2, Name)

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
@@ -393,7 +393,7 @@ CREATE TABLE [dbo].[Table1] (
   PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 
--- Create the Table3 table.
+-- Create the Table2 table.
 CREATE TABLE [dbo].[Table2] (
   [Id]        INT        NOT NULL,
   [TestData1] INT        NULL,
@@ -420,9 +420,9 @@ SELECT TestData1 FROM Table1
 RETURN 0
 GO
 
--- Insert data into the Table1 table.
 USE MyDatabase
 
+-- Insert data into the Table1 table.
 INSERT INTO Table1 (Id, TestData1, TestData2, Name)
   VALUES(1, 10, 5.5, 'Testing1');
 INSERT INTO Table1 (Id, TestData1, TestData2, Name)
@@ -436,6 +436,7 @@ INSERT INTO Table2 (Id, TestData1, TestData2, Name)
 INSERT INTO Table2 (Id, TestData1, TestData2, Name)
   VALUES(3, NULL, NULL, 'Testing3');
 
+-- Insert data into the Table3 table.
 INSERT INTO Table3 (Id, Name, Data)
   VALUES (1, 'Testing1', 10);
 INSERT INTO Table3 (Id, Name, Data)


### PR DESCRIPTION
- fixed code formatting in lists
- one-item lists are no longer lists
- removed `<br />`s
- fixed section link

This renders correctly for me in a local docfx build, but due to how fiddly formatting of code blocks in lists is, I can't guarantee that it will work the same on docs.MS.

cc: @cartermp
