### PR TITLE
Added clarification about app domain.

### DIFF
--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -5178,7 +5178,7 @@ index[,alignment][ :formatString] }
 > [!IMPORTANT]
 >  If two string objects are equal, the <xref:System.String.GetHashCode%2A> method returns identical values. However, there is not a unique hash code value for each unique string value. Different strings can return the same hash code.  
 >   
->  The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of the .NET Framework and across platforms (such as 32-bit and 64-bit) for a single version of the .NET Framework. In some cases, they can even differ by application domain.  
+>  The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of the .NET Framework and across platforms (such as 32-bit and 64-bit) for a single version of the .NET Framework. In some cases, they can even differ by application domain. This implies two subsequent runs of the same program will return different hashes.  
 >   
 >  As a result, hash codes should never be used outside of the application domain in which they were created, they should never be used as key fields in a collection, and they should never be persisted.  
 >   

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -5178,7 +5178,7 @@ index[,alignment][ :formatString] }
 > [!IMPORTANT]
 >  If two string objects are equal, the <xref:System.String.GetHashCode%2A> method returns identical values. However, there is not a unique hash code value for each unique string value. Different strings can return the same hash code.  
 >   
->  The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of the .NET Framework and across platforms (such as 32-bit and 64-bit) for a single version of the .NET Framework. In some cases, they can even differ by application domain. This implies two subsequent runs of the same program will return different hashes.  
+>  The hash code itself is not guaranteed to be stable. Hash codes for identical strings can differ across versions of the .NET Framework and across platforms (such as 32-bit and 64-bit) for a single version of the .NET Framework. In some cases, they can even differ by application domain. This implies two subsequent runs of the same program may return different hash codes.  
 >   
 >  As a result, hash codes should never be used outside of the application domain in which they were created, they should never be used as key fields in a collection, and they should never be persisted.  
 >   


### PR DESCRIPTION
That two subsequent runs will change the application domain which in turn will create a new hash for (string).GetHashCode() came to a surprise to me.

I filed bug [#19703](https://github.com/dotnet/corefx/issues/19703), which probably is moot.  
So I instead suggest a clarification in the documentation.

Is it worth going through other (type).GetHashCode documentation too?  
Should the same for Core2 be updated?