### PR TITLE
Fixed thread safety for the ValueTask example

### DIFF
--- a/samples/snippets/csharp/new-in-7/AsyncWork.cs
+++ b/samples/snippets/csharp/new-in-7/AsyncWork.cs
@@ -77,12 +77,12 @@ namespace new_in_7
         }
         private bool cache = false;
         private int cacheResult;
-        private async Task<int> loadCache()
+        private async Task<int> LoadCache()
         {
             // simulate async work:
             await Task.Delay(100);
-            cache = true;
             cacheResult = 100;
+            cache = true;
             return cacheResult;
         }
         #endregion

--- a/samples/snippets/csharp/new-in-7/AsyncWork.cs
+++ b/samples/snippets/csharp/new-in-7/AsyncWork.cs
@@ -73,7 +73,7 @@ namespace new_in_7
         #region 31_AsyncOptimizedValueTask
         public ValueTask<int> CachedFunc()
         {
-            return (cache) ? new ValueTask<int>(cacheResult) : new ValueTask<int>(loadCache());
+            return (cache) ? new ValueTask<int>(cacheResult) : new ValueTask<int>(LoadCache());
         }
         private bool cache = false;
         private int cacheResult;


### PR DESCRIPTION
Fixes #1758 

The ```cache = true``` line should be after the ```cacheResult = 100``` line, otherwise it is not thread safe.
Also fixed method's name casing.
