### PR TITLE
Fixed VB code and syntax highlighting

### DIFF
--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -33,22 +33,24 @@ Used to test for null before performing a member access (`?.`) or index (`?[`) o
 int? length = customers?.Length; // null if customers is null   
 Customer first = customers?[0];  // null if customers is null  
 int? count = customers?[0]?.Orders?.Count();  // null if customers, the first customer, or Orders is null  
-  
 ```  
   
 ```vb  
-Dim length = customers?.Length  ‘’ null if customers is null  
-Dim first as Customer = customers?(0);  ‘’ null if customers is null  
-Dim count as Integer? = customers?[0]?.Orders?.Count();  // null if customers, the first customer, or Orders is null  
-  
+Dim length = customers?.Length  ' null if customers is null  
+Dim first as Customer = customers?(0)  ' null if customers is null  
+Dim count as Integer? = customers?(0)?.Orders?.Count()  ' null if customers, the first customer, or Orders is null  
 ```  
   
  The last example demonstrates that the null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  Other operations with lower precedence in the expression continue.  For example, `E` in the following always executes, and the `??` and `==` operations execute.  
   
-```vb-c#  
+```csharp
 A?.B?.C?[0] ?? E  
 A?.B?.C?[0] == E  
-  
+```
+
+```vb
+A?.B?.C?(0) ?? E  
+A?.B?.C?(0) == E  
 ```  
   
  Another use for the null-condition member access is invoking delegates in a thread-safe way with much less code.  The old way requires code like the following:  
@@ -57,21 +59,18 @@ A?.B?.C?[0] == E
 var handler = this.PropertyChanged;  
 if (handler != null)  
     handler(…)  
-  
 ```  
   
 ```vb  
 Dim handler = AddressOf(Me.PropertyChanged)  
 If handler IsNot Nothing  
     Call handler(…)  
-  
 ```  
   
  The new way is much simpler:  
   
-```vb-c#  
+```csharp
 PropertyChanged?.Invoke(e)  
-  
 ```  
   
  The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in temporary variable.  

--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -58,7 +58,7 @@ A?.B?.C?(0) == E
 ```csharp  
 var handler = this.PropertyChanged;  
 if (handler != null)  
-    handler(…)  
+    handler(…);
 ```  
   
 ```vb  
@@ -72,8 +72,12 @@ If handler IsNot Nothing
 ```csharp
 PropertyChanged?.Invoke(e)  
 ```  
+
+```vb
+PropertyChanged?.Invoke(e)
+```  
   
- The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in temporary variable.  
+ The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in a temporary variable.  
   
  You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  There were too many ambiguous parsing situations to allow it.  
   


### PR DESCRIPTION
When reviewing https://github.com/dotnet/docs/pull/1796, I noticed that this article used the invalid language identifier `vb-c#`. I fixed that by changing it to `csharp` in one case and added a separate VB block in the second, because the code was not valid VB.

While here, I also fixed other invalid VB code.