### PR TITLE
reenable incremental build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -5,7 +5,6 @@
     "need_generate_pdf_url_template": true,
     "git_repository_branch_open_to_public_contributors": "master",
     "git_repository_url_open_to_public_contributors": "https://github.com/dotnet/core-docs",
-    "enable_incremental_build": false,
     "branch_target_mapping": {
         "live": [
             "Publish",


### PR DESCRIPTION
# Title

Reenable incremental build.

## Summary

Reenable incremental build as OPS fixes an issue that reports PathTooLongException error.

## Suggested Reviewers

@fenxu @chenkennt @mairaw @ansyral
