### PR TITLE
Added a missing bracket in a code example

### DIFF
--- a/docs/standard/native-interop.md
+++ b/docs/standard/native-interop.md
@@ -269,7 +269,7 @@ The reason marshalling is needed is because the types in the managed and unmanag
 
 ```cs
 [DllImport("somenativelibrary.dll"]
-static extern int MethodA([MarshalAs(UnmanagedType.LPStr) string parameter);
+static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);
 
 ```
 


### PR DESCRIPTION
Added a missing bracket in a code example (@docs/standard/native-interop.md). The parameter attribute was missing the closing bracket.

    static extern int MethodA([MarshalAs(UnmanagedType.LPStr) string parameter);

Changed to:

    static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);