### PR TITLE
removing caps link

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/subsystemversion.md
+++ b/docs/visual-basic/reference/command-line-compiler/subsystemversion.md
@@ -1,13 +1,11 @@
 ---
 title: "-subsystemversion (Visual Basic) | Microsoft Docs"
-
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 helpviewer_keywords: 
   - "/subsystemversion compiler option [Visual Basic]"
@@ -17,7 +15,6 @@ ms.assetid: 08be22b2-f447-4cd3-8203-120b1b920b54
 caps.latest.revision: 9
 author: "stevehoag"
 ms.author: "shoag"
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -86,4 +83,4 @@ Specifies the minimum version of the subsystem on which the generated executable
   
 ## See Also  
  [Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)
- [MSBuild Properties](https://www.microsoftonedoc.com/#/organizations/e6f6a65cf14f462597b64ac058dbe1d0/projects/3fedad16-eaf1-41a6-8f96-0c1949c68f32/containers/a3daf831-1c5f-4bbe-964d-503870caf874/tocpaths/ee3538c5-0d7d-4c18-a1d7-edf460cd1c8a/locales/en-US)
+ [MSBuild Properties](https://docs.microsoft.com/visualstudio/msbuild/msbuild-properties)

--- a/docs/visual-basic/reference/command-line-compiler/subsystemversion.md
+++ b/docs/visual-basic/reference/command-line-compiler/subsystemversion.md
@@ -82,5 +82,6 @@ Specifies the minimum version of the subsystem on which the generated executable
 
   
 ## See Also  
- [Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)
- [MSBuild Properties](https://docs.microsoft.com/visualstudio/msbuild/msbuild-properties)
+[Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)
+
+[MSBuild Properties](https://docs.microsoft.com/visualstudio/msbuild/msbuild-properties)


### PR DESCRIPTION
Not sure why this link when migrated kept a link to the topic in CAPS