### PR TITLE
Replace 'verison' on line 141 of 'debugging-with-visual-studio-2017.md' with 'version'

### DIFF
--- a/docs/csharp/getting-started/debugging-with-visual-studio-2017.md
+++ b/docs/csharp/getting-started/debugging-with-visual-studio-2017.md
@@ -138,6 +138,6 @@ To build and test the release version of your console application, change the bu
 
 ![Image](./media/release.jpg)
 
-When you press F5 or choose **Build Solution** from the **Build** menu, Visual Studio compiles the release version of your console application for you to test. You can then run and test it as you did the debug verison of the application.
+When you press F5 or choose **Build Solution** from the **Build** menu, Visual Studio compiles the release version of your console application for you to test. You can then run and test it as you did the debug version of the application.
 
 Once you've finished debugging your application, the next step is to publish a distributable version of your application. For information about how to do this, see [Publishing the C# Hello World application with Visual Studio 2017](./publishing-with-visual-studio-2017.md).


### PR DESCRIPTION
# Title

Remove typo on 'debugging-with-visual-studio-2017.md'

## Summary

Replace 'verison' on line 141 of 'debugging-with-visual-studio-2017.md' with 'version'


## Details

Remove typo on line 141 of  'debugging-with-visual-studio-2017.md' located at:
***docs/***
&nbsp;&nbsp;&nbsp;&nbsp;***docs/***
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;***csharp/***
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;***getting-started/***
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;***debugging-with-visual-studio-2017.md***


Replace 'verison' with 'version'.
