### PR TITLE
fixed a small typo in the title from 'String Interpolation in C' to 'String Interpolation in C#' 

### DIFF
--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -12,7 +12,7 @@ ms.devlang: csharp
 ms.assetid: f8806f6b-3ac7-4ee6-9b3e-c524d5301ae9
 ---
 
-# String Interpolation in C#
+# String Interpolation in C# #
 
 String Interpolation is the way that placeholders in a string are replaced by the value of a string variable. Before C# 6, the way to do this is with `System.String.Format`. This works okay, but since it uses numbered placeholders, it can be harder to read and more verbose.
 


### PR DESCRIPTION
…String Interpolation in C#'

# Title

fixed a small typo in the title from 'String Interpolation in C' to 'String Interpolation in C#' 

## Summary

fixed a small typo in the title from 'String Interpolation in C' to 'String Interpolation in C#' 



## Details

there was a typo in the title on page  

https://docs.microsoft.com/en-us/dotnet/articles/csharp/tutorials/string-interpolation

the title was 'String Interpolation in C' and i think the author meant   'String Interpolation in C#'

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
