### PR TITLE
Removed RC from Visual Studio 2017 product name

### DIFF
--- a/docs/core/getting-started.md
+++ b/docs/core/getting-started.md
@@ -21,9 +21,8 @@ Install .NET Core on [Windows](https://www.microsoft.com/net/core#windows).
 
 You can get started developing .NET Core apps by following these step-by-step tutorials.
 
-* [Building a C# Hello World Application with .NET Core in Visual Studio 2017 RC](../csharp/getting-started/with-visual-studio-2017.md) - Learn to to build, debug, and publish a simple .NET Core console application using Visual Studio 2017 RC.
-* [Building a class library with C# and .NET Core in Visual Studio 2017 RC](../csharp/getting-started/library-with-visual-studio-2017.md) - Learn how to build a class library written in C# using Visual Studio 2017 RC
-* [Getting started with .NET Core on Windows, using Visual Studio 2015](tutorials/using-on-windows.md) - Learn how to use [Visual Studio](https://www.visualstudio.com/), the full-featured integrated development environment (IDE) for Windows, for different .NET Core scenarios.  
+* [Building a C# Hello World Application with .NET Core in Visual Studio 2017](../csharp/getting-started/with-visual-studio-2017.md) - Learn to to build, debug, and publish a simple .NET Core console application using Visual Studio 2017.
+* [Building a class library with C# and .NET Core in Visual Studio 2017](../csharp/getting-started/library-with-visual-studio-2017.md) - Learn how to build a class library written in C# using Visual Studio 2017
 * [Get started with Visual Studio Code using C# and .NET Core on Windows](https://channel9.msdn.com/Blogs/dotnet/Get-started-with-VS-Code-using-CSharp-and-NET-Core) - This Channel9 video shows you how to install and use [Visual Studio Code](https://www.visualstudio.com/products/code-vs), Microsoft's lightweight cross-platform code editor, to create your first console application in .NET Core.
 * [Getting started with .NET Core on macOS, using Visual Studio Code](tutorials/using-on-macos.md) - This tutorial is mainly written for macOS, but you can follow the steps on Windows for a tour of the steps and workflow to create a .NET Core Solution using VS Code.
 * [Getting started with .NET Core using the command-line](tutorials/using-with-xplat-cli.md) - Use any code editor with the [.NET Core cross-platform command-line interface (CLI)](tools/index.md).

--- a/docs/core/windows-prerequisites.md
+++ b/docs/core/windows-prerequisites.md
@@ -37,56 +37,14 @@ You can see the full set of [supported operating systems](https://github.com/dot
 > <em>For Windows 7 and Windows Server 2008 machines only:</em><br>
 > Make sure that your Windows installation is up-to-date and includes hotfix [KB2533623](https://support.microsoft.com/en-us/kb/2533623) installed through Windows Update.
 
-## Prerequisites with Visual Studio
+## Prerequisites with Visual Studio 2017
 
-You can use any editor of your choice to develop .NET Core applications using the .NET Core SDK. However, if you want to develop .NET Core applications on Windows using Visual Studio, there are two versions you can use:
+You can use any editor of your choice to develop .NET Core applications using the .NET Core SDK. However, if you want to develop .NET Core applications on Windows in an integrated development environment, you can use [Visual Studio 2017](#visual-studio-2017).
 
-* [Visual Studio 2015](#visual-studio-2015)
-* [Visual Studio 2017 RC](#visual-studio-2017-rc)
+To use Visual Studio 2017 to develop .NET Core apps, you'll need to have the latest version of Visual Studio installed with the **.NET Core cross-platform development** toolset (in the **Other Toolsets** section) selected.
 
-Projects created with Visual Studio 2015 will be project.json-based by default while projects created with Visual Studio 2017 RC will always be MSBuild-based. For more information about the format changes, see [High-level overview of changes](./preview3/tools/layering.md).
+There are different editions of Visual Studio 2017. You can download [Visual Studio Community 2017](https://www.visualstudio.com/vs/visual-studio-2017/#downloadvs) for free to get started.  To learn more about the Visual Studio installation process, see [Install Visual Studio 2017](https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio).
 
-### Visual Studio 2015
-
-If you want to use Visual Studio 2015 to develop .NET Core apps, you'll need:
-
-* Visual Studio 2015 Update 3.3 or later.
-
-   There are different [editions](https://www.visualstudio.com/vs/compare) of Visual Studio 2015. You can download [Visual Studio Community 2015](https://www.visualstudio.com/downloads/) for free to get started. 
-
-   To verify that you're running [Visual Studio 2015 Update 3.3](https://msdn.microsoft.com/library/mt752379.aspx), do the following:
-
-   * On the **Help** menu, choose **About Microsoft Visual Studio**.
-   * In the **About Microsoft Visual Studio** dialog, the version number should be 14.0.25424.00 or higher, and include "Update 3".
-   * If you don't have Update 3, you first need to download and install [Visual Studio 2015 Update 3](https://www.visualstudio.com/news/releasenotes/vs2015-update3-vs).
-   * If you have Update 3 but the version number is smaller than 14.0.25424.00, you need to download and install [Visual Studio 2015 Update 3.3](https://msdn.microsoft.com/library/mt752379.aspx).
-
-   You can read more about the changes in Update 3 in the [release notes](https://www.visualstudio.com/news/releasenotes/vs2015-update3-vs).
-
-* NuGet Manager extension for Visual Studio
-
-   NuGet is the package manager for the Microsoft development platform including .NET Core. You need [NuGet 3.5.0-beta](https://dist.nuget.org/visualstudio-2015-vsix/v3.5.0-beta/NuGet.Tools.vsix) or higher to build .NET Core apps.
-
-* .NET Core Tooling Preview 2
-
-   Download and install the [.NET Core 1.0.1 - VS 2015 Tooling Preview 2][sdk]. 
-
-   The .NET Core Tooling package installs .NET Core, project templates and other tools for Visual Studio 2015.
-
-   > [!NOTE]
-   > Currently, you cannot download an offline installer for [.NET Core 1.0.1 - VS 2015 Tooling Preview 2][sdk]. Instead, you have to download the [regular bootstrapper][sdk] and run it with a command-line option (such as, `/layout c:\path`) to get an offline layout. After that, it can be used as an offline installer: just run the executable from the local path. Notice that because it's a full layout, this procedure downloads all the packages for all supported languages, which is around 1 GB in size.
-
-### Visual Studio 2017 RC
-
-If you want to use Visual Studio 2017 RC to develop .NET Core apps, you'll need to have the latest version of Visual Studio RC installed with the ".NET Core and Docker (Preview)" workload selected. 
-
-There are different editions of Visual Studio 2017 RC. You can download [Visual Studio Community 2017 RC](https://www.visualstudio.com/vs/visual-studio-2017-rc/#downloadvs) for free to get started.  To learn more about the Visual Studio installation process, see [Install Visual Studio 2017 RC](https://docs.microsoft.com/en-us/visualstudio/install/install-visual-studio).
-
-To verify that you're running the latest version of Visual Studio 2017 RC, do the following:
-
-* On the **Help** menu, choose **About Microsoft Visual Studio**.
-* In the **About Microsoft Visual Studio** dialog, the version number should be 15.0.26020.0 or higher.
-
-You can read more about the changes in Visual Studio 2017 RC in the [release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes).
+You can read more about the changes in Visual Studio 2017 in the [release notes](https://www.visualstudio.com/en-us/news/releasenotes/vs2017-relnotes).
 
 [sdk]: https://go.microsoft.com/fwlink/?LinkID=827546

--- a/docs/csharp/getting-started/consuming-library-with-visual-studio-2017.md
+++ b/docs/csharp/getting-started/consuming-library-with-visual-studio-2017.md
@@ -14,7 +14,7 @@ ms.assetid: d7b94076-1108-4174-94e7-a18f00072bb7
 
 # Consuming a class library with .NET Core in Visual Studio 2017 #
 
-Once you've followed the steps in [Building a C# class library with .NET Core in Visual Studio 2017 RC](./library-with-visual-studio-2017.md) and [Testing a class library with .NET Core in Visual Studio 2017 RC](testing-library-with-visual-studio.md) to build and test your class library, and you've built a Release version of the library, the next step is to make it available to callers. You can do this in two ways:
+Once you've followed the steps in [Building a C# class library with .NET Core in Visual Studio 2017](./library-with-visual-studio-2017.md) and [Testing a class library with .NET Core in Visual Studio 2017](testing-library-with-visual-studio.md) to build and test your class library, and you've built a Release version of the library, the next step is to make it available to callers. You can do this in two ways:
 
 - If the library will be used by a single solution (for example, if it is a component in a single large application), you can simply include it as a project in your solution.
 
@@ -22,9 +22,9 @@ Once you've followed the steps in [Building a C# class library with .NET Core in
 
 ## Including a library as a project in a solution ##
 
-Just as we included unit tests in the same solution as our class library, we can include our application as part of that solution. For example, let's use our class library in a console application that prompts the user to enter a string and reports whether its first charater is uppercase:
+Just as we included unit tests in the same solution as our class library, we can include our application as part of that solution. For example, let's use our class library in a console application that prompts the user to enter a string and reports whether its first character is uppercase:
 
-1. Open the `ClassLibraryProjects` solution created in the [Building a C# Class Library with .NET Core in Visual Studio 2017 RC](./library-with-visual-studio-2017.md) topic, and in Solution Explorer, open the context menu for the **ClassLibraryProjects** node and choose **Add**, **New Project**.
+1. Open the `ClassLibraryProjects` solution created in the [Building a C# Class Library with .NET Core in Visual Studio 2017](./library-with-visual-studio-2017.md) topic, and in Solution Explorer, open the context menu for the **ClassLibraryProjects** node and choose **Add**, **New Project**.
 
 1. In the **Add New Project** dialog, expand the **Visual C#** and **.NET Core** nodes, and choose the **Console App (.NET Core)** project template, as the following figure shows.
 
@@ -54,7 +54,7 @@ Just as we included unit tests in the same solution as our class library, we can
 
 1. Compile and run the program by clicking the green arrow on the **ShowCase** button.
 
-The application that uses this library can then be debugged and eventually published by following the steps listed in [Debugging your C# Hello World Application with Visual Studio 2017 RC](debugging-with-visual-studio-2017.md) and [Publishing your Hello World Application with Visual Studio 2017 RC](publishing-with-visual-studio-2017.md).
+The application that uses this library can then be debugged and eventually published by following the steps listed in [Debugging your C# Hello World Application with Visual Studio 2017](debugging-with-visual-studio-2017.md) and [Publishing your Hello World Application with Visual Studio 2017](publishing-with-visual-studio-2017.md).
 
 ## Distributing the library in a NuGet package ##
 

--- a/docs/csharp/getting-started/debugging-with-visual-studio-2017.md
+++ b/docs/csharp/getting-started/debugging-with-visual-studio-2017.md
@@ -12,9 +12,9 @@ ms.devlang: csharp
 ms.assetid: cb213625-cc60-438b-9b9e-49aed0e4a974
 ---
 
-# Debugging your C# Hello World application with Visual Studio 2017 RC #
+# Debugging your C# Hello World application with Visual Studio 2017 #
 
-So far, you've followed the steps in [Building a c# Hello World Application with .NET Core in Visual Studio 2017 RC](.\with-visual-studio-2017.md) to create and run a simple console application. Once you've written and compiled an application, you can begin testing it. Visual Studio includes a comprehensive set of debugging tools that you can use when testing and troubleshooting your application. Let's look at a few of them as we debug our application.
+So far, you've followed the steps in [Building a c# Hello World Application with .NET Core in Visual Studio 2017](.\with-visual-studio-2017.md) to create and run a simple console application. Once you've written and compiled an application, you can begin testing it. Visual Studio includes a comprehensive set of debugging tools that you can use when testing and troubleshooting your application. Let's look at a few of them as we debug our application.
 
 ## Debugging in Debug mode ##
 

--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -14,17 +14,17 @@ ms.assetid: b77c7263-7cbf-4729-9626-8fbc3f5f14d9
 
 # Getting started with C# #
 
-This section provides short, simple tutorials that let you quickly build an application using C# and .NET Core. There are getting started topics for Visual Studio 2015, Visual Studio 2017 RC, and Visual Studio Code. You can build either a simple Hello World application or, if you have Visual Studio 2017, a simple class library that can be used by other applications. 
+This section provides short, simple tutorials that let you quickly build an application using C# and .NET Core. There are getting started topics for Visual Studio 2017 and Visual Studio Code. You can build either a simple Hello World application or, if you have Visual Studio 2017, a simple class library that can be used by other applications.
 
-The following topics are available: 
+The following topics are available:
 
-- [Building a C# Hello World application with .NET Core in Visual Studio 2017 RC](with-visual-studio-2017.md)
+- [Building a C# Hello World application with .NET Core in Visual Studio 2017](with-visual-studio-2017.md)
 
-   Visual Studio 2017 RC,  the latest release of Visual Studio, lets you code, compile, run, debug, profile, and publish your applications from a integrated development environment for Windows.
+   Visual Studio 2017, the latest release of Visual Studio, lets you code, compile, run, debug, profile, and publish your applications from a integrated development environment for Windows.
 
    The topic lets you create and run a simple Hello World application and then modify it to run a slightly more interactive Hello World application. Once you've finished building and running your application, you can also learn how to [debug it](.\debugging-with-visual-studio-2017.md) and how to [publish it](.\publishing-with-visual-studio-2017.md) so that it can be run on any platform supported by .NET Core.
 
-- [Building a class library with C# and .NET Core in Visual Studio 2017 RC](library-with-visual-studio-2017.md)
+- [Building a class library with C# and .NET Core in Visual Studio 2017](library-with-visual-studio-2017.md)
 
    A class library lets you define types and type members that can be called from another application. This topic lets you create a class library with a single method that determines whether a string begins with an uppercase character. Once you've finished building the library, you can develop a [unit test](testing-library-with-visual-studio.md) to ensure that it works as expected, and then you can make it available to [applications that want to consume it](consuming-library-with-visual-studio-2017.md).
 
@@ -33,10 +33,4 @@ The following topics are available:
    Visual Studio Code is a programming editor for Windows, Linux, and macOS that supports IntelliSense (code completion) and debugging.
 
    This topic shows you how to create and run a simple Hello World application with Visual Studio Code and .NET Core.
-
-- [Building a C# Hello World application with .NET Core in Visual Studio 2015](with-visual-studio.md)
-
-   Visual Studio 2015, like the later Visual Studio 2017 RC,  lets you code, compile, run, debug, profile, and publish your applications from a integrated development environment for Windows.
-
-   The topic lets you create and run an interactive Hello World application. Once you've finished building and running your application, you can also learn how to [debug it](.\debugging-with-visual-studio.md) and how to [publish it](.\publishing-with-visual-studio.md) so that it can be run on any platform supported by .NET Core.
-
+   

--- a/docs/csharp/getting-started/library-with-visual-studio-2017.md
+++ b/docs/csharp/getting-started/library-with-visual-studio-2017.md
@@ -1,5 +1,5 @@
 ---
-title: Building a class library with C# and .NET Core in Visual Studio 2017 RC
+title: Building a class library with C# and .NET Core in Visual Studio 2017
 description: Learn how to build a class library written in C# using Visual Studio 2017
 keywords: .NET Core, .NET Standard class library, Visual Studio 2017
 author: stevehoag
@@ -12,7 +12,7 @@ ms.devlang: csharp
 ms.assetid: c849ca26-6a25-4d35-9544-f343af88e0e7
 ---
 
-# Building a class library with C# and .NET Core in Visual Studio 2017 RC #
+# Building a class library with C# and .NET Core in Visual Studio 2017 #
 
 A class library defines types and methods that can be called from any application. A class library developed using .NET Core supports the .NET Standard Library, which allows your library to be called by any .NET platform that supports that version of the .NET Standard Library. When you finish your class library, you can decide whether you want to distribute it as a third-party component, or whether you want to include it as a component that is bundled with one or more applications.
 

--- a/docs/csharp/getting-started/publishing-with-visual-studio-2017.md
+++ b/docs/csharp/getting-started/publishing-with-visual-studio-2017.md
@@ -14,7 +14,7 @@ ms.assetid: a19545d3-24af-4a32-9778-cfb5ae938287
 
 # Publishing your Hello World application with Visual Studio 2017
 
-In [Building a C# Hello World application with .NET Core in Visual Studio 2017 RC](with-visual-studio-2017.md), you built your Hello World console application, and in [Debugging your C# Hello World application with Visual Studio 2017 RC](debugging-with-visual-studio-2017.md), you tested it using the Visual Studio debugger. Now that you're sure that it works as expected, you an publish it so that other users can run it. Publishing creates the set of files that are needed to run your application; you can deploy them by copying them to a target machine.
+In [Building a C# Hello World application with .NET Core in Visual Studio 2017](with-visual-studio-2017.md), you built your Hello World console application, and in [Debugging your C# Hello World application with Visual Studio 2017](debugging-with-visual-studio-2017.md), you tested it using the Visual Studio debugger. Now that you're sure that it works as expected, you an publish it so that other users can run it. Publishing creates the set of files that are needed to run your application; you can deploy them by copying them to a target machine.
 
 Publishing .NET Core console applications from Visual Studio has not yet been implemented in the RC release. It will be implemented in the final release of Visual Studio 2017.
 

--- a/docs/csharp/getting-started/testing-library-with-visual-studio.md
+++ b/docs/csharp/getting-started/testing-library-with-visual-studio.md
@@ -12,9 +12,9 @@ ms.devlang: csharp
 ms.assetid: 069ad711-3eaa-45c6-94d7-b40249cc8b99
 ---
 
-# Testing a class library with .NET Core in Visual Studio 2017 RC #
+# Testing a class library with .NET Core in Visual Studio 2017 #
 
-In [Building a class library with C# and .NET Core in Visual Studio 2017 RC](library-with-visual-studio-2017.md), we created a simple class library that adds an extension method to the @System.String class. Now, we'll create a unit test to make sure that it works as expected. We'll add our unit test project to the solution we created in the previous topic.
+In [Building a class library with C# and .NET Core in Visual Studio 2017](library-with-visual-studio-2017.md), we created a simple class library that adds an extension method to the @System.String class. Now, we'll create a unit test to make sure that it works as expected. We'll add our unit test project to the solution we created in the previous topic.
 
 ## Creating a unit test project ##
 

--- a/docs/csharp/getting-started/with-visual-studio-2017.md
+++ b/docs/csharp/getting-started/with-visual-studio-2017.md
@@ -1,5 +1,5 @@
 ---
-title: Building a C# Hello World Application with .NET Core in Visual Studio 2017 RC
+title: Building a C# Hello World Application with .NET Core in Visual Studio 2017
 description: Learn how to build a simple .NET Core console application using Visual Studio 2017
 keywords: .NET Core, .NET Core console application, Visual Studio 2017
 author: stevehoag
@@ -12,7 +12,7 @@ ms.devlang: csharp
 ms.assetid: 97aa50bf-bdf8-416d-a56c-ac77504c14ea
 ---
 
-# Building a C# Hello World application with .NET Core in Visual Studio 2017 RC #
+# Building a C# Hello World application with .NET Core in Visual Studio 2017 #
 
 This topic provides a step-by-step introduction to building, debugging, and publishing a simple .NET Core console application using Visual Studio 2017. Visual Studio 2017 provides a full-featured development environment for building .NET Core applications. As long as the application does not have any platform-specific dependencies, the application itself can run on any platform that .NET Core targets and on any system that has .NET Core installed.
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -25,9 +25,8 @@ In this topic, you'll learn the language rules governing Tuples in C# 7,
 different ways to use them, and initial guidance on working with Tuples.
 
 > [!NOTE]
-> The new tuples features require the `System.ValueTuple` type. For Visual Studio 2017
-> RC and earlier preview releases, you must add the NuGet package "System.ValueTuple",
-> available in the pre-release stream.
+> The new tuples features require the `System.ValueTuple` type. For Visual Studio 2017,
+> you must add the NuGet package "System.ValueTuple", available in the pre-release stream.
 
 Let's start with the reasons for adding new Tuple support. Methods return
 a single object. Tuples enable you to package multiple values in that single
@@ -99,7 +98,7 @@ the fields in the Tuple.
 
 > [!NOTE]
 > Development Tools, such as Visual Studio, also read that metadata,
-> and provide intellisense and other features using the metadata
+> and provide IntelliSense and other features using the metadata
 > field names.
 
 It is important to understand these underlying fundamentals of


### PR DESCRIPTION
# Removed RC from Visual Studio 2017 product name

## Summary

This PR modifies the 10 documents that included the string "Visual Studio 2017 RC". 

Fixes #1420 

## Details

I've also made assorted other changes in text that was closely coupled either to Visual Studio 2015 or Visual Studio 2017 RC.

## Suggested Reviewers

@mairaw 
