### PR TITLE
Update OutExample.cs with C# 7 improvement

### DIFF
--- a/samples/snippets/csharp/tour/classes-and-objects/OutExample.cs
+++ b/samples/snippets/csharp/tour/classes-and-objects/OutExample.cs
@@ -10,8 +10,7 @@ namespace ClassesAndObjects
         }
         public static void OutUsage() 
         {
-            int res, rem;
-            Divide(10, 3, out res, out rem);
+            Divide(10, 3, out int res, out int rem);
             Console.WriteLine("{0} {1}", res, rem);	// Outputs "3 1"
         }
     }


### PR DESCRIPTION
The old existing syntax that supports out parameters should be replaced with the new improved syntax in C# 7.

# Title
Update OutExample.cs in with C# 7 improvement syntax

## Summary
The old existing syntax that supports out parameters is replaced with the new improved syntax in C# 7.