### PR TITLE
renamed repo/fixed headings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,4 @@
-Contributing
-============
+# Contributing
 
 Thank you for your interest in contributing to the .NET documentation!
 
@@ -54,7 +53,7 @@ Also, remove the "wrench" icon (🔧) from the TOC and the file heading, if appl
         /porting
           porting_sample.cs
 
-**Step 5:** Submit a Pull Request (PR) from your branch to `dotnet/core-docs/master`.
+**Step 5:** Submit a Pull Request (PR) from your branch to `dotnet/docs/master`.
 
 If your PR is addressing an existing issue, add the `Fixes #Issue_Number` keyword to the commit message or PR description, so the issue can be automatically closed when the PR is merged. For more information, see [Closing issues via commit messages](https://help.github.com/articles/closing-issues-via-commit-messages/).
 
@@ -77,7 +76,7 @@ Below is a short list of guiding rules that you should keep in mind when you are
 - **DO** follow the [GitHub Flow workflow](https://guides.github.com/introduction/flow/). 
 - **DO** blog and tweet (or whatever) about your contributions, frequently!
 
-> Note: you might notice that some of the topics are not currently following all the guidelines specified here and on the [style guide](./styleguide/template.md) as well. We're working towards achieving consistency throughout the site. Check the list of [open issues](https://github.com/dotnet/core-docs/issues?q=is%3Aissue+is%3Aopen+label%3Aguidelines-adherence) we're currently tracking for that specific goal. 
+> Note: you might notice that some of the topics are not currently following all the guidelines specified here and on the [style guide](./styleguide/template.md) as well. We're working towards achieving consistency throughout the site. Check the list of [open issues](https://github.com/dotnet/docs/issues?q=is%3Aissue+is%3Aopen+label%3Aguidelines-adherence) we're currently tracking for that specific goal. 
 
 ## Building the docs
 
@@ -139,4 +138,4 @@ with `http://docs.microsoft.com/dotnet/articles`.
 
 Your topic will also contain links to the sample. Link directly to the sample's folder on GitHub.
 
-For more information, see the [Samples Readme](https://github.com/dotnet/core-docs/blob/master/samples/README.md).
+For more information, see the [Samples Readme](https://github.com/dotnet/docs/blob/master/samples/README.md).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-.NET Core Documentation
-=======================
+#.NET Core Documentation
 
-This repo contains work-in-progress documentation for .NET Core. To contribute, see the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/core-docs/issues). 
+This repo contains work-in-progress documentation for .NET Core. To contribute, see the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/docs/issues). 
 
 We welcome contributions to help us improve and complete the .NET Core docs. Feel free to copy/paste documentation from [.NET Framework docs](https://msdn.microsoft.com/library/w0x726c2.aspx) as a starting point for .NET Core docs. We hope to port higher-quality .NET Core content to the .NET Framework docs, so investments in this repo will benefit all .NET users. We anticipate that [Xamarin](http://developer.xamarin.com/api/root/classlib/), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib) and [Unity](http://docs.unity3d.com/Manual/index.html) will also use this documentation.
 

--- a/api/index.md
+++ b/api/index.md
@@ -597,4 +597,4 @@ The following is a list of namespaces in the .NET Core class library. Each names
 
 ## Improving the Documentation ##
 
-If you find an issue or an inconsistency, we would love to hear about it! Go to the [.NET Core docs repo](https://github.com/dotnet/core-docs/ ".NET Core docs repo") on Github, and open an issue to let us know.
+If you find an issue or an inconsistency, we would love to hear about it! Go to the [.NET Core docs repo](https://github.com/dotnet/docs/ ".NET Core docs repo") on Github, and open an issue to let us know.

--- a/ci-scripts/provisionvm.ps1
+++ b/ci-scripts/provisionvm.ps1
@@ -94,7 +94,7 @@ LogWrite "Will execute this:"
 $executedCommand = "$java $jar $destSource $jnlpCredentialsFlag $credentials $jnlpUrl $serverURL }"
 LogWrite $executedCommand
 
-Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/core-docs/master/ci-scripts/agentman.ps1" -OutFile "$ProvisionArtifacts\agentman.ps1"
+Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/docs/master/ci-scripts/agentman.ps1" -OutFile "$ProvisionArtifacts\agentman.ps1"
 $executedCommand | Out-File -Encoding "UTF8" $ProvisionArtifacts\agentman.ps1 -append
 
 # SchTasks /Create /SC MINUTE /MO 1 /TN "Jenkins Agent Inspector" /TR "powershell.exe -File $ProvisionArtifacts\agentman.ps1 -WindowStyle Hidden"

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -12,8 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 2e38e9d9-8284-46ee-a15f-199adc4f26f4
 ---
 
-About .NET
-==========
+# About .NET
 
 > Check out the ["Getting Started with .NET Core" tutorials](../core/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
@@ -31,8 +30,7 @@ Multiple [.NET implementations and products](products.md) are available, based o
 - Browse the [.NET API Library](../../api/index.md)
 - [Introduction to the Common Language Runtime](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/intro-to-clr.md)
 
-Fundamentals
-------------
+## Fundamentals
 
 **Multi-Language** -- .NET provides a well-defined type system, file formats, runtime, framework and tools that can be used by multiple languages, both for their own execution and also to interoperate with other languages using those same components of .NET as their shared currency.
 
@@ -40,8 +38,7 @@ Fundamentals
 
 **Type Safety** -- The primary .NET model for functionality and memory representation is "types". Types define shape and optionally behavior. The runtime ensures that calling code can only operate on types according to their definition and specified visibility of members, providing consistent, reliable and secure results.
 
-Features
---------
+## Features
 
 **User-defined Value Types** -- Value types are a useful category of types since they offer the semantic of "pass by value" instead of "pass by reference", as is the case for classes. Value types are most obviously usefully for numeric data. .NET enables value types for both primitive types, like integers, and user-defined types.
 
@@ -53,15 +50,13 @@ Features
 
 **Cross-platform** -- .NET was intended to be cross platform from its inception. The binary format and the instruction set are operating system, CPU and pointer-size agnostic. A given .NET binary built in 2000 to run on a 32-bit Windows machine can run on the ARM64 iOS device on 2016 without modification.
 
-Open source
------------
+## Open source
 
 The [.NET Core](https://github.com/dotnet/core) and [Mono](https://github.com/mono/mono) implementations of .NET are open source, using the MIT license. Documentation uses the [Creative Commons CC-BY](https://creativecommons.org/licenses/by/4.0/) license. .NET Core and Mono are sponsored by Microsoft and have many contributors from the community. 
 
 These general purpose runtimes can be used as the basis of academic research or teaching/learning or commercial products. Their open nature also means that anyone can contribute back to the upstream product code given a bug or the desire for a new feature.
 
-Projects
---------
+## Projects
 
 - [CoreCLR](https://github.com/dotnet/coreclr) - .NET runtime, used by .NET Core.
 - [Mono](https://github.com/mono/mono) - .NET runtime, used by Xamarin and others.
@@ -70,8 +65,7 @@ Projects
 - [F#](https://github.com/microsoft/visualfsharp) - F# compiler.
 - [Xamarin SDK](http://open.xamarin.com) - Tools and libraries needed to write Android, iOS and macOS in C# and F#.
 
-Standardized
-------------
+## Standardized
 
 .NET is specified via open [ECMA standards](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/dotnet-standards.md) that outline its capabilities and that can be used to make a new implementation. There are other .NET implementations, with Mono and Unity being the most popular beyond the Microsoft ones.
 

--- a/docs/about/products.md
+++ b/docs/about/products.md
@@ -12,8 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 2e38e9d9-8284-46ee-a15f-199adc4f26f4
 ---
 
-.NET Products
-=============
+# .NET Products
 
 .NET is a very flexible, general purpose and inherently cross-platform [specification](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/dotnet-standards.md) for building developer products. It is used for all of the most popular app categories: desktop, mobile, cloud, gaming and IoT.
 
@@ -22,8 +21,7 @@ There are two subtly different terms used in this document:
 - ".NET product" - Enables you to build an app for one or more target platforms.
 - ".NET implementation" - Some combination of a runtime, framework and tools that can execute ".NET code" on which products are based.
 
-Product Categories
-------------------
+## Product Categories
 
 .NET products are available for each of the following product categories.
 
@@ -66,8 +64,7 @@ You can build Web and Cloud apps for Windows and Linux.
 - [ASP.NET](http://www.asp.net/) for Windows with the [.NET Framework](#net-framework)
 - [ASP.NET Core](http://docs.asp.net/) for Windows, macOS and Linux with [.NET Core](#net-core)
 
-.NET Implementations
---------------------
+## .NET Implementations
 
 Major commercial and open source .NET implementations are listed below, in alphabetical order.
 
@@ -83,7 +80,7 @@ The following are the main characteristics of .NET Core:
 
 **Cross-platform** - .NET Core supports three operating systems families: Linux, Windows and macOS. .NET Core apps are cross-platform by default. You can write apps and libraries that run unmodified across supported OSes.
 
-**Open Source** - [.NET Core](https://github.com/dotnet/core) is available on GitHub, licensed with the [MIT](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) and [Apache 2](https://github.com/dotnet/roslyn/blob/master/License.txt) licenses (licensing is per component). Documentation is [CC-BY](https://github.com/dotnet/core-docs/blob/master/license.txt). .NET Core also makes use of a significant set of open source industry dependencies, listed in the [.NET Core release notes](https://github.com/dotnet/core/releases). 
+**Open Source** - [.NET Core](https://github.com/dotnet/core) is available on GitHub, licensed with the [MIT](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) and [Apache 2](https://github.com/dotnet/roslyn/blob/master/License.txt) licenses (licensing is per component). Documentation is [CC-BY](https://github.com/dotnet/docs/blob/master/license.txt). .NET Core also makes use of a significant set of open source industry dependencies, listed in the [.NET Core release notes](https://github.com/dotnet/core/releases). 
 
 **Natural acquisition** - NET Core is distributed in several forms, aligning with specific developer needs. You can acquire .NET Core with the [.NET Core SDK](https://dot.net/core) installer (or zips) or via OS-specific package managers, such as APT and Yum. [Official .NET Core Docker images](https://hub.docker.com/r/microsoft/dotnet/) are available on Docker Hub. Higher-level framework libraries and the larger .NET library ecosystem are available on [NuGet](http://www.nuget.org/). 
 

--- a/docs/core/app-types.md
+++ b/docs/core/app-types.md
@@ -10,10 +10,10 @@ ms.prod: .net-core
 ms.technology: .net-core-technologies
 ms.devlang: dotnet
 ms.assetid: 93488a0b-c94c-4ed6-97ea-571bb23a862e
+redirect_url: /deploying/index
 ---
 
-.NET Core App Types
-===================
+# .NET Core App Types
 
 ## Content moved!
 This content has merged and moved to the [.NET Core Application Deployment](deploying/index.md) topic. 

--- a/docs/core/deploying/applications.md
+++ b/docs/core/deploying/applications.md
@@ -21,5 +21,5 @@ ms.assetid: 1db00fb1-d947-480d-8d7d-7152e67b0585
 > We welcome your input to help shape the scope and approach. 
 > 
 > Learn more about how you can contribute on
-> [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/core/porting/nuget-packages.md
+++ b/docs/core/porting/nuget-packages.md
@@ -21,7 +21,7 @@ ms.assetid: 4d823e71-19ac-4419-953e-b47aa58f5538
 > We welcome your input to help shape the scope and approach.
 > 
 > Learn more about how you can contribute on
-> [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >
         
   

--- a/docs/core/porting/project-structure.md
+++ b/docs/core/porting/project-structure.md
@@ -100,18 +100,18 @@ Please see [.NET Core porting documentation][porting-doc] for more guidance on m
 
 [porting-doc]: index.md
 [example-initial-project]: media/project-structure/project.png "Existing project"
-[example-initial-project-code]: https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/migrate-library/
+[example-initial-project-code]: https://github.com/dotnet/docs/tree/master/samples/framework/libraries/migrate-library/
 
 [example-xproj]: media/project-structure/project.xproj.png "Create an xproj that targets multiple frameworks"
-[example-xproj-code]: https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/migrate-library-xproj/
-[example-xproj-projectjson]: https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/migrate-library-xproj/src/Car/project.json
-[example-xproj-projectjson-test]: https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/migrate-library-xproj/tests/Car.Tests/project.json
+[example-xproj-code]: https://github.com/dotnet/docs/tree/master/samples/framework/libraries/migrate-library-xproj/
+[example-xproj-projectjson]: https://github.com/dotnet/docs/tree/master/samples/framework/libraries/migrate-library-xproj/src/Car/project.json
+[example-xproj-projectjson-test]: https://github.com/dotnet/docs/tree/master/samples/framework/libraries/migrate-library-xproj/tests/Car.Tests/project.json
 
 [example-xproj-different-folder]: media/project-structure/project.xproj.different.png ".NET Core project with existing PCL in different folder"
-[example-xproj-different-code]: https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/migrate-library-xproj-keep-csproj/
+[example-xproj-different-code]: https://github.com/dotnet/docs/tree/master/samples/framework/libraries/migrate-library-xproj-keep-csproj/
 
 [example-pcl]: media/project-structure/project.pcl.png "PCL Targeting .NET Core"
-[example-pcl-code]: https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/migrate-library-pcl
+[example-pcl-code]: https://github.com/dotnet/docs/tree/master/samples/framework/libraries/migrate-library-pcl
 
 [option-xproj]: #replace-existing-projects-with-a-multi-targeted-net-core-project-xproj
 [option-pcl]: #create-a-portable-class-library-pcl-to-target-net-core

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -16,7 +16,7 @@ ms.assetid: bdcdb812-6f13-4f20-9e90-0c0977937142
 
 By [Steve Smith](http://ardalis.com) and [Bill Wagner](https://github.com/BillWagner)
 
-[View or download sample code](https://github.com/dotnet/core-docs/tree/master/samples/core/getting-started/unit-testing-using-dotnet-test)
+[View or download sample code](https://github.com/dotnet/docs/tree/master/samples/core/getting-started/unit-testing-using-dotnet-test)
 
 ## Creating the Projects
 
@@ -138,7 +138,7 @@ not in the NuGet feed. Without this key, you might download
 a package with the same name as your internal library.
 
 You can see the entire file in the
-[samples repository](https://github.com/dotnet/core-docs/blob/master/samples/core/getting-started/unit-testing-using-dotnet-test/test/PrimeService.Tests/project.json) 
+[samples repository](https://github.com/dotnet/docs/blob/master/samples/core/getting-started/unit-testing-using-dotnet-test/test/PrimeService.Tests/project.json) 
 on GitHub.
 
 After this initial structure is in place, you can write your first test.
@@ -242,9 +242,9 @@ Now, these tests all pass.
 You continue to iterate by adding more tests, more theories,
 and more code in the main library. You'll quickly end up
 with the
-[finished version of the tests](https://github.com/dotnet/core-docs/blob/master/samples/core/getting-started/unit-testing-using-dotnet-test/test/PrimeService.Tests/PrimeServie_IsPrimeShould.cs)
+[finished version of the tests](https://github.com/dotnet/docs/blob/master/samples/core/getting-started/unit-testing-using-dotnet-test/test/PrimeService.Tests/PrimeServie_IsPrimeShould.cs)
 and the
-[complete implementation of the library](https://github.com/dotnet/core-docs/blob/master/samples/core/getting-started/unit-testing-using-dotnet-test/src/PrimeService/PrimeService.cs).
+[complete implementation of the library](https://github.com/dotnet/docs/blob/master/samples/core/getting-started/unit-testing-using-dotnet-test/src/PrimeService/PrimeService.cs).
 
 You've built a small library and a set of unit tests for that library.
 You've structured this solution so that adding new packages and tests

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -73,7 +73,7 @@ Just use:
 dotnet: 1.0.0-preview2-003121
 ```
 
-Travis can run both `osx` (OS X 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/core-docs/blob/master/.travis.yml) 
+Travis can run both `osx` (OS X 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/docs/blob/master/.travis.yml) 
 for more information.
 
 ### AppVeyor
@@ -87,7 +87,7 @@ Just use:
 os: Visual Studio 2015
 ```
 
-It's possible to install a specific version of .NET Core SDK, see [example appveyor.yml](https://github.com/dotnet/core-docs/blob/master/appveyor.yml) 
+It's possible to install a specific version of .NET Core SDK, see [example appveyor.yml](https://github.com/dotnet/docs/blob/master/appveyor.yml) 
 for more info. 
 
 In the example, the .NET Core SDK binaries are downloaded, unzipped in a subdirectory and added to `PATH` env var.

--- a/docs/core/tutorials/cli-console-app-tutorial-advanced.md
+++ b/docs/core/tutorials/cli-console-app-tutorial-advanced.md
@@ -20,11 +20,11 @@ ms.assetid: dab9e2f9-9088-4089-b990-fbc3d8dcd611
 >
 > We welcome your input to help shape the scope and approach. You can
 > track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/180) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/180) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this
 > topic, please leave a note with your contact information in the issue.
 >
 > Learn more about how you can contribute on
-> [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/core/tutorials/index.md
+++ b/docs/core/tutorials/index.md
@@ -12,8 +12,7 @@ ms.devlang: dotnet
 ms.assetid: f6f654b1-1d2c-4105-8376-7c1959e23803
 ---
 
-.NET Core Tutorials
-===================
+# .NET Core Tutorials
 
 The following tutorials are available for learning about .NET Core.
 

--- a/docs/core/tutorials/libraries-with-vs.md
+++ b/docs/core/tutorials/libraries-with-vs.md
@@ -21,5 +21,5 @@ ms.assetid: 01b988ed-583f-48c8-a016-caeee282e0a6
 > We welcome your input to help shape the scope and approach.
 > 
 > Learn more about how you can contribute on
-> [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -42,7 +42,7 @@ You can find the links to all of these at the [.NET home page](http://dot.net).
 ## Getting Started
 
 The source for this tutorial is available on
-[GitHub](https://github.com/dotnet/core-docs/tree/master/samples/core/getting-started/golden).
+[GitHub](https://github.com/dotnet/docs/tree/master/samples/core/getting-started/golden).
 
 Start Visual Studio Code. Press Ctrl + '\`' (the back-quote character) to open
 an embedded terminal in VS Code. (Alternatively, you can use a separate

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -24,7 +24,7 @@ Before you begin, ensure you have the [latest .NET Core CLI tooling](https://www
 
 ## Hello, Console App!
 
-First, navigate to or create a new folder with a name you like.  "Hello" is the name chosen for the sample code, which can be found [here](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps/Hello).
+First, navigate to or create a new folder with a name you like.  "Hello" is the name chosen for the sample code, which can be found [here](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/Hello).
 
 Open up a command prompt and type the following:
 
@@ -99,7 +99,7 @@ Let's try compiling a self-contained application instead of a portable applicati
 
 You need to make some changes to your `project.json`
 file to direct the tools to build a self-contained application. You can see these in the
-[HelloNative](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps/HelloNative)
+[HelloNative](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/HelloNative)
 project in the samples directory.
 
 The first change is to remove the `"type": "platform"` element from all dependencies. 
@@ -258,7 +258,7 @@ Now the fun part: making the new file do something!
 
 ### Example: A Fibonacci Sequence Generator
 
-Let's say you want to build off of the previous [Fibonacci example](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps/Fibonacci) by caching some Fibonacci values and add some recursive flair.  Your code for a [better Fibonacci example](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps/FibonacciBetter) might look something like this:
+Let's say you want to build off of the previous [Fibonacci example](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/Fibonacci) by caching some Fibonacci values and add some recursive flair.  Your code for a [better Fibonacci example](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/FibonacciBetter) might look something like this:
 
 ```csharp
 using System;
@@ -373,7 +373,7 @@ Say you wanted to introduce some new types to do work on.  You can do this by ad
 |__project.json
 ```
 
-This works great when the size of your project is relatively small.  However, if you have a larger app with many different data types and potentially multiple layers, you may wish to organize things logically.  This is where folders come into play.  You can either follow along with [the NewTypes sample project](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps/NewTypes) that this guide covers, or create your own files and folders.
+This works great when the size of your project is relatively small.  However, if you have a larger app with many different data types and potentially multiple layers, you may wish to organize things logically.  This is where folders come into play.  You can either follow along with [the NewTypes sample project](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/NewTypes) that this guide covers, or create your own files and folders.
 
 To begin, create a new folder under the root of your project.  `/Model` is chosen here.
 
@@ -552,7 +552,7 @@ You'll probably be wanting to test your projects at some point.  Here's a good w
    
 ### Example: Extending the NewTypes project
 
-Now that the project system is in place, you can create your test project and start writing tests!  From here on out, this guide will use and extend [the sample Types project](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps/NewTypes).  Additionally, it will use the [Xunit](https://xunit.github.io/) test framework.  Feel free to follow along or create your own multi-project system with tests.
+Now that the project system is in place, you can create your test project and start writing tests!  From here on out, this guide will use and extend [the sample Types project](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/NewTypes).  Additionally, it will use the [Xunit](https://xunit.github.io/) test framework.  Feel free to follow along or create your own multi-project system with tests.
 
 
 The whole project structure should look like this:

--- a/docs/core/versions/servicing.md
+++ b/docs/core/versions/servicing.md
@@ -20,12 +20,12 @@ ms.assetid: 48682290-4fd7-40dc-8a7b-bac528eba361
 >
 > We welcome your input to help shape the scope and approach. You can
 > track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/469) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/469) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this
 > topic, please leave a note with your contact information in the issue.
 >
 > Learn more about how you can contribute on
-> [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >
 	

--- a/docs/csharp/csharp-7.md
+++ b/docs/csharp/csharp-7.md
@@ -70,9 +70,9 @@ The remainder of this topic provides an overview
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/961) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/961) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/expression-trees-building.md
+++ b/docs/csharp/expression-trees-building.md
@@ -203,7 +203,7 @@ we'd like to avoid in our everyday coding tasks.
 
 For this section, I've also updated the visitor code to visit every node in this expression
 tree and write out information about the nodes that are created in this sample. You can see
-the code in [the samples section](https://github.com/dotnet/core-docs/tree/master/samples/csharp/expression-trees).
+the code in [the samples section](https://github.com/dotnet/docs/tree/master/samples/csharp/expression-trees).
 You can experiment for yourself: build it and run the samples.
 
 ## Examining the APIs

--- a/docs/csharp/generics.md
+++ b/docs/csharp/generics.md
@@ -19,9 +19,9 @@ ms.assetid: 63d1fe21-bb1f-46e3-92a0-89efcf0815e8
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/489) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/489) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -20,9 +20,9 @@ ms.assetid: b77c7263-7cbf-4729-9626-8fbc3f5f14d9
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/942) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/942) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/getting-started/with-cross-platform-tools.md
+++ b/docs/csharp/getting-started/with-cross-platform-tools.md
@@ -20,9 +20,9 @@ ms.assetid: 48cac496-2dc2-4dc7-b8fd-b9ade0fcdfd2
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/945) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/945) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/getting-started/with-csharp-interactive.md
+++ b/docs/csharp/getting-started/with-csharp-interactive.md
@@ -20,9 +20,9 @@ ms.assetid: a6907ffe-7920-4813-984f-6001d9e44756
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/946) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/946) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/getting-started/with-visual-studio-code.md
+++ b/docs/csharp/getting-started/with-visual-studio-code.md
@@ -20,9 +20,9 @@ ms.assetid: 76c23597-4cf9-467e-8a47-0c3703ce37e7
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/944) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/944) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/indexers.md
+++ b/docs/csharp/indexers.md
@@ -76,7 +76,7 @@ Let's walk through some of the common scenarios for using *indexers*.
 The code for all the samples is available at the core-docs [GitHub
 repository](https://github.com/dotnet/core-docs). Or, you can
 access the 
-[sample folder](https://github.com/dotnet/core-docs/tree/master/samples/csharp/indexers)
+[sample folder](https://github.com/dotnet/docs/tree/master/samples/csharp/indexers)
 directly.
 
 ### Arrays and Vectors

--- a/docs/csharp/interactive-with-bash.md
+++ b/docs/csharp/interactive-with-bash.md
@@ -19,9 +19,9 @@ ms.assetid: 6312a76a-a298-49a0-9116-b9d9e6b3c7c3
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/971) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/971) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/interactive-with-powershell.md
+++ b/docs/csharp/interactive-with-powershell.md
@@ -19,9 +19,9 @@ ms.assetid: 675d962b-f711-4f1a-9eb6-e04220344b5a
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/970) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/970) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/interactive-with-visualstudio.md
+++ b/docs/csharp/interactive-with-visualstudio.md
@@ -19,9 +19,9 @@ ms.assetid: abed9e00-2ddc-468e-9cca-d033bd6a7e36
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/969) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/969) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/interactive.md
+++ b/docs/csharp/interactive.md
@@ -19,9 +19,9 @@ ms.assetid: abed9e00-2ddc-468e-9cca-d033bd6a7e36
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/968) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/968) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/interfaces.md
+++ b/docs/csharp/interfaces.md
@@ -19,9 +19,9 @@ ms.assetid: be9a19c8-642c-48be-b481-2dab7d216fad
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/967) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/967) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/interop.md
+++ b/docs/csharp/interop.md
@@ -19,9 +19,9 @@ ms.assetid: 54485caa-09e0-466c-86fa-6a9aab6c332b
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/492) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/492) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/lambda-expressions.md
+++ b/docs/csharp/lambda-expressions.md
@@ -19,9 +19,9 @@ ms.assetid: b6a0539a-8ce5-4da7-adcf-44be345a2714
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/488) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/488) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/linq.md
+++ b/docs/csharp/linq.md
@@ -19,9 +19,9 @@ ms.assetid: 007cc736-f5cf-4919-b99b-0c00ab2814ce
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/490) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/490) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/methods-lambda-expressions.md
+++ b/docs/csharp/methods-lambda-expressions.md
@@ -19,9 +19,9 @@ ms.assetid: b6a0539a-8ce5-4da7-adcf-44be345a2714
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/488) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/488) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -19,9 +19,9 @@ ms.assetid: b6a0539a-8ce5-4da7-adcf-44be345a2714
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/488) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/488) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/namespaces-and-assemblies.md
+++ b/docs/csharp/namespaces-and-assemblies.md
@@ -19,9 +19,9 @@ ms.assetid: fe436e2b-c6ea-490d-a221-0d822c6e178b
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/962) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/962) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/parallel.md
+++ b/docs/csharp/parallel.md
@@ -19,9 +19,9 @@ ms.assetid: 8045b1b8-7835-4a7a-980d-bc9c70d62a0c
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/491) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/491) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -19,9 +19,9 @@ ms.assetid: 1e575c32-2e2b-4425-9dca-7d118f3ed15b
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/1114) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/1114) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/reflection.md
+++ b/docs/csharp/reflection.md
@@ -19,9 +19,9 @@ ms.assetid: 53339c51-0fbc-4827-9de2-39c805bfc06b
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/493) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/493) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/roslyn/index.md
+++ b/docs/csharp/roslyn/index.md
@@ -19,11 +19,11 @@ ms.assetid: abed9e00-2ddc-468e-9cca-d033bd6a7e36
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/972) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/972) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >
 
 This is a meta-topic for an entire section. Areas that need to be covered here include: 

--- a/docs/csharp/syntax.md
+++ b/docs/csharp/syntax.md
@@ -19,9 +19,9 @@ ms.assetid: 901184ac-1370-40b0-ad57-1f674890befe
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/485) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/485) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -19,9 +19,9 @@ ms.assetid: ee8bf7c3-aa3e-4c9e-a5c6-e05cc6138baa
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/1113) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/1113) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/asynchronous-server-programming.md
+++ b/docs/csharp/tutorials/asynchronous-server-programming.md
@@ -19,9 +19,9 @@ ms.assetid: 7402b29b-1093-456d-be4c-f60ecb8926bb
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/952) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/952) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/asynchronous-ui-programming.md
+++ b/docs/csharp/tutorials/asynchronous-ui-programming.md
@@ -19,9 +19,9 @@ ms.assetid: 7402b29b-1093-456d-be4c-f60ecb8926bb
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/951) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/951) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/concurrent-programming.md
+++ b/docs/csharp/tutorials/concurrent-programming.md
@@ -19,9 +19,9 @@ ms.assetid: 0f8b42de-858a-44a3-87d9-998211f26377
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/953) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/953) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -80,8 +80,8 @@ namespace TeleprompterConsole
 ## Reading and Echoing the File
 The first feature to add is to read a text file, and display all that text
 to the console. First, let’s add a text file. Copy the 
-[sampleQuotes.txt](https://github.com/dotnet/core-docs/blob/master/samples/csharp/getting-started/console-teleprompter/sampleQuotes.txt)
-file from the GitHub repository for this [sample](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/console-teleprompter) into your project directory. 
+[sampleQuotes.txt](https://github.com/dotnet/docs/blob/master/samples/csharp/getting-started/console-teleprompter/sampleQuotes.txt)
+file from the GitHub repository for this [sample](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-teleprompter) into your project directory. 
 This will serve as the script for your
 application.
 

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -485,7 +485,7 @@ Console.WriteLine(repo.LastPush);
 ```
 
 Your version should now match the finished version located
-[here](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/console-webapiclient).
+[here](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-webapiclient).
  
 ## Conclusion
 

--- a/docs/csharp/tutorials/create-debug-deploy.md
+++ b/docs/csharp/tutorials/create-debug-deploy.md
@@ -20,9 +20,9 @@ ms.assetid: 9b5ce7a7-7325-45b6-86c9-c199d0203997
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/948) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/948) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/creating-portable-libraries.md
+++ b/docs/csharp/tutorials/creating-portable-libraries.md
@@ -19,9 +19,9 @@ ms.assetid: 254836c0-3be7-4549-bd9a-40fc0f445c31
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/950) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/950) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/exploring-with-csharp-interactive.md
+++ b/docs/csharp/tutorials/exploring-with-csharp-interactive.md
@@ -19,9 +19,9 @@ ms.assetid: 13b5c1b7-d3f1-4c96-910c-4890162866c1
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/949) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/949) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -32,7 +32,7 @@ Along the way, you'll also see some C# language features:
 * How to process incoming HTTP Requests and generate the HTTP Response
 * How to work with nullable value types
 
-You can retrieve the code from our [GitHub repository.](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/WeatherMicroservice)
+You can retrieve the code from our [GitHub repository.](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/WeatherMicroservice)
 
 ### Why Docker?
 

--- a/docs/csharp/tutorials/working-with-linq.md
+++ b/docs/csharp/tutorials/working-with-linq.md
@@ -38,7 +38,7 @@ You'll also compare the updated order to the original order.
 
 This tutorial has multiple steps. After each step, you can run the
 application and see the progress. You can also see the completed
-sample in our [GitHub repository.](https://github.com/dotnet/core-docs/blob/master/samples/csharp/getting-started/console-linq)
+sample in our [GitHub repository.](https://github.com/dotnet/docs/blob/master/samples/csharp/getting-started/console-linq)
 
 
 ## Prerequisites

--- a/docs/csharp/type-system.md
+++ b/docs/csharp/type-system.md
@@ -19,9 +19,9 @@ ms.assetid: 08589912-2fa0-4636-9aa6-d8b2b83cdf88
 > This topic hasn’t been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
-> [issue](https://github.com/dotnet/core-docs/issues/487) at GitHub.
+> [issue](https://github.com/dotnet/docs/issues/487) at GitHub.
 > 
 > If you would like to review early drafts and outlines of this topic, please leave a note with your contact information in the issue.
 >
-> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/core-docs/blob/master/CONTRIBUTING.md).
+> Learn more about how you can contribute on [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
 >

--- a/docs/framework/docker/aspnetmvc.md
+++ b/docs/framework/docker/aspnetmvc.md
@@ -46,7 +46,7 @@ Moving your application involves these steps:
 4. [Verifying the application using your browser.](#verify-in-the-browser)
 
 The finished application is located in the
-[dotnet/core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/framework/docker/MVCRandomAnswerGenerator).
+[dotnet/core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/framework/docker/MVCRandomAnswerGenerator).
 
 ## Prerequisites
 
@@ -203,7 +203,7 @@ see the running site.
 > You can temporarily disable it to make sure your container is working.
 
 The sample directory on GitHub contains a 
-[PowerShell script](https://github.com/dotnet/core-docs/tree/master/samples/framework/docker/MVCRandomAnswerGenerator/run.ps1)
+[PowerShell script](https://github.com/dotnet/docs/tree/master/samples/framework/docker/MVCRandomAnswerGenerator/run.ps1)
 that executes these commands for you. Open a PowerShell window, change directory to
 your solution directory, and type:
 

--- a/docs/framework/docker/console.md
+++ b/docs/framework/docker/console.md
@@ -22,7 +22,7 @@ The sample console application is a simple example which takes an argument, a qu
 
 In addition to the answer, the `Environment.MachineName` has been added to the response to show the difference between running the application locally and in a Windows container. When running the application locally, your local machine name should be returned and when running in a Windows Container; the container session id is returned.
 
-The complete example is available in the [dotnet/core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/framework/docker/ConsoleRandomAnswerGenerator).
+The complete example is available in the [dotnet/core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/framework/docker/ConsoleRandomAnswerGenerator).
 
 You need to be familiar with some Docker terms before you begin working
 on moving your application to a container.

--- a/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
+++ b/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
@@ -15,7 +15,7 @@ ms.assetid: f9196bfc-b8a8-4d33-8b53-0dcbd58a69d8
 # Async Programming in F# #
 
 > [!NOTE]
-> Some inaccuracies have been discovered in this article.  It is being rewritten.  See [Issue #666](https://github.com/dotnet/core-docs/issues/666) to learn about the changes.
+> Some inaccuracies have been discovered in this article.  It is being rewritten.  See [Issue #666](https://github.com/dotnet/docs/issues/666) to learn about the changes.
 
 Async programming in F# can be accomplished through a language-level programming model designed to be easy to use and natural to the language.
 

--- a/docs/samples-and-tutorials/index.md
+++ b/docs/samples-and-tutorials/index.md
@@ -33,18 +33,18 @@ online playground, try these [interactive tutorials](http://go.microsoft.com/fwl
 
 **[Unit Testing in .NET Core using dotnet test](../core/testing/unit-testing-with-dotnet-test.md)**
 
-This guide shows how to create an ASP.NET Core web application and the associated unit tests. It will start by creating a simple web service application and then add tests, and continue by creating more tests to guide implementing new features. The completed code is available [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/core/getting-started/unit-testing-using-dotnet-test).
+This guide shows how to create an ASP.NET Core web application and the associated unit tests. It will start by creating a simple web service application and then add tests, and continue by creating more tests to guide implementing new features. The completed code is available [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/core/getting-started/unit-testing-using-dotnet-test).
 
 ### Tutorials
 
 **[Writing .NET Core console apps using the CLI tools: A step-by-step guide](../core/tutorials/using-with-xplat-cli.md)**
 
-This guide will show you how to use the .NET Core CLI tooling to build cross-platform console apps.  It will start with the most basic console app and eventually span multiple projects, including testing. You'll add these features step-by-step, building on what you've already seen and built. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/core/console-apps).
+This guide will show you how to use the .NET Core CLI tooling to build cross-platform console apps.  It will start with the most basic console app and eventually span multiple projects, including testing. You'll add these features step-by-step, building on what you've already seen and built. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/core/console-apps).
 
 **[Writing Libraries with Cross Platform Tools](../core/tutorials/libraries.md)**
 
 This sample covers how you can write libraries for .NET using cross-platform CLI tools.  They provide an efficient and low-level experience that works across any supported OS.
-The completed code is available [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/framework/libraries/frameworks-library).
+The completed code is available [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/framework/libraries/frameworks-library).
 
 ## C# Language
 
@@ -52,53 +52,53 @@ The completed code is available [in the core-docs repository on GitHub](https://
 
 **[Iterators](../csharp/iterators.md)**
 
-This sample demonstrates the syntax and features for creating and consuming C# iterators. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/iterators).
+This sample demonstrates the syntax and features for creating and consuming C# iterators. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/iterators).
 
 **[Indexers](../csharp/indexers.md)**
 
-This sample demonstrates the syntax and features for C# indexers. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/indexers).
+This sample demonstrates the syntax and features for C# indexers. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/indexers).
 
 **[Delegates and Events](../csharp/delegates-events.md)**
 
-This sample demonstrates the syntax and features for C# delegates and events. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/delegates-and-events). A second sample, focused on events is also in the
-[same repository](https://github.com/dotnet/core-docs/tree/master/samples/csharp/events).
+This sample demonstrates the syntax and features for C# delegates and events. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/delegates-and-events). A second sample, focused on events is also in the
+[same repository](https://github.com/dotnet/docs/tree/master/samples/csharp/events).
 
 **[Expression Trees](../csharp/expression-trees.md)**
 
-This sample demonstrates many of the problems that can be solved by using Expression Trees. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/expression-trees).
+This sample demonstrates many of the problems that can be solved by using Expression Trees. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/expression-trees).
 
 **LINQ Samples**
 
-These series of samples demonstrate many of the features of Language Integrated Query.  A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/core/linq/csharp).
+These series of samples demonstrate many of the features of Language Integrated Query.  A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/core/linq/csharp).
 
 ### Tutorials
 
 **[Console Application](../csharp/tutorials/console-teleprompter.md)**
 
 This tutorial demonstrates Console I/O, the structure of a Console application, and
-the basics of the Task based asynchronous programming model. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/console-teleprompter).
+the basics of the Task based asynchronous programming model. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-teleprompter).
 
 **[REST Client](../csharp/tutorials/console-webapiclient.md)**
 
 This tutorial demonstrates web communications, JSON serialization, and Object Oriented
 features in the C# language. A finished version of the code you'll build is located
-[in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/console-webapiclient).
+[in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-webapiclient).
 
 **[Working with LINQ](../csharp/tutorials/working-with-linq.md)**
 
-This tutorial demonstrates many of the features of LINQ and the language elements that support it. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/console-linq).
+This tutorial demonstrates many of the features of LINQ and the language elements that support it. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-linq).
 
 **[Microservices hosted in Docker](../csharp/tutorials/microservices.md)**
 
-This tutorial demonstrates building an ASP.NET Core microservice and hosting it in Docker. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/csharp/getting-started/WeatherMicroservice).
+This tutorial demonstrates building an ASP.NET Core microservice and hosting it in Docker. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/WeatherMicroservice).
 
 ## Deploying to Containers
 
 **[Running ASP.NET MVC Applications in Windows Docker Containers](../framework/docker/aspnetmvc.md)**
 
 This tutorial demonstrates how to deploy an existing ASP.NET MVC application in a Windows Docker Container.
-A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/framework/docker/MVCRandomAnswerGenerator).
+A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/framework/docker/MVCRandomAnswerGenerator).
 
 **[Running .NET Framework Console Applications in Windows Containers](../framework/docker/console.md)**
 
-This tutorial demonstrates how to deploy and existing console application in a Windows container. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/core-docs/tree/master/samples/framework/docker/ConsoleRandomAnswerGenerator).
+This tutorial demonstrates how to deploy and existing console application in a Windows container. A finished version of the code you'll build is located [in the core-docs repository on GitHub](https://github.com/dotnet/docs/tree/master/samples/framework/docker/ConsoleRandomAnswerGenerator).

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -12,8 +12,7 @@ ms.devlang: dotnet
 ms.assetid: cb788dcf-2120-467f-9c34-c02a90e1f68f
 ---
 
-Welcome to .NET
-===============
+# Welcome to .NET
 
 > Check out the ["Getting Started with .NET Core" tutorials](core/getting-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
@@ -21,8 +20,7 @@ Welcome to .NET! You can build any kind of application you want with .NET, from 
 
 You can develop apps and games on Windows, macOS and Linux. There are free tools that you can use to build apps or games and deploy them on servers or desktops or publish them to app stores. It's accessible to students and  used by large businesses throughout the world.
 
-News
-----
+## News
 
 There is always something new to learn or explore in the .NET community. Here's the latest news you may want to check out.
 
@@ -35,8 +33,7 @@ There is always something new to learn or explore in the .NET community. Here's 
 - [The week in .NET](https://blogs.msdn.microsoft.com/dotnet/tag/week-in-net/)
 - [Thank you for watching dotnetConf 2016!](https://blogs.msdn.microsoft.com/dotnet/2016/06/09/thank-you-for-watching-dotnetconf-2016/)
 
-Documentation
--------------
+## Documentation
 
 This documentation will show you how to build an app from scratch or finish one that you are already working on. Key sections you should check out:
 
@@ -46,12 +43,10 @@ This documentation will show you how to build an app from scratch or finish one 
 - [.NET Core Guide](core/index.md)
 - [.NET Standard Guide](standard/index.md)
 
-Open Source
------------
+## Open Source
 
 Many parts of .NET are built by open source contributors. You can contribute to this [.NET Documentation](https://github.com/dotnet/core-docs). You can also read the source of and contribute to .NET products, including [.NET Core](https://github.com/dotnet/core) and [Xamarin](http://open.xamarin.com). Key projects from Microsoft have been contributed to the [.NET Foundation](http://dotnetfoundation.org).
 
-Community
----------
+## Community
 
 Welcome to the .NET community. You can join other people who are already active in the [.NET community](https://www.microsoft.com/net/community), to find out what's new or ask for help.

--- a/samples/README.md
+++ b/samples/README.md
@@ -53,7 +53,7 @@ We will have a CI system in place to build these projects shortly.
 
 To create a sample:
 
-1. File an [issue](https://github.com/dotnet/core-docs/issues) or add a comment to an existing one that you are working on it.
+1. File an [issue](https://github.com/dotnet/docs/issues) or add a comment to an existing one that you are working on it.
 2. Write the topic that explains the concepts demonstrated in your sample (example: `docs/standard/linq/where-clause.md`) 
 3. Write your sample (example: `WhereClause-Sample1.cs`)
 4. Create a Program.cs with a Main entry point that calls your samples. If there is already one there, add the call to your sample:

--- a/samples/framework/libraries/README.md
+++ b/samples/framework/libraries/README.md
@@ -38,7 +38,7 @@ And that's it!
 
 The project under `/new-library` is a project targeting **only** .NET Core. For that reason,
 this project is stored under the core project directory, so our build server builds it on
-all platforms. Look under https://github.com/dotnet/core-docs/tree/master/samples/core/libraries/new-library/
+all platforms. Look under https://github.com/dotnet/docs/tree/master/samples/core/libraries/new-library/
 
 It demonstrates two other things: how to use multiple projects and how to test.
 

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -23,14 +23,14 @@ ms.assetid: [GET ONE FROM guidgenerator.com]
 
 # Metadata and Markdown Template
 
-This core-docs template contains examples of Markdown syntax, as well as guidance on setting the metadata. To get the most of it, you must view both the [raw Markdown](https://raw.githubusercontent.com/dotnet/core-docs/master/styleguide/template.md) and the [rendered view](https://github.com/dotnet/core-docs/blob/master/styleguide/template.md) (for instance, the raw Markdown shows the metadata block, while the rendered view does not).
+This core-docs template contains examples of Markdown syntax, as well as guidance on setting the metadata. To get the most of it, you must view both the [raw Markdown](https://raw.githubusercontent.com/dotnet/docs/master/styleguide/template.md) and the [rendered view](https://github.com/dotnet/docs/blob/master/styleguide/template.md) (for instance, the raw Markdown shows the metadata block, while the rendered view does not).
 
 When creating a Markdown file, you should copy this template to a new file, fill out the metadata as specified below, set the H1 heading above to the title of the article, and delete the content. 
 
 
 ## Metadata 
 
-The full metadata block is above (in the [raw Markdown](https://raw.githubusercontent.com/dotnet/core-docs/master/styleguide/template.md)), divided into required fields and optional fields. Some key notes:
+The full metadata block is above (in the [raw Markdown](https://raw.githubusercontent.com/dotnet/docs/master/styleguide/template.md)), divided into required fields and optional fields. Some key notes:
 
 - You **must** have a space between the colon (:) and the value for a metadata element.
 - If an optional metadata element does not have a value, comment out the element with a # or remove it (do not leave it blank or use "na"); if you are adding a value to an element that was commented out, be sure to remove the #.


### PR DESCRIPTION
Fixed links to point to the new repo name and noticed we still had a couple of topics with the old heading style, so fixed that too (I just didn't change the ones in the readme.md files for samples).
