### PR TITLE
Updated dotnet restore verbosity sample

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -100,6 +100,6 @@ Restore the dependencies and tools for the project in the current directory usin
 
 `dotnet restore -s c:\packages\mypackages -s c:\packages\myotherpackages` 
 
-Restore dependencies and tools for the project in the current directory and shows only errors in the output:
+Restore dependencies and tools for the project in the current directory and shows only minimal output:
 
-`dotnet restore --verbosity Error`
+`dotnet restore --verbosity minimal`


### PR DESCRIPTION
# Title
Updated dotnet restore verbosity sample

## Summary

Error is no longer a valid verbosity, it'll raise this error:
```console
MSBUILD : error MSB1018: Verbosity level is not valid.
Switch: Error
```