### PR TITLE
Add redirects for base-types, garbage-collection and thread-safe.

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -250,8 +250,228 @@
             "redirect_url": "/dotnet/articles/core/tutorials/target-dotnetcore-with-msbuild"
         },
         {
+            "source_path": "docs/standard/base-types/alternation.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/alternation-constructs-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/anchors.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/anchors-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/backreference.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/backreference-constructs-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/backtracking.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/backtracking-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/changing-formats.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/regular-expression-example-changing-date-formats"
+        },
+        {
+            "source_path": "docs/standard/base-types/classes.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/character-classes-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/compilation.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/compilation-and-reuse-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/composite-format.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/composite-formatting"
+        },
+        {
+            "source_path": "docs/standard/base-types/custom-datetime.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/custom-date-and-time-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/custom-numeric.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/custom-numeric-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/custom-timespan.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/custom-timespan-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/define-custom.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-define-and-use-custom-numeric-format-providers"
+        },
+        {
+            "source_path": "docs/standard/base-types/display-dates.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-display-dates-in-non-gregorian-calendars"
+        },
+        {
+            "source_path": "docs/standard/base-types/display-milliseconds.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-display-milliseconds-in-date-and-time-values"
+        },
+        {
+            "source_path": "docs/standard/base-types/enumeration-format.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/enumeration-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/escapes.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/character-escapes-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/extract-day.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-extract-the-day-of-the-week-from-a-specific-date"
+        },
+        {
+            "source_path": "docs/standard/base-types/extract-protocol.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-extract-a-protocol-and-port-number-from-a-url"
+        },
+        {
+            "source_path": "docs/standard/base-types/grouping.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/grouping-constructs-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/index.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/"
+        },
+        {
+            "source_path": "docs/standard/base-types/miscellaneous.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/miscellaneous-constructs-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/object-model.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/the-regular-expression-object-model"
+        },
+        {
+            "source_path": "docs/standard/base-types/options.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/regular-expression-options"
+        },
+        {
+            "source_path": "docs/standard/base-types/pad-number.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-pad-a-number-with-leading-zeros"
+        },
+        {
+            "source_path": "docs/standard/base-types/quantifiers.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/quantifiers-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/quick-ref.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/regular-expression-language-quick-reference"
+        },
+        {
+            "source_path": "docs/standard/base-types/regex-behavior.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/details-of-regular-expression-behavior"
+        },
+        {
+            "source_path": "docs/standard/base-types/regex-examples.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/regular-expression-examples"
+        },
+        {
+            "source_path": "docs/standard/base-types/roundtrip.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-round-trip-date-and-time-values"
+        },
+        {
+            "source_path": "docs/standard/base-types/scanning.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/regular-expression-example-scanning-for-hrefs"
+        },
+        {
+            "source_path": "docs/standard/base-types/standard-datetime.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/standard-date-and-time-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/standard-numeric.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/standard-numeric-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/standard-timespan.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/standard-timespan-format-strings"
+        },
+        {
+            "source_path": "docs/standard/base-types/strip-characters.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-strip-invalid-characters-from-a-string"
+        },
+        {
+            "source_path": "docs/standard/base-types/substitutions.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/substitutions-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/thread-safety.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/thread-safety-in-regular-expressions"
+        },
+        {
+            "source_path": "docs/standard/base-types/verify-format.md",
+            "redirect_url": "/dotnet/articles/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/blockingcollection-overview.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/blockingcollection-overview"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/how-to-add-and-remove-items.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/how-to-add-and-remove-items"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/how-to-add-and-take-items.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/how-to-add-and-take-items"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/how-to-add-bounding-and-blocking.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/how-to-add-bounding-and-blocking"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/how-to-create-an-object-pool.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/how-to-create-an-object-pool"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/how-to-use-arrays-of-blockingcollections.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/how-to-use-arrays-of-blockingcollections"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/how-to-use-foreach-to-remove.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/how-to-use-foreach-to-remove"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/index.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/"
+        },
+        {
+            "source_path": "docs/standard/collections/threadsafe/when-to-use-a-thread-safe-collection.md",
+            "redirect_url": "/dotnet/articles/standard/collections/thread-safe/when-to-use-a-thread-safe-collection"
+        },
+        {
             "source_path": "docs/standard/concepts.md",
             "redirect_url": "/dotnet/articles/standard/"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/fundamentals.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/fundamentals"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/gc.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/gc"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/implementing-dispose.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/implementing-dispose"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/index.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/induced.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/induced"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/latency.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/latency"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/unmanaged.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/unmanaged"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/using-objects.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/using-objects"
+        },
+        {
+            "source_path": "docs/standard/garbagecollection/weak-references.md",
+            "redirect_url": "/dotnet/articles/standard/garbage-collection/weak-references"
         },
         {
             "source_path": "docs/tutorials/getting-started-with-csharp/microservices.md",


### PR DESCRIPTION
# Title
Add redirects for base-types, garbage-collection and thread-safe.

## Summary
Added redirects to account for merged files and changes in some directory names: basetypes became base-types, collections\threadsafe became collections\thread-safe, and garbagecollection became garbage-collection.
