### PR TITLE
Improves link to sampleQuotes.txt in console-teleprompter tutorial

### DIFF
--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -80,7 +80,7 @@ namespace TeleprompterConsole
 ## Reading and Echoing the File
 The first feature to add is to read a text file, and display all that text
 to the console. First, let’s add a text file. Copy the 
-[sampleQuotes.txt](https://github.com/dotnet/docs/blob/master/samples/csharp/getting-started/console-teleprompter/sampleQuotes.txt)
+[sampleQuotes.txt](https://raw.githubusercontent.com/dotnet/docs/master/samples/csharp/getting-started/console-teleprompter/sampleQuotes.txt)
 file from the GitHub repository for this [sample](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-teleprompter) into your project directory. 
 This will serve as the script for your
 application.


### PR DESCRIPTION
# Title

Improves link to sampleQuotes.txt in console-teleprompter tutorial.

## Summary

The link to sampleQuotes.txt now references a raw version of the file.

## Details

This makes it easier to `wget` the file. I did not realize I had the html source of the github page instead of the actual quotes until I finished the tutorial and ran the result.