### PR TITLE
Changing some docs for RC3

### DIFF
--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -108,16 +108,7 @@ Deploying a framework-dependent deployment with one or more third-party dependen
 
     ```xml
       <ItemGroup>
-        <PackageReference Include="Microsoft.NETCore.App">
-          <Version>1.0.1</Version>
-        </PackageReference>
-        <PackageReference Include="Newtonsoft.Json">
-          <Version>9.0.1</Version>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Sdk">
-          <Version>1.0.0-alpha-20161102-2</Version>
-          <PrivateAssets>All</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
       </ItemGroup>
     ```
 
@@ -223,8 +214,7 @@ The published files can be deployed in any way you'd like. For example, you can 
 The following is the complete `csproj` file for this project.
 
 ```xml
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -232,24 +222,6 @@ The following is the complete `csproj` file for this project.
     <DebugType>Portable</DebugType>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161102-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
 ```
 
@@ -262,16 +234,7 @@ Deploying a self-contained deployment with one or more third-party dependencies 
 
     ```xml
       <ItemGroup>
-        <PackageReference Include="Microsoft.NETCore.App">
-          <Version>1.0.1</Version>
-        </PackageReference>
-        <PackageReference Include="Microsoft.NET.Sdk">
-          <Version>1.0.0-alpha-20161102-2</Version>
-          <PrivateAssets>All</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="Newtonsoft.Json">
-          <Version>9.0.1</Version>
-        </PackageReference>
+        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
       </ItemGroup>
     ```
 2. If you haven't already, download the NuGet package containing the third-party dependency to your system. To make the dependency available to your app, execute the `dotnet restore` command after adding the dependency. Because the dependency is resolved out of the local NuGet cache at publish time, it must be available on your system.
@@ -279,9 +242,8 @@ Deploying a self-contained deployment with one or more third-party dependencies 
 The following is the complete csproj file for this project:
 
 ```xml
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  <PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+\  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
@@ -289,23 +251,8 @@ The following is the complete csproj file for this project:
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161102-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
 ```
 
@@ -328,23 +275,12 @@ This operation indicates that, instead of using the entire `netcoreapp1.0` frame
 
 2. Replace the `<ItemGroup>` containing package references with the following:
 
-    ```xml
-    <ItemGroup>
-      <PackageReference Include="NETSTandard.Library">
-        <Version>1.6.0</Version>
-      </PackageReference>
-      <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-        <Version>1.0.2</Version>
-      </PackageReference>
-      <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">
-        <Version>1.0.1</Version>
-      </PackageReference>
-      <PackageReference Include="Microsoft.NET.Sdk">
-        <Version>1.0.0-alpha-20161102-2</Version>
-        <PrivateAssets>All</PrivateAssets>
-      </PackageReference>
-    </ItemGroup>
-  ```
+  ```xml
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.1" />
+  </ItemGroup>
+```
 
    This defines the system components used by our app. The system components packaged with our app include the .NET Standard Library, the .NET Core runtime, and the .NET Core host. This produces a self-contained deployment with a smaller footprint.
 
@@ -383,8 +319,7 @@ The published files can be deployed in any way you'd like. For example, you can 
 The following is the complete `csproj` file for this project.
 
 ```xml
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -393,26 +328,9 @@ The following is the complete `csproj` file for this project.
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
+    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.2" />
+    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.1" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="NETSTandard.Library">
-      <Version>1.6.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161102-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
 ```
 

--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -191,15 +191,7 @@ Note that you also need to add a semicolon to separate the RIDs. Also, please no
 
 4. Run the `dotnet restore` command to restore the dependencies specified in your project.
 
-5. Create debug builds of your app on each of the target platforms by using the `dotnet build` command. Unless you specify the runtime identifier you'd like to build, the `dotnet build` command creates a build only for the current system's runtime ID. You can build your app for both target platforms with the commands:
-
-    ```console
-    dotnet build -r win10-x64
-    dotnet build -r osx.10.11-x64
-    ```
-The debug builds of your app for each platform will be found in the project's `.\bin\Debug\netcoreapp1.0\<runtime_identifier>` subdirectory.
-
-6. After you've debugged and tested the program, you can create the files to be deployed with your app for each platform that it targets by using the `dotnet publish` command for both target platforms as follows:
+5. After you've debugged and tested the program, you can create the files to be deployed with your app for each platform that it targets by using the `dotnet publish` command for both target platforms as follows:
 
    ```console
    dotnet publish -c release -r win10-x64
@@ -207,7 +199,7 @@ The debug builds of your app for each platform will be found in the project's `.
    ```
 This creates a release (rather than a debug) version of your app for each target platform. The resulting files are placed in a subdirectory named `publish` that is in a subdirectory of your project's `.\bin\release\netcoreapp1.0\<runtime_identifier>` subdirectory. Note that each subdirectory contains the complete set of files (both your app files and all .NET Core files) needed to launch your app.
 
-7. Along with your application's files, the publishing process emits a program database (.pdb) file that contains debugging information about your app. The file is useful primarily for debugging exceptions; you can choose not to package it with your application's files.
+6. Along with your application's files, the publishing process emits a program database (.pdb) file that contains debugging information about your app. The file is useful primarily for debugging exceptions; you can choose not to package it with your application's files.
 
 The published files can be deployed in any way you'd like. For example, you can package them in a zip file, use a simple `copy` command, or deploy them with any installation package of your choice. 
 
@@ -243,7 +235,7 @@ The following is the complete csproj file for this project:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
-\  <PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <VersionPrefix>1.0.0</VersionPrefix>
@@ -297,14 +289,7 @@ This operation indicates that, instead of using the entire `netcoreapp1.0` frame
 
 4. Run the `dotnet restore` command to restore the dependencies specified in your project.
 
-5. Create debug builds of your app on each of the target platforms by using the `dotnet build` command. Unless you specify the runtime identifier you'd like to build, the `dotnet build` command creates a build only for the current system's runtime ID. You can build your app for both target platforms with the commands:
-
-    ```console
-    dotnet build -r win10-x64
-    dotnet build -r osx.10.11-x64
-    ```
-
-6. After you've debugged and tested the program, you can create the files to be deployed with your app for each platform that it targets by using the `dotnet publish` command for both target platforms as follows:
+5. After you've debugged and tested the program, you can create the files to be deployed with your app for each platform that it targets by using the `dotnet publish` command for both target platforms as follows:
 
    ```console
    dotnet publish -c release -r win10-x64
@@ -312,7 +297,7 @@ This operation indicates that, instead of using the entire `netcoreapp1.0` frame
    ```
 This creates a release (rather than a debug) version of your app for each target platform. The resulting files are placed in a subdirectory named `publish` that is in a subdirectory of your project's `.\bin\release\netstandard1.6\<runtime_identifier>` subdirectory. Note that each subdirectory contains the complete set of files (both your app files and all .NET Core files) needed to launch your app.
 
-7. Along with your application's files, the publishing process emits a program database (.pdb) file that contains debugging information about your app. The file is useful primarily for debugging exceptions; you can choose not to package it with your application's files.
+6. Along with your application's files, the publishing process emits a program database (.pdb) file that contains debugging information about your app. The file is useful primarily for debugging exceptions; you can choose not to package it with your application's files.
 
 The published files can be deployed in any way you'd like. For example, you can package them in a zip file, use a simple `copy` command, or deploy them with any installation package of your choice. 
 

--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -4,7 +4,7 @@ description: .NET Core Application Deployment
 keywords: .NET, .NET Core, .NET Core deployment
 author: rpetrusha
 ms.author: ronpet
-ms.date: 11/13/2016
+ms.date: 07/02/2017
 ms.topic: article
 ms.prod: .net-core
 ms.devlang: dotnet

--- a/docs/core/preview3/tools/csproj.md
+++ b/docs/core/preview3/tools/csproj.md
@@ -25,81 +25,103 @@ see [the MSBuild project file](https://docs.microsoft.com/visualstudio/msbuild/m
 Specifies a NuGet dependency in the project. The `Include` attribute specifies the package ID. 
 
 ```xml
-<PackageReference Include="<package-id>">
-    <Version></Version>
-    <PrivateAssets></PrivateAssets>
-    <IncludeAssets></IncludeAssets>
-    <ExcludeAssets></ExcludeAssets>
-</PackageReference>
+<PackageReference Include="<package-id>" Version="" PrivateAssets="" IncludeAssets="" ExcludeAssets="" />
 ```
 
 #### Version
 `<Version>` specifies the version of the package to restore. The element respects the rules of the NuGet versioning scheme.
 
 #### IncludeAssets
-`<IncludeAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should be 
+`<IncludeAssets>` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
 consumed. 
 
-The element can contain one or more of the following values:
+The attribute can contain one or more of the following values:
 
-* Compile – the contents of the lib folder are available to compile against.
-* Runtime – the contents of the runtime folder are distributed.
-* ContentFiles – the contents of the contentfiles folder are used.
-* Build – the props/targets in the build folder are used.
-* Native – the contents from native assets are copied to the output folder for runtime.
-* Analyzers – the analyzers are used.
+* `Compile` – the contents of the lib folder are available to compile against.
+* `Runtime` – the contents of the runtime folder are distributed.
+* `ContentFiles` – the contents of the contentfiles folder are used.
+* `Build` – the props/targets in the build folder are used.
+* `Native` – the contents from native assets are copied to the output folder for runtime.
+* `Analyzers` – the analyzers are used.
 
-Alternatively, the element can contain:
+Alternatively, the attribute can contain:
 
-* None – none of the assets are used.
-* All – all assets are used.
+* `None` – none of the assets are used.
+* `All` – all assets are used.
 
 #### ExcludeAssets
-`<ExcludeAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should not 
+`<ExcludeAssets>` attribute specifies what assets belonging to the package specified by `<PackageReference>` should not 
 be consumed.
 
-The element can contain one or more of the following values:
+The attribute can contain one or more of the following values:
 
-* Compile – the contents of the lib folder are available to compile against.
-* Runtime – the contents of the runtime folder are distributed.
-* ContentFiles – the contents of the contentfiles folder are used.
-* Build – the props/targets in the build folder are used.
-* Native – the contents from native assets are copied to the output folder for runtime.
-* Analyzers – the analyzers are used.
+* `Compile` – the contents of the lib folder are available to compile against.
+* `Runtime` – the contents of the runtime folder are distributed.
+* `ContentFiles` – the contents of the contentfiles folder are used.
+* `Build` – the props/targets in the build folder are used.
+* `Native` – the contents from native assets are copied to the output folder for runtime.
+* `Analyzers` – the analyzers are used.
 
 Alternatively, the element can contain:
 
-* None – none of the assets are used.
-* All – all assets are used.
+* `None` – none of the assets are used.
+* `All` – all assets are used.
 
 #### PrivateAssets
-`<PrivateAssets>` child element specifies what assets belonging to the package specified by parent `<PackageReference>` should be 
+`<PrivateAssets>` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
 consumed but that they should not flow to the next project. 
 
 > [!NOTE]
 > This is a new term for project.json/xproj `SuppressParent` element. 
 
-The element can contain one or more of the following values:
+The attribute can contain one or more of the following values:
 
-* Compile – the contents of the lib folder are available to compile against.
-* Runtime – the contents of the runtime folder are distributed.
-* ContentFiles – the contents of the contentfiles folder are used.
-* Build – the props/targets in the build folder are used.
-* Native – the contents from native assets are copied to the output folder for runtime.
-* Analyzers – the analyzers are used.
+* `Compile` – the contents of the lib folder are available to compile against.
+* `Runtime` – the contents of the runtime folder are distributed.
+* `ContentFiles` – the contents of the contentfiles folder are used.
+* `Build` – the props/targets in the build folder are used.
+* `Native` – the contents from native assets are copied to the output folder for runtime.
+* `Analyzers` – the analyzers are used.
 
-Alternatively, the element can contain:
+Alternatively, the attribute can contain:
 
-* None – none of the assets are used.
-* All – all assets are used.
+* `None` – none of the assets are used.
+* `All` – all assets are used.
 
 ### DotnetCliToolReference
 `<DotnetCliToolReference>` element specifies the CLI tool that the user wants restores in the context of the project. It is 
 a replacement for the `tools` node in `project.json`. 
 
+```xml
+<DotnetCliToolReference Include="<package-id>" Version="" />
+```
+
 #### Version
-`<Version>` specifies the version of the package to restore. The element respect the rules of the NuGet versioning scheme.
+`<Version>` specifies the version of the package to restore. The attribute respect the rules of the NuGet versioning scheme.
 
 ### RuntimeIdentifiers
 The `<RuntimeIdentifiers>` element lets you specify a semicolon-delimited list of [Runtime Identifiers (RIDs)](../../rid-catalog.md) for the project. 
-RIDs enable publishing self-contained deployments. 
+RIDs enable publishing a self-contained deployments. 
+
+
+### RuntimeIdentifier
+The `<RuntieIdentifier>` elements allows you to specify only one [Runtime Identifier (RID)](../../rid-catalog.md) for the project. RIDs enable publishing a self-contained deployment. 
+
+### PackageTargetFallback 
+The `<PackageTargetFallback>` property allows you to specify a set of compatible targets to be used when restoring packages. They are designed to allow packages that use the dotnet TxM to operate with packages that don't declare a dotnet TxM. If your project is using the dotnet TxM then all the packages you depend on must also have a dotnet TxM, unless you add the `<PackageTargetFallback>` to your project in order to allow non dotnet platforms to be compatible with dotnet. 
+
+Below is an example of providing the fallbacks for all of the targets in your project: 
+
+```xml
+<PackageTargetFallback>
+    $(PackageTargetFallback);portable-net45+win8+wpa81+wp8
+</PackageTargetFallback >
+```
+
+This example specifies the fallbacks only for `netcoreapp1.0` target:
+
+```xml
+<PackageTargetFallback Condition="'$(TargetFramework)'=='netcoreapp1.0'">
+    $(PackageTargetFallback);portable-net45+win8+wpa81+wp8
+</PackageTargetFallback >
+```

--- a/docs/core/preview3/tools/csproj.md
+++ b/docs/core/preview3/tools/csproj.md
@@ -4,7 +4,7 @@ description: Learn about the differences between existing and .NET Core csproj f
 keywords: reference, csproj, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/12/2016
+ms.date: 07/02/2017
 ms.topic: article
 ms.prod: .net-core
 ms.devlang: dotnet
@@ -21,17 +21,17 @@ see [the MSBuild project file](https://docs.microsoft.com/visualstudio/msbuild/m
 
 ## Additions
 
-### PackageReference
+* PackageReference
 Item that specifies a NuGet dependency in the project. The `Include` attribute specifies the package ID. 
 
 ```xml
 <PackageReference Include="<package-id>" Version="" PrivateAssets="" IncludeAssets="" ExcludeAssets="" />
 ```
 
-#### Version
+*# Version
 `Version` specifies the version of the package to restore. The element respects the rules of the NuGet versioning scheme.
 
-#### IncludeAssets
+*# IncludeAssets
 `IncludeAssets` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
 consumed. 
 
@@ -49,7 +49,7 @@ Alternatively, the attribute can contain:
 * `None` – none of the assets are used.
 * `All` – all assets are used.
 
-#### ExcludeAssets
+*# ExcludeAssets
 `ExcludeAssets` attribute specifies what assets belonging to the package specified by `<PackageReference>` should not 
 be consumed.
 
@@ -67,7 +67,7 @@ Alternatively, the element can contain:
 * `None` – none of the assets are used.
 * `All` – all assets are used.
 
-#### PrivateAssets
+*# PrivateAssets
 `PrivateAssets` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
 consumed but that they should not flow to the next project. 
 
@@ -88,7 +88,7 @@ Alternatively, the attribute can contain:
 * `None` – none of the assets are used.
 * `All` – all assets are used.
 
-### DotnetCliToolReference
+* DotnetCliToolReference
 `<DotnetCliToolReference>` item element specifies the CLI tool that the user wants to restore in the context of the project. It is 
 a replacement for the `tools` node in `project.json`. 
 
@@ -96,10 +96,10 @@ a replacement for the `tools` node in `project.json`.
 <DotnetCliToolReference Include="<package-id>" Version="" />
 ```
 
-#### Version
+*# Version
 `Version` specifies the version of the package to restore. The attribute respect the rules of the NuGet versioning scheme.
 
-### RuntimeIdentifiers
+* RuntimeIdentifiers
 The `<RuntimeIdentifiers>` element lets you specify a semicolon-delimited list of [Runtime Identifiers (RIDs)](../../rid-catalog.md) for the project. 
 RIDs enable publishing a self-contained deployments. 
 
@@ -108,7 +108,7 @@ RIDs enable publishing a self-contained deployments.
 ```
 
 
-### RuntimeIdentifier
+* RuntimeIdentifier
 The `<RuntieIdentifier>` element allows you to specify only one [Runtime Identifier (RID)](../../rid-catalog.md) for the project. RIDs enable publishing a self-contained deployment. 
 
 ```xml
@@ -116,7 +116,7 @@ The `<RuntieIdentifier>` element allows you to specify only one [Runtime Identif
 ```
 
 
-### PackageTargetFallback 
+* PackageTargetFallback 
 The `<PackageTargetFallback>` element allows you to specify a set of compatible targets to be used when restoring packages. It is designed to allow packages that use the dotnet TxM to operate with packages that don't declare a dotnet TxM. If your project uses the dotnet TxM then all the packages you depend on must also have a dotnet TxM, unless you add the `<PackageTargetFallback>` to your project in order to allow non dotnet platforms to be compatible with dotnet. 
 
 The following example provides the fallbacks for all targets in your project: 
@@ -138,32 +138,32 @@ The following example specifies the fallbacks only for the `netcoreapp1.0` targe
 ## NuGet metadata properties
 With the move to MSbuild, we have moved the input metadata that is used when packing a NuGet package from project.json to csproj files. The inputs are MSBuild properties. The following is the list of properties that are used as inputs to the packing process when using the `dotnet pack` command or the `Pack` MSBuild target that is part of the SDK. 
 
-### IsPackable
-### PackageVersion
-### PackageId
-### Title
-### Authors
-### Description
-### Copyright
-### PackageRequireLicenseAcceptance
-### PackageLicenseUrl
-### PackageProjectUrl
-### PackageIconUrl
-### PackageReleaseNotes
-### PackageTags
-### PackageOutputPath
-### IncludeSymbols
-### IncludeSource
-### PackageTypes
-### IsTool
-### RepositoryUrl
-### RepositoryType
-### NoPackageAnalysis
-### MinClientVersion
-### IncludeBuildOutput
-### IncludeContentInPack
-### BuildOutputTargetFolder
-### ContentTargetFolders
-### NuspecFile
-### NuspecBasePath
-### NuspecProperties
+* IsPackable
+* PackageVersion
+* PackageId
+* Title
+* Authors
+* Description
+* Copyright
+* PackageRequireLicenseAcceptance
+* PackageLicenseUrl
+* PackageProjectUrl
+* PackageIconUrl
+* PackageReleaseNotes
+* PackageTags
+* PackageOutputPath
+* IncludeSymbols
+* IncludeSource
+* PackageTypes
+* IsTool
+* RepositoryUrl
+* RepositoryType
+* NoPackageAnalysis
+* MinClientVersion
+* IncludeBuildOutput
+* IncludeContentInPack
+* BuildOutputTargetFolder
+* ContentTargetFolders
+* NuspecFile
+* NuspecBasePath
+* NuspecProperties

--- a/docs/core/preview3/tools/csproj.md
+++ b/docs/core/preview3/tools/csproj.md
@@ -22,17 +22,17 @@ see [the MSBuild project file](https://docs.microsoft.com/visualstudio/msbuild/m
 ## Additions
 
 ### PackageReference
-Specifies a NuGet dependency in the project. The `Include` attribute specifies the package ID. 
+Item that specifies a NuGet dependency in the project. The `Include` attribute specifies the package ID. 
 
 ```xml
 <PackageReference Include="<package-id>" Version="" PrivateAssets="" IncludeAssets="" ExcludeAssets="" />
 ```
 
 #### Version
-`<Version>` specifies the version of the package to restore. The element respects the rules of the NuGet versioning scheme.
+`Version` specifies the version of the package to restore. The element respects the rules of the NuGet versioning scheme.
 
 #### IncludeAssets
-`<IncludeAssets>` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
+`IncludeAssets` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
 consumed. 
 
 The attribute can contain one or more of the following values:
@@ -50,7 +50,7 @@ Alternatively, the attribute can contain:
 * `All` – all assets are used.
 
 #### ExcludeAssets
-`<ExcludeAssets>` attribute specifies what assets belonging to the package specified by `<PackageReference>` should not 
+`ExcludeAssets` attribute specifies what assets belonging to the package specified by `<PackageReference>` should not 
 be consumed.
 
 The attribute can contain one or more of the following values:
@@ -68,7 +68,7 @@ Alternatively, the element can contain:
 * `All` – all assets are used.
 
 #### PrivateAssets
-`<PrivateAssets>` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
+`PrivateAssets` attribute specifies what assets belonging to the package specified by `<PackageReference>` should be 
 consumed but that they should not flow to the next project. 
 
 > [!NOTE]
@@ -89,7 +89,7 @@ Alternatively, the attribute can contain:
 * `All` – all assets are used.
 
 ### DotnetCliToolReference
-`<DotnetCliToolReference>` element specifies the CLI tool that the user wants restores in the context of the project. It is 
+`<DotnetCliToolReference>` item element specifies the CLI tool that the user wants to restore in the context of the project. It is 
 a replacement for the `tools` node in `project.json`. 
 
 ```xml
@@ -97,20 +97,29 @@ a replacement for the `tools` node in `project.json`.
 ```
 
 #### Version
-`<Version>` specifies the version of the package to restore. The attribute respect the rules of the NuGet versioning scheme.
+`Version` specifies the version of the package to restore. The attribute respect the rules of the NuGet versioning scheme.
 
 ### RuntimeIdentifiers
 The `<RuntimeIdentifiers>` element lets you specify a semicolon-delimited list of [Runtime Identifiers (RIDs)](../../rid-catalog.md) for the project. 
 RIDs enable publishing a self-contained deployments. 
 
+```xml
+<RuntimeIdentifiers>win10-x64;osx.10.11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
+```
+
 
 ### RuntimeIdentifier
-The `<RuntieIdentifier>` elements allows you to specify only one [Runtime Identifier (RID)](../../rid-catalog.md) for the project. RIDs enable publishing a self-contained deployment. 
+The `<RuntieIdentifier>` element allows you to specify only one [Runtime Identifier (RID)](../../rid-catalog.md) for the project. RIDs enable publishing a self-contained deployment. 
+
+```xml
+<RuntimeIdentifier>ubuntu.16.04-x64</RuntimeIdentifier>
+```
+
 
 ### PackageTargetFallback 
-The `<PackageTargetFallback>` property allows you to specify a set of compatible targets to be used when restoring packages. They are designed to allow packages that use the dotnet TxM to operate with packages that don't declare a dotnet TxM. If your project is using the dotnet TxM then all the packages you depend on must also have a dotnet TxM, unless you add the `<PackageTargetFallback>` to your project in order to allow non dotnet platforms to be compatible with dotnet. 
+The `<PackageTargetFallback>` element allows you to specify a set of compatible targets to be used when restoring packages. It is designed to allow packages that use the dotnet TxM to operate with packages that don't declare a dotnet TxM. If your project uses the dotnet TxM then all the packages you depend on must also have a dotnet TxM, unless you add the `<PackageTargetFallback>` to your project in order to allow non dotnet platforms to be compatible with dotnet. 
 
-Below is an example of providing the fallbacks for all of the targets in your project: 
+The following example provides the fallbacks for all targets in your project: 
 
 ```xml
 <PackageTargetFallback>
@@ -118,10 +127,43 @@ Below is an example of providing the fallbacks for all of the targets in your pr
 </PackageTargetFallback >
 ```
 
-This example specifies the fallbacks only for `netcoreapp1.0` target:
+The following example specifies the fallbacks only for the `netcoreapp1.0` target:
 
 ```xml
 <PackageTargetFallback Condition="'$(TargetFramework)'=='netcoreapp1.0'">
     $(PackageTargetFallback);portable-net45+win8+wpa81+wp8
 </PackageTargetFallback >
 ```
+
+## NuGet metadata properties
+With the move to MSbuild, we have moved the input metadata that is used when packing a NuGet package from project.json to csproj files. The inputs are MSBuild properties. The following is the list of properties that are used as inputs to the packing process when using the `dotnet pack` command or the `Pack` MSBuild target that is part of the SDK. 
+
+### IsPackable
+### PackageVersion
+### PackageId
+### Title
+### Authors
+### Description
+### Copyright
+### PackageRequireLicenseAcceptance
+### PackageLicenseUrl
+### PackageProjectUrl
+### PackageIconUrl
+### PackageReleaseNotes
+### PackageTags
+### PackageOutputPath
+### IncludeSymbols
+### IncludeSource
+### PackageTypes
+### IsTool
+### RepositoryUrl
+### RepositoryType
+### NoPackageAnalysis
+### MinClientVersion
+### IncludeBuildOutput
+### IncludeContentInPack
+### BuildOutputTargetFolder
+### ContentTargetFolders
+### NuspecFile
+### NuspecBasePath
+### NuspecProperties

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -24,9 +24,7 @@ This document describes the new reference type. It also shows how to add a packa
 The `<PackageReference>` has the following basic structure:
 
 ```xml
-<PackageReference Include="PACKAGE_ID">
-    <Version>PACKAGE_VERSION</Version>
-</PackageReference>
+<PackageReference Include="PACKAGE_ID" Version="PACKAGE_VERSION" />
 ```
 
 If you are familiar with MSBuild, it will look familiar to the other reference types that already exist. The key is the `Include` statement which specifies the package id that you wish to add to the project. The `<Version>` child element specifies the version to get. The versions are specified as per [NuGet version rules](https://docs.microsoft.com/nuget/create-packages/dependency-versions#version-ranges).
@@ -37,9 +35,7 @@ If you are familiar with MSBuild, it will look familiar to the other reference t
 Adding a dependency that is available only in a specific target is done using conditions like in the following example:
 
 ```xml
-<PackageReference Include="PACKAGE_ID" Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
-    <Version>PACKAGE_VERSION</Version>
-</PackageReference>
+<PackageReference Include="PACKAGE_ID" Version="PACKAGE_VERSION" Condition="'$(TargetFramework)' == 'netcoreapp1.0'" />
 ```
 
 The above means that the dependency will only be valid if the build is happening for that given target. The `$(TargetFramework)` in the condition is a MSBuild property that is being set in the project. For most common .NET Core applications, you will not need to do this. 
@@ -52,42 +48,22 @@ When you open your project file, you will see two or more `<ItemGroup>` nodes. Y
 In this example we will use the default template that is dropped by `dotnet new`. This is a simple console application. When we open up the project, we first find the `<ItemGroup>` with already existing `<PackageReference>` in it. We then add the following to it:
 
 ```xml
-<PackageReference Include="Newtonsoft.Json">
-    <Version>9.0.1</Version>
-</PackageReference>
+<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
 ```
 After this, we save the project and run the `dotnet restore` command to install the dependency. 
 
 The full project looks like this:
 
 ```xml
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
-  
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-        <Version>9.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
 ```
 

--- a/docs/core/preview3/tools/dotnet-clean.md
+++ b/docs/core/preview3/tools/dotnet-clean.md
@@ -15,7 +15,7 @@ ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
 #dotnet-clean
 
 > [!WARNING]
-> This topic applies to Visual Studio 2017 RC - .NET Core Tools TODO:addtoolingstring 
+> This topic applies to Visual Studio 2017 RC - .NET Core Tools RC3 
 
 ## Name 
 `dotnet-clean` -- Cleans the output of a project. 

--- a/docs/core/preview3/tools/dotnet-clean.md
+++ b/docs/core/preview3/tools/dotnet-clean.md
@@ -1,0 +1,63 @@
+---
+title: dotnet-clean command | Microsoft Docs
+description: The dotnet-clean command cleans the current directory.
+keywords: dotnet-clean, CLI, CLI command, .NET Core
+author: blackdwarf
+ms.author: mairaw
+ms.date: 01/31/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
+---
+
+#dotnet-clean
+
+> [!WARNING]
+> This topic applies to Visual Studio 2017 RC - .NET Core Tools TODO:addtoolingstring 
+
+## Name 
+`dotnet-clean` -- Cleans the output of a project. 
+
+## Synopsis
+
+`dotnet clean [--help] [--output]  [--framework]  
+    [--configuration]  [--verbosity]
+    [<project>]`
+
+## Description
+The `dotnet clean` command will clean the output of the previous build. It is implemented as an MSBuild target, so the project will get evaluated. Only the outputs that were created during the build are cleaned. Both intermediate (`obj`) and final output (`bin`) folders are cleaned. 
+
+## Options
+
+`-h|--help`
+
+Prints out a short help for the command.  
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Directory in which the built binaries were placed. You also need to define `--framework` when you specify this option. If you didn't specify this property during build time, you don't have to specify it for clean.
+
+`-f|--framework <FRAMEWORK>`
+
+The framework that was specified at build time. If you didn't specify this property during build time, you don't have to specify it for clean. The framework needs to be defined in the [project file](csproj.md).
+
+`-c|--configuration [Debug|Release]`
+
+Defines a configuration under which the build was running.  If omitted, it defaults to `Debug`. If you didn't specify this property during build time, you don't have to specify it for clean.
+
+`-v|--verbosity [Quiet|Minimal|Normal|Diag]`
+
+Defines verbosity to use for the invocation of the `dotnet clean` command. The verbosity levels are standard [MSBuild verbosity levels](https://msdn.microsoft.com/en-us/library/ms164311.aspx). 
+
+
+## Examples
+
+Clean a default build of the project:
+
+`dotnet clean`
+
+Clean a project built using the Release configuration:
+
+`dotnet clean --configuration Release`

--- a/docs/core/preview3/tools/extensibility.md
+++ b/docs/core/preview3/tools/extensibility.md
@@ -113,7 +113,7 @@ The sample target's project file is included below for reference. It shows how t
     <EmbeddedResource Include="Resources\Pkg\dist-template.xml;compiler\resources\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <None Include="build\SampleTargets.PackerTarget.targets" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Label="dotnet pack instructions">
     <Content Include="build\*.targets;$(OutputPath)\*.dll;$(OutputPath)\*.json">
       <Pack>true</Pack>
       <PackagePath>build\</PackagePath>

--- a/docs/core/preview3/tools/extensibility.md
+++ b/docs/core/preview3/tools/extensibility.md
@@ -4,7 +4,7 @@ description: .NET Core CLI extensibility model
 keywords: CLI, extensibility, custom commands, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 11/13/2016
+ms.date: 02/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -58,35 +58,16 @@ API, here is a console application's project file that uses that tool:
 
 
 ```xml
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1/TargetFramework>
-    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <EmbeddedResource Include="**\*.resx" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.1.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161102-2</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <!-- The tools reference -->
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-api-search">
-      <Version></Version>
-    </DotNetCliToolReference>
+    <DotNetCliToolReference Include="dotnet-api-search" Version="1.0.0" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
 ```
 
@@ -99,23 +80,8 @@ your code, information about its dependencies and so on. The package name can be
 application inside, the actual tool binary, has to conform to the convention of `dotnet-<command>` in order for `dotnet` 
 to be able to invoke it. 
 
-In RC3 bits, the `dotnet pack` command will not pack the `runtimeconfig.json` file that is needed to run the tool. In order to package this file, you have two options:
-
-1. Create a `nuspec` file and use `dotnet nuget pack` command newly available to RC3 CLI to include the file
-2. Use the new `<Content>` element in an `<ItemGroup>` in your project file to include the file manually
-
-Working with nuspec files is beyond the scope of this article, however you can find a lot of good information in the [official NuGet docs](https://docs.microsoft.com/nuget/create-packages/creating-a-package#the-role-and-structure-of-the-nuspec-file). If you decide on the second approach, you can see the example `csproj` file and how it is configured below:
-
-```xml
-  <ItemGroup>
-    <Content Include="$(OutputPath)\*.runtimeconfig.json">
-      <Pack>true</Pack>
-      <PackagePath>lib\$(TargetFramework)</PackagePath>
-    </Content>
-  </ItemGroup>
-```
-
-This `<ItemGroup>` instructs the `dotnet pack` command to pack any `runtimeconfig.json` files in the build output directory (designated by the `$(OutputPath)` variable) and place it into the `lib` folder for the built target framework. The built target framework is designated similarly to the output path by using a MSBuild property. After this is set, the resulting tool nupkg file will contain all that is needed for running the tool.
+> [!NOTE]
+> In pre-RC3 versions of the .NET Core command line tools, the `dotnet pack` command had a bug that caused the `runtime.config.json` to not be packed with the tool. Lacking that file results in errors at runtime. If you encounter this behavior, be sure to update to the latest tooling and try the `dotnet pack` again. 
 
 Since tools are portable applications, the user consuming the tool has to have the version of the .NET Core libraries 
 that the tool was built against in order to run the tool. Any other dependency that the tool uses and that is not 
@@ -135,8 +101,7 @@ NuGet has had the capability to package custom MSBuild target and props files fo
 The sample target's project file is included below for reference. It shows how to use the new `csproj` syntax for instructing `dotnet pack` command what to package to place the targets files as well as assemblies into the `build` folder inside the package. Take note of the `<ItemGroup>` below that has the `Label` property set to "dotnet pack instructions". 
 
 ```xml
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Sample Packer</Description>
     <VersionPrefix>0.1.0-preview</VersionPrefix>
@@ -145,50 +110,31 @@ The sample target's project file is included below for reference. It shows how t
     <AssemblyName>SampleTargets.PackerTarget</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-    <EmbeddedResource Include="**\*.resx" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <EmbeddedResource Include="Resources\Pkg\dist-template.xml;compiler\resources\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="build\SampleTargets.PackerTarget.targets" />
   </ItemGroup>
-  <ItemGroup Label="dotent pack instructions">
+  <ItemGroup>
     <Content Include="build\*.targets;$(OutputPath)\*.dll;$(OutputPath)\*.json">
       <Pack>true</Pack>
       <PackagePath>build\</PackagePath>
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161029-1</Version>
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel">
-      <Version>1.0.1-beta-000933</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Build.Framework">
-      <Version>0.1.0-preview-00028-160627</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>0.1.0-preview-00028-160627</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>9.0.1</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="NETStandard.Library">
-      <Version>1.6.0</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.1-beta-000933"/>
+    <PackageReference Include="Microsoft.Build.Framework" Version="0.1.0-preview-00028-160627" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="0.1.0-preview-00028-160627" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>463c66f0-921d-4d34-8bde-7c9d0bffaf7b</ProjectGuid>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);NETSTANDARD1_3</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>
 ```
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -178,6 +178,7 @@
 ### [dotnet-restore](core/preview3/tools/dotnet-restore.md)
 ### [dotnet-run](core/preview3/tools/dotnet-run.md)
 ### [dotnet-build](core/preview3/tools/dotnet-build.md)
+### [dotnet-clean](core/preview3/tools/dotnet-clean.md)
 ### [dotnet-test](core/preview3/tools/dotnet-test.md)
 ### [dotnet-pack](core/preview3/tools/dotnet-pack.md)
 ### [dotnet-publish](core/preview3/tools/dotnet-publish.md)


### PR DESCRIPTION
Some of the docs had outdated syntax so that is now updated. Added the
<PackageFallbackTarget> to the csproj reference. More work is needed to
get the docs up to date completely especially given the new CRUD
commands.

Fixes #1455