### PR TITLE
Update classes-and-objects.md

### DIFF
--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -63,9 +63,9 @@ Each member of a class has an associated accessibility, which controls the regio
 * `protected`
 	- Access limited to this class or classes derived from this class
 * `internal`
-	- Access limited to this Assembly (.exe, .dll etc.)
+	- Access limited to the current assembly (.exe, .dll, etc.)
 * `protected internal`
-	- Access limited to this Assembly (.exe, .dll etc.) or classes derived from this class
+	- Access limited to the containing class or classes derived from the containing class
 * `private`
 	- Access limited to this class
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -63,9 +63,9 @@ Each member of a class has an associated accessibility, which controls the regio
 * `protected`
 	- Access limited to this class or classes derived from this class
 * `internal`
-	- Access limited to this program
+	- Access limited to this Assembly (.exe, .dll etc.)
 * `protected internal`
-	- Access limited to this program or classes derived from this class
+	- Access limited to this Assembly (.exe, .dll etc.) or classes derived from this class
 * `private`
 	- Access limited to this class
 


### PR DESCRIPTION
A Program in .Net can be composed of none, one or several Dlls. Each Dll is an Assembly. So the "Access limited to this Program" would be incorrent and it can drive the Programmer to an incorrect or misundertood interpretation of the internal modifier.
reference: (my experience and https://msdn.microsoft.com/en-us/library/7c5ka91b.aspx)

# Title

Corretion on Accessibility "internal" to avoid misunderstood or incorrect concept

## Summary

The way that internal modifier is explained here can lead to misunderstand and it should be explained in a better way.

## Details

The original documentation is: "protected internal - Access limited to this program or classes derived from this class"
This might lead the Developer to think that internal modifier is used on Program scope which is incorret. internal modifier means that the object is visible in the current Assembly not Program, since the Program can contain several assemblies. 
I suggest change Program for assembly unless you define Program = Assembly
