### PR TITLE
Changed description of output parameter

### DIFF
--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -122,15 +122,15 @@ The *signature* of a method must be unique in the class in which the method is d
 
 Parameters are used to pass values or variable references to methods. The parameters of a method get their actual values from the *arguments* that are specified when the method is invoked. There are four kinds of parameters: value parameters, reference parameters, output parameters, and parameter arrays.
 
-A *value parameter* is used for input parameter passing. A value parameter corresponds to a local variable that gets its initial value from the argument that was passed for the parameter. Modifications to a value parameter do not affect the argument that was passed for the parameter. 
+A *value parameter* is used for passing input arguments. A value parameter corresponds to a local variable that gets its initial value from the argument that was passed for the parameter. Modifications to a value parameter do not affect the argument that was passed for the parameter. 
 
 Value parameters can be optional, by specifying a default value so that corresponding arguments can be omitted.
 
-A *reference parameter* is used for both input and output parameter passing. The argument passed for a reference parameter must be a variable, and during execution of the method, the reference parameter represents the same storage location as the argument variable. A reference parameter is declared with the `ref` modifier. The following example shows the use of `ref` parameters.
+A *reference parameter* is used for passing arguments by reference. The argument passed for a reference parameter must be a variable with a definite value, and during execution of the method, the reference parameter represents the same storage location as the argument variable. A reference parameter is declared with the `ref` modifier. The following example shows the use of `ref` parameters.
 
 [!code-csharp[swapExample](../../../samples/snippets/csharp/tour/classes-and-objects/RefExample.cs#L3-L18)]
 
-An *output parameter* is used for passing arguments by reference. It is similar to a reference parameter, except that it does not require that you explicitly assign a value to the caller-provided argument. An output parameter is declared with the `out` modifier. The following example shows the use of `out` parameters using the syntax introduced in C# 7.
+An *output parameter* is used for passing arguments by reference. It's similar to a reference parameter, except that it doesn't require that you explicitly assign a value to the caller-provided argument. An output parameter is declared with the `out` modifier. The following example shows the use of `out` parameters using the syntax introduced in C# 7.
 
 [!code-csharp[OutExample](../../../samples/snippets/csharp/tour/classes-and-objects/OutExample.cs#L3-L17)]
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -130,7 +130,7 @@ A *reference parameter* is used for both input and output parameter passing. The
 
 [!code-csharp[swapExample](../../../samples/snippets/csharp/tour/classes-and-objects/RefExample.cs#L3-L18)]
 
-An *output parameter* is used for output parameter passing. An output parameter is similar to a reference parameter except that the initial value of the caller-provided argument is unimportant. An output parameter is declared with the `out` modifier. The following example shows the use of `out` parameters.
+An *output parameter* is used for passing arguments by reference. It is similar to a reference parameter, except that it does not require that you explicitly assign a value to the caller-provided argument. An output parameter is declared with the `out` modifier. The following example shows the use of `out` parameters using the syntax introduced in C# 7.
 
 [!code-csharp[OutExample](../../../samples/snippets/csharp/tour/classes-and-objects/OutExample.cs#L3-L17)]
 


### PR DESCRIPTION
# Changed description of output parameter

## Summary

This addresses an issue raised by @svick in PR #1747 

## Details

Modified text to remove a the phrase "initial value", since when using the new syntax for `out` supported in C# 7, arguments cannot be assigned an initial value. 

## Suggested Reviewers

@svick @kflili @BillWagner 