### PR TITLE
Added the "Constant Visitor" class

### DIFF
--- a/docs/csharp/expression-trees-interpreting.md
+++ b/docs/csharp/expression-trees-interpreting.md
@@ -217,6 +217,23 @@ public class ParameterVisitor : Visitor
         Console.WriteLine($"{prefix}Type: {node.Type.ToString()}, Name: {node.Name}, ByRef: {node.IsByRef}");
     }
 }
+
+// Constant visitor:
+public class ConstantVisitor : Visitor
+{
+    private readonly ConstantExpression node;
+    public ConstantVisitor(ConstantExpression node) : base(node)
+    {
+        this.node = node;
+    }
+
+    public override void Visit(string prefix)
+    {
+        Console.WriteLine($"{prefix}This is an {NodeType} expression type");
+        Console.WriteLine($"{prefix}The type of the constant value is {node.Type}");
+        Console.WriteLine($"{prefix}The value of the constant value is {node.Value}");
+    }
+}
 ```
 
 This algorithm is the basis of an algorithm that can visit


### PR DESCRIPTION
# Add `ConstantVisitor` class to the sample code

Although the sample code used this class, it was not defined in the sample code. I've written it so that it produces the same output (as shown in the docs) when it's run.