### PR TITLE
Update snippet6902.fs

### DIFF
--- a/samples/snippets/fsharp/lang-ref-2/snippet6902.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet6902.fs
@@ -10,8 +10,8 @@ let degreesCelsius temp = temp * 1.0<degC>
 
 printfn "Enter a temperature in degrees Fahrenheit."
 let input = System.Console.ReadLine()
-let mutable floatValue = 0.
-if System.Double.TryParse(input, &floatValue)
+let parsedOk, floatValue = System.Double.TryParse(input)
+if parsedOk
    then
       printfn "That temperature in Celsius is %8.2f degrees C." ((convertFtoC (degreesFahrenheit floatValue))/(1.0<degC>))
    else


### PR DESCRIPTION

# Title

Made usage of TryParse more idiomatic

## Summary

Made a style change to more idiomatic F# code. Instead of using a mutable value, used the tuple result from TryParse.

Fixes N/A. A nit I found when in the docs.

## Details

Changed 

let mutable floatValue = 0.
if System.Double.TryParse(input, &floatValue)

to

let parsedOk, floatValue = System.Double.TryParse(input)
if parsedOk

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
