### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/core/tools/project-json-to-csproj.md
+++ b/docs/core/tools/project-json-to-csproj.md
@@ -327,7 +327,7 @@ There is no equivalent in csproj.
 
 ```xml
 <PropertyGroup>
-  <RuntimeIdentifiers>win7-x64;osx.10-11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
+  <RuntimeIdentifiers>win7-x64;osx.10.11-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
Changed the invalid RuntimeIdentifiers "osx.10-11-x64" to "osx.10.11-x64".