### PR TITLE
Fix typo in WebExceptionStatus

### DIFF
--- a/xml/System.Net/WebExceptionStatus.xml
+++ b/xml/System.Net/WebExceptionStatus.xml
@@ -227,7 +227,7 @@
         <ReturnType>System.Net.WebExceptionStatus</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The request was a piplined request and the connection was closed before the response was received.</summary>
+        <summary>The request was a pipelined request and the connection was closed before the response was received.</summary>
       </Docs>
     </Member>
     <Member MemberName="ProtocolError">


### PR DESCRIPTION
# Fix Typo in WebExceptionStatus

## Summary

Changes a typo in the description for a value of System.Net.WebExceptionStatus from "piplined" to "pipelined".