### PR TITLE
Fix DotNetCliToolReference casing

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -111,8 +111,8 @@ Alternatively, the attribute can contain:
 * `None` – none of the assets are used.
 * `All` – all assets are used.
 
-### DotnetCliToolReference
-`<DotnetCliToolReference>` item element specifies the CLI tool that the user wants to restore in the context of the project. It's 
+### DotNetCliToolReference
+`<DotNetCliToolReference>` item element specifies the CLI tool that the user wants to restore in the context of the project. It's 
 a replacement for the `tools` node in *project.json*. 
 
 ```xml

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -116,7 +116,7 @@ Alternatively, the attribute can contain:
 a replacement for the `tools` node in *project.json*. 
 
 ```xml
-<DotnetCliToolReference Include="<package-id>" Version="" />
+<DotNetCliToolReference Include="<package-id>" Version="" />
 ```
 
 #### Version


### PR DESCRIPTION
# Fix DotNetCliToolReference casing

Element name is incorrect here, and won't work when copied into a .csproj file.
