### PR TITLE
Link to C# article on tuples from ValueTuple

### DIFF
--- a/xml/System/ValueTuple.xml
+++ b/xml/System/ValueTuple.xml
@@ -39,7 +39,7 @@
 ## Remarks  
 A tuple is a data structure that has a specific number and sequence of elements. An example of a tuple is a data structure with three elements (known as a 3-tuple or triple) that is used to store an identifier such as a person's name in the first element, a year in the second element, and the person's income for that year in the third element.  
   
-Value tuples are tuple types introduced in the [!INCLUDE[net_v463](~/includes/net-v463-md.md)] to provide the runtime implementation of tuples in C# and struct tuples in F#. They differ from the tuple classes, such as  <xref:System.Tuple%601>, <xref:System.Tuple%602>, etc., as follows:  
+Value tuples are tuple types introduced in the [!INCLUDE[net_v463](~/includes/net-v463-md.md)] to provide the runtime implementation of [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#. They differ from the tuple classes, such as  <xref:System.Tuple%601>, <xref:System.Tuple%602>, etc., as follows:  
   
 -   They are structures (value types) rather than classes (reference types).  
   

--- a/xml/System/ValueTuple`1.xml
+++ b/xml/System/ValueTuple`1.xml
@@ -51,7 +51,7 @@
   
 -   Its field is mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%601> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%60%601%28%60%600%29?displayProperty=fullName> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%601> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%60%601%28%60%600%29?displayProperty=fullName> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`2.xml
+++ b/xml/System/ValueTuple`2.xml
@@ -53,7 +53,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%602> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%602> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`3.xml
+++ b/xml/System/ValueTuple`3.xml
@@ -55,7 +55,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%603> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%603> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`4.xml
+++ b/xml/System/ValueTuple`4.xml
@@ -57,7 +57,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%604> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%604> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`5.xml
+++ b/xml/System/ValueTuple`5.xml
@@ -59,7 +59,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%605> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%605> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`6.xml
+++ b/xml/System/ValueTuple`6.xml
@@ -61,7 +61,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%606> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%606> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`7.xml
+++ b/xml/System/ValueTuple`7.xml
@@ -63,7 +63,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%607> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%607> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%2A> factory method.  
   
  ]]></format>
     </remarks>

--- a/xml/System/ValueTuple`8.xml
+++ b/xml/System/ValueTuple`8.xml
@@ -71,7 +71,7 @@
   
 -   Their fields are mutable rather than read-only.  
   
- The value tuple types provide the runtime implementation that supports tuples in C# and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%608> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%60%608%28%60%600%2C%60%601%2C%60%602%2C%60%603%2C%60%604%2C%60%605%2C%60%606%2C%60%607%29?displayProperty=fullName> factory method.  
+ The value tuple types provide the runtime implementation that supports [tuples in C#](~/docs/csharp/tuples.md) and struct tuples in F#.  In addition to creating a <xref:System.ValueTuple%608> instance by using language syntax, you can call the <xref:System.ValueTuple.Create%60%608%28%60%600%2C%60%601%2C%60%602%2C%60%603%2C%60%604%2C%60%605%2C%60%606%2C%60%607%29?displayProperty=fullName> factory method.  
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
I think that this link is important in understanding how to properly use `ValueTuple`.

I couldn't find a good link for F#, so I didn't add that. ([The F# *Tuples* article](https://docs.microsoft.com/en-us/dotnet/articles/fsharp/language-reference/tuples) contains a note that value tuples will be documented there in the future.)