### PR TITLE
dotnet new updates for MSBuild/csproj

### DIFF
--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -11,11 +11,7 @@ ms.devlang: dotnet
 ms.assetid: da7a31a0-8072-4f23-82aa-8a19184cb701
 ---
 
-# .NET Core Application Deployment (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 documentation,
-> see the [.NET Core Application Deployment](../../deploying/index.md) topic.
+# .NET Core Application Deployment (.NET Core SDK 1.0.0 Tools)
 
 You can create two types of deployments for .NET Core applications: 
 

--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -47,7 +47,7 @@ There are also a few disadvantages:
 
 Deploying a framework-dependent deployment with no third-party dependencies simply involves building, testing, and publishing the app. A simple example written in C# illustrates the process. The example uses the [dotnet utility](../tools/dotnet.md) from the command line; however, you can also use a development environment, such as Visual Studio or Visual Studio Code, to compile, test, and publish the example.
 
-1. Create a directory for your project; and from the command line, type [dotnet new console](../tools/dotnet-new.md) to create a new C# console project.
+1. Create a directory for your project; and from the command line, type `[dotnet new console](../tools/dotnet-new.md)` to create a new C# console project.
 
 2. Open the `Program.cs` file in an editor, and replace the auto-generated code with the following code. It prompts the user to enter text, and then displays the individual words entered by the user. It uses the regular expression `\w+` to separate the words in the input text.
 

--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -11,7 +11,7 @@ ms.devlang: dotnet
 ms.assetid: da7a31a0-8072-4f23-82aa-8a19184cb701
 ---
 
-# .NET Core Application Deployment (.NET Core SDK 1.0.0 Tools)
+# .NET Core Application Deployment
 
 You can create two types of deployments for .NET Core applications: 
 

--- a/docs/core/preview3/deploying/index.md
+++ b/docs/core/preview3/deploying/index.md
@@ -4,7 +4,7 @@ description: .NET Core Application Deployment
 keywords: .NET, .NET Core, .NET Core deployment
 author: rpetrusha
 ms.author: ronpet
-ms.date: 07/02/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.devlang: dotnet
@@ -47,7 +47,7 @@ There are also a few disadvantages:
 
 Deploying a framework-dependent deployment with no third-party dependencies simply involves building, testing, and publishing the app. A simple example written in C# illustrates the process. The example uses the [dotnet utility](../tools/dotnet.md) from the command line; however, you can also use a development environment, such as Visual Studio or Visual Studio Code, to compile, test, and publish the example.
 
-1. Create a directory for your project, and from the command line, type [dotnet new](../tools/dotnet-new.md) to create a new C# console project.
+1. Create a directory for your project; and from the command line, type [dotnet new console](../tools/dotnet-new.md) to create a new C# console project.
 
 2. Open the `Program.cs` file in an editor, and replace the auto-generated code with the following code. It prompts the user to enter text, and then displays the individual words entered by the user. It uses the regular expression `\w+` to separate the words in the input text.
 
@@ -142,7 +142,7 @@ It also has a number of disadvantages:
 
 Deploying a self-contained deployment with no third-party dependencies involves creating the project, modifying the csproj file, building, testing, and publishing the app.  A simple example written in C# illustrates the process. The example uses the `dotnet` utility from the command line; however, you can also use a development environment, such as Visual Studio or Visual Studio Code, to compile, test, and publish the example.
 
-1. Create a directory for your project, and from the command line, type `dotnet new` to create a new C# console project.
+1. Create a directory for your project, and from the command line, type `dotnet new console` to create a new C# console project.
 
 2. Open the `Program.cs` file in an editor, and replace the auto-generated code with the following code. It prompts the user to enter text, and then displays the individual words entered by the user. It uses the regular expression `\w+` to separate the words in the input text.
 
@@ -217,7 +217,6 @@ The following is the complete `csproj` file for this project.
 </Project>
 ```
 
-
 ### Deploying a self-contained deployment with third-party dependencies ###
 
 Deploying a self-contained deployment with one or more third-party dependencies involves adding the third party dependency:
@@ -256,12 +255,12 @@ Note that you can only deploy a self-contained deployment with a third-party lib
 
 If the availability of adequate storage space on target systems is likely to be an issue, you can reduce the overall footprint of your app by excluding some system components. To do this, you explicitly define the .NET Core components that your app includes in your csproj file.
 
-To create a self-contained deployment with a smaller footprint, start by following the first two steps for creating a self-contained deployment. Once you've run the `dotnet new` command and added the C# source code to your app, do the following:
+To create a self-contained deployment with a smaller footprint, start by following the first two steps for creating a self-contained deployment. Once you've run the `dotnet new console` command and added the C# source code to your app, do the following:
 
 1. Open the `csproj` file and replace the `<TargetFramework>` element with the following:
 
-    ```xml
-      <TargetFramework>netstandard1.6</TargetFramework>
+  ```xml
+  <TargetFramework>netstandard1.6</TargetFramework>
   ```
 This operation indicates that, instead of using the entire `netcoreapp1.0` framework, which includes .NET Core CLR, the .NET Core Library, and a number of other system components, our app uses only the .NET Standard Library.
 
@@ -272,20 +271,19 @@ This operation indicates that, instead of using the entire `netcoreapp1.0` frame
     <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.2" />
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="1.0.1" />
   </ItemGroup>
-```
+  ```
 
    This defines the system components used by our app. The system components packaged with our app include the .NET Standard Library, the .NET Core runtime, and the .NET Core host. This produces a self-contained deployment with a smaller footprint.
 
 3. As you did in the [Deploying a simple self-contained deployment](#simpleSelf) example, create a `<RuntimeIdentifiers>` element within a `<PropertyGroup>` in your `csproj` file that defines the platforms your app targets and specify the runtime identifier of each platform that you target. See [Runtime IDentifier catalog](../../rid-catalog.md) for a list of runtime identifiers. For example, the following example indicates that the app runs on 64-bit Windows 10 operating systems and the 64-bit OS X Version 10.11 operating system.
 
     ```xml
-        <PropertyGroup>
-          <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
-        </PropertyGroup>
+    <PropertyGroup>
+      <RuntimeIdentifiers>win10-x64;osx.10.11-x64</RuntimeIdentifiers>
+    </PropertyGroup>
     ```
     
-
- A complete sample `csproj` file appears later in this section.
+   A complete sample `csproj` file appears later in this section.
 
 4. Run the `dotnet restore` command to restore the dependencies specified in your project.
 

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -4,7 +4,7 @@ description: Explains how to manage your dependencies with the .NET Core tools.
 keywords: CLI, extensibility, custom commands, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 11/12/2016
+ms.date: 03/06/2016
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -45,7 +45,7 @@ Adding a dependency to your project is straightforward. Here is an example of ho
 
 When you open your project file, you will see two or more `<ItemGroup>` nodes. You will notice that one of the nodes already has `<PackageReference>` elements in it. You can add your new dependency to this node, or create a new one; it is completely up to you as the result will be the same. 
 
-In this example we will use the default template that is dropped by `dotnet new`. This is a simple console application. When we open up the project, we first find the `<ItemGroup>` with already existing `<PackageReference>` in it. We then add the following to it:
+In this example we will use the default template that is dropped by `dotnet new console`. This is a simple console application. When we open up the project, we first find the `<ItemGroup>` with already existing `<PackageReference>` in it. We then add the following to it:
 
 ```xml
 <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -4,7 +4,7 @@ description: Explains how to manage your dependencies with the .NET Core tools.
 keywords: CLI, extensibility, custom commands, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 03/06/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 74b87cdb-a244-4c13-908c-539118bfeef9
 ---
 
-# Managing dependencies in .NET Core RC4 tooling
+# Managing dependencies with .NET Core SDK 1.0.0 tooling
 
 [!INCLUDE[preview-warning](../../../includes/warning.md)]
 

--- a/docs/core/preview3/tools/dependencies.md
+++ b/docs/core/preview3/tools/dependencies.md
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 74b87cdb-a244-4c13-908c-539118bfeef9
 ---
 
-# Managing dependencies with .NET Core SDK 1.0.0 tooling
+# Managing dependencies with .NET Core SDK
 
 [!INCLUDE[preview-warning](../../../includes/warning.md)]
 

--- a/docs/core/preview3/tools/dotnet-add-package.md
+++ b/docs/core/preview3/tools/dotnet-add-package.md
@@ -49,7 +49,7 @@ The *ToDo.csproj* file now contains a [`<PackageReference>`](https://docs.micros
 
 ```xml
 <PackageReference Include="Newtonsoft.Json">
-    <Version>9.0.1</Version>
+  <Version>9.0.1</Version>
 </PackageReference>
 ```
 

--- a/docs/core/preview3/tools/dotnet-add-package.md
+++ b/docs/core/preview3/tools/dotnet-add-package.md
@@ -20,7 +20,7 @@ ms.assetid: 88e0da69-a5ea-46cc-8b46-5493242b7af9
 ## Synopsis
 
 ```
-dotnet add [<PROJECT>] package <PACKAGE_NAME> [-v|--version] [-f|--framework] [-s|--source] [--package-directory]
+dotnet add [<project>] package <package_name> [-v|--version] [-f|--framework] [-n|--no-restore] [-s|--source] [--package-directory]
 dotnet add package [-h|--help]
 ```
 
@@ -55,11 +55,11 @@ The *ToDo.csproj* file now contains a [`<PackageReference>`](https://docs.micros
 
 ## Arguments
 
-`PROJECT`
+`project`
 
 The project file to operate on. If not specified, the command searches the current directory for one.
 
-`PACKAGE_NAME`
+`package_name`
 
 The package reference to add.
 

--- a/docs/core/preview3/tools/dotnet-add-package.md
+++ b/docs/core/preview3/tools/dotnet-add-package.md
@@ -4,7 +4,7 @@ description: The dotnet-add package command provides a convenient option to add 
 keywords: dotnet-add , CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 02/28/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -12,8 +12,6 @@ ms.devlang: dotnet
 ms.assetid: 88e0da69-a5ea-46cc-8b46-5493242b7af9
 ---
 # dotnet-add package
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
 
 ## Name
 

--- a/docs/core/preview3/tools/dotnet-add-reference.md
+++ b/docs/core/preview3/tools/dotnet-add-reference.md
@@ -30,9 +30,9 @@ The `dotnet add reference` command provides a convenient option to add project r
 
 ```xml
 <ItemGroup>
-    <ProjectReference Include="app.csproj" />
-    <ProjectReference Include="..\lib2\lib2.csproj" />
-    <ProjectReference Include="..\lib1\lib1.csproj" />
+  <ProjectReference Include="app.csproj" />
+  <ProjectReference Include="..\lib2\lib2.csproj" />
+  <ProjectReference Include="..\lib1\lib1.csproj" />
 </ItemGroup>
 ```
 

--- a/docs/core/preview3/tools/dotnet-add-reference.md
+++ b/docs/core/preview3/tools/dotnet-add-reference.md
@@ -20,7 +20,7 @@ ms.assetid: 5e2a3efd-443c-4f23-a1b1-a662a5387879
 ## Synopsis
 
 ```
-dotnet add [<PROJECT>] reference [-f|--framework] <PROJECT_REFERENCES>
+dotnet add [<project>] reference [-f|--framework] <project_references>
 dotnet add reference [-h|--help]
 ```
 
@@ -38,11 +38,11 @@ The `dotnet add reference` command provides a convenient option to add project r
 
 ## Arguments
 
-`PROJECT`
+`project`
 
 Project file to operate on. If not specified, the command will search the current directory for one.
 
-`PROJECT_REFERENCES`
+`project_references`
 
 Project to project references to add. You can specify one or multiple projects. Glob pattern is supported on Unix/Linux-based terminals.
 

--- a/docs/core/preview3/tools/dotnet-add-reference.md
+++ b/docs/core/preview3/tools/dotnet-add-reference.md
@@ -1,10 +1,10 @@
 ---
 title: dotnet-add reference command | Microsoft Docs
 description: The dotnet-add reference command provides a convenient option to add project to project references.
-keywords: dotnet-add , CLI, CLI command, .NET Core
+keywords: dotnet-add, CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 02/28/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -12,8 +12,6 @@ ms.devlang: dotnet
 ms.assetid: 5e2a3efd-443c-4f23-a1b1-a662a5387879
 ---
 # dotnet-add reference
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
 
 ## Name
 

--- a/docs/core/preview3/tools/dotnet-build.md
+++ b/docs/core/preview3/tools/dotnet-build.md
@@ -15,7 +15,7 @@ ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
 #dotnet-build (.NET Core Tools RC4)
 
 ## Name 
-dotnet-build -- Builds a project and all of its dependencies 
+dotnet-build - Builds a project and all of its dependencies 
 
 ## Synopsis
 

--- a/docs/core/preview3/tools/dotnet-build.md
+++ b/docs/core/preview3/tools/dotnet-build.md
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
 ---
 
-#dotnet-build (.NET Core Tools RC4)
+#dotnet-build (.NET Core SDK 1.0.0 Tools)
 
 ## Name 
 dotnet-build - Builds a project and all of its dependencies 

--- a/docs/core/preview3/tools/dotnet-build.md
+++ b/docs/core/preview3/tools/dotnet-build.md
@@ -4,7 +4,7 @@ description: The dotnet-build command builds a project and all of its dependenci
 keywords: dotnet-build, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/13/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,10 +13,6 @@ ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
 ---
 
 #dotnet-build (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-build](../../tools/dotnet-build.md) topic.
 
 ## Name 
 dotnet-build -- Builds a project and all of its dependencies 
@@ -46,7 +42,7 @@ In order to build an executable application instead of a library, you need to se
 
 ```xml
 <PropertyGroup>
-    <OutputType>Exe</OutputType>
+  <OutputType>Exe</OutputType>
 </PropertyGroup>
 ```
 

--- a/docs/core/preview3/tools/dotnet-build.md
+++ b/docs/core/preview3/tools/dotnet-build.md
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
 ---
 
-#dotnet-build (.NET Core SDK 1.0.0 Tools)
+#dotnet-build
 
 ## Name 
 dotnet-build - Builds a project and all of its dependencies 

--- a/docs/core/preview3/tools/dotnet-build.md
+++ b/docs/core/preview3/tools/dotnet-build.md
@@ -11,18 +11,18 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
 ---
-
 #dotnet-build
 
-## Name 
-dotnet-build - Builds a project and all of its dependencies 
+## Name
+
+`dotnet-build` - Builds a project and all of its dependencies 
 
 ## Synopsis
 
-`dotnet build [--help] [--output]  [--framework]  
-    [--configuration]  [--runtime] [--version-suffix]
-    [--build-profile]  [--no-incremental] [--no-dependencies]
-    [<project>]`
+```
+dotnet build [<project>] [-o|--output] [-f|--framework] [-c|--configuration] [-r|--runtime] [--version-suffix] [--no-incremental] [--no-dependencies] [-v|--verbosity]
+dotnet build [--help]
+```
 
 ## Description
 
@@ -62,7 +62,7 @@ Compiles for a specific framework. The framework needs to be defined in the [pro
 
 `-c|--configuration [Debug|Release]`
 
-Defines a configuration under which to build.  If omitted, it defaults to `Debug`.
+Defines a configuration under which to build. If omitted, it defaults to `Debug`.
 
 `-r|--runtime [RUNTIME_IDENTIFIER]`
 
@@ -83,6 +83,10 @@ Marks the build as unsafe for incremental build. This turns off incremental comp
 `--no-dependencies`
 
 Ignores project-to-project references and only builds the root project specified to build.
+
+`-v|--verbosity`
+
+Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-clean.md
+++ b/docs/core/preview3/tools/dotnet-clean.md
@@ -15,7 +15,7 @@ ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
 #dotnet-clean
 
 ## Name 
-`dotnet-clean` -- Cleans the output of a project. 
+`dotnet-clean` - Cleans the output of a project. 
 
 ## Synopsis
 

--- a/docs/core/preview3/tools/dotnet-clean.md
+++ b/docs/core/preview3/tools/dotnet-clean.md
@@ -4,7 +4,7 @@ description: The dotnet-clean command cleans the current directory.
 keywords: dotnet-clean, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 01/31/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
 ---
 
 #dotnet-clean
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
 
 ## Name 
 `dotnet-clean` -- Cleans the output of a project. 
@@ -49,7 +47,6 @@ Defines a configuration under which the build was running.  If omitted, it defau
 `-v|--verbosity [Quiet|Minimal|Normal|Diag]`
 
 Defines verbosity to use for the invocation of the `dotnet clean` command. The verbosity levels are standard [MSBuild verbosity levels](https://msdn.microsoft.com/en-us/library/ms164311.aspx). 
-
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-clean.md
+++ b/docs/core/preview3/tools/dotnet-clean.md
@@ -11,19 +11,21 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
 ---
-
 #dotnet-clean
 
-## Name 
+## Name
+
 `dotnet-clean` - Cleans the output of a project. 
 
 ## Synopsis
 
-`dotnet clean [--help] [--output]  [--framework]  
-    [--configuration]  [--verbosity]
-    [<project>]`
+```
+dotnet clean [<project>] [-o|--output] [-f|--framework] [-c|--configuration] [-v|--verbosity]
+dotnet clean [--help] 
+```
 
 ## Description
+
 The `dotnet clean` command will clean the output of the previous build. It is implemented as an MSBuild target, so the project will get evaluated. Only the outputs that were created during the build are cleaned. Both intermediate (`obj`) and final output (`bin`) folders are cleaned. 
 
 ## Options
@@ -44,9 +46,9 @@ The framework that was specified at build time. If you didn't specify this prope
 
 Defines a configuration under which the build was running.  If omitted, it defaults to `Debug`. If you didn't specify this property during build time, you don't have to specify it for clean.
 
-`-v|--verbosity [Quiet|Minimal|Normal|Diag]`
+`-v|--verbosity <Quiet|Minimal|Normal|Diag>`
 
-Defines verbosity to use for the invocation of the `dotnet clean` command. The verbosity levels are standard [MSBuild verbosity levels](https://msdn.microsoft.com/en-us/library/ms164311.aspx). 
+Defines verbosity to use for the invocation of the `dotnet clean` command. The verbosity levels are standard [MSBuild verbosity levels](https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference). 
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-install-script.md
+++ b/docs/core/preview3/tools/dotnet-install-script.md
@@ -12,7 +12,7 @@ ms.devlang: dotnet
 ms.assetid: b64e7e6f-ffb4-4fc8-b43b-5731c89479c2
 ---
 
-#dotnet-install scripts reference (.NET Core SDK 1.0.0 Tools)
+#dotnet-install scripts reference
 
 ## Name
 dotnet-install.ps1 | dotnet-install.sh - script used to install the Command Line Interface (CLI) tools and the shared runtime

--- a/docs/core/preview3/tools/dotnet-install-script.md
+++ b/docs/core/preview3/tools/dotnet-install-script.md
@@ -11,11 +11,11 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: b64e7e6f-ffb4-4fc8-b43b-5731c89479c2
 ---
-
 #dotnet-install scripts reference
 
 ## Name
-dotnet-install.ps1 | dotnet-install.sh - script used to install the Command Line Interface (CLI) tools and the shared runtime
+
+`dotnet-install.ps1` | `dotnet-install.sh` - script used to install the Command Line Interface (CLI) tools and the shared runtime
 
 ## Synopsis
 Windows:
@@ -31,6 +31,7 @@ macOS/Linux:
     [--shared-runtime]`
 
 ## Description
+
 The `dotnet-install` scripts are used to perform a non-admin install of the CLI toolchain and the shared runtime. You can download the scripts from our [CLI GitHub repo](https://github.com/dotnet/cli/tree/rel/1.0.0-preview2/scripts/obtain). 
 
 Their main use case is to help with automation scenarios and non-admin installations. There are two scripts, one for PowerShell that works on Windows and a bash script that works on Linux/OS X. They both have the same behavior. Bash script also "understands" PowerShell switches so you can use them across the board. 

--- a/docs/core/preview3/tools/dotnet-install-script.md
+++ b/docs/core/preview3/tools/dotnet-install-script.md
@@ -4,7 +4,7 @@ description: Learn about the dotnet-install scripts to install the .NET Core CLI
 keywords: dotnet-install, dotnet-install scripts, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/12/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -12,11 +12,7 @@ ms.devlang: dotnet
 ms.assetid: b64e7e6f-ffb4-4fc8-b43b-5731c89479c2
 ---
 
-#dotnet-install scripts reference (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-install scripts reference](../../tools/dotnet-install-script.md) topic.
+#dotnet-install scripts reference (.NET Core SDK 1.0.0 Tools)
 
 ## Name
 dotnet-install.ps1 | dotnet-install.sh - script used to install the Command Line Interface (CLI) tools and the shared runtime

--- a/docs/core/preview3/tools/dotnet-list-reference.md
+++ b/docs/core/preview3/tools/dotnet-list-reference.md
@@ -1,10 +1,10 @@
 ---
 title: dotnet-list reference command | Microsoft Docs
 description: The dotnet-list reference command provides a convenient option to list project to project references.
-keywords: dotnet-list , CLI, CLI command, .NET Core
+keywords: dotnet-list, CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 02/28/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -12,8 +12,6 @@ ms.devlang: dotnet
 ms.assetid: 8f954a0c-03f8-4fbc-a529-b313ab12c623
 ---
 # dotnet-list reference
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
 
 ## Name
 

--- a/docs/core/preview3/tools/dotnet-list-reference.md
+++ b/docs/core/preview3/tools/dotnet-list-reference.md
@@ -20,7 +20,7 @@ ms.assetid: 8f954a0c-03f8-4fbc-a529-b313ab12c623
 ## Synopsis
 
 ```
-dotnet list [<PROJECT>] reference
+dotnet list [<project>] reference
 dotnet list reference [-h|--help]
 ```
 
@@ -30,7 +30,7 @@ The `dotnet list reference` command provides a convenient option to list project
 
 ## Arguments
 
-`PROJECT`
+`project`
 
 The project file to list the references for. If not specified, the command will search the current directory for one.
 

--- a/docs/core/preview3/tools/dotnet-migrate.md
+++ b/docs/core/preview3/tools/dotnet-migrate.md
@@ -4,7 +4,7 @@ description: The dotnet-migrate command migrates a project and all of its depend
 keywords: dotnet-migrate, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 11/13/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -14,10 +14,8 @@ ms.assetid: 0da07253-5ae1-42e9-9455-bffee9950952
 
 #dotnet-migrate
 
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
-
 ## Name 
-dotnet-migrate -- Migrates a Preview 2 .NET Core project to RC4 .NET Core project
+dotnet-migrate -- Migrates a Preview 2 .NET Core project to .NET Core SDK 1.0.0 project
 
 ## Synopsis
 
@@ -28,7 +26,7 @@ dotnet-migrate -- Migrates a Preview 2 .NET Core project to RC4 .NET Core projec
     [<arguments>]`
 
 ## Description
-The `dotnet migrate` command will migrate a valid Preview 2 `project.json` based project to a valid RC4 `csproj` project. 
+The `dotnet migrate` command will migrate a valid Preview 2 `project.json` based project to a valid SDK 1.0.0 `csproj` project. 
 By default, the command will migrate the root project and any project references that the root project contains. This behavior 
 can be disabled using the `--skip-project-references` option at runtime. 
 
@@ -44,9 +42,7 @@ exist. This can be overriden using the `--skip-backup` option.
 By default, the migration operation will output the state of the migration process to standard output (STDOUT). If you use the 
 `--report-file` option, that output will also be saved to a file that you specify. 
 
-As of RC4, the `dotnet migrate` command only supports valid Preview 2 `project.json` files. This means that you cannot 
-use it to migrate old DNX or Preview 1 `project.json` files directly to csproj; you first need to migrate them to Preview 2 project.json files and then 
-to csproj files. In the future, we will add support for Preview 1 projects. 
+As of the release of .NET Core SDK 1.0.0, the `dotnet migrate` command only supports valid Preview 2 `project.json` files. This means that you cannot use it to migrate old DNX or Preview 1 `project.json` files directly to csproj; you first need to migrate them to Preview 2 project.json files and then to csproj files. In the future, we will add support for Preview 1 projects. 
 
 ## Options
 
@@ -56,7 +52,7 @@ Prints out a short help for the command.
 
 `-t|--template-file <TEMPLATE_FILE>`
 
-Template csproj file to use for migration. By default, the same template as the one dropped by `dotnet new` will be used. 
+Template csproj file to use for migration. By default, the same template as the one dropped by `dotnet new console` will be used. 
 
 `-v|--sdk-package-version <VERSION>`
 

--- a/docs/core/preview3/tools/dotnet-migrate.md
+++ b/docs/core/preview3/tools/dotnet-migrate.md
@@ -11,21 +11,21 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 0da07253-5ae1-42e9-9455-bffee9950952
 ---
-
 #dotnet-migrate
 
-## Name 
-dotnet-migrate -- Migrates a Preview 2 .NET Core project to .NET Core SDK 1.0.0 project
+## Name
+
+`dotnet-migrate` - Migrates a Preview 2 .NET Core project to .NET Core SDK 1.0.0 project
 
 ## Synopsis
 
-`dotnet migrate [--help] [--template-file]  
-    [--sdk-package-version] [--xproj-file]  
-    [--skip-project-references]  [--report-file] [--format-report-file-json]
-    [--skip-backup]
-    [<arguments>]`
+```
+dotnet migrate [-t|--template-file] [-v|--sdk-package-version] [-x|--xproj-file] [-s|--skip-project-references] [-r|--report-file] [--format-report-file-json] [--skip-backup] [<arguments>]
+dotnet migrate [-h|--help]
+```
 
 ## Description
+
 The `dotnet migrate` command will migrate a valid Preview 2 `project.json` based project to a valid SDK 1.0.0 `csproj` project. 
 By default, the command will migrate the root project and any project references that the root project contains. This behavior 
 can be disabled using the `--skip-project-references` option at runtime. 
@@ -64,7 +64,7 @@ The path to the xproj file to use. Required when there is more than one xproj in
 
 `-s|--skip-project-references [Debug|Release]`
 
-Skip migrating project references. By default project references are migrated recursively.
+Skip migrating project references. By default, project references are migrated recursively.
 
 `-r|--report-file <REPORT_FILE>`
 

--- a/docs/core/preview3/tools/dotnet-msbuild.md
+++ b/docs/core/preview3/tools/dotnet-msbuild.md
@@ -15,7 +15,7 @@ ms.assetid: ffdc40ba-ef33-463e-aa35-b0af1fe615a2
 #dotnet-msbuild
 
 ## Name 
-dotnet-msbuild -- Builds a project and all of its dependencies.
+dotnet-msbuild - Builds a project and all of its dependencies.
 
 ## Synopsis
 

--- a/docs/core/preview3/tools/dotnet-msbuild.md
+++ b/docs/core/preview3/tools/dotnet-msbuild.md
@@ -4,7 +4,7 @@ description: The dotnet-msbuild command provides access to the MSBuild command l
 keywords: dotnet-msmsbuild, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/13/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: ffdc40ba-ef33-463e-aa35-b0af1fe615a2
 ---
 
 #dotnet-msbuild
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
 
 ## Name 
 dotnet-msbuild -- Builds a project and all of its dependencies.

--- a/docs/core/preview3/tools/dotnet-msbuild.md
+++ b/docs/core/preview3/tools/dotnet-msbuild.md
@@ -11,17 +11,21 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: ffdc40ba-ef33-463e-aa35-b0af1fe615a2
 ---
-
 #dotnet-msbuild
 
-## Name 
-dotnet-msbuild - Builds a project and all of its dependencies.
+## Name
+
+`dotnet-msbuild` - Builds a project and all of its dependencies.
 
 ## Synopsis
 
-`dotnet msbuild <msbuild_arguments>`
+```
+dotnet msbuild <msbuild_arguments>
+dotnet msbuild [-h]
+```
 
 ## Description
+
 The `dotnet msbuild` command allows access to a fully functional MSBuild 
 
 The command has the exact same capabilities as existing MSBuild command-line client. The options are all the same. You can 

--- a/docs/core/preview3/tools/dotnet-new.md
+++ b/docs/core/preview3/tools/dotnet-new.md
@@ -11,7 +11,7 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: fcc3ed2e-9265-4d50-b59e-dc2e5c190b34
 ---
-#dotnet-new (.NET Core SDK 1.0.0 Tools)
+#dotnet-new
 
 ## Name
 dotnet-new - Creates a new .NET Core project in the current directory

--- a/docs/core/preview3/tools/dotnet-new.md
+++ b/docs/core/preview3/tools/dotnet-new.md
@@ -14,17 +14,19 @@ ms.assetid: fcc3ed2e-9265-4d50-b59e-dc2e5c190b34
 #dotnet-new
 
 ## Name
-dotnet-new - Creates a new .NET Core project in the current directory
+
+`dotnet-new` - Creates a new .NET Core project in the current directory
 
 ## Synopsis
 ```
-dotnet new [template] [-lang|--language] [-n|--name] [-o|--output] [-h|--help]
+dotnet new [template] [-lang|--language] [-n|--name] [-o|--output]
 dotnet new [template] [-l|--list]
 dotnet new [-all|--show-all]
 dotnet new [-h|--help]
 ```
 
 ## Description
+
 The `dotnet new` command provides a convenient way to initialize a valid .NET Core project and sample source code to try out the Command-line interface (CLI) toolset. 
 
 This command is invoked in the context of a directory. When invoked, the command will scaffold out the resources and files according to the template and options passed into the command. 
@@ -32,7 +34,10 @@ This command is invoked in the context of a directory. When invoked, the command
 After this, the project is ready to be compiled and/or edited further. 
 
 ## Arguments
-template - The template to instansiate when the command is invoked.
+
+`template`
+
+The template to instansiate when the command is invoked.
 
 The command contains a default list of templates; use `dotnet new --help`. 
 

--- a/docs/core/preview3/tools/dotnet-new.md
+++ b/docs/core/preview3/tools/dotnet-new.md
@@ -4,18 +4,14 @@ description: The dotnet-new command creates new .NET Core projects in the curren
 keywords: dotnet-new, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 02/15/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: fcc3ed2e-9265-4d50-b59e-dc2e5c190b34
 ---
-#dotnet-new (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-new](../../tools/dotnet-new.md) topic.
+#dotnet-new (.NET Core SDK 1.0.0 Tools)
 
 ## Name
 dotnet-new - Creates a new .NET Core project in the current directory

--- a/docs/core/preview3/tools/dotnet-nuget-delete.md
+++ b/docs/core/preview3/tools/dotnet-nuget-delete.md
@@ -11,17 +11,18 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 6ddffde4-c789-4e90-990e-d35f6a6565d4
 ---
-
 #dotnet-nuget-delete
 
-## Name 
+## Name
+
 `dotnet-nuget-delete` - Deletes or unlists a package from the server. 
 
 ## Synopsis
 
-`dotnet nuget delete [<package_name> <package_version>] 
-    [--help] [--source] [--non-interactive] 
-    [--api-key] [--force-english-output] [--verbosity] [--config-file]`
+```
+dotnet nuget delete [<package_name> <package_version>] [-s|--source] [--non-interactive] [-k|--api-key] [--force-english-output]
+dotnet nuget delete [-h|--help]
+```
 
 ## Description
 
@@ -49,14 +50,6 @@ The API key for the server.
 
 Forces command-line output to be in English.
 
-`--verbosity <LEVEL>`
-
-Displays this amount of details in the output. Level can be `normal`, `quiet`, or `detailed`.
-
-`--config-file <FILE>`
-
-A NuGet configuration file used specifically for this command, replacing other config files found by the standard config file discovery and chaining process. The path can be absolute or relative. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
-
 ## Examples
 
 Deletes version 1.0 of package MyPackage:
@@ -66,11 +59,3 @@ Deletes version 1.0 of package MyPackage:
 Deletes version 1.0 of package MyPackage, not prompting user for credentials or other input:
 
 `dotnet nuget delete MyPackage 1.0 --non-interactive`
-
-Deletes version 1.0 of package MyPackage, specifying a custom config file *./config/My.Config*:
-
-`dotnet nuget delete MyPackage 1.0 --config-file ./config/My.Config`
-
-Deletes version 1.0 of package MyPackage, with maximum verbosity:
-
-`dotnet nuget delete MyPackage 1.0 --verbosity detailed`

--- a/docs/core/preview3/tools/dotnet-nuget-delete.md
+++ b/docs/core/preview3/tools/dotnet-nuget-delete.md
@@ -4,7 +4,7 @@ description: The dotnet-nuget-delete command deletes or unlists a package from t
 keywords: dotnet-nuget-delete, CLI, CLI command, .NET Core
 author: karann-msft
 ms.author: mairaw
-ms.date: 11/11/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: 6ddffde4-c789-4e90-990e-d35f6a6565d4
 ---
 
 #dotnet-nuget-delete
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
 
 ## Name 
 `dotnet-nuget-delete` - Deletes or unlists a package from the server. 
@@ -37,8 +35,7 @@ Prints out a short help for the command.
 
 `-s|--source <SOURCE>`
 
-Specifies the server URL. Supported URL's for nuget.org include `http://www.nuget.org`, `http://www.nuget.org/api/v3` and `http://www.nuget.org/api/v2/package`. 
-For private feeds, substitute the host name (for example, `%hostname%/api/v3`).
+Specifies the server URL. Supported URL's for nuget.org include `http://www.nuget.org`, `http://www.nuget.org/api/v3` and `http://www.nuget.org/api/v2/package`. For private feeds, substitute the host name (for example, `%hostname%/api/v3`).
 
 `--non-interactive`
 
@@ -58,9 +55,7 @@ Displays this amount of details in the output. Level can be `normal`, `quiet`, o
 
 `--config-file <FILE>`
 
-A NuGet configuration file used specifically for this command, replacing other config files found by the standard config file discovery and chaining process. 
-The path can be absolute or relative.
-For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
+A NuGet configuration file used specifically for this command, replacing other config files found by the standard config file discovery and chaining process. The path can be absolute or relative. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior).
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-nuget-locals.md
+++ b/docs/core/preview3/tools/dotnet-nuget-locals.md
@@ -4,7 +4,7 @@ description: The dotnet-nuget-locals command clears or lists local NuGet resourc
 keywords: dotnet-nuget-locals, CLI, CLI command, .NET Core
 author: karann-msft
 ms.author: mairaw
-ms.date: 11/15/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: 8440229e-317e-4dc1-9463-cba5fdb12c3b
 ---
 
 #dotnet-nuget-locals
-
-[!INCLUDE[preview-warning](../../../includes/warning.md)] 
 
 ## Name 
 `dotnet-nuget-locals` - Clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder. 
@@ -55,8 +53,7 @@ Prints out a short help for the command.
 
 `-c|--clear`
 
-The clear option is used to perform a clear operation on the specified cache type. The contents of the cache directories are deleted recursively. 
-The executing user/group should have permission to the files in the cache directories for the operation to be successful. If not, then an error is displayed indication the files/folders which were not cleared.
+The clear option is used to perform a clear operation on the specified cache type. The contents of the cache directories are deleted recursively. The executing user/group should have permission to the files in the cache directories for the operation to be successful. If not, then an error is displayed indication the files/folders which were not cleared.
 
 `-l|--list`
 

--- a/docs/core/preview3/tools/dotnet-nuget-locals.md
+++ b/docs/core/preview3/tools/dotnet-nuget-locals.md
@@ -11,15 +11,18 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 8440229e-317e-4dc1-9463-cba5fdb12c3b
 ---
-
 #dotnet-nuget-locals
 
-## Name 
+## Name
+
 `dotnet-nuget-locals` - Clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder. 
 
 ## Synopsis
 
-`dotnet nuget locals <cache_location> [--clear|--list] [--help] [--force-english-output]`
+```
+dotnet nuget locals <cache_location> [(-c|--clear)|(-l|--list)] [--force-english-output]
+dotnet nuget locals [-h|--help]
+```
 
 where `<cache_location>` is one of the following values: `all`, `http-cache`, `packages-cache`, `global-packages`, or `temp`.
 

--- a/docs/core/preview3/tools/dotnet-nuget-push.md
+++ b/docs/core/preview3/tools/dotnet-nuget-push.md
@@ -4,32 +4,29 @@ description: The dotnet-nuget-push command pushes a package to the server and pu
 keywords: dotnet-nuget-push, CLI, CLI command, .NET Core
 author: karann-msft
 ms.author: mairaw
-ms.date: 11/11/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: f54d9adf-94f8-41cc-bb52-42f7ca3be6ff
 ---
-
 #dotnet-nuget-push
 
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
+## Name
 
-## Name 
 `dotnet-nuget-push` - Pushes a package to the server and publishes it. 
 
 ## Synopsis
 
-`dotnet nuget push [<package>] [--help] [--source] [--symbols-source] 
-    [--timeout] [--api-key] [--symbol-api-key] [--disable-buffering] [--no-symbols] 
-    [--force-english-output] [--config-file] [--verbosity]`
+```
+dotnet nuget push [<package>] [-s|--source] [-ss|--symbol-source] [-t|--timeout] [-k|--api-key] [-sk|--symbol-api-key] [-d|--disable-buffering] [-n|--no-symbols] [--force-english-output] [-v|--verbosity]
+dotnet nuget push [-h|--help]
+```
 
 ## Description
 
-The `dotnet nuget push` command pushes a package to the server and publishes it. 
-The push command uses server and credential details found in the system's NuGet config file, or chain of config files. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior). 
-NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.local/share* (Linux/macOS), then loading any *nuget.config* or *.nuget\nuget.config* 
+The `dotnet nuget push` command pushes a package to the server and publishes it. The push command uses server and credential details found in the system's NuGet config file, or chain of config files. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior). NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.local/share* (Linux/macOS), then loading any *nuget.config* or *.nuget\nuget.config* 
 starting from root of drive and ending in current directory.
 
 ## Options
@@ -70,12 +67,6 @@ Does not push symbols (even if present).
 
 Forces all logged output to be in English. As well as the flexibility of producing English output on a non-English machine, the consistency across platforms provided by this option is a helpful feature for 
 automated tools which scrape the logs for text.
-
-`--config-file <FILE>`
-
-A NuGet configuration file used specifically for this command, replacing other config files found by the standard config file discovery and chaining process. 
-The path can be absolute or relative.
-For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior). 
 
 `--verbosity <LEVEL>`
 

--- a/docs/core/preview3/tools/dotnet-pack.md
+++ b/docs/core/preview3/tools/dotnet-pack.md
@@ -20,7 +20,7 @@ ms.assetid: 8dbbb3f7-b817-4161-a6c8-a3489d05e051
 ## Synopsis
 
 ```
-dotnet pack [<project>] [-o|--output] [--no-build] [--include-symbols] [--include-source] [-s|--servicable] [-c|--configuration] [--version-suffix] [-v|--verbosity]
+dotnet pack [<PROJECT>] [-o|--output] [--no-build] [--include-symbols] [--include-source] [-c|--configuration] [--version-suffix] [-s|--serviceable] [-v|--verbosity]
 dotnet pack [-h|--help]
 ```
 
@@ -34,16 +34,18 @@ Project-to-project references are not packaged inside the project. Currently, yo
 
 `dotnet pack` by default first builds the project. If you wish to avoid this, pass the `--no-build` option. This can be useful in Continuous Integration (CI) build scenarios in which you know the code was just previously built, for example. 
 
+## Arguments
+
+`PROJECT` 
+    
+The project to pack. It can be either a path to a [csproj file](csproj.md) or to a directory. If omitted, it will
+default to the current directory. 
+
 ## Options
 
 `-h|--help`
 
 Prints out a short help for the command.  
-
-`project` 
-    
-The project to pack. It can be either a path to a [csproj file](csproj.md) or to a directory. If omitted, it will
-default to the current directory. 
 
 `-o|--output <OUTPUT_DIRECTORY>`
 
@@ -53,25 +55,29 @@ Places the built packages in the directory specified.
 
 Does not build the project before packing. 
 
+`--include-symbols`
+
+Generates the symbols nupkg. 
+
 `--include-source`
 
 Includes the source files in the NuGet package. The sources files are included in the `src` folder within the `nupkg`. 
-
-`--include-symbols`
-
-Generate the symbols nupkg. 
 
 `-c|--configuration <Debug|Release>`
 
 Configuration to use when building the project. If not specified, will default to `Debug`.
 
-`--version-suffix`
+`--version-suffix <VERSION_SUFFIX>`
 
-Updates the star in `-*` package version suffix with a specified string.
+Defines the value for the $(VersionSuffix) MSBuild property in the project.
+
+`-s|--serviceable`
+
+Sets the serviceable flag in the package. For more information, see https://aka.ms/nupkgservicing.
 
 `--verbosity <LEVEL>`
 
-Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ## Examples
 
@@ -91,6 +97,6 @@ Pack the project in the current directory into the specified folder and skip the
 
 `dotnet pack --no-build --output nupkgs`
 
-Pack the current project and updates the resulting packages version with the given suffix. For example, version `1.0.0-*` will be updated to `1.0.0-ci-1234`.
+Pack the current project and updates the resulting package version with the given suffix. The project's version suffix is configured as `<VersionSuffix>$(VersionSuffix)</VersionSuffix>` in the *.csproj*  file.
 
 `dotnet pack --version-suffix "ci-1234"`

--- a/docs/core/preview3/tools/dotnet-pack.md
+++ b/docs/core/preview3/tools/dotnet-pack.md
@@ -4,19 +4,14 @@ description: The dotnet-pack command creates NuGet packages for your .NET Core p
 keywords: dotnet-pack, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/12/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 8dbbb3f7-b817-4161-a6c8-a3489d05e051
 ---
-
-#dotnet-pack (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-pack](../../tools/dotnet-pack.md) topic.
+#dotnet-pack
 
 ## Name
 
@@ -24,11 +19,10 @@ ms.assetid: 8dbbb3f7-b817-4161-a6c8-a3489d05e051
 
 ## Synopsis
 
-`dotnet pack [--help] [--output]  
-    [--no-build] [--include-symbols]
-    [--include-source] [--servicable]
-    [--configuration]  [--version-suffix]
-    [project]`  
+```
+dotnet pack [<project>] [-o|--output] [--no-build] [--include-symbols] [--include-source] [-s|--servicable] [-c|--configuration] [--version-suffix] [-v|--verbosity]
+dotnet pack [-h|--help]
+```
 
 ## Description
 
@@ -46,7 +40,7 @@ Project-to-project references are not packaged inside the project. Currently, yo
 
 Prints out a short help for the command.  
 
-`[project]` 
+`project` 
     
 The project to pack. It can be either a path to a [csproj file](csproj.md) or to a directory. If omitted, it will
 default to the current directory. 
@@ -74,6 +68,10 @@ Configuration to use when building the project. If not specified, will default t
 `--version-suffix`
 
 Updates the star in `-*` package version suffix with a specified string.
+
+`--verbosity <LEVEL>`
+
+Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-publish.md
+++ b/docs/core/preview3/tools/dotnet-publish.md
@@ -20,7 +20,7 @@ ms.assetid: f2ef275a-7c5e-430a-8c30-65f52af62771
 ## Synopsis
 
 ```
-dotnet publish [project] [-f|--framework] [-r|--runtime] [-o|--output] [--version-suffix] [-c|--configuration] [-v|--verbosity]
+dotnet publish [<PROJECT>] [-f|--framework] [-r|--runtime] [-o|--output] [--version-suffix] [-c|--configuration] [-v|--verbosity]
 dotnet publish [-h|--help]
 ```
 
@@ -35,11 +35,13 @@ Depending on the type of portable app, the resulting directory will contain the 
 
 For more information, see the [.NET Core Application Deployment](../deploying/index.md) topic.
 
+## Arguments
+
+`<PROJECT>` 
+
+The project to publish, which defaults to the current directory if `<PROJECT>` is not specified. 
+
 ## Options
-
-`project` 
-
-The project to publish, which defaults to the current directory if `[project]` is not specified. 
 
 `-h|--help`
 
@@ -47,11 +49,11 @@ Prints out a short help for the command.
 
 `-f|--framework <FRAMEWORK>`
 
-Publishes the application for a given framework identifier (FID). 
+Publishes the application for specified target framework. The target framework has to be specified in the project file.
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 
-Publishes the application for a given runtime. For a list of Runtime Identifiers (RIDs) you can use, see the [RID catalog](../../rid-catalog.md).
+Publishes the application for a given runtime. This is used when creating a [self-contained deployment](../deploying/index.md#self-contained-deployments-scd). For a list of Runtime Identifiers (RIDs) you can use, see the [RID catalog](../../rid-catalog.md). Default is to publish a [framework-dependented app](../deploying/index.md#framework-dependent-deployments-fdd).
 
 `-o|--output <OUTPUT_PATH>`
 
@@ -66,28 +68,28 @@ Defines what `*` should be replaced with in the version field in the project fil
 
 Configuration to use when publishing. The default value is `Debug`.
 
-`-v|--verbosity`
+`-v|--verbosity <LEVEL>`
 
-Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
 ## Examples
 
-Publish an application.
+Publish the project found in the current directory:
 
 `dotnet publish`
 
-Publish the application using the specified project file
+Publish the application using the specified project file:
 
 `dotnet publish ~/projects/app1/app1.csproj`
 	
-Publish the current application using the `netcoreapp1.0` framework:
+Publish the project found in the current directory using the `netcoreapp1.1` framework:
 
-`dotnet publish --framework netcoreapp1.0`
+`dotnet publish --framework netcoreapp1.1`
 	
-Publish the current application using the `netcoreapp1.0` framework and runtime for `OS X 10.10` (this RID has to 
+Publish the current application using the `netcoreapp1.1` framework and runtime for `OS X 10.10` (this RID has to 
 exist in the project file).
 
-`dotnet publish --framework netcoreapp1.0 --runtime osx.10.11-x64`
+`dotnet publish --framework netcoreapp1.1 --runtime osx.10.11-x64`
 
 ## See also
 * [Frameworks](../../../standard/frameworks.md)

--- a/docs/core/preview3/tools/dotnet-publish.md
+++ b/docs/core/preview3/tools/dotnet-publish.md
@@ -4,19 +4,14 @@ description: The dotnet-publish command publishes your .NET Core project into a 
 keywords: dotnet-publish, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/07/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: f2ef275a-7c5e-430a-8c30-65f52af62771
 ---
-
-#dotnet-publish (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-publish](../../tools/dotnet-publish.md) topic.
+#dotnet-publish
 
 ## Name
 
@@ -24,14 +19,14 @@ ms.assetid: f2ef275a-7c5e-430a-8c30-65f52af62771
 
 ## Synopsis
 
-`dotnet publish [project] 
-    [--help] [--framework]  
-    [--runtime] [--output]  
-    [--version-suffix] [--configuration]`
+```
+dotnet publish [project] [-f|--framework] [-r|--runtime] [-o|--output] [--version-suffix] [-c|--configuration] [-v|--verbosity]
+dotnet publish [-h|--help]
+```
 
 ## Description
 
-`dotnet publish` compiles the application, reads through its dependencies specified in the project file and publishes the resulting set of files to a directory. 
+`dotnet publish` compiles the application, reads through its dependencies specified in the project file, and publishes the resulting set of files to a directory. 
 
 Depending on the type of portable app, the resulting directory will contain the following:
 
@@ -42,7 +37,7 @@ For more information, see the [.NET Core Application Deployment](../deploying/in
 
 ## Options
 
-`[project]` 
+`project` 
 
 The project to publish, which defaults to the current directory if `[project]` is not specified. 
 
@@ -70,6 +65,10 @@ Defines what `*` should be replaced with in the version field in the project fil
 `-c|--configuration [Debug|Release]`
 
 Configuration to use when publishing. The default value is `Debug`.
+
+`-v|--verbosity`
+
+Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-remove-package.md
+++ b/docs/core/preview3/tools/dotnet-remove-package.md
@@ -1,10 +1,10 @@
 ---
 title: dotnet-remove package command | Microsoft Docs
 description: The dotnet-remove package command provides a convenient option to remove NuGet package reference to a project.
-keywords: dotnet-remove , CLI, CLI command, .NET Core
+keywords: dotnet-remove, CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 02/16/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: 2fcc8d37-16b3-4581-8038-832160e72d36
 ---
 # dotnet-remove package
 
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
-
 ## Name
 
 `dotnet-remove package` - Removes package reference from a project file.
@@ -22,7 +20,7 @@ ms.assetid: 2fcc8d37-16b3-4581-8038-832160e72d36
 ## Synopsis
 
 ```
-dotnet remove [<PROJECT>] package <PACKAGE_NAME>
+dotnet remove [<project>] package <package_name>
 dotnet remove package [-h|--help]
 ```
 
@@ -32,11 +30,11 @@ The `dotnet remove package` command provides a convenient option to remove a NuG
 
 ## Arguments
 
-`PROJECT`
+`project`
 
 Project file to operate on. If not specified, the command will search the current directory for one.
 
-`PACKAGE_NAME`
+`package_name`
 
 The package reference to remove.
 

--- a/docs/core/preview3/tools/dotnet-remove-reference.md
+++ b/docs/core/preview3/tools/dotnet-remove-reference.md
@@ -1,10 +1,10 @@
 ---
 title: dotnet-remove reference command | Microsoft Docs
 description: The dotnet-remove reference command provides a convenient option to remove project to project references.
-keywords: dotnet-remove , CLI, CLI command, .NET Core
+keywords: dotnet-remove, CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 02/28/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: 889c6b7e-a313-40b1-9fd3-6a6f4c52f1d0
 ---
 # dotnet-remove reference
 
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
-
 ## Name
 
 `dotnet-remove reference` - Removes project to project references.
@@ -22,7 +20,7 @@ ms.assetid: 889c6b7e-a313-40b1-9fd3-6a6f4c52f1d0
 ## Synopsis
 
 ```
-dotnet remove [<PROJECT>] reference [-f|--framework] <PROJECT_REFERENCES>
+dotnet remove [<project>] reference [-f|--framework] <project_references>
 dotnet remove reference [-h|--help]
 ```
 
@@ -32,11 +30,11 @@ The `dotnet remove reference` command provides a convenient option to remove pro
 
 ## Arguments
 
-`PROJECT`
+`project`
 
 Project file to operate on. If not specified, the command will search the current directory for one.
 
-`PROJECT_REFERENCES`
+`project_references`
 
 Project to project references to remove. You can specify one or multiple projects. Glob pattern is supported on Unix/Linux based terminals.
 

--- a/docs/core/preview3/tools/dotnet-restore.md
+++ b/docs/core/preview3/tools/dotnet-restore.md
@@ -4,19 +4,14 @@ description: Learn how to restore dependencies and project-specific tools with t
 keywords: dotnet-restore, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/07/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: fd7a5769-afbe-4838-bbaf-3ae0cfcbb914
 ---
-
-#dotnet-restore (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-restore](../../tools/dotnet-restore.md) topic.
+#dotnet-restore
 
 ## Name
 
@@ -24,9 +19,10 @@ ms.assetid: fd7a5769-afbe-4838-bbaf-3ae0cfcbb914
 
 ## Synopsis
 
-`dotnet restore [root] [--help] [--source]  
-    [--packages] [--disable-parallel] [--configfile] 
-    [--no-cache] [--ignore-failed-sources] [--no-dependencies]`
+```
+dotnet restore [root] [-s|--source] [-r|--runtime] [--packages] [--disable-parallel] [--configfile] [--no-cache] [--ignore-failed-sources] [--no-dependencies] [-v|--verbosity]
+dotnet restore [-h|--help]
+```
 
 ## Description
 
@@ -48,7 +44,7 @@ proceeds to restore the tool's dependencies as specified in its project file.
 
 ## Options
 
-`[root]` 
+`root` 
     
 Optional path to the project file to restore. 
 
@@ -82,7 +78,11 @@ Only warn about failed sources if there are packages meeting version requirement
 
 `--no-dependencies`
 
-When restoring a project with P2P references, do not restore the references, just the root project. 
+When restoring a project with P2P references, do not restore the references, just the root project.
+
+`--verbosity <LEVEL>`
+
+Displays this amount of details in the output. Level can be `normal`, `quiet`, or `detailed`.
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-run.md
+++ b/docs/core/preview3/tools/dotnet-run.md
@@ -4,30 +4,28 @@ description: The dotnet-run command provides a convenient option to run your app
 keywords: dotnet-run, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/07/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 40d4e60f-9900-4a48-b03c-0bae06792d91
 ---
-
-#dotnet-run (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-run](../../tools/dotnet-run.md) topic.
+#dotnet-run
 
 ## Name 
 
-dotnet-run -- Runs source code 'in-place' without any explicit compile or launch commands.
+`dotnet-run` - Runs source code 'in-place' without any explicit compile or launch commands.
 
 ## Synopsis
 
-`dotnet run [--help] [--framework] [--configuration]
-    [--project] [[--] [application arguments]]`
+```
+dotnet run [-p|--project] [-f|--framework] [-c|--configuration] [[--] [application arguments]]
+dotnet run [-h|--help]
+```
 
 ## Description
+
 The `dotnet run` command provides a convenient option to run your application from the source code with one command. 
 It compiles source code, generates an output program and then runs that program. 
 This command is useful for fast iterative development and can also be used to run a source-distributed program (for example, a website).
@@ -59,19 +57,18 @@ All arguments after this one will be passed to the application being run.
 
 Prints out a short help for the command.
 
-`-f`, `--framework <FRAMEWORK_IDENTIFIER>`
+`-p|--project [PATH]`
+
+Specifies which project to run. It can be a path to a [csproj](csproj.md) file or to a directory containing a [csproj](csproj.md) file. It defaults to
+current directory if not specified. 
+
+`-f|--framework <FRAMEWORK_IDENTIFIER>`
 
 Runs the application for a given framework identifier (FID). 
 
-`-c`, `--configuration <Debug|Release>`
+`-c|--configuration <Debug|Release>`
 
 Configuration to use when publishing. The default value is `Debug`.
-
-`-p`, `--project [PATH]`
-
-Specifies which project to run. 
-It can be a path to a [csproj](csproj.md) file or to a directory containing a [csproj](csproj.md) file. It defaults to
-current directory if not specified. 
 
 ## Examples
 

--- a/docs/core/preview3/tools/dotnet-sln.md
+++ b/docs/core/preview3/tools/dotnet-sln.md
@@ -4,7 +4,7 @@ description: The dotnet-sln command provides a convenient option to add, remove,
 keywords: dotnet-sln, CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 02/06/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,8 +13,6 @@ ms.assetid: e5a72d3e-c14b-4b0a-a978-c5e54a0988c6
 ---
 # dotnet-sln
 
-[!INCLUDE[preview-warning](../../../includes/warning.md)]
-
 ## Name
 
 `dotnet-sln` - Modifies a .NET Core solution file.
@@ -22,11 +20,11 @@ ms.assetid: e5a72d3e-c14b-4b0a-a978-c5e54a0988c6
 ## Synopsis
 
 ```
-dotnet sln [<SLN_NAME>] add <project> <project>
-dotnet sln [<SLN_NAME>] add **/**
-dotnet sln [<SLN_NAME>] remove <project> <project>
-dotnet sln [<SLN_NAME>] remove **/**
-dotnet sln [<SLN_NAME>] list
+dotnet sln [<solution_name>] add <project> <project>
+dotnet sln [<solution_name>] add **/**
+dotnet sln [<solution_name>] remove <project> <project>
+dotnet sln [<solution_name>] remove **/**
+dotnet sln [<solution_name>] list
 dotnet sln [-h|--help]
 ```
 
@@ -54,9 +52,9 @@ List all projects in a solution file.
 
 ## Arguments
 
-`SLN_NAME`
+`solution_name`
 
-Solution file to use. If not specified, the command will search the current directory for one. If there are multiple solution files in the directory; one must be specified.
+Solution file to use. If not specified, the command will search the current directory for one. If there are multiple solution files in the directory, one must be specified.
 
 ## Options
 

--- a/docs/core/preview3/tools/dotnet-test.md
+++ b/docs/core/preview3/tools/dotnet-test.md
@@ -4,19 +4,14 @@ description: The `dotnet test` command is used to execute unit tests in a given 
 keywords: dotnet-test, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 02/08/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 4bf0aef4-148a-41c6-bb95-0a9e1af8762e
 ---
-
-#dotnet-test (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet-test](../../tools/dotnet-test.md) topic.
+#dotnet-test
 
 ## Name
 
@@ -24,18 +19,14 @@ ms.assetid: 4bf0aef4-148a-41c6-bb95-0a9e1af8762e
 
 ## Synopsis
 
-`dotnet test [project] [--help] 
-    [--settings] [--list-tests] [--filter] 
-    [--test-adapter-path] [--logger] 
-    [--configuration] [--framework] [--output] [--diag]
-    [--no-build] [--verbosity]`
+```
+dotnet test [project] [-s|--settings] [-t|--list-tests] [--filter] [-a|--test-adapter-path] [-l|--logger] [-c|--configuration] [-f|--framework] [-o|--output] [-d|--diag] [--no-build] [-v|--verbosity]
+dotnet test [-h|--help]
+```
 
 ## Description
 
-The `dotnet test` command is used to execute unit tests in a given project. Unit tests are class library 
-projects that have dependencies on the unit test framework (for example, NUnit or xUnit) and the 
-dotnet test runner for that unit testing framework. 
-These are packaged as NuGet packages and are restored as ordinary dependencies for the project.
+The `dotnet test` command is used to execute unit tests in a given project. Unit tests are class library projects that have dependencies on the unit test framework (for example, NUnit or xUnit) and the dotnet test runner for that unit testing framework. These are packaged as NuGet packages and are restored as ordinary dependencies for the project.
 
 Test projects also need to specify the test runner. This is specified using an ordinary `<PackageReference>` element, as 
 seen in the following sample project file:
@@ -44,7 +35,7 @@ seen in the following sample project file:
 
 ## Options
 
-`[project]`
+`project`
     
 Specifies a path to the test project. If omitted, it defaults to current directory.
 
@@ -92,7 +83,7 @@ Enables diagnostic mode for the test platform and write diagnostic messages to t
 
 Does not build the test project prior to running it.
 
-`-v|--verbosity [quiet|minimal|normal|diagnostic]`
+`-v|--verbosity <LEVEL>`
 
 Set the verbosity level of the command. You can specify the following verbosity levels: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]. 
 

--- a/docs/core/preview3/tools/dotnet.md
+++ b/docs/core/preview3/tools/dotnet.md
@@ -11,15 +11,18 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 256e468e-eaaa-4715-b5fb-8cbddcf80e69
 ---
-# dotnet command (.NET Core SDK 1.0.0 Tools)
+# dotnet command
 
 ## Name
 
-dotnet -- General driver for running the command-line commands
+`dotnet` - General driver for running the command-line commands
 
 ## Synopsis
 
-`dotnet [--version] [--verbose] [--info] [command] [arguments] [--help]`
+```
+dotnet [command] [arguments] [--version] [--info] [-d|--diagnostics] [-v|--verbose]
+dotnet [-h|--help]
+```
 
 ## Description
 
@@ -34,6 +37,10 @@ The only time `dotnet` is used as a command on its own is to run portable apps. 
 `-v|--verbose`
 
 Enables verbose output.
+
+`-d|--diagnostics`
+
+Enables diagnostic output.
 
 `--version`
 
@@ -69,6 +76,8 @@ The following commands exist for dotnet:
   * Migrates a valid Preview 2 project to a .NET Core SDK 1.0.0 project.
 * [dotnet-msbuild](dotnet-msbuild.md)
   * Provides access to the MSBuild command line.
+* [dotnet-clean](dotnet-clean.md)
+  * Clean build output(s).
 * [dotnet-sln](dotnet-sln.md)
   * Options to add, remove, and list projects in a solution file.
 * Project modification commands

--- a/docs/core/preview3/tools/dotnet.md
+++ b/docs/core/preview3/tools/dotnet.md
@@ -4,18 +4,14 @@ description: Learn about the dotnet command (the generic driver for the .NET Cor
 keywords: dotnet, CLI, CLI commands, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 02/16/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 256e468e-eaaa-4715-b5fb-8cbddcf80e69
 ---
-# dotnet command (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [dotnet command](../../tools/dotnet.md) topic.
+# dotnet command (.NET Core SDK 1.0.0 Tools)
 
 ## Name
 
@@ -70,7 +66,7 @@ The following commands exist for dotnet:
 * [dotnet-pack](dotnet-pack.md)
   * Creates a NuGet package of your code.
 * [dotnet-migrate](dotnet-migrate.md)
-  * Migrates a valid Preview 2 project to a RC4 project.
+  * Migrates a valid Preview 2 project to a .NET Core SDK 1.0.0 project.
 * [dotnet-msbuild](dotnet-msbuild.md)
   * Provides access to the MSBuild command line.
 * [dotnet-sln](dotnet-sln.md)

--- a/docs/core/preview3/tools/index.md
+++ b/docs/core/preview3/tools/index.md
@@ -4,7 +4,7 @@ description: An overview of what the Command-Line Interface (CLI) is and its mai
 keywords: CLI, CLI tools, .NET, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 10/06/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -12,11 +12,7 @@ ms.devlang: dotnet
 ms.assetid: 7c5eee9f-d873-4224-8f5f-ed83df329a59
 ---
 
-# .NET Core command-line interface tools (.NET Core Tools RC4)
-
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [.NET Core command-line interface tools](../../tools/index.md) topic.
+# .NET Core command-line interface tools (.NET Core SDK 1.0.0 Tools)
 
 The .NET Core command-line interface (CLI) is a new foundational cross-platform toolchain for developing 
 .NET Core applications. It is "foundational" because it is the primary layer on which other, 
@@ -69,7 +65,7 @@ The following example utilizes several commands from the CLI standard install to
 restore the dependencies, build the application and then run it. 
 
 ```console
-dotnet new
+dotnet new console
 dotnet restore
 dotnet build --output /stuff
 dotnet /stuff/new.dll
@@ -115,12 +111,12 @@ CLI enables applications to be portable in two main ways:
 
 You can learn more about both of these in the [.NET Core application deployment](../deploying/index.md) topic. 
 
-## Migration from RC4/project.json
-If you used Preview 2 tooling and project.json projects, you can consult the [dotnet migrate](dotnet-migrate.md) command docs
+## Migration from project.json
+If you used Preview 2 tooling and *project.json* projects, you can consult the [dotnet migrate](dotnet-migrate.md) command docs
 to get acquainted with the command and how to migrate your project. 
 
 > [!NOTE]
-> The `dotnet migrate` command currently does not migrate pre-preview 2 project.json files. 
+> The `dotnet migrate` command currently does not migrate pre-preview 2 *project.json* files. 
 
 ## Extensibility
 Of course, not every tool that you could use in your workflow will be part of the core CLI tools. However, .NET Core 

--- a/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
+++ b/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
@@ -4,7 +4,7 @@ description: This tutorial explains how to organize and test .NET Core projects 
 keywords: .NET, .NET Core
 author: cartermp
 ms.author: mairaw
-ms.date: 03/06/2017
+ms.date: 03/07/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -13,6 +13,9 @@ ms.assetid: 52ff1be3-d92e-4477-9c84-8c1771e87ab5
 ---
 
 # Organizing and testing projects with the .NET Core command line
+
+> [!WARNING]
+> This topic hasn't been updated to the latest version of the tooling yet.
 
 This tutorial follows [Getting started with .NET Core on Windows/Linux/macOS using the command line(./using-with-xplat-cli-msbuild.md) to show how to go beyond simple "Hello world!" scenarios and pave the way for more advanced and well-organized applications.
 
@@ -193,7 +196,7 @@ You'll probably be wanting to test your projects at some point. Here's a good wa
    |__/test
    ```
 
-3. Initialize the directory with a `dotnet new xunit` command. This assumes Xunit, but you can also use MS Test by replacing `xunit` with `mstest`.
+3. Initialize the directory with a `dotnet new xunit` command. This assumes xUnit, but you can also use MSTest by replacing `xunit` with `mstest`.
    
 ### Example: Extending the NewTypes project
 
@@ -219,13 +222,13 @@ The whole project structure should look like this:
 
 There are two new things to make sure you have in your test project:
 
-1. A correct `NewTypesTests.csproj` file with the following:
+1. A correct *NewTypesTests.csproj* file with the following:
 
    * A reference to `xunit`
    * A reference to `dotnet-test-xunit`
    * A reference to the namespace corresponding to the code under test
 
-   This can be built by typing `dotnet new xunit` at a command prompt in the `NewTypesTests` directory, then adding a project reference to the `NewTypes` project.
+   This can be built by typing `dotnet new xunit` at a command prompt in the *NewTypesTests* directory, then adding a project reference to the `NewTypes` project.
 
     `NewTypesTests/NewTypesTests.csproj`:
     ```xml
@@ -266,7 +269,7 @@ There are two new things to make sure you have in your test project:
     </Project>
     ```
 
-2. An Xunit test class.
+2. An xUnit test class.
 
     `PetTests.cs`: 
     ```csharp

--- a/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
+++ b/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
@@ -1,6 +1,6 @@
 ---
 title: Organizing and testing projects with the .NET Core command line (.NET Core SDK 1.0.0 Tools) | Microsoft Docs
-description: This tutorial explains how to organize and test .NET Core projects from the .NET Core command line.
+description: This tutorial explains how to organize and test .NET Core projects from the command line.
 keywords: .NET, .NET Core
 author: cartermp
 ms.author: mairaw

--- a/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
+++ b/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
@@ -1,6 +1,6 @@
 ---
 title: Organizing and testing projects with the .NET Core command line (.NET Core SDK 1.0.0 Tools) | Microsoft Docs
-description: Move beyond simple scenarios and pave the way for more advanced and well-organized applications.
+description: This tutorial explains how to organize and test .NET Core projects from the .NET Core command line.
 keywords: .NET, .NET Core
 author: cartermp
 ms.author: mairaw

--- a/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
+++ b/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
@@ -1,5 +1,5 @@
 ---
-title: Organizing and testing projects with the .NET Core command line (.NET Core SDK 1.0.0 Tools) | Microsoft Docs
+title: Organizing and testing projects with the .NET Core command line | Microsoft Docs
 description: This tutorial explains how to organize and test .NET Core projects from the command line.
 keywords: .NET, .NET Core
 author: cartermp
@@ -12,9 +12,9 @@ ms.devlang: dotnet
 ms.assetid: 52ff1be3-d92e-4477-9c84-8c1771e87ab5
 ---
 
-# Organizing and testing projects with the .NET Core command line (.NET Core SDK 1.0.0 Tools)
+# Organizing and testing projects with the .NET Core command line
 
-This tutorial follows <xref:using-with-xplat-cli-msbuild> to show how to go beyond simple "Hello world!" scenarios and pave the way for more advanced and well-organized applications.
+This tutorial follows [Getting started with .NET Core on Windows/Linux/macOS using the command line(./using-with-xplat-cli-msbuild.md) to show how to go beyond simple "Hello world!" scenarios and pave the way for more advanced and well-organized applications.
 
 ## Using folders to organize code
 

--- a/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
+++ b/docs/core/preview3/tutorials/using-with-xplat-cli-msbuild-folders.md
@@ -1,10 +1,10 @@
 ---
-title: Organizing and testing projects with the .NET Core command line (.NET Core Tools RC4) | Microsoft Docs
-description: Organizing and testing projects with the .NET Core command line (.NET Core Tools RC4)
+title: Organizing and testing projects with the .NET Core command line (.NET Core SDK 1.0.0 Tools) | Microsoft Docs
+description: Move beyond simple scenarios and pave the way for more advanced and well-organized applications.
 keywords: .NET, .NET Core
 author: cartermp
 ms.author: mairaw
-ms.date: 06/20/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -12,17 +12,13 @@ ms.devlang: dotnet
 ms.assetid: 52ff1be3-d92e-4477-9c84-8c1771e87ab5
 ---
 
-# Organizing and testing projects with the .NET Core command line (.NET Core Tools RC4)
+# Organizing and testing projects with the .NET Core command line (.NET Core SDK 1.0.0 Tools)
 
-> [!WARNING]
-> This topic applies to .NET Core Tools RC4. For the .NET Core Tools Preview 2 version,
-> see the [Getting started with .NET Core on Windows/Linux/macOS using the command line](../../tutorials/using-with-xplat-cli.md) topic.
-
-This tutorial follows [Getting started with .NET Core on Windows/Linux/macOS using the command line (.NET Core Tools RC4)](./using-with-xplat-cli-msbuild.md) to show how to go beyond simple "hello world" scenarios and pave the way for more advanced and well-organized applications.
+This tutorial follows <xref:using-with-xplat-cli-msbuild> to show how to go beyond simple "Hello world!" scenarios and pave the way for more advanced and well-organized applications.
 
 ## Using folders to organize code
 
-Say you wanted to introduce some new types to do work on.  You can do this by adding more files and making sure to give them namespaces you can include in your `Program.cs` file.
+Say you wanted to introduce some new types to do work on. You can do this by adding more files and making sure to give them namespaces you can include in your *Program.cs* file.
 
 ```
 /MyProject
@@ -32,7 +28,7 @@ Say you wanted to introduce some new types to do work on.  You can do this by ad
 |__MyProject.csproj
 ```
 
-This works great when the size of your project is relatively small.  However, if you have a larger app with many different data types and potentially multiple layers, you may wish to organize things logically. This is where folders come into play.  You can either follow along with [the NewTypes sample project](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/NewTypesMsBuild) that this guide covers, or create your own files and folders.
+This works great when the size of your project is relatively small. However if you have a larger app with many different data types and potentially multiple layers, you may wish to organize things logically. This is where folders come into play. You can either follow along with [the NewTypes sample project](https://github.com/dotnet/docs/tree/master/samples/core/console-apps/NewTypesMsBuild) that this guide covers, or create your own files and folders.
 
 To begin, create a new folder under the root of your project. `/Model` is chosen here.
 
@@ -180,7 +176,7 @@ New pet types can be added (such as a `Bird`), extending this project.
 
 ## Testing your Console App
 
-You'll probably be wanting to test your projects at some point.  Here's a good way to do it:
+You'll probably be wanting to test your projects at some point. Here's a good way to do it:
 
 1. Move any source of your existing project into a new `src` folder.
 
@@ -197,7 +193,7 @@ You'll probably be wanting to test your projects at some point.  Here's a good w
    |__/test
    ```
 
-3. Initialize the directory with a `dotnet new -t Xunittest` command. This assumes Xunit, but you can also use MS Test by replacing `Xunittest` with `Mstest`.
+3. Initialize the directory with a `dotnet new xunit` command. This assumes Xunit, but you can also use MS Test by replacing `xunit` with `mstest`.
    
 ### Example: Extending the NewTypes project
 
@@ -229,7 +225,7 @@ There are two new things to make sure you have in your test project:
    * A reference to `dotnet-test-xunit`
    * A reference to the namespace corresponding to the code under test
 
-   This can be built by simply doing `dotnet new -t Xunittest` from the command-line in the `NewTypesTests` directory, then adding a project reference to the `NewTypes` project.
+   This can be built by typing `dotnet new xunit` at a command prompt in the `NewTypesTests` directory, then adding a project reference to the `NewTypes` project.
 
     `NewTypesTests/NewTypesTests.csproj`:
     ```xml
@@ -299,7 +295,7 @@ There are two new things to make sure you have in your test project:
     }
     ```
    
-Now you can run tests!  The [`dotnet test`](../tools/dotnet-test.md) command runs the test runner you have specified in your project. Make sure you start at the top-level directory.
+Now you can run tests! The [`dotnet test`](../tools/dotnet-test.md) command runs the test runner you have specified in your project. Make sure you start at the top-level directory.
  
 ```
 $ cd test/NewTypesTests

--- a/docs/csharp/getting-started/with-visual-studio-code.md
+++ b/docs/csharp/getting-started/with-visual-studio-code.md
@@ -4,7 +4,7 @@ description: Learn how to create and debug your first .NET Core application in C
 keywords: C#, Getting Started, Acquisition, Install, Visual Studio Code, Cross Platform
 author: kendrahavens
 ms.author: mairaw
-ms.date: 01/03/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -14,7 +14,7 @@ ms.assetid: 76c23597-4cf9-467e-8a47-0c3703ce37e7
 
 # Getting Started with Visual Studio Code
 
-.NET Core gives you a fast and modular platform for creating server applications that run on Windows, Linux and macOS. Use Visual Studio Code with the C# extension to get a powerful editing experience with full support for C# IntelliSense (smart code completion) and debugging.
+.NET Core gives you a fast and modular platform for creating server applications that run on Windows, Linux, and macOS. Use Visual Studio Code with the C# extension to get a powerful editing experience with full support for C# IntelliSense (smart code completion) and debugging.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ Let's get started with a simple "Hello World" program on .NET Core:
 
 2. Initialize a C# project:
     * Open the Integrated Terminal from VS Code by typing <kbd>CTRL</kbd>+<kbd>`</kbd> (backtick).
-    * In the terminal window, type `dotnet new`.
+    * In the terminal window, type `dotnet new console`.
     * This creates a `Program.cs` file in your folder with a simple "Hello World" program already written, along with a C# project file named `HelloWorld.csproj`.
 
   ![The dotnet new command](media/with-visual-studio-code/dotnetnew.png)
@@ -58,11 +58,11 @@ Let's get started with a simple "Hello World" program on .NET Core:
 You can also watch a short video tutorial for further setup help on [Windows](https://channel9.msdn.com/Blogs/dotnet/Get-started-with-VS-Code-using-CSharp-and-NET-Core), [macOS](https://channel9.msdn.com/Blogs/dotnet/Get-started-with-VS-Code-using-CSharp-and-NET-Core-on-MacOS), or [Linux](https://channel9.msdn.com/Blogs/dotnet/Get-started-with-VS-Code-Csharp-dotnet-Core-Ubuntu).
 
 ## Debug
-1. Open Program.cs by clicking on it. The first time you open a C# file in VS Code, [OmniSharp](http://www.omnisharp.net/) will load in the editor.
+1. Open *Program.cs* by clicking on it. The first time you open a C# file in VS Code, [OmniSharp](http://www.omnisharp.net/) will load in the editor.
 
   ![Open the Program.cs file](media/with-visual-studio-code/opencs.png)
 
-2. VS Code will prompt you to add the missing assets to build and debug your app. Click **Yes**. 
+2. VS Code will prompt you to add the missing assets to build and debug your app. Select **Yes**. 
 
   ![Prompt for missing assets](media/with-visual-studio-code/missing-assets.png)
 

--- a/docs/csharp/getting-started/with-visual-studio-code.md
+++ b/docs/csharp/getting-started/with-visual-studio-code.md
@@ -4,7 +4,7 @@ description: Learn how to create and debug your first .NET Core application in C
 keywords: C#, Getting Started, Acquisition, Install, Visual Studio Code, Cross Platform
 author: kendrahavens
 ms.author: mairaw
-ms.date: 03/06/2017
+ms.date: 03/07/2017
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -37,7 +37,7 @@ Let's get started with a simple "Hello World" program on .NET Core:
     * Alternatively, you can select **File** > **Open Folder** from the main menu to open your project folder.
 
 2. Initialize a C# project:
-    * Open the Integrated Terminal from VS Code by typing <kbd>CTRL</kbd>+<kbd>`</kbd> (backtick).
+    * Open the Integrated Terminal from VS Code by typing <kbd>CTRL</kbd>+<kbd>\`</kbd> (backtick).
     * In the terminal window, type `dotnet new console`.
     * This creates a `Program.cs` file in your folder with a simple "Hello World" program already written, along with a C# project file named `HelloWorld.csproj`.
 

--- a/docs/csharp/tutorials/attributes.md
+++ b/docs/csharp/tutorials/attributes.md
@@ -4,7 +4,7 @@ description: Learn how attributes work in C#
 keywords: .NET, .NET Core, C#, attributes
 author: mgroves
 ms.author: wiwagn
-ms.date: 1/22/2017
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -34,10 +34,9 @@ comfortable with.
 
 ## Create the Application
 
-Now that you've installed all the tools, create a new .NET Core
-application. To use the command line generator, execute the following command in your favorite shell:
+Now that you've installed all the tools, create a new .NET Core application. To use the command line generator, execute the following command in your favorite shell:
 
-`dotnet new`
+`dotnet new console`
 
 This command will create barebones .NET core project files. You will need to execute `dotnet restore` to restore the dependencies needed to compile this project.
 

--- a/docs/csharp/tutorials/attributes.md
+++ b/docs/csharp/tutorials/attributes.md
@@ -1,6 +1,6 @@
 ---
 title: Attributes | C#
-description: Learn how attributes work in C#
+description: Learn how attributes work in C#.
 keywords: .NET, .NET Core, C#, attributes
 author: mgroves
 ms.author: wiwagn

--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -1,10 +1,10 @@
 ---
 title: Console Application
-description: Console Application
+description: This tutorial teaches you a number of features in .NET Core and the C# language.
 keywords: .NET, .NET Core
 author: BillWagner
 ms.author: wiwagn
-ms.date: 11/06/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: devlang-csharp
@@ -37,7 +37,7 @@ You’ll need to install your favorite code editor.
 ## Create the Application
 The first step is to create a new application. Open a command prompt and
 create a new directory for your application. Make that the current
-directory. Type the command `dotnet new` at the command prompt. This
+directory. Type the command `dotnet new console` at the command prompt. This
 creates the starter files for a basic “Hello World” application.
 
 Before you start making modifications, let’s go through the steps to run

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -1,10 +1,10 @@
 ---
 title: Creates a REST client using .NET Core
-description: REST client
+description: This tutorial teaches you a number of features in .NET Core and the C# language. 
 keywords: .NET, .NET Core
 author: BillWagner
 ms.author: wiwagn
-ms.date: 06/20/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: devlang-csharp
@@ -41,7 +41,7 @@ comfortable with.
 ## Create the Application
 The first step is to create a new application. Open a command prompt and
 create a new directory for your application. Make that the current
-directory. Type the command `dotnet new` at the command prompt. This
+directory. Type the command `dotnet new console` at the command prompt. This
 creates the starter files for a basic “Hello World” application.
 
 Before you start making modifications, let’s go through the steps to run

--- a/docs/csharp/tutorials/inheritance.md
+++ b/docs/csharp/tutorials/inheritance.md
@@ -5,7 +5,7 @@ keywords: inheritance (C#), base classes, derived classes, abstract base classes
 author: rpetrusha
 manager: wpickett
 ms.author: ronpet
-ms.date: 12/13/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: .net-core-technologies
@@ -28,7 +28,7 @@ To create and run the examples in this tutorial, you use the [dotnet](../../core
 
 1. Create a directory to store the example.
 
-1. Enter the [dotnet new](../../core/tools/dotnet-new.md) command from the command line to create a new .NET Core project.
+1. Enter the [dotnet new console](../../core/tools/dotnet-new.md) command at a command prompt to create a new .NET Core project.
 
 1. Copy and paste the code from the example into your code editor.
 

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -4,7 +4,7 @@ description: Learn how string interpolation works in C# 6
 keywords: .NET, .NET Core, C#, string
 author: mgroves
 ms.author: wiwagn
-ms.date: 12/09/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -41,9 +41,11 @@ comfortable with.
 Now that you've installed all the tools, create a new .NET Core
 application. To use the command line generator, create a directory for your project, such as `interpolated`, and execute the following command in your favorite shell:
 
-`dotnet new`
+```
+dotnet new console
+```
 
-This command will create a barebones .NET core project with a project file, `interpolated.csproj`, and a source code file, `Program.cs`. You will need to execute `dotnet restore` to restore the dependencies needed to compile this project.
+This command will create a barebones .NET core project with a project file, *interpolated.csproj*, and a source code file, *Program.cs*. You will need to execute `dotnet restore` to restore the dependencies needed to compile this project.
 
 To execute the program, use `dotnet run`. You should see "Hello, World" output to the console.
 

--- a/docs/csharp/tutorials/working-with-linq.md
+++ b/docs/csharp/tutorials/working-with-linq.md
@@ -1,6 +1,6 @@
 ---
 title: Working with LINQ
-description: This tutorial teaches you how to generate sequences with LINQ, how to write methods that can be easily used in LINQ queries, and how to distinguish between eager and lazy evaluation.
+description: This tutorial teaches you how to generate sequences with LINQ, write methods for use in LINQ queries, and distinguish between eager and lazy evaluation.
 keywords: .NET, .NET Core
 author: BillWagner
 ms.author: wiwagn

--- a/docs/csharp/tutorials/working-with-linq.md
+++ b/docs/csharp/tutorials/working-with-linq.md
@@ -1,10 +1,10 @@
 ---
 title: Working with LINQ
-description: Working with LINQ
+description: This tutorial teaches you how to generate sequences with LINQ, how to write methods that can be easily used in LINQ queries, and how to distinguish between eager and lazy evaluation.
 keywords: .NET, .NET Core
 author: BillWagner
 ms.author: wiwagn
-ms.date: 06/20/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -55,7 +55,7 @@ comfortable with.
 
 The first step is to create a new application. Open a command prompt and
 create a new directory for your application. Make that the current
-directory. Type the command "dotnet new" at the command prompt. This
+directory. Type the command `dotnet new console` at the command prompt. This
 creates the starter files for a basic “Hello World” application.
 
 If you've never used C# before, [this tutorial](console-teleprompter.md)

--- a/docs/fsharp/tutorials/getting-started/getting-started-command-line.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-command-line.md
@@ -4,7 +4,7 @@ description: Learn how to use F# with the cross-platform .NET CLI.
 keywords: visual f#, f#, functional programming, .NET, .NET Core
 author: cartermp
 ms.author: phcart
-ms.date: 02/13/2016
+ms.date: 03/06/2017
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-fsharp
@@ -14,13 +14,13 @@ ms.assetid: 615db1ec-6ef3-4de2-bae6-4586affa9771
 
 # Getting started with F# with command-line tools
 
-This article covers how you can get started with using F# on .NET Core.  It will go through building a multi-project solution with a Class Library that is called by a Console Application.
+This article covers how you can get started with using F# on .NET Core. It will go through building a multi-project solution with a Class Library that is called by a Console Application.
 
 ## Prerequisites
 
-To begin, you must install the [.NET Core SDK 1.0.3 - (build 004769 or later)](https://dot.net/core).  There is no need to uninstall a previous version of the .NET Core SDK, as it supports side-by-side installations.
+To begin, you must install the [.NET Core SDK 1.0.3 - (build 004769 or later)](https://dot.net/core). There is no need to uninstall a previous version of the .NET Core SDK, as it supports side-by-side installations.
 
-This article assumes that you know how to use a command line and have a preferred text editor.  If you don't already use it, [Visual Studio Code](https://code.visualstudio.com) is a great option as a text editor for F#.  To get awesome features like IntelliSense, better syntax highlighting, and more, you can download the [Ionide Extension](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp).
+This article assumes that you know how to use a command line and have a preferred text editor. If you don't already use it, [Visual Studio Code](https://code.visualstudio.com) is a great option as a text editor for F#. To get awesome features like IntelliSense, better syntax highlighting, and more, you can download the [Ionide Extension](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp).
 
 ## Building a Simple Multi-project Solution
 
@@ -113,7 +113,7 @@ open Library
 
 [<EntryPoint>]
 let main argv = 
-    printfn "Nice command-line arguments!  Here's what JSON.NET has to say about them:"
+    printfn "Nice command-line arguments! Here's what JSON.NET has to say about them:"
 
     argv
     |> Array.map getJsonNetJson
@@ -144,7 +144,7 @@ dotnet run Hello World
 You should see the following results:
 
 ```
-Nice command-line arguments!  Here's what JSON.NET has to say about them:
+Nice command-line arguments! Here's what JSON.NET has to say about them:
 
 I used to be Hello but now I'm ""Hello"" thanks to JSON.NET!
 I used to be World but now I'm ""World"" thanks to JSON.NET!


### PR DESCRIPTION
Fixes #1574

* Update `ms.date` to today (03/06/2017)
* Didn't touch `tutorials/libraries.md` and `turorials/using-on-macos.md` ... the docs are heavily PJ-based. See: #1646 and #1648 
* Touched a couple of grammar/style things here and there
* Slow! 🐢 ... but I wanted to read all of these to gain familiarity with `dotnet/docs` docs.