### PR TITLE
Update hub links to actual content

### DIFF
--- a/index.md
+++ b/index.md
@@ -94,7 +94,7 @@ ms.assetid:
                                             </div>
                                             <div class="cardText">
                                                 <h3><a href="/dotnet/articles/welcome">What is .NET?</a></h3>
-                                                <p><a href="dotnet/articles/standard/getting-started">Get Started</a></p>
+                                                <p><a href="/dotnet/articles/standard/getting-started">Get Started</a></p>
                                                 <p><a href="/dotnet/articles/standard/tour">Tour of .NET</a></p>
                                                 <p><a href="/dotnet/articles/standard/components">.NET Architectural Concepts</a></p>
                                             </div>

--- a/index.md
+++ b/index.md
@@ -94,8 +94,8 @@ ms.assetid:
                                             </div>
                                             <div class="cardText">
                                                 <h3><a href="/dotnet/articles/welcome">What is .NET?</a></h3>
-                                                <p><a href="https://www.microsoft.com/net">Get Started</a></p>
-                                                <p><a href="/dotnet/articles/standard/#a-stroll-through-net">Tour of .NET</a></p>
+                                                <p><a href="dotnet/articles/standard/getting-started">Get Started</a></p>
+                                                <p><a href="/dotnet/articles/standard/tour">Tour of .NET</a></p>
                                                 <p><a href="/dotnet/articles/standard/components">.NET Architectural Concepts</a></p>
                                             </div>
                                         </div>


### PR DESCRIPTION
What is .NET? section (we should probably change that name...) had two dummy links because the content didn't exist yet.  Now that the content exists, the will link there.