### PR TITLE
try fix project load error

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -5,7 +5,9 @@
         {
           "files": [
             "corefx/src/**/ref/**/*.csproj",
-            "wcf/src/**/ref/**/*.csproj"
+            "corefx/src/**/ref/**/project.json",
+            "wcf/src/**/ref/**/*.csproj",
+            "wcf/src/**/ref/**/project.json"
           ],
           "exclude": [ "**/bin/**", "**/obj/**"],
           "cwd": ".."
@@ -18,7 +20,9 @@
         {
           "files": [
             "corefx/src/**/src/**/*.csproj",
+            "corefx/src/**/src/**/project.json",
             "wcf/src/**/src/**/*.csproj",
+            "wcf/src/**/src/**/project.json",
             "coreclr/src/mscorlib/System.Private.CoreLib.csproj"
           ],
           "exclude": [ "**/bin/**", "**/obj/**"],

--- a/docfx.json
+++ b/docfx.json
@@ -5,11 +5,33 @@
         {
           "files": [
             "corefx/src/**/ref/**/*.csproj",
-            "corefx/src/**/ref/**/project.json",
-            "wcf/src/**/ref/**/*.csproj",
-            "wcf/src/**/ref/**/project.json"
+            "wcf/src/**/ref/**/*.csproj"
           ],
-          "exclude": [ "**/bin/**", "**/obj/**"],
+          "exclude": [ "corefx/src/mscorlib/ref/Compat/mscorlib.csproj", "corefx/src/System.Runtime/ref/System.Runtime.csproj", "**/bin/**", "**/obj/**"],
+          "cwd": ".."
+        }
+      ],
+      "dest": "api"
+    },
+    {
+      "src": [
+        {
+          "files": [
+            "corefx/src/mscorlib/ref/Compat/mscorlib.csproj"
+          ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "cwd": ".."
+        }
+      ],
+      "dest": "api"
+    },
+    {
+      "src": [
+        {
+          "files": [
+            "corefx/src/System.Runtime/ref/System.Runtime.csproj"
+          ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
           "cwd": ".."
         }
       ],
@@ -20,9 +42,7 @@
         {
           "files": [
             "corefx/src/**/src/**/*.csproj",
-            "corefx/src/**/src/**/project.json",
             "wcf/src/**/src/**/*.csproj",
-            "wcf/src/**/src/**/project.json",
             "coreclr/src/mscorlib/System.Private.CoreLib.csproj"
           ],
           "exclude": [ "**/bin/**", "**/obj/**"],


### PR DESCRIPTION
`docfx metadata` would log warning like below:

`Warning: Error opening project XX/corefx/src/System.Linq.Parallel/ref/System.Linq.Parallel.csproj: An element with the same key but a different value already exists. Key: XX\corefx\src\mscorlib\ref\Compat\mscorlib.csproj. Ignored.`

this error message is thrown from roslyn, so some projects couldn't be loaded successfully, which is why some APIs are missing.
@chenkennt @vwxyzh 
