### PR TITLE
link to old project.json version of docs

### DIFF
--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -21,7 +21,7 @@ The documentation version from before the March 7 update is available in a PDF f
 
 The best source of the earlier documentation is PDF files:
 
-* [.NET Core - PDF for project.json and Visual Studio 2015](https://github.com/dotnet/docs/raw/project.json/net-core-project-json.pdf)
+* [.NET Core - PDF for project.json and Visual Studio 2015](https://github.com/dotnet/docs/blob/project.json/net-core-project-json.pdf)
 * [ASP.NET Core - PDF for project.json and Visual Studio 2015](https://github.com/aspnet/Docs/blob/master/aspnetcore/common/_static/aspnet-core-project-json.pdf)
 
 ## Documentation repository branch

--- a/docs/project-json.md
+++ b/docs/project-json.md
@@ -1,0 +1,37 @@
+---
+title: project.json and Visual Studio 2015 with .NET Core | Microsoft Docs
+description: Where to find documentation for pre-release tooling for .NET Core and ASP.NET Core (project.json and Visual Studio 2015).
+keywords: project.json, Visual Studio 2015, .NET Core, ASP.NET Core
+author: mairaw
+ms.author: mairaw
+ms.date: 03/08/2017
+ms.topic: article
+ms.prod: .net
+ms.devlang: dotnet
+ms.assetid: e282c43b-593e-40a6-af91-de0babcd7b72
+---
+
+# project.json and Visual Studio 2015 with .NET Core
+
+On March 7, 2017, the .NET Core and ASP.NET Core documentation was updated for the release of Visual Studio 2017. The previous version of the documentation used Visual Studio 2015 and pre-release tooling based on the *project.json* file.
+
+The documentation version from before the March 7 update is available in a PDF file and in a branch in the documentation repository.
+
+## PDF files
+
+The best source of the earlier documentation is PDF files:
+
+* [.NET Core - PDF for project.json and Visual Studio 2015](https://github.com/dotnet/docs/raw/project.json/net-core-project-json.pdf)
+* [ASP.NET Core - PDF for project.json and Visual Studio 2015](https://github.com/aspnet/Docs/blob/master/aspnetcore/common/_static/aspnet-core-project-json.pdf)
+
+## Documentation repository branch
+
+You can view the earlier version of the documentation in the repository, but many links won't work and many code snippets are references that aren't expanded.
+
+* [.NET Core - project.json branch in the documentation repository](https://github.com/dotnet/docs/tree/project.json/docs)
+* [ASP.NET Core - project.json branch in the documentation repository](https://github.com/aspnet/Docs/tree/project.json/aspnetcore)
+
+## Current version of the documentation
+
+* [.NET Core documentation](https://docs.microsoft.com/en-us/dotnet/articles/core/)
+* [ASP.NET Core documentation](https://docs.microsoft.com/en-us/aspnet/core/)


### PR DESCRIPTION
Creating an article that tells how to get the VS2015/project.json version of docs

