### PR TITLE
Bugfix Tour of F# Binary Search Tree insert function

### DIFF
--- a/samples/snippets/fsharp/tour.fs
+++ b/samples/snippets/fsharp/tour.fs
@@ -479,8 +479,8 @@ module UnionTypes =
         | Empty -> Node(item, Empty, Empty)
         | Node(x, left, right) as node ->
             if item = x then node // No need to insert, it already exists; return the node.
-            elif item < x then Node(item, insert x left, right) // Call into left subtree.
-            else Node(item, left, insert x right) // Call into right subtree.
+            elif item < x then Node(x, insert item left, right) // Call into left subtree.
+            else Node(x, left, insert item right) // Call into right subtree.
 
 // ---------------------------------------------------------------
 //         Option types


### PR DESCRIPTION
# Fix Tour of F# Binary Search Tree insert function
## Summary

The Binary Search Tree insert function in the Tour of F# code samples had a bug. Instead of inserting the new node as a new leaf it incorrectly inserted the new node as the root.
