### PR TITLE
Revisions for support of binary literals

### DIFF
--- a/docs/csharp/language-reference/keywords/byte.md
+++ b/docs/csharp/language-reference/keywords/byte.md
@@ -1,6 +1,6 @@
 ---
 title: "byte (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,21 +32,28 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # byte (C# Reference)
-The `byte` keyword denotes an integral type that stores values as indicated in the following table.  
+
+`byte` denotes an integral type that stores values as indicated in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
 |----------|-----------|----------|-------------------------|  
 |`byte`|0 to 255|Unsigned 8-bit integer|<xref:System.Byte?displayProperty=fullName>|  
   
 ## Literals  
- You can declare and initialize a `byte` variable like this example:  
+
+ You can declare and initialize a `byte` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it. If the integer literal is outside the range of `byte` (that is, if it is less than <xref:System.Byte.MinValue?displayProperty=fullName> or greater than <xref:System.Byte.MaxValue?displayProperty=fullName>, a compilation error occurs.
+
+In the following example, integers equal to 201 that are represented as decimal, hexadecimal, and binary literals are implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `byte` values.    
   
-```  
-byte myByte = 255;  
-```  
-  
- In the preceding declaration, the integer literal `255` is implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `byte`. If the integer literal exceeds the range of `byte`, a compilation error will occur.  
-  
+[!code-cs[Byte](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#Byte)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix.
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[Byte](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#ByteS)]  
+ 
 ## Conversions  
  There is a predefined implicit conversion from `byte` to [short](../../../csharp/language-reference/keywords/short.md), [ushort](../../../csharp/language-reference/keywords/ushort.md), [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), [ulong](../../../csharp/language-reference/keywords/ulong.md), [float](../../../csharp/language-reference/keywords/float.md), [double](../../../csharp/language-reference/keywords/double.md), or [decimal](../../../csharp/language-reference/keywords/decimal.md).  
   

--- a/docs/csharp/language-reference/keywords/int.md
+++ b/docs/csharp/language-reference/keywords/int.md
@@ -1,6 +1,6 @@
 ---
 title: "int (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,33 +32,48 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # int (C# Reference)
-The `int` keyword denotes an integral type that stores values according to the size and range shown in the following table.  
+
+`int` denotes an integral type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|Default Value|  
 |----------|-----------|----------|-------------------------|-------------------|  
 |`int`|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|<xref:System.Int32?displayProperty=fullName>|0|  
   
 ## Literals  
- You can declare and initialize a variable of the type `int` like this example:  
+ 
+You can declare and initialize an `int` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it.  If the integer literal is outside the range of `int` (that is, if it is less than <xref:System.Int32.MinValue?displayProperty=fullName> or greater than <xref:System.Int32.MaxValue?displayProperty=fullName>, a compilation error occurs. 
+
+In the following example, integers equal to 16,342 that are represented as decimal, hexadecimal, and binary literals are assigned to `int` values.  
   
-```  
-  
-int i = 123;  
-```  
-  
- When an integer literal has no suffix, its type is the first of these types in which its value can be represented: `int`, [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), [ulong](../../../csharp/language-reference/keywords/ulong.md). In this example, it is of the type `int`.  
+[!code-cs[int](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#Int)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix. 
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[int](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#IntS)]  
+ 
+ Integer literals can also include a suffix that denotes the type, although there is no suffix that denotes the `int` type. If an integer literal has no suffix, its type is the first of the following types in which its value can be represented: 
+
+1. `int`
+2. [uint](../../../csharp/language-reference/keywords/uint.md)
+3. [long](../../../csharp/language-reference/keywords/long.md)
+4. [ulong](../../../csharp/language-reference/keywords/ulong.md) 
+ 
+In these examples, the literal 90946 is of type `int`.
   
 ## Conversions  
  There is a predefined implicit conversion from `int` to [long](../../../csharp/language-reference/keywords/long.md), [float](../../../csharp/language-reference/keywords/float.md), [double](../../../csharp/language-reference/keywords/double.md), or [decimal](../../../csharp/language-reference/keywords/decimal.md). For example:  
   
-```  
+```cs  
 // '123' is an int, so an implicit conversion takes place here:  
 float f = 123;  
 ```  
   
  There is a predefined implicit conversion from [sbyte](../../../csharp/language-reference/keywords/sbyte.md), [byte](../../../csharp/language-reference/keywords/byte.md), [short](../../../csharp/language-reference/keywords/short.md), [ushort](../../../csharp/language-reference/keywords/ushort.md), or [char](../../../csharp/language-reference/keywords/char.md) to `int`. For example, the following assignment statement will produce a compilation error without a cast:  
   
-```  
+```cs  
 long aLong = 22;  
 int i1 = aLong;       // Error: no implicit conversion from long.  
 int i2 = (int)aLong;  // OK: explicit conversion.  
@@ -66,9 +81,8 @@ int i2 = (int)aLong;  // OK: explicit conversion.
   
  Notice also that there is no implicit conversion from floating-point types to `int`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
-  
-      int x = 3.0;         // Error: no implicit conversion from double.  
+```cs  
+int x = 3.0;         // Error: no implicit conversion from double.  
 int y = (int)3.0;    // OK: explicit conversion.  
 ```  
   

--- a/docs/csharp/language-reference/keywords/long.md
+++ b/docs/csharp/language-reference/keywords/long.md
@@ -65,7 +65,7 @@ long value = 4294967296L;
   
  When you use the suffix `L`, the type of the literal integer is determined to be either `long` or [ulong](../../../csharp/language-reference/keywords/ulong.md), depending on its size. In this case, it is `long` because it less than the range of [ulong](../../../csharp/language-reference/keywords/ulong.md).  
   
- A common use of the suffix is to call overloaded methods. Tor example, the following overloaded methods have parameters of type `long` and [int](../../../csharp/language-reference/keywords/int.md):  
+ A common use of the suffix is to call overloaded methods. For example, the following overloaded methods have parameters of type `long` and [int](../../../csharp/language-reference/keywords/int.md):  
   
 ```cs
 public static void SampleMethod(int i) {}  

--- a/docs/csharp/language-reference/keywords/long.md
+++ b/docs/csharp/language-reference/keywords/long.md
@@ -1,6 +1,6 @@
 ---
 title: "long (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,60 +32,73 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # long (C# Reference)
-The `long` keyword denotes an integral type that stores values according to the size and range shown in the following table.  
+
+`long` denotes an integral type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
 |----------|-----------|----------|-------------------------|  
 |`long`|–9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|<xref:System.Int64?displayProperty=fullName>|  
   
-## Literals  
- You can declare and initialize a `long` variable like this example:  
+## Literals 
+
+You can declare and initialize a `long` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it. 
+
+In the following example, integers equal to 4,294,967,296 that are represented as decimal, hexadecimal, and binary literals are assigned to `long` values.  
   
+[!code-cs[long](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#Long)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix. 
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[long](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#LongS)]  
+ 
+ Integer literals can also include a suffix that denotes the type. The suffix `L` denotes a `long`. The following example uses the `L` suffix to denote a long integer:
+ 
+```cs
+long value = 4294967296L;  
 ```  
+
+> [!NOTE]
+>  You can also use the lowercase letter "l" as a suffix. However, this generates a compiler warning because the letter "l" is easily confused with the digit "1." Use "L" for clarity.  
   
-long long1 = 4294967296;  
-```  
+ When you use the suffix `L`, the type of the literal integer is determined to be either `long` or [ulong](../../../csharp/language-reference/keywords/ulong.md), depending on its size. In this case, it is `long` because it less than the range of [ulong](../../../csharp/language-reference/keywords/ulong.md).  
   
- When an integer literal has no suffix, its type is the first of these types in which its value can be represented: [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), `long`, [ulong](../../../csharp/language-reference/keywords/ulong.md). In the preceding example, it is of the type `long` because it exceeds the range of [uint](../../../csharp/language-reference/keywords/uint.md) (see [Integral Types Table](../../../csharp/language-reference/keywords/integral-types-table.md) for the storage sizes of integral types).  
+ A common use of the suffix is to call overloaded methods. Tor example, the following overloaded methods have parameters of type `long` and [int](../../../csharp/language-reference/keywords/int.md):  
   
- You can also use the suffix L with the `long` type like this:  
-  
-```  
-  
-long long2 = 4294967296L;  
-```  
-  
- When you use the suffix L, the type of the literal integer is determined to be either `long` or [ulong](../../../csharp/language-reference/keywords/ulong.md) according to its size. In the case it is `long` because it less than the range of [ulong](../../../csharp/language-reference/keywords/ulong.md).  
-  
- A common use of the suffix is with calling overloaded methods. Consider, for example, the following overloaded methods that use `long` and [int](../../../csharp/language-reference/keywords/int.md) parameters:  
-  
-```  
+```cs
 public static void SampleMethod(int i) {}  
 public static void SampleMethod(long l) {}  
 ```  
   
- Using the suffix L guarantees that the correct type is called, for example:  
+ The `L` suffix guarantees that the correct overload is called:  
   
+```cs  
+SampleMethod(5);    // Calls the method with the int parameter  
+SampleMethod(5L);   // Calls the method with the long parameter  
 ```  
-SampleMethod(5);    // Calling the method with the int parameter  
-SampleMethod(5L);   // Calling the method with the long parameter  
-```  
+If an integer literal has no suffix, its type is the first of the following types in which its value can be represented: 
+
+1. [int](int.md)
+2. [uint](../../../csharp/language-reference/keywords/uint.md)
+3. `long`
+4. [ulong](../../../csharp/language-reference/keywords/ulong.md) 
+
+The literal 4294967296 in the previous examples is of type `long`, because it exceeds the range of [uint](../../../csharp/language-reference/keywords/uint.md) (see [Integral Types Table](../../../csharp/language-reference/keywords/integral-types-table.md) for the storage sizes of integral types).  
   
- You can use the `long` type with other numeric integral types in the same expression, in which case the expression is evaluated as `long` (or [bool](../../../csharp/language-reference/keywords/bool.md) in the case of relational or Boolean expressions). For example, the following expression evaluates as `long`:  
+ If you use the `long` type with other integral types in the same expression, the expression is evaluated as `long` (or [bool](../../../csharp/language-reference/keywords/bool.md) in the case of relational or Boolean expressions). For example, the following expression evaluates as `long`:  
   
-```  
+```cs  
 898L + 88  
 ```  
-  
-> [!NOTE]
->  You can also use the lowercase letter "l" as a suffix. However, this generates a compiler warning because the letter "l" is easily confused with the digit "1." Use "L" for clarity.  
   
  For information on arithmetic expressions with mixed floating-point types and integral types, see [float](../../../csharp/language-reference/keywords/float.md) and [double](../../../csharp/language-reference/keywords/double.md).  
   
 ## Conversions  
  There is a predefined implicit conversion from `long` to [float](../../../csharp/language-reference/keywords/float.md), [double](../../../csharp/language-reference/keywords/double.md), or [decimal](../../../csharp/language-reference/keywords/decimal.md). Otherwise a cast must be used. For example, the following statement will produce a compilation error without an explicit cast:  
   
-```  
+```cs  
 int x = 8L;        // Error: no implicit conversion from long to int  
 int x = (int)8L;   // OK: explicit conversion to int  
 ```  
@@ -94,9 +107,8 @@ int x = (int)8L;   // OK: explicit conversion to int
   
  Notice also that there is no implicit conversion from floating-point types to `long`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
-  
-      long x = 3.0;         // Error: no implicit conversion from double  
+```cs  
+long x = 3.0;         // Error: no implicit conversion from double  
 long y = (long)3.0;   // OK: explicit conversion  
 ```  
   

--- a/docs/csharp/language-reference/keywords/sbyte.md
+++ b/docs/csharp/language-reference/keywords/sbyte.md
@@ -1,6 +1,6 @@
 ---
 title: "sbyte (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,32 +32,42 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # sbyte (C# Reference)
-The `sbyte` keyword indicates an integral type that stores values according to the size and range shown in the following table.  
+
+`sbyte` denotes an integral type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
 |----------|-----------|----------|-------------------------|  
 |`sbyte`|-128 to 127|Signed 8-bit integer|<xref:System.SByte?displayProperty=fullName>|  
   
 ## Literals  
- You can declare and initialize an `sbyte` variable in this manner:  
+
+You can declare and initialize an `sbyte` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it. 
+
+In the following example, integers equal to -102 that are represented as decimal, hexadecimal, and binary literals are converted from [int](../../../csharp/language-reference/keywords/int.md) to `sbyte` values.    
   
-```  
-  
-sbyte sByte1 = 127;  
-```  
-  
- In the previous declaration, the integer literal 127 is implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `sbyte`. If the integer literal exceeds the range of `sbyte`, a compilation error will occur.  
-  
+[!code-cs[SByte](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#SByte)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix.
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[SByteSeparator](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#SByteS)]  
+
+If the integer literal is outside the range of `sbyte` (that is, if it is less than <xref:System.SByte.MinValue?displayProperty=fullName> or greater than <xref:System.SByte.MaxValue?displayProperty=fullName>, a compilation error occurs. When an integer literal has no suffix, its type is the first of these types in which its value can be represented: [int](int.md), [uint](uint.md), [long](long.md), [ulong](ulong.md). This means that, in this example, the numeric literals `0x9A` and `0b10011010` are interpreted as 32-bit signed integers with a value of 156, which exceeds <xref:System.SByte.MaxValue?displayProperty=fullName>. Because of this, the casting operator is needed, and the assignment must occur in an [unchecked](unchecked.md) context. 
+
+## Compiler overload resolution
+
  A cast must be used when calling overloaded methods. Consider, for example, the following overloaded methods that use `sbyte` and [int](../../../csharp/language-reference/keywords/int.md) parameters:  
   
-```  
+```cs  
 public static void SampleMethod(int i) {}  
 public static void SampleMethod(sbyte b) {}  
 ```  
   
  Using the `sbyte` cast guarantees that the correct type is called, for example:  
   
-```  
+```cs 
 // Calling the method with the int parameter:  
 SampleMethod(5);  
 // Calling the method with the sbyte parameter:  
@@ -69,39 +79,34 @@ SampleMethod((sbyte)5);
   
  You cannot implicitly convert nonliteral numeric types of larger storage size to `sbyte` (see [Integral Types Table](../../../csharp/language-reference/keywords/integral-types-table.md) for the storage sizes of integral types). Consider, for example, the following two `sbyte` variables `x` and `y`:  
   
-```  
-  
+```cs  
 sbyte x = 10, y = 20;  
 ```  
   
  The following assignment statement will produce a compilation error, because the arithmetic expression on the right side of the assignment operator evaluates to [int](../../../csharp/language-reference/keywords/int.md) by default.  
   
-```  
-  
+```cs  
 sbyte z = x + y;   // Error: conversion from int to sbyte  
 ```  
   
  To fix this problem, cast the expression as in the following example:  
   
-```  
-  
+```cs  
 sbyte z = (sbyte)(x + y);   // OK: explicit conversion  
 ```  
   
  It is possible though to use the following statements, where the destination variable has the same storage size or a larger storage size:  
   
-```  
-  
-      sbyte x = 10, y = 20;  
+```cs
+sbyte x = 10, y = 20;  
 int m = x + y;  
 long n = x + y;  
 ```  
   
  Notice also that there is no implicit conversion from floating-point types to `sbyte`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
-  
-      sbyte x = 3.0;         // Error: no implicit conversion from double  
+```cs  
+sbyte x = 3.0;         // Error: no implicit conversion from double  
 sbyte y = (sbyte)3.0;  // OK: explicit conversion  
 ```  
   

--- a/docs/csharp/language-reference/keywords/short.md
+++ b/docs/csharp/language-reference/keywords/short.md
@@ -1,6 +1,6 @@
 ---
 title: "short (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,66 +32,77 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # short (C# Reference)
-The `short` keyword denotes an integral data type that stores values according to the size and range shown in the following table.  
+
+`short` denotes an integral data type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
 |----------|-----------|----------|-------------------------|  
 |`short`|-32,768 to 32,767|Signed 16-bit integer|<xref:System.Int16?displayProperty=fullName>|  
   
 ## Literals  
- You can declare and initialize a `short` variable like this example:  
+
+You can declare and initialize a `short` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it.  If the integer literal is outside the range of `short` (that is, if it is less than <xref:System.Int16.MinValue?displayProperty=fullName> or greater than <xref:System.Int16.MaxValue?displayProperty=fullName>, a compilation error occurs. 
+
+In the following example, integers equal to 1,034 that are represented as decimal, hexadecimal, and binary literals are implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `short` values.  
   
-```  
-  
-short x = 32767;  
-```  
-  
- In the preceding declaration, the integer literal `32767` is implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `short`. If the integer literal does not fit into a `short` storage location, a compilation error will occur.  
-  
+[!code-cs[Short](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#Short)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix.
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[Short](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#ShortS)]  
+ 
+## Compiler overload resolution
+
  A cast must be used when calling overloaded methods. Consider, for example, the following overloaded methods that use `short` and [int](../../../csharp/language-reference/keywords/int.md) parameters:  
   
-```  
+```cs  
 public static void SampleMethod(int i) {}  
 public static void SampleMethod(short s) {}  
 ```  
   
  Using the `short` cast guarantees that the correct type is called, for example:  
   
-```  
+```cs  
 SampleMethod(5);         // Calling the method with the int parameter  
 SampleMethod((short)5);  // Calling the method with the short parameter  
 ```  
   
 ## Conversions  
+
  There is a predefined implicit conversion from `short` to [int](../../../csharp/language-reference/keywords/int.md), [long](../../../csharp/language-reference/keywords/long.md), [float](../../../csharp/language-reference/keywords/float.md), [double](../../../csharp/language-reference/keywords/double.md), or [decimal](../../../csharp/language-reference/keywords/decimal.md).  
   
  You cannot implicitly convert nonliteral numeric types of larger storage size to `short` (see [Integral Types Table](../../../csharp/language-reference/keywords/integral-types-table.md) for the storage sizes of integral types). Consider, for example, the following two `short` variables `x` and `y`:  
   
-```  
-  
+```cs  
 short x = 5, y = 12;  
 ```  
   
- The following assignment statement will produce a compilation error, because the arithmetic expression on the right-hand side of the assignment operator evaluates to [int](../../../csharp/language-reference/keywords/int.md) by default.  
+ The following assignment statement produces a compilation error because the arithmetic expression on the right-hand side of the assignment operator evaluates to [int](../../../csharp/language-reference/keywords/int.md) by default.  
   
- `short`   `z = x + y;   // Error: no conversion from int to short`  
-  
+```cs
+short z  = x + y;        // Compiler error CS0266: no conversion from int to short
+```
+
  To fix this problem, use a cast:  
   
- `short`   `z = (`  `short`  `)(x + y);   // OK: explicit conversion`  
+```cs
+short z  = (short)(x + y);   // Explicit conversion
+```
   
- It is possible though to use the following statements, where the destination variable has the same storage size or a larger storage size:  
+ It is also possible to use the following statements, where the destination variable has the same storage size or a larger storage size:  
   
-```  
+```cs  
 int m = x + y;  
 long n = x + y;  
 ```  
   
  There is no implicit conversion from floating-point types to `short`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
-  
-      short x = 3.0;          // Error: no implicit conversion from double  
+```cs  
+short x = 3.0;          // Error: no implicit conversion from double  
 short y = (short)3.0;   // OK: explicit conversion  
 ```  
   

--- a/docs/csharp/language-reference/keywords/uint.md
+++ b/docs/csharp/language-reference/keywords/uint.md
@@ -56,7 +56,7 @@ Starting with C# 7, you can also use the underscore character, `_`, as a digit s
 
 [!code-cs[uint](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#UIntS)]  
  
- Integer literals can also include a suffix that denotes the type. The suffix `U` or 'u' denotes either a `uint` or a `ulong`, depending on the numeric value of the literal. The following example uses the `u` suffix to denote an unsigned integer of both types. Note that the first literal is an `uint` because its value is less than <xref:System.UInt32.MaxValue?displayProperty=fullName>, while the second is a `ulong` because its value is greater than <xref:System.UInt32.MaxValue?displayProperty=fullName>.
+ Integer literals can also include a suffix that denotes the type. The suffix `U` or 'u' denotes either a `uint` or a `ulong`, depending on the numeric value of the literal. The following example uses the `u` suffix to denote an unsigned integer of both types. Note that the first literal is a `uint` because its value is less than <xref:System.UInt32.MaxValue?displayProperty=fullName>, while the second is a `ulong` because its value is greater than <xref:System.UInt32.MaxValue?displayProperty=fullName>.
 
 [!code-cs[usuffix](../../../../samples/snippets/csharp/language-reference/keywords/numeric-suffixes.cs#1)]  
  

--- a/docs/csharp/language-reference/keywords/uint.md
+++ b/docs/csharp/language-reference/keywords/uint.md
@@ -1,6 +1,6 @@
 ---
 title: "uint (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,6 +32,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # uint (C# Reference)
+
 The `uint` keyword signifies an integral type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
@@ -41,46 +42,41 @@ The `uint` keyword signifies an integral type that stores values according to th
  **Note** The `uint` type is not CLS-compliant. Use `int` whenever possible.  
   
 ## Literals  
- You can declare and initialize a variable of the type `uint` like this example:  
+
+You can declare and initialize a `uint` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it. If the integer literal is outside the range of `uint` (that is, if it is less than <xref:System.UInt32.MinValue?displayProperty=fullName> or greater than <xref:System.UInt32.MaxValue?displayProperty=fullName>, a compilation error occurs.
+
+In the following example, integers equal to 3,000,000,000 that are represented as decimal, hexadecimal, and binary literals are assigned to `uint` values.  
   
-```  
-  
-uint myUint = 4294967290;  
-```  
-  
- When an integer literal has no suffix, its type is the first of these types in which its value can be represented: [int](../../../csharp/language-reference/keywords/int.md), `uint`, [long](../../../csharp/language-reference/keywords/long.md), [ulong](../../../csharp/language-reference/keywords/ulong.md). In this example, it is `uint`:  
-  
-```  
-  
-uint uInt1 = 123;  
-```  
-  
- You can also use the suffix u or U, such as this:  
-  
-```  
-  
-uint uInt2 = 123U;  
-```  
-  
- When you use the suffix `U` or `u`, the type of the literal is determined to be either `uint` or `ulong` according to the numeric value of the literal. For example:  
-  
-```  
-Console.WriteLine(44U.GetType());  
-Console.WriteLine(323442434344U.GetType());  
-```  
-  
- This code displays `System.UInt32`, followed by `System.UInt64` -- the underlying types for `uint` and `ulong` respectively -- because the second literal is too large to be stored by the `uint` type.  
+[!code-cs[uint](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#UInt)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix. 
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[uint](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#UIntS)]  
+ 
+ Integer literals can also include a suffix that denotes the type. The suffix `U` or 'u' denotes either a `uint` or a `ulong`, depending on the numeric value of the literal. The following example uses the `u` suffix to denote an unsigned integer of both types. Note that the first literal is an `uint` because its value is less than <xref:System.UInt32.MaxValue?displayProperty=fullName>, while the second is a `ulong` because its value is greater than <xref:System.UInt32.MaxValue?displayProperty=fullName>.
+
+[!code-cs[usuffix](../../../../samples/snippets/csharp/language-reference/keywords/numeric-suffixes.cs#1)]  
+ 
+If an integer literal has no suffix, its type is the first of the following types in which its value can be represented: 
+
+1. [int](int.md)
+2. `uint`
+3. [long](../../../csharp/language-reference/keywords/long.md)
+4. [ulong](../../../csharp/language-reference/keywords/ulong.md) 
   
 ## Conversions  
  There is a predefined implicit conversion from `uint` to [long](../../../csharp/language-reference/keywords/long.md), [ulong](../../../csharp/language-reference/keywords/ulong.md), [float](../../../csharp/language-reference/keywords/float.md), [double](../../../csharp/language-reference/keywords/double.md), or [decimal](../../../csharp/language-reference/keywords/decimal.md). For example:  
   
-```  
+```cs  
 float myFloat = 4294967290;   // OK: implicit conversion to float  
 ```  
   
  There is a predefined implicit conversion from [byte](../../../csharp/language-reference/keywords/byte.md), [ushort](../../../csharp/language-reference/keywords/ushort.md), or [char](../../../csharp/language-reference/keywords/char.md) to `uint`. Otherwise you must use a cast. For example, the following assignment statement will produce a compilation error without a cast:  
   
-```  
+```cs  
 long aLong = 22;  
 // Error -- no implicit conversion from long:  
 uint uInt1 = aLong;   
@@ -90,7 +86,7 @@ uint uInt2 = (uint)aLong;
   
  Notice also that there is no implicit conversion from floating-point types to `uint`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
+```cs  
 // Error -- no implicit conversion from double:  
 uint x = 3.0;  
 // OK -- explicit conversion:  

--- a/docs/csharp/language-reference/keywords/ulong.md
+++ b/docs/csharp/language-reference/keywords/ulong.md
@@ -1,6 +1,6 @@
 ---
 title: "ulong (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,6 +32,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # ulong (C# Reference)
+
 The `ulong` keyword denotes an integral type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
@@ -39,44 +40,43 @@ The `ulong` keyword denotes an integral type that stores values according to the
 |`ulong`|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|<xref:System.UInt64?displayProperty=fullName>|  
   
 ## Literals  
- You can declare and initialize a `ulong` variable like this example:  
+
+You can declare and initialize a `ulong` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it.  If the integer literal is outside the range of `ulong` (that is, if it is less than <xref:System.UInt64.MinValue?displayProperty=fullName> or greater than <xref:System.UInt64.MaxValue?displayProperty=fullName>, a compilation error occurs. 
+
+In the following example, integers equal to 7,934,076,125 that are represented as decimal, hexadecimal, and binary literals are assigned to `ulong` values.  
   
-```  
-  
-ulong uLong = 9223372036854775808;  
-```  
-  
- When an integer literal has no suffix, its type is the first of these types in which its value can be represented: [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), `ulong`. In the example above, it is of the type `ulong`.  
-  
- You can also use suffixes to specify the type of the literal according to the following rules:  
-  
--   If you use L or l, the type of the literal integer will be either [long](../../../csharp/language-reference/keywords/long.md) or `ulong` according to its size.  
-  
-    > [!NOTE]
-    >  You can use the lowercase letter "l" as a suffix. However, this generates a compiler warning because the letter "l" is easily confused with the digit "1." Use "L" for clarity.  
-  
--   If you use `U` or `u`, the type of the literal integer will be either [uint](../../../csharp/language-reference/keywords/uint.md) or `ulong` according to its size.  
-  
--   If you use UL, ul, Ul, uL, LU, lu, Lu, or lU, the type of the literal integer will be `ulong`.  
-  
-     For example, the output of the following three statements will be the system type `UInt64`, which corresponds to the alias `ulong`:  
-  
-    ```  
-    Console.WriteLine(9223372036854775808L.GetType());  
-    Console.WriteLine(123UL.GetType());  
-    Console.WriteLine((123UL + 456).GetType());  
-    ```  
+[!code-cs[ulong](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#ULong)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix. 
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[long](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#LongS)]  
+ 
+ Integer literals can also include a suffix that denotes the type. The suffix `UL` or `ul` unambiguously identifies a numeric literal as a `ulong` value. The `L` suffix denotes a `ulong` if the literal value exceeds <xref:System.Int64.MaxValue?displayProperty=fullName>. And the `U` or `u` suffix denotes a `ulong` if the literal value exceeds <xref:System.UInt32.MaxValue?displayProperty=fullName>. The following example uses the `ul` suffix to denote a long integer:
+ 
+[!code-cs[ulsuffix](../../../../samples/snippets/csharp/language-reference/keywords/numeric-suffixes.cs#2)]
+
+If an integer literal has no suffix, its type is the first of the following types in which its value can be represented: 
+
+1. [int](int.md)
+2. [uint](../../../csharp/language-reference/keywords/uint.md)
+3. [long](long.md)
+4. `ulong`
+
+## Compiler overload resolution
   
  A common use of the suffix is with calling overloaded methods. Consider, for example, the following overloaded methods that use `ulong` and [int](../../../csharp/language-reference/keywords/int.md) parameters:  
   
-```  
+```cs  
 public static void SampleMethod(int i) {}  
 public static void SampleMethod(ulong l) {}  
 ```  
   
  Using a suffix with the `ulong` parameter guarantees that the correct type is called, for example:  
   
-```  
+```cs  
 SampleMethod(5);    // Calling the method with the int parameter  
 SampleMethod(5UL);  // Calling the method with the ulong parameter  
 ```  
@@ -86,7 +86,7 @@ SampleMethod(5UL);  // Calling the method with the ulong parameter
   
  There is no implicit conversion from `ulong` to any integral type. For example, the following statement will produce a compilation error without an explicit cast:  
   
-```  
+```cs  
 long long1 = 8UL;   // Error: no implicit conversion from ulong  
 ```  
   
@@ -94,7 +94,7 @@ long long1 = 8UL;   // Error: no implicit conversion from ulong
   
  Also, there is no implicit conversion from floating-point types to `ulong`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
+```cs  
 // Error -- no implicit conversion from double:  
 ulong x = 3.0;  
 // OK -- explicit conversion:  

--- a/docs/csharp/language-reference/keywords/ushort.md
+++ b/docs/csharp/language-reference/keywords/ushort.md
@@ -1,6 +1,6 @@
 ---
 title: "ushort (C# Reference) | Microsoft Docs"
-ms.date: "2015-07-20"
+ms.date: "2017-03-14"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,6 +32,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # ushort (C# Reference)
+
 The `ushort` keyword indicates an integral data type that stores values according to the size and range shown in the following table.  
   
 |Type|Range|Size|.NET Framework type|  
@@ -39,25 +40,32 @@ The `ushort` keyword indicates an integral data type that stores values accordin
 |`ushort`|0 to 65,535|Unsigned 16-bit integer|<xref:System.UInt16?displayProperty=fullName>|  
   
 ## Literals  
- You can declare and initialize a `ushort` variable such as this example:  
+
+You can declare and initialize a `ushort` variable by assigning a decimal literal, a hexadecimal literal, or (starting with C# 7) a binary literal to it. If the integer literal is outside the range of `ushort` (that is, if it is less than <xref:System.UInt16.MinValue?displayProperty=fullName> or greater than <xref:System.UInt16.MaxValue?displayProperty=fullName>, a compilation error occurs.
+
+In the following example, integers equal to 65,034 that are represented as decimal, hexadecimal, and binary literals are implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `ushort` values.    
   
-```  
-  
-ushort myShort = 65535;  
-```  
-  
- In the previous declaration, the integer literal `65535` is implicitly converted from [int](../../../csharp/language-reference/keywords/int.md) to `ushort`. If the integer literal exceeds the range of `ushort`, a compilation error will occur.  
+[!code-cs[UShort](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#UShort)]  
+
+> [!NOTE] 
+> You use the prefix `0x` or `0X` to denote a hexadecimal literal and the prefix `0b` or `0B` to denote a binary literal. Decimal literals have no prefix.
+
+Starting with C# 7, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
+
+[!code-cs[UShort](../../../../samples/snippets/csharp/language-reference/keywords/numeric-literals.cs#UShortS)]  
+ 
+## Compiler overload resolution
   
  A cast must be used when you call overloaded methods. Consider, for example, the following overloaded methods that use `ushort` and [int](../../../csharp/language-reference/keywords/int.md) parameters:  
   
-```  
+```cs  
 public static void SampleMethod(int i) {}  
 public static void SampleMethod(ushort s) {}  
 ```  
-  
+ 
  Using the `ushort` cast guarantees that the correct type is called, for example:  
   
-```  
+```cs  
 // Calls the method with the int parameter:  
 SampleMethod(5);  
 // Calls the method with the ushort parameter:  
@@ -69,35 +77,32 @@ SampleMethod((ushort)5);
   
  There is a predefined implicit conversion from [byte](../../../csharp/language-reference/keywords/byte.md) or [char](../../../csharp/language-reference/keywords/char.md) to `ushort`. Otherwise a cast must be used to perform an explicit conversion. Consider, for example, the following two `ushort` variables `x` and `y`:  
   
-```  
-  
+```cs 
 ushort x = 5, y = 12;  
 ```  
   
  The following assignment statement will produce a compilation error, because the arithmetic expression on the right side of the assignment operator evaluates to `int` by default.  
   
-```  
-  
+```cs  
 ushort z = x + y;   // Error: conversion from int to ushort  
 ```  
   
  To fix this problem, use a cast:  
   
-```  
-  
+```cs 
 ushort z = (ushort)(x + y);   // OK: explicit conversion   
 ```  
   
  It is possible though to use the following statements, where the destination variable has the same storage size or a larger storage size:  
   
-```  
+```cs
 int m = x + y;  
 long n = x + y;  
 ```  
   
  Notice also that there is no implicit conversion from floating-point types to `ushort`. For example, the following statement generates a compiler error unless an explicit cast is used:  
   
-```  
+```cs  
 // Error -- no implicit conversion from double:  
 ushort x = 3.0;   
 // OK -- explicit conversion:  

--- a/samples/snippets/csharp/language-reference/keywords/numeric-literals.cs
+++ b/samples/snippets/csharp/language-reference/keywords/numeric-literals.cs
@@ -1,0 +1,314 @@
+using System;
+
+public class Example
+{
+   public static void Main()
+   {
+       Console.WriteLine("\nByte Assignments:");
+       AssignByte();
+       Console.WriteLine("\nByte Assignments with Separator:");
+       AssignByteWithSeparator();
+
+       Console.WriteLine("\nShort Assignments:");
+       AssignShort();
+       Console.WriteLine("\nShort Assignments with Separator:");
+       AssignShortWithSeparator();
+
+       Console.WriteLine("\nInteger Assignments:");
+       AssignInteger();
+       Console.WriteLine("\nInteger Assignments with Separator:");
+       AssignIntegerWithSeparator();
+
+       Console.WriteLine("\nLong Assignments:");
+       AssignLong();
+       Console.WriteLine("\nLong Assignments with Separator:");
+       AssignLongWithSeparator();
+
+       Console.WriteLine("\nSigned Byte Assignments:");
+       AssignSByte();
+       Console.WriteLine("\nSigned Byte Assignments with Separator:");
+       AssignSByteWithSeparator();
+
+       Console.WriteLine("\nUShort Assignments:");
+       AssignUShort();
+       Console.WriteLine("\nUShort Assignments with Separator:");
+       AssignUShortWithSeparator();
+
+       Console.WriteLine("\nUInteger Assignments:");
+       AssignUInteger();
+       Console.WriteLine("\nUInteger Assignments with Separator:");
+       AssignUIntegerWithSeparator();
+
+       Console.WriteLine("\nULong Assignments:");
+       AssignULong();
+       Console.WriteLine("\nULong Assignments with Separator:");
+       AssignULongWithSeparator();
+   }
+
+   private static void AssignByte()
+   {
+      // <SnippetByte>
+      byte byteValue1 = 201;
+      Console.WriteLine(byteValue1);
+      
+      byte byteValue2 = 0x00C9;
+      Console.WriteLine(byteValue2);
+      
+      byte byteValue3 = 0b11001001;
+      Console.WriteLine(byteValue3);
+      // The example displays the following output:
+      //          201
+      //          201
+      //          201
+      // </SnippetByte>
+   }
+
+   private static void AssignByteWithSeparator()
+   {
+      // <SnippetByteS>
+      byte byteValue3 = 0b1100_1001;
+      Console.WriteLine(byteValue3);
+      // The example displays the following output:
+      //          201
+      // </SnippetByteS>
+   }
+
+   private static void AssignShort()
+   {
+      // <SnippetShort>
+      short shortValue1 = 1034;
+      Console.WriteLine(shortValue1);
+      
+      short shortValue2 = 0x040A;
+      Console.WriteLine(shortValue2);
+      
+      short shortValue3 = 0b010000001010;
+      Console.WriteLine(shortValue3);
+      // The example displays the following output:
+      //          1034
+      //          1034
+      //          1034
+      // </SnippetShort>
+   }
+
+   private static void AssignShortWithSeparator()
+   {
+      // <SnippetShortS>
+      short shortValue1 = 1_034;
+      Console.WriteLine(shortValue1);
+      
+      short shortValue3 = 0b00000100_00001010;
+      Console.WriteLine(shortValue3);
+      // The example displays the following output:
+      //          1034
+      //          1034
+      // </SnippetShortS>
+   }
+
+   private static void AssignInteger()
+   {
+      // <SnippetInt>
+      int intValue1 = 90946;
+      Console.WriteLine(intValue1);
+      int intValue2 = 0x16342;
+      Console.WriteLine(intValue2);
+      
+      int intValue3 = 0b00010110001101000010;
+      Console.WriteLine(intValue3);
+      // The example displays the following output:
+      //          90946
+      //          90946
+      //          90946
+      // </SnippetInt>
+   }
+
+   private static void AssignIntegerWithSeparator()
+   {
+      // <SnippetIntS>
+      int intValue1 = 90_946;
+      Console.WriteLine(intValue1);
+      
+      int intValue2 = 0x0001_6342;
+      Console.WriteLine(intValue2);
+      
+      int intValue3 = 0b0001_0110_0011_0100_0010;
+      Console.WriteLine(intValue3);
+      // The example displays the following output:
+      //          90946
+      //          90946
+      //          90946
+      // </SnippetIntS>
+   }
+
+   private static void AssignLong()
+   {
+      // <SnippetLong>
+      long longValue1 = 4294967296;
+      Console.WriteLine(longValue1);
+      
+      long longValue2 = 0x100000000;
+      Console.WriteLine(longValue2);
+      
+      long longValue3 = 0b100000000000000000000000000000000;
+      Console.WriteLine(longValue3);
+      // The example displays the following output:
+      //          4294967296
+      //          4294967296
+      //          4294967296
+      // </SnippetLong>
+   }
+
+   private static void AssignLongWithSeparator()
+   {
+      // <SnippetLongS>
+      long longValue1 = 4_294_967_296;
+      Console.WriteLine(longValue1);
+      
+      long longValue2 = 0x1_0000_0000;
+      Console.WriteLine(longValue2);
+      
+      long longValue3 = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
+      Console.WriteLine(longValue3);
+      // The example displays the following output:
+      //          4294967296
+      //          4294967296
+      //          4294967296
+      // </SnippetLongS>
+   }
+
+   private static void AssignSByte()
+   {
+      // <SnippetSByte>
+      sbyte sbyteValue1 = -102;
+      Console.WriteLine(sbyteValue1);
+      
+      unchecked {
+         sbyte sbyteValue4 = (sbyte)0x9A;
+         Console.WriteLine(sbyteValue4);
+         
+         sbyte sbyteValue5 = (sbyte)0b10011010;
+         Console.WriteLine(sbyteValue5);
+      }
+      // The example displays the following output:
+      //          -102
+      //          -102
+      //          -102
+      // </SnippetSByte>
+   }
+
+   private static void AssignSByteWithSeparator()
+   {
+      // <SnippetSByteS>
+      unchecked {
+         sbyte sbyteValue3 = (sbyte)0b10011010;
+         Console.WriteLine(sbyteValue3);
+      }
+      // The example displays the following output:
+      //          -102
+      // </SnippetSByteS>
+   }
+
+   private static void AssignUShort()
+   {
+      // <SnippetUShort>
+      ushort ushortValue1 = 65034;
+      Console.WriteLine(ushortValue1);
+      
+      ushort ushortValue2 = 0xFE0A;
+      Console.WriteLine(ushortValue2);
+      
+      ushort ushortValue3 = 0b1111111000001010;
+      Console.WriteLine(ushortValue3);
+      // The example displays the following output:
+      //          65034
+      //          65034
+      //          65034
+      // </SnippetUShort>
+   }
+
+   private static void AssignUShortWithSeparator()
+   {
+      // <SnippetUShortS>
+      ushort ushortValue1 = 65_034;
+      Console.WriteLine(ushortValue1);
+      
+      ushort ushortValue3 = 0b11111110_00001010;
+      Console.WriteLine(ushortValue3);
+      // The example displays the following output:
+      //          65034
+      //          65034
+      // </SnippetUShortS>
+   }
+
+   private static void AssignUInteger()
+   {
+      // <SnippetUInt>
+      uint uintValue1 = 3000000000;
+      Console.WriteLine(uintValue1);
+      
+      uint uintValue2 = 0xB2D05E00;
+      Console.WriteLine(uintValue2);
+      
+      uint uintValue3 = 0b10110010110100000101111000000000;
+      Console.WriteLine(uintValue3);
+      // The example displays the following output:
+      //          3000000000
+      //          3000000000
+      //          3000000000
+      // </SnippetUInt>
+   }
+
+   private static void AssignUIntegerWithSeparator()
+   {
+      // <SnippetUIntS>
+      uint uintValue1 = 3000000000;
+      Console.WriteLine(uintValue1);
+      
+      uint uintValue2 = 0xB2D0_5E00;
+      Console.WriteLine(uintValue2);
+      
+      uint uintValue3 = 0b10110010_11010000_01011110_00000000;
+      Console.WriteLine(uintValue3);
+      // The example displays the following output:
+      //          3000000000
+      //          3000000000
+      //          3000000000
+      // </SnippetUIntS>
+   }
+
+   private static void AssignULong()
+   {
+      // <SnippetULong>
+      ulong ulongValue1 = 7934076125;
+      Console.WriteLine(ulongValue1);
+      
+      ulong ulongValue2 = 0x0001D8e864DD;
+      Console.WriteLine(ulongValue2);
+      
+      ulong ulongValue3 = 0b000111011000111010000110010011011101;
+      Console.WriteLine(ulongValue3);
+      // The example displays the following output:
+      //          7934076125
+      //          7934076125
+      //          7934076125
+      // </SnippetULong>
+   }
+
+   private static void AssignULongWithSeparator()
+   {
+      // <SnippetIntULong>
+      ulong ulongValue1 = 7_934_076_125;
+      Console.WriteLine(ulongValue1);
+      
+      ulong ulongValue2 = 0x0001_D8e8_64DD;
+      Console.WriteLine(ulongValue2);
+      
+      ulong ulongValue3 = 0b00000001_11011000_11101000_01100100_11011101;
+      Console.WriteLine(ulongValue3);
+      // The example displays the following output:
+      //          7934076125
+      //          7934076125
+      //          7934076125
+      // </SnippetULongS>
+   }
+}

--- a/samples/snippets/csharp/language-reference/keywords/numeric-literals.cs
+++ b/samples/snippets/csharp/language-reference/keywords/numeric-literals.cs
@@ -54,7 +54,7 @@ public class Example
       byte byteValue2 = 0x00C9;
       Console.WriteLine(byteValue2);
       
-      byte byteValue3 = 0b11001001;
+      byte byteValue3 = 0b1100_1001;
       Console.WriteLine(byteValue3);
       // The example displays the following output:
       //          201
@@ -82,7 +82,7 @@ public class Example
       short shortValue2 = 0x040A;
       Console.WriteLine(shortValue2);
       
-      short shortValue3 = 0b010000001010;
+      short shortValue3 = 0b0100_00001010;
       Console.WriteLine(shortValue3);
       // The example displays the following output:
       //          1034
@@ -113,7 +113,7 @@ public class Example
       int intValue2 = 0x16342;
       Console.WriteLine(intValue2);
       
-      int intValue3 = 0b00010110001101000010;
+      int intValue3 = 0b0001_0110_0011_0100_0010;
       Console.WriteLine(intValue3);
       // The example displays the following output:
       //          90946
@@ -149,7 +149,7 @@ public class Example
       long longValue2 = 0x100000000;
       Console.WriteLine(longValue2);
       
-      long longValue3 = 0b100000000000000000000000000000000;
+      long longValue3 = 0b1_0000_0000_0000_0000_0000_0000_0000_0000;
       Console.WriteLine(longValue3);
       // The example displays the following output:
       //          4294967296
@@ -186,7 +186,7 @@ public class Example
          sbyte sbyteValue4 = (sbyte)0x9A;
          Console.WriteLine(sbyteValue4);
          
-         sbyte sbyteValue5 = (sbyte)0b10011010;
+         sbyte sbyteValue5 = (sbyte)0b1001_1010;
          Console.WriteLine(sbyteValue5);
       }
       // The example displays the following output:
@@ -200,7 +200,7 @@ public class Example
    {
       // <SnippetSByteS>
       unchecked {
-         sbyte sbyteValue3 = (sbyte)0b10011010;
+         sbyte sbyteValue3 = (sbyte)0b1001_1010;
          Console.WriteLine(sbyteValue3);
       }
       // The example displays the following output:
@@ -217,7 +217,7 @@ public class Example
       ushort ushortValue2 = 0xFE0A;
       Console.WriteLine(ushortValue2);
       
-      ushort ushortValue3 = 0b1111111000001010;
+      ushort ushortValue3 = 0b1111_1110_0000_1010;
       Console.WriteLine(ushortValue3);
       // The example displays the following output:
       //          65034
@@ -249,7 +249,7 @@ public class Example
       uint uintValue2 = 0xB2D05E00;
       Console.WriteLine(uintValue2);
       
-      uint uintValue3 = 0b10110010110100000101111000000000;
+      uint uintValue3 = 0b1011_0010_1101_0000_0101_1110_0000_0000;
       Console.WriteLine(uintValue3);
       // The example displays the following output:
       //          3000000000
@@ -261,13 +261,13 @@ public class Example
    private static void AssignUIntegerWithSeparator()
    {
       // <SnippetUIntS>
-      uint uintValue1 = 3000000000;
+      uint uintValue1 = 3_000_000_000;
       Console.WriteLine(uintValue1);
       
       uint uintValue2 = 0xB2D0_5E00;
       Console.WriteLine(uintValue2);
       
-      uint uintValue3 = 0b10110010_11010000_01011110_00000000;
+      uint uintValue3 = 0b1011_0010_1101_0000_0101_1110_0000_0000;
       Console.WriteLine(uintValue3);
       // The example displays the following output:
       //          3000000000
@@ -285,7 +285,7 @@ public class Example
       ulong ulongValue2 = 0x0001D8e864DD;
       Console.WriteLine(ulongValue2);
       
-      ulong ulongValue3 = 0b000111011000111010000110010011011101;
+      ulong ulongValue3 = 0b0001_1101_1000_1110_1000_0110_0100_1101_1101;
       Console.WriteLine(ulongValue3);
       // The example displays the following output:
       //          7934076125
@@ -303,7 +303,7 @@ public class Example
       ulong ulongValue2 = 0x0001_D8e8_64DD;
       Console.WriteLine(ulongValue2);
       
-      ulong ulongValue3 = 0b00000001_11011000_11101000_01100100_11011101;
+      ulong ulongValue3 = 0b0000_0001_1101_1000_1110_1000_0110_0100_1101_1101;
       Console.WriteLine(ulongValue3);
       // The example displays the following output:
       //          7934076125

--- a/samples/snippets/csharp/language-reference/keywords/numeric-suffixes.cs
+++ b/samples/snippets/csharp/language-reference/keywords/numeric-suffixes.cs
@@ -1,0 +1,31 @@
+using System;
+
+class Example
+{
+   static void Main()
+   {
+      U();
+      UL();
+   }
+   
+   private static void U()
+   {
+      // <Snippet1>
+      object value1 = 4000000000u;
+      Console.WriteLine($"{value1} ({4000000000u.GetType().Name})");
+      object value2 = 6000000000u;
+      Console.WriteLine($"{value2} ({6000000000u.GetType().Name})");
+      // </Snippet1>
+   }
+
+   private static void UL()
+   {
+      // <Snippet2>
+      object value1 = 700000000000ul;
+      Console.WriteLine($"{value1} ({700000000000ul.GetType().Name})");
+      // </Snippet2>
+   }
+
+}
+
+


### PR DESCRIPTION
# Revisions for support of binary literals

## Summary

Documents support for 0x to define hexadecimal literals and 0b to define binary literals

Fixes #1709

## Details

Expands the literal assignment section of each primitive integral type (`byte`, `short`, `int`, `long`, `sbyte`, `ushort`, `uint`, `ulong` to include hex and binary assignment.

Also fixed a number of other issues, including absence of language in fenced code blocks, organization of section, separating literals from compiler overload resolution, etc.

## Suggested Reviewers

@BillWagner 