### PR TITLE
Fixed table of nullable operators

### DIFF
--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -19,9 +19,8 @@ Nullable operators are binary arithmetic or comparison operators that work with 
 ## Table of Nullable Operators
 The following table lists nullable operators supported in the F# language.
 
-||
-|-|
 |Nullable on left|Nullable on right|Both sides nullable|
+|---|---|---|
 |[?>=](https://msdn.microsoft.com/library/94d29e32-a204-4f60-a527-6b0af86268f3)|[>=?](https://msdn.microsoft.com/library/0a255d8e-8cae-4160-ae61-243a5d96583f)|[?>=?](https://msdn.microsoft.com/library/3051a50f-d276-4c84-9d73-bf2efeddef94)|
 |[?>](https://msdn.microsoft.com/library/62dc0021-1312-4ac3-be87-798b60b81bb6)|[>?](https://msdn.microsoft.com/library/0ad1284b-de48-4a04-83d8-b6f13c9c8936)|[?>?](https://msdn.microsoft.com/library/dc18b6fa-30c4-47b0-9057-794439378a05)|
 |[?<=](https://msdn.microsoft.com/library/56fddf0a-e4ca-4891-a3be-fad1876be3b6)|[<=?](https://msdn.microsoft.com/library/02454a0f-30ca-4e77-ad84-ee7837461804)|[?<=?](https://msdn.microsoft.com/library/5c37c28c-0b57-4da5-be11-5a123f7e8ee4)|


### PR DESCRIPTION
The table of nullable operators currently does not render as table at all. This PR fixes that.

cc: @cartermp 
