### PR TITLE
cleanup migration

### DIFF
--- a/docs/standard/garbage-collection/index.md
+++ b/docs/standard/garbage-collection/index.md
@@ -31,7 +31,7 @@ ms.author: "ronpet"
 manager: "wpickett"
 ---
 # Garbage Collection
-The .NET Framework's garbage collector manages the allocation and release of memory for your application. Each time you create a new object, the common language runtime allocates memory for the object from the managed heap. As long as address space is available in the managed heap, the runtime continues to allocate space for new objects. However, memory is not infinite. Eventually the garbage collector must perform a collection in order to free some memory. The garbage collector's optimizing engine determines the best time to perform a collection, based upon the allocations being made. When the garbage collector performs a collection, it checks for objects in the managed heap that are no longer being used by the application and performs the necessary operations to reclaim their memory.  
+.NET's garbage collector manages the allocation and release of memory for your application. Each time you create a new object, the common language runtime allocates memory for the object from the managed heap. As long as address space is available in the managed heap, the runtime continues to allocate space for new objects. However, memory is not infinite. Eventually the garbage collector must perform a collection in order to free some memory. The garbage collector's optimizing engine determines the best time to perform a collection, based upon the allocations being made. When the garbage collector performs a collection, it checks for objects in the managed heap that are no longer being used by the application and performs the necessary operations to reclaim their memory.  
   
 <a name="related_topics"></a>   
 ## Related Topics  

--- a/docs/standard/garbage-collection/induced.md
+++ b/docs/standard/garbage-collection/induced.md
@@ -27,7 +27,7 @@ In most cases, the garbage collector can determine the best time to perform a co
   
 |`GCCollectionMode` value|Description|  
 |------------------------------|-----------------|  
-|<xref:System.GCCollectionMode>|Uses the default garbage collection setting for the running version of the .NET Framework.|  
+|<xref:System.GCCollectionMode>|Uses the default garbage collection setting for the running version of .NET.|  
 |<xref:System.GCCollectionMode>|Forces garbage collection to occur immediately. This is equivalent to calling the <xref:System.GC.Collect?displayProperty=fullName> overload. It results in a full blocking collection of all generations.<br /><br /> You can also compact the large object heap by setting the <xref:System.Runtime.GCSettings.LargeObjectHeapCompactionMode%2A?displayProperty=fullName> property to <xref:System.Runtime.GCLargeObjectHeapCompactionMode?displayProperty=fullName> before forcing an immediate full blocking garbage collection.|  
 |<xref:System.GCCollectionMode>|Enables the garbage collector to determine whether the current time is optimal to reclaim objects.<br /><br /> The garbage collector could determine that a collection would not be productive enough to be justified, in which case it will return without reclaiming objects.|  
   

--- a/docs/standard/garbage-collection/memory-management-and-gc.md
+++ b/docs/standard/garbage-collection/memory-management-and-gc.md
@@ -19,15 +19,15 @@ author: "rpetrusha"
 ms.author: "ronpet"
 manager: "wpickett"
 ---
-# Memory Management and Garbage Collection in the .NET Framework
-This section of the documentation provides information about managing memory in the .NET Framework.  
+# Memory Management and Garbage Collection in .NET
+This section of the documentation provides information about managing memory in .NET.  
   
 ## In This Section  
  [Cleaning Up Unmanaged Resources](../../../docs/standard/garbage-collection/unmanaged.md)  
  Describes how to properly manage and clean up unmanaged resources..  
   
  [Garbage Collection](../../../docs/standard/garbage-collection/index.md)  
- Provides information about the .NET Framework garbage collector.  
+ Provides information about the .NET garbage collector.  
   
 ## Related Sections  
  [Development Guide](../../../docs/framework/development-guide.md)

--- a/docs/standard/garbage-collection/optimization-for-shared-web-hosting.md
+++ b/docs/standard/garbage-collection/optimization-for-shared-web-hosting.md
@@ -20,7 +20,7 @@ ms.author: "ronpet"
 manager: "wpickett"
 ---
 # Optimization for Shared Web Hosting
-If you are the administrator for a server that is shared by hosting several small Web sites, you can optimize performance and increase site capacity by adding the following `gcTrimCommitOnLowMemory` setting to the `runtime` node in the Aspnet.config file in the .NET Framework directory:  
+If you are the administrator for a server that is shared by hosting several small Web sites, you can optimize performance and increase site capacity by adding the following `gcTrimCommitOnLowMemory` setting to the `runtime` node in the Aspnet.config file in the .NET directory:  
   
  `<gcTrimCommitOnLowMemory enabled="true|false"/>`  
   

--- a/docs/standard/garbage-collection/unmanaged.md
+++ b/docs/standard/garbage-collection/unmanaged.md
@@ -25,7 +25,7 @@ ms.author: "ronpet"
 manager: "wpickett"
 ---
 # Cleaning Up Unmanaged Resources
-For the majority of the objects that your app creates, you can rely on the .NET Framework's garbage collector to handle memory management. However, when you create objects that include unmanaged resources, you must explicitly release those resources when you finish using them in your app. The most common types of unmanaged resource are objects that wrap operating system resources, such as files, windows, network connections, or database connections. Although the garbage collector is able to track the lifetime of an object that encapsulates an unmanaged resource, it doesn't know how to release and clean up the unmanaged resource.  
+For the majority of the objects that your app creates, you can rely on .NET's garbage collector to handle memory management. However, when you create objects that include unmanaged resources, you must explicitly release those resources when you finish using them in your app. The most common types of unmanaged resource are objects that wrap operating system resources, such as files, windows, network connections, or database connections. Although the garbage collector is able to track the lifetime of an object that encapsulates an unmanaged resource, it doesn't know how to release and clean up the unmanaged resource.  
   
  If your types use unmanaged resources, you should do the following:  
   


### PR DESCRIPTION
Redirects for the change from garbagecollection to garbage-collection are in #1869

This just changes instances of .NET Framework to .NET.

There are a lot of links to the .NET Framework  docs and notes about how GC changed from one version of .NET Framework to another; the whole collection should be more closely reviewed at some point in the future to determine what content actually belong in standard vs. what belongs in framework.
