### PR TITLE
Added missing words in TextWriter documentation

### DIFF
--- a/xml/System.IO/TextWriter.xml
+++ b/xml/System.IO/TextWriter.xml
@@ -1138,7 +1138,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -1227,7 +1227,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -1364,7 +1364,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -1450,7 +1450,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2312,7 +2312,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2403,7 +2403,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2543,7 +2543,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2631,7 +2631,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses the  of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   

--- a/xml/System.IO/TextWriter.xml
+++ b/xml/System.IO/TextWriter.xml
@@ -1138,7 +1138,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -1227,7 +1227,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -1364,7 +1364,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -1450,7 +1450,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2312,7 +2312,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2403,7 +2403,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2543,7 +2543,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
@@ -2631,7 +2631,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses composite formatting of the .NET Framework to convert the value of an object to its string representation and to embed that representation in a string. The .NET Framework provides extensive formatting support, which is described in greater detail in the following formatting topics:  
+ This method uses composite formatting to convert the value of an object to its string representation and to embed that representation in a string. .NET provides extensive formatting support, which is described in greater detail in the following formatting topics:  
   
 -   For more information about the composite formatting feature, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   


### PR DESCRIPTION
This seems to have been broken at some point in the past on MSDN. For example, https://msdn.microsoft.com/en-us/library/xxhes7h2(v=vs.100).aspx is correct, but https://msdn.microsoft.com/en-us/library/xxhes7h2(v=vs.110).aspx is not.

While I'm here, also contribute to https://github.com/dotnet/docs/issues/2028.