### PR TITLE
Fix list formatting in Request​Validator.​Is​Valid​Request​String Method

### DIFF
--- a/xml/System.Web.Util/RequestValidator.xml
+++ b/xml/System.Web.Util/RequestValidator.xml
@@ -180,7 +180,14 @@
         <param name="value">The HTTP request data to validate.</param>
         <param name="requestValidationSource">An enumeration that represents the source of request data that is being validated. The following are possible values for the enumeration:  
   
- <see langword="QueryString" /><see langword="Form " /><see langword="Cookies" /><see langword="Files" /><see langword="RawUrl" /><see langword="Path" /><see langword="PathInfo" /><see langword="Headers" /></param>
+- <see langword="QueryString" />
+- <see langword="Form " />
+- <see langword="Cookies" />
+- <see langword="Files" />
+- <see langword="RawUrl" />
+- <see langword="Path" />
+- <see langword="PathInfo" />
+- <see langword="Headers" /></param>
         <param name="collectionKey">The key in the request collection of the item to validate. This parameter is optional. This parameter is used if the data to validate is obtained from a collection. If the data to validate is not from a collection, <c>collectionKey</c> can be <see langword="null" />.</param>
         <param name="validationFailureIndex">When this method returns, indicates the zero-based starting point of the problematic or invalid text in the request collection. This parameter is passed uninitialized.</param>
         <summary>Validates a string that contains HTTP request data.</summary>


### PR DESCRIPTION
See the `requestValidationSource` parameter in the documentation for [`Request​Validator.​Is​Valid​Request​String`](https://docs.microsoft.com/en-us/dotnet/api/system.web.util.requestvalidator.isvalidrequeststring?view=netframework-4.7) and compare it with [`Request​Validator.​Invoke​Is​Valid​Request​String`](https://docs.microsoft.com/en-us/dotnet/api/system.web.util.requestvalidator.invokeisvalidrequeststring?view=netframework-4.7), which is already formatted properly.