### PR TITLE
Improve formatting in List<T>

### DIFF
--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -209,7 +209,7 @@
 ## Remarks  
  The elements are copied onto the <xref:System.Collections.Generic.List%601> in the same order they are read by the enumerator of the collection.  
   
- This constructor is an O(`n`) operation, where `n` is the number of elements in `collection`.  
+ This constructor is an O(*n*) operation, where *n* is the number of elements in `collection`.  
   
    
   
@@ -261,7 +261,7 @@
   
  The capacity can be decreased by calling the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method or by setting the <xref:System.Collections.Generic.List%601.Capacity%2A> property explicitly. Decreasing the capacity reallocates memory and copies all the elements in the <xref:System.Collections.Generic.List%601>.  
   
- This constructor is an O(`n`) operation, where `n` is `capacity`.  
+ This constructor is an O(*n*) operation, where *n* is `capacity`.  
   
    
   
@@ -314,7 +314,7 @@
   
  If <xref:System.Collections.Generic.List%601.Count%2A> already equals <xref:System.Collections.Generic.List%601.Capacity%2A>, the capacity of the <xref:System.Collections.Generic.List%601> is increased by automatically reallocating the internal array, and the existing elements are copied to the new array before the new element is added.  
   
- If <xref:System.Collections.Generic.List%601.Count%2A> is less than <xref:System.Collections.Generic.List%601.Capacity%2A>, this method is an O(1) operation. If the capacity needs to be increased to accommodate the new element, this method becomes an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ If <xref:System.Collections.Generic.List%601.Count%2A> is less than <xref:System.Collections.Generic.List%601.Capacity%2A>, this method is an O(1) operation. If the capacity needs to be increased to accommodate the new element, this method becomes an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -374,7 +374,7 @@
   
  If the new <xref:System.Collections.Generic.List%601.Count%2A> (the current <xref:System.Collections.Generic.List%601.Count%2A> plus the size of the collection) will be greater than <xref:System.Collections.Generic.List%601.Capacity%2A>, the capacity of the <xref:System.Collections.Generic.List%601> is increased by automatically reallocating the internal array to accommodate the new elements, and the existing elements are copied to the new array before the new elements are added.  
   
- If the <xref:System.Collections.Generic.List%601> can accommodate the new elements without increasing the <xref:System.Collections.Generic.List%601.Capacity%2A>, this method is an O(`n`) operation, where `n` is the number of elements to be added. If the capacity needs to be increased to accommodate the new elements, this method becomes an O(`n` + `m`) operation, where `n` is the number of elements to be added and `m` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ If the <xref:System.Collections.Generic.List%601> can accommodate the new elements without increasing the <xref:System.Collections.Generic.List%601.Capacity%2A>, this method is an O(*n*) operation, where *n* is the number of elements to be added. If the capacity needs to be increased to accommodate the new elements, this method becomes an O(*n* + *m*) operation, where *n* is the number of elements to be added and *m* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -482,7 +482,7 @@
   
  If the <xref:System.Collections.Generic.List%601> does not contain the specified value, the method returns a negative integer. You can apply the bitwise complement operation (~) to this negative integer to get the index of the first element that is larger than the search value. When inserting the value into the <xref:System.Collections.Generic.List%601>, this index should be used as the insertion point to maintain the sort order.  
   
- This method is an O(log `n`) operation, where `n` is the number of elements in the range.  
+ This method is an O(log *n*) operation, where *n* is the number of elements in the range.  
   
    
   
@@ -553,7 +553,7 @@
   
  If the <xref:System.Collections.Generic.List%601> does not contain the specified value, the method returns a negative integer. You can apply the bitwise complement operation (~) to this negative integer to get the index of the first element that is larger than the search value. When inserting the value into the <xref:System.Collections.Generic.List%601>, this index should be used as the insertion point to maintain the sort order.  
   
- This method is an O(log `n`) operation, where `n` is the number of elements in the range.  
+ This method is an O(log *n*) operation, where *n* is the number of elements in the range.  
   
    
   
@@ -629,7 +629,7 @@
   
  If the <xref:System.Collections.Generic.List%601> does not contain the specified value, the method returns a negative integer. You can apply the bitwise complement operation (~) to this negative integer to get the index of the first element that is larger than the search value. When inserting the value into the <xref:System.Collections.Generic.List%601>, this index should be used as the insertion point to maintain the sort order.  
   
- This method is an O(log `n`) operation, where `n` is the number of elements in the range.  
+ This method is an O(log *n*) operation, where *n* is the number of elements in the range.  
   
    
   
@@ -695,7 +695,7 @@
   
  If the capacity is significantly larger than the count and you want to reduce the memory used by the <xref:System.Collections.Generic.List%601>,  you can  decrease capacity by calling the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method or by setting the <xref:System.Collections.Generic.List%601.Capacity%2A> property explicitly to a lower value. When the value of <xref:System.Collections.Generic.List%601.Capacity%2A> is set explicitly, the internal array is also reallocated to accommodate the specified capacity, and all the elements are copied.  
   
- Retrieving the value of this property is an O(1) operation; setting the property is an O(`n`) operation, where `n` is the new capacity.  
+ Retrieving the value of this property is an O(1) operation; setting the property is an O(*n*) operation, where *n* is the new capacity.  
   
    
   
@@ -754,7 +754,7 @@
   
  <xref:System.Collections.Generic.List%601.Capacity%2A> remains unchanged. To reset the capacity of the <xref:System.Collections.Generic.List%601>, call the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method or set the <xref:System.Collections.Generic.List%601.Capacity%2A> property directly. Decreasing the capacity reallocates memory and copies all the elements in the <xref:System.Collections.Generic.List%601>. Trimming an empty <xref:System.Collections.Generic.List%601> sets the capacity of the <xref:System.Collections.Generic.List%601> to the default capacity.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -806,7 +806,7 @@
 ## Remarks  
  This method determines equality by using the default equality comparer, as defined by the object's implementation of the <xref:System.IEquatable%601.Equals%2A?displayProperty=fullName> method for `T` (the type of values in the list).  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -861,7 +861,7 @@
   
  The current <xref:System.Collections.Generic.List%601> remains unchanged.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -914,7 +914,7 @@
   
  The elements are copied to the <xref:System.Array> in the same order in which the enumerator iterates through the <xref:System.Collections.Generic.List%601>.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -970,7 +970,7 @@
   
  The elements are copied to the <xref:System.Array> in the same order in which the enumerator iterates through the <xref:System.Collections.Generic.List%601>.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1032,7 +1032,7 @@
   
  The elements are copied to the <xref:System.Array> in the same order in which the enumerator iterates through the <xref:System.Collections.Generic.List%601>.  
   
- This method is an O(`n`) operation, where `n` is `count`.  
+ This method is an O(*n*) operation, where *n* is `count`.  
   
    
   
@@ -1155,7 +1155,7 @@
 ## Remarks  
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate, and processing is stopped when a match is found.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1224,7 +1224,7 @@
 > [!IMPORTANT]
 >  When searching a list containing value types, make sure the default value for the type does not satisfy the search predicate. Otherwise, there is no way to distinguish between a default value indicating that no match was found and a list element that happens to have the default value for the type. If the default value satisfies the search predicate, use the <xref:System.Collections.Generic.List%601.FindIndex%2A> method instead.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1292,7 +1292,7 @@
 ## Remarks  
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate, and the elements that match the conditions are saved in the returned <xref:System.Collections.Generic.List%601>.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1365,7 +1365,7 @@ public bool methodName(T obj)
 Public Function methodName(obj As T) As Boolean  
 ```  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1438,7 +1438,7 @@ public bool methodName(T obj)
 Public Function methodName(obj As T) As Boolean  
 ```  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is the number of elements from `startIndex` to the end of the <xref:System.Collections.Generic.List%601>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is the number of elements from `startIndex` to the end of the <xref:System.Collections.Generic.List%601>.  
   
    
   
@@ -1515,7 +1515,7 @@ public bool methodName(T obj)
 Public Function methodName(obj As T) As Boolean  
 ```  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is `count`.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is `count`.  
   
    
   
@@ -1589,7 +1589,7 @@ Public Function StartsWith(e As Employee) As Boolean
 > [!IMPORTANT]
 >  When searching a list containing value types, make sure the default value for the type does not satisfy the search predicate. Otherwise, there is no way to distinguish between a default value indicating that no match was found and a list element that happens to have the default value for the type. If the default value satisfies the search predicate, use the <xref:System.Collections.Generic.List%601.FindLastIndex%2A> method instead.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1654,7 +1654,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -1721,7 +1721,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is the number of elements from the beginning of the <xref:System.Collections.Generic.List%601> to `startIndex`.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is the number of elements from the beginning of the <xref:System.Collections.Generic.List%601> to `startIndex`.  
   
  ]]></format>
         </remarks>
@@ -1772,7 +1772,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is `count`.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is `count`.  
   
    
   
@@ -1843,7 +1843,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  The <xref:System.Action%601> is a delegate to a method that performs an action on the object passed to it.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Action%601> delegate.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  Modifying the underlying collection in the body of the <xref:System.Action%601> delegate is not supported and causes undefined behavior.  
   
@@ -1958,7 +1958,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  In contrast, a deep copy of a collection copies the elements and everything directly or indirectly referenced by the elements.  
   
- This method is an O(`n`) operation, where `n` is `count`.  
+ This method is an O(*n*) operation, where *n* is `count`.  
   
    
   
@@ -2018,7 +2018,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2072,7 +2072,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is the number of elements from `index` to the end of the <xref:System.Collections.Generic.List%601>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is the number of elements from `index` to the end of the <xref:System.Collections.Generic.List%601>.  
   
    
   
@@ -2130,7 +2130,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is `count`.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is `count`.  
   
    
   
@@ -2195,7 +2195,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  If `index` is equal to <xref:System.Collections.Generic.List%601.Count%2A>, `item` is added to the end of <xref:System.Collections.Generic.List%601>.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2265,7 +2265,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  The order of the elements in the collection is preserved in the <xref:System.Collections.Generic.List%601>.  
   
- This method is an O(`n` + `m`) operation, where `n` is the number of elements to be added and `m` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n* + *m*) operation, where *n* is the number of elements to be added and *m* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2389,7 +2389,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2443,7 +2443,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is the number of elements from the beginning of the <xref:System.Collections.Generic.List%601> to `index`.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is the number of elements from the beginning of the <xref:System.Collections.Generic.List%601> to `index`.  
   
    
   
@@ -2501,7 +2501,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is `count`.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is `count`.  
   
    
   
@@ -2562,7 +2562,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  If type `T` implements the <xref:System.IEquatable%601> generic interface, the equality comparer is the <xref:System.IEquatable%601.Equals%2A> method of that interface; otherwise, the default equality comparer is <xref:System.Object.Equals%2A?displayProperty=fullName>.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2619,7 +2619,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate, and the elements that match the conditions are removed from the <xref:System.Collections.Generic.List%601>.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2681,7 +2681,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  When you call <xref:System.Collections.Generic.List%601.RemoveAt%2A> to remove an item, the remaining items in the list are renumbered to replace the removed item. For example, if you remove the item at index 3, the item at index 4 is moved to the 3 position. In addition, the number of items in the list (as represented by the <xref:System.Collections.Generic.List%601.Count%2A> property) is reduced by 1.  
   
- This method is an O(`n`) operation, where `n` is (<xref:System.Collections.Generic.List%601.Count%2A> - `index`).  
+ This method is an O(*n*) operation, where *n* is (<xref:System.Collections.Generic.List%601.Count%2A> - `index`).  
   
    
   
@@ -2738,7 +2738,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  The items are removed and all the elements following them in the <xref:System.Collections.Generic.List%601> have their indexes reduced by `count`.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2792,7 +2792,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  This method uses <xref:System.Array.Reverse%2A?displayProperty=fullName> to reverse the order of the elements.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2843,7 +2843,7 @@ Public Function StartsWith(e As Employee) As Boolean
 ## Remarks  
  This method uses <xref:System.Array.Reverse%2A?displayProperty=fullName> to reverse the order of the elements.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -2901,13 +2901,13 @@ Public Function StartsWith(e As Employee) As Boolean
   
 -   If the partition size is fewer than 16 elements, it uses an insertion sort algorithm.  
   
--   If the number of partitions exceeds 2 * LogN, where *N* is the range of the input array, it uses a Heapsort algorithm.  
+-   If the number of partitions exceeds 2 log *n*, where *n* is the range of the input array, it uses a Heapsort algorithm.  
   
 -   Otherwise, it uses a Quicksort algorithm.  
   
  This implementation performs an unstable sort; that is, if two elements are equal, their order might not be preserved. In contrast, a stable sort preserves the order of elements that are equal.  
   
- On average, this method is an O(`n` log `n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(`n` ^ 2) operation.  
+ On average, this method is an O(*n* log *n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(*n*<sup>2</sup>) operation.  
   
    
   
@@ -2975,13 +2975,13 @@ Public Function StartsWith(e As Employee) As Boolean
   
 -   If the partition size is fewer than 16 elements, it uses an insertion sort algorithm.  
   
--   If the number of partitions exceeds 2 * LogN, where *N* is the range of the input array, it uses a Heapsort algorithm.  
+-   If the number of partitions exceeds 2 log *n*, where *n* is the range of the input array, it uses a Heapsort algorithm.  
   
 -   Otherwise, it uses a Quicksort algorithm.  
   
  This implementation performs an unstable sort; that is, if two elements are equal, their order might not be preserved. In contrast, a stable sort preserves the order of elements that are equal.  
   
- On average, this method is an O(`n` log `n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(`n` ^ 2) operation.  
+ On average, this method is an O(*n* log *n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(*n*<sup>2</sup>) operation.  
   
    
   
@@ -3045,13 +3045,13 @@ Public Function StartsWith(e As Employee) As Boolean
   
 -   If the partition size is fewer than 16 elements, it uses an insertion sort algorithm  
   
--   If the number of partitions exceeds 2 * LogN, where N is the range of the input array, it uses a [Heapsort](http://en.wikipedia.org/wiki/Heapsort) algorithm.  
+-   If the number of partitions exceeds 2 log *n*, where *n* is the range of the input array, it uses a [Heapsort](http://en.wikipedia.org/wiki/Heapsort) algorithm.  
   
 -   Otherwise, it uses a Quicksort algorithm.  
   
  This implementation performs an unstable sort; that is, if two elements are equal, their order might not be preserved. In contrast, a stable sort preserves the order of elements that are equal.  
   
- On average, this method is an O(`n` log `n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(`n` ^ 2) operation.  
+ On average, this method is an O(*n* log *n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(*n*<sup>2</sup>) operation.  
   
    
   
@@ -3122,13 +3122,13 @@ Public Function StartsWith(e As Employee) As Boolean
   
 -   If the partition size is fewer than 16 elements, it uses an insertion sort algorithm  
   
--   If the number of partitions exceeds 2 * LogN, where N is the range of the input array, it uses a [Heapsort](http://en.wikipedia.org/wiki/Heapsort) algorithm.  
+-   If the number of partitions exceeds 2 log *n*, where *n* is the range of the input array, it uses a [Heapsort](http://en.wikipedia.org/wiki/Heapsort) algorithm.  
   
 -   Otherwise, it uses a Quicksort algorithm.  
   
  This implementation performs an unstable sort; that is, if two elements are equal, their order might not be preserved. In contrast, a stable sort preserves the order of elements that are equal.  
   
- On average, this method is an O(`n` log `n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(`n` ^ 2) operation.  
+ On average, this method is an O(*n* log *n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>; in the worst case it is an O(*n*<sup>2</sup>) operation.  
   
    
   
@@ -3293,7 +3293,7 @@ Public Function StartsWith(e As Employee) As Boolean
 > [!NOTE]
 >  If the type of the source <xref:System.Collections.ICollection> cannot be cast automatically to the type of the destination `array`, the nongeneric implementations of <xref:System.Collections.ICollection.CopyTo%2A?displayProperty=fullName> throw <xref:System.InvalidCastException>, whereas the generic implementations throw <xref:System.ArgumentException>.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  ]]></format>
         </remarks>
@@ -3513,7 +3513,7 @@ finally
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- If <xref:System.Collections.Generic.List%601.Count%2A> is less than <xref:System.Collections.Generic.List%601.Capacity%2A>, this method is an O(1) operation. If the capacity needs to be increased to accommodate the new element, this method becomes an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ If <xref:System.Collections.Generic.List%601.Count%2A> is less than <xref:System.Collections.Generic.List%601.Capacity%2A>, this method is an O(1) operation. If the capacity needs to be increased to accommodate the new element, this method becomes an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  ]]></format>
         </remarks>
@@ -3557,7 +3557,7 @@ finally
 ## Remarks  
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  ]]></format>
         </remarks>
@@ -3598,7 +3598,7 @@ finally
 ## Remarks  
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  ]]></format>
         </remarks>
@@ -3642,7 +3642,7 @@ finally
 ## Remarks  
  If `index` equals the number of items in the <xref:System.Collections.IList>, then `item` is appended to the end.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  ]]></format>
         </remarks>
@@ -3810,7 +3810,7 @@ finally
 ## Remarks  
  This method determines equality using the default equality comparer <xref:System.Collections.Generic.EqualityComparer%601.Default%2A?displayProperty=fullName> for `T`, the type of values in the list.  
   
- This method performs a linear search; therefore, this method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method performs a linear search; therefore, this method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  ]]></format>
         </remarks>
@@ -3848,9 +3848,9 @@ finally
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The elements are copied using <xref:System.Array.Copy%2A?displayProperty=fullName>, which is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ The elements are copied using <xref:System.Array.Copy%2A?displayProperty=fullName>, which is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   
@@ -3899,7 +3899,7 @@ finally
 > [!NOTE]
 >  The current threshold of 90 percent might change in future releases.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
  To reset a <xref:System.Collections.Generic.List%601> to its initial state, call the <xref:System.Collections.Generic.List%601.Clear%2A> method before calling the <xref:System.Collections.Generic.List%601.TrimExcess%2A> method. Trimming an empty <xref:System.Collections.Generic.List%601> sets the capacity of the <xref:System.Collections.Generic.List%601> to the default capacity.  
   
@@ -3960,7 +3960,7 @@ finally
 ## Remarks  
  The <xref:System.Predicate%601> is a delegate to a method that returns `true` if the object passed to it matches the conditions defined in the delegate.  The elements of the current <xref:System.Collections.Generic.List%601> are individually passed to the <xref:System.Predicate%601> delegate, and processing is stopped when the delegate returns `false` for any element. The elements are processed in order, and all calls are made on a single thread.  
   
- This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n*) operation, where *n* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   

--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -4000,16 +4000,16 @@ finally
 ## Overloaded method syntax  
  The  <xref:System.Collections.Generic.List%601.Sort%2A> methods enable you to sort with the default comparer for the object type in the list, or specify a customer sort method.  
   
- [List\<T>.Sort()](http://msdn.microsoft.com/en-us/library/b0zbh7b6\(v=vs.110\).aspx)  
+ [List\<T>.Sort()](xref:System.Collections.Generic.List%601.Sort%28%29)
  Sorts the elements in the entire list using the default comparer of the object type held in the list.  
   
- [List\<T>.Sort M(Comparison\<T> comparison)](http://msdn.microsoft.com/en-us/library/w56d4y5z\(v=vs.110\).aspx)  
+ [List\<T>.Sort M(Comparison\<T> comparison)](xref:System.Collections.Generic.List%601.Sort%28System.Comparison%7B%600%7D%29)
  Sorts the elements in the entire list using the specified comparer.  
   
- [List\<T>.Sort(IComparer\<T> comparer)](http://msdn.microsoft.com/en-us/library/234b841s\(v=vs.110\).aspx)  
+ [List\<T>.Sort(IComparer\<T> comparer)](xref:System.Collections.Generic.List%601.Sort%28System.Collections.Generic.IComparer%7B%600%7D%29)
  Sorts the elements in the entire list using the specified <xref:System.Comparison%601?displayProperty=fullName>.  
   
- [List\<T>.Sort(Int32 index, Int32 count, IComparer\<T> comparer)](http://msdn.microsoft.com/en-us/library/8ce6t5ad\(v=vs.110\).aspx)  
+ [List\<T>.Sort(Int32 index, Int32 count, IComparer\<T> comparer)](xref:System.Collections.Generic.List%601.Sort%28System.Int32,System.Int32,System.Collections.Generic.IComparer%7B%600%7D%29)
  Sorts the elements in a range of elements in list using the specified comparer.  
   
 ## Parameters  
@@ -4017,7 +4017,7 @@ finally
 |Parameter|Type|Description|  
 |---------------|----------|-----------------|  
 |`comparison`|<xref:System.Comparison%601>|The delegate method to use when comparing elements|  
-|comparer|<xref:System.Collections.Generic.IComparer%601>|The  HYPERLINK "http://msdn.microsoft.com/en-us/library/8ehhxeaf(v=vs.110).aspx" IComparer\<T> implementation to use when comparing elements, or null to use the default comparer  HYPERLINK "http://msdn.microsoft.com/en-us/library/azhsac5f(v=vs.110).aspx" Comparer\<T>.Default.|  
+|comparer|<xref:System.Collections.Generic.IComparer%601>|The <xref:System.Collections.Generic.IComparer%601> implementation to use when comparing elements, or null to use the default comparer <xref:System.Collections.Generic.Comparer%601.Default>.|  
 |`index`|<xref:System.Int32>|The zero-based starting index of the range to sort.|  
 |`count`|<xref:System.Int32>|The length of the range to sort.|  
   


### PR DESCRIPTION
When it comes to math formatting, the conventions I used:

* Use italics for variables.
* Use `<sup>` for exponentiation.
* Use the same formatting for complexity and number of partitions in `Sort`.