### PR TITLE
removed the note on delete build assets

### DIFF
--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -388,11 +388,6 @@ argument provides a tag, or name, for this container image. In the command line 
 tag used for the Docker container is `weather-microservice`. When this command completes,
 you have a container ready to run your new service. 
 
-> [!Note]
-> The copy command will copy all built assets, as well as the source for your application.
-> You should remove the `obj`, `bin`, and `out` directories from your local machine
-> before building your Docker image.
-
 Run the following command to start
 the container and launch your service:
 


### PR DESCRIPTION
## Summary

I think this note is not needed, since we have already added the .dockerignore file in one of the above paragraphs. This should ensure that the build binaries are *not* included in the final image. 