### PR TITLE
Update Iterator.cs

### DIFF
--- a/samples/snippets/csharp/new-in-7/Iterator.cs
+++ b/samples/snippets/csharp/new-in-7/Iterator.cs
@@ -11,9 +11,9 @@ namespace new_in_7
         #region 25_IteratorMethod
         public static IEnumerable<char> AlphabetSubset(char start, char end)
         {
-            if ((start < 'a') || (start > 'z'))
+            if (start < 'a' || start > 'z')
                 throw new ArgumentOutOfRangeException(paramName: nameof(start), message: "start must be a letter");
-            if ((end < 'a') || (end > 'z'))
+            if (end < 'a' || end > 'z')
                 throw new ArgumentOutOfRangeException(paramName: nameof(end), message: "end must be a letter");
 
             if (end <= start)
@@ -26,9 +26,9 @@ namespace new_in_7
         #region 27_IteratorMethodRefactored
         public static IEnumerable<char> AlphabetSubset2(char start, char end)
         {
-            if ((start < 'a') || (start > 'z'))
+            if (start < 'a' || start > 'z')
                 throw new ArgumentOutOfRangeException(paramName: nameof(start), message: "start must be a letter");
-            if ((end < 'a') || (end > 'z'))
+            if (end < 'a' || end > 'z')
                 throw new ArgumentOutOfRangeException(paramName: nameof(end), message: "end must be a letter");
 
             if (end <= start)
@@ -46,9 +46,9 @@ namespace new_in_7
         #region 28_IteratorMethodLocal
         public static IEnumerable<char> AlphabetSubset3(char start, char end)
         {
-            if ((start < 'a') || (start > 'z'))
+            if (start < 'a' || start > 'z')
                 throw new ArgumentOutOfRangeException(paramName: nameof(start), message: "start must be a letter");
-            if ((end < 'a') || (end > 'z'))
+            if (end < 'a' || end > 'z')
                 throw new ArgumentOutOfRangeException(paramName: nameof(end), message: "end must be a letter");
 
             if (end <= start)


### PR DESCRIPTION
I believe the use of parenthesis in obvious cases where they're not needed (i.e. 3 + (4 * 5)) increase the cognitive burden. Granted, a very little bit but when reading a lot of code where too many of the expressions includes obviously useless parenthesis, it does impact the reading/understanding (i.e. Am I misunderstanding something?)