### PR TITLE
Fix for MSBuild Error MSB1003

### DIFF
--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -101,6 +101,9 @@ The template creates eight files for you:
 * A web.config file. This contains basic configuration information.
 * A Properties/launchSettings.json file. This contains debugging settings used by IDEs.
 
+Run following command to create "proj" file.
+`dotnet migrate`
+
 Now you can run the template generated application. That's done using a series
 of tools from the command line. The `dotnet` command runs the tools necessary
 for .NET development. Each verb executes a different command


### PR DESCRIPTION
To build and run .NET core application, the proj file is required. So, prior to ‘dotnet restore’, ‘dotnet migrate’ command has to be executed.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
