### PR TITLE
Fix typo in Native interoperability doc

### DIFF
--- a/docs/standard/native-interop.md
+++ b/docs/standard/native-interop.md
@@ -268,7 +268,7 @@ Both of the above examples depend on parameters, and in both cases, the paramete
 The reason marshalling is needed is because the types in the managed and unmanaged code are different. In managed code, for instance, you have a `String`, while in the unmanaged world strings can be Unicode (“wide”), non-Unicode, null-terminated, ASCII, etc. By default, the P/Invoke subsystem will try to do the Right Thing based on the default behavior which you can see on [MSDN](https://msdn.microsoft.com/library/zah6xy75.aspx). However, for those situations where you need extra control, you can employ the `MarshalAs` attribute to specify what is the expected type on the unmanaged side. For instance, if we want the string to be sent as a null-terminated ANSI string, we could do it like this:
 
 ```csharp
-[DllImport("somenativelibrary.dll"]
+[DllImport("somenativelibrary.dll")]
 static extern int MethodA([MarshalAs(UnmanagedType.LPStr)] string parameter);
 
 ```


### PR DESCRIPTION
## Summary

Fix typo (missing right bracket) in Native interoperability doc.

