### PR TITLE
removed quote causing rendering issues

### DIFF
--- a/docs/visual-basic/language-reference/data-types/string-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/string-data-type.md
@@ -25,7 +25,7 @@ helpviewer_keywords:
   - "fixed-length strings"
   - "string literals"
   - "data types [Visual Basic], assigning"
-  - "" String literals"
+  - "String literals"
   - "identifier type characters, $"
 ms.assetid: 15ac03f5-cabd-42cc-a754-1df3893c25d9
 caps.latest.revision: 19


### PR DESCRIPTION
The extra quote is causing the topic to be rendered incorrectly on docs right now: 
https://docs.microsoft.com/en-us/dotnet/articles/visual-basic/language-reference/data-types/string-data-type