### PR TITLE
Fix ordinal number in F# example string

### DIFF
--- a/samples/snippets/fsharp/tour.fs
+++ b/samples/snippets/fsharp/tour.fs
@@ -116,7 +116,7 @@ module BasicFunctions =
     let sampleFunction2 (x:int) = 2*x*x - x/5 + 3
 
     let result2 = sampleFunction2 (7 + 4)
-    printfn "The result of applying the 1st sample function to (7 + 4) is %d" result2
+    printfn "The result of applying the 2nd sample function to (7 + 4) is %d" result2
 
     /// Conditionals use if/then/elif/else.
     ///


### PR DESCRIPTION
# Fix ordinal number in F# example string

## Summary

Inside a code block on `fsharp/tour.fs`, a string referred to `sampleFunction2` as "the 1st function", even though `sampleFunction1` is also defined.

I replaced "1st" with "2nd"—an enormous contribution.