### PR TITLE
Fixed error with classlib

### DIFF
--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -57,7 +57,7 @@ Your next task is to create the library. In the terminal window
 cd to *golden/* and type the command:
 
 ```
-dotnet new classlib library
+dotnet new classlib -o library
 ```
 
 This creates a library project, with two files: *library.csproj* and


### PR DESCRIPTION
# Fixed faulty command

## Summary

The command was throwing an error 

```
Parameter names must start with -- or -
   at Microsoft.TemplateEngine.Cli.AppExtensions.ParseExtraArgs(CommandLineApplication app, IList`1 extraArgFileNames)
   at Microsoft.TemplateEngine.Cli.ExtendedCommandParser.ParseArgs(IList`1 extraArgFileNames)
   at Microsoft.TemplateEngine.Cli.New3Command.<ExecuteAsync>d__66.MoveNext()
```

This fixes it

