### PR TITLE
Added .NET Core CLI to .net command topic titles.

### DIFF
--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-add package command | Microsoft Docs
+title: dotnet-add package command - .NET Core CLI | Microsoft Docs
 description: The dotnet-add package command provides a convenient option to add NuGet package reference to a project.
 keywords: dotnet-add, CLI, CLI command, .NET Core
 author: spboyer

--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-add reference command | Microsoft Docs
+title: dotnet-add reference command - .NET Core CLI | Microsoft Docs
 description: The dotnet-add reference command provides a convenient option to add project to project references.
 keywords: dotnet-add, CLI, CLI command, .NET Core
 author: spboyer

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-build command | Microsoft Docs
+title: dotnet-build command - .NET Core CLI | Microsoft Docs
 description: The dotnet-build command builds a project and all of its dependencies. 
 keywords: dotnet-build, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-clean command | Microsoft Docs
+title: dotnet-clean command - .NET Core CLI | Microsoft Docs
 description: The dotnet-clean command cleans the current directory.
 keywords: dotnet-clean, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-list-reference.md
+++ b/docs/core/tools/dotnet-list-reference.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-list reference command | Microsoft Docs
+title: dotnet-list reference command - .NET Core CLI | Microsoft Docs
 description: The dotnet-list reference command provides a convenient option to list project to project references.
 keywords: dotnet-list, CLI, CLI command, .NET Core
 author: spboyer

--- a/docs/core/tools/dotnet-migrate.md
+++ b/docs/core/tools/dotnet-migrate.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-migrate command | Microsoft Docs
+title: dotnet-migrate command - .NET Core CLI | Microsoft Docs
 description: The dotnet-migrate command migrates a project and all of its dependencies. 
 keywords: dotnet-migrate, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-msbuild command | Microsoft Docs
+title: dotnet-msbuild command - .NET Core CLI | Microsoft Docs
 description: The dotnet-msbuild command provides access to the MSBuild command line.
 keywords: dotnet-msmsbuild, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-new command | Microsoft Docs
+title: dotnet-new command - .NET Core CLI | Microsoft Docs
 description: The dotnet-new command creates new .NET Core projects in the current directory.
 keywords: dotnet-new, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-nuget-delete.md
+++ b/docs/core/tools/dotnet-nuget-delete.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-nuget-delete command | Microsoft Docs
+title: dotnet-nuget-delete command - .NET Core CLI | Microsoft Docs
 description: The dotnet-nuget-delete command deletes or unlists a package from the server. 
 keywords: dotnet-nuget-delete, CLI, CLI command, .NET Core
 author: karann-msft

--- a/docs/core/tools/dotnet-nuget-locals.md
+++ b/docs/core/tools/dotnet-nuget-locals.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-nuget-locals command | Microsoft Docs
+title: dotnet-nuget-locals command - .NET Core CLI | Microsoft Docs
 description: The dotnet-nuget-locals command clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder. 
 keywords: dotnet-nuget-locals, CLI, CLI command, .NET Core
 author: karann-msft

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-nuget-push command | Microsoft Docs
+title: dotnet-nuget-push command - .NET Core CLI | Microsoft Docs
 description: The dotnet-nuget-push command pushes a package to the server and publishes it. 
 keywords: dotnet-nuget-push, CLI, CLI command, .NET Core
 author: karann-msft

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-pack command | Microsoft Docs
+title: dotnet-pack command - .NET Core CLI | Microsoft Docs
 description: The dotnet-pack command creates NuGet packages for your .NET Core project.
 keywords: dotnet-pack, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-publish command | Microsoft Docs
+title: dotnet-publish command - .NET Core CLI | Microsoft Docs
 description: The dotnet-publish command publishes your .NET Core project into a directory. 
 keywords: dotnet-publish, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-remove-package.md
+++ b/docs/core/tools/dotnet-remove-package.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-remove package command | Microsoft Docs
+title: dotnet-remove package command - .NET Core CLI | Microsoft Docs
 description: The dotnet-remove package command provides a convenient option to remove NuGet package reference to a project.
 keywords: dotnet-remove, CLI, CLI command, .NET Core
 author: spboyer

--- a/docs/core/tools/dotnet-remove-reference.md
+++ b/docs/core/tools/dotnet-remove-reference.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-remove reference command | Microsoft Docs
+title: dotnet-remove reference command - .NET Core CLI | Microsoft Docs
 description: The dotnet-remove reference command provides a convenient option to remove project to project references.
 keywords: dotnet-remove, CLI, CLI command, .NET Core
 author: spboyer

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-restore command | Microsoft Docs
+title: dotnet-restore command - .NET Core CLI | Microsoft Docs
 description: Learn how to restore dependencies and project-specific tools with the dotnet restore command.
 keywords: dotnet-restore, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-run command | Microsoft Docs
+title: dotnet-run command - .NET Core CLI | Microsoft Docs
 description: The dotnet-run command provides a convenient option to run your application from the source code.
 keywords: dotnet-run, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-sln command | Microsoft Docs
+title: dotnet-sln command - .NET Core CLI | Microsoft Docs
 description: The dotnet-sln command provides a convenient option to add, remove, and list projects in a solution file.
 keywords: dotnet-sln, CLI, CLI command, .NET Core
 author: spboyer

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet-test command | Microsoft Docs
+title: dotnet-test command - .NET Core CLI | Microsoft Docs
 description: The `dotnet test` command is used to execute unit tests in a given project.
 keywords: dotnet-test, CLI, CLI command, .NET Core
 author: blackdwarf

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: dotnet command | Microsoft Docs
+title: dotnet command - .NET Core CLI | Microsoft Docs
 description: Learn about the dotnet command (the generic driver for the .NET Core CLI tools) and its usage.  
 keywords: dotnet, CLI, CLI commands, .NET Core
 author: blackdwarf


### PR DESCRIPTION
# Title
Added .NET Core CLI to the title of all .NET Core CLI command topics.

## Summary
Increase the usefulness of searches for ".NET CLI", by adding it to the title of all 20 .NET Core CLI commands:  
title: <command name> command | Microsoft Docs -> 
title: <command name> command - .NET Core CLI | Microsoft Docs

Fixes #1764 

## Suggested Reviewers
@mairaw 

