### PR TITLE
Use latest OPS build tool

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -40,7 +40,7 @@
     "dependent_repositories": [{
         "path_to_root": "_themes",
         "url": "https://github.com/Microsoft/templates.docs.msft",
-        "branch": "S110Plugins"
+        "branch": "master"
     }, {
         "path_to_root": "api_ref",
         "url": "https://github.com/docascode/coreapi.git",
@@ -49,6 +49,5 @@
         "path_to_root": "_themes.pdf",
         "url": "https://github.com/Microsoft/templates.docs.msft.pdf",
         "branch": "master"
-    }],
-    "package_version": "1.22.3"
+    }]
 }


### PR DESCRIPTION
# Title

Use latest build tool to build content after perf issue fix.

## Summary

Yesterday, OPS build has a perf issue which results in build failure. We've fixed it today and revert the workaround to make dotnet/docs use latest build version.

Related [LSI 829961](https://mseng.visualstudio.com/DefaultCollection/VSChina/_workitems?_a=edit&id=829961): [LSI] [OPS]: OPS builds keep failing for dotnet/docs]

## Details

The perf issue has been resolved. Currently all the PRs should pass now. If other users want to validate the PR again, please close and reopen the PR.

## Suggested Reviewers

@mairaw

