### PR TITLE
fixed broken links to visualstudio/data-tools

### DIFF
--- a/docs/visual-basic/developing-apps/accessing-data.md
+++ b/docs/visual-basic/developing-apps/accessing-data.md
@@ -35,13 +35,13 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # Accessing data in Visual Basic applications
-[!INCLUDE[vbprvb](../../csharp/programming-guide/concepts/linq/includes/vbprvb_md.md)] includes several new features to assist in developing applications that access data. Data-bound forms for Windows applications are created by dragging items from the [Data Sources Window](https://docs.microsoft.com/visualstudio/data-tools/bind-controls-to-data-in-visual-studio) onto the form. You bind controls to data by dragging items from the **Data Sources Window** onto existing controls.  
+[!INCLUDE[vbprvb](../../csharp/programming-guide/concepts/linq/includes/vbprvb_md.md)] includes several new features to assist in developing applications that access data. Data-bound forms for Windows applications are created by dragging items from the [Data Sources Window](https://docs.microsoft.com/en-us/visualstudio/data-tools/add-new-data-sources) onto the form. You bind controls to data by dragging items from the **Data Sources Window** onto existing controls.  
   
 ## Related sections  
- [Creating Data Applications](https://docs.microsoft.com/visualstudio/data-tools/creating-data-applications)  
+ [Accessing Data in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/)  
  Provides links to pages that discuss incorporating data access functionality into your applications.
 
- [Overview of Data Applications in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/overview-of-data-applications-in-visual-studio)  
+ [Visual Studio data tools for .NET](https://docs.microsoft.com/visualstudio/data-tools/visual-studio-data-tools-for-dotnet)  
  Provides links to pages on creating applications that work with data, using [!INCLUDE[vsprvs](../../csharp/includes/vsprvs_md.md)].  
   
  [LINQ](../../visual-basic/programming-guide/language-features/linq/index.md)  
@@ -56,22 +56,22 @@ translation.priority.ht:
  [Work with datasets in n-tier applications](https://docs.microsoft.com/visualstudio/data-tools/work-with-datasets-in-n-tier-applications)  
  Provides links to topics about how to create multitiered data applications.  
      
- [Connecting to Data in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/connecting-to-data-in-visual-studio)  
+ [Add new connections](https://docs.microsoft.com/en-us/visualstudio/data-tools/add-new-connections)  
  Provides links to pages on connecting your application to data with design-time tools and ADO.NET connection objects, using [!INCLUDE[vsprvs](../../csharp/includes/vsprvs_md.md)].  
 
- [Fetching Data into Your Application](https://docs.microsoft.com/visualstudio/data-tools/fetching-data-into-your-application)  
+ [Dataset Tools in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/data-tools/dataset-tools-in-visual-studio)  
  Provides links to pages describing how to load data into datasets and how to execute SQL statements and stored procedures.  
   
  [Bind controls to data in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/bind-controls-to-data-in-visual-studio)  
  Provides links to pages that explain how to display data on Windows Forms through data-bound controls.  
   
- [Editing Data in Your Application](https://docs.microsoft.com/visualstudio/data-tools/editing-data-in-your-application)  
+ [Edit Data in Datasets](https://docs.microsoft.com/en-us/visualstudio/data-tools/edit-data-in-datasets)  
  Provides links to pages describing how to manipulate the data in the data tables of a dataset.  
   
  [Validate data in datasets](https://docs.microsoft.com/visualstudio/data-tools/validate-data-in-datasets)  
  Provides links to pages describing how to add validation to a dataset during column and row changes.  
   
- [Saving Data](https://docs.microsoft.com/visualstudio/data-tools/saving-data)  
+ [Save data back to the database](https://docs.microsoft.com/visualstudio/data-tools/save-data-back-to-the-database)  
  Provides links to pages explaining how to send updated data from an application to the database.  
   
  [ADO.NET](https://msdn.microsoft.com/library/e80y5yhx.aspx)  

--- a/docs/visual-basic/developing-apps/accessing-data.md
+++ b/docs/visual-basic/developing-apps/accessing-data.md
@@ -35,7 +35,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # Accessing data in Visual Basic applications
-[!INCLUDE[vbprvb](../../csharp/programming-guide/concepts/linq/includes/vbprvb_md.md)] includes several new features to assist in developing applications that access data. Data-bound forms for Windows applications are created by dragging items from the [Data Sources Window](https://docs.microsoft.com/en-us/visualstudio/data-tools/add-new-data-sources) onto the form. You bind controls to data by dragging items from the **Data Sources Window** onto existing controls.  
+[!INCLUDE[vbprvb](../../csharp/programming-guide/concepts/linq/includes/vbprvb_md.md)] includes several new features to assist in developing applications that access data. Data-bound forms for Windows applications are created by dragging items from the [Data Sources Window](https://docs.microsoft.com/visualstudio/data-tools/add-new-data-sources) onto the form. You bind controls to data by dragging items from the **Data Sources Window** onto existing controls.  
   
 ## Related sections  
  [Accessing Data in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/)  
@@ -56,16 +56,16 @@ translation.priority.ht:
  [Work with datasets in n-tier applications](https://docs.microsoft.com/visualstudio/data-tools/work-with-datasets-in-n-tier-applications)  
  Provides links to topics about how to create multitiered data applications.  
      
- [Add new connections](https://docs.microsoft.com/en-us/visualstudio/data-tools/add-new-connections)  
+ [Add new connections](https://docs.microsoft.com/visualstudio/data-tools/add-new-connections)  
  Provides links to pages on connecting your application to data with design-time tools and ADO.NET connection objects, using [!INCLUDE[vsprvs](../../csharp/includes/vsprvs_md.md)].  
 
- [Dataset Tools in Visual Studio](https://docs.microsoft.com/en-us/visualstudio/data-tools/dataset-tools-in-visual-studio)  
+ [Dataset Tools in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/dataset-tools-in-visual-studio)  
  Provides links to pages describing how to load data into datasets and how to execute SQL statements and stored procedures.  
   
  [Bind controls to data in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/bind-controls-to-data-in-visual-studio)  
  Provides links to pages that explain how to display data on Windows Forms through data-bound controls.  
   
- [Edit Data in Datasets](https://docs.microsoft.com/en-us/visualstudio/data-tools/edit-data-in-datasets)  
+ [Edit Data in Datasets](https://docs.microsoft.com/visualstudio/data-tools/edit-data-in-datasets)  
  Provides links to pages describing how to manipulate the data in the data tables of a dataset.  
   
  [Validate data in datasets](https://docs.microsoft.com/visualstudio/data-tools/validate-data-in-datasets)  


### PR DESCRIPTION
fixed broken links to visualstudio/data-tools topics. This is prefereable to creating redirects because the link text also needed to change in some cases. Le me know if i missed any.

also: These could be site-relative urls of the form: /visualstudio/data-tools/<topic> ?

@svick @mairaw 