### PR TITLE
Fix mistake in docker rmi command

### DIFF
--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -459,7 +459,7 @@ docker rm hello-docker
 If you want to remove unused images from your machine, you use this command:
 
 ```console
-docker rmi hello-docker
+docker rmi weather-microservice
 ```
 
 ## Conclusion 


### PR DESCRIPTION
It had the container name, not the image name.

Reported via LiveFyre.