### PR TITLE
Document dotnet restore --runtime

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -57,6 +57,10 @@ Prints out a short help for the command.
 
 Specifies a NuGet package source to use during the restore operation. This overrides all of the sources specified in the NuGet.config file(s). Multiple sources can be provided by specifying this option multiple times.
 
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+Specifies a runtime to restore packages for. This is used to restore packages for runtimes not explicitly listed in the `<RuntimeIdentifiers>` tag in the `csproj` file. For a list of Runtime Identifiers (RIDs) you can use, see the [RID catalog](../rid-catalog.md).  Multiple RIDs can be provided by specifying this option multiple times.
+
 `--packages <PACKAGES_DIRECTORY]`
 
 Specifies the directory to place the restored packages in. 

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -59,7 +59,7 @@ Specifies a NuGet package source to use during the restore operation. This overr
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 
-Specifies a runtime to restore packages for. This is used to restore packages for runtimes not explicitly listed in the `<RuntimeIdentifiers>` tag in the `csproj` file. For a list of Runtime Identifiers (RIDs) you can use, see the [RID catalog](../rid-catalog.md).  Multiple RIDs can be provided by specifying this option multiple times.
+Specifies a runtime for the package restore. This is used to restore packages for runtimes not explicitly listed in the `<RuntimeIdentifiers>` tag in the *.csproj* file. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). Provide multiple RIDs by specifying this option multiple times.
 
 `--packages <PACKAGES_DIRECTORY]`
 


### PR DESCRIPTION
Adds documentation for the `runtime` option in the `dotnet-restore` command.

Feedback on the language used would be appreciated. I included a reason to use this option, so the description is relatively long.