### PR TITLE
Update choosing-core-framework-server.md

### DIFF
--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -89,7 +89,7 @@ Some .NET Framework technologies are not available in .NET Core. Some of them wi
 
 * Workflow related services: Windows Workflow Foundation (WF), Workflow Services (WCF + WF in a single service) and WCF Data Services (formerly known as “ADO.NET Data Services”) are only available on the .NET Framework and there are no plans to bring them to .NET Core.
 
-* WPF and Windows Forms: WPF (Windows Presentation Foundation) and Windows Forms Applications are only available on the .NET Framework and there are no plans to bring them to .NET Core and these will continue to be part of .NET Framework. 
+* Windows Presentation Foundation (WPF) and Windows Forms: WPF and Windows Forms applications are only available on the .NET Framework. There are no plans to port them to .NET Core, and they remain part of the .NET Framework. 
 
 * Language support: Visual Basic and F# don’t currently have tooling support .NET Core, but both will be supported in Visual Studio 2017 and later versions of Visual Studio.
 

--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -89,6 +89,8 @@ Some .NET Framework technologies are not available in .NET Core. Some of them wi
 
 * Workflow related services: Windows Workflow Foundation (WF), Workflow Services (WCF + WF in a single service) and WCF Data Services (formerly known as “ADO.NET Data Services”) are only available on the .NET Framework and there are no plans to bring them to .NET Core.
 
+* WPF and Windows Forms: WPF (Windows Presentation Foundation) and Windows Forms Applications are only available on the .NET Framework and there are no plans to bring them to .NET Core and these will continue to be part of .NET Standard. 
+
 * Language support: Visual Basic and F# don’t currently have tooling support .NET Core, but both will be supported in Visual Studio 2017 and later versions of Visual Studio.
 
 In addition to the official roadmap, there are other frameworks to be ported to .NET Core - For a full list, take a look at CoreFX issues marked as [port-to-core](https://github.com/dotnet/corefx/issues?q=is%3Aopen+is%3Aissue+label%3Aport-to-core). Please note that this list doesn’t represent a commitment from Microsoft to bring those components to .NET Core — they are simply capturing the desire from the community to do so. That being said, if you care about any of the components listed above, consider participating in the discussions on GitHub so that your voice can be heard. And if you think something is missing, please [file a new issue in the CoreFX repository](https://github.com/dotnet/corefx/issues/new).

--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -89,7 +89,7 @@ Some .NET Framework technologies are not available in .NET Core. Some of them wi
 
 * Workflow related services: Windows Workflow Foundation (WF), Workflow Services (WCF + WF in a single service) and WCF Data Services (formerly known as “ADO.NET Data Services”) are only available on the .NET Framework and there are no plans to bring them to .NET Core.
 
-* WPF and Windows Forms: WPF (Windows Presentation Foundation) and Windows Forms Applications are only available on the .NET Framework and there are no plans to bring them to .NET Core and these will continue to be part of .NET Standard. 
+* WPF and Windows Forms: WPF (Windows Presentation Foundation) and Windows Forms Applications are only available on the .NET Framework and there are no plans to bring them to .NET Core and these will continue to be part of .NET Framework. 
 
 * Language support: Visual Basic and F# don’t currently have tooling support .NET Core, but both will be supported in Visual Studio 2017 and later versions of Visual Studio.
 

--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -89,7 +89,7 @@ Some .NET Framework technologies are not available in .NET Core. Some of them wi
 
 * Workflow related services: Windows Workflow Foundation (WF), Workflow Services (WCF + WF in a single service) and WCF Data Services (formerly known as “ADO.NET Data Services”) are only available on the .NET Framework and there are no plans to bring them to .NET Core.
 
-* Windows Presentation Foundation (WPF) and Windows Forms: WPF and Windows Forms applications are only available on the .NET Framework. There are no plans to port them to .NET Core, and they remain part of the .NET Framework. 
+* Windows Presentation Foundation (WPF) and Windows Forms: WPF and Windows Forms applications are only available on the .NET Framework. There are no plans to port them to .NET Core. 
 
 * Language support: Visual Basic and F# don’t currently have tooling support .NET Core, but both will be supported in Visual Studio 2017 and later versions of Visual Studio.
 


### PR DESCRIPTION
Added WPF and WinForms in the list of most common technologies not found in .NET Core 1.0: