### PR TITLE
fixed `dotnet sln add` blobs

### DIFF
--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -37,13 +37,15 @@ The `dotnet sln` command provides a convenient way to add, remove, and list proj
 
 `add <PROJECT> ...`
 
+`add <GLOBBING_PATTERN>`
+
 Adds a project or multiple projects to the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
 
 `remove <PROJECT> ...`
 
-`remove **/*.csproj`
+`remove <GLOBBING_PATTERN>`
 
-Removes a C# project or multiple C# projects from the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
+Removes a project or multiple projects from the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
 
 `list`
 
@@ -67,7 +69,7 @@ Add a C# project to a solution:
 
 `dotnet sln todo.sln add todo-app/todo-app.csproj`
 
-Remove a project from a solution:
+Remove a C# project from a solution:
 
 `dotnet sln todo.sln remove todo-app/todo-app.csproj`
 
@@ -81,8 +83,8 @@ Remove multiple C# projects to a solution:
 
 Add multiple C# projects to a solution using a globbing pattern:
 
-`dotnet sln todo.sln add **/.csproj`
+`dotnet sln todo.sln add **/*.csproj`
 
 Remove multiple C# projects from a solution using a globbing pattern:
 
-`dotnet sln todo.sln remove **/.csproj`
+`dotnet sln todo.sln remove **/*.csproj`

--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -22,7 +22,7 @@ ms.assetid: e5a72d3e-c14b-4b0a-a978-c5e54a0988c6
 
 ```
 dotnet sln [<SOLUTION_NAME>] add <PROJECT> <PROJECT> ...
-dotnet sln [<SOLUTION_NAME>] add **/**
+dotnet sln [<SOLUTION_NAME>] add **/**.{csproj,fsproj}
 dotnet sln [<SOLUTION_NAME>] remove <PROJECT> <PROJECT> ...
 dotnet sln [<SOLUTION_NAME>] remove **/**
 dotnet sln [<SOLUTION_NAME>] list
@@ -37,7 +37,7 @@ The `dotnet sln` command provides a convenient way to add, remove, and list proj
 
 `add <PROJECT> ...`
 
-`add **/*`
+`add **/*.{csproj,fsproj}`
 
 Adds a project or multiple projects to the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
 
@@ -65,11 +65,15 @@ Prints out a short help for the command.
 
 ## Examples
 
-Add a project to a solution:
+Add a C# project to a solution:
 
 `dotnet sln todo.sln add todo-app/todo-app.csproj`
 
-Add a project to the solution in the current directory:
+Add an F# project to a solution:
+
+`dotnet sln todo.sln add todo-app/todo-app.fsproj`
+
+Add a solution in the current directory:
 
 `dotnet sln add todo-app.csproj`
 
@@ -77,6 +81,14 @@ Remove a project from a solution:
 
 `dotnet sln todo.sln remove todo-app/todo-app.csproj`
 
-Add multiple projects to a solution using a globbing pattern:
+Add multiple C# projects to a solution using a globbing pattern:
 
-`dotnet sln add **/**/*.fsproj`
+`dotnet sln todo.sln add **/**/*.csproj`
+
+Add multiple F# projects to a solution using a globbing pattern:
+
+`dotnet sln todo.sln add **/**/*.fsproj`
+
+Add multiple C# and F# projects to a solution using a globbing pattern:
+
+`dotnet sln todo.sln add **/**/*.{csproj,fsproj}`

--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -4,7 +4,7 @@ description: The dotnet-sln command provides a convenient option to add, remove,
 keywords: dotnet-sln, CLI, CLI command, .NET Core
 author: spboyer
 ms.author: mairaw
-ms.date: 03/15/2017
+ms.date: 04/11/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -22,9 +22,9 @@ ms.assetid: e5a72d3e-c14b-4b0a-a978-c5e54a0988c6
 
 ```
 dotnet sln [<SOLUTION_NAME>] add <PROJECT> <PROJECT> ...
-dotnet sln [<SOLUTION_NAME>] add **/**.{csproj,fsproj}
+dotnet sln [<SOLUTION_NAME>] add <GLOBBING_PATTERN>
 dotnet sln [<SOLUTION_NAME>] remove <PROJECT> <PROJECT> ...
-dotnet sln [<SOLUTION_NAME>] remove **/**
+dotnet sln [<SOLUTION_NAME>] remove <GLOBBING_PATTERN>
 dotnet sln [<SOLUTION_NAME>] list
 dotnet sln [-h|--help]
 ```
@@ -37,15 +37,13 @@ The `dotnet sln` command provides a convenient way to add, remove, and list proj
 
 `add <PROJECT> ...`
 
-`add **/*.{csproj,fsproj}`
-
 Adds a project or multiple projects to the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
 
 `remove <PROJECT> ...`
 
-`remove **/*`
+`remove **/*.csproj`
 
-Remove a project or multiple projects from the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
+Removes a C# project or multiple C# projects from the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
 
 `list`
 
@@ -69,26 +67,22 @@ Add a C# project to a solution:
 
 `dotnet sln todo.sln add todo-app/todo-app.csproj`
 
-Add an F# project to a solution:
-
-`dotnet sln todo.sln add todo-app/todo-app.fsproj`
-
-Add a solution in the current directory:
-
-`dotnet sln add todo-app.csproj`
-
 Remove a project from a solution:
 
 `dotnet sln todo.sln remove todo-app/todo-app.csproj`
 
+Add multiple C# projects to a solution:
+
+`dotnet sln todo.sln add todo-app/todo-app.csproj back-end/back-end.csproj`
+
+Remove multiple C# projects to a solution:
+
+`dotnet sln todo.sln remove todo-app/todo-app.csproj back-end/back-end.csproj`
+
 Add multiple C# projects to a solution using a globbing pattern:
 
-`dotnet sln todo.sln add **/**/*.csproj`
+`dotnet sln todo.sln add **/.csproj`
 
-Add multiple F# projects to a solution using a globbing pattern:
+Remove multiple C# projects from a solution using a globbing pattern:
 
-`dotnet sln todo.sln add **/**/*.fsproj`
-
-Add multiple C# and F# projects to a solution using a globbing pattern:
-
-`dotnet sln todo.sln add **/**/*.{csproj,fsproj}`
+`dotnet sln todo.sln remove **/.csproj`

--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -77,7 +77,7 @@ Add multiple C# projects to a solution:
 
 `dotnet sln todo.sln add todo-app/todo-app.csproj back-end/back-end.csproj`
 
-Remove multiple C# projects to a solution:
+Remove multiple C# projects from a solution:
 
 `dotnet sln todo.sln remove todo-app/todo-app.csproj back-end/back-end.csproj`
 


### PR DESCRIPTION
# fixed `dotnet sln add` blobs

## Summary

No projects are added to the solution file when the user runs `dotnet sln todo.sln add **/**` if there are any sub-directories that do not contain a project file. For example, the presence of  wwwroot/ in an API project will cause the command to fail. Most solutions contain projects that have sub-folders.

Using `dotnet sln todo.sln add **/**.{csproj,fsproj}` does work.

## Details

Under bash 4.3.42(1) `dotnet sln add` fails when the wildcard blob does not include a file extension qualifier (e.g., .csproj)

`dotnet sln <FILE.sln> add **/*`

The CLI terminates when it comes across a sub directory that does not contain a project file. E.g., wwwroot/.
Adding a qualifier to the blob, (.{csproj,fsproj}) seems to be the correct way to use blobs with `dotnet sln add`.

This does not apply to `dotnet sln remove` which can use unqualified wildcard blobs.
