### PR TITLE
Grammar error

### DIFF
--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -91,7 +91,7 @@ $ dotnet run
 Hello, World!
 ```
 
-You can also execute [`dotnet build`](../tools/dotnet-build.md) to compile and the code without running the build console applications.
+You can also execute [`dotnet build`](../tools/dotnet-build.md) to compile the code without running the build console applications.
 
 ### Building a self-contained application
 


### PR DESCRIPTION
# Title

Changed "to compile and the code" to "to compile the code"
## Summary

It must be wrong English right?
