### PR TITLE
Add overwrite note to summary of File.​Create​Text

### DIFF
--- a/xml/System.IO/File.xml
+++ b/xml/System.IO/File.xml
@@ -886,7 +886,7 @@
       </Parameters>
       <Docs>
         <param name="path">The file to be opened for writing.</param>
-        <summary>Creates or opens a file for writing UTF-8 encoded text.</summary>
+        <summary>Creates or opens a file for writing UTF-8 encoded text. If the file already exists, its contents are overwritten.</summary>
         <returns>A <see cref="T:System.IO.StreamWriter" /> that writes to the specified file using UTF-8 encoding.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  


### PR DESCRIPTION
Fixes #1937 

Adds overwrite note to the summary of `File.​Create​Text`.