### PR TITLE
Cache Font

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Winforms/Control.Paint/CS/form1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Winforms/Control.Paint/CS/form1.cs
@@ -32,6 +32,10 @@ namespace ControlPaintEx
         {
             if( disposing )
             {
+                if (fnt != null)
+                {
+                    fnt.Dispose();
+                }
                 if (components != null)
                 {
                     components.Dispose();
@@ -73,6 +77,8 @@ namespace ControlPaintEx
         // connected to the Load event of the form.
 
         private PictureBox pictureBox1 = new PictureBox();
+        // Cache font instead of recreating font objects each time we paint.
+        private Font fnt = new Font("Arial",10);
         private void Form1_Load(object sender, System.EventArgs e)
         {
             // Dock the PictureBox to the form and set its background to white.
@@ -92,7 +98,7 @@ namespace ControlPaintEx
 
             // Draw a string on the PictureBox.
             g.DrawString("This is a diagonal line drawn on the control",
-                new Font("Arial",10), System.Drawing.Brushes.Blue, new Point(30,30));
+                fnt, System.Drawing.Brushes.Blue, new Point(30,30));
             // Draw a line in the PictureBox.
             g.DrawLine(System.Drawing.Pens.Red, pictureBox1.Left, pictureBox1.Top,
                 pictureBox1.Right, pictureBox1.Bottom);

--- a/samples/snippets/visualbasic/VS_Snippets_Winforms/Control.Paint/VB/form1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Winforms/Control.Paint/VB/form1.vb
@@ -31,7 +31,10 @@ Public Class Form1
     '/ </summary>
     Protected Overloads Overrides Sub Dispose(ByVal disposing As Boolean)
         If disposing Then
-            If (components IsNot Nothing) Then
+            If fnt IsNot Nothing Then
+                fnt.Dispose()
+            End If
+            If components IsNot Nothing Then
                 components.Dispose()
             End If
         End If
@@ -65,6 +68,7 @@ Public Class Form1
     ' This example assumes that the Form_Load event handler method is connected 
     ' to the Load event of the form.
     Private pictureBox1 As New PictureBox()
+    Private fnt as New Font("Arial", 10)
 
     Private Sub Form1_Load(ByVal sender As Object, ByVal e As System.EventArgs) Handles MyBase.Load
         ' Dock the PictureBox to the form and set its background to white.
@@ -84,7 +88,7 @@ Public Class Form1
 
         ' Draw a string on the PictureBox.
         g.DrawString("This is a diagonal line drawn on the control", _
-            New Font("Arial", 10), Brushes.Red, New PointF(30.0F, 30.0F))
+            fnt, Brushes.Red, New PointF(30.0F, 30.0F))
         ' Draw a line in the PictureBox.
         g.DrawLine(System.Drawing.Pens.Red, pictureBox1.Left, _ 
             pictureBox1.Top, pictureBox1.Right, pictureBox1.Bottom)


### PR DESCRIPTION

# Font Cache
Don't create new Font objects on each Paint.

## Summary

Show the right way to create the Font object and cache it.

## Details

Created a cached Font object that is disposed when the Form is disposed.  This prevents fonts from being created on every Paint.
## Suggested Reviewers

If you know who should review this, use '@' to request a review.
