### PR TITLE
Fixed formatting in MailAddress remarks

### DIFF
--- a/xml/System.Net.Mail/MailAddress.xml
+++ b/xml/System.Net.Mail/MailAddress.xml
@@ -21,11 +21,11 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Net.Mail.MailAddress> class is used by the <xref:System.Net.Mail.SmtpClient> and <xref:System.Net.Mail.MailMessage> classes to store address information for e-mail messages.  
+The <xref:System.Net.Mail.MailAddress> class is used by the <xref:System.Net.Mail.SmtpClient> and <xref:System.Net.Mail.MailMessage> classes to store address information for e-mail messages.  
   
- A mail address is composed of a <xref:System.Net.Mail.MailAddress.User%2A> name, <xref:System.Net.Mail.MailAddress.Host%2A> name and optionally, a <xref:System.Net.Mail.MailAddress.DisplayName%2A>. The <xref:System.Net.Mail.MailAddress.DisplayName%2A> can contain non-ASCII characters if you encode them.  
+A mail address is composed of a <xref:System.Net.Mail.MailAddress.User%2A> name, <xref:System.Net.Mail.MailAddress.Host%2A> name and optionally, a <xref:System.Net.Mail.MailAddress.DisplayName%2A>. The <xref:System.Net.Mail.MailAddress.DisplayName%2A> can contain non-ASCII characters if you encode them.  
   
- The <xref:System.Net.Mail.MailAddress> class supports the following mail address formats:  
+The <xref:System.Net.Mail.MailAddress> class supports the following mail address formats:  
   
 -   A simple address format of `user@host`. If a <xref:System.Net.Mail.MailAddress.DisplayName%2A> is not set, this is the mail address format generated.  
   
@@ -35,7 +35,7 @@
   
 -   Quotes are added around the <xref:System.Net.Mail.MailAddress.DisplayName%2A> for `display name <user@host>`, if these are not included.  
   
--   Unicode characters are supported in the <xref:System.Net.Mail.MailAddress.DisplayName%2A>. property.  
+-   Unicode characters are supported in the <xref:System.Net.Mail.MailAddress.DisplayName%2A> property.  
   
 -   A <xref:System.Net.Mail.MailAddress.User%2A> name with quotes. For example, `"user name"@host`.  
   
@@ -45,45 +45,45 @@
   
 -   Comments. For example, `(comment)"display name"(comment)<(comment)user(comment)@(comment)domain(comment)>(comment)`. Comments are removed before transmission.  
   
- A comma is used to separate elements in a list of mail addresses. As a result, a comma should not be used in unquoted display names in a list. The following mail addresses would be allowed  
+A comma is used to separate elements in a list of mail addresses. As a result, a comma should not be used in unquoted display names in a list. The following mail addresses would be allowed:
   
- `"John, Doe" <user@host>, "Bob, Smith" <user2@host>`  
+`"John, Doe" <user@host>, "Bob, Smith" <user2@host>`  
   
- The following mail address would not be allowed:  
+The following mail address would not be allowed:  
   
- `John, Doe <user@host>, Bob, Smith <user2@host>`  
+`John, Doe <user@host>, Bob, Smith <user2@host>`  
   
- Quotes can be embedded in a quoted string, but they must be escaped. The following mail addresses would be allowed  
+Quotes can be embedded in a quoted string, but they must be escaped. The following mail addresses would be allowed:
   
- `"John \"Jr\" Doe" <user@host>`  
+`"John \"Jr\" Doe" <user@host>`  
   
- `"\"John \\\"Jr\\\" Doe\" <user@host>"`  
+`"\"John \\\"Jr\\\" Doe\" <user@host>"`  
   
- The following mail address would not be allowed:  
+The following mail address would not be allowed:  
   
- `"John "Jr" Doe" <user@host>`  
+`"John "Jr" Doe" <user@host>`  
   
- When the username is note quoted, all text between the start of the string (or comma) and the address are considered part of the <xref:System.Net.Mail.MailAddress.DisplayName%2A>, including comments.  
+When the username is note quoted, all text between the start of the string (or comma) and the address are considered part of the <xref:System.Net.Mail.MailAddress.DisplayName%2A>, including comments. For example:
   
- -- Example: (non comment) unquoted display (non comment) name (non comment) \<user@host>  
+`(non comment) unquoted display (non comment) name (non comment) <user@host>`
   
- Although the <xref:System.Net.Mail.MailAddress> class accepts a mail address as valid, other mail servers may not accept the mail address.  
+Although the <xref:System.Net.Mail.MailAddress> class accepts a mail address as valid, other mail servers may not accept the mail address.  
   
- The <xref:System.Net.Mail.MailAddress> class does not support the following mail address formats:  
+The <xref:System.Net.Mail.MailAddress> class does not support the following mail address formats:  
   
- Mixed quoted and unquoted display names. For example, `display "name" <user@host>`  
+- Mixed quoted and unquoted display names. For example, `display "name" <user@host>`.
   
- Groups, as defined in RFC 2822 Section 3.4 published by the IETF.  
+- Groups, as defined in RFC 2822 Section 3.4 published by the IETF.  
   
- The obsolete user name formats of `"user"."name"@host, user."name"@host` or `"user".name@host`  
+- The obsolete user name formats of `"user"."name"@host`, `user."name"@host` or `"user".name@host`.
   
    
   
 ## Examples  
- The following code example demonstrates sending an e-mail message by using the <xref:System.Net.Mail.SmtpClient>, <xref:System.Net.Mail.MailAddress>, and <xref:System.Net.Mail.MailMessage> classes.  
+The following code example demonstrates sending an e-mail message by using the <xref:System.Net.Mail.SmtpClient>, <xref:System.Net.Mail.MailAddress>, and <xref:System.Net.Mail.MailMessage> classes.  
   
- [!code-cpp[NclMailSync#10](~/samples/snippets/cpp/VS_Snippets_Remoting/NCLMailSync/CPP/NclMailSync.cpp#10)]
- [!code-csharp[NclMailSync#10](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLMailSync/CS/mail.cs#10)]  
+[!code-cpp[NclMailSync#10](~/samples/snippets/cpp/VS_Snippets_Remoting/NCLMailSync/CPP/NclMailSync.cpp#10)]
+[!code-csharp[NclMailSync#10](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLMailSync/CS/mail.cs#10)]  
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
- Paragraphs after list should not be part of the list.
- Missing colons.
- Missing list formatting.
- Fixed strange "-- Example:".
- Added missing periods, removed stray period.
- Improved code formatting.