### PR TITLE
Fix typo in unit-testing-with-dotnet-test.md

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -43,7 +43,7 @@ namespace Prime.Services
 
 ### Creating the test project
 
-Change the directory back to the *unit-testing-using-dotnet-test* directory and create the *PrimeServices.Tests* directory. The directory structure is shown below:
+Change the directory back to the *unit-testing-using-dotnet-test* directory and create the *PrimeService.Tests* directory. The directory structure is shown below:
 
 ```
 /unit-testing-using-dotnet-test

--- a/docs/core/testing/unit-testing-with-mstest.md
+++ b/docs/core/testing/unit-testing-with-mstest.md
@@ -43,7 +43,7 @@ namespace Prime.Services
 
 ### Creating the test project
 
-Change the directory back to the *unit-testing-using-mstest* directory and create the *PrimeServices.Tests* directory. The directory structure is shown below:
+Change the directory back to the *unit-testing-using-mstest* directory and create the *PrimeService.Tests* directory. The directory structure is shown below:
 
 ```
 /unit-testing-using-mstest


### PR DESCRIPTION
# Fixed a typo in the name of a directory in the tutorial.

## Details
I have fixed a typo in the name of the directory we have to create to follow the tutorial. 
In latter steps the directory is named "PrimeService.Tests", not "PrimeServices.Tests".
