### PR TITLE
Fixes typo in code block of console-webapiclient tutorial

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -254,7 +254,7 @@ the name of each repository. Replace the lines that read:
 ```cs
 var msg = await stringTask;   //**Deleted this
 Console.Write(msg);
-```cs
+```
 
 with the following:
 


### PR DESCRIPTION
# Title

Fixes typo in code block of console-webapiclient tutorial

## Summary

This change correctly splits the code block into two separate blocks.

## Details

The affected token should indicate the end of the current code block - not the start of another.