### PR TITLE
Escaped asterisks in regex quick reference

### DIFF
--- a/docs/standard/base-types/regular-expression-language-quick-reference.md
+++ b/docs/standard/base-types/regular-expression-language-quick-reference.md
@@ -64,7 +64,7 @@ manager: "wpickett"
 |`\x` *nn*|Uses hexadecimal representation to specify a character (*nn* consists of exactly two digits).|`\w\x20\w`|"a b", "c d" in<br /><br /> "a bc d"|  
 |`\c` *X*<br /><br /> `\c` *x*|Matches the ASCII control character that is specified by *X* or *x*, where *X* or *x* is the letter of the control character.|`\cC`|"\x0003" in "\x0003" (Ctrl-C)|  
 |`\u` *nnnn*|Matches a Unicode character by using hexadecimal representation (exactly four digits, as represented by *nnnn*).|`\w\u0020\w`|"a b", "c d" in<br /><br /> "a bc d"|  
-|`\`|When followed by a character that is not recognized as an escaped character in this and other tables in this topic, matches that character. For example, `\*` is the same as `\x2A`, and `\.` is the same as `\x2E`. This allows the regular expression engine to disambiguate language elements (such as * or ?) and character literals (represented by `\*` or `\?`).|`\d+[\+-x\*]\d+`|"2+2" and "3\*9" in "(2+2) \* 3\*9"|  
+|`\`|When followed by a character that is not recognized as an escaped character in this and other tables in this topic, matches that character. For example, `\*` is the same as `\x2A`, and `\.` is the same as `\x2E`. This allows the regular expression engine to disambiguate language elements (such as \* or ?) and character literals (represented by `\*` or `\?`).|`\d+[\+-x\*]\d+`|"2+2" and "3\*9" in "(2+2) \* 3\*9"|  
   
  [Back to top](#top)  
   

--- a/docs/standard/base-types/regular-expression-language-quick-reference.md
+++ b/docs/standard/base-types/regular-expression-language-quick-reference.md
@@ -64,7 +64,7 @@ manager: "wpickett"
 |`\x` *nn*|Uses hexadecimal representation to specify a character (*nn* consists of exactly two digits).|`\w\x20\w`|"a b", "c d" in<br /><br /> "a bc d"|  
 |`\c` *X*<br /><br /> `\c` *x*|Matches the ASCII control character that is specified by *X* or *x*, where *X* or *x* is the letter of the control character.|`\cC`|"\x0003" in "\x0003" (Ctrl-C)|  
 |`\u` *nnnn*|Matches a Unicode character by using hexadecimal representation (exactly four digits, as represented by *nnnn*).|`\w\u0020\w`|"a b", "c d" in<br /><br /> "a bc d"|  
-|`\`|When followed by a character that is not recognized as an escaped character in this and other tables in this topic, matches that character. For example, `\*` is the same as `\x2A`, and `\.` is the same as `\x2E`. This allows the regular expression engine to disambiguate language elements (such as * or ?) and character literals (represented by `\*` or `\?`).|`\d+[\+-x\*]\d+`|"2+2" and "3*9" in "(2+2) \* 3\*9"|  
+|`\`|When followed by a character that is not recognized as an escaped character in this and other tables in this topic, matches that character. For example, `\*` is the same as `\x2A`, and `\.` is the same as `\x2E`. This allows the regular expression engine to disambiguate language elements (such as * or ?) and character literals (represented by `\*` or `\?`).|`\d+[\+-x\*]\d+`|"2+2" and "3\*9" in "(2+2) \* 3\*9"|  
   
  [Back to top](#top)  
   
@@ -114,7 +114,7 @@ manager: "wpickett"
 |------------------------|-----------------|-------------|-------------|  
 |`(` *subexpression* `)`|Captures the matched subexpression and assigns it a one-based ordinal number.|`(\w)\1`|"ee" in "deep"|  
 |`(?<` *name* `>` *subexpression* `)`|Captures the matched subexpression into a named group.|`(?<double>\w)\k<double>`|"ee" in "deep"|  
-|`(?<` *name1* `-` *name2* `>` *subexpression* `)`|Defines a balancing group definition. For more information, see the "Balancing Group Definition" section in [Grouping Constructs](grouping-constructs-in-regular-expressions.md).|`(((?'Open'\()[^\(\)]*)+((?'Close-Open'\))[^\(\)]*)+)*(?(Open)(?!))$`|"((1-3)*(3-1))" in "3+2^((1-3)\*(3-1))"|  
+|`(?<` *name1* `-` *name2* `>` *subexpression* `)`|Defines a balancing group definition. For more information, see the "Balancing Group Definition" section in [Grouping Constructs](grouping-constructs-in-regular-expressions.md).|`(((?'Open'\()[^\(\)]*)+((?'Close-Open'\))[^\(\)]*)+)*(?(Open)(?!))$`|"((1-3)\*(3-1))" in "3+2^((1-3)\*(3-1))"|  
 |`(?:` *subexpression* `)`|Defines a noncapturing group.|`Write(?:Line)?`|"WriteLine" in "Console.WriteLine()"<br /><br /> "Write" in "Console.Write(value)"|  
 |`(?imnsx-imnsx:` *subexpression* `)`|Applies or disables the specified options within *subexpression*. For more information, see [Regular Expression Options](regular-expression-options.md).|`A\d{2}(?i:\w+)\b`|"A12xl", "A12XL" in "A12xl A12XL a12xl"|  
 |`(?=` *subexpression* `)`|Zero-width positive lookahead assertion.|`\w+(?=\.)`|"is", "ran", and "out" in "He is. The dog ran. The sun is out."|  


### PR DESCRIPTION
Without this change, the asterisks are rendered as `<em>` tags.