### PR TITLE
Add .NET Platform getting started

### DIFF
--- a/docs/standard/getting-started.md
+++ b/docs/standard/getting-started.md
@@ -1,7 +1,7 @@
 ---
-title: Getting Started
-description: Getting started with .NET
-keywords: .NET
+title: Getting Started with .NET
+description: Lists various articles for getting started with .NET, both from a language and platform perspective.
+keywords: .NET, Getting Started, C#, F#, Visual Basic
 author: cartermp
 manager: wpickett
 ms.author: phcart

--- a/docs/standard/getting-started.md
+++ b/docs/standard/getting-started.md
@@ -1,18 +1,36 @@
 ---
 title: Getting Started
 description: Getting started with .NET
-keywords: .NET, .NET Core
+keywords: .NET
 author: cartermp
 manager: wpickett
-ms.date: 10/17/2016
+ms.author: phcart
+ms.date: 11/16/2016
 ms.topic: article
-ms.prod: .net-core
+ms.prod: .net
 ms.technology: .net-core-technologies
 ms.devlang: dotnet
-ms.assetid: bbfe6465-329d-4982-869d-472e7ef85d93
+ms.assetid: 81c07080-acdf-4aef-a66d-0ab52fab2c04
 ---
 
 # Getting Started
 
-> [!NOTE]
-This article is in-progress.
+There are a number of ways to get started with .NET.  Because .NET is a large and massive platform, there are multiple articles in this documentation which show how you can get started with .NET, each from a different perspective.
+
+## Getting started using .NET languages
+
+* For C#, the [Getting Started](../csharp/getting-started/index.md) articles and [C# Tutorials](../csharp/tutorials/index.md) provide a number of ways to get started in a C#-centric way.
+
+* For F#, the [Getting Started](../fsharp/tutorials/getting-started/index.md) tutorials provide three primary ways you can use F#: with Visual Studio, Visual Studio Code, or command-line tools.
+
+* For Visual Basic, the [Getting Started](../visual-basic/getting-started/index.md) articles provide guides for using Visual Basic in Visual Studio, and provide a number of other learning resources.
+
+## Getting started using .NET core
+
+* [Getting Started with .NET Core](../core/getting-started.md) provides an overview of articles which show how to get started with .NET Core on different operating systems and using different tools.
+
+* The [.NET Core Tutorials](../core/tutorials/index.md) detail a number of ways you can get started with .NET Core using your operating system and tooling of choice.
+
+## Getting started using Docker on .NET Framework
+
+The [Docker on .NET Framework](../framework/docker/index.md) shows how you can use .NET Framework on Windows Docker containers.

--- a/docs/standard/getting-started.md
+++ b/docs/standard/getting-started.md
@@ -15,15 +15,15 @@ ms.assetid: 81c07080-acdf-4aef-a66d-0ab52fab2c04
 
 # Getting Started
 
-There are a number of ways to get started with .NET.  Because .NET is a large and massive platform, there are multiple articles in this documentation which show how you can get started with .NET, each from a different perspective.
+There are a number of ways to get started with .NET.  Because .NET is a massive platform, there are multiple articles in this documentation which show how you can get started with .NET, each from a different perspective.
 
 ## Getting started using .NET languages
 
-* For C#, the [Getting Started](../csharp/getting-started/index.md) articles and [C# Tutorials](../csharp/tutorials/index.md) provide a number of ways to get started in a C#-centric way.
+* The [C# Getting Started](../csharp/getting-started/index.md) articles and [C# Tutorials](../csharp/tutorials/index.md) provide a number of ways to get started in a C#-centric way.
 
-* For F#, the [Getting Started](../fsharp/tutorials/getting-started/index.md) tutorials provide three primary ways you can use F#: with Visual Studio, Visual Studio Code, or command-line tools.
+* The [F# Getting Started](../fsharp/tutorials/getting-started/index.md) tutorials provide three primary ways you can use F#: with Visual Studio, Visual Studio Code, or command-line tools.
 
-* For Visual Basic, the [Getting Started](../visual-basic/getting-started/index.md) articles provide guides for using Visual Basic in Visual Studio, and provide a number of other learning resources.
+* The [Visual Basic Getting Started](../visual-basic/getting-started/index.md) articles provide guides for using Visual Basic in Visual Studio, and provide a number of other learning resources.
 
 ## Getting started using .NET core
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -2,7 +2,7 @@
 
 <!-- Start of .NET Platform Guide -->
 # [.NET Platform Guide](standard/index.md)
-## [Getting Started](standard/getting-started.md)
+## [Getting Started with .NET](standard/getting-started.md)
 ## [Tour of .NET](standard/tour.md)
 ## [.NET Concepts](standard/concepts.md)
 ## [.NET Standard Library](standard/library.md)


### PR DESCRIPTION
This is a small article that routes people to various guides we have in the documentation.  I think it's better to do this rather than write something that uses .NET Core and C#, since we already do that in more than one place.