### PR TITLE
Adds nuget.config behaviour section

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -106,3 +106,18 @@ Restore the dependencies and tools for the project in the current directory usin
 Restore dependencies and tools for the project in the current directory and shows only errors in the output:
 
 `dotnet restore --verbosity Error`
+
+
+## NuGet.Config
+
+Restore obeys some values from the NuGet.Config file in the solution folder.
+
+#### Config key: globalPackagesFolder
+Usage:
+```
+  <config>
+    <add key="globalPackagesFolder" value="./packages" />
+  </config>
+```
+
+Adding the `globalPackagesFolder` config value to the solution NuGet.Config file will place the restored nuget packages in the specified folder. This is an alternative to specifying the `--packages` command line argument.


### PR DESCRIPTION
Adds a new NuGet.Config section which includes the otherwise undocumented behaviour of dotnet restore with the globalPackagesFolder setting.

This is an alternative to users who rely upon the previous repositoryPath behaviour.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
