### PR TITLE
custom operators using `?`

### DIFF
--- a/docs/fsharp/language-reference/operator-overloading.md
+++ b/docs/fsharp/language-reference/operator-overloading.md
@@ -46,6 +46,8 @@ Depending on the exact character sequence you use, your operator will have a cer
 
 The operator character `.` does not affect precedence, so that, for example, if you want to define your own version of multiplication that has the same precedence and associativity as ordinary multiplication, you could create operators such as `.*`.
 
+Only the operators `?` and `?<-` may start with `?.`
+
 A table that shows the precedence of all operators in F# can be found in [Symbol and Operator Reference](symbol-and-operator-reference/index.md).
 
 


### PR DESCRIPTION
# custom operators using `?`

## Summary

additional documentation 

## Details

important note about operator definition was missing

## Suggested Reviewers

@cartermp 

added an additional rule for custom operators from the F# 4.0 Spec Section 3.7