### PR TITLE
adding noindex/nofollow to api docs

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -98,8 +98,11 @@
         "api/**.yml": "managed-reference"
       },
       "langs": {
-        "api/**.yml":  ["csharp", "vb", "cpp"]
-      }      
+        "api/**.yml": ["csharp", "vb", "cpp"]
+      },
+      "ROBOTS": {
+        "api/**.yml": "NOINDEX, NOFOLLOW"
+      }
     },
     "dest": "_site",
     "template": [


### PR DESCRIPTION
Temporarily adding no-index, no-follow to our api pages until we redirect msdn to docs.