### PR TITLE
fixing warning message

### DIFF
--- a/docs/core/tools/project-json.md
+++ b/docs/core/tools/project-json.md
@@ -4,7 +4,7 @@ description: project.json reference
 keywords: .NET, .NET Core, project.json
 author: aL3891
 ms.author: mairaw
-ms.date: 09/30/2016
+ms.date: 12/21/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -521,7 +521,7 @@ For example:
 }
 ```
 
-This ignores the warnings `The variable 'var' is assigned but its value is never used` and `The variable 'var' is assigned but its value is never used`
+This ignores the warnings `The variable 'var' is declared but never used` and `The variable 'var' is assigned but its value is never used`.
 
 ### additionalArguments
 Type: String[]

--- a/docs/csharp/misc/cs0168.md
+++ b/docs/csharp/misc/cs0168.md
@@ -1,7 +1,7 @@
 ---
 title: "Compiler Warning (level 3) CS0168 | Microsoft Docs"
 
-ms.date: "2015-07-20"
+ms.date: "2016-12-21"
 ms.prod: .net
 
 
@@ -37,28 +37,20 @@ translation.priority.mt:
   - "tr-tr"
 ---
 # Compiler Warning (level 3) CS0168
-The variable 'var' is assigned but its value is never used  
+The variable 'var' is declared but never used
+
+The compiler issues a level-three warning, when you declare a variable, but do not use it.
   
- The compiler warns when a variable is declared but not used.  
+The following sample generates a CS0168 warning:  
   
- The following sample generates two CS0168 warnings:  
-  
-```  
+```cs
 // CS0168.cs  
 // compile with: /W:3  
-public class clx  
-{  
-   public int i;  
-}  
-  
 public class clz  
 {  
    public static void Main()  
    {  
-      int j = 0;   // CS0168, uncomment the following line  
-      // j++;  
-      clx a;       // CS0168, try the following line instead  
-      // clx a = new clx();  
+      int a;   // CS0168
    }  
 }  
 ```

--- a/docs/csharp/misc/cs0168.md
+++ b/docs/csharp/misc/cs0168.md
@@ -1,13 +1,8 @@
 ---
 title: "Compiler Warning (level 3) CS0168 | Microsoft Docs"
-
 ms.date: "2016-12-21"
 ms.prod: .net
-
-
-ms.technology: 
-  - "devlang-csharp"
-
+ms.technology: "devlang-csharp"
 ms.topic: "article"
 f1_keywords: 
   - "CS0168"
@@ -19,7 +14,6 @@ ms.assetid: 6f5b7fe3-1e91-462f-8a73-b931327ab3f5
 caps.latest.revision: 7
 author: "BillWagner"
 ms.author: "wiwagn"
-
 translation.priority.ht: 
   - "de-de"
   - "es-es"
@@ -39,18 +33,24 @@ translation.priority.mt:
 # Compiler Warning (level 3) CS0168
 The variable 'var' is declared but never used
 
-The compiler issues a level-three warning, when you declare a variable, but do not use it.
+The compiler issues a level-three warning when you declare a variable, but do not use it.
   
 The following sample generates a CS0168 warning:  
   
 ```cs
 // CS0168.cs  
 // compile with: /W:3  
-public class clz  
-{  
-   public static void Main()  
-   {  
-      int a;   // CS0168
-   }  
-}  
+public class clx
+{
+    public int i;
+}
+
+public class clz
+{
+    public static void Main() {
+        clx a; // CS0168, the variable 'a' is declared but never used
+        // try the following line instead
+        // clx a = new clx();  // this does not generate a warning because the clx constructor must execute.
+    }
+}
 ```

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -1,13 +1,9 @@
 ---
 title: "Sorry, we don&#39;t have specifics on this C# error | Microsoft Docs"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-
 ms.technology: 
   - "devlang-csharp"
-
 ms.topic: "article"
 f1_keywords: 
   - "CS1583"
@@ -189,7 +185,6 @@ f1_keywords:
   - "CS0011"
   - "CS1057"
   - "CS0144"
-  - "CS0168"
   - "CS1985"
   - "CS0060"
   - "CS1643"
@@ -888,7 +883,6 @@ ms.assetid: 48320e4a-6e17-45a6-9966-88c6ec89bd2f
 caps.latest.revision: 15
 author: "BillWagner"
 ms.author: "wiwagn"
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"


### PR DESCRIPTION
Got the following anonymous feedback for the project.json topic:
""The variable 'var' is assigned but its value is never used" is repeated in "nowarn" section. Copy/paste ? :)"

While fixing this issue, I've also noticed that our compiler warning page actually had the same issue and example wasn't really giving the two warnings as it said, so I simplified the code.

/cc @BillWagner 