### PR TITLE
Refining Cookie.Value exception information

### DIFF
--- a/xml/System.Net/Cookie.xml
+++ b/xml/System.Net/Cookie.xml
@@ -968,7 +968,8 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is passed into the setter it will be replaced with an empty String. The following characters are reserved and cannot be used for this property: semicolon, comma. The setter won't throw an exception if invalid characters are passed into it but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> method the operation will fail and throw an exception.
+ The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is assigned to this property, it is replaced with an empty string. 
+ The following characters are reserved and cannot be used for this property: semicolon, comma. Assigning invalid characters to this property does not throw an exception, but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> method, the operation will fail and throw an exception.
   
    
   

--- a/xml/System.Net/Cookie.xml
+++ b/xml/System.Net/Cookie.xml
@@ -113,11 +113,11 @@
   
  The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The following characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes: semicolon, comma. So the following example constructor would succeed but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "");`  
+ `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "contoso.com");`  
   
  However, the following constructor with these special characters escaped will create a <xref:System.Net.Cookie> that can be added to a <xref:System.Net.CookieContainer> instance:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"");`  
+ `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "contoso.com");`  
   
  The comma character is used as a delimiter between separate cookies on the same line.  
   
@@ -180,11 +180,11 @@
   
  The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The following characters are reserved and can not cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes: semicolon, comma. So the following example constructor would succeed but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "");`  
+ `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "contoso.com");`  
   
  However, the following constructor with these special characters escaped will create a <xref:System.Net.Cookie> that can be added to a <xref:System.Net.CookieContainer> instance:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "");`  
+ `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "contoso.com");`  
   
  The comma character is used as a delimiter between separate cookies on the same line.  
   
@@ -249,11 +249,11 @@
   
  The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The following characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes: semicolon, comma. So the following example constructor would succeed but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "");`  
+ `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "contoso.com");`  
   
  However, the following constructor with these special characters escaped will create a <xref:System.Net.Cookie> that can be added to a <xref:System.Net.CookieContainer> instance:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "");`  
+ `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "", "contoso.com");`  
   
  The comma character is used as a delimiter between separate cookies on the same line.  
   

--- a/xml/System.Net/Cookie.xml
+++ b/xml/System.Net/Cookie.xml
@@ -968,8 +968,9 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is assigned to this property, it is replaced with an empty string. 
- The following characters are reserved and cannot be used for this property: semicolon, comma. Assigning invalid characters to this property does not throw an exception, but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> method, the operation will fail and throw an exception.
+ The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is assigned to this property, it's replaced with an empty string. 
+
+ Semicolons and commas are reserved characters that cannot be used in the value of this property. Assigning invalid characters to this property doesn't throw an exception; but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> method, the operation will fail and throw an exception.
   
    
   

--- a/xml/System.Net/Cookie.xml
+++ b/xml/System.Net/Cookie.xml
@@ -968,7 +968,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. The following characters are reserved and cannot be used for this property: semicolon, comma.  
+ The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is passed into the Setter it will be replaced with an empty String. The following characters are reserved and cannot be used for this property: semicolon, comma. The Setter won't throw an exception if invalid characters are passed into it but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception
   
    
   

--- a/xml/System.Net/Cookie.xml
+++ b/xml/System.Net/Cookie.xml
@@ -111,13 +111,21 @@
 ## Remarks  
  The default for the `value` parameter uses the empty string ("").  
   
- The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The following characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes: semicolon, comma. So the following example constructor would succeed but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception:  
+ The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The semicolon (";") and comma (",") characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes. So the following example constructor would succeed, but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add(System.Net.Cookie)> or <xref:System.Net.CookieContainer.Add(System.Uri,System.Net.Cookie)> methods, the operation will fail and throw an exception:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "contoso.com");`  
+ ```
+ System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456");
+ cookie.Domain = "https://contoso.com";
+ new CookieContainer().Add(cookie);
+ ```  
   
  However, the following constructor with these special characters escaped will create a <xref:System.Net.Cookie> that can be added to a <xref:System.Net.CookieContainer> instance:  
-  
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "contoso.com");`  
+ 
+ ```
+ System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"");
+ cookie.Domain = "https://contoso.com";
+ new CookieContainer().Add(cookie);
+ ```
   
  The comma character is used as a delimiter between separate cookies on the same line.  
   
@@ -178,13 +186,21 @@
 ## Remarks  
  The default for the `path` parameter uses the empty string ("").  
   
- The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The following characters are reserved and can not cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes: semicolon, comma. So the following example constructor would succeed but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception:  
+ The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The semicolon (";") and comma (",") characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes. So the following example constructor would succeed, but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add(System.Net.Cookie)> or <xref:System.Net.CookieContainer.Add(System.Uri,System.Net.Cookie)> methods, the operation will fail and throw an exception:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "contoso.com");`  
+ ```
+ System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "");
+ cookie.Domain = "https://contoso.com";
+ new CookieContainer().Add(cookie);
+ ```  
   
  However, the following constructor with these special characters escaped will create a <xref:System.Net.Cookie> that can be added to a <xref:System.Net.CookieContainer> instance:  
-  
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "contoso.com");`  
+ 
+ ```
+ System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "");
+ cookie.Domain = "https://contoso.com";
+ new CookieContainer().Add(cookie);
+ ``` 
   
  The comma character is used as a delimiter between separate cookies on the same line.  
   
@@ -247,13 +263,19 @@
 ## Remarks  
  The default for the `domain` and `path` parameters uses the empty string ("").  
   
- The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The following characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes: semicolon, comma. So the following example constructor would succeed but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception:  
+ The `value` parameter for a <xref:System.Net.Cookie> must not be a `null` reference (Nothing in Visual Basic). The semicolon (";") and comma (",") characters are reserved and cannot be passed in the `value` parameter unless the string passed in the `value` parameter is enclosed in double quotes. So the following example constructor would succeed, but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add(System.Net.Cookie)> or <xref:System.Net.CookieContainer.Add(System.Uri,System.Net.Cookie)> methods, the operation will fail and throw an exception:  
   
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "contoso.com");`  
+ ```
+ System.Net.Cookie cookie = new System.Net.Cookie("contoso", "123,456", "", "https://contoso.com");
+ new CookieContainer().Add(cookie);
+ ```  
   
  However, the following constructor with these special characters escaped will create a <xref:System.Net.Cookie> that can be added to a <xref:System.Net.CookieContainer> instance:  
-  
- `System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "", "contoso.com");`  
+ 
+ ```
+ System.Net.Cookie cookie = new System.Net.Cookie("contoso", "\"123,456\"", "", "https://contoso.com");
+ new CookieContainer().Add(cookie);
+ ```  
   
  The comma character is used as a delimiter between separate cookies on the same line.  
   

--- a/xml/System.Net/Cookie.xml
+++ b/xml/System.Net/Cookie.xml
@@ -968,7 +968,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is passed into the Setter it will be replaced with an empty String. The following characters are reserved and cannot be used for this property: semicolon, comma. The Setter won't throw an exception if invalid characters are passed into it but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> or <xref:System.Net.CookieContainer.Add%2A> methods the operation will fail and throw an exception
+ The <xref:System.Net.Cookie.Value%2A> of a <xref:System.Net.Cookie> must not be `null`. If a `null` value is passed into the setter it will be replaced with an empty String. The following characters are reserved and cannot be used for this property: semicolon, comma. The setter won't throw an exception if invalid characters are passed into it but when you try to add this <xref:System.Net.Cookie> to a <xref:System.Net.CookieContainer> instance with the <xref:System.Net.CookieContainer.Add%2A> method the operation will fail and throw an exception.
   
    
   


### PR DESCRIPTION
## Summary

Refining Cookie.Value Remarks so that it is clear when an exception gets thrown.

## Related
corefx issue: https://github.com/dotnet/corefx/issues/7459#issuecomment-294178391

cc: @karelz 
