### PR TITLE
Add notes about valid member constraints

### DIFF
--- a/docs/fsharp/language-reference/generics/constraints.md
+++ b/docs/fsharp/language-reference/generics/constraints.md
@@ -30,7 +30,7 @@ There are several different constraints you can apply to limit the types that ca
 |----------|------|-----------|
 |Type Constraint|*type-parameter* :&gt; *type*|The provided type must be equal to or derived from the type specified, or, if the type is an interface, the provided type must implement the interface.|
 |Null Constraint|*type-parameter* : null|The provided type must support the null literal. This includes all .NET object types but not F# list, tuple, function, class, record, or union types.|
-|Explicit Member Constraint|[(]*type-parameter* [or ... or *type-parameter*)] : (*member-signature *)|At least one of the type arguments provided must have a member that has the specified signature; not intended for common use.|
+|Explicit Member Constraint|[(]*type-parameter* [or ... or *type-parameter*)] : (*member-signature *)|At least one of the type arguments provided must have a member that has the specified signature; not intended for common use. Members must be either explicitly defined on the type or part of an implicit type extension to be valid targets for an Explicit Member Constraint.|
 |Constructor Constraint|*type-parameter* : ( new : unit -&gt; 'a )|The provided type must have a default constructor.|
 |Value Type Constraint|: struct|The provided type must be a .NET value type.|
 |Reference Type Constraint|: not struct|The provided type must be a .NET reference type.|


### PR DESCRIPTION
# Add notes about valid members for member constraints.

## Summary

After a conversation on FP slack realized that explicit type extensions could not be used as member constraints, so I figured that if the valid set of members were documented it may short-circuit discussions like that in the future.

## Suggested Reviewers

@cartermp