### PR TITLE
Fixed operator keyword typo

### DIFF
--- a/docs/csharp/language-reference/keywords/toc.md
+++ b/docs/csharp/language-reference/keywords/toc.md
@@ -114,7 +114,7 @@
 ## [Conversion Keywords](conversion-keywords.md)
 ### [explicit](explicit.md)
 ### [implicit](implicit.md)
-### [operator2](operator.md)
+### [operator](operator.md)
 ## [Access Keywords](access-keywords.md)
 ### [base](base.md)
 ### [this](this.md)


### PR DESCRIPTION
# Fix typo in TOC

Currently the TOC lists the `operator` keyword as `operator2`. This PR corrects it.
