### PR TITLE
Corrected collection initializer requirements

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -68,7 +68,7 @@ select new {p.ProductName, Price = p.UnitPrice};
  It is a compile-time error to use an object initializer with a nullable struct.  
   
 ## Collection initializers  
- Collection initializers let you specify one or more element initializers when you initialize a collection type that implements <xref:System.Collections.IEnumerable> and has `Add` with appropriate signature as instance method or extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
+ Collection initializers let you specify one or more element initializers when you initialize a collection type that implements <xref:System.Collections.IEnumerable> and has `Add` with the appropriate signature as an instance method or an extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
   
  The following examples shows two simple collection initializers:  
   

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -68,7 +68,7 @@ select new {p.ProductName, Price = p.UnitPrice};
  It is a compile-time error to use an object initializer with a nullable struct.  
   
 ## Collection initializers  
- Collection initializers let you specify one or more element initializers when you initialize a collection class that implements <xref:System.Collections.IEnumerable> and has `Add` with appropriate signature as instance method or extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
+ Collection initializers let you specify one or more element initializers when you initialize a collection type that implements <xref:System.Collections.IEnumerable> and has `Add` with appropriate signature as instance method or extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
   
  The following examples shows two simple collection initializers:  
   

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -68,7 +68,7 @@ select new {p.ProductName, Price = p.UnitPrice};
  It is a compile-time error to use an object initializer with a nullable struct.  
   
 ## Collection initializers  
- Collection initializers let you specify one or more element initializers when you initialize a collection class that implements <xref:System.Collections.IEnumerable> or a class with an `Add` extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
+ Collection initializers let you specify one or more element initializers when you initialize a collection class that implements <xref:System.Collections.IEnumerable> and has `Add` with appropriate signature as instance method or extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
   
  The following examples shows two simple collection initializers:  
   

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -44,7 +44,7 @@ Object initializers let you assign values to any accessible fields or properties
 ## Object Initializers with anonymous types  
  Although object initializers can be used in any context, they are especially useful in [!INCLUDE[vbteclinq](../../../csharp/includes/vbteclinq_md.md)] query expressions. Query expressions make frequent use of [anonymous types](../../../csharp/programming-guide/classes-and-structs/anonymous-types.md), which can only be initialized by using an object initializer, as shown in the following declaration.  
   
-```  
+```csharp
 var pet = new { Age = 10, Name = "Fluffy" };  
 ```  
   
@@ -54,13 +54,13 @@ var pet = new { Age = 10, Name = "Fluffy" };
   
  When this query is executed, the `productInfos` variable will contain a sequence of objects that can be accessed in a `foreach` statement as shown in this example:  
   
-```  
+```csharp
 foreach(var p in productInfos){...}  
 ```  
   
  Each object in the new anonymous type has two public properties which receive the same names as the properties or fields in the original object. You can also rename a field when you are creating an anonymous type; the following example renames the `UnitPrice` field to `Price`.  
   
-```  
+```csharp
 select new {p.ProductName, Price = p.UnitPrice};  
 ```  
   
@@ -72,7 +72,7 @@ select new {p.ProductName, Price = p.UnitPrice};
   
  The following examples shows two simple collection initializers:  
   
-```  
+```csharp
 List<int> digits = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };  
 List<int> digits2 = new List<int> { 0 + 1, 12 % 3, MakeInt() };  
 ```  
@@ -87,7 +87,7 @@ List<int> digits2 = new List<int> { 0 + 1, 12 % 3, MakeInt() };
   
  You can specify indexed elements if the collection supports indexing.  
   
-```  
+```csharp
 var numbers = new Dictionary<int, string> {   
     [7] = "seven",   
     [9] = "nine",   


### PR DESCRIPTION
According to the previous wording, code like `new C { 1 }` should compile, as long as `C` has an extension method called `Add` that takes an `int` parameter, even if `C` does not implement `IEnumerable`. But it doesn't, according to [the spec](https://github.com/dotnet/csharplang/blob/master/spec/expressions.md#collection-initializers):

> The collection object to which a collection initializer is applied must be of a type that implements `System.Collections.IEnumerable` or a compile-time error occurs. For each specified element in order, the collection initializer invokes an `Add` method on the target object with the expression list of the element initializer as argument list, applying normal member lookup and overload resolution for each invocation. Thus, the collection object must have an applicable instance or extension method with the name `Add` for each element initializer.

The type also does not have to be a class, so I changed that too.

While here, I have also added missing language identifiers.

cc: @DavidArno