### PR TITLE
Update core/tutorials/libraries.md

### DIFF
--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -233,6 +233,8 @@ Each of these contain the `.dll` files for each target.
 
 It's important to be able to test across platforms.  You can use either [xUnit](http://xunit.github.io/) or MSTest out of the box.  Both either are perfectly suitable for unit testing your library on .NET Core.  How you set up your solution with test projects will depend on the [structure of your solution](#structuring-a-solution).  The following example assumes that test and source directories live in the same top-level directory.
 
+> [!INFO] This uses some [.NET CLI commands](../tools/index.md).  See [dotnet new](../tools/dotnet-new.md) and [dotnet sln](../tools/dotnet-sln.md) for more information.
+
 1. Set up your solution.  You can do so with the following commands:
 
 ```bash
@@ -303,7 +305,7 @@ open AwesomeLibrary.FSharp
 ...
 
 let doWork data = async {
-    let! result = AwesomeLibrary.AsyncConvert data
+    let! result = AwesomeLibrary.AsyncConvert data // Uses an F# async function rather than C# async method
     // do something with result
 }
 ```

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -20,7 +20,7 @@ This article covers how to write libraries for .NET using cross-platform CLI too
 
 You need [the .NET Core SDK and CLI](https://www.microsoft.com/net/core) installed on your machine.
 
-For the sections of this document dealing with .NET Framework versions or Portable Class Libraries (PCL), you need the [.NET Framework](http://getdotnet.azurewebsites.net/) installed on a Windows machine.  
+For the sections of this document dealing with .NET Framework versions, you need the [.NET Framework](http://getdotnet.azurewebsites.net/) installed on a Windows machine.  
 
 Additionally, if you wish to support older .NET Framework targets, you need to install targeting/developer packs for older framework versions from the [.NET target platforms page](http://getdotnet.azurewebsites.net/target-dotnet-platforms.html).  Refer to this table:
 
@@ -84,7 +84,7 @@ If you want to reach the maximum number of developers and projects, use the .NET
 .NET Framework 4.6   --> net46
 .NET Framework 4.6.1 --> net461
 .NET Framework 4.6.2 --> net462
-.NET Framework 4.6.3 --> net463
+.NET Framework 4.7 --> net47
 ```
 
 You then insert this TFM into the `TargetFramework` section of your project file.  For example, here's how you would write a library which targets the .NET Framework 4.0:

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -212,7 +212,7 @@ namespace MultitargetLib
 
              int dotNetCount = Regex.Matches(result, ".NET").Count;
 
-             return $"dotnetfoundation.orgmentions .NET {dotNetCount} times in its HTML!";
+             return $"dotnetfoundation.org mentions .NET {dotNetCount} times in its HTML!";
          }
  #endif
     }

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -4,7 +4,7 @@ description: Developing Libraries with Cross Platform Tools
 keywords: .NET, .NET Core
 author: cartermp
 ms.author: mairaw
-ms.date: 03/23/2017
+ms.date: 05/01/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -14,9 +14,6 @@ ms.assetid: 9f6e8679-bd7e-4317-b3f9-7255a260d9cf
 
 # Developing Libraries with Cross Platform Tools
 
-> [!WARNING]
-> This topic hasn't been updated to the latest version of the tooling yet.
-
 This article covers how to write libraries for .NET using cross-platform CLI tools.  The CLI provides an efficient and low-level experience that works across any supported OS.  You can still build libraries with Visual Studio, and if that is your preferred experience [refer to the Visual Studio guide](libraries-with-vs.md).
 
 ## Prerequisites
@@ -231,63 +228,6 @@ netstandard1.4/
 ```
 
 Each of these contain the `.dll` files for each target.
-
-## How to use native dependencies
-
-You may wish to write a library which depends on a native `.dll` file.  If you're writing such a library, you have have two options:
-
-1. Reference the native `.dll` directly in your `project.json`.
-2. Package that `.dll` into its own NuGet package and depend on that package.
-
-For the first option, you'll need to include the following in your `project.json` file:
-
-1. Setting `allowUnsafe` to `true` in a `buildOptions` section.
-2. Specifying a [Runtime Identifier (RID)](../rid-catalog.md) in a `runtimes` section.
-3. Specifying the path to the native `.dll` file(s) that you are referencing.
-
-Here's an example `project.json` for a native `.dll` file in the root directory of the project which runs on Windows:
-
-TODO: probably this in it
-```xml
-<RuntimeIdentifiers>win10-x64;</RuntimeIdentifiers>
-```
-
-```json
-{
-    "buildOptions":{
-        "allowUnsafe":true
-    },
-    "runtimes":{
-        "win10-x64":{}
-    },
-    "packOptions":{
-        "files":{
-            "mappings":{
-                "runtimes/win10-x64/native":{
-                    "includeFiles":[ "native-lib.dll"]
-                }
-            }            
-        }
-    }
-}
-```
-
-If you're distributing your library as a package, it's recommended that you place the `.dll` file at the root level of your project.
-
-For the second option, you'll need to build a NuGet package out of your `.dll` file(s), host on a NuGet or MyGet feed, and depend on it directly.  You'll still need to set `allowUnsafe` to `true` in the `buildOptions` section of your `project.json`.  Here's an example (assuming `MyNativeLib` is a Nuget package at version `1.2.0`):
-
-```json
-{
-    "buildOptions":{
-        "allowUnsafe":true
-    },
-    "dependencies":{
-        "MyNativeLib":"1.2.0"
-    }
-}
-```
-
-To see an example of packaging up cross-platform native binaries, check out the [ASP.NET Libuv Package](https://github.com/aspnet/libuv-package) and the [corresponding reference in KestrelHttpServer](https://github.com/aspnet/KestrelHttpServer/blob/1.0.0/src/Microsoft.AspNetCore.Server.Kestrel/project.json#L19).
 
 ## How to test libraries on .NET Core
 


### PR DESCRIPTION
#1646 

I got rid of the PCL section.  We're moving people away from PCL.  It's also such a problematic thing to use with the new tools that I think it does more harm than good documenting it.  I still have to figure out how to reference a native library in the new tools.