### PR TITLE
Update the 404 link for NETStandard.Library source

### DIFF
--- a/docs/standard/library.md
+++ b/docs/standard/library.md
@@ -63,7 +63,7 @@ The .NET Standard Library spec is a standardized set of APIs. The spec is mainta
 
 The official spec is a set of .cs files that define the APIs that are part of the standard. The [ref directory](https://github.com/dotnet/corefx/tree/master/src/System.Runtime/ref) for each [component](https://github.com/dotnet/corefx/tree/master/src) defines the .NET Standard Library APIs. While the ref artifacts reside in the [CoreFX repo](https://github.com/dotnet/corefx), they are not .NET Core specific.
 
-The [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library) metapackage ([source](https://github.com/dotnet/corefx/blob/master/pkg/NETStandard.Library/NETStandard.Library.packages.targets)) describes the set of libraries that define (in part) one or more .NET Standard Library versions.
+The [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library) metapackage ([source](https://github.com/dotnet/standard/blob/master/netstandard/pkg/targets/NETStandard.Library.targets)) describes the set of libraries that define (in part) one or more .NET Standard Library versions.
 
 A given component, like System.Runtime, describes:
 

--- a/docs/standard/library.md
+++ b/docs/standard/library.md
@@ -63,7 +63,7 @@ The .NET Standard Library spec is a standardized set of APIs. The spec is mainta
 
 The official spec is a set of .cs files that define the APIs that are part of the standard. The [ref directory](https://github.com/dotnet/corefx/tree/master/src/System.Runtime/ref) for each [component](https://github.com/dotnet/corefx/tree/master/src) defines the .NET Standard Library APIs. While the ref artifacts reside in the [CoreFX repo](https://github.com/dotnet/corefx), they are not .NET Core specific.
 
-The [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library) metapackage ([source](https://github.com/dotnet/standard/blob/master/netstandard/pkg/targets/NETStandard.Library.targets)) describes the set of libraries that define (in part) one or more .NET Standard Library versions.
+The [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library) metapackage ([source](https://github.com/dotnet/standard/blob/master/netstandard/pkg/NETStandard.Library.dependencies.props)) describes the set of libraries that define (in part) one or more .NET Standard Library versions.
 
 A given component, like System.Runtime, describes:
 


### PR DESCRIPTION
## Details
 Update the link to NETStandard.Library source which is now in https://github.com/dotnet/standard/blob/master/netstandard/pkg/targets/NETStandard.Library.targets

