### PR TITLE
Fixed included notes

### DIFF
--- a/docs/csharp/programming-guide/concepts/assemblies-gac/walkthrough-embedding-type-information-from-microsoft-office-assemblies.md
+++ b/docs/csharp/programming-guide/concepts/assemblies-gac/walkthrough-embedding-type-information-from-microsoft-office-assemblies.md
@@ -25,7 +25,7 @@ translation.priority.mt:
 # Walkthrough: Embedding Type Information from Microsoft Office Assemblies in Visual Studio (C#)
 If you embed type information in an application that references COM objects, you can eliminate the need for a primary interop assembly (PIA). Additionally, the embedded type information enables you to achieve version independence for your application. That is, your program can be written to use types from multiple versions of a COM library without requiring a specific PIA for each version. This is a common scenario for applications that use objects from Microsoft Office libraries. Embedding type information enables the same build of a program to work with different versions of Microsoft Office on different computers without the need to redeploy either the program or the PIA for each version of Microsoft Office.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## Prerequisites  
  This walkthrough requires the following:  

--- a/docs/csharp/programming-guide/concepts/assemblies-gac/walkthrough-embedding-types-from-managed-assemblies-in-visual-studio.md
+++ b/docs/csharp/programming-guide/concepts/assemblies-gac/walkthrough-embedding-types-from-managed-assemblies-in-visual-studio.md
@@ -59,7 +59,7 @@ If you embed type information from a strong-named managed assembly, you can loos
   
 -   Run the client program to see that the new version of the runtime assembly is being used without having to recompile the client program.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## Creating an Interface  
   

--- a/docs/visual-basic/developing-apps/programming/computer-resources/how-to-check-connection-status.md
+++ b/docs/visual-basic/developing-apps/programming/computer-resources/how-to-check-connection-status.md
@@ -39,7 +39,7 @@ translation.priority.ht:
 # How to: Check Connection Status in Visual Basic
 The <xref:Microsoft.VisualBasic.Devices.Network.IsAvailable%2A> property can be used to determine whether the computer has a working network or Internet connection.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To check whether a computer has a working connection  
   

--- a/docs/visual-basic/developing-apps/programming/computer-resources/how-to-download-a-file.md
+++ b/docs/visual-basic/developing-apps/programming/computer-resources/how-to-download-a-file.md
@@ -50,7 +50,7 @@ The <xref:Microsoft.VisualBasic.Devices.Network.DownloadFile%2A> method can be u
   
 -   The request is denied by the Web site (<xref:System.Net.WebException>).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 > [!IMPORTANT]
 >  Do not make decisions about the contents of the file based on the name of the file. For example, the file Form1.vb may not be a Visual Basic source file. Verify all inputs before using the data in your application. The contents of the file may not be what is expected, and methods to read from the file may fail.  

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/walkthrough-manipulating-files-and-directories.md
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/walkthrough-manipulating-files-and-directories.md
@@ -49,7 +49,7 @@ This walkthrough provides an introduction to the fundamentals of file I/O in [!I
   
  This walkthrough uses members of the `My.Computer.FileSystem Object`, which are available in [!INCLUDE[vbprvb](../../../../csharp/programming-guide/concepts/linq/includes/vbprvb_md.md)]. See <xref:Microsoft.VisualBasic.FileIO.FileSystem> for more information. At the end of the walkthrough, an equivalent example is provided that uses classes from the <xref:System.IO> namespace.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create the project  
   

--- a/docs/visual-basic/developing-apps/programming/drives-directories-files/walkthrough-manipulating-files-by-using-net-framework-methods.md
+++ b/docs/visual-basic/developing-apps/programming/drives-directories-files/walkthrough-manipulating-files-by-using-net-framework-methods.md
@@ -47,7 +47,7 @@ translation.priority.ht:
 # Walkthrough: Manipulating Files by Using .NET Framework Methods (Visual Basic)
 This walkthrough demonstrates how to open and read a file using the <xref:System.IO.StreamReader> class, check to see if a file is being accessed, search for a string within a file read with an instance of the <xref:System.IO.StreamReader> class, and write to a file using the <xref:System.IO.StreamWriter> class.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## Creating the Application  
  Start [!INCLUDE[vsprvs](../../../../csharp/includes/vsprvs_md.md)] and begin the project by creating a form that the user can use to write to the designated file.  

--- a/docs/visual-basic/programming-guide/concepts/assemblies-gac/walkthrough-embedding-type-information-from-microsoft-office-assemblies-in-vs.md
+++ b/docs/visual-basic/programming-guide/concepts/assemblies-gac/walkthrough-embedding-type-information-from-microsoft-office-assemblies-in-vs.md
@@ -25,7 +25,7 @@ translation.priority.mt:
 # Walkthrough: Embedding Type Information from Microsoft Office Assemblies in Visual Studio (Visual Basic)
 If you embed type information in an application that references COM objects, you can eliminate the need for a primary interop assembly (PIA). Additionally, the embedded type information enables you to achieve version independence for your application. That is, your program can be written to use types from multiple versions of a COM library without requiring a specific PIA for each version. This is a common scenario for applications that use objects from Microsoft Office libraries. Embedding type information enables the same build of a program to work with different versions of Microsoft Office on different computers without the need to redeploy either the program or the PIA for each version of Microsoft Office.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## Prerequisites  
  This walkthrough requires the following:  

--- a/docs/visual-basic/programming-guide/concepts/assemblies-gac/walkthrough-embedding-types-from-managed-assemblies-in-vs.md
+++ b/docs/visual-basic/programming-guide/concepts/assemblies-gac/walkthrough-embedding-types-from-managed-assemblies-in-vs.md
@@ -59,7 +59,7 @@ If you embed type information from a strong-named managed assembly, you can loos
   
 -   Run the client program to see that the new version of the runtime assembly is being used without having to recompile the client program.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## Creating an Interface  
   

--- a/docs/visual-basic/programming-guide/language-features/constants-enums/how-to-declare-a-constant.md
+++ b/docs/visual-basic/programming-guide/language-features/constants-enums/how-to-declare-a-constant.md
@@ -59,7 +59,7 @@ You use the `Const` statement to declare a constant and set its value. By declar
   
  The constant must have a valid symbolic name (the rules are the same as those for creating variable names) and an expression composed of numeric or string constants and operators (but no function calls).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To declare a constant  
   

--- a/docs/visual-basic/programming-guide/language-features/control-flow/walkthrough-implementing-ienumerable-of-t.md
+++ b/docs/visual-basic/programming-guide/language-features/control-flow/walkthrough-implementing-ienumerable-of-t.md
@@ -45,7 +45,7 @@ The <xref:System.Collections.Generic.IEnumerable%601> interface is implemented b
   
  In this walkthrough, you will create a class that implements the `IEnumerable(Of String)` interface and a class that implements the `IEnumerator(Of String)` interface to read a text file one line at a time.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## Creating the Enumerable Class  
   

--- a/docs/visual-basic/programming-guide/language-features/interfaces/walkthrough-creating-and-implementing-interfaces.md
+++ b/docs/visual-basic/programming-guide/language-features/interfaces/walkthrough-creating-and-implementing-interfaces.md
@@ -44,7 +44,7 @@ Interfaces describe the characteristics of properties, methods, and events, but 
 > [!NOTE]
 >  This walkthrough doesn't provide information about how to create a user interface.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To define an interface  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-call-a-stored-procedure-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-call-a-stored-procedure-by-using-linq.md
@@ -43,7 +43,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information, i
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-count-sum-or-average-data-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-count-sum-or-average-data-by-using-linq.md
@@ -51,7 +51,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information an
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-filter-query-results-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-filter-query-results-by-using-linq.md
@@ -47,7 +47,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information an
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-find-the-minimum-or-maximum-value-in-a-query-result.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-find-the-minimum-or-maximum-value-in-a-query-result.md
@@ -50,7 +50,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information an
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-query-a-database-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-query-a-database-by-using-linq.md
@@ -45,7 +45,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information an
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ## To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-return-a-linq-query-result-as-a-specific-type.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-return-a-linq-query-result-as-a-specific-type.md
@@ -45,7 +45,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information an
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/linq/how-to-sort-query-results-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/linq/how-to-sort-query-results-by-using-linq.md
@@ -47,7 +47,7 @@ Language-Integrated Query (LINQ) makes it easy to access database information an
   
  The examples in this topic use the Northwind sample database. If you do not have the Northwind sample database on your development computer, you can download it from the [Microsoft Download Center](http://go.microsoft.com/fwlink/?LinkID=98088) Web site. For instructions, see [Downloading Sample Databases](https://msdn.microsoft.com/library/bb399411).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To create a connection to a database  
   

--- a/docs/visual-basic/programming-guide/language-features/objects-and-classes/walkthrough-defining-classes.md
+++ b/docs/visual-basic/programming-guide/language-features/objects-and-classes/walkthrough-defining-classes.md
@@ -47,7 +47,7 @@ translation.priority.ht:
 # Walkthrough: Defining Classes (Visual Basic)
 This walkthrough demonstrates how to define classes, which you can then use to create objects. It also shows you how to add properties and methods to the new class, and demonstrates how to initialize an object.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To define a class  
   

--- a/docs/visual-basic/programming-guide/language-features/xml/how-to-enable-xml-intellisense.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/how-to-enable-xml-intellisense.md
@@ -48,7 +48,7 @@ XML IntelliSense in Visual Basic provides word completion for elements that are 
   
  For more information on the capabilities of XML IntelliSense in Visual Basic, see [XML IntelliSense in Visual Basic](../../../../visual-basic/programming-guide/language-features/xml/xml-intellisense.md). For more information on importing XML namespaces, see [Imports Statement (XML Namespace)](../../../../visual-basic/language-reference/statements/imports-statement-xml-namespace.md) or [References Page, Project Designer (Visual Basic)](/visualstudio/ide/reference/references-page-project-designer-visual-basic).  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
  ![link to video](../../../../visual-basic/programming-guide/language-features/xml/media/playvideo.gif "PlayVideo") For a video version of this topic, see [Video How to: Enable XML IntelliSense in Visual Basic](http://go.microsoft.com/fwlink/?LinkId=102466). For a related video demonstration, see [How Do I Enable XML IntelliSense and Use XML Namespaces?](http://go.microsoft.com/fwlink/?LinkId=143035).  
   

--- a/docs/visual-basic/programming-guide/language-features/xml/how-to-load-xml-from-a-file-string-or-stream.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/how-to-load-xml-from-a-file-string-or-stream.md
@@ -37,7 +37,7 @@ translation.priority.ht:
 # How to: Load XML from a File, String, or Stream (Visual Basic)
 You can create [XML Literals](../../../../visual-basic/language-reference/xml-literals/index.md) and populate them with the contents from an external source such as a file, a string, or a stream by using several methods. These methods are shown in the following examples.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To load XML from a file  
   

--- a/docs/visual-basic/programming-guide/language-features/xml/how-to-transform-xml-by-using-linq.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/how-to-transform-xml-by-using-linq.md
@@ -39,7 +39,7 @@ translation.priority.ht:
   
  The example in this topic transforms content from an XML source document to HTML to be viewed in a browser.  
   
- [!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
+[!INCLUDE[note_settings_general](../../../../csharp/language-reference/compiler-messages/includes/note_settings_general_md.md)]  
   
 ### To transform an XML document  
   


### PR DESCRIPTION
When an included note is indented, it renders incorrectly.

For example, the note in [How to: Check Connection Status in Visual Basic](https://docs.microsoft.com/en-us/dotnet/articles/visual-basic/developing-apps/programming/computer-resources/how-to-check-connection-status):

![](http://imgur.com/bjqxzl3.png)

Removing the indentation should fix it.