### PR TITLE
Update exception-handling_4.cs

### DIFF
--- a/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/exception-handling_4.cs
+++ b/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/exception-handling_4.cs
@@ -7,6 +7,6 @@
             catch(System.IndexOutOfRangeException e)
             {
                 throw new System.ArgumentOutOfRangeException(
-                    "Parameter index is out of range.");
+                    "Parameter index is out of range.", e);
             }
         }


### PR DESCRIPTION
Not good to have broken examples  This code generates a CS0168 error because e is not used.  You should definitely use it to set IndexOutOfRangeException to the new exception's InnerException.  You do this correctly in the topic "How to: Handle an Exception Using try/catch (C# Programming Guide)"

