### PR TITLE
Added missing summary description

### DIFF
--- a/xml/System.Web/HttpResponse.xml
+++ b/xml/System.Web/HttpResponse.xml
@@ -2369,7 +2369,8 @@ Response.RedirectToRoutePermanent("Product",
       </Parameters>
       <Docs>
         <param name="cookie">The cookie in the collection to be updated.</param>
-        <summary>Updates an existing cookie in the cookie collection.</summary>
+        <summary>This API supports the product infrastructure and is not intended to be used directly from your code. 
+          Updates an existing cookie in the cookie collection.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Web/HttpResponse.xml
+++ b/xml/System.Web/HttpResponse.xml
@@ -2369,8 +2369,7 @@ Response.RedirectToRoutePermanent("Product",
       </Parameters>
       <Docs>
         <param name="cookie">The cookie in the collection to be updated.</param>
-        <summary>This API supports the product infrastructure and is not intended to be used directly from your code. 
-          Updates an existing cookie in the cookie collection.</summary>
+        <summary>Because the <b>HttpResponse.SetCookie</b> method is intended for internal use only, you should not call it in your code. Instead, you can call the <b>HttpResponse.Cookies.Set</b> method, as the following example shows</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Web/HttpResponse.xml
+++ b/xml/System.Web/HttpResponse.xml
@@ -2369,7 +2369,7 @@ Response.RedirectToRoutePermanent("Product",
       </Parameters>
       <Docs>
         <param name="cookie">The cookie in the collection to be updated.</param>
-        <summary>Because the <b>HttpResponse.SetCookie</b> method is intended for internal use only, you should not call it in your code. Instead, you can call the <b>HttpResponse.Cookies.Set</b> method, as the following example shows</summary>
+        <summary>Because the <b>HttpResponse.SetCookie</b> method is intended for internal use only, you should not call it in your code. Instead, you can call the <b>HttpResponse.Cookies.Set</b> method, as the following example shows.<br/>Updates an existing cookie in the cookie collection.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
The summary is missing the important bit of info that is present on the old site at https://msdn.microsoft.com/en-us/library/system.web.httpresponse.setcookie(v=vs.110).aspx