### PR TITLE
C# TOC changes for when keyword

### DIFF
--- a/docs/csharp/language-reference/keywords/contextual-keywords.md
+++ b/docs/csharp/language-reference/keywords/contextual-keywords.md
@@ -1,6 +1,6 @@
 ---
 title: "Contextual Keywords (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-07"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -44,6 +44,7 @@ A contextual keyword is used to provide a specific meaning in the code, but it i
 |[set](../../../csharp/language-reference/keywords/set.md)|Defines an accessor method for a property or an indexer.|  
 |[value](../../../csharp/language-reference/keywords/value.md)|Used to set accessors and to add or remove event handlers.|  
 |[var](../../../csharp/language-reference/keywords/var.md)|Enables the type of a variable declared at method scope to be determined by the compiler.|  
+|[when](when.md)|Specifies a filter condition for a `catch` block or the `case` label of a `switch` statement.|
 |[where](../../../csharp/language-reference/keywords/where-generic-type-constraint.md)|Adds constraints to a generic declaration. (See also [where](../../../csharp/language-reference/keywords/where-clause.md)).|  
 |[yield](../../../csharp/language-reference/keywords/yield.md)|Used in an iterator block to return a value to the enumerator object or to signal the end of iteration.|  
   

--- a/docs/csharp/language-reference/keywords/index.md
+++ b/docs/csharp/language-reference/keywords/index.md
@@ -1,6 +1,6 @@
 ---
 title: "C# Keywords | Microsoft Docs"
-ms.date: "2017-02-09"
+ms.date: "2017-03-07"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -73,7 +73,7 @@ Keywords are predefined, reserved identifiers that have special meanings to the 
 |[join](../../../csharp/language-reference/keywords/join-clause.md)|[let](../../../csharp/language-reference/keywords/let-clause.md)|[orderby](../../../csharp/language-reference/keywords/orderby-clause.md)|  
 |[partial (type)](../../../csharp/language-reference/keywords/partial-type.md)|[partial (method)](../../../csharp/language-reference/keywords/partial-method.md)|[remove](../../../csharp/language-reference/keywords/remove.md)|  
 |[select](../../../csharp/language-reference/keywords/select-clause.md)|[set](../../../csharp/language-reference/keywords/set.md)|[value](../../../csharp/language-reference/keywords/value.md)|  
-|[var](../../../csharp/language-reference/keywords/var.md)|[where (generic type constraint)](../../../csharp/language-reference/keywords/where-generic-type-constraint.md)|[where (query clause)](../../../csharp/language-reference/keywords/where-clause.md)|  
+|[var](../../../csharp/language-reference/keywords/var.md)|[when (filter condition)](when.md)|[where (generic type constraint)](../../../csharp/language-reference/keywords/where-generic-type-constraint.md)|[where (query clause)](../../../csharp/language-reference/keywords/where-clause.md)|  
 |[yield](../../../csharp/language-reference/keywords/yield.md)||  
   
 ## See Also  

--- a/docs/csharp/language-reference/keywords/toc.md
+++ b/docs/csharp/language-reference/keywords/toc.md
@@ -128,6 +128,7 @@
 ### [partial (Method)](partial-method.md)
 ### [remove](remove.md)
 ### [set](set.md)
+### [when (filter condition)](when.md)
 ### [where (generic type constraint)](where-generic-type-constraint.md)
 ### [value](value.md)
 ### [yield](yield.md)


### PR DESCRIPTION
# C# TOC changes for when keywordOn the title describe

## Summary

Added `when` to the list of contextual keywords.

## Suggested Reviewers

@mairaw @BillWagner 