### PR TITLE
fix example tour.fs typo

### DIFF
--- a/samples/snippets/fsharp/tour.fs
+++ b/samples/snippets/fsharp/tour.fs
@@ -329,7 +329,7 @@ module Lists =
     let daysList = 
         [ for month in 1 .. 12 do
               for day in 1 .. System.DateTime.DaysInMonth(2017, month) do 
-                  yield System.DateTime(2012, month, day) ]
+                  yield System.DateTime(2017, month, day) ]
 
     // Print the first 5 elements of 'daysList' using 'List.take'.
     printfn "The first 5 days of 2017 are: %A" (daysList |> List.take 5)


### PR DESCRIPTION
# Changed 2012 to 2017 in example code

The intention was to use 2017 as it is above the line and below where it is printed.