### PR TITLE
Explained where the CLI looks for global.json

### DIFF
--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -16,7 +16,7 @@ ms.assetid: 96102f96-d403-4385-8ef6-5d80e406eb0c
 
 The *global.json* file allows selection of the .NET Core tools version being used through the `sdk` property.
 
-.NET Core CLI tools look for this file in the current working directory (which is not necessarily the same as the project directory) or one of its parent directories.
+.NET Core CLI tools look for this file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
 
 ## sdk
 Type: Object

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -4,7 +4,7 @@ description: global.json reference
 keywords: .NET, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 03/06/2016
+ms.date: 04/05/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -14,9 +14,9 @@ ms.assetid: 96102f96-d403-4385-8ef6-5d80e406eb0c
 
 # global.json reference
 
-The global.json file allows selection of the .NET Core tools version being used through the `sdk` property.
+The *global.json* file allows selection of the .NET Core tools version being used through the `sdk` property.
 
-.NET Core CLI tools look for this file in the current working directory (which does not have to be the project directory), or one of its parent directories.
+.NET Core CLI tools look for this file in the current working directory (which is not necessarily the same as the project directory) or one of its parent directories.
 
 ## sdk
 Type: Object
@@ -32,8 +32,8 @@ For example:
 
 ```json
 {
-    "sdk": {
-        "version": "1.0.0-preview2-003121"
-    }
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
 }
 ```

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -14,7 +14,9 @@ ms.assetid: 96102f96-d403-4385-8ef6-5d80e406eb0c
 
 # global.json reference
 
-The global.json file allows selection of the .NET Core tools version being used through the `sdk` property. 
+The global.json file allows selection of the .NET Core tools version being used through the `sdk` property.
+
+.NET Core CLI tools look for this file in the current directory, or one of its parent directories.
 
 ## sdk
 Type: Object

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -16,7 +16,7 @@ ms.assetid: 96102f96-d403-4385-8ef6-5d80e406eb0c
 
 The global.json file allows selection of the .NET Core tools version being used through the `sdk` property.
 
-.NET Core CLI tools look for this file in the current directory, or one of its parent directories.
+.NET Core CLI tools look for this file in the current working directory (which does not have to be the project directory), or one of its parent directories.
 
 ## sdk
 Type: Object


### PR DESCRIPTION
The document explained what global.json is, but not where it can be located. This is especially important when it is in one of the parent directories or when calling `dotnet` from outside the project directory ([like this SO commenter was](http://stackoverflow.com/questions/40699867/choose-the-sdk-version-e-g-preview3-vs-preview2-that-the-dotnet-cli-uses/40708595?noredirect=1#comment73457646_40708595)).

I'm not happy about the "one of its parent directories" part (because a directory can have at most one parent), but I couldn't figure out anything else that is both succinct and accurate.