### PR TITLE
Fix example in "Getting Started" command-line tutorial 

### DIFF
--- a/samples/core/console-apps/FibonacciBetterMsBuild/Program.cs
+++ b/samples/core/console-apps/FibonacciBetterMsBuild/Program.cs
@@ -1,13 +1,16 @@
 using System;
 
-class Program
+namespace Hello
 {
-    static void Main(string[] args)
+    class Program
     {
-        var generator = new FibonacciGenerator();
-        foreach (var digit in generator.Generate(15))
+        static void Main(string[] args)
         {
-            Console.WriteLine(digit);
+            var generator = new FibonacciGenerator();
+            foreach (var digit in generator.Generate(15))
+            {
+                Console.WriteLine(digit);
+            }
         }
     }
 }


### PR DESCRIPTION
# Fix example in "Getting Started" command-line tutorial 

## Summary

This example from the ["Getting started with .NET Core on Windows/Linux/macOS using the command line"](https://docs.microsoft.com/en-us/dotnet/articles/core/tutorials/using-with-xplat-cli) tutorial was not building since Program and FibonacciGenerator did not belong to the same namespace. See the ["Working with multiple files"](https://docs.microsoft.com/en-us/dotnet/articles/core/tutorials/using-with-xplat-cli#working-with-multiple-files) section of the tutorial.
