### PR TITLE
removing unused stub

### DIFF
--- a/docs/core/tutorials/libraries-with-vs.md
+++ b/docs/core/tutorials/libraries-with-vs.md
@@ -1,22 +1,8 @@
 ---
-title: Developing .NET Core libraries using Visual Studio
-description: Developing .NET Core libraries using Visual Studio
-keywords: .NET, .NET Core
-ms.date: 06/20/2016
-ms.topic: article
-ms.prod: .net-core
-ms.devlang: dotnet
-ms.assetid: 01b988ed-583f-48c8-a016-caeee282e0a6
+redirect_url: /dotnet/articles/csharp/getting-started/library-with-visual-studio-2017
 ---
 
 # 🔧 Developing .NET Core libraries using Visual Studio
 
-> **Note**
-> 
-> This topic hasn’t been written yet! 
->
-> We welcome your input to help shape the scope and approach.
-> 
-> Learn more about how you can contribute on
-> [GitHub](https://github.com/dotnet/docs/blob/master/CONTRIBUTING.md).
->
+## Content moved!
+This article has moved to the [Building a class library with C# and .NET Core in Visual Studio 2017 RC](../../csharp/getting-started/library-with-visual-studio-2017.md) topic.


### PR DESCRIPTION
Fixes #470 

Library topic has been written in the C# Guide instead (https://docs.microsoft.com/en-us/dotnet/articles/csharp/getting-started/library-with-visual-studio-2017). So, the only thing left is to remove the old stub. Topic was not on TOC, so no need to change that file.

/cc @rpetrusha @BillWagner 