### PR TITLE
redirecting old topics

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,0 +1,3 @@
+---
+redirect_url: /dotnet/articles/standard/about
+---

--- a/docs/about/products.md
+++ b/docs/about/products.md
@@ -1,3 +1,3 @@
 ---
-redirect_url: /dotnet/articles/standard/concepts
+redirect_url: /dotnet/articles/standard/components
 ---

--- a/docs/about/products.md
+++ b/docs/about/products.md
@@ -1,0 +1,3 @@
+---
+redirect_url: /dotnet/articles/standard/concepts
+---

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -3,6 +3,7 @@
 <!-- Start of .NET Platform Guide -->
 # [.NET Platform Guide](standard/index.md)
 ## [Getting Started with .NET](standard/getting-started.md)
+## [About .NET](standard/about.md)
 ## [Tour of .NET](standard/tour.md)
 ## [.NET Architectural Components](standard/components.md)
 ## [.NET Standard Library](standard/library.md)


### PR DESCRIPTION
these files were removed from the repo instead of being redirected. also added the new filename under the TOC for Platform guide.