### PR TITLE
.NET Tour: Move 'using' statement example to section on unmanaged resources

### DIFF
--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -57,9 +57,21 @@ The following example will throw an exception as a result of memory safety.
 
 [!code-csharp[MemoryManagement](../../samples/csharp/snippets/tour/MemoryManagement.csx#L4-L5)]
 
+## Handling unmanaged resources
 
+Some objects work with *unmanaged resources*: resources that are not automatically handled by the .NET runtime.  For example, @System.IO.FileStream objects operate on file handles provided by the operating system.  You will need to let the FileStream know when you are done using it, so that the FileStream can release the file handle back to the operating system.
 
+In .NET, objects that work with unmanaged resources implement the @System.IDisposable interface.  When you are done using the object, you call the object's @System.IDisposable.Dispose method.  .NET languages provide a convenient `using` syntax for such objects, as in the following example:
 
+[!code-csharp[UnmanagedResources](../../samples/csharp/snippets/tour/UnmanagedResources.csx#L1-L6)]
+
+Once the `using` block completes, the .NET runtime will automatically call the `stream` object's @System.IDisposable.Dispose method.  The runtime will also do this if an exception causes control to leave the block.
+
+For more details, check out the following pages:
+
+* For C#, [using Statement](../csharp/language-reference/keywords/using-statement.md)
+* For F#, [Resource Management: The `use` Keyword](../fsharp/language-reference/resource-management-the-use-keyword.md)
+* For Visual Basic, [Using Statement](../visual-basic/language-reference/statements/using-statement.md)
 
 ## Type safety
 

--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -49,11 +49,9 @@ The following two lines both allocate memory:
 
 There is no analogous keyword to de-allocate memory, as de-allocation happens automatically when the garbage collector reclaims the memory through its scheduled run.
 
-One of the less obvious but quite far-reaching features that a garbage collector enables is memory safety. The invariant of memory safety is very simple: a program is memory safe if it accesses only memory that has been allocated (and not freed). Dangling pointers are always bugs, and tracking them down is often quite difficult.
+The garbage collector is just one of the services that help ensure *memory safety*.  The invariant of memory safety is very simple: a program is memory safe if it accesses only memory that has been allocated (and not freed).  For instance, the runtime ensures that programs do not index off the end of an array or access a phantom field off the end of an object.
 
-The .NET runtime provides additional services, to complete the promise of memory safety, not naturally offered by a GC. It ensures that programs do not index off the end of an array or access a phantom field off the end of an object.
-
-The following example will throw an exception as a result of memory safety.
+In the following example, the runtime will throw an `InvalidIndexException` exception, to enforce memory safety.
 
 [!code-csharp[MemoryManagement](../../samples/csharp/snippets/tour/MemoryManagement.csx#L4-L5)]
 

--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -4,7 +4,7 @@ description: A guided tour through some of the prominent features of the .NET pl
 keywords: .NET, .NET Core, Tour, Programming Languages, Unsafe, Memory Management, Type Safety, Async
 author: cartermp
 ms.author: wiwagn
-ms.date: 11/16/2016
+ms.date: 02/09/2016
 ms.topic: article
 ms.prod: .net
 ms.technology: dotnet-standard
@@ -51,7 +51,7 @@ There is no analogous keyword to de-allocate memory, as de-allocation happens au
 
 One of the less obvious but quite far-reaching features that a garbage collector enables is memory safety. The invariant of memory safety is very simple: a program is memory safe if it accesses only memory that has been allocated (and not freed). Dangling pointers are always bugs, and tracking them down is often quite difficult.
 
-The .NET runtime provides additional services, to complete the promise of memory safety, not naturally offered by a GC. It ensures that programs do not index off the end of an array or accessing a phantom field off the end of an object.
+The .NET runtime provides additional services, to complete the promise of memory safety, not naturally offered by a GC. It ensures that programs do not index off the end of an array or access a phantom field off the end of an object.
 
 The following example will throw an exception as a result of memory safety.
 

--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -55,15 +55,15 @@ In the following example, the runtime will throw an `InvalidIndexException` exce
 
 [!code-csharp[MemoryManagement](../../samples/csharp/snippets/tour/MemoryManagement.csx#L4-L5)]
 
-## Handling unmanaged resources
+## Working with unmanaged resources
 
-Some objects work with *unmanaged resources*: resources that are not automatically handled by the .NET runtime.  For example, @System.IO.FileStream objects operate on file handles provided by the operating system.  You will need to let the FileStream know when you are done using it, so that the FileStream can release the file handle back to the operating system.
+Some objects reference *unmanaged resources*. Unmanaged resources are resources that are not automatically maintained by the .NET runtime.  For example, a file handle is an unmanaged resource.  A @System.IO.FileStream object is a managed object, but it references a file handle, which is unmanaged.  When you are done using the FileStream, you need to release the file handle.
 
-In .NET, objects that work with unmanaged resources implement the @System.IDisposable interface.  When you are done using the object, you call the object's @System.IDisposable.Dispose method.  .NET languages provide a convenient `using` syntax for such objects, as in the following example:
+In .NET, objects that reference unmanaged resources implement the @System.IDisposable interface.  When you are done using the object, you call the object's @System.IDisposable.Dispose method, which is responsible for releasing any unmanaged resources.  .NET languages provide a convenient `using` syntax for such objects, as in the following example:
 
 [!code-csharp[UnmanagedResources](../../samples/csharp/snippets/tour/UnmanagedResources.csx#L1-L6)]
 
-Once the `using` block completes, the .NET runtime will automatically call the `stream` object's @System.IDisposable.Dispose method.  The runtime will also do this if an exception causes control to leave the block.
+Once the `using` block completes, the .NET runtime will automatically call the `stream` object's @System.IDisposable.Dispose method, which releases the file handle.  The runtime will also do this if an exception causes control to leave the block.
 
 For more details, check out the following pages:
 

--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -49,21 +49,17 @@ The following two lines both allocate memory:
 
 There is no analogous keyword to de-allocate memory, as de-allocation happens automatically when the garbage collector reclaims the memory through its scheduled run.
 
-Types within a given scope normally go out of scope once a method completes, at which point they can be collected. However, you can indicate to the GC that a particular object is out of scope sooner than method exit using the `using` statement:
-
-[!code-csharp[MemoryManagement](../../samples/csharp/snippets/tour/MemoryManagement.csx#L6-L9)]
-
-Once the `using` block completes, the GC will know that the `stream` object in the previous example is free to be collected and its memory reclaimed.
-
-Rules for this have slightly different semantics in F#.  To learn more about resource management in F#, check out [Resource Management: The `use` Keyword](../fsharp/language-reference/resource-management-the-use-keyword.md)
-
 One of the less obvious but quite far-reaching features that a garbage collector enables is memory safety. The invariant of memory safety is very simple: a program is memory safe if it accesses only memory that has been allocated (and not freed). Dangling pointers are always bugs, and tracking them down is often quite difficult.
 
 The .NET runtime provides additional services, to complete the promise of memory safety, not naturally offered by a GC. It ensures that programs do not index off the end of an array or accessing a phantom field off the end of an object.
 
 The following example will throw an exception as a result of memory safety.
 
-[!code-csharp[MemoryManagement](../../samples/csharp/snippets/tour/MemoryManagement.csx#L11-L12)]
+[!code-csharp[MemoryManagement](../../samples/csharp/snippets/tour/MemoryManagement.csx#L4-L5)]
+
+
+
+
 
 ## Type safety
 

--- a/samples/csharp/snippets/tour/MemoryManagement.csx
+++ b/samples/csharp/snippets/tour/MemoryManagement.csx
@@ -1,12 +1,5 @@
 var title = ".NET Primer";
 var list = new List<string>();
 
-using System.IO;
-
-using (FileStream stream = GetFileStream(context))
-{
-    // Operations on the stream
-}
-
 int[] numbers = new int[42];
 int number = numbers[42]; // Will throw an exception (indexes are 0-based)

--- a/samples/csharp/snippets/tour/UnmanagedResources.csx
+++ b/samples/csharp/snippets/tour/UnmanagedResources.csx
@@ -1,0 +1,6 @@
+using System.IO;
+
+using (FileStream stream = GetFileStream(context))
+{
+    // Operations on the stream
+}


### PR DESCRIPTION
Fixes #1508

Presently this branch removes the `using` statement example from the Automatic memory management section, and re-adds it to a new Handling unmanaged resources section.

We could also choose to just remove the example with no replacement; or merge both managed and unmanged resource handling into a single section, but with a clear demonstration that `using` statement deals with unmanaged resources.

(This is a repeat of PR #1527, but under an employer-sanctioned account).