### PR TITLE
removing broken links

### DIFF
--- a/docs/csharp/language-reference/compiler-options/highentropyva-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/highentropyva-compiler-option.md
@@ -53,6 +53,4 @@ The **/highentropyva** compiler option tells the Windows kernel whether a partic
 ## Remarks  
  The **/highentropyva** option enables compatible versions of the Windows kernel to use higher degrees of entropy when randomizing the address space layout of a process as part of ASLR. Using higher degrees of entropy means that a larger number of addresses can be allocated to memory regions such as stacks and heaps. As a result, it is more difficult to guess the location of a particular memory region.  
   
- When the **/highentropyva** compiler option is specified, the target executable and any modules that it depends on must be able to handle pointer values that are larger than 4 gigabytes (GB) when they are running as a 64-bit process.  
-  
- For more information about ASLR, see [Mitigating Software Vulnerabilities](http://go.microsoft.com/fwlink/?LinkId=226234).
+ When the **/highentropyva** compiler option is specified, the target executable and any modules that it depends on must be able to handle pointer values that are larger than 4 gigabytes (GB) when they are running as a 64-bit process.

--- a/docs/visual-basic/reference/command-line-compiler/highentropyva.md
+++ b/docs/visual-basic/reference/command-line-compiler/highentropyva.md
@@ -50,8 +50,6 @@ Indicates whether a 64-bit executable or an executable that's marked by the [/pl
   
  When the option is on, the target executable and any modules on which it depends must be able to handle pointer values that are larger than 4 gigabytes (GB) when those modules are running as 64-bit processes.  
   
- For more information about ASLR, see [Mitigating Software Vulnerabilities](http://go.microsoft.com/fwlink/?LinkId=226234).  
-  
 ## See Also  
  [Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)   
  [Sample Compilation Command Lines](../../../visual-basic/reference/command-line-compiler/sample-compilation-command-lines.md)


### PR DESCRIPTION
@svick had pointed out a couple of broken FwLinks on a previous PR.

The article that this FwLink in particular points to no longer exists so removing the links from the docs.