### PR TITLE
Update generating-fsharp-types-from-dbml.md

### DIFF
--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
@@ -107,7 +107,7 @@ In this section, you create a type provider and generate types from the schema t
 open Microsoft.FSharp.Data.TypeProviders
 
 
-type dbml = DbmlFile<"MyDatabase.dbml", ResolutionFolder = @"<path-to-folder-that-contains-.dbml-file>>
+type dbml = DbmlFile<"MyDatabase.dbml", ResolutionFolder = @"<path-to-folder-that-contains-.dbml-file>">
 
 // This connection string can be specified at run time.
 let connectionString = "Data Source=MYSERVER\INSTANCE;Initial Catalog=MyDatabase;Integrated Security=SSPI;"


### PR DESCRIPTION
# Adding closing "
## Summary

When instantiating the DBML type provider, the ResolutionFolder static parameter is missing the closing ". A consequence of this is that the next line of code, which instantiates the connection string, looks like a string itself.
