### PR TITLE
rid-catalog: Remove rhel minor versions

### DIFF
--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -100,11 +100,6 @@ For the latest version, please check the [runtime.json](https://github.com/dotne
 
 * Red Hat Enterprise Linux
     * `rhel.7-x64`
-    * `rhel.7.0-x64`
-    * `rhel.7.1-x64`
-    * `rhel.7.2-x64`
-    * `rhel.7.3-x64`
-    * `rhel.7.4-x64`
 * Ubuntu
     * `ubuntu.14.04-x64`
     * `ubuntu.14.10-x64`


### PR DESCRIPTION
RHEL minor versions are binary compatible. The rhel major should be used for publishing.

cfr https://github.com/ellismg/core-setup/commit/b16864201a3a33f0e55f68c4539bbafcffc718ea

CC @omajid @ellismg 