### PR TITLE
Methods topic ported from MSDN and revised.

### DIFF
--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -68,7 +68,7 @@ The method definition specifies the names and types of any parameters that are r
 
 The most common form of method invocation used positional arguments; it supplies arguments in the same order as method parameters. The methods of the `Motorcycle` class can therefore be called as in the following example. The call to the `Drive` method, for example, includes two arguments that correspond to the two parameters in the method's syntax. The first becomes the value of the `miles` parameter, the second the value of the `speed` parameter.
 
-[!CODE [csSnippets.Methods#41](../../samples/snippets/csharp/concepts/methods/method40.cs#41)]
+[!CODE [csSnippets.Methods#41](../../samples/snippets/csharp/concepts/methods/methods40.cs#41)]
 
 You can also used *named arguments* instead of positional arguments when invoking a method. When using named arguments, you specify the parameter name followed by a colon (":") and the argument. Arguments to the method can appear in any order, as long as all required arguments are present. The following example uses named arguments to invoke the `TestMotorcycle.Drive` method. In this example, the named arguments are passed in the opposite order from the method's parameter list.
 
@@ -178,7 +178,7 @@ To use a value returned from a method, the calling method can use the method cal
 
 [!CODE [csSnippets.Methods#45](../../samples/snippets/csharp/concepts/methods/return44.cs#45)]
 
-[!CODE [csSnippets.Methods#46](../../samples/snippets/csharp/concepts/methods/reteurn44.cs#46)]
+[!CODE [csSnippets.Methods#46](../../samples/snippets/csharp/concepts/methods/return44.cs#46)]
 
 Using a local variable, in this case, `result`, to store a value is optional. It may help the readability of the code, or it may be necessary if you need to store the original value of the argument for the entire scope of the method.
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -1,27 +1,295 @@
 ---
-title: Methods
-description: Methods are how you expression the actions a program takes. Learn how to describe them here.
-keywords: .NET, .NET Core
-author: dotnet-bot
+title: Methods | C# Guide
+description: Overview of methods, method parameters, and method return values
+keywords: .NET, .NET Core, C#
+author: rpetrusha
 manager: wpickett
-ms.date: 06/20/2016
+ms.author: ronpet
+ms.date: 10/26/2016
 ms.topic: article
-ms.prod: visual-studio-dev-14
-ms.technology: devlang-csharp
+ms.prod: .net-core
+ms.technology: .net-core-technologies
 ms.devlang: csharp
-ms.assetid: b6a0539a-8ce5-4da7-adcf-44be345a2714
+ms.assetid: 577a8527-1081-4b36-9b9e-0685b6553c6e
 ---
+# Methods #
 
-# 🔧 Methods
+A method is a code block that contains a series of statements. A program causes the statements to be executed by calling the method and specifying any required method arguments. In C#, every executed instruction is performed in the context of a method. The `Main` method is the entry point for every C# application and it is called by the common language runtime (CLR) when the program is started.
 
-> **Note**
-> 
-> This topic hasn’t been written yet! 
->
-> We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/docs/issues/488) at GitHub.
-> 
-> If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
->
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
->
+> [!NOTE]
+> This topic discusses named methods. For information about anonymous functions, see [Anonymous Functions](https://msdn.microsoft.com/en-us/library/bb882516.aspx).
+
+This topic contains the following sections:
+
+- [Method signatures](#signatures)
+- [Method invocation](#invocation)
+- [Inherited and overridden methods](#inherited)
+- [Passing parameters](#passing)
+  - [Passing parameters by value](#byval)
+  - [Passing parameters by reference](#byref)
+  - [Parameter arrays](#paramarray)
+- [Optional parameters and arguments](#optional)
+- [Return values](#return)
+- [Extension methods](#extension)
+- [Async Methods](#async)
+- [Expression body definitions](#expr)
+- [Iterators](#iterators)
+
+## <a name="signatures" /a> Method signatures ##
+
+Methods are declared in a `class` or `struct` by specifying:
+
+- An access level, such as `public` or `private`.
+- Optional modifiers such as `abstract` or `sealed`.
+- The return value, or `void` if the method has none.
+- The method name.
+- Any method parameters. Method parameters are enclosed in parentheses and are separated by commas. Empty parentheses indicate that the method requires no parameters.
+
+These parts together form the method signature.
+
+> [!NOTE]
+> A return type of a method is not part of the signature of the method for the purposes of method overloading. However, it is part of the signature of the method when determining the compatibility between a delegate and the method that it points to.
+
+The following example defines a class named `Motorcycle` that contains five methods:
+
+[!CODE [csSnippets.Methods#40](../../samples/snippets/csharp/concepts/methods/methods40.cs#40)]
+
+Note that the `Motorcycle` class includes an overloaded method, `Drive`. Two methods have the same namne, but can be differentiated by their parameter types.
+
+## <a name="invocation" /> Method invocation ##
+
+Methods can be either *instance* or *static*. Invoking an instance method requires that you instantiate a object and call the method on that object; an instance method operates on that instance and its data. You invoke a static method by referencing the name of the type to which the method belongs; static methods operate do not operate on instance data. Attempting to call a static method through an object instance generates a compiler error.
+
+Calling a method is like accessing a field. After the object name (if you are calling an instance method) or the type name (if you are calling a `static` method), add a period, the name of the method, and parentheses. Arguments are listed within the parentheses, and are separated by commas.
+
+The method definition specifies the names and types of any parameters that are required. When a caller invokes the method, it provides concrete values, called arguments, for each parameter. The arguments must be compatible with the parameter type, but the argument name, if one is used in the calling code, does not have to be the same as the parameter named defined in the method. In the following example, the `Square` method includes a single parameter of type `int` named *i*. The first method call passes the `Square` method a variable of type `int` named *num*; the second, a numeric constant; and the third, an expression.
+
+[!CODE [csSnippets.Methods#74](../../samples/snippets/csharp/concepts/methods/params74.cs#74)]
+
+The most common form of method invocation used positional arguments; it supplies arguments in the same order as method parameters. The methods of the `Motorcycle` class can therefore be called as in the following example. The call to the `Drive` method, for example, includes two arguments that correspond to the two parameters in the method's syntax. The first becomes the value of the `miles` parameter, the second the value of the `speed` parameter.
+
+[!CODE [csSnippets.Methods#41](../../samples/snippets/csharp/concepts/methods/method40.cs#41)]
+
+You can also used *named arguments* instead of positional arguments when invoking a method. When using named arguments, you specify the parameter name followed by a colon (":") and the argument. Arguments to the method can appear in any order, as long as all required arguments are present. The following example uses named arguments to invoke the `TestMotorcycle.Drive` method. In this example, the named arguments are passed in the opposite order from the method's parameter list.
+
+[!CODE [csSnippets.Methods#45](../../samples/snippets/csharp/concepts/methods/named1.cs#45)]
+
+You can invoke a method using both positional arguments and named arguments. However, a positional argument cannot follow a named argument. The following example invokes the `TestMotorcycle.Drive` method from the previous example using one positional argument and one named argument.
+
+[!CODE [csSnippets.Methods#46](../../samples/snippets/csharp/concepts/methods/named2.cs#46)]
+
+## <a name="inherited" /> Inherited and overridden methods ##
+
+In addition to the members that are explicitly defined in a type, a type inherits members defined in its base classes. Since all types in the managed type system inherit directly or indirectly from the @System.Object class, all types inherit its members, such as @System.Object.Equals(System.Object), @System.Object.GetType, and @System.Object.ToString. The following example defines a `Person` class, instantiates two `Person` objects, and calls the `Person.Equals` method to determine whether the two objects are equal. The `Equals` method, however, is not defined in the `Person` class; it is inherited from @System.Object.
+
+[!CODE [csSnippets.Methods#104](../../samples/snippets/csharp/concepts/methods/inherited1.cs#104)]
+
+Types can override inherited members by using the `override` keyword and providing an implementation for the overridden method. The method signature must be the same as that of the overriden method. The following example is like the previous one, except that it overrides the @Object.Equals(System.Object) method. (It also overrides the @Object.GetHashCode method, since the two methods are intended to provide consistent results.)
+
+[!CODE [csSnippets.Methods#105](../../samples/snippets/csharp/concepts/methods/overridden1.cs#105)]
+
+## <a name="passing" /> Passing parameters ##
+
+Types in C# are either *value types* or *reference types*. For a list of built-in value types, see [Types and variables](./tour-of-csharp/types-and-variables.md). By default, both value types and reference types are passed to a method by value.
+
+### <a name="byval" /> Passing parameters by value ###
+
+When a value type is passed to a method by value, a copy of the object instead of the object itself is passed to the method. Therefore, changes to the object in the called method have no effect on the original object when control returns to the caller.
+
+The following example passes a value type to a method by value, and the called method attempts to change the value type's value. It defines a variable of type `int`, which is a value type, initializes its value to 20, and passes it to a method named `ModifyValue` that changes the variable's value to 30. When the method returns, however, the variable's value remains unchanged.
+
+[!CODE [csSnippets.Methods#10](../../samples/snippets/csharp/concepts/methods/byvalue10.cs#10)]
+
+When an object of a reference type is passed to a method by value, a reference to the object is passed by value. That is, the method receives not the object itself, but an argument that indicates the location of the object. If you change a member of the object by using this reference, the change is reflected in the object when control returns to the calling method. However, replacing the object passed to the method has no effect on the original object when control returns to the caller.
+
+The following example defines a class (which is a reference type) named `SampleRefType`. It instantiates a `SampleRefType` object, assigns 44 to its `value` field, and passes the object to the `ModifyObject` method. This example does essentially the same thing as the previous example -- it passes an argument by value to a method. But because a reference type is used, the result is different. The modification that is made in `ModifyObject` to the `obj.value` field also changes the `value` field of the argument, `rt`, in the `Main` method to 33, as the output from the example shows.
+
+[!CODE [csSnippets.Methods#42](../../samples/snippets/csharp/concepts/methods/byvalue42.cs#42)]
+
+### <a name="byref" /> Passing parameters by reference ###
+
+You pass a parameter by reference when you want to change the calling method to change the value of the parameter and refect that change in the calling program. To pass a parameter by reference, you use the `ref` or `out` keyword.
+
+The following example is identical to the previous one, except the value is passed by reference to the `ModifyValue` method. When the value of the parameter is modified in the `ModifyValue` method, the change in value is reflected when control returns to the caller.
+
+[!CODE [csSnippets.Methods#106](../../samples/snippets/csharp/concepts/methods/byref106.cs#106)]
+
+A common pattern that uses by ref parameters involves swapping the values of variables. You pass two variables to a method by reference, and the method swaps their contents. The following example swaps integer values.
+
+[!CODE [csSnippets.Methods#106](../../samples/snippets/csharp/concepts/methods/swap107.cs#107)]
+
+Passing a reference-type parameter allows you to change the value of the reference itself, rather than the value of its individual elements or fields.
+
+### <a name="paramarray" /> Parameter arrays ###
+
+Sometimes, the requirement that you specify the exact number of arguments to your method is restrictive. By using the `params` keyword to indicate that a parameter is a parameter array, you allow your method to be called with a variable number of arguments. The parameter tagged with the `params` keyword must must be an array type, and it must be the last parameter in the method's parameter list.
+
+A caller can then invoke the method in either of three ways:
+
+- By passing an array of the appropriate type that contains the desired number of elements.
+- By passing a comma-separated list of individual arguments of the appropriate type to the method.
+- By not providing an argument to the parameter array.
+
+The following example defines a method named `DoStringOperation` that performs the string operation specified by its first parameter, a `StringOperation` enumeration member. The strings upon which it is to perform the operation are defined by a parameter array. The `Main` method illustrates all three ways of invoking the method. Note that the method tagged with the `params` keyword must be prepared to handle the case in which no argument is supplied for the parameter array, so that its value is `null`.
+
+[!CODE [csSnippets.Methods#106](../../samples/snippets/csharp/concepts/methods/byref108.cs#108)]
+
+## <a name="optional" /> Optional parameters and arguments ##
+
+A method definition can specify that its parameters are required or that they are optional. By default, parameters are required. Optional parameters are specified by including the parameter's default value in the method definition. When the method is called, if no argument is supplied for an optional parameter, the default value is used instead.
+
+The parameter's default value must be assigned by one of the following kinds of expressions:
+
+- A constant, such as a literal string or number.
+- An expression of the form `new ValType`, where `ValType` is a value type. Note that this invokes the value type's implicit default constructor, which is not an actual member of the type.
+- An expression of the form `default(ValType)`, where `ValType` is a value type.
+
+If a method includes both required and optional parameters, optional parameters are defined at the end of the parameter list, after all required parameters.
+
+The following example defines a method, `ExampleMethod`, that has one required and two optional parameters.
+
+[!CODE [csSnippets.Methods#21](../../samples/snippets/csharp/concepts/methods/optional1.cs#21)]
+
+If a method with multiple optional arguments is invoked using positional arguments, there can be no comma-separated arguments included in the method call. The caller must supply an argument for all optional parameters from the first one to the last one for which an argument is supplied. In the case of the  `ExampleMethod` method, for example, if the caller supplies an argument for the `description` parameter, it must also supply one for the `optionalInt` parameter. If a method is called using named arguments or a combination of positional and named arguments, the caller can omit any arguments that follow the last positional argument in the method call.
+
+The following example calls the `ExampleMethod` method three times.  The first two method calls use positional arguments. The first omits both optional arguments, while the second omits the last argument. The third method call supplies a positional argument for the required parameter, but uses a named argument to supply a value to the `description` parameter while omitting the `optionalInt` argument.
+
+[!CODE [csSnippets.Methods#22](../../samples/snippets/csharp/concepts/methods/optional1.cs#22)]
+
+The use of optional parameters affects *overload resolution*, or the way in which the C# compiler determines which particular overload should be invoked by a method call, as follows:
+
+- A method, indexer, or constructor is a candidate for execution if each of its parameters either is optional or corresponds, by name or by position, to a single argument in the calling statement, and that argument can be converted to the type of the parameter.
+- If more than one candidate is found, overload resolution rules for preferred conversions are applied to the arguments that are explicitly specified. Omitted arguments for optional parameters are ignored.
+- If two candidates are judged to be equally good, preference goes to a candidate that does not have optional parameters for which arguments were omitted in the call. This is a consequence of a general preference in overload resolution for candidates that have fewer parameters.
+
+## <a name="return" /> Return values ##
+
+Methods can return a value to the caller. If the return type (the type listed before the method name) is not `void`, the method can return the value by using the `return` keyword. A statement with the `return` keyword followed by a value that matches the return type will return that value to the method caller. Methods with a non-void return type are required to use the `return` keyword to return a value. The `return` keyword also stops the execution of the method.
+
+If the return type is `void`, a `return` statement without a value is still useful to stop the execution of the method. Without the `return` keyword, the method will stop executing when it reaches the end of the code block.
+
+For example, these two methods use the `return` keyword to return integers:
+
+[!CODE [csSnippets.Methods#44](../../samples/snippets/csharp/concepts/methods/return44.cs#44)]
+
+To use a value returned from a method, the calling method can use the method call itself anywhere a value of the same type would be sufficient. You can also assign the return value to a variable. For example, the following two code examples accomplish the same goal:
+
+[!CODE [csSnippets.Methods#45](../../samples/snippets/csharp/concepts/methods/return44.cs#45)]
+
+[!CODE [csSnippets.Methods#46](../../samples/snippets/csharp/concepts/methods/reteurn44.cs#46)]
+
+Using a local variable, in this case, `result`, to store a value is optional. It may help the readability of the code, or it may be necessary if you need to store the original value of the argument for the entire scope of the method.
+
+Sometimes, you want your method to return more than a single value. Starting with C# 7.0, you can do this easily by using *tuple types* and *tuple literals*. The tuple type defines the data types of the tuple's elements. Tuple literals provide the actual values of the returned tuple. In teh following example, `(string, string, string, int)` defines the tuple type that is returned by the `GetPersonalInfo` method. The expression `(per.FirstName, per.MiddleName, per.LastName, per.Age)` is the tuple literal; the method returns the first, middle, and last name, along with the age, of a `PersonInfo` object.
+
+```cs
+public (string, string, string, int) GetPersonalInfo(string id)
+{
+    PersonInfo per = PersonInfo.RetrieveInfoById(id);
+    if (per != null)
+       return (per.FirstName, per.MiddleName, per.LastName, per.Age);
+    else
+       return null;
+}
+```
+
+The caller can then consume the returned tuple with code like the following:
+
+```cs
+var person = GetPersonalInfo("111111111")
+if (person != null)
+   Console.WriteLine("{person.Item1} {person.Item3}: age = {person.Item4})";
+```
+
+Names can also be assigned to the tuple elements in the tuple type definition. The following example shows an alternate version of the `GetPersonalInfo` method that uses named elements:
+
+```cs
+public (string FName, string MName, string LName, int Age) GetPersonalInfo(string id)
+{
+    PersonInfo per = PersonInfo.RetrieveInfoById(id);
+    if (per != null)
+       return (per.FirstName, per.MiddleName, per.LastName, per.Age);
+    else
+       return null;
+}
+```
+
+The previous call to the `GetPersonInfo` method can then be modified as follows:
+
+```cs
+var person = GetPersonalInfo("111111111");
+if (person != null)
+   Console.WriteLine("{person.FName} {person.LName}: age = {person.Age})";
+```
+
+If a method is passed an array as an argument and modifies the value of individual elements, it is not necessary for the method to return the array, although you may choose to do so for good style or functional flow of values.  This is because C# passes all reference types by value, and the value of an array reference is the pointer to the array. In the following example, changes to the contents of the `values` array that are made in the `DoubleValues` method are observable by any code that has a reference to the array.
+
+[!CODE [csSnippets.Methods#101](../../samples/snippets/csharp/concepts/methods/returnarray1.cs#101)]
+
+## <a name="exten" /> Extension methods ##
+
+Ordinarily, there are two ways to add a method to an existing type:
+
+- Modify the source code for that type. You cannot do this, of course, if you do not own the type's source code. And this becomes a breaking change if you also add any private data fields to support the method.
+- Define the new method in a derived class. A method cannot be added in this way using inheritance for other types, such as structures and enumerations. Nor can it be used to "add" a method to a sealed class.
+
+Extension methods let you "add" a method to an existing type without modifying the type itself or implementing the new method in an inherited type. The extension method also does not have to reside in the same assembly as the type it extends. You call an extension method as if it were a defined member of a type.
+
+For more information, see [Extension Methods](https://msdn.microsoft.com/en-us/library/bb383977.aspx).
+
+## <a name="async" /> Async Methods ##
+
+By using the async feature, you can invoke asynchronous methods without using explicit callbacks or manually splitting your code across multiple methods or lambda expressions.
+
+If you mark a method with the [async](https://msdn.microsoft.com/en-us/library/hh156513.aspx) modifier, you can use the [await](https://msdn.microsoft.com/en-us/library/hh156528.aspx) operator in the method. When control reaches an `await` expression in the async method, control returns to the caller, and progress in the method is suspended until the awaited task completes. When the task is complete, execution can resume in the method.
+
+> [!NOTE]
+> An async method returns to the caller when either it encounters the first awaited object that’s not yet complete or it gets to the end of the async method, whichever occurs first.
+
+An async method can have a return type of @System.Threading.Tasks.Task<TResult>, @System.Threading.Tasks.Task, or `void`. The `void` return type is used primarily to define event handlers, where a `void` return type is required. An async method that returns `void` can't be awaited, and the caller of a void-returning method can't catch exceptions that the method throws.
+
+In the following example, `DelayAsync` is an async method that has a return statement that returns an integer. Because it is an async method, its method declaration must have a return type of `Task<int>`. Because the return type is `Task<int>`, the evaluation of the `await` expression in `DoSomethingAsync` produces an integer, as the following `int result = await delayTask` statement demonstrates.
+
+[!CODE [csSnippets.Methods#102](../../samples/snippets/csharp/concepts/methods/async1.cs#102)]
+
+An async method can't declare any [ref](https://msdn.microsoft.com/en-us/library/14akc2c7.aspx) or [out](https://msdn.microsoft.com/en-us/library/t3c3bfhx.aspx) parameters, but it can call methods that have such parameters.
+
+ For more information about async methods, see [Asynchronous Programming with Async and Await](https://msdn.microsoft.com/en-us/library/mt674882.aspx), [Control Flow in Async Programs](https://msdn.microsoft.com/en-us/library/mt674892.aspx), and [Async Return Types](https://msdn.microsoft.com/en-us/library/mt674893.aspx).
+
+## <a name="expr" /> Expression body definitions ##
+
+It is common to have method definitions that simply return immediately with the result of an expression, or that have a single statement as the body of the method.  There is a syntax shortcut for defining such methods using `=>`:
+
+```c#
+
+public Point Move(int dx, int dy) => new Point(x + dx, y + dy);
+public void Print() => Console.WriteLine(First + " " + Last);
+// Works with operators, properties, and indexers too.
+public static Complex operator +(Complex a, Complex b) => a.Add(b);
+public string Name => First + " " + Last;
+public Customer this[long id] => store.LookupCustomer(id);
+
+```
+
+If the method returns `void` or is an async method, the body of the method must be a statement expression (same as with lambdas).  For properties and indexers, they must be read-only, and you do not use the `get` accessor keyword.
+
+## <a name="iterators" /> Iterators ##
+
+An iterator performs a custom iteration over a collection, such as a list or an array. An iterator uses the [yield return](https://msdn.microsoft.com/en-us/library/9k7k7cf0.aspx) statement to return each element one at a time. When a `yield return` statement is reached, the current location in code is remembered. Execution is restarted from that location when the iterator is called the next time.
+
+You call an iterator from client code by using a [foreach](https://msdn.microsoft.com/en-us/library/ttw7t8t6.aspx) statement.
+
+The return type of an iterator can be @System.Collections.IEnumerable, @System.Collections.Generic.IEnumerable%601, @System.Collections.IEnumerator, or @System.Collections.Generic.IEnumerator%601.
+
+For more information, see [Iterators](https://msdn.microsoft.com/en-us/library/mt639331.aspx).
+
+## See also ##
+
+[Access Modifiers](https://msdn.microsoft.com/en-us/library/wxh6fsc7.aspx)
+[Static Classes and Static Class Members](https://msdn.microsoft.com/en-us/library/79b3xss3.aspx)
+[Inheritance](https://msdn.microsoft.com/en-us/library/ms173149.aspx)
+[Abstract and Sealed Classes and Class Members](https://msdn.microsoft.com/en-us/library/ms173150.aspx)
+[params](https://msdn.microsoft.com/en-us/library/w5zay9db.aspx)
+[out](https://msdn.microsoft.com/en-us/library/t3c3bfhx.aspx)
+[ref](https://msdn.microsoft.com/en-us/library/14akc2c7.aspx)
+[Passing Parameters](https://msdn.microsoft.com/en-us/library/0f66670z.aspx)

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -32,14 +32,14 @@ This topic contains the following sections:
 - [Return values](#return)
 - [Extension methods](#extension)
 - [Async Methods](#async)
-- [Expression body definitions](#expr)
+- [Expression bodied members](#expr)
 - [Iterators](#iterators)
 
 ## <a name="signatures" /a> Method signatures ##
 
 Methods are declared in a `class` or `struct` by specifying:
 
-- An access level, such as `public` or `private`.
+- An optional access level, such as `public` or `private`. The default is `private`.
 - Optional modifiers such as `abstract` or `sealed`.
 - The return value, or `void` if the method has none.
 - The method name.
@@ -54,7 +54,7 @@ The following example defines a class named `Motorcycle` that contains five meth
 
 [!CODE [csSnippets.Methods#40](../../samples/snippets/csharp/concepts/methods/methods40.cs#40)]
 
-Note that the `Motorcycle` class includes an overloaded method, `Drive`. Two methods have the same namne, but can be differentiated by their parameter types.
+Note that the `Motorcycle` class includes an overloaded method, `Drive`. Two methods have the same namne, but must be differentiated by their parameter types.
 
 ## <a name="invocation" /> Method invocation ##
 
@@ -108,7 +108,7 @@ The following example defines a class (which is a reference type) named `SampleR
 
 ### <a name="byref" /> Passing parameters by reference ###
 
-You pass a parameter by reference when you want to change the calling method to change the value of the parameter and refect that change in the calling program. To pass a parameter by reference, you use the `ref` or `out` keyword.
+You pass a parameter by reference when you want to change the value of an argument in a method and want to refect that change when control returns to the calling method. To pass a parameter by reference, you use the `ref` or `out` keyword.
 
 The following example is identical to the previous one, except the value is passed by reference to the `ModifyValue` method. When the value of the parameter is modified in the `ModifyValue` method, the change in value is reflected when control returns to the caller.
 
@@ -150,7 +150,7 @@ The following example defines a method, `ExampleMethod`, that has one required a
 
 [!CODE [csSnippets.Methods#21](../../samples/snippets/csharp/concepts/methods/optional1.cs#21)]
 
-If a method with multiple optional arguments is invoked using positional arguments, the caller must supply an argument for all optional parameters from the first one to the last one for which an argument is supplied. In the case of the  `ExampleMethod` method, for example, if the caller supplies an argument for the `description` parameter, it must also supply one for the `optionalInt` parameter. `opt.ExampleMethod(2, 2, "Addition of 2 and 2");` is a valid method call; `opt.ExampleMethod(2, , "Addition of 2 and 0);` generates an "Argument missing" compiler error, 
+If a method with multiple optional arguments is invoked using positional arguments, the caller must supply an argument for all optional parameters from the first one to the last one for which an argument is supplied. In the case of the  `ExampleMethod` method, for example, if the caller supplies an argument for the `description` parameter, it must also supply one for the `optionalInt` parameter. `opt.ExampleMethod(2, 2, "Addition of 2 and 2");` is a valid method call; `opt.ExampleMethod(2, , "Addition of 2 and 0);` generates an "Argument missing" compiler error.
 
 If a method is called using named arguments or a combination of positional and named arguments, the caller can omit any arguments that follow the last positional argument in the method call.
 
@@ -258,7 +258,7 @@ An async method can't declare any [ref](https://msdn.microsoft.com/en-us/library
 
  For more information about async methods, see [Asynchronous Programming with Async and Await](https://msdn.microsoft.com/en-us/library/mt674882.aspx), [Control Flow in Async Programs](https://msdn.microsoft.com/en-us/library/mt674892.aspx), and [Async Return Types](https://msdn.microsoft.com/en-us/library/mt674893.aspx).
 
-## <a name="expr" /> Expression body definitions ##
+## <a name="expr" /> Expression bodied members ##
 
 It is common to have method definitions that simply return immediately with the result of an expression, or that have a single statement as the body of the method.  There is a syntax shortcut for defining such methods using `=>`:
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -54,11 +54,11 @@ The following example defines a class named `Motorcycle` that contains five meth
 
 [!CODE [csSnippets.Methods#40](../../samples/snippets/csharp/concepts/methods/methods40.cs#40)]
 
-Note that the `Motorcycle` class includes an overloaded method, `Drive`. Two methods have the same namne, but must be differentiated by their parameter types.
+Note that the `Motorcycle` class includes an overloaded method, `Drive`. Two methods have the same name, but must be differentiated by their parameter types.
 
 ## <a name="invocation" /> Method invocation ##
 
-Methods can be either *instance* or *static*. Invoking an instance method requires that you instantiate a object and call the method on that object; an instance method operates on that instance and its data. You invoke a static method by referencing the name of the type to which the method belongs; static methods operate do not operate on instance data. Attempting to call a static method through an object instance generates a compiler error.
+Methods can be either *instance* or *static*. Invoking an instance method requires that you instantiate an object and call the method on that object; an instance method operates on that instance and its data. You invoke a static method by referencing the name of the type to which the method belongs; static methods operate do not operate on instance data. Attempting to call a static method through an object instance generates a compiler error.
 
 Calling a method is like accessing a field. After the object name (if you are calling an instance method) or the type name (if you are calling a `static` method), add a period, the name of the method, and parentheses. Arguments are listed within the parentheses, and are separated by commas.
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -150,7 +150,9 @@ The following example defines a method, `ExampleMethod`, that has one required a
 
 [!CODE [csSnippets.Methods#21](../../samples/snippets/csharp/concepts/methods/optional1.cs#21)]
 
-If a method with multiple optional arguments is invoked using positional arguments, there can be no comma-separated arguments included in the method call. The caller must supply an argument for all optional parameters from the first one to the last one for which an argument is supplied. In the case of the  `ExampleMethod` method, for example, if the caller supplies an argument for the `description` parameter, it must also supply one for the `optionalInt` parameter. If a method is called using named arguments or a combination of positional and named arguments, the caller can omit any arguments that follow the last positional argument in the method call.
+If a method with multiple optional arguments is invoked using positional arguments, the caller must supply an argument for all optional parameters from the first one to the last one for which an argument is supplied. In the case of the  `ExampleMethod` method, for example, if the caller supplies an argument for the `description` parameter, it must also supply one for the `optionalInt` parameter. `opt.ExampleMethod(2, 2, "Addition of 2 and 2");` is a valid method call; `opt.ExampleMethod(2, , "Addition of 2 and 0);` generates an "Argument missing" compiler error, 
+
+If a method is called using named arguments or a combination of positional and named arguments, the caller can omit any arguments that follow the last positional argument in the method call.
 
 The following example calls the `ExampleMethod` method three times.  The first two method calls use positional arguments. The first omits both optional arguments, while the second omits the last argument. The third method call supplies a positional argument for the required parameter, but uses a named argument to supply a value to the `description` parameter while omitting the `optionalInt` argument.
 
@@ -164,7 +166,7 @@ The use of optional parameters affects *overload resolution*, or the way in whic
 
 ## <a name="return" /> Return values ##
 
-Methods can return a value to the caller. If the return type (the type listed before the method name) is not `void`, the method can return the value by using the `return` keyword. A statement with the `return` keyword followed by a value that matches the return type will return that value to the method caller. Methods with a non-void return type are required to use the `return` keyword to return a value. The `return` keyword also stops the execution of the method.
+Methods can return a value to the caller. If the return type (the type listed before the method name) is not `void`, the method can return the value by using the `return` keyword. A statement with the `return` keyword followed by a variable, constant, or expression that matches the return type will return that value to the method caller. Methods with a non-void return type are required to use the `return` keyword to return a value. The `return` keyword also stops the execution of the method.
 
 If the return type is `void`, a `return` statement without a value is still useful to stop the execution of the method. Without the `return` keyword, the method will stop executing when it reaches the end of the code block.
 
@@ -241,12 +243,12 @@ For more information, see [Extension Methods](https://msdn.microsoft.com/en-us/l
 
 By using the async feature, you can invoke asynchronous methods without using explicit callbacks or manually splitting your code across multiple methods or lambda expressions.
 
-If you mark a method with the [async](https://msdn.microsoft.com/en-us/library/hh156513.aspx) modifier, you can use the [await](https://msdn.microsoft.com/en-us/library/hh156528.aspx) operator in the method. When control reaches an `await` expression in the async method, control returns to the caller, and progress in the method is suspended until the awaited task completes. When the task is complete, execution can resume in the method.
+If you mark a method with the [async](https://msdn.microsoft.com/en-us/library/hh156513.aspx) modifier, you can use the [await](https://msdn.microsoft.com/en-us/library/hh156528.aspx) operator in the method. When control reaches an `await` expression in the async method, control returns to the caller if the awaited task is not completed, and progress in the method with the `await` keyword is suspended until the awaited task completes. When the task is complete, execution can resume in the method.
 
 > [!NOTE]
 > An async method returns to the caller when either it encounters the first awaited object that’s not yet complete or it gets to the end of the async method, whichever occurs first.
 
-An async method can have a return type of @System.Threading.Tasks.Task<TResult>, @System.Threading.Tasks.Task, or `void`. The `void` return type is used primarily to define event handlers, where a `void` return type is required. An async method that returns `void` can't be awaited, and the caller of a void-returning method can't catch exceptions that the method throws.
+An async method can have a return type of @System.Threading.Tasks.Task<TResult>, @System.Threading.Tasks.Task, or `void`. The `void` return type is used primarily to define event handlers, where a `void` return type is required. An async method that returns `void` can't be awaited, and the caller of a void-returning method can't catch exceptions that the method throws. C# 7, when it is released, will ease this restriction to allow an async method [to return any task-like type](https://github.com/ljw1004/roslyn/blob/features/async-return/docs/specs/feature%20-%20arbitrary%20async%20returns.md).
 
 In the following example, `DelayAsync` is an async method that has a return statement that returns an integer. Because it is an async method, its method declaration must have a return type of `Task<int>`. Because the return type is `Task<int>`, the evaluation of the `await` expression in `DoSomethingAsync` produces an integer, as the following `int result = await delayTask` statement demonstrates.
 
@@ -275,9 +277,7 @@ If the method returns `void` or is an async method, the body of the method must 
 
 ## <a name="iterators" /> Iterators ##
 
-An iterator performs a custom iteration over a collection, such as a list or an array. An iterator uses the [yield return](https://msdn.microsoft.com/en-us/library/9k7k7cf0.aspx) statement to return each element one at a time. When a `yield return` statement is reached, the current location in code is remembered. Execution is restarted from that location when the iterator is called the next time.
-
-You call an iterator from client code by using a [foreach](https://msdn.microsoft.com/en-us/library/ttw7t8t6.aspx) statement.
+An iterator performs a custom iteration over a collection, such as a list or an array. An iterator uses the [yield return](https://msdn.microsoft.com/en-us/library/9k7k7cf0.aspx) statement to return each element one at a time. When a `yield return` statement is reached, the current location is remembered so that the caller can request the next element in the sequence.
 
 The return type of an iterator can be @System.Collections.IEnumerable, @System.Collections.Generic.IEnumerable%601, @System.Collections.IEnumerator, or @System.Collections.Generic.IEnumerator%601.
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -50,7 +50,7 @@
 ### [🔧 Tuples and unnamed types](csharp/tuples.md)
 ### [🔧 Interfaces](csharp/interfaces.md)
 ### [🔧 Methods and Lambda Expressions](csharp/methods-lambda-expressions.md)
-#### [🔧 methods](csharp/methods.md)
+#### [Methods](csharp/methods.md)
 #### [🔧 Lambda Expressions](csharp/lambda-expressions.md)
 ### [Properties](csharp/properties.md)
 ### [Indexers](csharp/indexers.md)

--- a/samples/snippets/csharp/concepts/methods/async1.cs
+++ b/samples/snippets/csharp/concepts/methods/async1.cs
@@ -1,0 +1,31 @@
+﻿// <Snippet102>
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+public class Example
+{
+    // This Click event is marked with the async modifier.
+    public static void Main()
+    {
+       DoSomethingAsync().Wait();
+    }
+
+    private static async Task DoSomethingAsync()
+    {
+        int result = await DelayAsync();
+        Console.WriteLine("Result: " + result);
+    }
+
+    private static async Task<int> DelayAsync()
+    {
+        await Task.Delay(100);
+        return 5;
+    }
+
+    // Output:
+    //  Result: 5
+}
+// The example displays the following output:
+//        Result: 5
+// </Snippet102> 

--- a/samples/snippets/csharp/concepts/methods/byref106.cs
+++ b/samples/snippets/csharp/concepts/methods/byref106.cs
@@ -1,0 +1,26 @@
+// <Snippet106>
+using System;
+
+public class Example
+{
+   public static void Main()
+   {
+      int value = 20;
+      Console.WriteLine("In Main, value = {0}", value);
+      ModifyValue(ref value);
+      Console.WriteLine("Back in Main, value = {0}", value);
+   }
+
+   static void ModifyValue(ref int i)
+   {
+      i = 30;
+      Console.WriteLine("In ModifyValue, parameter value = {0}", i);
+      return;
+   }
+}
+// The example displays the following output:
+//      In Main, value = 20
+//      In ModifyValue, parameter value = 30
+//      Back in Main, value = 30
+// </Snippet106>
+

--- a/samples/snippets/csharp/concepts/methods/byref108.cs
+++ b/samples/snippets/csharp/concepts/methods/byref108.cs
@@ -1,0 +1,29 @@
+// <Snippet108>
+using System;
+
+class Example 
+{
+    static void Main() 
+    {
+        int[] arr = {1, 4, 5};
+        Console.WriteLine("In Main, array has {0} elements and starts with {1}",
+                          arr.Length, arr[0]);
+
+        Change(ref arr);
+        Console.WriteLine("Back in Main, array has {0} elements and starts with {1}",
+                          arr.Length, arr[0]);
+    }
+
+    static void Change(ref int[] arr)
+    {
+        // Both of the following changes will affect the original variables:
+        arr = new int[5] {-9, -7, -5, -3, -1};
+        Console.WriteLine("In Change, array has {0} elements and starts with {1}",
+                          arr.Length, arr[0]);
+    }
+}
+// The example displays the following output:
+//        In Main, array has 3 elements and starts with 1
+//        In Change, array has 5 elements and starts with -9
+//        Back in Main, array has 5 elements and starts with -9
+// </Snippet108>

--- a/samples/snippets/csharp/concepts/methods/byvalue10.cs
+++ b/samples/snippets/csharp/concepts/methods/byvalue10.cs
@@ -1,0 +1,26 @@
+// <Snippet10>
+using System;
+
+public class Example
+{
+   public static void Main()
+   {
+      int value = 20;
+      Console.WriteLine("In Main, value = {0}", value);
+      ModifyValue(value);
+      Console.WriteLine("Back in Main, value = {0}", value);
+   }
+
+   static void ModifyValue(int i)
+   {
+      i = 30;
+      Console.WriteLine("In ModifyValue, parameter value = {0}", i);
+      return;
+   }
+}
+// The example displays the following output:
+//      In Main, value = 20
+//      In ModifyValue, parameter value = 30
+//      Back in Main, value = 20
+// </Snippet10>
+

--- a/samples/snippets/csharp/concepts/methods/byvalue42.cs
+++ b/samples/snippets/csharp/concepts/methods/byvalue42.cs
@@ -1,0 +1,25 @@
+// <Snippet42>
+using System;
+
+public class SampleRefType
+{
+    public int value;
+}
+
+public class Example
+{
+    public static void Main()
+    {
+        var rt = new SampleRefType();
+        rt.value = 44;
+        ModifyObject(rt);
+        Console.WriteLine(rt.value);
+    }
+        
+    static void ModifyObject(SampleRefType obj)
+    {
+        obj.value = 33;
+    }
+}
+//</Snippet42>
+

--- a/samples/snippets/csharp/concepts/methods/inherited1.cs
+++ b/samples/snippets/csharp/concepts/methods/inherited1.cs
@@ -1,0 +1,23 @@
+// <Snippet104>
+using System;
+
+public class Person
+{
+   public String FirstName;
+}
+
+public class Example
+{
+   public static void Main()
+   {
+      var p1 = new Person();
+      p1.FirstName = "John";
+      var p2 = new Person();
+      p2.FirstName = "John";
+      Console.WriteLine("p1 = p2: {0}", p1.Equals(p2));
+   }
+}
+// The example displays the following output:
+//      p1 = p2: False
+// </Snippet104>
+

--- a/samples/snippets/csharp/concepts/methods/methods40.cs
+++ b/samples/snippets/csharp/concepts/methods/methods40.cs
@@ -1,0 +1,46 @@
+//<Snippet40>
+using System;
+
+abstract class Motorcycle
+{
+   // Anyone can call this.
+   public void StartEngine() {/* Method statements here */ }
+
+   // Only derived classes can call this.
+   protected void AddGas(int gallons) { /* Method statements here */ }
+
+   // Derived classes can override the base class implementation.
+   public virtual int Drive(int miles, int speed) { /* Method statements here */ return 1; }
+
+   // Derived classes can override the base class implementation.
+   public virtual int Drive(TimeSpan time, int speed) { /* Method statements here */ return 0; }
+
+   // Derived classes must implement this.
+   public abstract double GetTopSpeed(); 
+}
+//</Snippet40>
+
+namespace Invocation {
+//<Snippet41>
+class TestMotorcycle : Motorcycle
+{
+   public override double GetTopSpeed()
+   {
+      return 108.4;
+   }
+
+   static void Main()
+   {
+      
+      TestMotorcycle moto = new TestMotorcycle();
+
+      moto.StartEngine();
+      moto.AddGas(15);
+      moto.Drive(5, 20);
+      double speed = moto.GetTopSpeed();
+      Console.WriteLine("My top speed is {0}", speed);            
+   }
+}
+//</Snippet41>
+}
+

--- a/samples/snippets/csharp/concepts/methods/named1.cs
+++ b/samples/snippets/csharp/concepts/methods/named1.cs
@@ -1,0 +1,53 @@
+
+// <Snippet45>
+using System;
+
+class TestMotorcycle : Motorcycle
+{
+   public override int Drive(int miles, int speed)
+   {
+      return (int) Math.Round( ((double)miles) / speed, 0);
+   }
+
+   public override double GetTopSpeed()
+   {
+      return 108.4;
+   }
+
+   static void Main()
+   {
+      
+      TestMotorcycle moto = new TestMotorcycle();
+      moto.StartEngine();
+      moto.AddGas(15);
+      var travelTime = moto.Drive(speed: 60, miles: 170);
+      Console.WriteLine("Travel time: approx. {0} hours", travelTime);            
+   }
+}
+// The example displays the following output:
+//      Travel time: approx. 3 hours
+// </Snippet45>
+
+
+
+abstract class Motorcycle
+{
+   // Anyone can call this.
+   public void StartEngine() {/* Method statements here */ }
+
+   // Only derived classes can call this.
+   protected void AddGas(int gallons) { /* Method statements here */ }
+
+   // Derived classes can override the base class implementation.
+   public virtual int Drive(int miles, int speed) { /* Method statements here */ return 1; }
+
+   // Derived classes can override the base class implementation.
+   public virtual int Drive(TimeSpan time, int speed) { /* Method statements here */ return 0; }
+
+   // Derived classes must implement this.
+   public abstract double GetTopSpeed(); 
+}
+
+
+
+

--- a/samples/snippets/csharp/concepts/methods/named2.cs
+++ b/samples/snippets/csharp/concepts/methods/named2.cs
@@ -1,0 +1,51 @@
+
+using System;
+
+class TestMotorcycle : Motorcycle
+{
+   public override int Drive(int miles, int speed)
+   {
+      return (int) Math.Round( ((double)miles) / speed, 0);
+   }
+
+   public override double GetTopSpeed()
+   {
+      return 108.4;
+   }
+
+   static void Main()
+   {
+      
+      TestMotorcycle moto = new TestMotorcycle();
+      moto.StartEngine();
+      moto.AddGas(15);
+      // <Snippet46>
+      var travelTime = moto.Drive(170, speed: 55);
+      // <Snippet46>
+      Console.WriteLine("Travel time: approx. {0} hours", travelTime);            
+   }
+}
+
+
+
+abstract class Motorcycle
+{
+   // Anyone can call this.
+   public void StartEngine() {/* Method statements here */ }
+
+   // Only derived classes can call this.
+   protected void AddGas(int gallons) { /* Method statements here */ }
+
+   // Derived classes can override the base class implementation.
+   public virtual int Drive(int miles, int speed) { /* Method statements here */ return 1; }
+
+   // Derived classes can override the base class implementation.
+   public virtual int Drive(TimeSpan time, int speed) { /* Method statements here */ return 0; }
+
+   // Derived classes must implement this.
+   public abstract double GetTopSpeed(); 
+}
+
+
+
+

--- a/samples/snippets/csharp/concepts/methods/named2.cs
+++ b/samples/snippets/csharp/concepts/methods/named2.cs
@@ -21,7 +21,7 @@ class TestMotorcycle : Motorcycle
       moto.AddGas(15);
       // <Snippet46>
       var travelTime = moto.Drive(170, speed: 55);
-      // <Snippet46>
+      // </Snippet46>
       Console.WriteLine("Travel time: approx. {0} hours", travelTime);            
    }
 }

--- a/samples/snippets/csharp/concepts/methods/optional1.cs
+++ b/samples/snippets/csharp/concepts/methods/optional1.cs
@@ -1,0 +1,30 @@
+// <Snippet21>
+using System;
+
+public class Options
+{
+   public void ExampleMethod(int required, int optionalInt = default(int),
+                             string description = "Optional Description")
+   {
+      Console.WriteLine("{0}: {1} + {2} = {3}", description, required, 
+                        optionalInt, required + optionalInt);
+   }
+}
+// </Snippet21>
+
+// <Snippet22>
+public class Example
+{
+   public static void Main()
+   {
+      var opt = new Options();
+      opt.ExampleMethod(10);
+      opt.ExampleMethod(10, 2);
+      opt.ExampleMethod(12, description: "Addition with zero:");
+   }
+} 
+// The example displays the following output:
+//      Optional Description: 10 + 0 = 10
+//      Optional Description: 10 + 2 = 12
+//      Addition with zero:: 12 + 0 = 12
+// <Snippet22>

--- a/samples/snippets/csharp/concepts/methods/optional1.cs
+++ b/samples/snippets/csharp/concepts/methods/optional1.cs
@@ -27,4 +27,4 @@ public class Example
 //      Optional Description: 10 + 0 = 10
 //      Optional Description: 10 + 2 = 12
 //      Addition with zero:: 12 + 0 = 12
-// <Snippet22>
+// </Snippet22>

--- a/samples/snippets/csharp/concepts/methods/overridden1.cs
+++ b/samples/snippets/csharp/concepts/methods/overridden1.cs
@@ -1,0 +1,37 @@
+// <Snippet105>
+using System;
+
+public class Person
+{
+   public String FirstName;
+
+   public override bool Equals(object obj)
+   {
+      var p2 = obj as Person; 
+      if (p2 == null)
+         return false;
+      else
+         return FirstName.Equals(p2.FirstName);
+   }
+
+   public override int GetHashCode()
+   {
+      return FirstName.GetHashCode();
+   } 
+}
+
+public class Example
+{
+   public static void Main()
+   {
+      var p1 = new Person();
+      p1.FirstName = "John";
+      var p2 = new Person();
+      p2.FirstName = "John";
+      Console.WriteLine("p1 = p2: {0}", p1.Equals(p2));
+   }
+}
+// The example displays the following output:
+//      p1 = p2: True
+// </Snippet105>
+

--- a/samples/snippets/csharp/concepts/methods/params74.cs
+++ b/samples/snippets/csharp/concepts/methods/params74.cs
@@ -1,0 +1,24 @@
+//<Snippet74>
+public class Example
+{
+   public static void Main()
+   {
+      // Call with an int variable.
+      int num = 4;
+      int productA = Square(num);
+
+      // Call with an integer literal.
+      int productB = Square(12);
+
+      // Call with an expression that evaulates to int.
+      int productC = Square(productA * 3);
+   }
+   
+   static int Square(int i)
+   {
+      // Store input argument in a local variable.
+      int input = i;
+      return input * input;
+   }
+}
+//</Snippet74>

--- a/samples/snippets/csharp/concepts/methods/return44.cs
+++ b/samples/snippets/csharp/concepts/methods/return44.cs
@@ -1,0 +1,37 @@
+using System;
+
+//<Snippet44>
+class SimpleMath
+{
+    public int AddTwoNumbers(int number1, int number2)
+    {
+        return number1 + number2;
+    }
+
+    public int SquareANumber(int number)
+    {
+        return number * number;
+    }
+}
+//</Snippet44>
+
+class TestSimpleMath
+{
+    static void Main()
+    {
+       SimpleMath obj = new SimpleMath();
+
+       //<Snippet45>
+       int result = obj.AddTwoNumbers(1, 2);
+       result = obj.SquareANumber(result);
+       // The result is 9.
+       Console.WriteLine(result);
+       //</Snippet45>
+
+       //<Snippet46>
+       result = obj.SquareANumber(obj.AddTwoNumbers(1, 2));
+       // The result is 9.
+       Console.WriteLine(result);
+       //</Snippet46>
+    }
+}

--- a/samples/snippets/csharp/concepts/methods/returnarray1.cs
+++ b/samples/snippets/csharp/concepts/methods/returnarray1.cs
@@ -1,0 +1,26 @@
+// <Snippet101>
+
+
+using System;
+
+public class Example
+{
+   static void Main(string[] args)  
+   {  
+      int[] values = { 2, 4, 6, 8 };
+      DoubleValues(values);
+      foreach (var value in values)
+         Console.Write("{0}  ", value);
+   }  
+  
+   public static void DoubleValues(int[] arr)
+   {
+      for (int ctr = 0; ctr <= arr.GetUpperBound(0); ctr++)
+         arr[ctr] = arr[ctr] * 2;
+   }
+}
+// The example displays the following output:
+//       4  8  12  16
+// </Snippet101>
+
+

--- a/samples/snippets/csharp/concepts/methods/swap107.cs
+++ b/samples/snippets/csharp/concepts/methods/swap107.cs
@@ -1,0 +1,26 @@
+// <Snippet107>
+using System;
+
+public class Example
+{
+   static void Main()
+   {
+      int i = 2, j = 3;
+      System.Console.WriteLine("i = {0}  j = {1}" , i, j);
+
+      Swap(ref i, ref j);
+
+      System.Console.WriteLine("i = {0}  j = {1}" , i, j);
+   }
+
+   static void Swap(ref int x, ref int y)
+   {
+      int temp = x;
+      x = y;
+      y = temp;
+   }   
+}
+// The example displays the following output:
+//      i = 2  j = 3
+//      i = 3  j = 2
+// </Snippet107>


### PR DESCRIPTION
# Title

Ported and revised Methods topic
## Summary

Ported and revised [Methods (C# Programming Guide)](https://msdn.microsoft.com/en-us/library/ms173114.aspx) from MSDN. Also added a discussion of tuples added in C# 7.0
## Details

This topic replaces the following MSDN topics:
- [Methods](https://msdn.microsoft.com/en-us/library/ms173114.aspx)
- [Passing parameters](https://msdn.microsoft.com/en-us/library/0f66670z.aspx)
- [Passing Value-Type Parameters](https://msdn.microsoft.com/en-us/library/9t0za5es.aspx)
- [Passing Reference-Type Parameters](https://msdn.microsoft.com/en-us/library/s6938f28.aspx)
- [Named and optional arguments](https://msdn.microsoft.com/en-us/library/dd264739.aspx)

Remaining MSDN topics not incorporated into this topic:
- [How to: Know the Difference...](https://msdn.microsoft.com/en-us/library/8b0bdca4.aspx) -- I don't think that this topic is useful enough to port.
- [Implicitly Typed Local Variables](https://msdn.microsoft.com/en-us/library/bb384061.aspx) -- This really shouldn't be paired with methods; it's related to variables.
- [Extension Methods](https://msdn.microsoft.com/en-us/library/bb383977.aspx) and its two child topics -- These should also be ported.
- [How to: Use Named and Optional Arguments in Office Programming](https://msdn.microsoft.com/en-us/library/dd264738.aspx) -- Isn't this best placed in an Office programming doc set?
## Suggested Reviewers

@billwagner @mairaw
