### PR TITLE
Updated information about availibility of C# specs

### DIFF
--- a/docs/csharp/language-reference/language-specification.md
+++ b/docs/csharp/language-reference/language-specification.md
@@ -36,7 +36,7 @@ The C# Language Specification is the definitive source for C# syntax and usage. 
   
 You can download version 5.0 of this specification from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2015, you can also find the specification on your computer in the Program Files (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033 folder. If you have another version of Visual Studio installed or if you installed Visual Studio in a language other than English, change the path as appropriate.
 
-Version 6.0 of the specification is not currently available.
+Version 6.0 of the specification is not currently available, but an unofficial draft exists in [the dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md).
   
 ## See Also  
  [C# Reference](../../csharp/language-reference/index.md)   

--- a/docs/csharp/language-reference/language-specification.md
+++ b/docs/csharp/language-reference/language-specification.md
@@ -34,7 +34,9 @@ translation.priority.ht:
 # C# Language Specification
 The C# Language Specification is the definitive source for C# syntax and usage. This spec contains detailed information about all aspects of the language, including many points that the documentation for Visual C# doesn't cover.  
   
- You can download this spec from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2013, you can also find the spec on your computer in the Program Files (x86)/Microsoft Visual Studio 12.0/VC#/Specifications/1033 folder. However, installations of Visual Studio Express 2013 don't include this file.  
+You can download version 5.0 of this spec from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2015, you can also find the spec on your computer in the Program Files (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033 folder. However, installations of Visual Studio Express 2015 don't include this file.
+
+Version 6.0 of the spec is not currently available.
   
 ## See Also  
  [C# Reference](../../csharp/language-reference/index.md)   

--- a/docs/csharp/language-reference/language-specification.md
+++ b/docs/csharp/language-reference/language-specification.md
@@ -32,11 +32,11 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # C# Language Specification
-The C# Language Specification is the definitive source for C# syntax and usage. This spec contains detailed information about all aspects of the language, including many points that the documentation for Visual C# doesn't cover.  
+The C# Language Specification is the definitive source for C# syntax and usage. This specification contains detailed information about all aspects of the language, including many points that the documentation for Visual C# doesn't cover.  
   
-You can download version 5.0 of this spec from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2015, you can also find the spec on your computer in the Program Files (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033 folder. However, installations of Visual Studio Express 2015 don't include this file.
+You can download version 5.0 of this specification from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2015, you can also find the specification on your computer in the Program Files (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033 folder. If you have another version of Visual Studio installed or if you installed Visual Studio in a language other than English, change the path as appropriate.
 
-Version 6.0 of the spec is not currently available.
+Version 6.0 of the specification is not currently available.
   
 ## See Also  
  [C# Reference](../../csharp/language-reference/index.md)   


### PR DESCRIPTION
VS 2013 should also contain the 5.0 spec, but I expect more people have VS 2015 installed, so I think it makes sense to update this.

Also, I don't know how relevant VS Express is and whether it would make sense to remove the note about it.

cc: @BillWagner 