### PR TITLE
Improve note about System.ValueTuple

### DIFF
--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -26,7 +26,9 @@ different ways to use them, and initial guidance on working with Tuples.
 
 > [!NOTE]
 > The new tuples features require the `System.ValueTuple` type. For Visual Studio 2017,
-> you must add the NuGet package "System.ValueTuple", available in the pre-release stream.
+> you must add the NuGet package [System.ValueTuple](https://www.nuget.org/packages/System.ValueTuple/), available on the NuGet Gallery.
+> Without this package you may get a compilation error similar to `error CS8179: Predefined type 'System.ValueTuple``2' is not defined or imported`
+> or `error CS8137: Cannot define a class or member that utilizes tuples because the compiler required type 'System.Runtime.CompilerServices.TupleElementNamesAttribute' cannot be found.`
 
 Let's start with the reasons for adding new Tuple support. Methods return
 a single object. Tuples enable you to package multiple values in that single


### PR DESCRIPTION
# Title

Improve note about System.ValueTuple

## Summary
Improved the note about adding a reference to System.ValueTuple so users can locate the documentation when search for error messages online. Also removed the language about the pre-release stream.

## Details

I feel that the current user experience around Tuple types and VS 2017 is undesirable and hope this change helps ease some of that for users.

## Suggested Reviewers

Those with empathy.
