### PR TITLE
testing issue 977838

### DIFF
--- a/docs/framework/wcf/creating-ws-i-basic-profile-1-1-interoperable-services.md
+++ b/docs/framework/wcf/creating-ws-i-basic-profile-1-1-interoperable-services.md
@@ -42,8 +42,7 @@ To configure a [!INCLUDE[indigo2](../../../includes/indigo2-md.md)] service endp
 ### Code  
  [!code-csharp[C_HowTo-WCFServiceAndASMXClient#0](../../../samples/snippets/csharp/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/cs/program.cs#0)]
  [!code-vb[C_HowTo-WCFServiceAndASMXClient#0](../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/vb/program.vb#0)]  
-  
- <!-- TODO: review snippet reference [!code[C_HowTo-WCFServiceAndASMXClient#1](../../../samples/snippets/common/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/common/app.config#1)]  -->  
+ [!code[C_HowTo-WCFServiceAndASMXClient#1](../../../samples/snippets/common/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/common/app.config#1)]
   
 ## See Also  
  [Interoperability with ASP.NET Web Services](../../../docs/framework/wcf/feature-details/interop-with-aspnet-web-services.md)

--- a/docs/framework/wcf/creating-ws-i-basic-profile-1-1-interoperable-services.md
+++ b/docs/framework/wcf/creating-ws-i-basic-profile-1-1-interoperable-services.md
@@ -42,7 +42,7 @@ To configure a [!INCLUDE[indigo2](../../../includes/indigo2-md.md)] service endp
 ### Code  
  [!code-csharp[C_HowTo-WCFServiceAndASMXClient#0](../../../samples/snippets/csharp/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/cs/program.cs#0)]
  [!code-vb[C_HowTo-WCFServiceAndASMXClient#0](../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/vb/program.vb#0)]  
- [!code[C_HowTo-WCFServiceAndASMXClient#1](../../../samples/snippets/common/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/common/app.config#1)]
+ [!code-xml[C_HowTo-WCFServiceAndASMXClient#1](../../../samples/snippets/common/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/common/app.config#1)]
   
 ## See Also  
  [Interoperability with ASP.NET Web Services](../../../docs/framework/wcf/feature-details/interop-with-aspnet-web-services.md)


### PR DESCRIPTION
I've opened an internal bug for the warning 
.config is not supported languaging name, alias or extension for parsing code snippet with tag name, you can use line numbers instead when resolving "[!code[C_HowTo-WCFServiceAndASMXClient#1](../../../samples/snippets/common/VS_Snippets_CFX/c_howto-wcfserviceandasmxclient/common/app.config#1)]"

I wanna make sure it's fixed.
