### PR TITLE
Add notes to use platform agnostic RSA.Create

### DIFF
--- a/xml/System.Security.Cryptography/RSACng.xml
+++ b/xml/System.Security.Cryptography/RSACng.xml
@@ -34,7 +34,7 @@
 -   <xref:System.Security.Cryptography.RSACng> performs such operations as signing and verifying signatures by using properties of the <xref:System.Security.Cryptography.RSACng> object, just as <xref:System.Security.Cryptography.ECDsaCng> uses its object properties to control signing and verification operations.  
 
 > [!NOTE]
-> The <xref:System.Security.Cryptography.RSACng> class is a CNG implementation for Windows platforms. In a cross-platform scenario, you should use the platform agnostic <xref:System.Security.Cryptography.RSA.Create%2A?displayProperty=fullName> to create an instance of the default implementation for the platform where your code will run.
+> The <xref:System.Security.Cryptography.RSACng> class is an implementation of the RSA algorithm using the Windows CNG libraries and isn't available on operating systems other than Windows. For applications which aren't doing Windows interop, you're encouraged to use <xref:System.Security.Cryptography.RSA.Create%2A?displayProperty=fullName> instead of referencing this type directly.
   
  ]]></format>
     </remarks>

--- a/xml/System.Security.Cryptography/RSACng.xml
+++ b/xml/System.Security.Cryptography/RSACng.xml
@@ -32,6 +32,9 @@
 -   The key used by <xref:System.Security.Cryptography.RSACng> is managed by a separate <xref:System.Security.Cryptography.CngKey> object. In contrast, <xref:System.Security.Cryptography.RSACryptoServiceProvider> has a key that is directly tied to the operations of the type itself.  
   
 -   <xref:System.Security.Cryptography.RSACng> performs such operations as signing and verifying signatures by using properties of the <xref:System.Security.Cryptography.RSACng> object, just as <xref:System.Security.Cryptography.ECDsaCng> uses its object properties to control signing and verification operations.  
+
+> [!NOTE]
+> The <xref:System.Security.Cryptography.RSACng> class is a CNG implementation for Windows platforms. In a cross-platform scenario, you should use the platform agnostic <xref:System.Security.Cryptography.RSA.Create%2A?displayProperty=fullName> to create an instance of the default implementation for the platform where your code will run.
   
  ]]></format>
     </remarks>

--- a/xml/System.Security.Cryptography/RSAOpenSsl.xml
+++ b/xml/System.Security.Cryptography/RSAOpenSsl.xml
@@ -17,7 +17,7 @@
   
 ## Remarks  
 > [!NOTE]
-> The <xref:System.Security.Cryptography.RSAOpenSsl> class is a CNG implementation for Linux and macOS platforms. In a cross-platform scenario, you should use the platform agnostic <xref:System.Security.Cryptography.RSA.Create%2A?displayProperty=fullName> to create an instance of the default implementation for the platform where your code will run.
+> The <xref:System.Security.Cryptography.RSAOpenSsl> class is an implementation of the RSA algorithm using OpenSSL. It isn't available on Windows and is only available on other operating systems when OpenSSL is installed. For applications which aren't doing OpenSSL-specific interop, you're encouraged to use <xref:System.Security.Cryptography.RSA.Create%2A?displayProperty=fullName> instead of referencing this type directly.
   
  ]]></format>
     </remarks>

--- a/xml/System.Security.Cryptography/RSAOpenSsl.xml
+++ b/xml/System.Security.Cryptography/RSAOpenSsl.xml
@@ -12,7 +12,15 @@
   <Interfaces />
   <Docs>
     <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+> [!NOTE]
+> The <xref:System.Security.Cryptography.RSAOpenSsl> class is a CNG implementation for Linux and macOS platforms. In a cross-platform scenario, you should use the platform agnostic <xref:System.Security.Cryptography.RSA.Create%2A?displayProperty=fullName> to create an instance of the default implementation for the platform where your code will run.
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">


### PR DESCRIPTION
Fixes #824 

Adds notes to `System.Security.Cryptography,RSACng` and `System.Security.Cryptography.RSAOpenSsl` instructing devs to use `RSA.Create` (platform agnostic) in xplat scenarios.

cc/ @joshfree @bartonjs