### PR TITLE
Change class reference to match image

### DIFF
--- a/docs/csharp/getting-started/testing-library-with-visual-studio.md
+++ b/docs/csharp/getting-started/testing-library-with-visual-studio.md
@@ -36,7 +36,7 @@ To create the unit test project, do the following:
 
    - It imports the [Microsoft.VisualStudio.TestTools.UnitTesting](https://msdn.microsoft.com/library/microsoft.visualstudio.testtools.unittesting.aspx) namespace, which contains the types used for unit testing.
 
-   - It applies the [\[TestClass\]](https://msdn.microsoft.com/library/microsoft.visualstudio.testtools.unittesting.testclassattribute.aspx) attribute to the `TestClass1` class. Each test method in a test class tagged with the \[TestMethod\] attribute will be executed automatically when the unit test is run.
+   - It applies the [\[TestClass\]](https://msdn.microsoft.com/library/microsoft.visualstudio.testtools.unittesting.testclassattribute.aspx) attribute to the `UnitTest1` class. Each test method in a test class tagged with the \[TestMethod\] attribute will be executed automatically when the unit test is run.
 
    - It applies the [\[TestMethod\]](https://msdn.microsoft.com/library/microsoft.visualstudio.testtools.unittesting.testmethodattribute.aspx) attribute to define `TestMethod1` as a test method to be automatically executed when the unit test is run.
 


### PR DESCRIPTION


# Fixing references

Fixed the class name.

## Summary

Class name in text doesn't match the one on an image.

## Details

The text contains reference to a "TestClass1" when the image with the source code shows a class named "UnitTest1".