### PR TITLE
Updated netcore version to 2.0 in netstandard implementation table

### DIFF
--- a/docs/standard/library.md
+++ b/docs/standard/library.md
@@ -31,7 +31,7 @@ You can see the complete set of .NET runtimes that support the .NET Standard Lib
 | Platform Name | Alias |  |  |  |  |  | | | |
 | :---------- | :--------- |:--------- |:--------- |:--------- |:--------- |:--------- |:--------- |:--------- |:--------- |
 |.NET Standard | netstandard | 1.0 | 1.1 | 1.2 | 1.3 | 1.4 | 1.5 | 1.6 | 2.0 |
-|.NET Core|netcoreapp|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|1.0|vNext|
+|.NET Core|netcoreapp|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|1.0|2.0|
 |.NET Framework|net|&rarr;|4.5|4.5.1|4.6|4.6.1|4.6.2|vNext|4.6.1|
 |Mono/Xamarin Platforms||&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|&rarr;|vNext|
 |Universal Windows Platform|uap|&rarr;|&rarr;|&rarr;|&rarr;|10.0|&rarr;|&rarr;|vNext|


### PR DESCRIPTION
Updated to show .NET Core 2.0 as implementation/runtime for .NET Standard 2.0 since this documentation page is commonly used as source of truth for versions.