### PR TITLE
Update package references of xUnit test sample

### DIFF
--- a/samples/snippets/csharp/xunit-test/xunit-test.csproj
+++ b/samples/snippets/csharp/xunit-test/xunit-test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170123-02" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Title

Update package references of xUnit test sample

## Summary

The current xUnit test sample still used the old, non-RTM versions of the VSTest runner and xUnit packages. 

## Details

People should be using the RTM versions of the VSTest and xUnit packages.

## Suggested Reviewers

