### PR TITLE
fixing hub title

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: HubPage
 
-title: .NET Core Documentation
+title: .NET Documentation
 description:
 keywords:
 author:


### PR DESCRIPTION
@Rick-Anderson noticed it was still saying .NET Core documentation