### PR TITLE
Updates to the CLI commands reference

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -70,7 +70,7 @@ Directory in which to place temporary outputs.
 
 `-f|--framework <FRAMEWORK>`
 
-Compiles for a specific framework. The framework needs to be defined in the [project.json](project-json,md#frameworks) file.
+Compiles for a specific framework. The framework needs to be defined in the [project.json](project-json.md#frameworks) file.
 
 `-c|--configuration [Debug|Release]`
 
@@ -82,7 +82,7 @@ Target runtime to build for. For a list of Runtime Identifiers (RIDs) you can us
 
 `--version-suffix [VERSION_SUFFIX]`
 
-Defines what `*` should be replaced with in the version field in the [project.json](project-json,md#version) file. The format follows NuGet's version guidelines. 
+Defines what `*` should be replaced with in the version field in the [project.json](project-json.md#version) file. The format follows NuGet's version guidelines. 
 
 `--build-profile`
 

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -4,7 +4,7 @@ description: The dotnet-build command builds a project and all of its dependenci
 keywords: dotnet-build, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 10/12/2016
+ms.date: 10/13/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -106,6 +106,6 @@ Build a project and its dependencies using Release configuration:
 
 `dotnet build --configuration Release`
 
-Build a project and its dependencies for a specific runtime (in this excample, Ubuntu 16.04):
+Build a project and its dependencies for a specific runtime (in this example, Ubuntu 16.04):
 
 `dotnet build --runtime ubuntu.16.04-x64`

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -4,7 +4,7 @@ description: The dotnet-build command builds a project and all of its dependenci
 keywords: dotnet-build, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 10/07/2016
+ms.date: 10/12/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -95,3 +95,17 @@ Marks the build as unsafe for incremental build. This turns off incremental comp
 `--no-dependencies`
 
 Ignores project-to-project references and only builds the root project specified to build.
+
+## Examples
+
+Build a project and its dependencies:
+
+`dotnet build`
+
+Build a project and its dependencies using Release configuration:
+
+`dotnet build --configuration Release`
+
+Build a project and its dependencies for a specific runtime (in this excample, Ubuntu 16.04):
+
+`dotnet build --runtime ubuntu.16.04-x64`

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-build
-description: dotnet-build
-keywords: .NET, .NET Core
+title: dotnet-build command | .NET Core SDK
+description: The dotnet-build command builds a project and all of its dependencies. 
+keywords: dotnet-build, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,21 +12,20 @@ ms.devlang: dotnet
 ms.assetid: 70285a83-4103-4617-be8b-d0e1e9a4a91d
 ---
 
-dotnet-build
-===========
+#dotnet-build
 
-## NAME 
+## Name 
 dotnet-build -- Builds a project and all of its dependencies 
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet build [--output]  
+`dotnet build [--help] [--output]  
     [--build-base-path] [--framework]  
     [--configuration]  [--runtime] [--version-suffix]
     [--build-profile]  [--no-incremental] [--no-dependencies]
-    [<project>]`  
+    [<project>]`
 
-## DESCRIPTION
+## Description
 
 The `dotnet build` command builds multiple source file from a source project and its dependencies into a binary. 
 By default, the resulting binary is in Intermediate Language (IL) and has a DLL extension. 
@@ -55,31 +54,35 @@ In order to build an executable application instead of a library, you need a [sp
 }
 ```
 
-## OPTIONS
+## Options
 
-`-o`, `--output` [DIR]
+`-h|--help`
 
-Directory in which to place the built binaries. 
+Prints out a short help for the command.  
 
-`-b`, `--build-base-path` [DIR]
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Directory in which to place the built binaries. You also need to define `--framework` when you specify this option.
+
+`-b|--build-base-path <OUTPUT_DIRECTORY>`
 
 Directory in which to place temporary outputs.
 
-`-f`, `--framework` [FRAMEWORK]
+`-f|--framework <FRAMEWORK>`
 
-Compiles for a specific framework. The framework needs to be defined in the project.json file.
+Compiles for a specific framework. The framework needs to be defined in the [project.json](project-json,md#frameworks) file.
 
-`-c`, `--configuration` [Debug|Release]
+`-c|--configuration [Debug|Release]`
 
-Defines a configuration under which to build.  If omitted, it defaults to Debug.
+Defines a configuration under which to build.  If omitted, it defaults to `Debug`.
 
-`-r`, `--runtime` [RUNTIME_IDENTIFIER]
+`-r|--runtime [RUNTIME_IDENTIFIER]`
 
-Target runtime to build for. 
+Target runtime to build for. For a list of Runtime Identifiers (RIDs) you can use, see the [RID catalog](../rid-catalog.md). 
 
-`--version-suffix` [VERSION_SUFFIX]
+`--version-suffix [VERSION_SUFFIX]`
 
-Defines what `*` should be replaced with in the version field in the project.json file. The format follows NuGet's version guidelines. 
+Defines what `*` should be replaced with in the version field in the [project.json](project-json,md#version) file. The format follows NuGet's version guidelines. 
 
 `--build-profile`
 

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-install scripts reference
-description: dotnet-install scripts reference
+title: dotnet-install scripts | .NET Core SDK
+description: Learn about the dotnet-install scripts to install the .NET Core CLI tools and the shared runtime. 
 keywords: .NET, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,26 +12,25 @@ ms.devlang: dotnet
 ms.assetid: 59b9c456-2bfd-4adc-8202-a1c6a0a6c787
 ---
 
-dotnet-install scripts reference
-================================
+#dotnet-install scripts reference
 
-## NAME
-dotnet-install.ps1 | dotnet-install.sh - script used to install the Command Line Interface (CLI) tools and shared runtime
+## Name
+dotnet-install.ps1 | dotnet-install.sh - script used to install the Command Line Interface (CLI) tools and the shared runtime
 
-## SYNOPSIS
+## Synopsis
 Windows:
 
 `dotnet-install.ps1 [-Channel] [-Version]
     [-InstallDir] [-Debug] [-NoPath] 
     [-SharedRuntime]`
 
-OS X/Linux:
+macOS/Linux:
 
 `dotnet-install.sh [--channel] [--version]
     [--install-dir] [--debug] [--no-path] 
     [--shared-runtime]`
 
-## DESCRIPTION
+## Description
 The `dotnet-install` scripts are used to perform a non-admin install of the CLI toolchain and the shared runtime. You can download the scripts from our [CLI GitHub repo](https://github.com/dotnet/cli/tree/rel/1.0.0-preview2/scripts/obtain). 
 
 Their main use case is to help with automation scenarios and non-admin installations. There are two scripts, one for PowerShell that works on Windows and a bash script that works on Linux/OS X. They both have the same behavior. Bash script also "understands" PowerShell switches so you can use them across the board. 
@@ -43,7 +42,7 @@ By default, the script will add the install location to the $PATH for the curren
 
 Before running the script, please install all the required [dependencies](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md).
 
-You can install a specific version using the `--version` argument. The version needs to be specified as 3-part version (for example 1.0.0-13232). If omitted, it will default to the first global.json file found in the hierarchy above the folder where the script was invoked in that contains the `sdkVersion` property. If that is not present, it will use Latest.
+You can install a specific version using the `--version` argument. The version needs to be specified as 3-part version (for example, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) file found in the hierarchy above the folder where the script was invoked in that contains the `sdkVersion` property. If that is not present, it will use Latest.
 
 You can also use this script to get the SDK or shared runtime debug binaries with debug symbols by using the `--debug` argument. If you do not do this on first install and realize you do need debug symbols later on, you can re-run the script with this argument and the version of the bits you installed. 
 
@@ -53,38 +52,38 @@ Options are different between script implementations.
 ### PowerShell (Windows)
 `-Channel [CHANNEL]`
 
-Which channel (for example, "future", "preview", "production") to install from. The default value is "Production".
+Which channel (for example, `future`, `preview`, `production`) to install from. The default value is `production`.
 
 `-Version [VERSION]`
 
-Which version of CLI to install; you need to specify the version as 3-part version (i.e. 1.0.0-13232). If omitted, it will default to the first global.json that contains the sdkVersion property; if that is not present, it will use Latest. 	
+Which version of CLI to install; you need to specify the version as 3-part version (that is, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) that contains the [sdkVersion](global-json.md#sdkversion) property; if that is not present, it will use Latest. 	
 
 `-InstallDir [DIR]`
 
-Path to install to. The directory is created if it doesn't exist. The default value is `%LocalAppData%\.dotnet`.
+Path to install to. The directory is created if it doesn't exist. The default value is *%LocalAppData%\.dotnet*.
 
 `-Debug`
 
-**true** to indicate that larger packages containing debugging symbols should be used; otherwise, **false**. The default value is **false**.
+`true` to indicate that larger packages containing debugging symbols should be used; otherwise, `false`. The default value is `false`.
 
 `-NoPath`
 
-**true** to indicate that the prefix/installdir are not exported to the path for the current session; otherwise, **false**. 
-The default value is **false**, that is, the PATH is modified. 
+`true` to indicate that the prefix/installdir are not exported to the path for the current session; otherwise, `false`. 
+The default value is `false`, that is, the PATH is modified. 
 This makes the CLI tools available immediately after install. 
 
 `-SharedRuntime`
 
-**true** to install just the shared runtime bits; **false** to install the entire SDK. The default value is **false**.
+`true` to install just the shared runtime bits; `false` to install the entire SDK. The default value is `false`.
 
-### Bash (OS X/Linux)
+### Bash (macOS/Linux)
 `--channel [CHANNEL]`
 
 Which channel (for example "future", "preview", "production") to install from. The default value is "Production".
 
 `--version [VERSION]`
 
-Which version of CLI to install; you need to specify the version as 3-part version (i.e. 1.0.0-13232). If omitted, it will default to the first global.json that contains the sdkVersion property; if that is not present, it will use Latest. 	
+Which version of CLI to install; you need to specify the version as 3-part version (that is, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) that contains the [sdkVersion](global-json.md#sdkversion) property; if that is not present, it will use Latest. 	
 
 `--install-dir [DIR]`
 
@@ -92,44 +91,36 @@ Path to where to install. The directory is created if it doesn't exist. The defa
 
 `--debug`
 
-**true** to indicate that larger packages containing debugging symbols should be used; otherwise, **false**. The default value is **false**.
+`true` to indicate that larger packages containing debugging symbols should be used; otherwise, `false`. The default value is `false`.
 
 `--no-path`
 
-**true** to indicate that the prefix/installdir are not exported to the path for the current session; otherwise, **false**. 
-The default value is **false**, that is, the PATH is modified. 
+`true` to indicate that the prefix/installdir are not exported to the path for the current session; otherwise, `false`. 
+The default value is `false`, that is, the PATH is modified. 
 This makes the CLI tools available immediately after install.  
 
 `--shared-runtime`
 
-**true** to install just the shared runtime bits; **false** to install the entire SDK. The default value is **false**.
+`true` to install just the shared runtime bits; `false` to install the entire SDK. The default value is `false`.
 
-## EXAMPLES
+## Examples
 
-Windows:
-
-```
-./dotnet-install.ps1 -Channel Future
-```
-
-OS X/Linux:
-
-```
-./dotnet-install.sh --channel Future
-```
-
-Installs the dev latest version to the default location.
+Install the dev latest version to the default location:
 
 Windows:
 
-```
-./dotnet-install.ps1 -Channel preview -InstallDir C:\cli
-```
+`./dotnet-install.ps1 -Channel Future`
 
 OS X/Linux:
 
-```
-./dotnet-install.sh --channel preview --install-dir ~/cli
-```
+`./dotnet-install.sh --channel Future`
 
-Installs the latest preview to the specified location.
+Install the latest preview to the specified location:
+
+Windows:
+
+`./dotnet-install.ps1 -Channel preview -InstallDir C:\cli`
+
+OS X/Linux:
+
+`./dotnet-install.sh --channel preview --install-dir ~/cli`

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -1,10 +1,10 @@
 ---
 title: dotnet-install scripts | .NET Core SDK
 description: Learn about the dotnet-install scripts to install the .NET Core CLI tools and the shared runtime. 
-keywords: .NET, .NET Core
+keywords: dotnet-install, dotnet-install scripts, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 10/07/2016
+ms.date: 10/12/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -56,7 +56,7 @@ Which channel (for example, `future`, `preview`, `production`) to install from. 
 
 `-Version [VERSION]`
 
-Which version of CLI to install; you need to specify the version as 3-part version (that is, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) that contains the [sdkVersion](global-json.md#sdkversion) property; if that is not present, it will use Latest. 	
+Which version of CLI to install; you need to specify the version as 3-part version (for example, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) that contains the [sdkVersion](global-json.md#sdkversion) property; if that is not present, it will use Latest. 	
 
 `-InstallDir [DIR]`
 
@@ -83,7 +83,7 @@ Which channel (for example "future", "preview", "production") to install from. T
 
 `--version [VERSION]`
 
-Which version of CLI to install; you need to specify the version as 3-part version (that is, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) that contains the [sdkVersion](global-json.md#sdkversion) property; if that is not present, it will use Latest. 	
+Which version of CLI to install; you need to specify the version as 3-part version (for example, 1.0.0-13232). If omitted, it will default to the first [global.json](global-json.md) that contains the [sdkVersion](global-json.md#sdkversion) property; if that is not present, it will use Latest. 	
 
 `--install-dir [DIR]`
 
@@ -111,7 +111,7 @@ Windows:
 
 `./dotnet-install.ps1 -Channel Future`
 
-OS X/Linux:
+macOS/Linux:
 
 `./dotnet-install.sh --channel Future`
 
@@ -121,6 +121,6 @@ Windows:
 
 `./dotnet-install.ps1 -Channel preview -InstallDir C:\cli`
 
-OS X/Linux:
+macOS/Linux:
 
 `./dotnet-install.sh --channel preview --install-dir ~/cli`

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -54,6 +54,6 @@ Create an F# project in the current directory:
 
 `dotnet new --lang f#`
   
-Create a new ASP.NET Core project in the current directory.
+Create a new ASP.NET Core project in the current directory:
 
 `dotnet new -t web`

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -46,14 +46,14 @@ Type of the project. Valid values for C# are `console`, `web`, `lib` and `xunitt
 
 ## Examples
 
-Create a C# console application in the current directory:
+Create a C# console application project in the current directory:
 
 `dotnet new` or `dotnet new --lang c#` 
    
-Create an F# console application in the current directory:
+Create an F# console application project in the current directory:
 
 `dotnet new --lang f#`
   
-Create a new ASP.NET Core application in the current directory:
+Create a new ASP.NET Core C# application project in the current directory:
 
 `dotnet new -t web`

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -4,7 +4,7 @@ description: The dotnet-new command creates new .NET Core projects in the curren
 keywords: dotnet-new, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 10/07/2016
+ms.date: 10/12/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -38,22 +38,22 @@ Prints out a short help for the command.
 
 `-l|--lang <C#|F#>`
 
-Language of the project. Defaults to `C#`. Valid values are `csharp`, `fsharp`, `cs` and `fs`.
+Language of the project. Defaults to `C#`. Other valid values are `csharp`, `fsharp`, `cs` and `fs`.
 
-`-t`, `--type`
+`-t|--type`
 
 Type of the project. Valid values for C# are `console`, `web`, `lib` and `xunittest` and for F# only `console` is valid. 
 
 ## Examples
 
-Create a C# project in the current directory:
+Create a C# console application in the current directory:
 
 `dotnet new` or `dotnet new --lang c#` 
    
-Create an F# project in the current directory:
+Create an F# console application in the current directory:
 
 `dotnet new --lang f#`
   
-Create a new ASP.NET Core project in the current directory:
+Create a new ASP.NET Core application in the current directory:
 
 `dotnet new -t web`

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-new
-description: dotnet-new
-keywords: .NET, .NET Core
+title: dotnet-new command | .NET Core
+description: The dotnet-new command creates new .NET Core projects in the current directory.
+keywords: dotnet-new, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,19 +12,18 @@ ms.devlang: dotnet
 ms.assetid: 263c3d05-3a47-46a6-8023-3ca16b488410
 ---
 
-dotnet-new
-==========
+#dotnet-new
 
-## NAME
-dotnet-new -- Creates a new .NET Core project
+## Name
+dotnet-new -- Creates a new .NET Core project in the current directory
 
-## SYNOPSIS
-`dotnet new [--type] [--lang]`
+## Synopsis
+`dotnet new [--help] [--type] [--lang]`
 
-## DESCRIPTION
+## Description
 The `dotnet new` command provides a convenient way to initialize a valid .NET Core project and sample source code to try out the Command Line Interface (CLI) toolset. 
 
-This command is invoked in the context of a directory. When invoked, the command will result in two main artifacts being dropped to the directory: 
+This command is invoked in the context of a directory. When invoked, the command will result in two main artifacts being dropped to the current directory: 
 
 1. A `Program.cs` (or `Program.fs`) file that contains a sample "Hello World" program.
 2. A valid `project.json` file.
@@ -33,28 +32,28 @@ After this, the project is ready to be compiled and/or edited further.
 
 ## Options
 
-`-l`, `--lang [C#|F#]`
+`-h|--help`
 
-Language of the project. Defaults to `C#`. `csharp` (`fsharp`) or `cs` (`fs`) are also valid options.
+Prints out a short help for the command.  
+
+`-l|--lang <C#|F#>`
+
+Language of the project. Defaults to `C#`. Valid values are `csharp`, `fsharp`, `cs` and `fs`.
 
 `-t`, `--type`
 
-Type of the project. Valid values are `console`, `web`, `lib` and `xunittest`. 
+Type of the project. Valid values for C# are `console`, `web`, `lib` and `xunittest` and for F# only `console` is valid. 
 
-## EXAMPLES
+## Examples
 
-`dotnet new`
-    
-Drops a C# project in the current directory.
+Create a C# project in the current directory:
+
+`dotnet new` or `dotnet new --lang c#` 
+   
+Create an F# project in the current directory:
 
 `dotnet new --lang f#`
-    
-Drops an F# project in the current directory.
-
-`dotnet new --lang c#`
-    
-Drops an C# project in the current directory.
+  
+Create a new ASP.NET Core project in the current directory.
 
 `dotnet new -t web`
-    
-Drops a new ASP.NET Core project in the current directory. 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -4,7 +4,7 @@ description: The dotnet-pack command creates NuGet packages for your .NET Core p
 keywords: dotnet-pack, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 09/27/2016
+ms.date: 10/12/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -57,7 +57,7 @@ Does not build the project before packing.
 
 Places the temporary build artifacts in the specified directory. By default, they go to the `obj` directory in the current directory. 
 
-`-c`, `--configuration <Debug|Release>`
+`-c|--configuration <Debug|Release>`
 
 Configuration to use when building the project. If not specified, will default to `Debug`.
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -1,7 +1,7 @@
 ---
-title: dotnet-pack
-description: dotnet-pack
-keywords: .NET, .NET Core
+title: dotnet-pack command | .NET Core SDK
+description: The dotnet-pack command creates NuGet packages for your .NET Core project.
+keywords: dotnet-pack, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
 ms.date: 09/27/2016
@@ -12,21 +12,20 @@ ms.devlang: dotnet
 ms.assetid: 8b4b8cef-f56c-4a10-aa01-fde8bfaae53e
 ---
 
-dotnet-pack
-===========
+#dotnet-pack
 
-## NAME
+## Name
 
 `dotnet-pack` - Packs the code into a NuGet package
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet pack [--output]  
+`dotnet pack [--help] [--output]  
     [--no-build] [--build-base-path]  
     [--configuration]  [--version-suffix]
-    [<project>]`  
+    [project]`  
 
-## DESCRIPTION
+## Description
 
 The `dotnet pack` command builds the project and creates NuGet packages. The result of this operation is two packages with the `nupkg` extension. One package contains the code and the other contains the debug symbols. 
 
@@ -35,51 +34,50 @@ Project-to-project references are not packaged inside the project. Currently, yo
 
 `dotnet pack` by default first builds the project. If you wish to avoid this, pass the `--no-build` option. This can be useful in Continuous Integration (CI) build scenarios in which you know the code was just previously built, for example. 
 
-## OPTIONS
+## Options
+
+`-h|--help`
+
+Prints out a short help for the command.  
 
 `[project]` 
     
-The project to pack. It can be either a path to a `project.json` file or to a directory. If omitted, it will
+The project to pack. It can be either a path to a [project.json](project-json.md) file or to a directory. If omitted, it will
 default to the current directory. 
 
-`-o`, `--output` [DIR]
+`-o|--output <OUTPUT_DIRECTORY>`
 
 Places the built packages in the directory specified. 
 
 `--no-build`
 
-Skips the building phase of the packing process. 
+Does not build the project before packing. 
 
 `--build-base-path`
 
-Places the temporary build artifacts in the specified directory. By default, they go to the obj directory in the current directory. 
+Places the temporary build artifacts in the specified directory. By default, they go to the `obj` directory in the current directory. 
 
-`-c`, `--configuration [Debug|Release]`
+`-c`, `--configuration <Debug|Release>`
 
-Configuration to use when building the project. If not specified, will default to "Debug".
+Configuration to use when building the project. If not specified, will default to `Debug`.
 
 `--version-suffix`
 
 Updates the star in `-*` package version suffix with a specified string.
 
-## EXAMPLES
+## Examples
 
+Pack the project in the current directory:
 `dotnet pack`
 
-Packs the current project.
-
+Pack the app1 project:
 `dotnet pack ~/projects/app1/project.json`
-    
-Packs the app1 project.
 	
+Pack the project in the current directory and place the resulting packages into the specified folder:
 `dotnet pack --output nupkgs`
-    
-Packs the current project and place the resulting packages into the specified folder.
 
+Pack the project in the current directory into the specified folder and skip the build step:
 `dotnet pack --no-build --output nupkgs`
 
-Packs the current project into the specified folder and skips the build step.
-
+Pack the current project and updates the resulting packages version with the given suffix. For example, version `1.0.0-*` will be updated to `1.0.0-ci-1234`.
 `dotnet pack --version-suffix "ci-1234"`
-
-Packs the current project and updates the resulting packages version with the given suffix. For example, version `1.0.0-*` will be updated to `1.0.0-ci-1234`.

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -68,16 +68,21 @@ Updates the star in `-*` package version suffix with a specified string.
 ## Examples
 
 Pack the project in the current directory:
+
 `dotnet pack`
 
 Pack the app1 project:
+
 `dotnet pack ~/projects/app1/project.json`
 	
 Pack the project in the current directory and place the resulting packages into the specified folder:
+
 `dotnet pack --output nupkgs`
 
 Pack the project in the current directory into the specified folder and skip the build step:
+
 `dotnet pack --no-build --output nupkgs`
 
 Pack the current project and updates the resulting packages version with the given suffix. For example, version `1.0.0-*` will be updated to `1.0.0-ci-1234`.
+
 `dotnet pack --version-suffix "ci-1234"`

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-publish
-description: dotnet-publish
-keywords: .NET, .NET Core
+title: dotnet-publish command | .NET Core SDK
+description: The dotnet-publish command publishes your .NET Core project into a directory. 
+keywords: dotnet-publish, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,81 +12,93 @@ ms.devlang: dotnet
 ms.assetid: 8a7e1c52-5c57-4bf5-abad-727450ebeefd
 ---
 
-dotnet-publish
-==============
+#dotnet-publish
 
-## NAME
+## Name
 
 `dotnet-publish` - Packs the application and all of its dependencies into a folder getting it ready for publishing
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet publish [--framework]  
+`dotnet publish [project] 
+    [--help] [--framework]  
     [--runtime] [--build-base-path] [--output]  
-    [--version-suffix] [--configuration]  
-    [<project>]`  
+    [--version-suffix] [--configuration] [--native-subdirectory] [--no-build]`
 
-## DESCRIPTION
+## Description
 
-`dotnet publish` compiles the application, reads through its dependencies specified in the `project.json` file and publishes the resulting set of files to a directory. 
+`dotnet publish` compiles the application, reads through its dependencies specified in the [project.json](project-json.md) file and publishes the resulting set of files to a directory. 
 
 Depending on the type of portable app, the resulting directory will contain the following:
 
-1. **Portable application** - application's intermediate language (IL) code and all of application's managed dependencies.
-    * **Portable application with native dependencies** - same as above with a sub-directory for the supported platform of each native
+1. *Portable application* - application's intermediate language (IL) code and all of application's managed dependencies.
+    * *Portable application with native dependencies* - same as above with a sub-directory for the supported platform of each native
     dependency. 
-2. **Self-contained application** - same as above plus the entire runtime for the targeted platform.
+2. *Self-contained application* - same as above plus the entire runtime for the targeted platform.
 
-The above types are covered in more details in the [types of portable applications](../app-types.md) topic.
+For more information, see the [.NET Core Application Deployment](../deploying/index.md) topic.
 
-## OPTIONS
+## Options
 
 `[project]` 
-    
-`dotnet publish` needs access to the `project.json` file to work. If it is not specified on invocation via [project], `project.json` in the current directory will be the default.     
-If no `project.json` can be found, `dotnet publish` will throw an error. 
 
-`-f`, `--framework` [FID]
+The project to publish, which defaults to the current directory if `[project]` is not specified. This value can be a path to the [project.json](project-json.md) file or to the project 
+directory that contains the [project.json](project-json.md) file. If no [project.json](project-json.md) file can be found, `dotnet publish` throws an error. 
 
-Publishes the application for a given framework identifier (FID). If not specified, FID is read from `project.json`. If no valid framework is found, the command will throw an error. If multiple valid frameworks are found, the command will publish for all valid frameworks. 
+`-h|--help`
 
+Prints out a short help for the command.  
 
-`-r`, `--runtime` [RID]
+`-f|--framework <FRAMEWORK>`
 
-Publishes the application for a given runtime. 
+Publishes the application for a given framework identifier (FID). If not specified, FID is read from [project.json](project-json.md#frameworks). If no valid framework is found, the command throws an error. If multiple valid frameworks are found, the command publishes for all valid frameworks. 
 
-`-b`, `--build-base-path` [DIR]
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+Publishes the application for a given runtime. For a list of Runtime Identifiers (RIDs) you can use, see the [RID catalog](../rid-catalog.md).
+
+`-b|--build-base-path <OUTPUT_DIRECTORY>`
 
 Directory in which to place temporary outputs.
 
-`-o`, `--output`
+`-o|--output <OUTPUT_PATH>`
 
-Specify the path where to place the directory. If not specified, it will default to _./bin/[configuration]/[framework]/_ 
-for portable applications or _./bin/[configuration]/[framework]/[runtime]_ for self-contained applications.
+Specify the path where to place the directory. If not specified, it will default to *_./bin/[configuration]/[framework]/_* 
+for portable applications or *_./bin/[configuration]/[framework]/[runtime]_* for self-contained deployments.
 
---version-suffix [VERSION_SUFFIX]
+`--version-suffix [VERSION_SUFFIX]`
 
 Defines what `*` should be replaced with in the version field in the project.json file.
 
-`-c`, `--configuration [Debug|Release]`
+`-c|--configuration [Debug|Release]`
 
-Configuration to use when publishing. The default value is Debug.
+Configuration to use when publishing. The default value is `Debug`.
 
-## EXAMPLES
+`[--native-subdirectory]`
+Temporary mechanism to include subdirectories from native assets of dependency packages in output. 
+
+`[--no-build]`
+Does not build projects before publishing.
+
+## Examples
+
+Publish an application using the framework found in `project.json`. If `project.json` contains [runtimes](project-json.md#runtimes) node, publish for the RID of the current platform.
 
 `dotnet publish`
 
-Publishes an application using the framework found in `project.json`. If `project.json` contains `runtimes` node, publish for the RID of the current platform.
+Publish the application using the specified [project.json](project-json.md):
 
 `dotnet publish ~/projects/app1/project.json`
-    
-Publishes the application using the specified `project.json`.
 	
+Publish the current application using the `netcoreapp1.0` framework:
+
 `dotnet publish --framework netcoreapp1.0`
-    
-Publishes the current application using the `netcoreapp1.0` framework.
 	
+Publish the current application using the `netcoreapp1.0` framework and runtime for `OS X 10.10` (this RID has to 
+exist in the `project.json` [runtimes](project-json.md#runtimes) node):
+
 `dotnet publish --framework netcoreapp1.0 --runtime osx.10.11-x64`
-    
-Publishes the current application using the `netcoreapp1.0` framework and runtime for `OS X 10.10`. This RID has to 
-exist in the `project.json` `runtimes` node.
+
+## See also
+* [Frameworks](../../standard/frameworks.md)
+* [Runtime IDentifier (RID) catalog](../rid-catalog.md)

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-restore
-description: dotnet-restore
-keywords: .NET, .NET Core
+title: dotnet-restore command | .NET Core SDK
+description: Learn how to restore dependencies and project-specific tools with the dotnet restore command 
+keywords: dotnet-restore, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,49 +12,55 @@ ms.devlang: dotnet
 ms.assetid: 60489b25-38de-47e6-bed1-59d9f42e2d46
 ---
 
-dotnet-restore
-==============
+#dotnet-restore
 
-## NAME
+## Name
 
 `dotnet-restore` - Restores the dependencies and tools of a project
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet restore [--source]  
-    [--packages] [--disable-parallel]  
-    [--fallbacksource] [--configfile] [--verbosity]
-    [<root>]`  
+`dotnet restore [root] [--help] [--force-english-output] [--source]  
+    [--packages] [--disable-parallel] [--fallbacksource] [--configfile] 
+    [--no-cache] [--infer-runtimes] [--verbosity] [--ignore-failed-sources]`
 
-## DESCRIPTION
+## Description
 
-The `dotnet restore` command uses NuGet to restore dependencies as well as project-specific tools that are specified in the project.json file. 
+The `dotnet restore` command uses NuGet to restore dependencies as well as project-specific tools that are specified in the [project.json](project-json.md) file. 
 By default, the restoration of dependencies and tools are done in parallel.
 
 In order to restore the dependencies, NuGet needs the feeds where the packages are located. 
 Feeds are usually provided via the NuGet.config configuration file; a default one is present when the CLI tools are installed. 
 You can specify more feeds by creating your own NuGet.config file in the project directory. 
-Feeds can also be specified per invocation on the command line. 
+Feeds can also be specified per invocation on the command prompt. 
 
 For dependencies, you can specify where the restored packages are placed during the restore operation using the 
 `--packages` argument. 
 If not specified, the default NuGet package cache is used. 
-It is found in the `.nuget/packages` directory in the user's home directory on all operating systems (for example, `/home/user1` on Linux or `C:\Users\user1` on Windows).
+It is found in the `.nuget/packages` directory in the user's home directory on all operating systems (for example, */home/user1* on Linux or *C:\Users\user1* on Windows).
 
 For project-specific tooling, `dotnet restore` first restores the package in which the tool is packed, and then
-proceeds to restore the tool's dependencies as specified in its project.json. 
+proceeds to restore the tool's dependencies as specified in its [project.json](project-json.md). 
 
-## OPTIONS
+## Options
 
 `[root]` 
     
- A list of projects or project folders to restore. The list can contain either a path to a `project.json` file, or a path to `global.json` file or folder. The restore operation runs recursively for all subdirectories and restores for each given project.json file it finds.
+ A list of projects or project folders to restore. Each value can be a path to a [project.json](project-json.md) or [global.json](global-json.md) file, or to a folder. If a folder is specified, the restore operation will recursively search for a [project.json](project-json.md) file in all subdirectories and restores for each [project.json](project-json.md) file found.
 
-`-s`, `--source` [SOURCE]
+`-h|--help`
 
-Specifies a source to use during the restore operation. This overrides all of the sources specified in the NuGet.config file(s). Multiple sources can be provided by specifying this option multiple times.
+Prints out a short help for the command.
 
-`--packages` [DIR]
+ `--force-english-output`
+
+Forces the application to run using an invariant, English-based culture.
+
+`-s|--source <SOURCE>`
+
+Specifies a NuGet package source to use during the restore operation. This overrides all of the sources specified in the NuGet.config file(s). Multiple sources can be provided by specifying this option multiple times.
+
+`--packages <PACKAGES_DIRECTORY]`
 
 Specifies the directory to place the restored packages in. 
 
@@ -62,37 +68,48 @@ Specifies the directory to place the restored packages in.
 
 Disables restoring multiple projects in parallel. 
 
-`-f`, `--fallbacksource` [FEED]
+`-f|--fallbacksource <FEED>`
 
-Specifies a fallback source that will be used in the restore operation if all other sources fail. All valid feed formats are allowed. Multiple fallback sources can be provided by specifying this option multiple times.
+Specifies a list of packages sources to use as a fallback in the restore operation if all other sources fail. All valid feed formats are allowed. Multiple fallback sources can be provided by specifying this option multiple times.
 
-`--configfile` [FILE]
+`--configfile <FILE>`
 
-Configuration file (NuGet.config) to use for the restore operation. 
+The NuGet configuration file (NuGet.config) to use for the restore operation.
 
-`--verbosity` [LEVEL]
+`--no-cache`
 
-The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Minimal, Warning, or Error.
+Specifies to not cache packages and HTTP requests.
 
-## EXAMPLES
+`--infer-runtimes`
 
-`dotnet restore`
+Temporary option to allow NuGet to infer Runtime Identifiers (RIDs) for legacy repositories.
 
-Restores dependencies and tools for the project in the current directory. 
+`--verbosity [LEVEL]`
+
+The verbosity of logging to use. Allowed values: `Debug`, `Verbose`, `Information`, `Minimal`, `Warning`, or `Error`.
+
+` --ignore-failed-sources`
+
+Only warn about failed sources if there are packages meeting version requirement.
+
+## Examples
+
+Restore dependencies and tools for the project in the current directory:
+
+`dotnet restore` 
+
+Restore dependencies and tools for the `app1` project found in the given path:
 
 `dotnet restore ~/projects/app1/project.json`
-    
-Restores dependencies and tools for the `app1` project found in the given path.
 	
-`dotnet restore -f c:\packages\mypackages`
-    
-Restores the dependencies and tools for the project in the current directory using the file path provided as the fallback source. 
+Restore the dependencies and tools for the project in the current directory using the file path provided as the fallback source:
 
-`dotnet restore -f c:\packages\mypackages -f c:\packages\myotherpackages`
-	
-Restores the dependencies and tools for the project in the current directory using the two file paths provided as the fallback sources. 
+`dotnet restore -f c:\packages\mypackages` 
+
+Restore the dependencies and tools for the project in the current directory using the two file paths provided as the fallback sources:
+
+`dotnet restore -f c:\packages\mypackages -f c:\packages\myotherpackages` 
+
+Restore dependencies and tools for the project in the current directory and shows only errors in the output:
 
 `dotnet restore --verbosity Error`
-    
-Restores dependencies and tools for the project in the current directory and shows only errors in the output.
-

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-run
-description: dotnet-run
-keywords: .NET, .NET Core
+title: dotnet-run command | .NET Core SDK
+description: The dotnet-run command provides a convenient option to run your application from the source code.
+keywords: dotnet-run, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,71 +12,72 @@ ms.devlang: dotnet
 ms.assetid: 495ff50b-cb30-4d30-8f20-beb3d5e7c31f
 ---
 
-dotnet-run
-==========
+#dotnet-run
 
-## NAME 
+## Name 
 
-dotnet-run -- Runs source code 'in-place' without any explicit compile or launch commands.
+dotnet-run -- Runs source code 'in-place' without any explicit compile or launch commands
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet run [--framework] [--configuration]
-    [--project] [--help] [--]`
+`dotnet run [--help] [--framework] [--configuration]
+    [--project] [[--] [application arguments]]`
 
-## DESCRIPTION
+## Description
 The `dotnet run` command provides a convenient option to run your application from the source code with one command. 
 It compiles source code, generates an output program and then runs that program. 
 This command is useful for fast iterative development and can also be used to run a source-distributed program (for example, a website).
 
-This command relies on [`dotnet build`](dotnet-build.md) to build source inputs to a .NET assembly, before launching the program. 
+This command relies on [dotnet build](dotnet-build.md) to build source inputs to a .NET assembly, before launching the program. 
 The requirements for this command and the handling of source inputs are all inherited from the build command. 
 The documentation for the build command provides more information on those requirements.
 
-Output files are written to the child `bin` folder, which will be created if it doesn't exist. 
+Output files are written to the child *bin* folder, which will be created if it doesn't exist. 
 Files will be overwritten as needed. 
-Temporary files are written to the child `obj` folder.  
+Temporary files are written to the child *obj* folder.  
 
 In case of a project with multiple specified frameworks, `dotnet run` will first select the .NET Core frameworks. If those do not exist, it will error out. To specify other frameworks, use the `--framework` argument.
 
-The `dotnet run` command must be used in the context of projects, not built assemblies. If you're trying to execute a DLL instead, you should use [`dotnet`](dotnet.md) without any command like in the following example:
+The `dotnet run` command must be used in the context of projects, not built assemblies. If you're trying to run a portable application DLL instead, you should use [dotnet](dotnet.md) without any command like in the following example:
  
 `dotnet myapp.dll`
 
 For more information about the `dotnet` driver, see the [.NET Core Command Line Tools (CLI)](index.md) topic.
 
-
-## OPTIONS
+## Options
 
 `--`
 
 Delimits arguments to `dotnet run` from arguments for the application being run. 
 All arguments after this one will be passed to the application being run. 
 
-`-f`, `--framework` [FID]
+`-h|--help`
+
+Prints out a short help for the command.
+
+`-f`, `--framework <FRAMEWORK_IDENTIFIER>`
 
 Runs the application for a given framework identifier (FID). 
 
-`-c`, `--configuration [Debug|Release]`
+`-c`, `--configuration <Debug|Release>`
 
-Configuration to use when publishing. The default value is "Debug".
+Configuration to use when publishing. The default value is `Debug`.
 
 `-p`, `--project [PATH]`
 
 Specifies which project to run. 
-It can be a path to a project.json file or to a directory containing a project.json file. It defaults to
+It can be a path to a [project.json](project-json.md) file or to a directory containing a [project.json](project-json.md) file. It defaults to
 current directory if not specified. 
 
-## EXAMPLES
+## Examples
 
-`dotnet run`
+Run the project in the current directory:
+`dotnet run` 
 
-Runs the project in the current directory. 
+Run the specified project:
 
 `dotnet run --project /projects/proj1/project.json`
 
-Runs the project specified.
+Run the project in the current directory (the `--help` argument in this example is passed to the application being run, since the `--` argument was used):
 
 `dotnet run --configuration Release -- --help`
-
-Runs the project in the current directory. The `--help` argument above is passed to the application being run, since the `--` argument was used.

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet-test
-description: dotnet-test
-keywords: .NET, .NET Core
+title: dotnet-test command | .NET Core SDK
+description: The `dotnet test` command is used to execute unit tests in a given project.
+keywords: dotnet-test, CLI, CLI command, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,22 +12,20 @@ ms.devlang: dotnet
 ms.assetid: 3a0fa917-eb0a-4d7e-9217-d06e65455675
 ---
 
-dotnet-test
-================
+#dotnet-test
 
-## NAME
+## Name
 
 `dotnet-test` - Runs unit tests using the configured test runner
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet test [--configuration]  
+`dotnet test [project] [--help] 
+    [--parentProcessId] [--port] [--configuration]   
     [--output] [--build-base-path] [--framework] [--runtime]
-    [--no-build]
-    [--parentProcessId] [--port]  
-    [<project>]`  
+    [--no-build]`  
 
-## DESCRIPTION
+## Description
 
 The `dotnet test` command is used to execute unit tests in a given project. Unit tests are class library 
 projects that have dependencies on the unit test framework (for example, NUnit or xUnit) and the 
@@ -67,42 +65,23 @@ The following sample project.json shows the properties needed:
   }
 }
 ```
+
 `dotnet test` supports two running modes:
 
 1. Console: In console mode, `dotnet test` simply executes fully any command gets passed to it and outputs the results. Anytime you invoke `dotnet test` without passing --port, it runs in console mode, which in turn will cause the runner to run in console mode.
 2. Design time: used in the context of other tools, such as editors or Integrated Development Environments (IDEs). You can find out more about this mode in the [dotnet-test protocol](test-protocol.md) document. 
 
-## OPTIONS
+## Options
 
 `[project]`
     
-Specifies a path to the test project. If omitted, it defaults to current directory. 
+Specifies a path to the test project. If omitted, it defaults to current directory.
 
-`-c`, `--configuration` [Debug|Release]
+`-?|-h|--help`
 
-Configuration under which to build. The default value is Release. 
+Prints out a short help for the command.
 
-`-o`, `--output` [DIR]
-
-Directory in which to find binaries to run.
-
-`-b`, `--build-base-path` [DIR]
-
-Directory in which to place temporary outputs.
-
-`-f`, `--framework` [FRAMEWORK]
-
-Looks for test binaries for a specific framework.
-
-`-r`, `--runtime` [RUNTIME_IDENTIFIER]
-
-Look for test binaries for a for the specified runtime.
-
-`--no-build` 
-
-Does not build the test project prior to running it. 
-
---parentProcessId
+`--parentProcessId`
 
 Used by IDEs to specify their process ID. Test will exit if the parent process does.
 
@@ -110,16 +89,44 @@ Used by IDEs to specify their process ID. Test will exit if the parent process d
 
 Used by IDEs to specify a port number to listen for a connection.
 
-## EXAMPLES
+`-c|--configuration <Debug|Release>`
 
-`dotnet test`
+Configuration under which to build. The default value is `Release`. 
 
-Runs the tests in the project in the current directory. 
+`-o|--output [OUTPUT_DIRECTORY]`
 
-`dotnet test /projects/test1/project.json`
+Directory in which to find the binaries to run.
 
-Runs the tests in the test1 project. 
+`-b|--build-base-path <OUTPUT_DIRECTORY>`
 
-## SEE ALSO
+Directory in which to place temporary outputs.
 
-* [dotnet-test communication protocol](test-protocol.md)
+`-f|--framework [FRAMEWORK]`
+
+Looks for test binaries for a specific framework.
+
+`-r|--runtime [RUNTIME_IDENTIFIER]`
+
+Look for test binaries for a for the specified runtime.
+
+`--no-build` 
+
+Does not build the test project prior to running it. 
+
+## Examples
+
+Run the tests in the project in the current directory:
+
+`dotnet test` 
+
+Run the tests in the test1 project:
+
+`dotnet test /projects/test1/project.json` 
+
+## See also
+
+[dotnet-test communication protocol](test-protocol.md)
+
+[Frameworks](../../standard/frameworks.md)
+
+[Runtime IDentifier (RID) catalog](../rid-catalog.md)

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -1,10 +1,10 @@
 ---
-title: dotnet command
-description: dotnet command
-keywords: .NET, .NET Core
+title: dotnet command | .NET Core SDK
+description: Learn about the dotnet command (the generic driver for the .NET Core CLI tools) and its usage.  
+keywords: dotnet, CLI, CLI commands, .NET Core
 author: mairaw
 manager: wpickett
-ms.date: 06/20/2016
+ms.date: 10/07/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -12,27 +12,26 @@ ms.devlang: dotnet
 ms.assetid: 93015521-2127-4fe9-8fce-ca79bcc4ff49
 ---
 
-dotnet command
-==============
+#dotnet command
 
-## NAME
+## Name
 
 dotnet -- General driver for running the command-line commands
 
-## SYNOPSIS
+## Synopsis
 
-`dotnet [--version] [--help] [--verbose] [--info] <command> [<args>]`
+`dotnet [--version] [--verbose] [--info] [command] [arguments] [--help]`
 
-## DESCRIPTION
+## Description
 `dotnet` is a generic driver for the Command Line Interface (CLI) toolchain. Invoked on its own, it will give out brief usage instructions. 
 
 Each specific feature is implemented as a command. In order to use the feature, the command is specified after `dotnet`, such as [`dotnet build`](dotnet-build.md). All of the arguments following the command are its own arguments. 
 
 The only time `dotnet` is used as a command on its own is to run portable apps. Just specify a portable application DLL after the `dotnet` verb to execute the application.    
 
+## Options
 
-## OPTIONS
-`-v, --verbose`
+`-v|--verbose`
 
 Enables verbose output.
 
@@ -44,11 +43,11 @@ Prints out the version of the CLI tooling.
 
 Prints out more detailed information about the CLI tooling, such as the current operating system, commit SHA for the version, etc. 
 
-`-h, --help`
+`-h|--help`
 
-Prints out a short help and a list of current commands. 
+Prints out a short help for the command. If using with `dotnet` only, it also prints a list of the available commands.  
 
-## DOTNET COMMANDS
+## dotnet commands
 
 The following commands exist for dotnet:
 
@@ -67,25 +66,24 @@ The following commands exist for dotnet:
 * [dotnet-pack](dotnet-pack.md)
    * Creates a NuGet package of your code.
 
-## EXAMPLES
+## Examples
+
+Initialize a sample .NET Core console application that can be compiled and run:
 
 `dotnet new`
 
-Initializes a sample .NET Core console application that can be compiled and run.
+Restore dependencies for a given application:
 
 `dotnet restore`
 
-Restores dependencies for a given application. 
+Build a project and its dependencies in a given directory: 
 
-`dotnet compile`
+`dotnet build`
 
-Compiles the application in a given directory. 
-
+Run a portable app named `myapp.dll`:
 `dotnet myapp.dll`
 
-Runs a portable app named `myapp.dll`. 
-
-## ENVIRONMENT 
+## Environment 
 
 `DOTNET_PACKAGES`
 
@@ -97,4 +95,4 @@ Specifies the location of the servicing index to use by the shared host when loa
 
 `DOTNET_CLI_TELEMETRY_OPTOUT`
 
-Specifies whether data about the .NET Core tools usage is collected and sent to Microsoft. **true** to opt-out of the telemetry feature (values true, 1 or yes accepted); otherwise, **false** (values false, 0 or no accepted). If not set, it defaults to **false**, that is, the telemetry feature is on.
+Specifies whether data about the .NET Core tools usage is collected and sent to Microsoft. `true` to opt-out of the telemetry feature (values true, 1 or yes accepted); otherwise, `false` (values false, 0 or no accepted). If not set, it defaults to `false`, that is, the telemetry feature is on.

--- a/docs/core/tools/extensibility.md
+++ b/docs/core/tools/extensibility.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Core CLI extensibility model 
 description: .NET Core CLI extensibility model 
-keywords: .NET, .NET Core
+keywords: CLI, extensibility, custom commands, .NET Core
 author: mairaw
 manager: wpickett
 ms.date: 06/20/2016

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -14,8 +14,6 @@ ms.assetid: b70e9ac0-c8be-49f7-9332-95ab93e0e7bc
 
 # .NET Core Command Line Tools
 
-By [Zlatko Knezevic](https://github.com/blackdwarf) and [Maira Wenzel](https://github.com/mairaw)
-
 ## What is the .NET Core Command Line Interface (CLI)?
 The .NET Core CLI is a new foundational cross-platform toolchain for developing 
 .NET Core applications. It is "foundational" because it is the primary layer on which other, 

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -14,6 +14,8 @@ ms.assetid: b70e9ac0-c8be-49f7-9332-95ab93e0e7bc
 
 # .NET Core Command Line Tools
 
+By [Zlatko Knezevic](https://github.com/blackdwarf) and [Maira Wenzel](https://github.com/mairaw)
+
 ## What is the .NET Core Command Line Interface (CLI)?
 The .NET Core CLI is a new foundational cross-platform toolchain for developing 
 .NET Core applications. It is "foundational" because it is the primary layer on which other, 


### PR DESCRIPTION
Since I was going to respond to a customer feedback given on LiveFyre who noticed an example using `dotnet compile` in our docs, I took the opportunity to also address the following issues for this set of topics which I've been wanting to do for a while now:
- #1083 
- #808 
- formatting issues
- changed the order of the example explanation
- added missing options (such as --help for all commands, dotnet-publish was missing a bunch, and so forth)

/cc @blackdwarf @piotrpMSFT can one of you please help review this?
