### PR TITLE
fix comment mistake in tour.fs example

### DIFF
--- a/samples/snippets/fsharp/tour.fs
+++ b/samples/snippets/fsharp/tour.fs
@@ -423,7 +423,7 @@ module Sequences =
     /// This a sequence of values.
     let seq2 = seq { yield "hello"; yield "world"; yield "and"; yield "hello"; yield "world"; yield "again" }
 
-    /// This is an on-demand sequence from 1 to 100.
+    /// This is an on-demand sequence from 1 to 1000.
     let numbersSeq = seq { 1 .. 1000 }
 
     /// This is a sequence producing the words "hello" and "world"


### PR DESCRIPTION
# Changed 100 to 1000 in comment of an example code

In the previous two examples 1000 was used, and I guess the intent was to be 1000 as it is in code.
It's a typo mistake