### PR TITLE
rc4 appveyor/travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ matrix:
     - os: osx # OSX 10.11
       osx_image: xcode7.2
       dotnet: 1.0.0-preview2-003121
+    - os: osx # OSX 10.11
+      osx_image: xcode7.3
+      dotnet: 1.0.0-rc4-0044771
 
 script:
+  - dotnet --info
   # Run a new console app
   - mkdir -p "test/test-dotnet-new" && pushd "test/test-dotnet-new"
   - dotnet new
   - dotnet restore
-  - dotnet --verbose run a b
+  - dotnet run a b
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,15 @@ matrix:
     - os: osx # OSX 10.11
       osx_image: xcode7.2
       dotnet: 1.0.0-preview2-003121
-    - os: osx # OSX 10.11
+    - os: osx # OSX 10.12
       osx_image: xcode7.3
       dotnet: 1.0.0-rc4-0044771
+
+## If `dotnet` configuration doesnt work, use install script instead
+# install:
+#  - export DOTNET_INSTALL_DIR="$PWD/.dotnetsdk"
+#  - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+#  - export PATH="$DOTNET_INSTALL_DIR:$PATH"  
 
 script:
   - dotnet --info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,33 +1,27 @@
 os: Visual Studio 2015
 
-## .NET Core SDK preview1 is already installed in the build worker image Visual Studio 2015
-##
-## To install a specific version:
-##
-## install:
-##   # .NET Core SDK binaries
-##   ## 1) from direct url  
-##   - ps: $url = "https://go.microsoft.com/fwlink/?LinkID=798402" # v1.0.0-preview1 x64
-##   ## 2) from url based on version, for example using an env var CLI_VERSION that can be a
-##   ##    a specific version `1.0.0-preview2-003121` or `Latest` (for latest dev version)
-##   - ps: $url = "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$($env:CLI_VERSION)/dotnet-dev-win-x64.$($env:CLI_VERSION.ToLower()).zip"
-##   # Download .NET Core SDK and add to PATH
-##   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
-##   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
-##   - ps: $tempFile = [System.IO.Path]::GetTempFileName()
-##   - ps: (New-Object System.Net.WebClient).DownloadFile($url, $tempFile)
-##   - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFile, $env:DOTNET_INSTALL_DIR)
-##   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+# NOTE .NET Core SDK preview2 is already installed in the build worker image Visual Studio 2015
+# so the `install` section is not required
+
+environment:
+  CLI_VERSION: 1.0.0-rc4-004771
+
+install:
+  - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
+  - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
+  - ps: Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version $env:CLI_VERSION -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
 
 build_script:
   # dotnet info
   - ps: dotnet --info
   # Run dotnet new 
   - ps: mkdir "test\test-dotnet-new" -Force | Push-Location
-  - ps: dotnet new --lang fsharp
+  - ps: dotnet new console -lang f#
   - ps: dotnet restore
-  - ps: dotnet --verbose build
-  - ps: dotnet --verbose run a b
+  - ps: dotnet build
+  - ps: dotnet run a b
   - ps: Pop-Location
 
 

--- a/docs/core/preview3/tools/using-ci-with-cli.md
+++ b/docs/core/preview3/tools/using-ci-with-cli.md
@@ -138,9 +138,6 @@ for more information.
 
 The MSBuild-based tools bring both the LTS and Current runtimes (1.0.x and 1.1.x respectively) in the package, so by installing the SDK you will get everything you need to build. 
 
-A build matrix can be added to run integration tests with multiple version of 
-the .NET Core SDK.
-
 ### AppVeyor
 
 The [appveyor.com ci](https://www.appveyor.com/) has .NET Core SDK Preview2 already installed in the build worker image `Visual Studio 2015`.

--- a/docs/core/preview3/tools/using-ci-with-cli.md
+++ b/docs/core/preview3/tools/using-ci-with-cli.md
@@ -123,6 +123,9 @@ $LOCALDOTNET="./$INSTALLDIR/dotnet"
 ### TravisCI
 
 The [Travis-CI](https://travis-ci.org/) can be configured to install the .NET Core SDK using the `csharp` language and the `dotnet` key.
+See official travis docs about [Building a C#, F#, or Visual Basic Project](https://docs.travis-ci.com/user/languages/csharp/) for more info.
+
+As a note, the `language: csharp` (community maintained) works for all .NET languages (for F# projects too) and support mono.
 
 Just use:
 
@@ -130,10 +133,13 @@ Just use:
 dotnet: 1.0.0-rc4-0044771
 ```
 
-Travis can run both `osx` (OS X 10.11) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/docs/blob/master/.travis.yml) 
+Travis can run both `osx` (OS X 10.11, OS X 10.12) and `linux` ( Ubuntu 14.04 ) job in a build matrix, see [example .travis.yml](https://github.com/dotnet/docs/blob/master/.travis.yml) 
 for more information.
 
 The MSBuild-based tools bring both the LTS and Current runtimes (1.0.x and 1.1.x respectively) in the package, so by installing the SDK you will get everything you need to build. 
+
+A build matrix can be added to run integration tests with multiple version of 
+the .NET Core SDK.
 
 ### AppVeyor
 
@@ -148,7 +154,7 @@ os: Visual Studio 2015
 It's possible to install a specific version of .NET Core SDK, see [example appveyor.yml](https://github.com/dotnet/docs/blob/master/appveyor.yml) 
 for more info. 
 
-In the example, the .NET Core SDK binaries are downloaded, unzipped in a subdirectory and added to `PATH` environment variable.
+In the example, the .NET Core SDK binaries are downloaded and unzipped in a subdirectory, using the install script, and added to `PATH` environment variable.
 
 A build matrix can be added to run integration tests with multiple version of 
 the .NET Core SDK.
@@ -157,12 +163,11 @@ the .NET Core SDK.
 environment:
   matrix:
     - CLI_VERSION: 1.0.0-preview2-003121
+    - CLI_VERSION: 1.0.0-rc4-004771
     - CLI_VERSION: Latest
 
 install:
-  # .NET Core SDK binaries
-  - ps: $url = "https://dotnetcli.blob.core.windows.net/dotnet/preview/Binaries/$($env:CLI_VERSION)/dotnet-dev-win-x64.$($env:CLI_VERSION.ToLower()).zip"
-  # follow normal installation from binaries
+  # see example appveyor.yml for install script
 ```
 
 ### Visual Studio Team Services


### PR DESCRIPTION
@blackdwarf checked travis/appveyor for rc4

- use install script in appveyor
- use install script in travis, if `dotnet` conf doesnt work
- added some info in doc

both example template in root directory are already built (green) in CI, using my projects, because are not enable in dotnet/docs repo:

- appveyor: https://ci.appveyor.com/project/enricosada/core-docs/build/0.0.1.20
- travis: https://travis-ci.org/enricosada/core-docs/builds/204945157


