### PR TITLE
Fixed incorrectly marked code blocks in docs and xml.

### DIFF
--- a/docs/framework/data/adonet/dataset-datatable-dataview/the-load-method.md
+++ b/docs/framework/data/adonet/dataset-datatable-dataview/the-load-method.md
@@ -30,9 +30,7 @@ You can use the <xref:System.Data.DataTable.Load%2A> method to load a <xref:Syst
   
  The following sample uses the **Load** method to display a list of birthdays for the employees in the **Northwind** database.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Private Sub LoadBirthdays(ByVal connectionString As String)  
     ' Assumes that connectionString is a valid connection string  
     ' to the Northwind database on SQL Server.  

--- a/docs/framework/data/adonet/getschema-and-schema-collections.md
+++ b/docs/framework/data/adonet/getschema-and-schema-collections.md
@@ -26,9 +26,7 @@ The **Connection** classes in each of the .NET Framework managed providers imple
 ### Retrieving Schema Collections Example  
  The following examples demonstrate how to use the <xref:System.Data.SqlClient.SqlConnection.GetSchema%2A> method of the .NET Framework Data Provider for the SQL Server <xref:System.Data.SqlClient.SqlConnection> class to retrieve schema information about all of the tables contained in the **AdventureWorks** sample database:  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Imports System.Data.SqlClient  
   
 Module Module1  
@@ -64,9 +62,7 @@ Module Module1
 End Module  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.Data;  
 using System.Data.SqlClient;  

--- a/docs/framework/data/adonet/oracle-lobs.md
+++ b/docs/framework/data/adonet/oracle-lobs.md
@@ -31,9 +31,7 @@ The .NET Framework Data Provider for Oracle includes the <xref:System.Data.Oracl
 ## Creating, Retrieving, and Writing to a LOB  
  The following C# example demonstrates how you can create LOBs in an Oracle table, and then retrieve and write to them in the form of **OracleLob** objects. The example demonstrates using the <xref:System.Data.OracleClient.OracleDataReader> object and the **OracleLob** **Read** and **Write** methods. The example uses Oracle **BLOB**, **CLOB**, and **NCLOB** data types.  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.IO;              
 using System.Text;             
@@ -226,9 +224,7 @@ public class LobExample
 ## Creating a Temporary LOB  
  The following C# example demonstrates how to create a temporary LOB.  
   
- [C#]  
-  
-```  
+```csharp  
 OracleConnection conn = new OracleConnection(  
   "server=test8172; integrated security=yes;");  
 conn.Open();  

--- a/docs/framework/data/adonet/schema-restrictions.md
+++ b/docs/framework/data/adonet/schema-restrictions.md
@@ -41,9 +41,7 @@ The second optional parameter of the **GetSchema** method is the restrictions th
 ### Example  
  The following examples demonstrate how to use the <xref:System.Data.SqlClient.SqlConnection.GetSchema%2A> method of the .NET Framework Data Provider for the SQL Server <xref:System.Data.SqlClient.SqlConnection> class to retrieve schema information about all of the tables contained in the **AdventureWorks** sample database, and to restrict the information returned to only those tables in the "Sales" schema:  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Imports System.Data.SqlClient  
   
 Module Module1  
@@ -75,9 +73,7 @@ End Sub
 End Module  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.Data;  
 using System.Data.SqlClient;  

--- a/docs/framework/data/adonet/sql/aspnet-apps-using-wait-handles.md
+++ b/docs/framework/data/adonet/sql/aspnet-apps-using-wait-handles.md
@@ -31,9 +31,7 @@ The callback and polling models for handling asynchronous operations are useful 
   
  Add the following code to the form's class, modifying the connection string as necessary for your environment.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 ' Add these to the top of the class  
 Imports System  
 Imports System.Data  
@@ -164,9 +162,7 @@ Imports System.Threading
     End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 // Add the following using statements, if they are not already there.  
 using System;  
 using System.Data;  
@@ -328,9 +324,7 @@ void Button1_Click(object sender, System.EventArgs e)
   
  Add the following code to the form's class, modifying the connection string as necessary for your environment.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 ' Add these to the top of the class  
 Imports System  
 Imports System.Data  
@@ -451,9 +445,7 @@ Imports System.Threading
     End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 // Add the following using statements, if they are not already there.  
 using System;  
 using System.Data;  

--- a/docs/framework/data/adonet/sql/polling-in-console-applications.md
+++ b/docs/framework/data/adonet/sql/polling-in-console-applications.md
@@ -23,9 +23,7 @@ Asynchronous operations in ADO.NET allow you to initiate time-consuming database
 ## Example  
  The following console application updates data within the **AdventureWorks** sample database, doing its work asynchronously. In order to emulate a long-running process, this example inserts a WAITFOR statement in the command text. Normally, you would not try to make your commands run slower, but doing so in this case makes it easier to demonstrate asynchronous behavior.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Imports System  
 Imports System.Data.SqlClient  
   
@@ -101,9 +99,7 @@ Module Module1
 End Module   
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.Data;  
 using System.Data.SqlClient;  

--- a/docs/framework/data/adonet/sql/provider-statistics-for-sql-server.md
+++ b/docs/framework/data/adonet/sql/provider-statistics-for-sql-server.md
@@ -124,9 +124,7 @@ Module Module1
 End Module  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.Collections;  
 using System.Collections.Generic;  

--- a/docs/framework/data/adonet/sql/specifying-xml-values-as-parameters.md
+++ b/docs/framework/data/adonet/sql/specifying-xml-values-as-parameters.md
@@ -28,7 +28,7 @@ If a query requires a parameter whose value is an XML string, developers can sup
   
  To create the file needed for the example to run, create a new text file in the same folder as your project. Name the file MyTestStoreData.xml. Open the file in Notepad and copy and paste the following text:  
   
-```  
+```xml  
 <StoreSurvey xmlns="http://schemas.microsoft.com/sqlserver/2004/07/adventure-works/StoreSurvey">  
   <AnnualSales>300000</AnnualSales>  
   <AnnualRevenue>30000</AnnualRevenue>  
@@ -43,9 +43,7 @@ If a query requires a parameter whose value is an XML string, developers can sup
 </StoreSurvey>  
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Imports System  
 Imports System.Data.SqlClient  
 Imports System.Data.SqlTypes  
@@ -103,9 +101,7 @@ End Sub
 End Module  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.Data;  
 using System.Data.SqlClient;  

--- a/docs/framework/data/adonet/sql/windows-applications-using-callbacks.md
+++ b/docs/framework/data/adonet/sql/windows-applications-using-callbacks.md
@@ -27,9 +27,7 @@ In most asynchronous processing scenarios, you want to start a database operatio
   
  To set up this example, create a new Windows application. Place a <xref:System.Windows.Forms.Button> control and two <xref:System.Windows.Forms.Label> controls on the form (accepting the default name for each control). Add the following code to the form's class, modifying the connection string as necessary for your environment.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 ' Add these to the top of the class:  
 Imports System  
 Imports System.Data  

--- a/docs/framework/interop/default-marshaling-for-arrays.md
+++ b/docs/framework/interop/default-marshaling-for-arrays.md
@@ -166,7 +166,7 @@ void New3(ref String ar);
   
  You can provide the marshaler with the array size by editing the Microsoft intermediate language (MSIL) code produced by Tlbimp.exe and then recompiling it. For details about how to modify MSIL code, see [Customizing Runtime Callable Wrappers](http://msdn.microsoft.com/en-us/4652beaf-77d0-4f37-9687-ca193288c0be). To indicate the number of elements in the array, apply the <xref:System.Runtime.InteropServices.MarshalAsAttribute> type to the array parameter of the managed method definition in one of the following ways:  
   
--   Identify another parameter that contains the number of elements in the array. The parameters are identified by position, starting with the first parameter as number 0. [Visual Basic]  
+-   Identify another parameter that contains the number of elements in the array. The parameters are identified by position, starting with the first parameter as number 0.     
   
     ```vb  
     Sub [New](ElemCnt As Integer, _  

--- a/docs/framework/wcf/designing-service-contracts.md
+++ b/docs/framework/wcf/designing-service-contracts.md
@@ -165,8 +165,6 @@ public interface IMyContract
   
  The following is the equivalent Visual Basic code.  
   
- [Visual Basic]  
-  
 ```vb  
 \<ServiceContractAttribute()> _  
 Public Interface IMyContract  
@@ -203,8 +201,6 @@ public interface ISampleService
   
  The following is the equivalent Visual Basic code.  
   
- [Visual Basic]  
-  
 ```vb  
 \<ServiceContractAttribute()> _  
 Public Interface ISampleService  
@@ -216,7 +212,6 @@ Public Interface ISampleService
   Public Function GetData() As Integer  
   
 End Interface  
-  
 ```  
   
  When interacting with an `ISampleService` implementation in an endpoint with a default <xref:System.ServiceModel.WSHttpBinding> (the default <xref:System.ServiceModel.SecurityMode?displayProperty=fullName>, which is <xref:System.ServiceModel.SecurityMode>), all messages are encrypted and signed because this is the default protection level. However, when an `ISampleService` service is used with a default <xref:System.ServiceModel.BasicHttpBinding> (the default <xref:System.ServiceModel.SecurityMode>, which is <xref:System.ServiceModel.SecurityMode>), all messages are sent as text because there is no security for this binding and so the protection level is ignored (that is, the messages are neither encrypted nor signed). If the <xref:System.ServiceModel.SecurityMode> was changed to <xref:System.ServiceModel.SecurityMode>, then these messages would be encrypted and signed (because that would now be the binding's default protection level).  
@@ -255,7 +250,6 @@ Public Interface IExplicitProtectionLevelSampleService
     End Function   
   
 End Interface  
-  
 ```  
   
  A service that implements this `IExplicitProtectionLevelSampleService` contract and has an endpoint that uses the default <xref:System.ServiceModel.WSHttpBinding> (the default <xref:System.ServiceModel.SecurityMode?displayProperty=fullName>, which is <xref:System.ServiceModel.SecurityMode>) has the following behavior:  

--- a/docs/framework/wcf/feature-details/using-message-contracts.md
+++ b/docs/framework/wcf/feature-details/using-message-contracts.md
@@ -134,7 +134,7 @@ public class BankingTransaction
   
  In this example, the `IsAudited` header is in the namespace specified in the code, and the body part that represents the `theData` member is represented by an XML element with the name `transactionData`. The following shows the XML generated for this message contract.  
   
-```  
+```xml  
 <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">  
   <s:Header>  
     <h:IsAudited xmlns:h="http://schemas.contoso.com/auditing/2005" xmlns="http://schemas.contoso.com/auditing/2005">false</h:IsAudited>  
@@ -183,7 +183,7 @@ public class BankingDepositLog
   
  This results in SOAP headers is similar to the following.  
   
-```  
+```xml  
 <BankingDepositLog>  
 <numRecords>3</numRecords>  
 <records>  
@@ -197,8 +197,7 @@ public class BankingDepositLog
   
  An alternative to this is to use the <xref:System.ServiceModel.MessageHeaderArrayAttribute>. In this case, each array element is serialized independently and so that each array element has one header, similar to the following.  
   
-```  
-  
+```xml  
 <numRecords>3</numRecords>  
 <records>Record1</records>  
 <records>Record2</records>  
@@ -291,8 +290,7 @@ bt.IsAudited.MustUnderstand=true;
   
  If you use both the dynamic and the static control mechanisms, the static settings are used as a default but can later be overridden by using the dynamic mechanism, as shown in the following code.  
   
-```  
-[C#]  
+```csharp  
 [MessageHeader(MustUnderstand=true)] public MessageHeader<Person> documentApprover;  
 // later on in the code:  
 BankingTransaction bt = new BankingTransaction();  

--- a/docs/framework/winforms/controls/app-icons-to-the-taskbar-with-wf-notifyicon.md
+++ b/docs/framework/winforms/controls/app-icons-to-the-taskbar-with-wf-notifyicon.md
@@ -40,9 +40,7 @@ The Windows Forms <xref:System.Windows.Forms.NotifyIcon> component displays a si
   
      In the following code example, the path set for the location of the icon is the **My Documents** folder. This location is used because you can assume that most computers running the Windows operating system will include this folder. Choosing this location also enables users with minimal system access levels to safely run the application. The following example requires a form with a <xref:System.Windows.Forms.NotifyIcon> control already added. It also requires an icon file named `Icon.ico`.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     ' You should replace the bold icon in the sample below  
     ' with an icon of your own choosing.  
     NotifyIcon1.Icon = New _   
@@ -51,12 +49,9 @@ The Windows Forms <xref:System.Windows.Forms.NotifyIcon> component displays a si
        & "\Icon.ico")  
     NotifyIcon1.Visible = True  
     NotifyIcon1.Text = "Antivirus program"  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     // You should replace the bold icon in the sample below  
     // with an icon of your own choosing.  
     // Note the escape character used (@) when specifying the path.  
@@ -66,12 +61,9 @@ The Windows Forms <xref:System.Windows.Forms.NotifyIcon> component displays a si
        + @"\Icon.ico");  
     notifyIcon1.Visible = true;  
     notifyIcon1.Text = "Antivirus program";  
-  
     ```  
   
-     [cpp]  
-  
-    ```  
+    ```cpp  
     // You should replace the bold icon in the sample below  
     // with an icon of your own choosing.  
     notifyIcon1->Icon = gcnew   

--- a/docs/framework/winforms/controls/create-and-set-a-custom-renderer-for-the-toolstrip-control-in-wf.md
+++ b/docs/framework/winforms/controls/create-and-set-a-custom-renderer-for-the-toolstrip-control-in-wf.md
@@ -46,12 +46,9 @@ manager: "wpickett"
             MyBase.OnRenderItemText(e)  
         End Sub  
     End Class  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     public class RedTextRenderer : _  
         System.Windows.Forms.ToolStripRenderer  
     {  
@@ -63,7 +60,6 @@ manager: "wpickett"
            base.OnRenderItemText(e);  
         }  
     }  
-  
     ```  
   
 ### To set the custom renderer to be the current renderer  
@@ -72,14 +68,10 @@ manager: "wpickett"
   
     ```vb  
     toolStrip1.Renderer = New RedTextRenderer()  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     toolStrip1.Renderer = new RedTextRenderer();  
-  
     ```  
   
 2.  Or to set the custom renderer for all <xref:System.Windows.Forms.ToolStrip> classes contained in your application: Set the <xref:System.Windows.Forms.ToolStripManager.Renderer%2A?displayProperty=fullName> property to the custom renderer and set the <xref:System.Windows.Forms.ToolStrip.RenderMode%2A> property to <xref:System.Windows.Forms.ToolStripRenderMode>.  
@@ -87,15 +79,11 @@ manager: "wpickett"
     ```vb  
     toolStrip1.RenderMode = ToolStripRenderMode.ManagerRenderMode  
     ToolStripManager.Renderer = New RedTextRenderer()  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     toolStrip1.RenderMode = ToolStripRenderMode.ManagerRenderMode;  
     ToolStripManager.Renderer = new RedTextRenderer();  
-  
     ```  
   
 ## See Also  

--- a/docs/framework/winforms/controls/how-to-add-enhancements-to-toolstripmenuitems.md
+++ b/docs/framework/winforms/controls/how-to-add-enhancements-to-toolstripmenuitems.md
@@ -87,9 +87,7 @@ You can enhance the usability of <xref:System.Windows.Forms.MenuStrip> and <xref
   
 -   After you define your <xref:System.Windows.Forms.MenuStrip> and the items it will contain, use the <xref:System.Windows.Forms.ToolStripItemCollection.AddRange%2A> or <xref:System.Windows.Forms.ToolStripItemCollection.Add%2A> method to add the menu commands and <xref:System.Windows.Forms.ToolStripSeparator> controls to the <xref:System.Windows.Forms.MenuStrip> in the order you want.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     ' This code adds a top-level File menu to the MenuStrip.  
     Me.menuStrip1.Items.Add(New ToolStripMenuItem() _  
     {Me.fileToolStripMenuItem})  
@@ -101,12 +99,9 @@ You can enhance the usability of <xref:System.Windows.Forms.MenuStrip> and <xref
     ToolStripMenuItem() {Me.newToolStripMenuItem, _  
     Me.openToolStripMenuItem, Me.toolStripSeparator1, _  
     Me.saveToolStripMenuItem, Me.exitToolStripMenuItem})  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     // This code adds a top-level File menu to the MenuStrip.  
     this.menuStrip1.Items.Add(new ToolStripItem[]_  
     {this.fileToolStripMenuItem});  

--- a/docs/framework/winforms/controls/how-to-add-menu-items-to-a-contextmenustrip.md
+++ b/docs/framework/winforms/controls/how-to-add-menu-items-to-a-contextmenustrip.md
@@ -28,9 +28,7 @@ You can add just one menu item or several items at a time to a <xref:System.Wind
   
 -   Use the <xref:System.Windows.Forms.ToolStripItemCollection.Add%2A> method to add one menu item to a <xref:System.Windows.Forms.ContextMenuStrip>.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Me.contextMenuStrip1.Items.Add(Me.toolStripMenuItem1)  
     ```  
   
@@ -42,9 +40,7 @@ You can add just one menu item or several items at a time to a <xref:System.Wind
   
 -   Use the <xref:System.Windows.Forms.ToolStripItemCollection.AddRange%2A> method to add several menu items to a <xref:System.Windows.Forms.ContextMenuStrip>.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Me.contextMenuStrip1.Items.AddRange(New _  
        System.Windows.Forms.ToolStripItem() {Me.toolStripMenuItem1, _  
           Me.toolStripMenuItem2})  

--- a/docs/framework/winforms/controls/how-to-append-a-menustrip-to-an-mdi-parent-window-windows-forms.md
+++ b/docs/framework/winforms/controls/how-to-append-a-menustrip-to-an-mdi-parent-window-windows-forms.md
@@ -60,12 +60,9 @@ In some applications, the kind of a multiple-document interface (MDI) child wind
         'Display the new form.  
             NewMDIChild.Show()  
     End Sub  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void openToolStripMenuItem_Click(object sender, EventArgs e)  
     {  
         Form2 newMDIChild = new Form2();  
@@ -74,7 +71,6 @@ In some applications, the kind of a multiple-document interface (MDI) child wind
         // Display the new form.  
             newMDIChild.Show();  
     }  
-  
     ```  
   
 12. Place code similar to the following code example in the `&Open`<xref:System.Windows.Forms.ToolStripMenuItem> to register the event handler.  
@@ -82,12 +78,10 @@ In some applications, the kind of a multiple-document interface (MDI) child wind
     ```vb  
     Private Sub openToolStripMenuItem_Click(sender As Object, e As _  
     EventArgs) Handles openToolStripMenuItem.Click  
-  
     ```  
   
     ```csharp  
     this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);  
-  
     ```  
   
 ## Compiling the Code  

--- a/docs/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
+++ b/docs/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
@@ -53,12 +53,9 @@ Use the multiple-document interface (MDI) to create applications that can open s
         'Display the new form.  
             NewMDIChild.Show()  
     End Sub  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void newToolStripMenuItem_Click(object sender, EventArgs e)  
     {  
         Form2 newMDIChild = new Form2();  
@@ -67,7 +64,6 @@ Use the multiple-document interface (MDI) to create applications that can open s
         // Display the new form.  
             newMDIChild.Show();  
     }  
-  
     ```  
   
 9. Place code like the following in the `&New`<xref:System.Windows.Forms.ToolStripMenuItem> to register the event handler.  
@@ -75,12 +71,10 @@ Use the multiple-document interface (MDI) to create applications that can open s
     ```vb  
     Private Sub newToolStripMenuItem_Click(sender As Object, e As _  
     EventArgs) Handles newToolStripMenuItem.Click  
-  
     ```  
   
     ```csharp  
     this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);  
-  
     ```  
   
 ## Compiling the Code  

--- a/docs/framework/winforms/controls/how-to-create-toggle-buttons-in-toolstrip-controls.md
+++ b/docs/framework/winforms/controls/how-to-create-toggle-buttons-in-toolstrip-controls.md
@@ -28,22 +28,16 @@ When a user clicks a toggle button, it appears sunken and retains the sunken app
   
 -   Use code such as the following code example. This code assumes that your form contains a <xref:System.Windows.Forms.ToolStrip> control, and that its <xref:System.Windows.Forms.ToolStrip.Items%2A> collection contains a <xref:System.Windows.Forms.ToolStripButton> called `toolStripButton1`. It also assumes that you have an event handler called `toolStripButton1_CheckedChanged`.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     toolStripButton1.CheckOnClick = True  
     toolStripButton1.CheckedChanged AddressOf _  
     EventHandler(toolStripButton1_CheckedChanged);  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     toolStripButton1.CheckOnClick = true;  
     toolStripButton1.CheckedChanged += new _  
     EventHandler(toolStripButton1_CheckedChanged);  
-  
     ```  
   
 ## See Also  

--- a/docs/framework/winforms/controls/how-to-custom-draw-a-toolstrip-control.md
+++ b/docs/framework/winforms/controls/how-to-custom-draw-a-toolstrip-control.md
@@ -63,9 +63,7 @@ The <xref:System.Windows.Forms.ToolStrip> controls have the following associated
   
 -   Override <xref:System.Windows.Forms.ProfessionalColorTable> and change the colors you want.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private Sub Form1_Load(ByVal sender As System.Object, ByVal e As _  
     System.EventArgs) Handles Me.Load  
         Dim t As MyColorTable = New MyColorTable  
@@ -115,7 +113,6 @@ The <xref:System.Windows.Forms.ToolStrip> controls have the following associated
         End Get  
     End Property  
     End Class  
-  
     ```  
   
 ### To change the rendering for all ToolStrip controls in your application  
@@ -134,22 +131,16 @@ The <xref:System.Windows.Forms.ToolStrip> controls have the following associated
   
 -   Use code similar to the following code example.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Dim colorTable As ProfessionalColorTable()  
     colorTable.UseSystemColors = True  
     Dim toolStrip.Renderer As ToolStripProfessionalRenderer(colorTable)  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     ProfessionalColorTable colorTable = new ProfessionalColorTable();  
     colorTable.UseSystemColors = true;  
     toolStrip.Renderer = new ToolStripProfessionalRenderer(colorTable);  
-  
     ```  
   
 ## See Also  

--- a/docs/framework/winforms/controls/how-to-remove-a-toolstripmenuitem-from-an-mdi-drop-down-menu-windows-forms.md
+++ b/docs/framework/winforms/controls/how-to-remove-a-toolstripmenuitem-from-an-mdi-drop-down-menu-windows-forms.md
@@ -65,12 +65,9 @@ In some applications, the kind of a multiple-document interface (MDI) child wind
         'Display the new form.  
             NewMDIChild.Show()  
     End Sub  
-  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void openToolStripMenuItem_Click(object sender, EventArgs e)  
     {  
         Form2 newMDIChild = new Form2();  
@@ -79,7 +76,6 @@ In some applications, the kind of a multiple-document interface (MDI) child wind
         // Display the new form.  
             newMDIChild.Show();  
     }  
-  
     ```  
   
 12. Place code similar to the following code example in the `&Open`<xref:System.Windows.Forms.ToolStripMenuItem> to register the event handler.  
@@ -87,13 +83,11 @@ In some applications, the kind of a multiple-document interface (MDI) child wind
     ```vb  
     Private Sub openToolStripMenuItem_Click(sender As Object, e As _  
     EventArgs) Handles openToolStripMenuItem.Click  
-  
     ```  
   
     ```csharp  
     this.openToolStripMenuItem.Click += new _  
     System.EventHandler(this.openToolStripMenuItem_Click);  
-  
     ```  
   
 ## Compiling the Code  

--- a/docs/framework/winforms/controls/load-save-and-cancel-bindingnavigator.md
+++ b/docs/framework/winforms/controls/load-save-and-cancel-bindingnavigator.md
@@ -63,17 +63,13 @@ The <xref:System.Windows.Forms.BindingNavigator> control is a special-purpose <x
   
      Your code should now look similar to the following:  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private Sub LoadButton_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles LoadButton.Click  
         TableAdapterName.Fill(DataSetName.TableName)  
     End Sub  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void LoadButton_Click(System.Object sender,   
         System.EventArgs e)  
     {  
@@ -83,17 +79,13 @@ The <xref:System.Windows.Forms.BindingNavigator> control is a special-purpose <x
   
 11. Create an event handler for the <xref:System.Windows.Forms.ToolStripItem.Click> event of the **Save**<xref:System.Windows.Forms.ToolStripButton> you created earlier and write code to update the data within the table the control is bound to.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private Sub SaveButton_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles SaveButton.Click  
         TableAdapterName.Update(DataSetName.TableName)  
     End Sub  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void SaveButton_Click(System.Object sender,   
         System.EventArgs e)  
     {  
@@ -106,17 +98,13 @@ The <xref:System.Windows.Forms.BindingNavigator> control is a special-purpose <x
   
 12. Create an event handler for the <xref:System.Windows.Forms.ToolStripItem.Click> event of the**Cancel**<xref:System.Windows.Forms.ToolStripButton> you created earlier and write code to cancel any changes to the data record that is displayed.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private Sub CancelButton_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles CancelButton.Click  
         BindingSourceName.CancelEdit()  
     End Sub  
     ```  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void CancelButton_Click(System.Object sender, System.EventArgs e)  
     {  
         BindingSourceName.CancelEdit();  

--- a/docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
+++ b/docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
@@ -104,38 +104,28 @@ Your custom controls will sometimes expose a collection as a property. This walk
   
 2.  Open the **Form1** node. Beneath it is a file called **Form1.Designer.cs** or **Form1.Designer.vb**. This is the file into which the **Windows Forms Designer** emits code representing the design-time state of your form and its child controls. Open this file in the **Code Editor**.  
   
-3.  Open the region called **Windows Form Designer generated code** and find the section labeled **serializationDemoControl1**. Beneath this label is the code representing the serialized state of your control. The strings you typed in step 5 appear in an assignment to the `Strings` property. The following code example shows code similar to what you will see if you typed the strings "red", "orange", and "yellow".  
+3.  Open the region called **Windows Form Designer generated code** and find the section labeled **serializationDemoControl1**. Beneath this label is the code representing the serialized state of your control. The strings you typed in step 5 appear in an assignment to the `Strings` property. The following code examples in C# and Visual Basic, show code similar to what you will see if you typed the strings "red", "orange", and "yellow".  
   
-4.  [Visual Basic]  
-  
-    ```  
-    Me.serializationDemoControl1.Strings = New String() {"red", "orange", "yellow"}  
-    ```  
-  
-5.  [C#]  
-  
-    ```  
+    ```csharp  
     this.serializationDemoControl1.Strings = new string[] {  
             "red",  
             "orange",  
             "yellow"};  
     ```  
-  
-6.  In the **Code Editor**, change the value of the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute> on the `Strings` property to <xref:System.ComponentModel.DesignerSerializationVisibility>.  
-  
-7.  [Visual Basic]  
-  
+    ```vb  
+    Me.serializationDemoControl1.Strings = New String() {"red", "orange", "yellow"}  
     ```  
+  
+4.  In the **Code Editor**, change the value of the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute> on the `Strings` property to <xref:System.ComponentModel.DesignerSerializationVisibility>.  
+  
+    ```csharp  
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]  
+    ```  
+    ```vb  
     <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _  
     ```  
   
-8.  [C#]  
-  
-    ```  
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]  
-    ```  
-  
-9. Rebuild the solution and repeat steps 4 through 8.  
+5. Rebuild the solution and repeat steps 3 and 4.  
   
 > [!NOTE]
 >  In this case, the **Windows Forms Designer** emits no assignment to the `Strings` property.  

--- a/docs/framework/winforms/controls/walkthrough-authoring-a-composite-control-with-visual-basic.md
+++ b/docs/framework/winforms/controls/walkthrough-authoring-a-composite-control-with-visual-basic.md
@@ -81,9 +81,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 7.  Modify the code so that it resembles the following code sample. Be sure to change the access modifier from `Private` to `Protected`.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Protected Sub Timer1_Tick(ByVal sender As Object, ByVal e As _  
         System.EventArgs) Handles Timer1.Tick  
         ' Causes the label to display the current time.    
@@ -95,9 +93,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 8.  Modify the method to be overridable. For more information, see the "Inheriting from a User Control" section below.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Protected Overridable Sub Timer1_Tick(ByVal sender As Object, ByVal _  
         e As System.EventArgs) Handles Timer1.Tick  
     ```  
@@ -115,9 +111,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 2.  Locate the `Public Class ctlClock` statement. Beneath it, type the following code.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private colFColor as Color  
     Private colBColor as Color  
     ```  
@@ -126,9 +120,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 3.  Insert the following code beneath the variable declarations from step 2.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     ' Declares the name and type of the property.  
     Property ClockBackColor() as Color  
         ' Retrieves the value of the private variable colBColor.  
@@ -211,9 +203,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 2.  Locate the class declaration for the ctlAlarmClock control, which appears as `Public Class ctlAlarmClock`.  In the class declaration, insert the following code.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private dteAlarmTime As Date  
     Private blnAlarmSet As Boolean  
     ' These properties will be declared as Public to allow future   
@@ -273,17 +263,13 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 2.  Locate the `Private blnAlarmSet As Boolean` statement. Immediately beneath it, add the following statement.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Dim blnColorTicker as Boolean  
     ```  
   
 3.  Locate the `End Class` statement at the bottom of the page. Just before the `End Class` statement, add the following code.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Protected Overrides Sub Timer1_Tick(ByVal sender As Object, ByVal e _  
         As System.EventArgs)  
         ' Calls the Timer1_Tick method of ctlClock.  
@@ -332,9 +318,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 3.  Modify this method so that it resembles the following code.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private Sub lblAlarm_Click(ByVal sender As Object, ByVal e As _  
      System.EventArgs) Handles lblAlarm.Click  
         ' Turns off the alarm.  
@@ -390,9 +374,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 13. Modify the code so that it resembles the following.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Private Sub dtpTest_ValueChanged(ByVal sender As Object, ByVal e As _  
         System.EventArgs) Handles dtpTest.ValueChanged  
         ctlAlarmClock1.AlarmTime = dtpTest.Value  

--- a/docs/framework/winforms/controls/walkthrough-authoring-a-composite-control-with-visual-csharp.md
+++ b/docs/framework/winforms/controls/walkthrough-authoring-a-composite-control-with-visual-csharp.md
@@ -79,9 +79,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 7.  Modify the code so that it resembles the following code sample. Be sure to change the access modifier from `private` to `protected`.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     protected void timer1_Tick(object sender, System.EventArgs e)  
     {  
         // Causes the label to display the current time.  
@@ -93,7 +91,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 8.  Modify the method to be overridable with the `virtual` keyword. For more information, see the  "Inheriting from a User Control" section below.  
   
-    ```  
+    ```csharp  
     protected virtual void timer1_Tick(object sender, System.EventArgs e)  
     ```  
   
@@ -110,9 +108,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 2.  Locate the `public partial class ctlClock` statement. Beneath the opening brace (`{)`, type the following code.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private Color colFColor;  
     private Color colBColor;  
     ```  
@@ -121,9 +117,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 3.  Type the following code beneath the variable declarations from step 2.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     // Declares the name and type of the property.  
     public Color ClockBackColor  
     {  
@@ -209,9 +203,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 2.  Locate the `public class` statement. Note that your control inherits from `ctlClockLib.ctlClock`. Beneath the opening brace (`{)` statement, type the following code.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private DateTime dteAlarmTime;  
     private bool blnAlarmSet;  
     // These properties will be declared as public to allow future   
@@ -275,17 +267,13 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 1.  In the **Code Editor**, locate the `private bool blnAlarmSet;` statement. Immediately beneath it, add the following statement.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private bool blnColorTicker;  
     ```  
   
 2.  In the **Code Editor**, locate the closing brace (`})` at the end of the class. Just before the brace, add the following code.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     protected override void timer1_Tick(object sender, System.EventArgs e)  
     {  
         // Calls the Timer1_Tick method of ctlClock.  
@@ -348,9 +336,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 4.  Modify this method so that it resembles the following code.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void btnAlarmOff_Click(object sender, System.EventArgs e)  
     {  
         // Turns off the alarm.  
@@ -400,9 +386,7 @@ Composite controls provide a means by which custom graphical interfaces can be c
   
 11. Modify the code so that it resembles the following.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     private void dtpTest_ValueChanged(object sender, System.EventArgs e)  
     {  
         ctlAlarmClock1.AlarmTime = dtpTest.Value;  

--- a/docs/framework/winforms/controls/walkthrough-inheriting-from-a-windows-forms-control-with-visual-basic.md
+++ b/docs/framework/winforms/controls/walkthrough-inheriting-from-a-windows-forms-control-with-visual-basic.md
@@ -66,9 +66,7 @@ With [!INCLUDE[vbprvb](../../../../includes/vbprvb-md.md)], you can create power
   
 2.  Locate the `Public Class ValueButton` statement. Immediately beneath this statement, type the following code:  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     ' Creates the private variable that will store the value of your   
     ' property.  
     Private varValue as integer  
@@ -140,9 +138,7 @@ With [!INCLUDE[vbprvb](../../../../includes/vbprvb-md.md)], you can create power
   
 9. Type the following line of code.  
   
-     [Visual Basic]  
-  
-    ```  
+    ```vb  
     Label1.Text = CStr(ValueButton1.ButtonValue)  
     ```  
   

--- a/docs/framework/winforms/controls/walkthrough-inheriting-from-a-windows-forms-control-with-visual-csharp.md
+++ b/docs/framework/winforms/controls/walkthrough-inheriting-from-a-windows-forms-control-with-visual-csharp.md
@@ -64,9 +64,7 @@ With [!INCLUDE[csprcslong](../../../../includes/csprcslong-md.md)], you can crea
   
 2.  Locate the `class` statement. Immediately after the `{`, type the following code:  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     // Creates the private variable that will store the value of your   
     // property.  
     private int varValue;  
@@ -137,9 +135,7 @@ With [!INCLUDE[csprcslong](../../../../includes/csprcslong-md.md)], you can crea
   
 9. Insert the following line of code.  
   
-     [C#]  
-  
-    ```  
+    ```csharp  
     label1.Text = valueButton1.ButtonValue.ToString();  
     ```  
   

--- a/docs/visual-basic/language-reference/error-messages/number-of-indices-exceeds-the-number-of-dimensions-of-the-indexed-array.md
+++ b/docs/visual-basic/language-reference/error-messages/number-of-indices-exceeds-the-number-of-dimensions-of-the-indexed-array.md
@@ -45,8 +45,7 @@ The number of indices used to access an array element must be exactly the same a
   
 -   Remove subscripts from the array reference until the total number of subscripts equals the rank of the array. For example:  
   
-    ```  
-    [Visual Basic]  
+    ```vb  
     Dim gameBoard(3, 3) As String  
   
     ' Incorrect code. The array has two dimensions.  

--- a/xml/System.CodeDom/CodeTypeDeclaration.xml
+++ b/xml/System.CodeDom/CodeTypeDeclaration.xml
@@ -121,18 +121,14 @@
   
  The following code illustrates the addition of a <xref:System.CodeDom.CodeTypeReference> to the collection that refers to <xref:System.Object>.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim ctd As New CodeTypeDeclaration("Class1")  
 ctd.IsClass = True  
 ctd.BaseTypes.Add(New CodeTypeReference(GetType(Object)))  
 ctd.BaseTypes.Add(New CodeTypeReference("Interface1"))  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 CodeTypeDeclaration ctd = new CodeTypeDeclaration("Class1");  
 ctd.IsClass = true;  
 ctd.BaseTypes.Add(new CodeTypeReference(typeof(Object)));  
@@ -141,14 +137,14 @@ ctd.BaseTypes.Add(new CodeTypeReference("Interface1"));
   
  The preceding code generates the equivalent of the following Visual Basic code.  
   
-```  
+```vb  
 Public Class Class1  
 Implements Interface1  
 ```  
   
  However, the Visual Basic code actually generated is the following.  
   
-```  
+```vb  
 Public Class Class1  
 Inherits Object  
 Implements Interface1  

--- a/xml/System.ComponentModel.Design.Serialization/ExpressionContext.xml
+++ b/xml/System.ComponentModel.Design.Serialization/ExpressionContext.xml
@@ -18,13 +18,13 @@
 ## Remarks  
  An <xref:System.ComponentModel.Design.Serialization.ExpressionContext> is placed on the context stack and contains the most relevant expression during serialization. The following C# code demonstrates an assignment.  
   
-```  
+```csharp  
 button1.Text = "Hello";  
 ```  
   
  During serialization, several serializers are responsible for creating this single statement. One of those serializers is responsible for creating "Hello". There are times when that serializer may need to know the context in which it is creating its expression. In the previous example, this context is not needed. The following C# code shows a situation in which knowledge of the context is necessary.  
   
-```  
+```csharp  
 button1.Text = rm.GetString("button1_Text");  
 ```  
   
@@ -175,9 +175,7 @@ button1.Text = rm.GetString("button1_Text");
   
  The following C# code shows how serializers can use this information to guide serialization.  
   
- [C#]  
-  
-```  
+```csharp  
 Padding p = new Padding();  
 p.Left = 5;  
 button1.Padding = p;  

--- a/xml/System.ComponentModel.Design/DesignSurface.xml
+++ b/xml/System.ComponentModel.Design/DesignSurface.xml
@@ -929,13 +929,13 @@
 ## Examples  
  The following code example shows how <xref:System.ComponentModel.Design.DesignSurface.View%2A> hides view technologies.  
   
- [C#]  
+ ```csharp 
+ IRootDesigner d;  
   
- `IRootDesigner d;`  
+ ViewTechnology[] supported = d.SupportedTechnologies;  
   
- `ViewTechnology[] supported = d.SupportedTechnologies;`  
-  
- `return d.GetView(supported[0]);`  
+ return d.GetView(supported[0]);
+ ``` 
   
  ]]></format>
         </remarks>

--- a/xml/System.Data.Common/DbConnectionStringBuilder.xml
+++ b/xml/System.Data.Common/DbConnectionStringBuilder.xml
@@ -47,18 +47,14 @@
   
  Both the <xref:System.Data.Common.DbConnectionStringBuilder.Add%2A> method and <xref:System.Data.Common.DbConnectionStringBuilder.Item%2A> property handle tries to insert malicious entries. For example, the following code correctly escapes the nested key/value pair:  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim builder As New System.Data.Common.DbConnectionStringBuilder  
 builder("Data Source") = "(local)"  
 builder("integrated sSecurity") = True  
 builder("Initial Catalog") = "AdventureWorks;NewValue=Bad"  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 System.Data.Common.DbConnectionStringBuilder builder =   
     new System.Data.Common.DbConnectionStringBuilder();  
 builder["Data Source"] = "(local)";  

--- a/xml/System.Data.Odbc/OdbcConnectionStringBuilder.xml
+++ b/xml/System.Data.Odbc/OdbcConnectionStringBuilder.xml
@@ -41,9 +41,7 @@
   
  The <xref:System.Data.Odbc.OdbcConnectionStringBuilder.Item%2A> property handles attempts to insert malicious code. For example, the following code, using the default <xref:System.Data.Odbc.OdbcConnectionStringBuilder.Item%2A> property (the indexer, in C#) correctly escapes the nested key/value pair.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim builder As _  
  New System.Data.Odbc.OdbcConnectionStringBuilder  
 ' Take advantage of the Driver property.   
@@ -52,9 +50,7 @@ builder("Server") = "MyServer;NewValue=Bad"
 Console.WriteLine(builder.ConnectionString)  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 System.Data.Odbc.OdbcConnectionStringBuilder builder =   
   new System.Data.Odbc.OdbcConnectionStringBuilder();  
 // Take advantage of the Driver property.   

--- a/xml/System.Data.OleDb/OleDbParameter.xml
+++ b/xml/System.Data.OleDb/OleDbParameter.xml
@@ -143,7 +143,7 @@ OleDbDataReader reader = command.ExecuteReader();
 ## Remarks  
  Use caution when you are using this overload of the <xref:System.Data.OleDb.OleDbParameter> constructor to specify integer parameter values. Because this overload takes a `value` of type <xref:System.Object>, you must convert the integral value to an <xref:System.Object> type when the value is zero, as the following C# example demonstrates.  
   
-```  
+```csharp  
 Parameter = new OleDbParameter("@pname", Convert.ToInt32(0));  
 ```  
   
@@ -579,18 +579,14 @@ public void CreateOleDbParameter()
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim parameter As New OleDbParameter("Description", OleDbType.VarChar, 88)  
     parameter.Direction = ParameterDirection.Output  
 End Sub 'CreateOleDbParameter  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     OleDbParameter parameter = new OleDbParameter("Description", OleDbType.VarChar, 88);  
@@ -645,9 +641,7 @@ public void CreateOleDbParameter()
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim parameter As New OleDbParameter("Price", OleDbType.Decimal)  
     parameter.Value = 3.1416  
@@ -656,9 +650,7 @@ Public Sub CreateOleDbParameter()
 End Sub 'CreateOleDbParameter  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     OleDbParameter parameter = new OleDbParameter("Price", OleDbType.Decimal);  
@@ -763,9 +755,7 @@ public void CreateOleDbParameter()
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim parameter As New OleDbParameter("Price", OleDbType.Decimal)  
     parameter.Value = 3.1416  
@@ -774,9 +764,7 @@ Public Sub CreateOleDbParameter()
 End Sub 'CreateOleDbParameter  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     OleDbParameter parameter = new OleDbParameter("Price", OleDbType.Decimal);  
@@ -828,9 +816,7 @@ public void CreateOleDbParameter()
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim myValue As String = "12 foot scarf - multiple colors, one previous owner"  
     Dim parameter As New OleDbParameter("Description", OleDbType.VarChar)  
@@ -840,9 +826,7 @@ Public Sub CreateOleDbParameter()
 End Sub 'CreateOleDbParameter  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     string myValue = "12 foot scarf - multiple colors, one previous owner";  
@@ -885,18 +869,14 @@ public void CreateOleDbParameter()
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim parameter As New OleDbParameter("Description", OleDbType.VarChar, 88)  
     parameter.SourceColumn = "Description"  
 End Sub 'CreateOleDbParameter  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     OleDbParameter parameter = new OleDbParameter("Description", OleDbType.VarChar, 88);  
@@ -975,9 +955,7 @@ FieldName = @OriginalFieldName
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim parameter As New OleDbParameter("Description", OleDbType.VarChar, 88)  
     parameter.SourceColumn = "Description"  
@@ -985,9 +963,7 @@ Public Sub CreateOleDbParameter()
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     OleDbParameter parameter = new OleDbParameter("Description", OleDbType.VarChar, 88);  
@@ -1088,18 +1064,14 @@ public void CreateOleDbParameter()
 ## Examples  
  The following example creates an <xref:System.Data.OleDb.OleDbParameter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOleDbParameter()  
     Dim parameter As New OleDbParameter("Description", OleDbType.VarChar, 88)  
     parameter.Value = "garden hose"  
 End Sub 'CreateOleDbParameter  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void CreateOleDbParameter()   
  {  
     OleDbParameter parameter = new OleDbParameter("Description", OleDbType.VarChar, 88);  

--- a/xml/System.Data.OracleClient/OracleClientFactory.xml
+++ b/xml/System.Data.OracleClient/OracleClientFactory.xml
@@ -49,16 +49,12 @@
 ## Examples  
  The following code fragment returns a strongly typed <xref:System.Data.Common.DbCommand> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim command As DbCommand = newFactory.CreateCommand()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbCommand command = newFactory.CreateCommand();  
 ```  
@@ -89,16 +85,12 @@ DbCommand command = newFactory.CreateCommand();
 ## Examples  
  The following code fragment returns a strongly typed <xref:System.Data.Common.DbCommandBuilder> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim commandBuilder As DbCommandBuilder = newFactory.CreateCommandBuilder()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbCommandBuilder commandBuilder = newFactory.CreateCommandBuilder();  
 ```  
@@ -129,16 +121,12 @@ DbCommandBuilder commandBuilder = newFactory.CreateCommandBuilder();
 ## Examples  
  The following code fragment returns a strongly typed <xref:System.Data.Common.DbConnection> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim connection As DbConnection = newFactory.CreateConnection()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbConnection connection = newFactory.CreateConnection();  
 ```  
@@ -169,16 +157,12 @@ DbConnection connection = newFactory.CreateConnection();
 ## Examples  
  The following code fragment returns a strongly typed <xref:System.Data.Common.DbConnectionStringBuilder> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim connectionBuilder As DbConnectionStringBuilder = newFactory.CreateConnectionStringBuilder()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbConnectionStringBuilder connectionBuilder = newFactory.CreateConnectionStringBuilder();  
 ```  
@@ -209,16 +193,12 @@ DbConnectionStringBuilder connectionBuilder = newFactory.CreateConnectionStringB
 ## Examples  
  The following code fragment returns a strongly typed <xref:System.Data.Common.DbDataAdapter> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim dataAdpater As DbDataAdapter = newFactory.CreateDataAdapter()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbDataAdapter dataAdpater = newFactory.CreateDataAdapter();  
 ```  
@@ -249,16 +229,12 @@ DbDataAdapter dataAdpater = newFactory.CreateDataAdapter();
 ## Examples  
  The following code fragment returns a strongly typed <xref:System.Data.Common.DbParameter> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim parameter As DbParameter = newFactory.CreateParameter()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbParameter parameter = newFactory.CreateParameter();  
 ```  
@@ -309,16 +285,12 @@ DbParameter parameter = newFactory.CreateParameter();
 ## Examples  
  The following code fragment uses the <xref:System.Data.OracleClient.OracleClientFactory.Instance> field to retrieve an <xref:System.Data.OracleClient.OracleClientFactory> instance and then return a strongly typed <xref:System.Data.Common.DbCommand> instance.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim newFactory As OracleClientFactory = OracleClientFactory.Instance  
 Dim command As DbCommand = newFactory.CreateCommand()  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 OracleClientFactory newFactory = OracleClientFactory.Instance;  
 DbCommand command = newFactory.CreateCommand();  
 ```  

--- a/xml/System.Data.OracleClient/OracleCommandBuilder.xml
+++ b/xml/System.Data.OracleClient/OracleCommandBuilder.xml
@@ -38,9 +38,7 @@
 ## Examples  
  The following example uses <xref:System.Data.OracleClient.OracleCommand>, along with <xref:System.Data.OracleClient.OracleDataAdapter> and <xref:System.Data.OracleClient.OracleConnection>, to select rows from a database. The example is passed an initialized <xref:System.Data.DataSet>, a connection string, a query string that is an SQL SELECT statement, and a string that is the name of the database table. The example then creates an <xref:System.Data.OracleClient.OracleCommandBuilder>.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Private Function SelectOracleRows(connection As String, queryString As String, tableName As String) As DataSet  
   
    Dim connection As New OracleConnection(connection)  
@@ -60,9 +58,7 @@ Private Function SelectOracleRows(connection As String, queryString As String, t
 End Function  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static DataSet SelectOracleSrvRows(string myConnection, string mySelectQuery, string myTableName)  
 {  
    OracleConnection myConn = new OracleConnection(myConnection);  

--- a/xml/System.Data.OracleClient/OracleConnectionStringBuilder.xml
+++ b/xml/System.Data.OracleClient/OracleConnectionStringBuilder.xml
@@ -37,9 +37,7 @@
   
  The <xref:System.Data.OracleClient.OracleConnectionStringBuilder> handles attempts to insert malicious entries. For example, the following code, using the default <xref:System.Data.OracleClient.OracleConnectionStringBuilder.Item%2A> property (the indexer, in C#) correctly escapes the nested key/value pair.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim builder As New System.Data. _  
     OracleClient.OracleConnectionStringBuilder  
 builder("Data Source") = "OracleDemo"  
@@ -48,9 +46,7 @@ builder("User ID") = "Mary;NewValue=Bad"
 System.Diagnostics.Debug.WriteLine(builder.ConnectionString)  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 System.Data.OracleClient.OracleConnectionStringBuilder builder =  
    new System.Data.OracleClient.OracleConnectionStringBuilder();  
 builder["Data Source"] = "OracleDemo";  

--- a/xml/System.Data.OracleClient/OracleDataAdapter.xml
+++ b/xml/System.Data.OracleClient/OracleDataAdapter.xml
@@ -142,7 +142,7 @@ END CURSPKG;
   
  Create the following Oracle package body on the Oracle server.  
   
-```  
+``` 
 CREATE OR REPLACE PACKAGE BODY CURSPKG AS   
     PROCEDURE OPEN_ONE_CURSOR (N_EMPNO IN NUMBER,   
                                IO_CURSOR OUT T_CURSOR)   
@@ -242,9 +242,7 @@ END CURSPKG;
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOracleDataAdapter()  
     Dim myOracleConnection As OracleConnection = New OracleConnection("Data Source=Oracle8i;Integrated Security=yes")  
     Dim custDA As OracleDataAdapter = New OracleDataAdapter  
@@ -268,9 +266,7 @@ Public Sub CreateOracleDataAdapter()
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static void CreateOracleDataAdapter()   
 {  
     OracleConnection myOracleConnection = new OracleConnection("Data Source=Oracle8i;Integrated Security=yes");  
@@ -334,9 +330,7 @@ public static void CreateOracleDataAdapter()
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOracleDataAdapter()  
     Dim myOracleConnection As OracleConnection = New OracleConnection("Data Source=Oracle8i;Integrated Security=yes")  
     Dim myOracleCommand As OracleCommand = New OracleCommand("SELECT DeptNo, DName FROM Dept", myOracleConnection)  
@@ -360,9 +354,7 @@ Public Sub CreateOracleDataAdapter()
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static void CreateOracleDataAdapter()   
 {  
     OracleConnection myOracleConnection = new OracleConnection("Data Source=Oracle8i;Integrated Security=yes");  
@@ -419,9 +411,7 @@ public static void CreateOracleDataAdapter()
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOracleDataAdapter()  
     Dim myOracleConnection As OracleConnection = New OracleConnection("Data Source=Oracle8i;Integrated Security=yes")  
     Dim mySelectText As String = "SELECT DeptNo, DName FROM Dept"  
@@ -445,9 +435,7 @@ Public Sub CreateOracleDataAdapter()
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static void CreateOracleDataAdapter()   
 {  
     OracleConnection myOracleConnection = new OracleConnection("Data Source=Oracle8i;Integrated Security=yes");  
@@ -501,9 +489,7 @@ public static void CreateOracleDataAdapter()
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets some of its properties.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub CreateOracleDataAdapter()  
     Dim myConnectionText As String = "Data Source=Oracle8i;Integrated Security=yes"  
     Dim mySelectText As String = "SELECT DeptNo, DName FROM Dept"  
@@ -529,9 +515,7 @@ Public Sub CreateOracleDataAdapter()
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static void CreateOracleDataAdapter()   
 {  
     string myConnectionText = "Data Source=Oracle8i;Integrated Security=yes";  
@@ -696,9 +680,7 @@ public static void CreateOracleDataAdapter()
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets the <xref:System.Data.OracleClient.OracleDataAdapter.SelectCommand%2A> and <xref:System.Data.OracleClient.OracleDataAdapter.DeleteCommand%2A> properties. It assumes you have already created an <xref:System.Data.OracleClient.OracleConnection> object.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As OracleDataAdapter   
   
   Dim da As OracleDataAdapter = New OracleDataAdapter()  
@@ -728,9 +710,7 @@ Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As Oracle
 End Function  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)  
 {  
   OracleDataAdapter da = new OracleDataAdapter();  
@@ -892,9 +872,7 @@ public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets the <xref:System.Data.OracleClient.OracleDataAdapter.SelectCommand%2A> and <xref:System.Data.OracleClient.OracleDataAdapter.InsertCommand%2A> properties. It assumes you have already created an <xref:System.Data.OracleClient.OracleConnection> object.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As OracleDataAdapter   
   
   Dim da As OracleDataAdapter = New OracleDataAdapter()  
@@ -924,9 +902,7 @@ Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As Oracle
 End Function  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)  
 {  
   OracleDataAdapter da = new OracleDataAdapter();  
@@ -1114,9 +1090,7 @@ public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets the <xref:System.Data.OracleClient.OracleDataAdapter.SelectCommand%2A> and <xref:System.Data.OracleClient.OracleDataAdapter.InsertCommand%2A> properties. It assumes you have already created an <xref:System.Data.OracleClient.OracleConnection> object.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As OracleDataAdapter   
   
   Dim da As OracleDataAdapter = New OracleDataAdapter()  
@@ -1146,9 +1120,7 @@ Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As Oracle
 End Function  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)  
 {  
   OracleDataAdapter da = new OracleDataAdapter();  
@@ -1416,9 +1388,7 @@ public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)
 ## Examples  
  The following example creates an <xref:System.Data.OracleClient.OracleDataAdapter> and sets the <xref:System.Data.OracleClient.OracleDataAdapter.SelectCommand%2A> and <xref:System.Data.OracleClient.OracleDataAdapter.UpdateCommand%2A> properties. It assumes you have already created an <xref:System.Data.OracleClient.OracleConnection> object.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As OracleDataAdapter   
   
   Dim da As OracleDataAdapter = New OracleDataAdapter()  
@@ -1452,9 +1422,7 @@ Public Shared Function CreateCustomerAdapter(conn As OracleConnection) As Oracle
 End Function  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static OracleDataAdapter CreateCustomerAdapter(OracleConnection conn)  
 {  
   OracleDataAdapter da = new OracleDataAdapter();  

--- a/xml/System.Data.OracleClient/OracleDataReader.xml
+++ b/xml/System.Data.OracleClient/OracleDataReader.xml
@@ -1142,9 +1142,7 @@ public void ReadOracleTypesExample(string connectionString)
 ## Examples  
  The following example demonstrates how to use the <xref:System.Data.OracleClient.OracleDataReader.GetOrdinal%2A> method.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Sub ReadOracleData(ByVal connectionString As String)  
   
     Dim queryString As String = "SELECT OrderID, CustomerID FROM Orders"  
@@ -1166,9 +1164,7 @@ Public Sub ReadOracleData(ByVal connectionString As String)
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public void ReadOracleData(string connectionString)  
 {  
     string queryString = "SELECT OrderID, CustomerID FROM Orders";  

--- a/xml/System.Data.SqlClient/SqlConnectionStringBuilder.xml
+++ b/xml/System.Data.SqlClient/SqlConnectionStringBuilder.xml
@@ -42,9 +42,7 @@
   
  The **Item** property handles tries to insert malicious entries. For example, the following code, using the default Item property (the indexer, in C#) correctly escapes the nested key/value pair:  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim builder As New System.Data.SqlClient.SqlConnectionStringBuilder  
 builder("Data Source") = "(local)"  
 builder("Integrated Security") = True  
@@ -52,9 +50,7 @@ builder("Initial Catalog") = "AdventureWorks;NewValue=Bad"
 Console.WriteLine(builder.ConnectionString)  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 System.Data.SqlClient.SqlConnectionStringBuilder builder =  
   new System.Data.SqlClient.SqlConnectionStringBuilder();  
 builder["Data Source"] = "(local)";  

--- a/xml/System.Data/DataTable.xml
+++ b/xml/System.Data/DataTable.xml
@@ -550,7 +550,7 @@
   
  C# and Visual Basic projects with this code sample can be found on [Developer Code Samples](http://code.msdn.microsoft.com/site/search?f%5B0%5D.Type=SearchText&f%5B0%5D.Value=How%20to%20automically%20update%20the%20structure%20of%20a%20cloned%20DataTable).  
   
-```  
+```csharp  
 using System;  
 using System.Linq;  
 using System.Data;  
@@ -885,7 +885,7 @@ GO
   
  You can now compile and run the sample. [How to modify data in DataTable and update to the data source](http://code.msdn.microsoft.com/How-to-modify-data-in-c68d35f4) has Visual Basic and C# projects of this sample.  
   
-```  
+```csharp  
 using System;  
 using System.Data;  
 using System.Data.SqlClient;  
@@ -3706,7 +3706,7 @@ Not present)|Current = \<Incoming><br /><br /> Original = \<Not available><br />
 > [!NOTE]
 >  The `DataSet` does not associate an XML element with its corresponding `DataColumn` or `DataTable` when legal XML characters like ("_") are escaped in the serialized XML. The `DataSet` itself only escapes illegal XML characters in XML element names and hence can only consume the same. When legal characters in XML element name are escaped, the element is ignored while processing.  
   
-```  
+```csharp  
 using System.Data;  
 public class A {  
    static void Main(string[] args) {  

--- a/xml/System.DirectoryServices/DirectoryEntries.xml
+++ b/xml/System.DirectoryServices/DirectoryEntries.xml
@@ -70,9 +70,7 @@ Console.WriteLine(myDirectoryEntry.Name + " entry is created in container.")
   
  The following C# example creates a new <xref:System.DirectoryServices.DirectoryEntry> object with a specified path, then creates a new entry in the container and saves it.  
   
- [C#]  
-  
-```  
+```csharp  
 String strPath = "IIS://localhost/W3SVC/1/Root";  
   
 // Create a new 'DirectoryEntry' object with the given path.  
@@ -89,7 +87,7 @@ Console.WriteLine (myDirectoryEntry.Name + " entry is created in container.");
   
  The following C++ example creates a new <xref:System.DirectoryServices.DirectoryEntry> object with a specified path, then creates a new entry in the container and saves it.  
   
-```  
+```cpp  
 String* strPath = S"IIS://localhost/W3SVC/1/Root";  
   
 // Create a new 'DirectoryEntry' object with the given path.  
@@ -246,7 +244,7 @@ class MyClass1
   
  The following C++ example creates a new <xref:System.DirectoryServices.DirectoryEntry> object with the specified path, then creates a new entry in the container and saves it. It attempts to retrieve the new entry.  
   
-```cpp#  
+```cpp  
 #using <mscorlib.dll>  
 #using <System.dll>  
 #using <System.Directoryservices.dll>  
@@ -420,7 +418,7 @@ class MyClass1
   
  The following C++ example creates a new <xref:System.DirectoryServices.DirectoryEntry> object with the specified path, then creates a new entry in the container and saves it. Finally, it retrieves the new entry and deletes it.  
   
-```cpp#  
+```cpp  
 #using <mscorlib.dll>  
 #using <System.dll>  
 #using <System.Directoryservices.dll>  

--- a/xml/System.DirectoryServices/SearchResultCollection.xml
+++ b/xml/System.DirectoryServices/SearchResultCollection.xml
@@ -432,9 +432,7 @@ ICollection MyCollection =...
  }  
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim myCollection as New ICollection()  
  SyncLock myCollection.SyncRoot  
   ' Some operation on the collection, which is now thread safe.  

--- a/xml/System.Management.Instrumentation/DefaultManagementInstaller.xml
+++ b/xml/System.Management.Instrumentation/DefaultManagementInstaller.xml
@@ -25,9 +25,7 @@
 ## Examples  
  The following example shows how to derive a class from the <xref:System.Management.Instrumentation.DefaultManagementInstaller> class to install a WMI provider.  
   
- [C#]  
-  
-```  
+```csharp  
 // This is the installer class that installs an instrumented assembly.  
 // To use the default project installer, simply derive a class from  
 // DefaultManagementInstaller.  No methods need to be overridden.  

--- a/xml/System.Management.Instrumentation/ManagementBindAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementBindAttribute.xml
@@ -38,9 +38,7 @@
 ## Examples  
  The following example shows how to use the ManagementBind attribute to mark the constructor of a class.  
   
- [C#]  
-  
-```  
+```csharp  
 // Use the ManagementBind attribute to specify that this constructor  
 // is used to attach a class instance to a specific WMI  
 // instance. The constructor should set the values of the  

--- a/xml/System.Management.Instrumentation/ManagementCommitAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementCommitAttribute.xml
@@ -34,9 +34,8 @@
    
   
 ## Examples  
- [C#]  
   
-```  
+```csharp  
 public class Process  
 {  
     /// Key attribute marks a key property. Keys are not changeable.  

--- a/xml/System.Management.Instrumentation/ManagementConfigurationAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementConfigurationAttribute.xml
@@ -32,9 +32,7 @@
 ## Examples  
  The following example shows how to use the ManagementConfiguration attribute to mark a property. This property is exposed to WMI.  
   
- [C#]  
-  
-```  
+```csharp  
 // Use the ManagementConfiguration attribute to specify that a property  
 // is a read/write property in the provider. Consumers will be  
 // able to get and set this property value through WMI.  

--- a/xml/System.Management.Instrumentation/ManagementEnumeratorAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementEnumeratorAttribute.xml
@@ -30,9 +30,7 @@
 ## Examples  
  The following example shows how to use the Enumerator attribute to mark a method that is used to enumerate instances of a class. In this case, the Enumerate method uses the <xref:System.Diagnostics.Process> class to retrieve all of the processes running on the computer.  
   
- [C#]  
-  
-```  
+```csharp  
 [ManagementEnumerator]  
 public static IEnumerable Enumerate()  
 {  

--- a/xml/System.Management.Instrumentation/ManagementKeyAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementKeyAttribute.xml
@@ -30,16 +30,14 @@
 ## Examples  
  The following example shows how to use the <xref:System.Management.Instrumentation.ManagementKeyAttribute> to mark a field as a key property of a WMI class.  
   
-```  
+```csharp  
 [ManagementKey]  
 public int id;  
 ```  
   
  The next example shows how to use the <xref:System.Management.Instrumentation.ManagementKeyAttribute> attribute to mark a key property of a WMI class.  
   
- [C#]  
-  
-```  
+```csharp  
 // Use the ManagementKey attribute to specify that this property   
 // is used as the key identifier of this class and for the WMI  
 // instances of this class.  This property must be unique for each  

--- a/xml/System.Management.Instrumentation/ManagementProbeAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementProbeAttribute.xml
@@ -30,16 +30,14 @@
 ## Examples  
  The following example shows how to use the ManagementProbe attribute to indicate that a field represents a read-only WMI property.  
   
-```  
+```csharp  
 [ManagementProbe]  
 string count;  
 ```  
   
  The next example shows how to use the ManagementProbe attribute to mark a property.  
   
- [C#]  
-  
-```  
+```csharp  
 // Use the ManagementProbe attribute to specify that a property  
 // is a read-only property in the provider. Consumers will be  
 // able to get this property value through WMI.  
@@ -48,7 +46,6 @@ public int ReadOnlyProperty
 {  
     get { return this.propertyValue; }  
 }  
-  
 ```  
   
  ]]></format>

--- a/xml/System.Management.Instrumentation/ManagementTaskAttribute.xml
+++ b/xml/System.Management.Instrumentation/ManagementTaskAttribute.xml
@@ -34,9 +34,7 @@
 ## Examples  
  The following example shows how to mark a method with the ManagementTask attribute to expose the method to WMI. The method will show up in WMI as ResetCounters.  
   
- [C#]  
-  
-```  
+```csharp  
 // Use the ManagementTask attribute to specify that a method  
 // is exposed to WMI through this provider. Consumers will be  
 // able to execute this method through WMI.  
@@ -44,9 +42,8 @@
 public void ResetCounters()  
 {  
     counter.Reset();  
+}  
 ```  
-  
- }  
   
  ]]></format>
     </remarks>

--- a/xml/System.Messaging/MessageQueue.xml
+++ b/xml/System.Messaging/MessageQueue.xml
@@ -852,7 +852,7 @@
   
  Do not use the asynchronous call <xref:System.Messaging.MessageQueue.BeginReceive%2A> with transactions. If you want to perform a transactional asynchronous operation, call <xref:System.Messaging.MessageQueue.BeginPeek%2A>, and put the transaction and the (synchronous) <xref:System.Messaging.MessageQueue.Receive%2A> method within the event handler you create for the peek operation. Your event handler might contain functionality as shown in the following C# code.  
   
-```  
+```csharp  
 myMessageQueue.BeginTransaction();  
  myMessageQueue.Receive();  
  myMessageQueue.CommitTransaction();  
@@ -931,7 +931,7 @@ myMessageQueue.BeginTransaction();
   
  Do not use the asynchronous call <xref:System.Messaging.MessageQueue.BeginReceive%2A> with transactions. If you want to perform a transactional asynchronous operation, call <xref:System.Messaging.MessageQueue.BeginPeek%2A>, and put the transaction and the (synchronous) <xref:System.Messaging.MessageQueue.Receive%2A> method within the event handler you create for the peek operation. Your event handler might contain functionality as shown in the following C# code.  
   
-```  
+```csharp  
 myMessageQueue.BeginTransaction();  
  myMessageQueue.Receive();  
  myMessageQueue.CommitTransaction();  
@@ -1010,7 +1010,7 @@ myMessageQueue.BeginTransaction();
   
  Do not use the asynchronous call <xref:System.Messaging.MessageQueue.BeginReceive%2A> with transactions. If you want to perform a transactional asynchronous operation, call <xref:System.Messaging.MessageQueue.BeginPeek%2A>, and put the transaction and the (synchronous) <xref:System.Messaging.MessageQueue.Receive%2A> method within the event handler you create for the peek operation. Your event handler might contain functionality as shown in the following C# code.  
   
-```  
+```csharp  
 myMessageQueue.BeginTransaction();  
  myMessageQueue.Receive();  
  myMessageQueue.CommitTransaction();  
@@ -1087,7 +1087,7 @@ myMessageQueue.BeginTransaction();
   
  Do not use the asynchronous call <xref:System.Messaging.MessageQueue.BeginReceive%2A> with transactions. If you want to perform a transactional asynchronous operation, call <xref:System.Messaging.MessageQueue.BeginPeek%2A>, and put the transaction and the (synchronous) <xref:System.Messaging.MessageQueue.Receive%2A> method within the event handler you create for the peek operation. Your event handler might contain functionality as shown in the following C# code.  
   
-```  
+```csharp  
 myMessageQueue.BeginTransaction();  
  myMessageQueue.Receive();  
  myMessageQueue.CommitTransaction();  
@@ -1166,7 +1166,7 @@ myMessageQueue.BeginTransaction();
   
  Do not use the asynchronous call <xref:System.Messaging.MessageQueue.BeginReceive%2A> with transactions. If you want to perform a transactional asynchronous operation, call <xref:System.Messaging.MessageQueue.BeginPeek%2A>, and put the transaction and the (synchronous) <xref:System.Messaging.MessageQueue.Receive%2A> method within the event handler you create for the peek operation. Your event handler might contain functionality as shown in the following C# code.  
   
-```  
+```csharp  
 myMessageQueue.BeginTransaction();  
  myMessageQueue.Receive();  
  myMessageQueue.CommitTransaction();  
@@ -1418,7 +1418,7 @@ myMessageQueue.BeginTransaction();
 ## Remarks  
  <xref:System.Messaging.MessageQueue.Close%2A> frees all resources associated with a <xref:System.Messaging.MessageQueue>, including shared resources if appropriate. The system re-acquires these resources automatically if they are still available, for example when you call the <xref:System.Messaging.MessageQueue.Send%28System.Object%29> method, as in the following C# code.  
   
-```  
+```csharp  
 myMessageQueue.Send("Text 1.");  
 myMessageQueue.Close();  
 myMessageQueue.Send("Text 2."); //Resources are re-acquired.  
@@ -6021,17 +6021,11 @@ myMessageQueue.Send("Text 2."); //Resources are re-acquired.
   
  The <xref:System.Messaging.MessageQueue.DefaultPropertiesToSend%2A> property applies to any object other than a <xref:System.Messaging.Message>. If you specify, for example, a label or a priority using the <xref:System.Messaging.MessageQueue.DefaultPropertiesToSend%2A> member, these values apply to any message that contains an object that is not of type <xref:System.Messaging.Message> when your application sends it to the queue. When sending a <xref:System.Messaging.Message>, the property values set for the <xref:System.Messaging.Message> take precedence over <xref:System.Messaging.MessageQueue.DefaultPropertiesToSend%2A> and the message's <xref:System.Messaging.Message.Formatter%2A?displayProperty=fullName> property takes precedence over the queue's <xref:System.Messaging.MessageQueue.Formatter%2A?displayProperty=fullName> property.  
   
- [Visual Basic]  
-  
  <xref:System.Messaging.MessageQueueTransaction> is threading apartment aware, so if your apartment state is `STA`, you cannot use the transaction in multiple threads. Visual Basic sets the state of the main thread to `STA`, so you must apply the <xref:System.MTAThreadAttribute> in the `Main` subroutine. Otherwise, sending a transactional message using another thread throws a <xref:System.Messaging.MessageQueueException> exception. You apply the <xref:System.MTAThreadAttribute> by using the following fragment.  
   
-```  
+```vb  
 <System.MTAThreadAttribute>  
  public sub Main()  
-```  
-  
-```vb  
-  
 ```  
   
  The following table shows whether this method is available in various Workgroup modes.  
@@ -6222,17 +6216,11 @@ myMessageQueue.Send("Text 2."); //Resources are re-acquired.
   
  The <xref:System.Messaging.MessageQueue.DefaultPropertiesToSend%2A> property applies to any object other than a <xref:System.Messaging.Message>. If you specify, for example, a label or a priority using the <xref:System.Messaging.MessageQueue.DefaultPropertiesToSend%2A> member, these values apply to any message that contains an object that is not of type <xref:System.Messaging.Message> when your application sends it to the queue. When sending a <xref:System.Messaging.Message>, the property values set for the <xref:System.Messaging.Message> take precedence over <xref:System.Messaging.MessageQueue.DefaultPropertiesToSend%2A> and the message's <xref:System.Messaging.Message.Formatter%2A?displayProperty=fullName> property takes precedence over the queue's <xref:System.Messaging.MessageQueue.Formatter%2A?displayProperty=fullName> property  
   
- [Visual Basic]  
-  
  <xref:System.Messaging.MessageQueueTransaction> is threading apartment aware, so if your apartment state is `STA`, you cannot use the transaction in multiple threads. Visual Basic sets the state of the main thread to `STA`, so you must apply the <xref:System.MTAThreadAttribute> in the `Main` subroutine. Otherwise, sending a transactional message using another thread throws a <xref:System.Messaging.MessageQueueException> exception. You apply the <xref:System.MTAThreadAttribute> by using the following fragment.  
   
-```  
+```vb  
 <System.MTAThreadAttribute>  
  public sub Main()  
-```  
-  
-```vb  
-  
 ```  
   
  The following table shows whether this method is available in various Workgroup modes.  
@@ -6770,17 +6758,11 @@ myMessageQueue.Send("Text 2."); //Resources are re-acquired.
   
  If you send a non-transactional message to a transactional queue, you will not be able to roll back the message in the event of an exception.  
   
- [Visual Basic]  
-  
  <xref:System.Messaging.MessageQueueTransaction> is threading apartment aware, so if your apartment state is `STA`, you cannot use the transaction in multiple threads. Visual Basic sets the state of the main thread to `STA`, so you must apply the <xref:System.MTAThreadAttribute> in the `Main` subroutine. Otherwise, sending a transactional message using another thread throws a <xref:System.Messaging.MessageQueueException> exception. You apply the <xref:System.MTAThreadAttribute> by using the following fragment.  
   
-```  
+```vb  
 <System.MTAThreadAttribute>  
  public sub Main()  
-```  
-  
-```vb  
-  
 ```  
   
  The following table shows whether this property is available in various Workgroup modes.  

--- a/xml/System.Messaging/MessageQueueTransaction.xml
+++ b/xml/System.Messaging/MessageQueueTransaction.xml
@@ -28,17 +28,11 @@
   
  If you instantiate a <xref:System.Messaging.MessageQueueTransaction> and pass it to an applicable overload of the <xref:System.Messaging.MessageQueue.Send%2A> method or <xref:System.Messaging.MessageQueue.Receive%2A> method to send a message to a non-transactional queue or receive a message from a non-transactional queue, the method throws an exception that indicates "Wrong Transaction Usage."  
   
- [Visual Basic]  
-  
  <xref:System.Messaging.MessageQueueTransaction> is threading apartment aware, so if your apartment state is `STA`, you cannot use the transaction in multiple threads. Visual Basic sets the state of the main thread to `STA`, so you must apply the <xref:System.MTAThreadAttribute> in the `Main` subroutine. Otherwise, sending a transactional message using another thread throws a <xref:System.Messaging.MessageQueueException> exception. You apply the <xref:System.MTAThreadAttribute> by using the following fragment.  
   
-```  
+```vb  
 <System.MTAThreadAttribute>  
  public sub Main()  
-```  
-  
-```vb  
-  
 ```  
   
  ]]></format>

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -1482,15 +1482,11 @@
 ## Remarks  
  This property is a convenience feature that indicates whether a <xref:System.Numerics.BigInteger> value is evenly divisible by two. It is equivalent to the following expression:  
   
- [C#]  
-  
-```  
+```csharp  
 value % 2 == 0;  
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 value Mod 2 = 0  
 ```  
   

--- a/xml/System.Runtime.Caching/CacheItemPolicy.xml
+++ b/xml/System.Runtime.Caching/CacheItemPolicy.xml
@@ -25,9 +25,7 @@
 ## Examples  
  The following example shows how to create an in-memory cache item that monitors the path for a text file. The cache creates a <xref:System.Runtime.Caching.CacheItemPolicy> object and sets the <xref:System.Runtime.Caching.CacheItemPolicy.AbsoluteExpiration%2A> property to evict the cache after 60 seconds.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Protected Sub Button1_Click(ByVal sender As Object, _  
             ByVal e As System.EventArgs) Handles Button1.Click  
     Dim cache As ObjectCache = MemoryCache.Default  
@@ -52,9 +50,7 @@ Protected Sub Button1_Click(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void Button1_Click(object sender, EventArgs e)  
     {  
         ObjectCache cache = MemoryCache.Default;  

--- a/xml/System.Runtime.InteropServices/SEHException.xml
+++ b/xml/System.Runtime.InteropServices/SEHException.xml
@@ -58,26 +58,20 @@
   
  Note that the <xref:System.Runtime.InteropServices.SEHException> class does not cause unmanaged C++ exception destructors to be called. To ensure that unmanaged C++ exception destructors are called, use the following syntax in the `catch` block.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Catch   
      ' Handle catch here.  
 End Try  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 catch  
 {  
      // Handle catch here.  
 }  
 ```  
   
- [C++]  
-  
-```  
+```cpp  
 catch(…)  
 {  
      // Handle catch here.  

--- a/xml/System.ServiceModel.Channels/HttpTransportBindingElement.xml
+++ b/xml/System.ServiceModel.Channels/HttpTransportBindingElement.xml
@@ -42,7 +42,7 @@
   
  `HttpTransportBindingElement` can also be used in a configuration file as shown in the following configuration.  
   
-```  
+```xml  
 <bindings>  
   <customBinding>  
     <binding name="Binding1">  
@@ -57,7 +57,6 @@
     </binding>  
   </customBinding>  
 </bindings>  
-  
 ```  
   
  ]]></format>
@@ -107,9 +106,7 @@
 ## Examples  
  The following example shows how to use the copy constructor in a derived class.  
   
- [C#]  
-  
-```  
+```csharp  
 public class MyBindingElement : HttpTransportBindingElement  
 {  
     public MyBindingElement(MyBindingElement elementToBeCloned) : base(elementToBeCloned)  
@@ -155,12 +152,9 @@ public class MyBindingElement : HttpTransportBindingElement
 ## Examples  
  The following example sets this property to indicate that all cookies from the server should be copied to future client requests.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBindingElement = new HttpBindingElement();  
 httpBindingElement.AllowCookies = true;  
-  
 ```  
   
  ]]></format>
@@ -199,9 +193,7 @@ httpBindingElement.AllowCookies = true;
 ## Examples  
  The following example sets this property to use when authenticating client requests.  
   
- [C#]  
-  
-```  
+```csharp  
 [ServiceContract]  
 interface ICalculator  
 {  
@@ -345,9 +337,7 @@ int odd=calc.Add(5,4);
 ## Examples  
  The following example sets this property to use when performing requests on the binding.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 httpBinding.BypassProxyOnLocal = true;  
 ```  
@@ -443,9 +433,7 @@ httpBinding.BypassProxyOnLocal = true;
 ## Examples  
  The following example clones the specified binding element.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpBindingElement bindingElement = elementToClone.Clone();  
 ```  
   
@@ -650,9 +638,7 @@ HttpBindingElement bindingElement = elementToClone.Clone();
 ## Examples  
  The following example sets this property to use when performing requests on the binding.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 httpBinding.MaxBufferSize = 16384;  
 ```  
@@ -739,9 +725,7 @@ httpBinding.MaxBufferSize = 16384;
 ## Examples  
  The following example sets this property to use when performing requests on the binding. All requests are routed through this proxy, unless <xref:System.ServiceModel.Channels.HttpTransportBindingElement.BypassProxyOnLocal%2A> is set to `true` and the endpoint is a local endpoint.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 httpBinding.ProxyAddress = new Uri(http://proxyserver);  
 ```  
@@ -777,9 +761,7 @@ httpBinding.ProxyAddress = new Uri(http://proxyserver);
 ## Examples  
  The following example sets this property to use when sending requests to the proxy specified in the <xref:System.ServiceModel.Channels.HttpTransportBindingElement.ProxyAddress%2A> property.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 httpBinding.ProxyAddress = new Uri(http://proxyserver);  
 httpBinding.ProxyAuthenticationScheme = AuthenticationSchemes.Digest;  
@@ -870,9 +852,7 @@ httpBinding.ProxyAuthenticationScheme = AuthenticationSchemes.Digest;
 ## Examples  
  The following example outputs the scheme of the binding to the console.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 Console.WriteLine("The scheme of the binding is {0}.",httpBinding.Scheme);  
 ```  
@@ -1120,9 +1100,7 @@ Console.WriteLine("The scheme of the binding is {0}.",httpBinding.Scheme);
 ## Examples  
  The following example sets the property to enable Unsafe Connection Sharing.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 httpBinding.AuthenticationScheme = AuthenticationSchemes.Ntlm;  
 httpBinding.UnsafeConnectionNtlmAuthentication = true;  
@@ -1181,9 +1159,7 @@ httpBinding.UnsafeConnectionNtlmAuthentication = true;
 ## Examples  
  The following example causes user-specific proxy settings to be used.  
   
- [C#]  
-  
-```  
+```csharp  
 HttpTransportBindingElement httpBinding = new HttpTransportBindingElement();  
 httpBinding.UseDefaultWebProxy = false;  
 ```  

--- a/xml/System.ServiceModel.Dispatcher/XPathMessageFilterTable`1.xml
+++ b/xml/System.ServiceModel.Dispatcher/XPathMessageFilterTable`1.xml
@@ -1043,14 +1043,10 @@
   
 ```csharp  
 myFilters[filter]  
-  
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 myFilters(filter)  
-  
 ```  
   
  You can also use the `Item` property to add new elements by setting the values of a `filter`/filter data pair that does not exist in the action filter table. However if `filter` is already in the table, setting the `Item` property overwrites the old value. In contrast, the <xref:System.ServiceModel.Dispatcher.XPathMessageFilterTable%601.Add%2A> method does not modify the filter data of an existing `filter`.  

--- a/xml/System.ServiceModel/IExtension`1.xml
+++ b/xml/System.ServiceModel/IExtension`1.xml
@@ -58,16 +58,13 @@
 ## Examples  
  The following example code shows how this method can be used to keep track of the <xref:System.ServiceModel.IExtensibleObject%601> object to which the current instance of the extension belongs.  
   
- [C#]  
-  
-```  
+```csharp  
 InstanceContext owner;  
   
 public void Attach(InstanceContext owner)  
 {  
   this.owner = owner;   
 }  
-  
 ```  
   
  ]]></format>

--- a/xml/System.ServiceModel/WSHttpBindingBase.xml
+++ b/xml/System.ServiceModel/WSHttpBindingBase.xml
@@ -116,7 +116,6 @@
    
   
 ## Examples  
- [C#]  
   
  The following example sets this property to indicate that the proxy should be bypassed for local resources.  
   

--- a/xml/System.Threading/WaitOrTimerCallback.xml
+++ b/xml/System.Threading/WaitOrTimerCallback.xml
@@ -44,7 +44,6 @@
   
  Create the registered wait handle by passing the <xref:System.Threading.WaitOrTimerCallback> delegate and a <xref:System.Threading.WaitHandle> to <xref:System.Threading.ThreadPool.RegisterWaitForSingleObject%2A?displayProperty=fullName>. Your callback method executes each time the <xref:System.Threading.WaitHandle> times out or is signaled.  
   
- [Visual Basic]  
   
 > [!NOTE]
 >  Visual Basic users can omit the <xref:System.Threading.WaitOrTimerCallback> constructor, and simply use the `AddressOf` operator when passing the callback method to <xref:System.Threading.ThreadPool.RegisterWaitForSingleObject%2A>. Visual Basic automatically calls the correct delegate constructor.  

--- a/xml/System.Web.DynamicData/DynamicValidator.xml
+++ b/xml/System.Web.DynamicData/DynamicValidator.xml
@@ -30,9 +30,7 @@
 ## Examples  
  The following example shows how to create a <xref:System.Web.DynamicData.DynamicValidator> control class that displays other exceptions in all pages.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 ''' <summary>   
 ''' Display other exceptions in all pages.   
 ''' </summary>   
@@ -69,9 +67,7 @@ Public Class MyDynamicValidator
 End Class  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 /// <summary>  
 /// Display other exceptions in all pages.   
 /// </summary>  
@@ -108,7 +104,7 @@ public class MyDynamicValidator : DynamicValidator {
   
  The following example shows how to use tag remapping in the web.config file to display the exception in all the Web pages.  
   
-```  
+```xml  
 <pages>  
   <tagMapping>  
     <add tagType="System.Web.DynamicData.DynamicValidator"   

--- a/xml/System.Web.UI.WebControls.Expressions/MethodExpression.xml
+++ b/xml/System.Web.UI.WebControls.Expressions/MethodExpression.xml
@@ -39,9 +39,7 @@
 ## Examples  
  The following example shows how to search the ListPrice field of the Products table in the AdventureWorks database for products that have a list price of 400 or more. This example shows how to create a custom LINQ query in a method in page code and how to invoke the method in the <xref:System.Web.UI.WebControls.QueryExtender> control.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Public Shared Function FilterStandardPrice(ByVal query As _  
         IQueryable(Of Product)) As IQueryable(Of Product)  
         Return From p In query _  
@@ -50,9 +48,7 @@ Public Shared Function FilterStandardPrice(ByVal query As _
     End Function  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 public static IQueryable<Product>   
         FilterStandardPrice(IQueryable<Product> query)  
 {  

--- a/xml/System.Web.UI.WebControls.WebParts/WebPartManager.xml
+++ b/xml/System.Web.UI.WebControls.WebParts/WebPartManager.xml
@@ -2746,9 +2746,7 @@
   
  The second step is to override the <xref:System.Web.UI.WebControls.WebParts.WebPartManager.IsAuthorized%28System.Type%2CSystem.String%2CSystem.String%2CSystem.Boolean%29> method, and create custom handling for authorization filters. Note that the code first checks whether the property has a value, so that any control that does not assign the <xref:System.Web.UI.WebControls.WebParts.WebPart.AuthorizationFilter%2A> property will be added automatically. If a control has a filter, the code returns `true` only if the filter value is equal to `admin`. This demonstrates a simple mechanism you can use for displaying certain controls to certain users, depending on their role. While a full example using roles is beyond the scope of this topic, you could use the same logic as the overridden method in this code example, except that you could check whether the current user is in a role that matches the authorization filter value, and then add the control only for that user. This would enable you to create pages where some users would see all the controls, and other users would see only selected controls. This is how the logic that checks the filter might look if you used roles:  
   
- [Visual Basic]  
-  
-```  
+```vb  
 If Roles.IsUserInRole(Page.User.Identity.Name, authorizationFilter) Then  
   return True  
 Else  
@@ -2756,9 +2754,7 @@ Else
 End If  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 if(Roles.IsUserInRole(Page.User.Identity.Name, authorizationFilter))  
     return true;  
 else  
@@ -3071,9 +3067,7 @@ else
   
  Because setting up users in roles is beyond the scope of this topic, this code example does not check user roles in the filtering. However, the scenario of filtering controls according to user roles is likely to be one of the most common uses of this filtering feature. If you have roles on your site, and you want to check user roles in this method to filter controls, the method would resemble the following code block (versus the simpler approach in the preceding code example, which does not use roles).  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Protected Sub WebPartManager1_AuthorizeWebPart(ByVal sender _  
   As Object, ByVal e As WebPartAuthorizationEventArgs)  
   
@@ -3090,9 +3084,7 @@ Protected Sub WebPartManager1_AuthorizeWebPart(ByVal sender _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void mgr1_AuthorizeWebPart(object sender,   
   WebPartAuthorizationEventArgs e)  
 {  

--- a/xml/System.Web.UI.WebControls.WebParts/WebPartTransformer.xml
+++ b/xml/System.Web.UI.WebControls.WebParts/WebPartTransformer.xml
@@ -46,9 +46,7 @@
   
  A customized transformer must be specified in the `<transformers>` section of the Web.config file to be available for use in a Web page. The third section of the code example shows how to add the customized transformer to the Web.config file.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 <webParts enableExport="true">  
     <transformers>  
        <add name="RowToStringTransformer"  
@@ -57,9 +55,7 @@
 </webParts>  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 <webParts enableExport="true">  
     <transformers>  
        <add name="RowToStringTransformer"  

--- a/xml/System.Web.UI.WebControls/BulletedList.xml
+++ b/xml/System.Web.UI.WebControls/BulletedList.xml
@@ -306,29 +306,21 @@
   
  The following code example shows a relative path to an image file:  
   
- [C#]  
-  
-```  
+```csharp  
 \\Images\\image1.jpg  
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 "Images\image1.jpg"  
 ```  
   
  The following code example shows an absolute path to an image file:  
   
- [C#]  
-  
-```  
+```csharp  
 "c:\\MyImagesDir\\image1.jpg"   
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 "c"\MyImagesDir\image1.jpg"  
 ```  
   

--- a/xml/System.Web.UI.WebControls/LinqDataSource.xml
+++ b/xml/System.Web.UI.WebControls/LinqDataSource.xml
@@ -1170,9 +1170,7 @@ Protected Sub LinqDataSource_Inserting(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Inserting(object sender,   
         LinqDataSourceInsertEventArgs e)  
 {  
@@ -1673,9 +1671,7 @@ End Sub
   
  The following example shows how to assign the <xref:System.Web.UI.WebControls.LinqDataSourceSelectEventArgs.Result%2A> property to the object that is returned from a method that represents a stored procedure.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Protected Sub LinqDataSource_Selecting(ByVal sender As Object, _  
         ByVal e As LinqDataSourceSelectEventArgs)  
     Dim exampleContext As ExampleDataContext = New ExampleDataContext()  
@@ -1683,9 +1679,7 @@ Protected Sub LinqDataSource_Selecting(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Selecting(object sender,   
         LinqDataSourceSelectEventArgs e)  
 {  
@@ -2061,9 +2055,7 @@ Protected Sub LinqDataSource_Updating(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Updating(object sender,   
         LinqDataSourceUpdateEventArgs e)  
 {  

--- a/xml/System.Web.UI.WebControls/LinqDataSourceInsertEventArgs.xml
+++ b/xml/System.Web.UI.WebControls/LinqDataSourceInsertEventArgs.xml
@@ -46,9 +46,7 @@ Protected Sub LinqDataSource_Inserting(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Inserting(object sender,   
         LinqDataSourceInsertEventArgs e)  
 {  
@@ -145,9 +143,7 @@ Protected Sub LinqDataSource_Inserting(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Inserting(object sender,   
         LinqDataSourceInsertEventArgs e)  
 {  
@@ -209,9 +205,7 @@ Protected Sub LinqDataSource_Inserting(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Inserting(object sender,   
         LinqDataSourceInsertEventArgs e)  
 {  

--- a/xml/System.Web.UI.WebControls/LinqDataSourceUpdateEventArgs.xml
+++ b/xml/System.Web.UI.WebControls/LinqDataSourceUpdateEventArgs.xml
@@ -48,9 +48,7 @@ Protected Sub LinqDataSource_Updating(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Updating(object sender,   
         LinqDataSourceUpdateEventArgs e)  
 {  
@@ -149,9 +147,7 @@ Protected Sub LinqDataSource_Updating(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Updating(object sender,   
         LinqDataSourceUpdateEventArgs e)  
 {  
@@ -213,9 +209,7 @@ Protected Sub LinqDataSource_Updating(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Updating(object sender,   
         LinqDataSourceUpdateEventArgs e)  
 {  

--- a/xml/System.Web.UI.WebControls/LinqDataSourceValidationException.xml
+++ b/xml/System.Web.UI.WebControls/LinqDataSourceValidationException.xml
@@ -47,9 +47,7 @@ Protected Sub LinqDataSource_Updating(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Updating(object sender,   
         LinqDataSourceUpdateEventArgs e)  
 {  
@@ -278,9 +276,7 @@ Protected Sub LinqDataSource_Updating(ByVal sender As Object, _
 End Sub  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 protected void LinqDataSource_Updating(object sender,   
         LinqDataSourceUpdateEventArgs e)   
 {  

--- a/xml/System.Web.UI/ControlBuilder.xml
+++ b/xml/System.Web.UI/ControlBuilder.xml
@@ -25,15 +25,11 @@
 ## Examples  
  The following code example creates a <xref:System.Web.UI.WebControls.Table> control whose attributes and content are defined at the time the table is built. The following is the command line to use to build the executable.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 vbc /r:System.dll /r:System.Web.dll /r:System.Drawing.dll /t:library /out:myWebAppPath/Bin/vb_mycontrolbuilder.dll myControlBuilder.vb  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 csc /t:library /out:myWebAppPath/Bin/cs_mycontrolbuilder.dll myControlBuilder.cs  
 ```  
   

--- a/xml/System.Web.UI/Page.xml
+++ b/xml/System.Web.UI/Page.xml
@@ -4066,15 +4066,11 @@
 ## Remarks  
  If a page is running in response to a request made through ASP.NET routing, this property provides access to the URL parameter values that were passed as route data. If the page runs in response to a physical URL instead of a route URL, this property is `null`. The following example shows how to extract the value of a URL parameter that is named `year`.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim year As Integer = Convert.ToInt32(Page.RouteData.Values("year"))  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 int year = Convert.ToInt32(Page.RouteData.Values["year"])  
 ```  
   
@@ -5311,7 +5307,6 @@ int year = Convert.ToInt32(Page.RouteData.Values["year"])
   
 ```vb  
 <%@ Page Language="VB" ViewStateEncryptionMode="Always" %>  
-  
 ```  
   
 ```csharp  
@@ -5324,7 +5319,6 @@ int year = Convert.ToInt32(Page.RouteData.Values["year"])
 <system.web>  
   <pages viewStateEncryptionMode="Always" />  
 </system.web>  
-  
 ```  
   
 ```csharp  

--- a/xml/System.Web.Util/RequestValidationSource.xml
+++ b/xml/System.Web.Util/RequestValidationSource.xml
@@ -22,9 +22,7 @@
 ## Examples  
  The following example shows how to create a custom request validator class that allows only a specific string for query-string values.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Imports System  
 Imports System.Web  
 Imports System.Web.Util  
@@ -74,9 +72,7 @@ End Function
 End Class  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 using System;  
 using System.Web;  
 using System.Web.Util;  

--- a/xml/System.Web/HttpApplication.xml
+++ b/xml/System.Web/HttpApplication.xml
@@ -1554,20 +1554,7 @@
   
 ## Examples  
  The following example shows how to programmatically specify the cache provider named `DiskCache` for any HTTP request that goes to the Advanced.aspx page.  
-  
- [Visual Basic]  
-  
-```  
-Public Overloads Overrides Sub GetOutputCacheProviderName(ByVal context _  
-        As HttpContext) As String   
-    If context.Request.Path.EndsWith("Advanced.aspx") Then   
-        Return "DiskCache"   
-    Else   
-        Return MyBase.GetOutputCacheProviderName(context)   
-    End If   
-End Sub  
-```  
-  
+
 ```csharp  
 public override string GetOutputCacheProviderName(HttpContext context)  
 {  
@@ -1576,6 +1563,17 @@ public override string GetOutputCacheProviderName(HttpContext context)
     else  
         return base.GetOutputCacheProviderName(context);  
 }  
+```  
+
+```vb  
+Public Overloads Overrides Sub GetOutputCacheProviderName(ByVal context _  
+        As HttpContext) As String   
+    If context.Request.Path.EndsWith("Advanced.aspx") Then   
+        Return "DiskCache"   
+    Else   
+        Return MyBase.GetOutputCacheProviderName(context)   
+    End If   
+End Sub  
 ```  
   
  ]]></format>

--- a/xml/System.Windows.Forms/DataGridTextBoxColumn.xml
+++ b/xml/System.Windows.Forms/DataGridTextBoxColumn.xml
@@ -22,8 +22,6 @@
   
  If the data source is a <xref:System.Data.DataTable> containing <xref:System.Data.DataColumn> objects, the <xref:System.Data.DataColumn.DataType%2A> property of the <xref:System.Data.DataColumn> should be set to a data type that can logically be edited in a text box control. The following data types are automatically associated with a <xref:System.Windows.Forms.DataGridTextBoxColumn> : <xref:System.Byte>, <xref:System.DateTime>, <xref:System.Decimal>, <xref:System.Double>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>, <xref:System.Single>, and <xref:System.String>.  
   
- [Visual Basic]  
-  
 > [!NOTE]
 >  The following types are not fully supported by Visual Basic: <xref:System.DateTime>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>, and <xref:System.TimeSpan>. (Operators are not allowed.)  
   
@@ -821,7 +819,7 @@
 ## Examples  
  The following example sets the <xref:System.ComponentModel.PropertyDescriptor> property of the <xref:System.Windows.Forms.DataGridTextBoxColumn>.  
   
-```  
+```csharp  
 [SampleID='Classic DataGridTextBoxColumn.PropertyDescriptor Example' SnippetID='1']  
 ```  
   

--- a/xml/System.Windows.Forms/DataGridView.xml
+++ b/xml/System.Windows.Forms/DataGridView.xml
@@ -14528,16 +14528,12 @@
 ## Remarks  
  You can use the <xref:System.Windows.Forms.DataGridView.Rows%2A> collection to manually populate a <xref:System.Windows.Forms.DataGridView> control instead of binding it to a data source. The following example shows you how to manually add and insert rows. This example assumes that you have added four <xref:System.Windows.Forms.DataGridViewTextBoxColumn> instances to the control's <xref:System.Windows.Forms.DataGridView.Columns%2A> collection.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Me.dataGridView1.Rows.Add("five", "six", "seven", "eight")  
 Me.dataGridView1.Rows.Insert(0, "one", "two", "three", "four")  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 this.dataGridView1.Rows.Add("five", "six", "seven", "eight");this.dataGridView1.Rows.Insert(0, "one", "two", "three", "four");  
 ```  
   
@@ -14549,9 +14545,7 @@ this.dataGridView1.Rows.Add("five", "six", "seven", "eight");this.dataGridView1.
   
  The following example shows you how to modify cell values programmatically.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 ' Modify the value in the first cell of the second row.  
 Me.dataGridView1.Rows[1].Cells[0].Value = "new value"  
   
@@ -14559,9 +14553,7 @@ Me.dataGridView1.Rows[1].Cells[0].Value = "new value"
 Me.dataGridView1[0, 1].Value = "new value"  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 // Modify the value in the first cell of the second row.  
 this.dataGridView1.Rows[1].Cells[0].Value = "new value";  
   
@@ -14573,9 +14565,7 @@ this.dataGridView1[0, 1].Value = "new value";
   
  The following example shows you how to retrieve the index of the first selected row, and then use it to programmatically delete the row.  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Dim rowToDelete As Int32 = Me.dataGridView1.Rows.GetFirstRow( _  
     DataGridViewElementStates.Selected)  
 If rowToDelete > -1 Then  
@@ -14583,9 +14573,7 @@ If rowToDelete > -1 Then
 End If  
 ```  
   
- [C#]  
-  
-```  
+```csharp  
 Int32 rowToDelete = this.dataGridView1.Rows.GetFirstRow(  
     DataGridViewElementStates.Selected);  
 if (rowToDelete > -1)  

--- a/xml/System.Windows.Media.Media3D/Point3DConverter.xml
+++ b/xml/System.Windows.Media.Media3D/Point3DConverter.xml
@@ -16,7 +16,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Examples  
- [C#]  
   
  The following sample uses a <xref:System.Windows.Media.Media3D.Point3DConverter> structure to convert a string into a <xref:System.Windows.Media.Media3D.Point3D> structure.  
   

--- a/xml/System.Windows.Media.Media3D/Point4DConverter.xml
+++ b/xml/System.Windows.Media.Media3D/Point4DConverter.xml
@@ -16,7 +16,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Examples  
- [C#]  
   
  The following sample uses a <xref:System.Windows.Media.Media3D.Point4DConverter> structure to convert a string into a <xref:System.Windows.Media.Media3D.Point4D> structure.  
   

--- a/xml/System.Windows.Media.Media3D/Size3DConverter.xml
+++ b/xml/System.Windows.Media.Media3D/Size3DConverter.xml
@@ -16,7 +16,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Examples  
- [C#]  
   
  The following sample uses a <xref:System.Windows.Media.Media3D.Size3DConverter> structure to convert a string into a <xref:System.Windows.Media.Media3D.Size3D> structure.  
   

--- a/xml/System.Windows.Media.Media3D/Vector3DConverter.xml
+++ b/xml/System.Windows.Media.Media3D/Vector3DConverter.xml
@@ -16,7 +16,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Examples  
- [C#]  
   
  The following sample uses a <xref:System.Windows.Media.Media3D.Vector3DConverter> structure to convert a string into a <xref:System.Windows.Media.Media3D.Vector3D> structure.  
   

--- a/xml/System.Xml.Linq/XDeclaration.xml
+++ b/xml/System.Xml.Linq/XDeclaration.xml
@@ -411,23 +411,18 @@ yes
 ## Examples  
  The following example uses this property to print the version property of a declaration.  
   
- [C#]  
-  
-```  
+```csharp  
 XDeclaration xd = new XDeclaration("1.0", "utf-8", "yes");  
 Console.WriteLine(xd.Version);  
 Console.WriteLine(xd.Encoding);  
 Console.WriteLine(xd.Standalone);  
 ```  
   
- [vb]  
-  
-```  
+```vb  
 Dim xd As XDeclaration = New XDeclaration("1.0", "utf-8", "yes")  
 Console.WriteLine(xd.Version)  
 Console.WriteLine(xd.Encoding)  
 Console.WriteLine(xd.Standalone)  
-  
 ```  
   
  This example produces the following output:  

--- a/xml/System.Xml.Linq/XNamespace.xml
+++ b/xml/System.Xml.Linq/XNamespace.xml
@@ -176,9 +176,7 @@ End Module
 ## Using Expanded Names  
  Another way to specify a namespace and a local name is to use an expanded name in the form `{namespace}name`:  
   
- [C#]  
-  
-```  
+```csharp  
 XElement e = new XElement("{http://www.adventure-works.com}Root",  
      new XAttribute("{http://www.adventure-works.com}Att", "content")  
 );  
@@ -1090,9 +1088,7 @@ Console.WriteLine(root)
   
  In Visual Basic, the preferred idiom is:  
   
- [vb]  
-  
-```  
+```vb  
 Imports <xmlns:aw='http://www.adventure-works.com'>  
   
 Module Module1  

--- a/xml/System.Xml.Serialization/XmlAttributeAttribute.xml
+++ b/xml/System.Xml.Serialization/XmlAttributeAttribute.xml
@@ -48,8 +48,10 @@
  // Set this to 'default' or 'preserve'.  
  [XmlAttribute("space",   
  Namespace = "http://www.w3.org/XML/1998/namespace")]  
- public string Space   
- [Visual Basic]  
+ public string Space 
+ ```
+
+ ```vb 
  <XmlAttribute("xml:lang")> _  
  Public Lang As String   
  ' Set this to 'default' or 'preserve'.  
@@ -408,7 +410,7 @@
   
  The default setting, `XmlSchemaForm.None`, instructs the <xref:System.Xml.Serialization.XmlSerializer> to check the schema for the XML document to determine whether the namespace is qualified. If the schema does not specify a value for an individual element or attribute, the <xref:System.Xml.Serialization.XmlSerializer> uses the `elementFormDefault` and `attributeFormDefault` values to determine whether an element or attribute is qualified. The following XML code shows a schema:  
   
-```  
+```xml  
 <schema elementFormDefault="qualified"   
 attributeFormDefault="unqualified"... >  
    <element name="Name"/>  

--- a/xml/System/DateTimeOffset.xml
+++ b/xml/System/DateTimeOffset.xml
@@ -3874,15 +3874,11 @@
   
  The <xref:System.DateTimeOffset.ToFileTime%2A> method converts the current <xref:System.DateTimeOffset> object's date and time to UTC before it performs the conversion. In other words, calling the <xref:System.DateTimeOffset.ToFileTime%2A> method is equivalent to the following method call:  
   
- [C#]  
-  
-```  
+```csharp  
 this.ToUtcDateTime().ToFileTime();  
 ```  
   
- [Visual Basic]  
-  
-```  
+```vb  
 Me.ToUtcDateTime().ToFileTime()  
 ```  
   

--- a/xml/System/TimeZoneInfo.xml
+++ b/xml/System/TimeZoneInfo.xml
@@ -1327,14 +1327,14 @@
   
  <xref:System.TimeZoneInfo.Equals%28System.TimeZoneInfo%29?displayProperty=fullName> returns the Boolean value that results from evaluating the following expression:  
   
- [C#]  
+ ```csharp 
+ other.Id == this.Id && HasSameRules(other);  
+ ```
   
- `other.Id == this.Id && HasSameRules(other);`  
-  
- [Visual Basic]  
-  
- `other.Id = me.Id AndAlso HasSameRules(other)`  
-  
+ ```vb
+ other.Id = me.Id AndAlso HasSameRules(other)  
+ ```
+
  If the `other` parameter is an uninitialized <xref:System.TimeZoneInfo> object, this method returns `false`.  
   
    


### PR DESCRIPTION
# Title
Fixed incorrectly marked code blocks in docs and xml.

## Summary
I did the following to find code blocks that were incorrectly marked:

1. Searched on "[C#]" in /xml branch (Fixed 49 files)
2. Searched on "[C#]" in /docs branch (Fixed 20 files)
3. Searched on "[Visual Basic]" in /xml = (Fixed 8 files)
4. Searched on "[Visual Basic]" in /docs = (Fixed 8 files)

Within these files, I deleted unneeded spaces and fixed other unmarked code blocks.
**Note:** Please review the topic:
	docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
It required some editing to the text and to a procedure when the correct labels were added.

Fixes #2069 

## Suggested Reviewers
@mairaw 
