### PR TITLE
dotnet new --auth not --autentification

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -92,7 +92,7 @@ Each project template may have additional options available. The core templates 
 
 `-f|--framework` - Specifies the [framework](../../standard/frameworks.md) to target. Values: `netcoreapp1.0` or `netcoreapp1.1` (`Default: netcoreapp1.0`)
 
-`-au|--authentication` - The type of authentication to use. Values: `None` or `Individual` (Default: `None`)
+`-au|--auth` - The type of authentication to use. Values: `None` or `Individual` (Default: `None`)
 
 `-uld|--use-local-db` - Specifies whether or not to use LocalDB instead of SQLite. Values: `true` or `false` (Default: `false`)
 


### PR DESCRIPTION
# Title
current cli don't recognize --autentification key, only --auth

## Summary
current cli don't recognize --autentification key, only --auth

## Details
![image](https://cloud.githubusercontent.com/assets/578954/25718978/ab7d56c4-3110-11e7-972a-286f059f21b4.png)
dotnet new mvc --authentication Individual
Invalid input switch:
  --authentication
Template Instantiation Commands for .NET Core CLI.

Usage: dotnet new [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         List templates containing the specified name.                                                         -lang|--language  Specifies the language of the template to create
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  -all|--show-all   Shows all templates


ASP.NET Core Web App (C#)
Author: Microsoft
Options:
  -au|--auth           The type of authentication to use
                           None          - No authentication
                           Individual    - Individual authentication
                       Default: None

  -uld|--use-local-db  Whether or not to use LocalDB instead of SQLite
                       bool - Optional
                       Default: false

  -f|--framework
                           netcoreapp1.0    - Target netcoreapp1.0
                           netcoreapp1.1    - Target netcoreapp1.1
                       Default: netcoreapp1.1
## Suggested Reviewers

If you know who should review this, use '@' to request a review.


