### PR TITLE
Added missing msprod values to metadata.

### DIFF
--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/add.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/add.md
@@ -2,6 +2,7 @@
 title: "&lt;add&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/audienceuris.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/audienceuris.md
@@ -2,6 +2,7 @@
 title: "&lt;audienceUris&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/caches.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/caches.md
@@ -2,6 +2,7 @@
 title: "&lt;caches&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/certificatereference.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/certificatereference.md
@@ -2,6 +2,7 @@
 title: "&lt;certificateReference&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/certificatevalidation.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/certificatevalidation.md
@@ -2,6 +2,7 @@
 title: "&lt;certificateValidation&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/certificatevalidator.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/certificatevalidator.md
@@ -2,6 +2,7 @@
 title: "&lt;certificateValidator&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/chunkedcookiehandler.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/chunkedcookiehandler.md
@@ -2,6 +2,7 @@
 title: "&lt;chunkedCookieHandler&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimsauthenticationmanager.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimsauthenticationmanager.md
@@ -2,6 +2,7 @@
 title: "&lt;claimsAuthenticationManager&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimsauthorizationmanager.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimsauthorizationmanager.md
@@ -2,6 +2,7 @@
 title: "&lt;claimsAuthorizationManager&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimtype.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimtype.md
@@ -2,6 +2,7 @@
 title: "&lt;claimType&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimtyperequired.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/claimtyperequired.md
@@ -2,6 +2,7 @@
 title: "&lt;claimTypeRequired&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/clear.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/clear.md
@@ -2,6 +2,7 @@
 title: "&lt;clear&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/cookiehandler.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/cookiehandler.md
@@ -2,6 +2,7 @@
 title: "&lt;cookieHandler&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/customcookiehandler.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/customcookiehandler.md
@@ -2,6 +2,7 @@
 title: "&lt;customCookieHandler&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/federationconfiguration.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/federationconfiguration.md
@@ -2,6 +2,7 @@
 title: "&lt;federationConfiguration&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/identityconfiguration.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/identityconfiguration.md
@@ -2,6 +2,7 @@
 title: "&lt;identityConfiguration&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/index.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/index.md
@@ -2,6 +2,7 @@
 title: "Windows Identity Foundation Configuration Schema | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/issuernameregistry.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/issuernameregistry.md
@@ -2,6 +2,7 @@
 title: "&lt;issuerNameRegistry&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/issuertokenresolver.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/issuertokenresolver.md
@@ -2,6 +2,7 @@
 title: "&lt;issuerTokenResolver&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/nameclaimtype.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/nameclaimtype.md
@@ -2,6 +2,7 @@
 title: "&lt;nameClaimType&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/remove.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/remove.md
@@ -2,6 +2,7 @@
 title: "&lt;remove&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/roleclaimtype.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/roleclaimtype.md
@@ -2,6 +2,7 @@
 title: "&lt;roleClaimType&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/samlsecuritytokenrequirement.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/samlsecuritytokenrequirement.md
@@ -2,6 +2,7 @@
 title: "&lt;samlSecurityTokenRequirement&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/securitytokenhandlerconfiguration.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/securitytokenhandlerconfiguration.md
@@ -2,6 +2,7 @@
 title: "&lt;securityTokenHandlerConfiguration&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/securitytokenhandlers.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/securitytokenhandlers.md
@@ -2,6 +2,7 @@
 title: "&lt;securityTokenHandlers&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/servicecertificate.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/servicecertificate.md
@@ -2,6 +2,7 @@
 title: "&lt;serviceCertificate&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/servicetokenresolver.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/servicetokenresolver.md
@@ -2,6 +2,7 @@
 title: "&lt;serviceTokenResolver&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/sessionsecuritytokencache.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/sessionsecuritytokencache.md
@@ -2,6 +2,7 @@
 title: "&lt;sessionSecurityTokenCache&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/sessiontokenrequirement.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/sessiontokenrequirement.md
@@ -2,6 +2,7 @@
 title: "&lt;sessionTokenRequirement&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel-services.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel-services.md
@@ -2,6 +2,7 @@
 title: "&lt;system.identityModel.services&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel.md
@@ -2,6 +2,7 @@
 title: "&lt;system.identityModel&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/tokenreplaycache.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/tokenreplaycache.md
@@ -2,6 +2,7 @@
 title: "&lt;tokenReplayCache&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/tokenreplaydetection.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/tokenreplaydetection.md
@@ -2,6 +2,7 @@
 title: "&lt;tokenReplayDetection&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/trustedissuers.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/trustedissuers.md
@@ -2,6 +2,7 @@
 title: "&lt;trustedIssuers&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/usernamesecuritytokenhandlerrequirement.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/usernamesecuritytokenhandlerrequirement.md
@@ -2,6 +2,7 @@
 title: "&lt;userNameSecurityTokenHandlerRequirement&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/wsfederation.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/wsfederation.md
@@ -2,6 +2,7 @@
 title: "&lt;wsFederation&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/x509securitytokenhandlerrequirement.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/x509securitytokenhandlerrequirement.md
@@ -2,6 +2,7 @@
 title: "&lt;x509SecurityTokenHandlerRequirement&gt; | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/configure-apps/file-schema/winforms/index.md
+++ b/docs/framework/configure-apps/file-schema/winforms/index.md
@@ -2,6 +2,7 @@
 title: "Windows Forms Configuration Section | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""

--- a/docs/framework/configure-apps/file-schema/winforms/windows-forms-add-configuration-element.md
+++ b/docs/framework/configure-apps/file-schema/winforms/windows-forms-add-configuration-element.md
@@ -2,6 +2,7 @@
 title: "Windows Forms Add Configuration Element | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""

--- a/docs/framework/migration-guide/mitigation-cspparameters-parentwindowhandle-expects-an-hwnd.md
+++ b/docs/framework/migration-guide/mitigation-cspparameters-parentwindowhandle-expects-an-hwnd.md
@@ -2,6 +2,7 @@
 title: "Mitigation: CspParameters.ParentWindowHandle Expects an HWND | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""

--- a/docs/framework/migration-guide/mitigation-grid-control.md
+++ b/docs/framework/migration-guide/mitigation-grid-control.md
@@ -2,6 +2,7 @@
 title: "Mitigation: Grid Control&#39;s Space Allocation to Star-columns | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""

--- a/docs/framework/migration-guide/mitigation-pointer-based-touch-and-stylus-support.md
+++ b/docs/framework/migration-guide/mitigation-pointer-based-touch-and-stylus-support.md
@@ -2,6 +2,7 @@
 title: "Mitigation: Pointer-based Touch and Stylus Support | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""

--- a/docs/framework/migration-guide/mitigation-serialization-control-characters.md
+++ b/docs/framework/migration-guide/mitigation-serialization-control-characters.md
@@ -2,6 +2,7 @@
 title: "Mitigation: Serialization of Control Characters with the DataContractJsonSerializer | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""

--- a/docs/framework/security/building-my-first-claims-aware-aspnet-web-app.md
+++ b/docs/framework/security/building-my-first-claims-aware-aspnet-web-app.md
@@ -2,6 +2,7 @@
 title: "Building My First Claims-Aware ASP.NET Web Application | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/building-my-first-claims-aware-wcf-service.md
+++ b/docs/framework/security/building-my-first-claims-aware-wcf-service.md
@@ -2,6 +2,7 @@
 title: "Building My First Claims-Aware WCF Service | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/claims-aware-aspnet-app-forms-authentication.md
+++ b/docs/framework/security/claims-aware-aspnet-app-forms-authentication.md
@@ -2,6 +2,7 @@
 title: "How To: Build Claims-Aware ASP.NET Application Using Forms-Based Authentication | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/claims-based-authorization-using-wif.md
+++ b/docs/framework/security/claims-based-authorization-using-wif.md
@@ -2,6 +2,7 @@
 title: "Claims Based Authorization Using WIF | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/claims-based-identity-model.md
+++ b/docs/framework/security/claims-based-identity-model.md
@@ -2,6 +2,7 @@
 title: "Claims-Based Identity Model | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/custom-token-handlers.md
+++ b/docs/framework/security/custom-token-handlers.md
@@ -2,6 +2,7 @@
 title: "Custom Token Handlers | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/downloading-the-json-web-token-handler-package.md
+++ b/docs/framework/security/downloading-the-json-web-token-handler-package.md
@@ -2,6 +2,7 @@
 title: "Downloading the JSON Web Token Handler Package | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/downloading-the-validating-issuer-name-registry-package.md
+++ b/docs/framework/security/downloading-the-validating-issuer-name-registry-package.md
@@ -2,6 +2,7 @@
 title: "Downloading the Validating Issuer Name Registry Package | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/getting-started-with-wif.md
+++ b/docs/framework/security/getting-started-with-wif.md
@@ -2,6 +2,7 @@
 title: "Getting Started With WIF | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/guidelines-for-migrating-an-application-built-using-wif-3-5-to-wif-4-5.md
+++ b/docs/framework/security/guidelines-for-migrating-an-application-built-using-wif-3-5-to-wif-4-5.md
@@ -2,6 +2,7 @@
 title: "Guidelines for Migrating an Application Built Using WIF 3.5 to WIF 4.5 | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-build-claims-aware-aspnet-app-using-windows-authentication.md
+++ b/docs/framework/security/how-to-build-claims-aware-aspnet-app-using-windows-authentication.md
@@ -2,6 +2,7 @@
 title: "How To: Build Claims-Aware ASP.NET Application Using Windows Authentication | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-build-claims-aware-aspnet-mvc-web-app-using-wif.md
+++ b/docs/framework/security/how-to-build-claims-aware-aspnet-mvc-web-app-using-wif.md
@@ -2,6 +2,7 @@
 title: "How To: Build Claims-Aware ASP.NET MVC Web Application Using WIF | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-build-claims-aware-aspnet-web-forms-app-using-wif.md
+++ b/docs/framework/security/how-to-build-claims-aware-aspnet-web-forms-app-using-wif.md
@@ -2,6 +2,7 @@
 title: "How To: Build Claims-Aware ASP.NET Web Forms Application Using WIF | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-debug-claims-aware-applications-and-services-using-wif-tracing.md
+++ b/docs/framework/security/how-to-debug-claims-aware-applications-and-services-using-wif-tracing.md
@@ -2,6 +2,7 @@
 title: "How To: Debug Claims-Aware Applications And Services Using WIF Tracing | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-display-signed-in-status-using-wif.md
+++ b/docs/framework/security/how-to-display-signed-in-status-using-wif.md
@@ -2,6 +2,7 @@
 title: "How To: Display Signed In Status Using WIF | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-enable-token-replay-detection.md
+++ b/docs/framework/security/how-to-enable-token-replay-detection.md
@@ -2,6 +2,7 @@
 title: "How To: Enable Token Replay Detection | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-enable-wif-for-a-wcf-web-service-application.md
+++ b/docs/framework/security/how-to-enable-wif-for-a-wcf-web-service-application.md
@@ -2,6 +2,7 @@
 title: "How To: Enable WIF for a WCF Web Service Application | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-enable-wif-tracing.md
+++ b/docs/framework/security/how-to-enable-wif-tracing.md
@@ -2,6 +2,7 @@
 title: "How To: Enable WIF Tracing | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/how-to-transform-incoming-claims.md
+++ b/docs/framework/security/how-to-transform-incoming-claims.md
@@ -2,6 +2,7 @@
 title: "How To: Transform Incoming Claims | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/identity-and-access-tool-for-vs.md
+++ b/docs/framework/security/identity-and-access-tool-for-vs.md
@@ -2,6 +2,7 @@
 title: "Identity and Access Tool for Visual Studio 2012 | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/index.md
+++ b/docs/framework/security/index.md
@@ -2,6 +2,7 @@
 title: "Windows Identity Foundation | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/json-web-token-handler-api-reference.md
+++ b/docs/framework/security/json-web-token-handler-api-reference.md
@@ -2,6 +2,7 @@
 title: "JSON Web Token Handler API Reference | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/json-web-token-handler.md
+++ b/docs/framework/security/json-web-token-handler.md
@@ -2,6 +2,7 @@
 title: "JSON Web Token Handler | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/namespace-mapping-between-wif-3-5-and-wif-4-5.md
+++ b/docs/framework/security/namespace-mapping-between-wif-3-5-and-wif-4-5.md
@@ -2,6 +2,7 @@
 title: "Namespace Mapping between WIF 3.5 and WIF 4.5 | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/validating-issuer-name-registry-api-reference.md
+++ b/docs/framework/security/validating-issuer-name-registry-api-reference.md
@@ -2,6 +2,7 @@
 title: "Validating Issuer Name Registry API Reference | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/validating-issuer-name-registry.md
+++ b/docs/framework/security/validating-issuer-name-registry.md
@@ -2,6 +2,7 @@
 title: "Validating Issuer Name Registry | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/whats-new-in-wif.md
+++ b/docs/framework/security/whats-new-in-wif.md
@@ -2,6 +2,7 @@
 title: "What&#39;s New in Windows Identity Foundation 4.5 | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-and-web-farms.md
+++ b/docs/framework/security/wif-and-web-farms.md
@@ -2,6 +2,7 @@
 title: "WIF and Web Farms | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-api-reference.md
+++ b/docs/framework/security/wif-api-reference.md
@@ -2,6 +2,7 @@
 title: "WIF API Reference | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-claims-programming-model.md
+++ b/docs/framework/security/wif-claims-programming-model.md
@@ -2,6 +2,7 @@
 title: "WIF Claims Programming Model | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-code-sample-index.md
+++ b/docs/framework/security/wif-code-sample-index.md
@@ -2,6 +2,7 @@
 title: "WIF Code Sample Index | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-configuration-reference.md
+++ b/docs/framework/security/wif-configuration-reference.md
@@ -2,6 +2,7 @@
 title: "WIF Configuration Reference | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-configuration-schema-conventions.md
+++ b/docs/framework/security/wif-configuration-schema-conventions.md
@@ -2,6 +2,7 @@
 title: "WIF Configuration Schema Conventions | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-extensions.md
+++ b/docs/framework/security/wif-extensions.md
@@ -2,6 +2,7 @@
 title: "WIF Extensions | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-features.md
+++ b/docs/framework/security/wif-features.md
@@ -2,6 +2,7 @@
 title: "WIF Features | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-guidelines.md
+++ b/docs/framework/security/wif-guidelines.md
@@ -2,6 +2,7 @@
 title: "WIF Guidelines | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-how-tos-index.md
+++ b/docs/framework/security/wif-how-tos-index.md
@@ -2,6 +2,7 @@
 title: "WIF How-To&#39;s Index | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-overview.md
+++ b/docs/framework/security/wif-overview.md
@@ -2,6 +2,7 @@
 title: "Windows Identity Foundation 4.5 Overview | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wif-session-management.md
+++ b/docs/framework/security/wif-session-management.md
@@ -2,6 +2,7 @@
 title: "WIF Session Management | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wsfederation-authentication-module-overview.md
+++ b/docs/framework/security/wsfederation-authentication-module-overview.md
@@ -2,6 +2,7 @@
 title: "WSFederation Authentication Module Overview | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/security/wstrustchannelfactory-and-wstrustchannel.md
+++ b/docs/framework/security/wstrustchannelfactory-and-wstrustchannel.md
@@ -2,6 +2,7 @@
 title: "WSTrustChannelFactory and WSTrustChannel | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.technology: 

--- a/docs/framework/winforms/high-dpi-support-in-windows-forms.md
+++ b/docs/framework/winforms/high-dpi-support-in-windows-forms.md
@@ -2,6 +2,7 @@
 title: "High DPI Support In Windows Forms | Microsoft Docs"
 ms.custom: ""
 ms.date: "04/07/2017"
+ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
 ms.tgt_pltfrm: ""


### PR DESCRIPTION
# Title
Added missing msprod values to metadata.

## Summary
I added the metadata value: ms.prod: ".net-framework"
For each topic listed in this spreadsheet: 
[missing_msprod.xlsx](https://github.com/dotnet/docs/files/971987/missing_msprod.xlsx)

I could not find these two topics (marked in red in the spreadsheet):
MEF Namespaces for .NET for Windows Store Apps (Asset ID: a9539685-cefe-449f-b243-5f1593b70030)  
.NET Framework Class Library:  (Asset ID: 76ee440c-7f7a-4ca6-bf78-498363162779)

Fixes #2061 

## Suggested Reviewers
@mairaw 

