### PR TITLE
[WIP]: Adding more CLI Preview 3 docs

### DIFF
--- a/docs/core/preview3/tools/getting-started.md
+++ b/docs/core/preview3/tools/getting-started.md
@@ -1,0 +1,78 @@
+---
+title: Getting started with .NET Core Preview 3 tooling
+description: Preview 3 brings about changes to projects 
+keywords: CLI, extensibility, custom commands, .NET Core
+author: blackdwarf
+manager: wpickett
+ms.date: 11/12/2016
+ms.topic: article
+ms.prod: .net-core
+ms.technology: .net-core-technologies
+ms.devlang: dotnet
+ms.assetid: ef8053b9-3864-46db-af65-ecde561effb1
+---
+
+Getting started with .NET Core Preview 3 tools
+----------------------------------------------
+
+This document will cover how to get started with the Preview 3 .NET Core tools. This version of the tooling has significant changes compared to the previous versions, mostly because of the move to [MSBuild](https://github.com/Microsoft/msbuild) as the build system and to csproj as the project file format. The Preview 3 tooling is the first release that completely removes support for project.json projects. 
+
+## Installation
+There are two main ways to get the Preview 3 tools:
+
+1. Global installation
+2. Local installation 
+
+Our reccomendation, given the major change that happened, is to install Preview 3 bits locally using the process outlined in this section below. Installing globally will mean that the CLI will use the Preview 3 bits for all solutions that don't have an explicit version of the tools set using `global.json` file, as explained in the [section below](#switching-between-versions-using-global.json). 
+
+In both cases, you can access the bits on our [Preview 3 download page](https://github.com/dotnet/core/blob/master/release-notes/preview3-download.md). 
+
+### Global Installation
+Global install is done via one of the native installers for the operating system you want, for example using the PKG on macOS or the MSI installer on Windows. Simply download the installer, run it and install. 
+
+### Local Installation
+Local installation is done using the zip/tarball files. These files can be downloaded and uncompressed to any location on disk. This way, the global tools are not impacted. The downside of this approach is that you will have to invoke the tools using a full path to the installation location. 
+
+You can use aliases, however, to help you with this. Let's say that you've unpacked the Preview 3 tooling locally in the following locations:
+
+* On Windows to **%HOME%\dotnetp3**
+* On macOS/Linux to **$HOME/dotnetp3**
+
+You can create an alias in PowerShell using the following command:
+
+    new-alias dotnetp3 $env:HOME\dotnetp3\dotnet.exe
+
+You can create an alias in bash/zsh using the following command:
+
+    alias dotnetp3=$HOME/dotnetp3/dotnet
+
+After this, you will be able to use `dotnetp3` as the command to invoke the Preview 3 tools. For example, invoking a build command would become `dotnetp3 build`. 
+
+### Switching between versions using global.json
+If you do install the Preview 3 tools globally, you need to make sure that you can still use Preview 2 tools on those projects that need it. You do this by using the `global.json` file and setting the `sdk` property to Preview 2 version. 
+
+Here is a sample of an `global.json` file that sets the version to the latest Preview 2 version:
+
+```json
+{
+    "sdk": {
+        "version": "1.0.0-preview2-003131"
+    }
+}
+```
+> [!NOTE]
+> Please note that you have to have the version of the CLI you are referncing installed. If not, the CLI will default to using the latest one you have on your machine. 
+
+## Migrating the project
+Once you have the tools installed you can migrate your project. To do this, you can use the [`dotnet migrate`](dotnet-migrate.md) command. By default, the command will migrate the given project and any project-to-project references. The project.json file will be moved into the `backup` folder that will be created in the current working directory. 
+
+Currently, the migrate command supports only valid .NET Core 1.0 RTM project.json files. We plan to add support for pre-1.0 project.json files in the future. In the meantime, you can get `dotnet migrate` to work by simply updating your project.json to the .NET Core 1.0 RTM format. 
+
+## Starting a new project
+Of course, if you do not wish to migrate an existing project, you can start a new one. The familiar `dotnet new` command is still here in Preview 3, and its templates have been updated to produce valid csproj projects. All of the types are still available (web, lib, console and xunittest). 
+
+## Running `dotnet restore`
+Regardless of how you get started, either via migration of an existing project or starting a new one, please be sure to run `dotnet restore` before you run any other command. `dotnet restore` will bring in the targets that comprise the MSBuild-based tooling. Without those targets, you will get errors or incorrect behavior, depending on what command you use. 
+
+## Further steps
+From this point on, you can either get familiar with [csproj changes](csproj.md) that came about as the product of this work, learn how to [work with dependencies](dependencies.md) in Preview 3 tooling or get more information on the [layering of the tools](layering.md) that has changed with Preview 3.

--- a/docs/core/preview3/tools/whats-new.md
+++ b/docs/core/preview3/tools/whats-new.md
@@ -14,3 +14,44 @@ ms.assetid: ac8ff967-3649-4463-bd65-ebb0457bca28
 
 What is new in .NET Core Tools Preview 3?
 -----------------------------------------
+
+This document will outline in high-level details what is new with the Preview 3 .NET Coore 
+Tooling, also known as the "CLI". Where needed, it will point to other documents in this 
+document set.
+
+Use this document as an overview and a guide to check out what is new and as an 
+index to the 
+
+## Move to MSBuild and csproj
+The main change in Prview 3 is the move from project.json to csproj as the project 
+system and moving to MSBuild as the build engine for .NET Core. This is a result of an overall 
+push that was announced [on the project.json future blog post](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/). 
+
+It is important to note that Preview 3 tooling does not contain **any support** for 
+project.json projects. You will not be able to build or run any project.json project with just 
+Preview 3 tools. You still need to have Preview 2 tools installed in order to work with 
+project.json projects. 
+
+## `dotnet migrate` command
+With the move to MSBuild and csproj, we have included a [dotnet migrate](dotnet-migrate.md) 
+command that will allow you to migrate a valid .NET Core 1.0.0 project to csproj. 
+
+## Advanced commands
+Since this release [changes the layering](layering.md) of the .NET Core Tools, we have 
+added a new category of commands called "advanced commands". These commands allow access to 
+the underlying engines (for example to MSBuild) and most of its functionalities. They can 
+also have different invocation patters and option formats. 
+
+The current advanced commands in Preview 3 are:
+
+* [dotnet msbuild](dotnet-msbuild.md)
+* [dotnet nuget](dotnet-nuget-locals.md)
+* dotnet vstest
+
+## More resources
+
+* [Changes to .NET Core tools layering](layering.md)
+* [Getting started with Preview 3 tools](getting-started.md)
+* [Additions to csproj format](csproj.md)
+* [global.json reference](global.json.md)
+

--- a/docs/core/preview3/tools/whats-new.md
+++ b/docs/core/preview3/tools/whats-new.md
@@ -1,0 +1,16 @@
+---
+title: Getting started with .NET Core Preview 3 tooling
+description: Preview 3 brings about changes to projects 
+keywords: CLI, extensibility, custom commands, .NET Core
+author: blackdwarf
+manager: wpickett
+ms.date: 11/12/2016
+ms.topic: article
+ms.prod: .net-core
+ms.technology: .net-core-technologies
+ms.devlang: dotnet
+ms.assetid: ac8ff967-3649-4463-bd65-ebb0457bca28
+---
+
+What is new in .NET Core Tools Preview 3?
+-----------------------------------------


### PR DESCRIPTION
# Adding more CLI Preview 3 docs

## Summary

Adding more CLI Preview 3 docs and upgrading the existing ones. This is a work in progress PR. 

Idea is to add the following docs:

* What's new?
* Getting started (but see below)
* Project.json to csproj mapping

Also, work more and fix the following docs:

* csproj.md

## Getting started vs. changing index
Since we are talking about a new version of the tools, we could remove the getting-started and fold it into the index page. I would not like to do this because at some point Preview 3 will become the shipped version of the Tools, so it seems that at that point we will go back to the original index page. 

Thoughts?

/cc @mairaw @BillWagner @svick @richlander 