### PR TITLE
Corrected description of ExpressionVisitor.VisitAndConvert

### DIFF
--- a/xml/System.Linq.Expressions/ExpressionVisitor.xml
+++ b/xml/System.Linq.Expressions/ExpressionVisitor.xml
@@ -199,13 +199,13 @@
         <Parameter Name="callerName" Type="System.String" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The type of the expression.</typeparam>
-        <param name="nodes">The expression to visit.</param>
+        <typeparam name="T">The type of the expressions.</typeparam>
+        <param name="nodes">The expressions to visit.</param>
         <param name="callerName">The name of the calling method; used to report to report a better error message.</param>
-        <summary>Visits an expression, casting the result back to the original expression type.</summary>
-        <returns>The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.</returns>
+        <summary>Visits all expressions in the collection, casting the results back to the original expression type.</summary>
+        <returns>The modified expression collection, if any expression was modified; otherwise, returns the original expression collection.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.InvalidOperationException">The visit method for this node returned a different type.</exception>
+        <exception cref="T:System.InvalidOperationException">The visit method for one of the expressions returned a different type.</exception>
       </Docs>
     </Member>
     <Member MemberName="VisitAndConvert&lt;T&gt;">


### PR DESCRIPTION
The original description of [this overload](https://docs.microsoft.com/en-us/dotnet/api/system.linq.expressions.expressionvisitor.visitandconvert--1?view=netframework-4.7#System_Linq_Expressions_ExpressionVisitor_VisitAndConvert__1_System_Collections_ObjectModel_ReadOnlyCollection___0__System_String_) was worded as if the collection operated on a single expression. But it operates on a collection of expressions, so I have updated the documentation to reflect that.

I have also noticed that many methods in this file have `<remarks>To be added.</remarks>`. Are they useful to track missing documentation, or should they just be removed?