### PR TITLE
Use S110 build tool version for building

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -38,7 +38,7 @@
     "skip_source_output_uploading": false,
     "dependent_repositories": [{
         "path_to_root": "_themes",
-        "url": "https://github.com/Microsoft/templates.docs.msft",
+        "url": "https://github.com/fenxu/templates.docs.msft",
         "branch": "master"
     }, {
         "path_to_root": "api_ref",
@@ -48,5 +48,6 @@
         "path_to_root": "_themes.pdf",
         "url": "https://github.com/Microsoft/templates.docs.msft.pdf",
         "branch": "master"
-    }]
+    }],
+    "package_version": "1.22.3"
 }

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -38,8 +38,8 @@
     "skip_source_output_uploading": false,
     "dependent_repositories": [{
         "path_to_root": "_themes",
-        "url": "https://github.com/fenxu/templates.docs.msft",
-        "branch": "master"
+        "url": "https://github.com/Microsoft/templates.docs.msft",
+        "branch": "S110Plugins"
     }, {
         "path_to_root": "api_ref",
         "url": "https://github.com/docascode/coreapi.git",


### PR DESCRIPTION
Use S110 build tool version for workaround. The root cause of S111 build failure is still under investigation.