### PR TITLE
switching xref syntax

### DIFF
--- a/docs/csharp/csharp-7.md
+++ b/docs/csharp/csharp-7.md
@@ -130,7 +130,7 @@ Using tuples in this way offers several advantages:
 
 * You save the work of authoring a `class` or a `struct` that defines the type returned. 
 * You do not need to create new type.
-* The language enhancements removes the need to call the @System.Tuple.Create%60%601(%60%600) methods.
+* The language enhancements removes the need to call the <xref:System.Tuple.Create``1(``0)> methods.
 
 The declaration for the method provides the names for the fields of the
 tuple that is returned. When you call the method, the return value is a 

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-initialize-a-dictionary-with-a-collection-initializer.md
@@ -35,14 +35,14 @@ translation.priority.mt:
   - "tr-tr"
 ---
 # How to: Initialize a Dictionary with a Collection Initializer (C# Programming Guide)
-A <xref:System.Collections.Generic.Dictionary%602> contains a collection of key/value pairs. Its <xref:System.Collections.Generic.Dictionary%602.Add%2A> method takes two parameters, one for the key and one for the value. To initialize a <xref:System.Collections.Generic.Dictionary%602>, or any collection whose `Add` method takes multiple parameters, enclose each set of parameters in braces as shown in the following example.  
+A <xref:System.Collections.Generic.Dictionary`2> contains a collection of key/value pairs. Its <xref:System.Collections.Generic.Dictionary`2.Add*> method takes two parameters, one for the key and one for the value. To initialize a <xref:System.Collections.Generic.Dictionary`2>, or any collection whose `Add` method takes multiple parameters, enclose each set of parameters in braces as shown in the following example.  
   
 ## Example  
- In the following code example, a <xref:System.Collections.Generic.Dictionary%602> is initialized with instances of type `StudentName`.  
+ In the following code example, a <xref:System.Collections.Generic.Dictionary`2> is initialized with instances of type `StudentName`.  
   
  [!code-cs[csProgGuideLINQ#34](../../../csharp/programming-guide/arrays/codesnippet/CSharp/how-to-initialize-a-dictionary-with-a-collection-initializer_1.cs)]  
   
- Note the two pairs of braces in each element of the collection. The innermost braces enclose the object initializer for the `StudentName`, and the outermost braces enclose the initializer for the key/value pair that will be added to the `students`<xref:System.Collections.Generic.Dictionary%602>. Finally, the whole collection initializer for the dictionary is enclosed in braces.  
+ Note the two pairs of braces in each element of the collection. The innermost braces enclose the object initializer for the `StudentName`, and the outermost braces enclose the initializer for the key/value pair that will be added to the `students`<xref:System.Collections.Generic.Dictionary`2>. Finally, the whole collection initializer for the dictionary is enclosed in braces.  
   
 ## Compiling the Code  
  To run this code, copy and paste the class into a Visual C# console application project that has been created in [!INCLUDE[vs_current_short](../../../csharp/programming-guide/classes-and-structs/includes/vs_current_short_md.md)]. By default, this project targets version 3.5 of the [!INCLUDE[dnprdnshort](../../../csharp/getting-started/includes/dnprdnshort_md.md)], and it has a reference to System.Core.dll and a using directive for System.Linq. If one or more of these requirements are missing from the project, you can add them manually.   

--- a/docs/visual-basic/language-reference/keywords/collection-object-summary.md
+++ b/docs/visual-basic/language-reference/keywords/collection-object-summary.md
@@ -42,7 +42,7 @@ Visual Basic language keywords and run-time library members are organized by pur
 |Add an item to a collection.|<xref:Microsoft.VisualBasic.Collection.Add*>|  
 |Remove an object from a collection.|<xref:Microsoft.VisualBasic.Collection.Remove*>|  
 |Reference an item in a collection.|<xref:Microsoft.VisualBasic.Collection.Item*>|  
-|Return a reference to an <xref:System.Collections.IEnumerator> interface.|<xref:Microsoft.VisualBasic.Collection.System#Collections#IEnumerable#GetEnumerator>|  
+|Return a reference to an <xref:System.Collections.IEnumerator> interface.|<xref:Microsoft.VisualBasic.Collection.System%23Collections%23IEnumerable%23GetEnumerator%2A>|  
   
 ## See Also  
  [Keywords](../../../visual-basic/language-reference/keywords/index.md)   

--- a/docs/visual-basic/language-reference/keywords/collection-object-summary.md
+++ b/docs/visual-basic/language-reference/keywords/collection-object-summary.md
@@ -39,10 +39,10 @@ Visual Basic language keywords and run-time library members are organized by pur
 |Action|Language element|  
 |------------|----------------------|  
 |Create a `Collection` object.|<xref:Microsoft.VisualBasic.Collection>|  
-|Add an item to a collection.|<xref:Microsoft.VisualBasic.Collection.Add%2A>|  
-|Remove an object from a collection.|<xref:Microsoft.VisualBasic.Collection.Remove%2A>|  
-|Reference an item in a collection.|<xref:Microsoft.VisualBasic.Collection.Item%2A>|  
-|Return a reference to an <xref:System.Collections.IEnumerator> interface.|<xref:Microsoft.VisualBasic.Collection.System%23Collections%23IEnumerable%23GetEnumerator%2A>|  
+|Add an item to a collection.|<xref:Microsoft.VisualBasic.Collection.Add*>|  
+|Remove an object from a collection.|<xref:Microsoft.VisualBasic.Collection.Remove*>|  
+|Reference an item in a collection.|<xref:Microsoft.VisualBasic.Collection.Item*>|  
+|Return a reference to an <xref:System.Collections.IEnumerator> interface.|<xref:Microsoft.VisualBasic.Collection.System#Collections#IEnumerable#GetEnumerator*>|  
   
 ## See Also  
  [Keywords](../../../visual-basic/language-reference/keywords/index.md)   

--- a/docs/visual-basic/language-reference/keywords/collection-object-summary.md
+++ b/docs/visual-basic/language-reference/keywords/collection-object-summary.md
@@ -42,7 +42,7 @@ Visual Basic language keywords and run-time library members are organized by pur
 |Add an item to a collection.|<xref:Microsoft.VisualBasic.Collection.Add*>|  
 |Remove an object from a collection.|<xref:Microsoft.VisualBasic.Collection.Remove*>|  
 |Reference an item in a collection.|<xref:Microsoft.VisualBasic.Collection.Item*>|  
-|Return a reference to an <xref:System.Collections.IEnumerator> interface.|<xref:Microsoft.VisualBasic.Collection.System#Collections#IEnumerable#GetEnumerator*>|  
+|Return a reference to an <xref:System.Collections.IEnumerator> interface.|<xref:Microsoft.VisualBasic.Collection.System#Collections#IEnumerable#GetEnumerator>|  
   
 ## See Also  
  [Keywords](../../../visual-basic/language-reference/keywords/index.md)   


### PR DESCRIPTION
Having to encode the links to APIs is problematic. According to @chenkennt, we can just use the UID directly with the <xref:uid> syntax, so I'm testing this now.