### PR TITLE
Fix list formatting in intro to functional programming

### DIFF
--- a/docs/fsharp/introduction-to-functional-programming/functions-as-first-class-values.md
+++ b/docs/fsharp/introduction-to-functional-programming/functions-as-first-class-values.md
@@ -171,7 +171,6 @@ To take it one step further, substitute the value that `applyIt` is bound to for
 The examples in the previous sections demonstrate that functions in F# satisfy the criteria for being first-class values in F#:
 
 - You can bind an identifier to a function definition.
-
 [!code-fsharp[Main](../../../samples/snippets/fsharp/contour/snippet21.fs)]
 
 - You can store a function in a data structure.


### PR DESCRIPTION
See [here](https://docs.microsoft.com/en-us/dotnet/articles/fsharp/introduction-to-functional-programming/functions-as-first-class-values#functions-are-first-class-values-in-f) that the first code block is not formatted inside a list like the following ones.