### PR TITLE
Remove [TestClass] attribute from xunit test example

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -103,7 +103,6 @@ using Prime.Services;
 
 namespace Prime.UnitTests.Services
 {
-    [TestClass]
     public class PrimeService_IsPrimeShould
     {
         private readonly PrimeService _primeService;


### PR DESCRIPTION
# Remove [TestClass] attribute from xunit test example

## Summary

`[TestClass]` attribute does not exist in xunit framework.
