### PR TITLE
Fix csharp and vb TODO snippets in \XML.

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp
@@ -1,3 +1,4 @@
+// <Snippet1>
 // This code example demonstrates the Console.WriteLine() method.
 // Formatting for this example uses the "en-US" culture.
 
@@ -98,3 +99,4 @@ Standard Enumeration Format Specifiers
 (X) Hexadecimal:. . . . . . . 00000003
 
 */
+// </Snippet1>

--- a/samples/snippets/csharp/VS_Snippets_CFX/c_custombindingsauthmode/cs/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/c_custombindingsauthmode/cs/source.cs
@@ -1,5 +1,5 @@
-//<snippet0>
-//<snippet1>
+// <Snippet0>
+// <Snippet1>
 using System;
 using System.Collections.Generic;
 using System.ServiceModel;
@@ -7,7 +7,7 @@ using System.ServiceModel.Channels;
 using System.ServiceModel.Security;
 using System.ServiceModel.Security.Tokens;
 using System.Security.Permissions;
-//</snippet1>
+// </Snippet1>
 [assembly: SecurityPermission(
    SecurityAction.RequestMinimum, Execution = true)]
 namespace Samples
@@ -17,7 +17,7 @@ namespace Samples
     {
         private CustomBindingCreator() { }
 
-        //<snippet2>
+        // <Snippet2>
         // These public methods create custom bindings based on the built-in 
         // authentication modes that use the static methods of 
         // the System.ServiceModel.Channels.SecurityBindingElement class.
@@ -204,10 +204,10 @@ namespace Samples
             bec.Add(new HttpsTransportBindingElement());
             return new CustomBinding(bec);
         }
-        //</snippet2>
+        // </Snippet2>
     }
 }
-//</snippet0>
+// </Snippet0>
 
 namespace samples2
 {
@@ -221,36 +221,36 @@ namespace samples2
 
         public static Binding CreateCustomBinding()
         {
-            //<snippet8>
-            //<snippet3>
+            // <Snippet8>
+            // <Snippet3>
             SymmetricSecurityBindingElement b =
                 SecurityBindingElement.
                 CreateAnonymousForCertificateBindingElement();
-            //</snippet3>
+            // </Snippet3>
 
-            //<snippet4>
+            // <Snippet4>
             BindingElementCollection outputBindings = 
                 new BindingElementCollection();
-            //</snippet4>
+            // </Snippet4>
             
-            //<snippet5>
+            // <Snippet5>
             b.DefaultAlgorithmSuite = SecurityAlgorithmSuite.Basic128;
             b.MessageProtectionOrder = 
                 MessageProtectionOrder.SignBeforeEncrypt;
             b.ProtectionTokenParameters = 
                 new KerberosSecurityTokenParameters();
-            //<snippet5>
-            //<snippet8>
+            // </Snippet5>
+            // </Snippet8>
             
-            //<snippet6>
+            // <Snippet6>
             outputBindings.Add(b);
             outputBindings.Add(new TextMessageEncodingBindingElement());
             outputBindings.Add(new HttpTransportBindingElement());
-            //</snippet6>
+            // </Snippet6>
 
-            //<snippet7>
+            // <Snippet7>
             return new CustomBinding(outputBindings);
-            //</snippet7>
+            // </Snippet7>
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CFX/channelcache/cs/client.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/channelcache/cs/client.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Samples.ChannelCache.EchoWorkflowClient
 
         static void CreateClientWorkflow()
         {
-            // </Snippet2>
+            // <Snippet2>
             Variable<string> message = new Variable<string>("message", "client");
             Variable<string> result = new Variable<string> { Name = "result" };
             

--- a/samples/snippets/csharp/VS_Snippets_CFX/creationendpoint/cs/creationendpoint.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/creationendpoint/cs/creationendpoint.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Samples.WF.CreationEndpoint
             }
             return creationContext;
         }
-// <Snippet1>
+// </Snippet1>
     }
 
 

--- a/samples/snippets/csharp/VS_Snippets_CFX/s_ue_servicedescription/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/s_ue_servicedescription/cs/program.cs
@@ -77,15 +77,15 @@ namespace ServiceDescriptionSnippet
             ServiceDescription sd2 = new ServiceDescription(endpoints);
             // </Snippet2>
 
-            //// <Snippet3>
-            //// Iterate through the list of behaviors in the ServiceDescription
+            // <Snippet3>
+            // Iterate through the list of behaviors in the ServiceDescription
             ServiceDescription svcDesc = serviceHost.Description;
             KeyedByTypeCollection<IServiceBehavior> sbCol = svcDesc.Behaviors;
             foreach (IServiceBehavior behavior in sbCol)
             {
                 Console.WriteLine("Behavior: {0}", behavior.ToString());
             }
-            //</Snippet3>
+            // </Snippet3>
 
             // <Snippet4>
             // svcDesc is a ServiceDescription.

--- a/samples/snippets/csharp/VS_Snippets_CFX/s_uelogrecordsequence/cs/mymultiplexlog.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/s_uelogrecordsequence/cs/mymultiplexlog.cs
@@ -45,7 +45,7 @@ namespace MyMultiplexLog
 					FileShare.ReadWrite);
 		// </Snippet11>
 
-		// <snippet13>
+		// <Snippet13>
 		// Start Appending in two streams with interleaving appends.
 
 				SequenceNumber previous1 = SequenceNumber.Invalid;
@@ -90,7 +90,7 @@ namespace MyMultiplexLog
 					previous2,
 					previous2,
 					RecordAppendOptions.ForceFlush);
-		// </snippet13>
+		// </Snippet13>
 				
 		// Read the log records from stream1 and stream2.
 
@@ -122,7 +122,7 @@ namespace MyMultiplexLog
 		// Cleanup...
 				sequence1.Dispose();
 				sequence2.Dispose();
-				// <Snippet12>
+				// </Snippet12>
 
 				LogStore.Delete(myLog);
 

--- a/samples/snippets/csharp/VS_Snippets_CFX/uemsmqmessage/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/uemsmqmessage/cs/program.cs
@@ -95,7 +95,7 @@ namespace UEMsmqMessage
 
             // <Snippet21>
             message.TimeToReachQueue = new TimeSpan(0,10,0);
-            // <Snippet21>
+            // </Snippet21>
         }
     }
 }

--- a/samples/snippets/csharp/VS_Snippets_CFX/uetransactedbatchingcode/common/serviceapp.config
+++ b/samples/snippets/csharp/VS_Snippets_CFX/uetransactedbatchingcode/common/serviceapp.config
@@ -5,7 +5,7 @@
     <!-- use appSetting to configure MSMQ queue name -->
     <add key="queueName" value=".\private$\ServiceModelSamples" />
   </appSettings>
-<!--
+<!-- <Snippet0> -->
   <system.serviceModel>
     <services>
       <service name="Microsoft.ServiceModel.Samples.CalculatorService"
@@ -37,5 +37,5 @@
     </behaviors>
   
   </system.serviceModel>
--->
+<!-- </Snippet0> -->
 </configuration>

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs
@@ -1,11 +1,11 @@
-//<Snippet11>
+// <Snippet11>
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
-//<Snippet11>
+// </Snippet11>
 
-//<Snippet12>
+// <Snippet12>
 public class SynchronizedCache 
 {
     private ReaderWriterLockSlim cacheLock = new ReaderWriterLockSlim();
@@ -131,7 +131,7 @@ public class SynchronizedCache
        if (cacheLock != null) cacheLock.Dispose();
     }
 }
-//</Snippet12>
+// </Snippet12>
 
 // <Snippet13>
 public class Example

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.consolecolor/cs/Example2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.consolecolor/cs/Example2.cs
@@ -12,4 +12,4 @@ public class Example
       }
    }
 }
-// <Snippet2>
+// </Snippet2>

--- a/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs
+++ b/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs
@@ -1,4 +1,4 @@
-//<!--<snippet1>-->
+// <Snippet1>
 using System;
 using System.CodeDom;
 using System.Web.UI;
@@ -19,15 +19,15 @@ public class MyExpressionBuilder : ExpressionBuilder
         return expression;
     }
 
-    //<!--<snippet3>-->
+    // <Snippet3>
     public override object EvaluateExpression(object target, BoundPropertyEntry entry, 
 	object parsedData, ExpressionBuilderContext context)
     {
         return GetEvalData(entry.Expression, target.GetType(), entry.Name);
     }
-    //<!--</snippet3>-->
+    // </Snippet3
 
-    //<!--<snippet4>-->
+    // <Snippet4>
     public override CodeExpression GetCodeExpression(BoundPropertyEntry entry, 
 	object parsedData, ExpressionBuilderContext context)
     {
@@ -40,16 +40,16 @@ public class MyExpressionBuilder : ExpressionBuilder
         return new CodeCastExpression(descriptor1.PropertyType, new CodeMethodInvokeExpression(new 
 	   CodeTypeReferenceExpression(base.GetType()), "GetEvalData", expressionArray1));
     }
-    //<!--</snippet4>-->
+    // </Snippet4>
 
-    //<!--<snippet2>-->
+    // <Snippet2> 
     public override bool SupportsEvaluate
     {
         get { return true; }
     }
-    //<!--</snippet2>-->
+    // </Snippet2> 
 }
-//<!--</snippet1>-->
+// </Snippet1> 
 
 
 /*
@@ -58,7 +58,7 @@ public class MyExpressionBuilder : ExpressionBuilder
 
 // web.config
 /*
-<!--<snippet5>-->
+<!-- <Snippet5> -->
 <configuration>
     <system.web>
        <compilation>
@@ -68,12 +68,12 @@ public class MyExpressionBuilder : ExpressionBuilder
        </compilation>
     </system.web>
 </configuration>
-<!--</snippet5>-->
+<!-- </Snippet5> -->
 */
 
 // ASPX page
 /*
-<!--<snippet6>-->
+<!-- <Snippet6> -->
 <asp:Label ID="Label1" runat="server" Text="<%$ MyCustomExpression:Hello, world! %>" />
-<!--</snippet6>-->
+<!-- </Snippet6> -->
 */

--- a/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs
+++ b/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs
@@ -25,7 +25,7 @@ public class MyExpressionBuilder : ExpressionBuilder
     {
         return GetEvalData(entry.Expression, target.GetType(), entry.Name);
     }
-    // </Snippet3
+    // </Snippet3>
 
     // <Snippet4>
     public override CodeExpression GetCodeExpression(BoundPropertyEntry entry, 

--- a/samples/snippets/csharp/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/CS/BirthdayPart.cs
+++ b/samples/snippets/csharp/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/CS/BirthdayPart.cs
@@ -1,4 +1,5 @@
-//<snippet1><snippet2>
+// <Snippet1>
+// <Snippet2>
 using System;
 using System.Security.Permissions;
 using System.Web;
@@ -73,7 +74,8 @@ namespace Samples.AspNet.CS.Controls
     }
   }
 
-//</snippet2><snippet3>
+  // </Snippet2>
+  // <Snippet3>
   public class BirthdayPartDesigner : WebPartDesigner
   {
     public override void Initialize(IComponent component)
@@ -132,4 +134,5 @@ namespace Samples.AspNet.CS.Controls
     }
   }
 }
-//</snippet3></snippet1>
+// </Snippet3>
+// </Snippet1>

--- a/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs
@@ -1,4 +1,4 @@
-// <snippet10>
+// <Snippet10>
 using System;
 using System.Windows;
 using System.Windows.Controls;
@@ -8,12 +8,12 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 
-// <snippet20>
+// <Snippet20>
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using System.Windows.Forms.Integration;
-// </snippet20>
+// </Snippet20>
 
 namespace PropertyMappingWithWfh
 {
@@ -28,7 +28,7 @@ namespace PropertyMappingWithWfh
             InitializeComponent();
         }
 
-        // <snippet11>
+        // <Snippet11>
         // The WindowLoaded method handles the Loaded event.
         // It enables Windows Forms visual styles, creates 
         // a Windows Forms checkbox control, and assigns the
@@ -69,9 +69,9 @@ namespace PropertyMappingWithWfh
             // Cause the OnBackgroundChange delegate to be called.
             wfHost.Background = new ImageBrush();
         }
-        // </snippet11>
+        // </Snippet11>
 
-        // <snippet12>
+        // <Snippet12>
         // The ReplaceFlowDirectionMapping method replaces the  
         // default mapping for the FlowDirection property.
         private void ReplaceFlowDirectionMapping()
@@ -109,18 +109,18 @@ namespace PropertyMappingWithWfh
                     System.Windows.FlowDirection.RightToLeft : 
                     System.Windows.FlowDirection.LeftToRight;
         }
-        // </snippet12>
+        // </Snippet12>
 
-        // <snippet13>
+        // <Snippet13>
         // The RemoveCursorMapping method deletes the default
         // mapping for the Cursor property.
         private void RemoveCursorMapping()
         {
             wfHost.PropertyMap.Remove("Cursor");
         }
-        // </snippet13>
+        // </Snippet13>
 
-        // <snippet14>
+        // <Snippet14>
         // The AddClipMapping method adds a custom 
         // mapping for the Clip property.
         private void AddClipMapping()
@@ -169,9 +169,9 @@ namespace PropertyMappingWithWfh
 
             return( new Region(path) );
         }
-        // </snippet14>
+        // </Snippet14>
 
-        // <snippet15>
+        // <Snippet15>
         // The ExtendBackgroundMapping method adds a property
         // translator if a mapping already exists.
         private void ExtendBackgroundMapping()
@@ -195,8 +195,8 @@ namespace PropertyMappingWithWfh
                 cb.BackgroundImage = new System.Drawing.Bitmap(@"C:\WINDOWS\Santa Fe Stucco.bmp");
             }
         }
-        // </snippet15>
+        // </Snippet15>
 
     }
 }
-// </snippet10>
+// </Snippet10>

--- a/samples/snippets/visualbasic/VS_Snippets_CFX/looselytypedextensions/vb/program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/looselytypedextensions/vb/program.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.Syndication.Samples
         Shared Sub Main(ByVal args As String())
             'Create an extensible object (in this case, SyndicationFeed). Other extensible types (SyndicationItem,
             'SyndicationCategory, SyndicationPerson, SyndicationLink) follow the same pattern.
-            ' </Snippet0>
+            ' <Snippet0>
             Dim feed As New SyndicationFeed()
 
             'Attribute extensions are stored in a dictionary indexed by XmlQualifiedName

--- a/samples/snippets/visualbasic/VS_Snippets_CFX/s_ue_servicedescription/vb/program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/s_ue_servicedescription/vb/program.vb
@@ -68,14 +68,14 @@ Namespace ServiceDescriptionSnippet
 			Dim sd2 As New ServiceDescription(endpoints)
 			' </Snippet2>
 
-			'// <Snippet3>
-			'// Iterate through the list of behaviors in the ServiceDescription
+			' <Snippet3>
+			' Iterate through the list of behaviors in the ServiceDescription
 			Dim svcDesc As ServiceDescription = serviceHost.Description
 			Dim sbCol As KeyedByTypeCollection(Of IServiceBehavior) = svcDesc.Behaviors
 			For Each behavior As IServiceBehavior In sbCol
 				Console.WriteLine("Behavior: {0}", CType(behavior, Object).ToString())
 			Next behavior
-			'</Snippet3>
+			' </Snippet3>
 
 			' <Snippet4>
 			' svcDesc is a ServiceDescription.

--- a/samples/snippets/visualbasic/VS_Snippets_CFX/s_uelogrecordsequence/vb/mymultiplexlog.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/s_uelogrecordsequence/vb/mymultiplexlog.vb
@@ -36,7 +36,7 @@ Namespace MyMultiplexLog
 				sequence2 = New LogRecordSequence(logStream2, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite)
 		' </Snippet11>
 
-		' <snippet13>
+		' <Snippet13>
 		' Start Appending in two streams with interleaving appends.
 
 				Dim previous1 As SequenceNumber = SequenceNumber.Invalid
@@ -57,7 +57,7 @@ Namespace MyMultiplexLog
 
 		' Append the third record in stream2.
 				previous2 = sequence2.Append(CreateData("MyLogStream2: Using LogRecordSequence..."), previous2, previous2, RecordAppendOptions.ForceFlush)
-		' </snippet13>
+		' </Snippet13>
 
 		' Read the log records from stream1 and stream2.
 
@@ -87,7 +87,7 @@ Namespace MyMultiplexLog
 		' Cleanup...
 				sequence1.Dispose()
 				sequence2.Dispose()
-				' <Snippet12>
+				' </Snippet12>
 
 				LogStore.Delete(myLog)
 

--- a/samples/snippets/visualbasic/VS_Snippets_CFX/uemsmqmessage/vb/program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/uemsmqmessage/vb/program.vb
@@ -95,7 +95,7 @@ Namespace UEMsmqMessage
 
             ' <Snippet21>
             message.TimeToReachQueue = New TimeSpan(0, 10, 0)
-            ' <Snippet21>
+            ' </Snippet21>
         End Sub
     End Class
 End Namespace

--- a/samples/snippets/visualbasic/VS_Snippets_CFX/x509clientcertificateauthentication/vb/source.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/x509clientcertificateauthentication/vb/source.vb
@@ -167,7 +167,7 @@ Public Class Test
             Case Else
                 Console.WriteLine("Default")
         End Select
-        '<snippet7>
+        '</snippet7>
     End Sub
 End Class
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb
@@ -5,7 +5,7 @@ Option Strict On
 Imports System.Collections.Generic
 Imports System.Threading
 Imports System.Threading.Tasks
-' <Snippet11>
+' </Snippet11>
 
 ' <Snippet12>
 Public Class SynchronizedCache

--- a/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb
@@ -1,4 +1,4 @@
-﻿' <!--<snippet1>-->
+﻿' <Snippet1> 
 Imports System
 Imports System.CodeDom
 Imports System.Web.UI
@@ -19,15 +19,15 @@ Public Class MyExpressionBuilder
         Return expression
     End Function
 
-    ' <!--<snippet3>-->
+    ' <Snippet3>
     Public Overrides Function EvaluateExpression(ByVal target As Object, _
        ByVal entry As BoundPropertyEntry, ByVal parsedData As Object, _
        ByVal context As ExpressionBuilderContext) As Object
         Return GetEvalData(entry.Expression, target.GetType(), entry.Name)
     End Function
-    ' <!--</snippet3>-->
+    ' </Snippet3> 
 
-    ' <!--<snippet4>-->
+    ' <Snippet4> 
     Public Overrides Function GetCodeExpression(ByVal entry _
        As BoundPropertyEntry, ByVal parsedData As Object, ByVal context _
        As ExpressionBuilderContext) As CodeExpression
@@ -42,15 +42,15 @@ Public Class MyExpressionBuilder
            New CodeMethodInvokeExpression(New CodeTypeReferenceExpression _
            (MyBase.GetType()), "GetEvalData", expressionArray1))
     End Function
-    ' <!--</snippet4>-->
+    ' </Snippet4> 
 
-    ' <!--<snippet2>-->
+    ' <Snippet2>
     Public Overrides ReadOnly Property SupportsEvaluate() As Boolean
         Get
             Return True
         End Get
     End Property
-    ' <!--</snippet2>-->
+    ' </Snippet2>
 End Class
-' <!--</snippet1>-->
+' </Snippet1>
 

--- a/samples/snippets/visualbasic/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/vb/birthdaypart.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/vb/birthdaypart.vb
@@ -1,4 +1,5 @@
-'<snippet1><snippet2>
+' <Snippet1>
+' <Snippet2>
 Imports System.Security.Permissions
 Imports System.Web
 Imports System.Web.UI.WebControls
@@ -63,7 +64,8 @@ Namespace Samples.AspNet.VB.Controls
         End Sub
     End Class
 
-    '</snippet2><snippet3>
+    ' </Snippet2>
+    ' <Snippet3>
     Public Class BirthdayPartDesigner
         Inherits WebPartDesigner
         Public Overrides Sub Initialize(component As IComponent)
@@ -108,4 +110,5 @@ Namespace Samples.AspNet.VB.Controls
         End Function
     End Class
 End Namespace
-'</snippet3></snippet1>
+' </Snippet3>
+' </Snippet1>

--- a/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb
@@ -1,4 +1,4 @@
- ' <snippet10>
+' <snippet10>
 Imports System
 Imports System.Windows
 Imports System.Windows.Controls

--- a/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb
@@ -1,4 +1,4 @@
-' <snippet10>
+' <Snippet10>
 Imports System
 Imports System.Windows
 Imports System.Windows.Controls
@@ -8,12 +8,12 @@ Imports System.Windows.Media
 Imports System.Windows.Media.Imaging
 Imports System.Windows.Shapes
 
-' <snippet20>
+' <Snippet20>
 Imports System.Drawing
 Imports System.Drawing.Drawing2D
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Integration
-' </snippet20>
+' </Snippet20>
 
 ' <summary>
 ' Interaction logic for Window1.xaml
@@ -27,7 +27,7 @@ Class Window1
     End Sub
     
     
-    ' <snippet11>
+    ' <Snippet11>
     ' The WindowLoaded method handles the Loaded event.
     ' It enables Windows Forms visual styles, creates 
     ' a Windows Forms checkbox control, and assigns the
@@ -71,9 +71,9 @@ Class Window1
         wfHost.Background = New ImageBrush()
 
     End Sub
-    ' </snippet11>
+    ' </Snippet11>
 
-    ' <snippet12>
+    ' <Snippet12>
     ' The ReplaceFlowDirectionMapping method replaces the
     ' default mapping for the FlowDirection property.
     Private Sub ReplaceFlowDirectionMapping()
@@ -124,17 +124,17 @@ Class Window1
         System.Windows.FlowDirection.LeftToRight)
 
     End Sub
-    ' </snippet12>
+    ' </Snippet12>
 
-    ' <snippet13>
+    ' <Snippet13>
     ' The RemoveCursorMapping method deletes the default
     ' mapping for the Cursor property.
     Private Sub RemoveCursorMapping()
         wfHost.PropertyMap.Remove("Cursor")
     End Sub
-    ' </snippet13>
+    ' </Snippet13>
 
-    ' <snippet14>
+    ' <Snippet14>
     ' The AddClipMapping method adds a custom mapping 
     ' for the Clip property.
     Private Sub AddClipMapping()
@@ -191,9 +191,9 @@ Class Window1
         Return New [Region](path)
     
     End Function
-    ' </snippet14>
+    ' </Snippet14>
 
-    ' <snippet15>
+    ' <Snippet15>
     ' The ExtendBackgroundMapping method adds a property
     ' translator if a mapping already exists.
     Private Sub ExtendBackgroundMapping() 
@@ -222,7 +222,7 @@ Class Window1
         End If
     
     End Sub
-    ' </snippet15>
+    ' </Snippet15>
 End Class
 
-' </snippet10>
+' </Snippet10>

--- a/xml/System.IO.Log/LogRecordSequence.xml
+++ b/xml/System.IO.Log/LogRecordSequence.xml
@@ -1429,13 +1429,13 @@ recordSequence.Append(undoRecordData, userSqn, previousSqn, RecordAppendOptions.
           <format type="text/markdown"><![CDATA[  
   
 ## Examples  
- This example shows how to use <xref:System.IO.Log.LogRecordSequence.Dispose%2A> to release resource:  
+ This example shows how to use <xref:System.IO.Log.LogRecordSequence.Dispose%2A> to release resources:  
   
  [!code-csharp[S_UELogRecordSequence#11](~/samples/snippets/csharp/VS_Snippets_CFX/s_uelogrecordsequence/cs/mymultiplexlog.cs#11)]
  [!code-vb[S_UELogRecordSequence#11](~/samples/snippets/visualbasic/VS_Snippets_CFX/s_uelogrecordsequence/vb/mymultiplexlog.vb#11)]  
   
- <!-- TODO: review snippet reference [!code-csharp[S_UELogRecordSequence#12](~/samples/snippets/csharp/VS_Snippets_CFX/s_uelogrecordsequence/cs/mymultiplexlog.cs#12)]  -->
- <!-- TODO: review snippet reference [!code-vb[S_UELogRecordSequence#12](~/samples/snippets/visualbasic/VS_Snippets_CFX/s_uelogrecordsequence/vb/mymultiplexlog.vb#12)]  -->  
+ [!code-csharp[S_UELogRecordSequence#12](~/samples/snippets/csharp/VS_Snippets_CFX/s_uelogrecordsequence/cs/mymultiplexlog.cs#12)] 
+ [!code-vb[S_UELogRecordSequence#12](~/samples/snippets/visualbasic/VS_Snippets_CFX/s_uelogrecordsequence/vb/mymultiplexlog.vb#12)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.Numerics/Complex.xml
+++ b/xml/System.Numerics/Complex.xml
@@ -777,8 +777,8 @@
 ## Examples  
  The following example illustrates the <xref:System.Numerics.Complex.Exp%2A> method. It shows that, with some allowance for the lack of precision of the <xref:System.Double> data type, passing the value returned by the <xref:System.Numerics.Complex.Log%2A> method to the <xref:System.Numerics.Complex.Exp%2A> method returns the original <xref:System.Numerics.Complex> value.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Numerics.Complex.Log#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.numerics.complex.log/cs/log1.cs#1)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Numerics.Complex.Log#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.numerics.complex.log/vb/log1.vb#1)]  -->  
+ [!code-csharp[System.Numerics.Complex.Log#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.numerics.complex.log/cs/log1.cs#1)] 
+ [!code-vb[System.Numerics.Complex.Log#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.numerics.complex.log/vb/log1.vb#1)]   
   
  ]]></format>
         </remarks>
@@ -981,8 +981,8 @@
 ## Examples  
  The following example illustrates the <xref:System.Numerics.Complex.Log%2A> method. It shows that, with some allowance for the lack of precision of the <xref:System.Double> data type, passing the value returned by the <xref:System.Numerics.Complex.Log%2A> method to the <xref:System.Numerics.Complex.Exp%2A> method returns the original <xref:System.Numerics.Complex> value.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Numerics.Complex.Log#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.numerics.complex.log/cs/log1.cs#1)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Numerics.Complex.Log#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.numerics.complex.log/vb/log1.vb#1)]  -->  
+ [!code-csharp[System.Numerics.Complex.Log#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.numerics.complex.log/cs/log1.cs#1)] 
+ [!code-vb[System.Numerics.Complex.Log#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.numerics.complex.log/vb/log1.vb#1)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.Reflection/PropertyInfo.xml
+++ b/xml/System.Reflection/PropertyInfo.xml
@@ -379,7 +379,6 @@
 ## Examples  
  The following example retrieves the accessors of the `ClassWithProperty.Caption` property and displays information about them. It also calls the <xref:System.Reflection.MethodBase.Invoke%2A> method of the setter to set the property value and of the getter to retrieve the property value.  
   
- <!-- TODO: review snippet reference [!code-cpp[Classic PropertyInfo.GetAccessors1 Example#1](~/samples/snippets/cpp/VS_Snippets_CLR_Classic/classic PropertyInfo.GetAccessors1 Example/CPP/source.cpp#1)]  -->
  [!code-csharp[Classic PropertyInfo.GetAccessors1 Example#1](~/samples/snippets/csharp/VS_Snippets_CLR_Classic/classic PropertyInfo.GetAccessors1 Example/CS/source.cs#1)]
  [!code-vb[Classic PropertyInfo.GetAccessors1 Example#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_Classic/classic PropertyInfo.GetAccessors1 Example/VB/source.vb#1)]  
   

--- a/xml/System.ServiceModel.Activities/Send.xml
+++ b/xml/System.ServiceModel.Activities/Send.xml
@@ -23,7 +23,7 @@
 ## Examples  
  The following example shows how to create a <xref:System.ServiceModel.Activities.Send> activity and add it to a workflow. The example also shows how to use <xref:System.ServiceModel.Activities.ReceiveReply> activity to receive the reply message.  
   
- <!-- TODO: review snippet reference [!code-csharp[ChannelCache#2](~/samples/snippets/csharp/VS_Snippets_CFX/channelcache/cs/client.cs#2)]  -->  
+ [!code-csharp[ChannelCache#2](~/samples/snippets/csharp/VS_Snippets_CFX/channelcache/cs/client.cs#2)]   
   
  ]]></format>
     </remarks>

--- a/xml/System.ServiceModel.Activities/WorkflowHostingResponseContext.xml
+++ b/xml/System.ServiceModel.Activities/WorkflowHostingResponseContext.xml
@@ -18,7 +18,7 @@
 ## Examples  
  The following example illustrates how a <xref:System.ServiceModel.Activities.WorkflowHostingResponseContext> is provided to a workflow hosting endpoint.  
   
- <!-- TODO: review snippet reference [!code-csharp[CreationEndpoint#1](~/samples/snippets/csharp/VS_Snippets_CFX/creationendpoint/cs/creationendpoint.cs#1)]  -->  
+ [!code-csharp[CreationEndpoint#1](~/samples/snippets/csharp/VS_Snippets_CFX/creationendpoint/cs/creationendpoint.cs#1)]    
   
  ]]></format>
     </remarks>

--- a/xml/System.ServiceModel.Channels/SecurityBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/SecurityBindingElement.xml
@@ -1284,7 +1284,7 @@
 ## Examples  
  The following code shows how to set this property.  
   
- <!-- TODO: review snippet reference [!code-csharp[c_CustomBindingsAuthMode#8](~/samples/snippets/csharp/VS_Snippets_CFX/c_custombindingsauthmode/cs/source.cs#8)]  -->  
+ [!code-csharp[c_CustomBindingsAuthMode#8](~/samples/snippets/csharp/VS_Snippets_CFX/c_custombindingsauthmode/cs/source.cs#8)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.ServiceModel.Description/ServiceDescription.xml
+++ b/xml/System.ServiceModel.Description/ServiceDescription.xml
@@ -120,9 +120,9 @@
    
   
 ## Examples  
- <!-- TODO: review snippet reference [!code-csharp[S_UE_ServiceDescription#3](~/samples/snippets/csharp/VS_Snippets_CFX/s_ue_servicedescription/cs/program.cs#3)]  -->
- [!code-csharp[S_UE_ServiceDescription#3](~/samples/snippets/csharp/VS_Snippets_CFX/s_ue_servicedescription/cs/snippets.cs#3)]
- <!-- TODO: review snippet reference [!code-vb[S_UE_ServiceDescription#3](~/samples/snippets/visualbasic/VS_Snippets_CFX/s_ue_servicedescription/vb/program.vb#3)]  -->
+ [!code-csharp[S_UE_ServiceDescription#3](~/samples/snippets/csharp/VS_Snippets_CFX/s_ue_servicedescription/cs/program.cs#3)] 
+ [!code-csharp[S_UE_ServiceDescription#3](~/samples/snippets/csharp/VS_Snippets_CFX/s_ue_servicedescription/cs/snippets.cs#3)]   
+ [!code-vb[S_UE_ServiceDescription#3](~/samples/snippets/visualbasic/VS_Snippets_CFX/s_ue_servicedescription/vb/program.vb#3)] 
  [!code-vb[S_UE_ServiceDescription#3](~/samples/snippets/visualbasic/VS_Snippets_CFX/s_ue_servicedescription/vb/snippets.vb#3)]  
   
  ]]></format>

--- a/xml/System.ServiceModel.Description/TransactedBatchingBehavior.xml
+++ b/xml/System.ServiceModel.Description/TransactedBatchingBehavior.xml
@@ -27,11 +27,10 @@
 ## Examples  
  The following example shows how to add the transacted batching behavior to a service in a configuration file.  
   
-  
+ [!code-xml[UETransactedBatchingConfig#0](~/samples/snippets/csharp/VS_Snippets_CFX/uetransactedbatchingcode/common/serviceapp.config#0)] 
   
  The following example shows how to add the transacted batching behavior to a service in code.  
   
- <!-- TODO: review snippet reference [!code-csharp[UETransactedBatchingCode#0](~/samples/snippets/csharp/VS_Snippets_CFX/uetransactedbatchingcode/cs/snippets.cs#0)]  -->
  [!code-csharp[UETransactedBatchingCode#0](~/samples/snippets/csharp/VS_Snippets_CFX/uetransactedbatchingcode/cs/service.cs#0)]  
   
  ]]></format>

--- a/xml/System.ServiceModel.MsmqIntegration/MsmqMessage`1.xml
+++ b/xml/System.ServiceModel.MsmqIntegration/MsmqMessage`1.xml
@@ -651,8 +651,8 @@
    
   
 ## Examples  
- <!-- TODO: review snippet reference [!code-csharp[UEMsmqMessage#21](~/samples/snippets/csharp/VS_Snippets_CFX/uemsmqmessage/cs/program.cs#21)]  -->
- <!-- TODO: review snippet reference [!code-vb[UEMsmqMessage#21](~/samples/snippets/visualbasic/VS_Snippets_CFX/uemsmqmessage/vb/program.vb#21)]  -->  
+ [!code-csharp[UEMsmqMessage#21](~/samples/snippets/csharp/VS_Snippets_CFX/uemsmqmessage/cs/program.cs#21)] 
+ [!code-vb[UEMsmqMessage#21](~/samples/snippets/visualbasic/VS_Snippets_CFX/uemsmqmessage/vb/program.vb#21)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.ServiceModel.Security/X509ClientCertificateAuthentication.xml
+++ b/xml/System.ServiceModel.Security/X509ClientCertificateAuthentication.xml
@@ -77,7 +77,7 @@
  The following example uses the <xref:System.ServiceModel.Security.X509ClientCertificateAuthentication.CertificateValidationMode%2A> to print to the screen.  
   
  [!code-csharp[X509ClientCertificateAuthentication#7](~/samples/snippets/csharp/VS_Snippets_CFX/x509clientcertificateauthentication/cs/source.cs#7)]
- <!-- TODO: review snippet reference [!code-vb[X509ClientCertificateAuthentication#7](~/samples/snippets/visualbasic/VS_Snippets_CFX/x509clientcertificateauthentication/vb/source.vb#7)]  -->  
+ [!code-vb[X509ClientCertificateAuthentication#7](~/samples/snippets/visualbasic/VS_Snippets_CFX/x509clientcertificateauthentication/vb/source.vb#7)]   
   
  The property can also be set in a configuration file.  
   

--- a/xml/System.ServiceModel.Syndication/SyndicationFeed.xml
+++ b/xml/System.ServiceModel.Syndication/SyndicationFeed.xml
@@ -353,8 +353,8 @@
 ## Examples  
  The following code shows how to add an attribute extension to a syndication feed.  
   
- [!code-csharp[LooselyTypedExtensions#0](~/samples/snippets/csharp/VS_Snippets_CFX/looselytypedextensions/cs/program.cs#0)]
- <!-- TODO: review snippet reference [!code-vb[LooselyTypedExtensions#0](~/samples/snippets/visualbasic/VS_Snippets_CFX/looselytypedextensions/vb/program.vb#0)]  -->  
+ [!code-csharp[LooselyTypedExtensions#0](~/samples/snippets/csharp/VS_Snippets_CFX/looselytypedextensions/cs/program.cs#0)] 
+ [!code-vb[LooselyTypedExtensions#0](~/samples/snippets/visualbasic/VS_Snippets_CFX/looselytypedextensions/vb/program.vb#0)]   
   
  The following XML shows how an attribute extension is serialized to Atom 1.0.  
   

--- a/xml/System.Threading/ReaderWriterLockSlim.xml
+++ b/xml/System.Threading/ReaderWriterLockSlim.xml
@@ -266,16 +266,16 @@
   
  In the second scenario, the thread enters read mode and then tries to enter write mode. <xref:System.Threading.LockRecursionException> is thrown regardless of the lock recursion policy.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Threading.LockRecursionPolicy#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#11)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Threading.LockRecursionPolicy#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb#11)]  -->  
-[!code-csharp[System.Threading.LockRecursionPolicy#12](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#12)]
+[!code-csharp[System.Threading.LockRecursionPolicy#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#11)] 
+[!code-vb[System.Threading.LockRecursionPolicy#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb#11)]   
+[!code-csharp[System.Threading.LockRecursionPolicy#12](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#12)] 
 [!code-vb[System.Threading.LockRecursionPolicy#12](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb#12)]  
   
  The following code then uses the `SynchronizedCache` object to store a dictionary of vegetable names. It creates three tasks. The first writes the names of vegetables stored in an array to a `SynchronizedCache` instance. The second and third task display the names of the vegetables, the first in ascending order (from low index to high index), the second in descending order. The final task searches for the string "cucumber" and, when it finds it, calls the <xref:System.Threading.ReaderWriterLockSlim.EnterUpgradeableReadLock%2A> method  to substitute the string "green bean".  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Threading.LockRecursionPolicy#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#11)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Threading.LockRecursionPolicy#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb#11)]  -->  
-[!code-csharp[System.Threading.LockRecursionPolicy#13](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#13)]
+[!code-csharp[System.Threading.LockRecursionPolicy#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#11)] 
+[!code-vb[System.Threading.LockRecursionPolicy#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb#11)]   
+[!code-csharp[System.Threading.LockRecursionPolicy#13](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/cs/ClassExample1.cs#13)] 
 [!code-vb[System.Threading.LockRecursionPolicy#13](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Threading.LockRecursionPolicy/vb/ClassExample1.vb#13)]  
   
  ]]></format>

--- a/xml/System.Web.Compilation/ExpressionBuilder.xml
+++ b/xml/System.Web.Compilation/ExpressionBuilder.xml
@@ -55,8 +55,8 @@ Text="<%$ MyCustomExpression:Hello, world! %>" />
   
  The third code example demonstrates how to develop a customized expression builder by deriving from <xref:System.Web.Compilation.ExpressionBuilder>. To run this code example, you must place the class in the App_Code folder.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#1)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#1)]  -->  
+ [!code-csharp[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#1)] 
+ [!code-vb[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#1)]   
   
  ]]></format>
     </remarks>
@@ -126,8 +126,8 @@ Text="<%$ MyCustomExpression:Hello, world! %>" />
 ## Examples  
  The following code example demonstrates how to use the overridden <xref:System.Web.Compilation.ExpressionBuilder.EvaluateExpression%2A> method to return an evaluated expression.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Web.Compilation.ExpressionBuilder#3](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#3)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Web.Compilation.ExpressionBuilder#3](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#3)]  -->  
+ [!code-csharp[System.Web.Compilation.ExpressionBuilder#3](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#3)]    
+ [!code-vb[System.Web.Compilation.ExpressionBuilder#3](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#3)]   
   
  ]]></format>
         </remarks>
@@ -170,8 +170,8 @@ Text="<%$ MyCustomExpression:Hello, world! %>" />
 ## Examples  
  The following code example demonstrates how to return a <xref:System.CodeDom.CodeExpression> object by overriding the <xref:System.Web.Compilation.ExpressionBuilder.GetCodeExpression%2A> method.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Web.Compilation.ExpressionBuilder#4](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#4)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Web.Compilation.ExpressionBuilder#4](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#4)]  -->  
+ [!code-csharp[System.Web.Compilation.ExpressionBuilder#4](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#4)] 
+ [!code-vb[System.Web.Compilation.ExpressionBuilder#4](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#4)]   
   
  ]]></format>
         </remarks>
@@ -240,8 +240,8 @@ Text="<%$ MyCustomExpression:Hello, world! %>" />
 ## Examples  
  The following code example demonstrates how to use the <xref:System.Web.Compilation.ExpressionBuilder.SupportsEvaluate%2A> property.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Web.Compilation.ExpressionBuilder#2](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#2)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Web.Compilation.ExpressionBuilder#2](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#2)]  -->  
+ [!code-csharp[System.Web.Compilation.ExpressionBuilder#2](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#2)] 
+ [!code-vb[System.Web.Compilation.ExpressionBuilder#2](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#2)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.Web.Compilation/ExpressionPrefixAttribute.xml
+++ b/xml/System.Web.Compilation/ExpressionPrefixAttribute.xml
@@ -54,8 +54,8 @@ Text="<%$ MyCustomExpression:Hello, world! %>" />
   
  The third code example demonstrates how to develop a customized expression builder by deriving from <xref:System.Web.Compilation.ExpressionBuilder>. To run this code example, you must place the class in the App_Code folder.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#1)]  -->
- <!-- TODO: review snippet reference [!code-vb[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#1)]  -->  
+ [!code-csharp[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/csharp/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/CS/MyExpressionBuilder.cs#1)] 
+ [!code-vb[System.Web.Compilation.ExpressionBuilder#1](~/samples/snippets/visualbasic/VS_Snippets_WebNet/System.Web.Compilation.ExpressionBuilder/VB/MyExpressionBuilder.vb#1)]   
   
  ]]></format>
     </remarks>

--- a/xml/System.Web.UI.Design.WebControls.WebParts/WebPartDesigner.xml
+++ b/xml/System.Web.UI.Design.WebControls.WebParts/WebPartDesigner.xml
@@ -29,8 +29,8 @@
   
  All the methods overridden in this example derive from the <xref:System.Web.UI.Design.ControlDesigner> base class. For other available members and their use, see <xref:System.Web.UI.Design.ControlDesigner?displayProperty=fullName>.  
   
- <!-- TODO: review snippet reference [!code-csharp[WebPartsDesigners_WebPartDesigner_Overview#1](~/samples/snippets/csharp/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/CS/BirthdayPart.cs#1)]  -->
- <!-- TODO: review snippet reference [!code-vb[WebPartsDesigners_WebPartDesigner_Overview#1](~/samples/snippets/visualbasic/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/vb/birthdaypart.vb#1)]  -->  
+ [!code-csharp[WebPartsDesigners_WebPartDesigner_Overview#1](~/samples/snippets/csharp/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/CS/BirthdayPart.cs#1)] 
+ [!code-vb[WebPartsDesigners_WebPartDesigner_Overview#1](~/samples/snippets/visualbasic/VS_Snippets_WebNet/WebPartsDesigners_WebPartDesigner_Overview/vb/birthdaypart.vb#1)]   
   
  ]]></format>
     </remarks>

--- a/xml/System.Windows.Forms.Integration/PropertyMap.xml
+++ b/xml/System.Windows.Forms.Integration/PropertyMap.xml
@@ -35,8 +35,8 @@
   
  The following code example shows how to replace the default mapping for the <xref:System.Windows.FrameworkElement.FlowDirection%2A> property on a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)] 
- [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]   
+ [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)] 
+ [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]   
   
  ]]></format>
     </remarks>
@@ -117,13 +117,13 @@
 ## Examples  
  The following code example shows how to add a mapping for the <xref:System.Windows.Forms.Control.Margin%2A> property to an <xref:System.Windows.Forms.Integration.ElementHost> control.  
   
- [!code-csharp[PropertyMappingWithElementHost#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithElementHost/CSharp/PropertyMappingWithElementHost/Form1.cs#12)]
+ [!code-csharp[PropertyMappingWithElementHost#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithElementHost/CSharp/PropertyMappingWithElementHost/Form1.cs#12)] 
  [!code-vb[PropertyMappingWithElementHost#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithElementHost/VisualBasic/PropertyMappingWithElementHost/Form1.vb#12)]  
   
  The following code example shows how to add a mapping for the <xref:System.Windows.UIElement.Clip%2A> property to a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- [!code-csharp[PropertyMappingWithWfh#14](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#14)] 
- [!code-vb[PropertyMappingWithWfh#14](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#14)]   
+ [!code-csharp[PropertyMappingWithWfh#14](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#14)] 
+ [!code-vb[PropertyMappingWithWfh#14](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#14)]   
   
  ]]></format>
         </remarks>
@@ -272,8 +272,8 @@
   
  The following code example shows how to retrieve the <xref:System.Windows.Forms.Integration.PropertyTranslator> delegate for the <xref:System.Windows.Controls.Control.Background%2A> property of a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- [!code-csharp[PropertyMappingWithWfh#15](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#15)] 
- [!code-vb[PropertyMappingWithWfh#15](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#15)]   
+ [!code-csharp[PropertyMappingWithWfh#15](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#15)] 
+ [!code-vb[PropertyMappingWithWfh#15](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#15)]   
   
  ]]></format>
         </remarks>
@@ -353,8 +353,8 @@
   
  The following code example shows how to add a mapping for the <xref:System.Windows.FrameworkElement.Cursor%2A> property to a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- [!code-csharp[PropertyMappingWithWfh#13](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#13)] 
- [!code-vb[PropertyMappingWithWfh#13](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#13)]   
+ [!code-csharp[PropertyMappingWithWfh#13](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#13)] 
+ [!code-vb[PropertyMappingWithWfh#13](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#13)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Forms.Integration/PropertyMap.xml
+++ b/xml/System.Windows.Forms.Integration/PropertyMap.xml
@@ -35,8 +35,8 @@
   
  The following code example shows how to replace the default mapping for the <xref:System.Windows.FrameworkElement.FlowDirection%2A> property on a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- <!-- TODO: review snippet reference [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)]  -->
- <!-- TODO: review snippet reference [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]  -->  
+ [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)] 
+ [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]   
   
  ]]></format>
     </remarks>
@@ -122,8 +122,8 @@
   
  The following code example shows how to add a mapping for the <xref:System.Windows.UIElement.Clip%2A> property to a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- <!-- TODO: review snippet reference [!code-csharp[PropertyMappingWithWfh#14](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#14)]  -->
- <!-- TODO: review snippet reference [!code-vb[PropertyMappingWithWfh#14](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#14)]  -->  
+ [!code-csharp[PropertyMappingWithWfh#14](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#14)] 
+ [!code-vb[PropertyMappingWithWfh#14](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#14)]   
   
  ]]></format>
         </remarks>
@@ -272,8 +272,8 @@
   
  The following code example shows how to retrieve the <xref:System.Windows.Forms.Integration.PropertyTranslator> delegate for the <xref:System.Windows.Controls.Control.Background%2A> property of a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- <!-- TODO: review snippet reference [!code-csharp[PropertyMappingWithWfh#15](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#15)]  -->
- <!-- TODO: review snippet reference [!code-vb[PropertyMappingWithWfh#15](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#15)]  -->  
+ [!code-csharp[PropertyMappingWithWfh#15](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#15)] 
+ [!code-vb[PropertyMappingWithWfh#15](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#15)]   
   
  ]]></format>
         </remarks>
@@ -353,8 +353,8 @@
   
  The following code example shows how to add a mapping for the <xref:System.Windows.FrameworkElement.Cursor%2A> property to a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- <!-- TODO: review snippet reference [!code-csharp[PropertyMappingWithWfh#13](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#13)]  -->
- <!-- TODO: review snippet reference [!code-vb[PropertyMappingWithWfh#13](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#13)]  -->  
+ [!code-csharp[PropertyMappingWithWfh#13](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#13)] 
+ [!code-vb[PropertyMappingWithWfh#13](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#13)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Forms.Integration/WindowsFormsHost.xml
+++ b/xml/System.Windows.Forms.Integration/WindowsFormsHost.xml
@@ -857,8 +857,8 @@
 ## Examples  
  The following code example shows how to add a mapping for the <xref:System.Windows.FrameworkElement.FlowDirection%2A> property to a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)] 
- [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]   
+ [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfhSample/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)] 
+ [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfhSample/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]   
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Forms.Integration/WindowsFormsHost.xml
+++ b/xml/System.Windows.Forms.Integration/WindowsFormsHost.xml
@@ -857,8 +857,8 @@
 ## Examples  
  The following code example shows how to add a mapping for the <xref:System.Windows.FrameworkElement.FlowDirection%2A> property to a <xref:System.Windows.Forms.Integration.WindowsFormsHost> control.  
   
- <!-- TODO: review snippet reference [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)]  -->
- <!-- TODO: review snippet reference [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]  -->  
+ [!code-csharp[PropertyMappingWithWfh#12](~/samples/snippets/csharp/VS_Snippets_Wpf/PropertyMappingWithWfh/CSharp/PropertyMappingWithWfh/Window1.xaml.cs#12)] 
+ [!code-vb[PropertyMappingWithWfh#12](~/samples/snippets/visualbasic/VS_Snippets_Wpf/PropertyMappingWithWfh/VisualBasic/PropertyMappingWithWfh/Window1.xaml.vb#12)]   
   
  ]]></format>
         </remarks>

--- a/xml/System/Console.xml
+++ b/xml/System/Console.xml
@@ -856,7 +856,7 @@
 ## Examples  
  The following example checks whether the console's background color is black and, if it is, it changes the background color to red and the foreground color to black.  
   
- <!-- TODO: review snippet reference [!code-csharp[System.ConsoleColor#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.consolecolor/cs/Example2.cs#2)]  -->
+ [!code-csharp[System.ConsoleColor#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.consolecolor/cs/Example2.cs#2)] 
  [!code-vb[System.ConsoleColor#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.consolecolor/vb/Example2.vb#2)]  
   
  The following example saves the values of the <xref:System.ConsoleColor> enumeration to an array and stores the current values of the <xref:System.Console.BackgroundColor%2A> and <xref:System.Console.ForegroundColor%2A> properties to variables. It then changes the foreground color to each color in the <xref:System.ConsoleColor> enumeration except to the color that matches the current background, and it changes the background color to each color in the <xref:System.ConsoleColor> enumeration except to the color that matches the current foreground. (If the foreground color is the same as the background color, the text isn't visible.) Finally, it calls the <xref:System.Console.ResetColor%2A> method to restore the original console colors.  
@@ -3312,8 +3312,8 @@
 ## Examples  
  The following example uses the `WriteLine` method to demonstrate the standard formatting specifiers for numbers, dates, and enumerations.  
   
- <!-- TODO: review snippet reference [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)]  -->
- [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)]
+ [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)] 
+ [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)] 
  [!code-vb[console.writelineFmt1#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/console.writelineFmt1/vb/wl.vb#1)]  
   
  The following example illustrates the use of the <xref:System.Console.Write%2A> method.  
@@ -3524,7 +3524,7 @@
 ## Examples  
  The following example uses the `WriteLine` method to demonstrate the standard formatting specifiers for numbers, dates, and enumerations.  
   
- <!-- TODO: review snippet reference [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)]  -->
+ [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)] 
  [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)]
  [!code-vb[console.writelineFmt1#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/console.writelineFmt1/vb/wl.vb#1)]  
   
@@ -3603,7 +3603,7 @@
 ## Examples  
  The following example uses the `WriteLine` method to demonstrate the standard formatting specifiers for numbers, dates, and enumerations.  
   
- <!-- TODO: review snippet reference [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)]  -->
+ [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)] 
  [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)]
  [!code-vb[console.writelineFmt1#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/console.writelineFmt1/vb/wl.vb#1)]  
   
@@ -4120,7 +4120,6 @@
 ## Examples  
  The following example uses the <xref:System.Console.WriteLine%28System.Object%29> method to display each value in an object array to the console.  
   
- <!-- TODO: review snippet reference [!code-cpp[System.Console.WriteLine#3](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.Console.WriteLine/CPP/con_writeline.cpp#3)]  -->
  [!code-cpp[System.Console.WriteLine#3](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.Console.WriteLine/CPP/writeline_obj1.cpp#3)]
  [!code-csharp[System.Console.WriteLine#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Console.WriteLine/CS/writeline_obj1.cs#3)]
  [!code-vb[System.Console.WriteLine#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Console.WriteLine/VB/writeline_obj1.vb#3)]  
@@ -4477,7 +4476,7 @@
 ## Examples  
  The following example demonstrates the standard formatting specifiers for numbers, dates, and enumerations.  
   
- <!-- TODO: review snippet reference [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)]  -->
+ [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)] 
  [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)]
  [!code-vb[console.writelineFmt1#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/console.writelineFmt1/vb/wl.vb#1)]  
   
@@ -4609,7 +4608,7 @@
 ## Examples  
  The following example demonstrates the standard formatting specifiers for numbers, dates, and enumerations.  
   
- <!-- TODO: review snippet reference [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)]  -->
+ [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)] 
  [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)]
  [!code-vb[console.writelineFmt1#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/console.writelineFmt1/vb/wl.vb#1)]  
   
@@ -4689,7 +4688,7 @@
 ## Examples  
  The following example demonstrates the standard formatting specifiers for numbers, dates, and enumerations.  
   
- <!-- TODO: review snippet reference [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)]  -->
+ [!code-cpp[console.writelineFmt1#1](~/samples/snippets/cpp/VS_Snippets_CLR/console.writelineFmt1/cpp/wl.cpp#1)] 
  [!code-csharp[console.writelineFmt1#1](~/samples/snippets/csharp/VS_Snippets_CLR/console.writelineFmt1/cs/wl.cs#1)]
  [!code-vb[console.writelineFmt1#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/console.writelineFmt1/vb/wl.vb#1)]  
   


### PR DESCRIPTION
# Title
Fix csharp and vb TODO snippets in the XML branch.

## Summary
This is the first batch of fixes for missing code snippets in the XML branch as part of the ["TODO: Review snippet reference" Task.
](https://github.com/dotnet/docs/search?p=1&q=%22TODO%3A+review+snippet+reference%22&type=&utf8=%E2%9C%93)
These are all references to C# or VB snippets (with one .config snippet). Many of them needed fixes to snippet tags in the code files.

## Suggested Reviewers
@mairaw 

