### PR TITLE
Fixed broken links to LINQ topic

### DIFF
--- a/docs/csharp/expression-trees.md
+++ b/docs/csharp/expression-trees.md
@@ -16,7 +16,7 @@ ms.assetid: aceb4719-0d5a-4b19-b01f-b51063bcc54f
 
 If you have used LINQ, you have experience with a rich library
 where the `Func` types are part of the API set. (If you are not familiar
-with LINQ, you probably want to read [the LINQ tutorial](linq.md) and
+with LINQ, you probably want to read [the LINQ tutorial](linq/index.md) and
 the tutorial on [lambda expressions](lambda-expressions.md) before this one.)
 *Expression Trees* provide richer interaction with the arguments that
 are functions.

--- a/docs/csharp/iterators.md
+++ b/docs/csharp/iterators.md
@@ -23,7 +23,7 @@ iterator for the elements of that class. These can be used for:
 
 + Performing an action on each item in a collection.
 + Enumerating a custom collection.
-+ Extending [LINQ](linq.md) or other libraries.
++ Extending [LINQ](linq/index.md) or other libraries.
 + Creating a data pipeline where data flows efficiently through iterator
 methods.
 

--- a/docs/csharp/lambda-expressions.md
+++ b/docs/csharp/lambda-expressions.md
@@ -18,7 +18,7 @@ A *lambda expression* is a block of code (an expression or a statement block) th
 
 - Passing the code that is to be executed to asynchronous methods, such as @System.Threading.Tasks.Task.Run(System.Action).
 
-- Writing [LINQ query expressions](linq.md).
+- Writing [LINQ query expressions](linq/index.md).
 
 - Creating [expression trees](expression-trees-building.md).
 

--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -1,15 +1,10 @@
 ---
 title: Language Integrated Query (LINQ)
 description: Introduces Language Integrated Query (LINQ) in C#
-keywords: .NET, .NET Core
-<<<<<<< HEAD
-ms.date: 06/20/2016
-=======
+keywords: .NET, .NET Core, LINQ, C#
 author: stevehoag
-manager: wpickett
 ms.author: wiwagn
 ms.date: 11/30/2016
->>>>>>> Updated LINQ topics for C# Concepts section
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp

--- a/docs/standard/collections/selecting-a-collection-class.md
+++ b/docs/standard/collections/selecting-a-collection-class.md
@@ -66,7 +66,7 @@ Consider the following questions:
     
 ## LINQ to Objects
 
-LINQ to Objects enables developers to use LINQ queries to access in-memory objects as long as the object type implements [System.Collections.IEnumerable](https://docs.microsoft.com/dotnet/core/api/System.Collections.IEnumerable) or [System.Collections.Generic.IEnumerable&lt;T&gt;](https://docs.microsoft.com/dotnet/core/api/System.Collections.Generic.IEnumerable-1). LINQ queries provide a common pattern for accessing data, are typically more concise and readable than standard foreach loops, and provide filtering, ordering, and grouping capabilities. For more information, see [Language Integrated Query (LINQ)](../../csharp/linq.md).
+LINQ to Objects enables developers to use LINQ queries to access in-memory objects as long as the object type implements [System.Collections.IEnumerable](https://docs.microsoft.com/dotnet/core/api/System.Collections.IEnumerable) or [System.Collections.Generic.IEnumerable&lt;T&gt;](https://docs.microsoft.com/dotnet/core/api/System.Collections.Generic.IEnumerable-1). LINQ queries provide a common pattern for accessing data, are typically more concise and readable than standard foreach loops, and provide filtering, ordering, and grouping capabilities. For more information, see [Language Integrated Query (LINQ)](../../csharp/linq/index.md).
 
 ## See Also
 


### PR DESCRIPTION
# Fixed broken links to LINQ topic

## Summary

The main LINQ topic was moved and renamed, breaking four links. This fixes them.

## Suggested Reviewers

@mairaw @stevehoag 

