### PR TITLE
Correct implicit inheritance of struct

### DIFF
--- a/docs/csharp/tour-of-csharp/structs.md
+++ b/docs/csharp/tour-of-csharp/structs.md
@@ -1,4 +1,4 @@
-<s---
+---
 title: C# structs | A tour of the C# language
 description: Learn the basics of C# value types, called structs
 keywords: .NET, C#, struct, value type

--- a/docs/csharp/tour-of-csharp/structs.md
+++ b/docs/csharp/tour-of-csharp/structs.md
@@ -1,4 +1,4 @@
----
+<s---
 title: C# structs | A tour of the C# language
 description: Learn the basics of C# value types, called structs
 keywords: .NET, C#, struct, value type
@@ -14,7 +14,7 @@ ms.assetid: 88a74571-f741-4a31-a2b5-1ccf165535b8
 
 # Structs
 
-Like classes, ***structs*** are data structures that can contain data members and function members, but unlike classes, structs are value types and do not require heap allocation. A variable of a struct type directly stores the data of the struct, whereas a variable of a class type stores a reference to a dynamically allocated object. Struct types do not support user-specified inheritance, and all struct types implicitly inherit from type `object`.
+Like classes, ***structs*** are data structures that can contain data members and function members, but unlike classes, structs are value types and do not require heap allocation. A variable of a struct type directly stores the data of the struct, whereas a variable of a class type stores a reference to a dynamically allocated object. Struct types do not support user-specified inheritance, and all struct types implicitly inherit from type <xref:System.ValueType>, which in turn implicitly inherits from `object`.
 
 Structs are particularly useful for small data structures that have value semantics. Complex numbers, points in a coordinate system, or key-value pairs in a dictionary are all good examples of structs. The use of structs rather than classes for small data structures can make a large difference in the number of memory allocations an application performs. For example, the following program creates and initializes an array of 100 points. With `Point` implemented as a class, 101 separate objects are instantiated—one for the array and one each for the 100 elements.
 


### PR DESCRIPTION
# Correct implicit inheritance of `struct`

## Summary

structs derive directly from ValueType, not object.

## Suggested Reviewers

@BillWagner 
