### PR TITLE
Added note about out variable declaration as it pertains to scope

### DIFF
--- a/docs/csharp/csharp-7.md
+++ b/docs/csharp/csharp-7.md
@@ -69,9 +69,16 @@ The most common use for this feature will be the `Try` pattern. In this
 pattern, a method returns a `bool` indicating success or failure and an
 `out` variable that provides the result if the method succeeds.
 
-> [!NOTE]
-> When using the `out` variable declaration, the scope of the declared variable is the same as it was in previous 
-> versions of C#. In other words, this is syntax sugar that enables inlining.  
+When using the `out` variable declaration, the declared variable "leaks" into the outer scope of the if statement. This allows you to use the variable afterwards:
+
+```csharp
+if (!int.TryParse(input, out int result))
+{    
+    return null;
+}
+
+return result;
+```
 
 ## Tuples
 

--- a/docs/csharp/csharp-7.md
+++ b/docs/csharp/csharp-7.md
@@ -69,6 +69,10 @@ The most common use for this feature will be the `Try` pattern. In this
 pattern, a method returns a `bool` indicating success or failure and an
 `out` variable that provides the result if the method succeeds.
 
+> [!NOTE]
+> When using the `out` variable declaration, the scope of the declared variable is the same as it was in previous 
+> versions of C#. In other words, this is syntax sugar that enables inlining.  
+
 ## Tuples
 
 C# provides a rich syntax for classes and structs that is used to explain


### PR DESCRIPTION
## Summary

I received clarification when inquiring about the variable scope as it pertains to the `out` variable declaration.

## Fixes

No specific issue, but does relate to https://github.com/dotnet/roslyn/issues/17669.
## Details

In preparation for an upcoming presentation that I'm giving on C# 7 - I discovered what appeared to be a discrepancy in the [C# Language - Out Variable Declaration](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.0/out-var.md) details surrounding scope. This https://github.com/dotnet/roslyn/issues/17669 explains the findings, the scope is by design.
## Suggested Reviewers

@BillWagner 
