### PR TITLE
Fix outdated example and whitespace

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -73,7 +73,7 @@ The NuGet configuration file (NuGet.config) to use for the restore operation.
 
 Specifies to not cache packages and HTTP requests.
 
-` --ignore-failed-sources`
+`--ignore-failed-sources`
 
 Only warn about failed sources if there are packages meeting version requirement.
 
@@ -95,13 +95,13 @@ Restore dependencies and tools for the `app1` project found in the given path:
 
 `dotnet restore ~/projects/app1/app1.csproj`
 	
-Restore the dependencies and tools for the project in the current directory using the file path provided as the fallback source:
+Restore the dependencies and tools for the project in the current directory using the file path provided as the source:
 
-`dotnet restore -f c:\packages\mypackages` 
+`dotnet restore -s c:\packages\mypackages` 
 
-Restore the dependencies and tools for the project in the current directory using the two file paths provided as the fallback sources:
+Restore the dependencies and tools for the project in the current directory using the two file paths provided as sources:
 
-`dotnet restore -f c:\packages\mypackages -f c:\packages\myotherpackages` 
+`dotnet restore -s c:\packages\mypackages -s c:\packages\myotherpackages` 
 
 Restore dependencies and tools for the project in the current directory and shows only errors in the output:
 


### PR DESCRIPTION
This is an update from my previous PR since the files moved.

# Title

Fix outdated example and whitespace

## Summary

Update an outdated example switch changing from -f to -s and removing one extra whitespace.