### PR TITLE
Preview 3 edits

### DIFF
--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -118,7 +118,7 @@ Deploying a framework-dependent deployment with one or more third-party dependen
       </ItemGroup>
     ```
 
-Note that the SDK dependency remains in the above example. This is by design, since this depdendency is required to restore all the needed targets to allow the command line tools to function.  
+ Note that the SDK dependency remains in the above example. This is by design, since this depdendency is required to restore all the needed targets to allow the command line tools to function.  
 
 2. If you haven't already, download the NuGet package containing the third-party dependency. To download the package, execute the `dotnet restore` command after adding the dependency. Because the dependency is resolved out of the local NuGet cache at publish time, it must be available on your system.
 
@@ -186,7 +186,7 @@ Deploying a self-contained deployment with no third-party dependencies involves 
     }
     ```
 
-3. Create a `<RuntimeIdentifiers>` tag under the `<PropertyGroup>` section in your `csproj` file that defines the platforms your app targets, and specify the runtime identifier of each platform that you target. See [Runtime IDentifier catalog](../../rid-catalog.md) for a list of runtime identifiers. For example, the following `runtimes` section indicates that the app runs on 64-bit Windows 10 operating systems and the 64-bit OS X Version 10.11 operating system.
+3. Create a `<RuntimeIdentifiers>` tag under the `<PropertyGroup>` section in your `csproj` file that defines the platforms your app targets, and specify the runtime identifier of each platform that you target. See [Runtime IDentifier catalog](../../rid-catalog.md) for a list of runtime identifiers. For example, the following example indicates that the app runs on 64-bit Windows 10 operating systems and the 64-bit OS X Version 10.11 operating system.
 
     ```xml
         <PropertyGroup>
@@ -316,16 +316,14 @@ If the availability of adequate storage space on target systems is likely to be 
 
 To create a self-contained deployment with a smaller footprint, start by following the first two steps for creating a self-contained deployment. Once you've run the `dotnet new` command and added the C# source code to your app, do the following:
 
-1. Open the `csproj` file and replace the `frameworks` section with the following:
+1. Open the `csproj` file and replace the `<TargetFramework>` element with the following:
 
     ```xml
-    <PropertyGroup>
       <TargetFramework>netstandard1.6</TargetFramework>
-  </PropertyGroup>
   ```
 This operation indicates that, instead of using the entire `netcoreapp1.0` framework, which includes .NET Core CLR, the .NET Core Library, and a number of other system components, our app uses only the .NET Standard Library.
 
-2. Replace the `dependencies` section with the following:
+2. Replace the `<ItemGroup>` containing package references with the following:
 
     ```xml
     <ItemGroup>
@@ -356,7 +354,7 @@ This operation indicates that, instead of using the entire `netcoreapp1.0` frame
     ```
     
 
-A complete sample `csproj` file appears later in this section.
+ A complete sample `csproj` file appears later in this section.
 
 4. Run the `dotnet restore` command to restore the dependencies specified in your project.
 
@@ -386,7 +384,7 @@ The following is the complete `csproj` file for this project.
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
     <DebugType>Portable</DebugType>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>

--- a/docs/core/preview3/tools/csproj.md
+++ b/docs/core/preview3/tools/csproj.md
@@ -15,7 +15,6 @@ ms.assetid: bdc29497-64f2-4d11-a21b-4097e0bdf5c9
 
 # Additions to csproj format for .NET Core
 
-## Overview 
 This document outlines the changes that were added to the csproj files as part of the move from project.json to csproj and 
 [MSBuild](https://github.com/Microsoft/MSBuild). This document outlines **only the deltas to non-core csproj files**. If 
 you need more information about general project file syntax and reference, please consult [the MSBuild project file]() documentation. 
@@ -46,17 +45,17 @@ consumed.
 
 The element can contain one or more of the following values:
 
-* Compile – are the contents of the lib folder available to compile against
-* Runtime – are the contents of the runtime folder distributed
-* ContentFiles – are the contents of the contentfiles folder used
-* Build – do the props/targets in the build folder get used
-* Native – are the contents from native assets copied to the output folder for runtime
-* Analyzers – do the analyzers get used
+* Compile â€“ are the contents of the lib folder available to compile against
+* Runtime â€“ are the contents of the runtime folder distributed
+* ContentFiles â€“ are the contents of the contentfiles folder used
+* Build â€“ do the props/targets in the build folder get used
+* Native â€“ are the contents from native assets copied to the output folder for runtime
+* Analyzers â€“ do the analyzers get used
 
 Alternatively, the element can contain:
 
-* None – none of those things get used
-* All – all of those things get used.
+* None â€“ none of those things get used
+* All â€“ all of those things get used.
 
 #### ExcludeAssets
 `<ExcluseAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should not 
@@ -64,17 +63,17 @@ be consumed.
 
 The element can contain one or more of the following values:
 
-* Compile – are the contents of the lib folder available to compile against
-* Runtime – are the contents of the runtime folder distributed
-* ContentFiles – are the contents of the contentfiles folder used
-* Build – do the props/targets in the build folder get used
-* Native – are the contents from native assets copied to the output folder for runtime
-* Analyzers – do the analyzers get used
+* Compile â€“ are the contents of the lib folder available to compile against
+* Runtime â€“ are the contents of the runtime folder distributed
+* ContentFiles â€“ are the contents of the contentfiles folder used
+* Build â€“ do the props/targets in the build folder get used
+* Native â€“ are the contents from native assets copied to the output folder for runtime
+* Analyzers â€“ do the analyzers get used
 
 Alternatively, the element can contain:
 
-* None – none of those things get used
-* All – all of those things get used.
+* None â€“ none of those things get used
+* All â€“ all of those things get used.
 
 #### PrivateAssets
 `<PrivateAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should be 
@@ -85,17 +84,17 @@ consumed but that they should not flow to the next project.
 
 The element can contain one or more of the following values:
 
-* Compile – are the contents of the lib folder available to compile against
-* Runtime – are the contents of the runtime folder distributed
-* ContentFiles – are the contents of the contentfiles folder used
-* Build – do the props/targets in the build folder get used
-* Native – are the contents from native assets copied to the output folder for runtime
-* Analyzers – do the analyzers get used
+* Compile â€“ are the contents of the lib folder available to compile against
+* Runtime â€“ are the contents of the runtime folder distributed
+* ContentFiles â€“ are the contents of the contentfiles folder used
+* Build â€“ do the props/targets in the build folder get used
+* Native â€“ are the contents from native assets copied to the output folder for runtime
+* Analyzers â€“ do the analyzers get used
 
 Alternatively, the element can contain:
 
-* None – none of those things get used
-* All – all of those things get used.
+* None â€“ none of those things get used
+* All â€“ all of those things get used.
 
 ### DotnetCliToolReference
 `<DotnetCliToolReference>` element specifies the CLI tool that the user wants restores in the context of the project. It is 

--- a/docs/core/preview3/tools/csproj.md
+++ b/docs/core/preview3/tools/csproj.md
@@ -13,19 +13,19 @@ ms.devlang: dotnet
 ms.assetid: bdc29497-64f2-4d11-a21b-4097e0bdf5c9
 ---
 
-Additions to csproj format for .NET Core
-----------------------------------------
+# Additions to csproj format for .NET Core
 
-# Overview 
+## Overview 
 This document outlines the changes that were added to the csproj files as part of the move from project.json to csproj and 
 [MSBuild](https://github.com/Microsoft/MSBuild). This document outlines **only the deltas to non-core csproj files**. If 
 you need more information about general project file syntax and reference, please consult [the MSBuild project file]() documentation. 
 
-> **Note:** this document will grow in the future, so please check back to see new additions. 
+> ![NOTE]
+> This document will grow in the future, so please check back to see new additions. 
 
-# Additions
+## Additions
 
-## PackageReference
+### PackageReference
 Specifies a NuGet dependency in the project. The `Include` attribute specifies the package ID. 
 
 ```xml
@@ -37,10 +37,10 @@ Specifies a NuGet dependency in the project. The `Include` attribute specifies t
 </PackageReference>
 ```
 
-### Version
-`<Version>` specifies the version of the package to restore. The element respect the rules of the NuGet versioning scheme.
+#### Version
+`<Version>` specifies the version of the package to restore. The element respects the rules of the NuGet versioning scheme.
 
-### IncludeAssets
+#### IncludeAssets
 `<IncludeAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should be 
 consumed. 
 
@@ -50,7 +50,7 @@ The element can contain one or more of the following values:
 * Runtime – are the contents of the runtime folder distributed
 * ContentFiles – are the contents of the contentfiles folder used
 * Build – do the props/targets in the build folder get used
-* Native - are the contents from native assets copied to the output folder for runtime
+* Native – are the contents from native assets copied to the output folder for runtime
 * Analyzers – do the analyzers get used
 
 Alternatively, the element can contain:
@@ -58,7 +58,7 @@ Alternatively, the element can contain:
 * None – none of those things get used
 * All – all of those things get used.
 
-### ExcludeAssets
+#### ExcludeAssets
 `<ExcluseAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should not 
 be consumed.
 
@@ -68,7 +68,7 @@ The element can contain one or more of the following values:
 * Runtime – are the contents of the runtime folder distributed
 * ContentFiles – are the contents of the contentfiles folder used
 * Build – do the props/targets in the build folder get used
-* Native - are the contents from native assets copied to the output folder for runtime
+* Native – are the contents from native assets copied to the output folder for runtime
 * Analyzers – do the analyzers get used
 
 Alternatively, the element can contain:
@@ -76,11 +76,12 @@ Alternatively, the element can contain:
 * None – none of those things get used
 * All – all of those things get used.
 
-### PrivateAssets
+#### PrivateAssets
 `<PrivateAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should be 
 consumed but that they should not flow to the next project. 
 
-> **Note:** this is a new term for project.json/xproj `SupressParent` element. 
+> [!NOTE]
+> This is a new term for project.json/xproj `SupressParent` element. 
 
 The element can contain one or more of the following values:
 
@@ -88,7 +89,7 @@ The element can contain one or more of the following values:
 * Runtime – are the contents of the runtime folder distributed
 * ContentFiles – are the contents of the contentfiles folder used
 * Build – do the props/targets in the build folder get used
-* Native - are the contents from native assets copied to the output folder for runtime
+* Native – are the contents from native assets copied to the output folder for runtime
 * Analyzers – do the analyzers get used
 
 Alternatively, the element can contain:
@@ -96,14 +97,14 @@ Alternatively, the element can contain:
 * None – none of those things get used
 * All – all of those things get used.
 
-## DotnetCliToolReference
+### DotnetCliToolReference
 `<DotnetCliToolReference>` element specifies the CLI tool that the user wants restores in the context of the project. It is 
 a replacement for the `tools` node in `project.json`. 
 
-### Version
+#### Version
 `<Version>` specifies the version of the package to restore. The element respect the rules of the NuGet versioning scheme.
 
-## RuntimeIdentifiers
+### RuntimeIdentifiers
 `<RuntimeIdentifiers>` element allows specifying a semicolon-delimited list of [Runtime Identifiers](../../rid-catalog.md) for the project. 
 These allow publishing self-contained deployments. 
 

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -14,7 +14,6 @@ ms.assetid: 74b87cdb-a244-4c13-908c-539118bfeef9
 
 # Managing dependencies in .NET Core Preview 3 tooling
 
-## Overview
 With the move of .NET Core projects from project.json to csproj and MSBuild, a significant invesment also happened that resulted in unification of the project file and assets that allow tracking of depenencies. For .NET Core projects this is similar to what project.json did. There is no separate JSON or XML file that tracks NuGet dependencies. With this change, we've also introduced another type of *reference* into the csproj syntax called the `<PackageReference>`. 
 
 This document describes the new reference type. It also shows how to add a package dependency using this new reference type to your project. 

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -12,39 +12,39 @@ ms.devlang: dotnet
 ms.assetid: 74b87cdb-a244-4c13-908c-539118bfeef9
 ---
 
-Managing dependencies in .NET Core Preview 3 tooling
-----------------------------------------------------
+# Managing dependencies in .NET Core Preview 3 tooling
 
-# Overview
+## Overview
 With the move of .NET Core projects from project.json to csproj and MSBuild, a significant invesment also happened that resulted in unification of the project file and assets that allow tracking of depenencies. For .NET Core projects this is similar to what project.json did. There is no separate JSON or XML file that tracks NuGet dependencies. With this change, we've also introduced another type of *reference* into the csproj syntax called the `<PackageReference>`. 
 
 This document describes the new reference type. It also shows how to add a package dependency using this new reference type to your project. 
 
-# The new <PackageReference> element
+## The new <PackageReference> element
 The `<PackageReference>` has the following basic structure:
 
 ```xml
-<PackageReference Include="<Package_ID>">
+<PackageReference Include="PACKAGE_ID">
     <Version>PACKAGE_VERSION</Version>
 </PackageReference>
 ```
 
-If you are familiar with MSBuild, it will look familiar to the other [reference types]() that already exist. The key is the `Include` statement which specifies the package id that you wish to add to the project. The `<Version>` child element specified the version to get. The versions are specified as per [NuGet version rules](https://docs.nuget.org/ndocs/create-packages/dependency-versions#version-ranges).  
+If you are familiar with MSBuild, it will look familiar to the other [reference types]() that already exist. The key is the `Include` statement which specifies the package id that you wish to add to the project. The `<Version>` child element specifies the version to get. The versions are specified as per [NuGet version rules](https://docs.nuget.org/ndocs/create-packages/dependency-versions#version-ranges).  
 
-> **Note:** if you are not faimilar with the overall `csproj` syntax, you can use the [MSBuild project reference documentation]() to get acquainted.  
+> [!NOTE]
+> If you are not familiar with the overall `csproj` syntax, you can use the [MSBuild project reference documentation]() to get acquainted.  
 
 Adding a dependency that is available only in a specific target is done using conditions:
 
 ```xml
-<PackageReference Include="<Package_ID>" Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+<PackageReference Include="PACKAGE_ID" Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
     <Version>PACKAGE_VERSION</Version>
 </PackageReference>
 ```
 
 The above means that the dependency will only be valid if the build is happening for that given target. The `$(TargetFramework)` in the condition is a MSBuild property that is being set in the project. For most common .NET Core applications, you will not need to do this. 
 
-# Adding a dependency to your project
-Adding a dependency to your project is straightforward. Here is an example of how to add `JSON.net` version `9.0.1` to your project. Of course, it is applicable to any other NuGet dependency. 
+## Adding a dependency to your project
+Adding a dependency to your project is straightforward. Here is an example of how to add Json.NET version `9.0.1` to your project. Of course, it is applicable to any other NuGet dependency. 
 
 When you open your project file, you will see two or more `<ItemGroup>` nodes. You will notice that one of the nodes already has `<PackageReference>` elements in it. You can add your new dependency to this node, or create a new one; it is completely up to you as the result will be the same. 
 
@@ -90,7 +90,7 @@ The full project looks like this:
 </Project>
 ```
 
-# Removing a dependency from the project
+## Removing a dependency from the project
 Removing a dependency from the project file involves simply removing the `<PackageReference>` from the project file. 
 
 

--- a/docs/core/preview3/tools/dotnet-build.md
+++ b/docs/core/preview3/tools/dotnet-build.md
@@ -28,7 +28,7 @@ dotnet-build -- Builds a project and all of its dependencies
 
 The `dotnet build` command builds multiple source file from a source project and its dependencies into a binary. 
 By default, the resulting binary is in Intermediate Language (IL) and has a DLL extension. 
-`dotnet build` also drops a `\*.deps` file which outlines what the host needs to run the application.  
+`dotnet build` also drops a `*.deps` file which outlines what the host needs to run the application.  
 
 Building requires the existence of an asset file (a file that lists all of the dependencies of your application), which 
 means that you have to run [`dotnet restore`](dotnet-restore.md) prior to building your code.

--- a/docs/core/preview3/tools/dotnet-new.md
+++ b/docs/core/preview3/tools/dotnet-new.md
@@ -36,9 +36,9 @@ After this, the project is ready to be compiled and/or edited further.
 
 Prints out a short help for the command.  
 
-`-l|--lang <C#|F#>`
+`-l|--lang C#`
 
-Language of the project. Defaults to `C#`. Other valid values are `csharp`, `fsharp`, `cs` and `fs`.
+Language of the project. Defaults to `C#`. Other valid values are `csharp` and `cs`.
 
 `-t|--type`
 
@@ -50,10 +50,6 @@ Create a C# console application project in the current directory:
 
 `dotnet new` or `dotnet new --lang c#` 
    
-Create an F# console application project in the current directory:
-
-`dotnet new --lang f#`
-  
 Create a new ASP.NET Core C# application project in the current directory:
 
 `dotnet new -t web`

--- a/docs/core/preview3/tools/dotnet-nuget-delete.md
+++ b/docs/core/preview3/tools/dotnet-nuget-delete.md
@@ -71,7 +71,7 @@ Deletes version 1.0 of package MyPackage:
 
 Deletes version 1.0 of package MyPackage, not prompting user for credentials or other input:
 
-`dotnet nuget delete MyPackage 1.0 --non-ìnteractive`
+`dotnet nuget delete MyPackage 1.0 --non-interactive`
 
 Deletes version 1.0 of package MyPackage, specifying a custom config file *./config/My.Config*:
 

--- a/docs/core/preview3/tools/dotnet-restore.md
+++ b/docs/core/preview3/tools/dotnet-restore.md
@@ -88,7 +88,7 @@ Restore dependencies and tools for the project in the current directory:
 
 Restore dependencies and tools for the `app1` project found in the given path:
 
-`dotnet restore ~/projects/app1/app1.csproj``
+`dotnet restore ~/projects/app1/app1.csproj`
 	
 Restore the dependencies and tools for the project in the current directory using the file path provided as the fallback source:
 

--- a/docs/core/preview3/tools/dotnet-test.md
+++ b/docs/core/preview3/tools/dotnet-test.md
@@ -111,6 +111,8 @@ Configuration under which to build. The default value is `Release`.
 
 Directory in which to find the binaries to run.
 
+`-f|--framework [FRAMEWORK]`
+
 Looks for test binaries for a specific framework.
 
 `-r|--runtime [RUNTIME_IDENTIFIER]`
@@ -133,7 +135,7 @@ Run the tests in the project in the current directory:
 
 Run the tests in the test1 project:
 
-`dotnet test /projects/test1/test1.csproj` 
+`dotnet test ~/projects/test1/test1.csproj` 
 
 ## See also
 

--- a/docs/core/preview3/tools/extensibility.md
+++ b/docs/core/preview3/tools/extensibility.md
@@ -75,12 +75,12 @@ API, here is a console application's project file that uses that tool:
     </PackageReference>
   </ItemGroup>
 
-   <!-- The tools reference -->
-   <ItemGroup>
+  <!-- The tools reference -->
+  <ItemGroup>
     <DotNetCliToolReference Include="dotnet-api-search">
-        <Version></Version>
+      <Version></Version>
     </DotNetCliToolReference>
-    </ItemGroup>
+  </ItemGroup>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/docs/core/preview3/tools/index.md
+++ b/docs/core/preview3/tools/index.md
@@ -48,6 +48,7 @@ the [driver](#driver) section.
 The following commands are installed by default:
 
 * [new](dotnet-new.md)
+* [migrate](dotnet-migrate.md)
 * [restore](dotnet-restore.md)
 * [run](dotnet-run.md)
 * [build](dotnet-build.md)
@@ -115,7 +116,8 @@ You can learn more about both of these in the [.NET Core application deployment]
 If you used Preview 2 tooling and project.json projects, you can consult the [dotnet migrate](dotnet-migrate.md) command docs
 to get acquainted with the command and how to migrate your project. 
 
-> **Note:** the `dotnet migrate` command currently does not migrate pre-preview 2 project.json files. 
+> [!NOTE]
+> The `dotnet migrate` command currently does not migrate pre-preview 2 project.json files. 
 
 ## Extensibility
 Of course, not every tool that you could use in your workflow will be part of the core CLI tools. However, .NET Core 

--- a/docs/core/preview3/tools/layering.md
+++ b/docs/core/preview3/tools/layering.md
@@ -13,7 +13,6 @@ ms.devlang: dotnet
 
 # High level overview of changes in CLI Preview 3
 
-## Overview
 This document will describe in high-level the changes that moving from `project.json` to MSBuild and `csproj` project system bring. It will outline the new way the tooling is layered all-up and which new pieces are available and what is their place in the overall picture. After reading this article, you should have a better understanding of all of the pieces that make up .NET Core tooling after moving to MSBuild and `csproj`. 
 
 > [!NOTE]

--- a/docs/core/preview3/tools/layering.md
+++ b/docs/core/preview3/tools/layering.md
@@ -11,25 +11,26 @@ ms.technology: .net-core-technologies
 ms.devlang: dotnet
 ---
 
-High level overview of changes in CLI Preview 3
------------------------------------------------
+# High level overview of changes in CLI Preview 3
 
-# Overview
+## Overview
 This document will describe in high-level the changes that moving from `project.json` to MSBuild and `csproj` project system bring. It will outline the new way the tooling is layered all-up and which new pieces are available and what is their place in the overall picture. After reading this article, you should have a better understanding of all of the pieces that make up .NET Core tooling after moving to MSBuild and `csproj`. 
 
-> **Note:** this article is **not required** to use the Preview 3 .NET Core Command Line tools. you can continue using the tools as you are 
+> [!NOTE]
+> This article is **not required** to use the Preview 3 .NET Core Command Line tools. you can continue using the tools as you are 
 > used to. This article is here to complete the picture of how the move to MSBuild changes the overall "layering" and the architecture of 
 > the command line tools. 
 
-# Moving away from project.json
+## Moving away from project.json
 The biggest change in the Preview 3 tooling for .NET Core is certainly the [move away from project.json to csproj](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/) as the project system. Preview 3 version of the command line tools is the first release of .NET Core command line tooling that does not contain any support for project.json. That means that it cannot be used to build, run or publish project.json based applications and libraries. In order to use this version of the tools, you will need to migrate your existing projects or start new ones. 
 
 As part of this move, the custom build engine that was developed to build project.json projects was replaced with a mature and fully capable build engine called [MSBuild](https://github.com/Microsoft/msbuild). MSBuild is a well-known engine in the .NET community, since it has been a key technology since the platform's first release. Of course, because it needs to build .NET Core applications, MSBuild has been ported to .NET Core and can be used on any platform that .NET Core runs on. One of the main promises of .NET Core is that of a cross-platform development stack, and we have made sure that this move does not break that promise.
 
-> **Note:** if you are new to MSBuild and would like to learn more about it, you can start by reading 
+> [!NOTE]
+> If you are new to MSBuild and would like to learn more about it, you can start by reading 
 > the [existing documentation](https://msdn.microsoft.com/en-us/library/dd637714.aspx). 
 
-# The tooling layers
+## The tooling layers
 With the move away from the existing project system as well as with building engine switches, the question that naturally follows is do any of these changes change the overall "layering" of the whole .NET Core tooling ecosystem? Are there new bits and components?
 
 Let's start with a quick refresher on Preview 2 layering as shown in the following picture:
@@ -44,11 +45,12 @@ With the move to the new project system, the previous diagram changes:
 
 The main difference is that the CLI is not the foundational layer anymore; this role is now filled by the "shared SDK component". This shared SDK component is a set of targets and associated tasks that are responsible for compiling your code, publishing it, packing nuget packages etc. The SDK itself is open-source and is available on GitHub on the [SDK repo](https://github.com/dotnet/sdk). 
 
-> **Note:** a "target" is an MSBuild term that indicates a named operation that MSBuild can invoke. It is usually coupled with one or more tasks that execute some logic that the target is supposed to do. MSBuild supports many ready-made targets such as `Copy` or `Execute`; it also allows users to write their own tasks using managed code and define targets to execute those tasks. You can read more about MSBuild tasks on [MSDN](https://msdn.microsoft.com/en-us/library/ms171466.aspx). 
+> [!NOTE]
+> A "target" is an MSBuild term that indicates a named operation that MSBuild can invoke. It is usually coupled with one or more tasks that execute some logic that the target is supposed to do. MSBuild supports many ready-made targets such as `Copy` or `Execute`; it also allows users to write their own tasks using managed code and define targets to execute those tasks. You can read more about MSBuild tasks on [MSDN](https://msdn.microsoft.com/en-us/library/ms171466.aspx). 
 
 All the toolsets now consume the shared SDK component and its targets, CLI included. For example, the next version of Visual Studio will not call into `dotnet restore` command to restore dependencies for .NET Core projects, it will use the "Restore" target directly. Since these are MSBuild targets, you can also use raw MSBuild to execute them using the [dotnet msbuild](dotnet-msbuild.md) command. 
 
-## Preview 3 CLI commands
+### Preview 3 CLI commands
 The shared SDK component means that the majority of existing CLI commands have been re-implemented as MSBuild tasks and targets. What does this mean for the CLI commands and your usage of the toolset? 
 
 From an usage perspective, it doesn't change the way you use the CLI. The CLI still has the core commands that exist in Preview 2 release:
@@ -65,14 +67,14 @@ These commands still do what you expect them to do (new up a project, build it, 
 
 From an execution perspective, the CLI commands will take their parameters and construct a call to "raw" MSBuild that will set the needed properties and run the desired target. To better illustrate this, consider the following command: 
 
-    `dotnet publish -o pub -c Release`. 
+    dotnet publish -o pub -c Release
     
 This command is publishing an application into a `pub` folder using the "Release" configuration. Internally, this command gets translated into the following MSBuild invocation: 
 
-    `dotnet msbuild /t:Publish /p:OutputPath=pub /p:Configuration`
+    dotnet msbuild /t:Publish /p:OutputPath=pub /p:Configuration=Release
 
 The notable exception to this rule are `new` and `run` commands, as they have not been implemented as MSBuild targets. 
 
-# Conclusion 
+## Conclusion 
 This document outlined at a high-level the changes that are happening to the overall CLI tooling architecture and functioning that are coming with Preview 3. It has introduced the notion of the shared SDK component as well as explained how the CLI commands function, from a technical perspective, in Preview 3. 
 

--- a/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
+++ b/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
@@ -268,7 +268,6 @@ There are two new things to make sure you have in your test project:
 
 2. An Xunit test class.
 
-
     `PetTests.cs`: 
     ```csharp
     using System;


### PR DESCRIPTION
* Added migrate to the list of commands
* Used docfx syntax for notes
* Fixed heading levels in new articles
* Made pseudo-variables in csproj consistent in dependencies
* Remove references to project.json sections from deploying
* Remove F# from dotnet new, since it's not supported
* Added back missing --framework to dotnet test
* Typos, grammar and other small fixes

cc: @blackdwarf, @mairaw 