### PR TITLE
Adds missing using statements in dotnet core tutorial

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -209,6 +209,8 @@ type to contain the information you use from this response. Let's build this slo
 a simple C# type that contains the name of the repository:
 
 ```cs
+using System;
+
 namespace WebAPIClient
 {
     public class repo
@@ -474,8 +476,16 @@ Let's go over the new constructs above. The `IgnoreDataMember` attribute instruc
 that this type should not be read to or written from any JSON object. This property contains only a
 `get` accessor. There is no `set` accessor. That's how you define a *read only* property in C#. (Yes,
 you can create *write only* properties in C#, but their value is limited.) The `DateTime.ParseExact`
-method parses a string and creates a `DateTime` object to return. If the parse operation fails, the
+method parses a string and creates a `DateTime` object using a provided date format, and adds additional 
+metadata to the `DateTime` using a `CultureInfo` object. If the parse operation fails, the
 property accessor throws an exception.
+
+To use `CultureInfo.InvariantCulture`, you will need to add `System.Globalization` to the using statements 
+in `repo.cs`:
+
+```cs
+using System.Globalization;
+```
 
 Finally, add one more output statement in the console, and you're ready to build and run this app
 again:


### PR DESCRIPTION
Fixes some missing `using` statements (and attempts to explain why one is necessary) with this tutorial: https://docs.microsoft.com/en-us/dotnet/articles/csharp/tutorials/console-webapiclient 

## Details

As I was following the tutorial, I noted that it was missing some using statements, making the code you would produce by following just the tutorial uncompilable. This change adds them in and attempts to explain why it's necessary.

## Suggested Reviewers

@BillWagner 
