### PR TITLE
Consistently use braces for single line blocks

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-define-value-equality-for-a-type_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-define-value-equality-for-a-type_1.cs
@@ -39,7 +39,9 @@
 
                 // If run-time types are not exactly the same, return false.
                 if (this.GetType() != p.GetType())
+                {
                     return false;
+                }
 
                 // Return true if the fields match.
                 // Note that the base class is not invoked because it is
@@ -85,7 +87,9 @@
                 : base(x, y)
             {
                 if ((z < 1) || (z > 2000))
+                {
                     throw new System.ArgumentException("Point must be in range 1 - 2000");
+                }    
                 this.Z = z;
             }
 
@@ -116,7 +120,9 @@
                     return base.Equals((TwoDPoint)p);
                 }
                 else
+                {
                     return false;
+                }    
             }
 
             public override int GetHashCode()

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-define-value-equality-for-a-type_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-define-value-equality-for-a-type_1.cs
@@ -13,7 +13,9 @@
             public TwoDPoint(int x, int y)
             {
                 if ((x < 1) || (x > 2000) || (y < 1) || (y > 2000))
+                {
                     throw new System.ArgumentException("Point must be in range 1 - 2000");
+                }
                 this.X = x;
                 this.Y = y;
             }


### PR DESCRIPTION
In some cases you where using {} for single line statements following conditionals such as if.  In other cases they where omitted.  As per StyleCop guidelines the usage should be consistent, and using {} is recommended.
