### PR TITLE
Added a missing letter

### DIFF
--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces.md
@@ -128,7 +128,7 @@ SampleImplementation<Button> button = new SampleImplementation<Button>();
  When you extend a variant generic interface, you have to use the `in` and `out` keywords to explicitly specify whether the derived interface supports variance. The compiler does not infer the variance from the interface that is being extended. For example, consider the following interfaces.  
   
 ```csharp  
-nterface ICovariant<out T> { }  
+interface ICovariant<out T> { }  
 interface IInvariant<T> : ICovariant<T> { }  
 interface IExtCovariant<out T> : ICovariant<T> { }  
 ```  


### PR DESCRIPTION
It was written "nterface" and I added "i" to complete it to "interface". This corrects the code coloring in VS Help Viewer too.
