### PR TITLE
Addressed issue #1888: bad return value for StreamReader async reads

### DIFF
--- a/xml/System.IO/StreamReader.xml
+++ b/xml/System.IO/StreamReader.xml
@@ -1230,7 +1230,7 @@
         <param name="index">The position in <c>buffer</c> at which to begin writing.</param>
         <param name="count">The maximum number of characters to read. If the end of the stream is reached before the specified number of characters is written into the buffer, the current method returns.</param>
         <summary>Reads a specified maximum number of characters from the current stream asynchronously and writes the data to a buffer, beginning at the specified index.</summary>
-        <returns>A task that represents the asynchronous read operation. The value of the <paramref name="TResult" /> parameter contains the total number of bytes read into the buffer. The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number, or it can be 0 (zero) if the end of the stream has been reached.</returns>
+        <returns>A task that represents the asynchronous read operation. The value of the <paramref name="TResult" /> parameter contains the total number of characters read into the buffer. The result value can be less than the number of characters requested if the number of characters currently available is less than the requested number, or it can be 0 (zero) if the end of the stream has been reached.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -1347,7 +1347,7 @@
         <param name="index">The position in <c>buffer</c> at which to begin writing.</param>
         <param name="count">The maximum number of characters to read. If the end of the stream is reached before the specified number of characters is written into the buffer, the method returns.</param>
         <summary>Reads a specified maximum number of characters from the current stream asynchronously and writes the data to a buffer, beginning at the specified index.</summary>
-        <returns>A task that represents the asynchronous read operation. The value of the <paramref name="TResult" /> parameter contains the total number of bytes read into the buffer. The result value can be less than the number of bytes requested if the number of bytes currently available is less than the requested number, or it can be 0 (zero) if the end of the stream has been reached.</returns>
+        <returns>A task that represents the asynchronous read operation. The value of the <paramref name="TResult" /> parameter contains the total number of characters read into the buffer. The result value can be less than the number of characters requested if the number of characters currently available is less than the requested number, or it can be 0 (zero) if the end of the stream has been reached.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
# Addressed issue #1888: bad return value for StreamReader async reads

## Summary

The documentation on both MSDN and docs.microsoft.com listed an incorrect return type for the task returned by the StreamReader.ReadAsync and StreamReader.ReadBlockAsync methods. I've also changed the documentation on MSDN for both methods.

Fixes #1888

## Suggested Reviewers

@stephentoub @danmosemsft @gwicksted




