### PR TITLE
Update components.md

### DIFF
--- a/docs/standard/components.md
+++ b/docs/standard/components.md
@@ -76,5 +76,5 @@ To learn more, visit the following:
 * [.NET Core Guide](../core/index.md)
 * [.NET Framework Guide](../framework/index.md)
 * [C# Guide](../csharp/index.md)
-* [F# Guide](../csharp/index.md)
-* [VB.NET Guide](../csharp/index.md)
+* [F# Guide](../fsharp/index.md)
+* [VB.NET Guide](../visual-basic/index.md)


### PR DESCRIPTION
F# and VB Guide navigation corrected

# Guide links fixed

## Summary

All C#, F# and VB guide links were pointing to C# language page. Its fixed to navigate to respective pages.
