### PR TITLE
Setting up master redirection file

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -54,7 +54,7 @@
     },
     {
         "source_path": "docs/tutorials/index.md", 
-        "redirect_url": "/dotnet/articles/csharp/tutorials/"
+        "redirect_url": "/dotnet/articles/samples-and-tutorials/"
     }
   ]
 }

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -10,10 +10,6 @@
     },
     {
         "source_path": "docs/csharp/features.md", 
-        "redirect_url": "/dotnet/articles/csharp"
-    },
-    {
-        "source_path": "docs/csharp/features.md", 
         "redirect_url": "/dotnet/articles/csharp/concepts"
     },
     {

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1,0 +1,64 @@
+{ 
+  "redirections": [ 
+    {   
+        "source_path": "docs/cli-preview3/tools/dotnet-nuget-delete.md", 
+        "redirect_url": "/dotnet/articles/core/preview3/tools/dotnet-nuget-delete"
+    },
+    {
+        "source_path": "docs/cli-preview3/tools/dotnet-nuget-locals.md", 
+        "redirect_url": "/dotnet/articles/core/preview3/tools/dotnet-nuget-locals"
+    },
+    {
+        "source_path": "docs/csharp/features.md", 
+        "redirect_url": "/dotnet/articles/csharp"
+    },
+    {
+        "source_path": "docs/csharp/features.md", 
+        "redirect_url": "/dotnet/articles/csharp/concepts"
+    },
+    {
+        "source_path": "docs/csharp/getting-started/library-with-visual-studio_2017.md", 
+        "redirect_url": "/dotnet/articles/csharp/getting-started/library-with-visual-studio-2017"
+    },
+    {
+        "source_path": "docs/fsharp/async.md", 
+        "redirect_url": "/dotnet/articles/fsharp/tutorials/asynchronous-and-concurrent-programming/async"
+    },
+    {
+        "source_path": "docs/fsharp/getting-started-netcore.md", 
+        "redirect_url": "/dotnet/articles/fsharp/tutorials/getting-started/getting-started-command-line"
+    },
+    {
+        "source_path": "docs/fsharp/tutorials/getting-started/getting-started-cross-platform-tooling.md", 
+        "redirect_url": "/dotnet/articles/fsharp/tutorials/getting-started/getting-started-command-line"
+    },
+    {
+        "source_path": "docs/scenarios/index.md", 
+        "redirect_url": "/dotnet/articles/core/tutorials/"
+    },
+    {
+        "source_path": "docs/scenarios/solution-authoring/index.md", 
+        "redirect_url": "/dotnet/articles/core/tutorials/"
+    },
+    {
+        "source_path": "docs/scenarios/solution-authoring/target-dotnetcore-with-msbuild.md", 
+        "redirect_url": "/dotnet/articles/core/tutorials/target-dotnetcore-with-msbuild"
+    },
+    {
+        "source_path": "docs/standard/concepts.md", 
+        "redirect_url": "/dotnet/articles/standard/"
+    },
+    {
+        "source_path": "docs/tutorials/getting-started-with-csharp/microservices.md", 
+        "redirect_url": "/dotnet/articles/csharp/tutorials/microservices"
+    },
+    {
+        "source_path": "docs/tutorials/getting-started-with-csharp/working-with-linq.md", 
+        "redirect_url": "/dotnet/articles/csharp/tutorials/working-with-linq"
+    },
+    {
+        "source_path": "docs/tutorials/index.md", 
+        "redirect_url": "/dotnet/articles/csharp/tutorials/"
+    }
+  ]
+}


### PR DESCRIPTION
I've received several broken link bugs for published content that was removed from the repo without setting up redirection. So decided to fix those using the new master redirection file.

If this works, we can also remove other redirected topics currently living in the repo and add them here.