### PR TITLE
var is not really a type

### DIFF
--- a/docs/csharp/language-reference/keywords/var.md
+++ b/docs/csharp/language-reference/keywords/var.md
@@ -32,7 +32,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # var (C# Reference)
-Beginning in Visual C# 3.0, variables that are declared at method scope can have an implicit type `var`. An implicitly typed local variable is strongly typed just as if you had declared the type yourself, but the compiler determines the type. The following two declarations of `i` are functionally equivalent:  
+Beginning in Visual C# 3.0, variables that are declared at method scope can have an implicit "type" `var`. An implicitly typed local variable is strongly typed just as if you had declared the type yourself, but the compiler determines the type. The following two declarations of `i` are functionally equivalent:  
   
 ```  
 var i = 10; // implicitly typed  

--- a/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
+++ b/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md
@@ -35,7 +35,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # Implicitly Typed Local Variables (C# Programming Guide)
-Local variables can be given an inferred "type" of `var` instead of an explicit type. The `var` keyword instructs the compiler to infer the type of the variable from the expression on the right side of the initialization statement. The inferred type may be a built-in type, an anonymous type, a user-defined type, or a type defined in the .NET Framework class library. For more information about how to initialize arrays with `var`, see [Implicitly Typed Arrays](../../../csharp/programming-guide/arrays/implicitly-typed-arrays.md).  
+Local variables can be declared without giving an explicit type. The `var` keyword instructs the compiler to infer the type of the variable from the expression on the right side of the initialization statement. The inferred type may be a built-in type, an anonymous type, a user-defined type, or a type defined in the .NET Framework class library. For more information about how to initialize arrays with `var`, see [Implicitly Typed Arrays](../../../csharp/programming-guide/arrays/implicitly-typed-arrays.md).  
   
  The following examples show various ways in which local variables can be declared with `var`:  
   


### PR DESCRIPTION
- use quotation mark around "type"

Strictly speaking `var` is not a type, it's a syntactic sugar. ["Implicitly typed local variables"](https://github.com/dotnet/docs/blob/master/docs/csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md) article use quotation marks to point that out, which is correct.