### PR TITLE
excluding tokens from ops validation

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -39,7 +39,8 @@
         {
           "files": ["**/*.md"],
           "src": "docs",
-          "dest": "articles"
+          "dest": "articles",
+          "exclude": ["**/includes/**"] 
         },
         {
           "files": ["*.md"],


### PR DESCRIPTION
Prepping master with changes needed for the migration in case we need to rerun the export tool again since branch is excluded
