### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,5 +1,4 @@
 {
-    "need_generate_pdf": false,
     "need_generate_intellisense": false,
     "need_preview_pull_request": true,
     "need_pr_comments": false,


### PR DESCRIPTION
@saldana @dend removing deprecated value

Two questions:
1. If I have the branch_target_mapping set like this
```json
"branch_target_mapping":{ "live": ["Publish", "Pdf"]}
```
do I need the "need_generate_pdf_url_template": true or is that just redundant?

2. Do we need to generate the PDF for the master branch or should I remove that too from the branch_target_mapping setting?

thanks!