### PR TITLE
Newer version of dotnet based on install doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
     - os: linux # Ubuntu 14.04
       dist: trusty
       sudo: required
-      dotnet: 1.0.0-preview2-003121
+      dotnet: 1.0.0-preview2.1-003177
     - os: osx # OSX 10.11
       osx_image: xcode7.2
-      dotnet: 1.0.0-preview2-003121
+      dotnet: 1.0.0-preview2.1-003177
 
 script:
   # Run a new console app

--- a/docs/core/tools/using-ci-with-cli.md
+++ b/docs/core/tools/using-ci-with-cli.md
@@ -74,7 +74,7 @@ The [travis-ci](https://travis-ci.org/) can be configured to install the .NET Co
 Just use:
 
 ```yaml
-dotnet: 1.0.0-preview2-003121
+dotnet: 1.0.0-preview2.1-003177
 ```
 
 Travis can run both `osx` (OS X 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/docs/blob/master/.travis.yml) 


### PR DESCRIPTION
# Title

Using version from [install docs](https://www.microsoft.com/net/core#linuxubuntu)

## Summary

Since the install documentation references a newer version of dotnet, it could be helpful to use that in this documentation as well, in order to lead people on the right path.

## Suggested Reviewers

@enricosada 