### PR TITLE
Fix rules for tuple assignment.

### DIFF
--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -110,8 +110,8 @@ the rules for assigning named tuples to each other.
 ## Assignment and tuples
 
 The language supports assignment between tuple types that have
-the same number of fields and the same types for each of those
-fields. Those types must be exact compile-time matches. Other
+the same number of fields and implicit conversions for the types for each of those
+fields. Other
 conversions are not considered for assignments. Let's look at the kinds
 of assignments that are allowed between tuple types.
 

--- a/samples/snippets/csharp/tuples/tuples/Program.cs
+++ b/samples/snippets/csharp/tuples/tuples/Program.cs
@@ -55,10 +55,8 @@ namespace tuples
             #endregion
 
             #region 04_VariableAssignment
-            // unnamed to named:
             unnamed = named;
 
-            // named to unnamed:
             named = unnamed;
             // 'named' still has fields that can be referred to
             // as 'answer', and 'message':

--- a/samples/snippets/csharp/tuples/tuples/Program.cs
+++ b/samples/snippets/csharp/tuples/tuples/Program.cs
@@ -72,6 +72,10 @@ namespace tuples
             // The field names are not assigned. 'named' still has 
             // fields that can be referred to as 'answer' and 'message':
             Console.WriteLine($"{named.Answer}, {named.Message}");
+
+            // With implicit conversions:
+            // int can be implicitly converted to long
+            (long, string) conversion = named;
             #endregion
 
         }


### PR DESCRIPTION
Implicit conversions are considered in addition to identity conversions.

/cc @repetrusha