### PR TITLE
Two fixes for example WriteEventCore

### DIFF
--- a/xml/System.Diagnostics.Tracing/EventSource.xml
+++ b/xml/System.Diagnostics.Tracing/EventSource.xml
@@ -2477,7 +2477,7 @@ class AnotherEventSource : EventSource {
   
         fixed (char* arg1Ptr = arg1)  
         {  
-            EventData* dataDesc = stackalloc EventProvider.EventData[4];  
+            EventData* dataDesc = stackalloc EventData[4];  
   
             dataDesc[0].DataPointer = (IntPtr)arg1Ptr;  
             dataDesc[0].Size = (arg1.Length + 1) * 2; // Size in bytes, including a null terminator.   
@@ -2488,7 +2488,7 @@ class AnotherEventSource : EventSource {
             dataDesc[3].DataPointer = (IntPtr)(&arg4);  
             dataDesc[3].Size = 4;  
   
-            WriteEventCore(eventId, 4, (IntPtr)dataDesc);  
+            WriteEventCore(eventId, 4, dataDesc);  
         }  
     }  
 }  


### PR DESCRIPTION
Two changes in the example:

1) EventProvider.EventData should be EventSource.EventData. EventSource can be omitted, so it is simplified to just EventData. 
2) The (IntPtr) cast causes a compile error. The third parameter of WriteEventCore is EventData* and dataDesc is already that type so no cast is needed.
