### PR TITLE
Restore index page dropped content

### DIFF
--- a/index.md
+++ b/index.md
@@ -81,7 +81,7 @@ title: .NET Documentation
                                                 </div>
                                             </div>
                                             <div class="cardText">
-                                                <h3><a href="/dotnet/articles/welcome">.NET Platform Guide</a></h3>
+                                                <h3><a href="/dotnet/articles/standard">.NET Platform Guide</a></h3>
                                                 <p><a href="/dotnet/articles/standard/get-started">Get Started</a></p>
                                                 <p><a href="/dotnet/articles/standard/tour">Tour of .NET</a></p>
                                                 <p><a href="/dotnet/articles/standard/components">.NET Architectural Concepts</a></p>
@@ -120,11 +120,11 @@ title: .NET Documentation
                                                 </div>
                                             </div>
                                             <div class="cardText">
-                                                <h3><a href="https://msdn.microsoft.com/library/w0x726c2(v=vs.110).aspx">.NET Framework Guide</a></h3>
-                                                <p><a href="https://msdn.microsoft.com/library/hh425099(v=vs.110).aspx">Get Started</a></p>
-                                                <p><a href="https://msdn.microsoft.com/library/hh156542(v=vs.110).aspx">Tutorials</a></p>
-                                                <p><a href="https://msdn.microsoft.com/library/54xbah2z(v=vs.110).aspx">Client Development</a></p>
-                                                <p><a href="https://msdn.microsoft.com/library/bb400852(v=vs.110).aspx">ASP.NET</a></p>
+                                                <h3><a href="/dotnet/articles/framework/">.NET Framework Guide</a></h3>
+                                                <p><a href="/dotnet/articles/framework/get-started/">Get Started</a></p>
+                                                <p><a href="/dotnet/articles/framework/development-guide">Tutorials</a></p>
+                                                <p><a href="/dotnet/articles/framework/develop-client-apps">Client Development</a></p>
+                                                <p><a href="/aspnet/#pivot=aspnet">ASP.NET</a></p>
                                             </div>
                                         </div>
                                     </div>
@@ -210,6 +210,7 @@ title: .NET Documentation
                             <li class="fullSpan">
                                 <div class="container footer">
                                     <p><a href="https://github.com/dotnet/Docs/blob/master/CONTRIBUTING.md">Contribute to .NET docs and samples</a></p>
+                                    <p><a href="https://docs.microsoft.com/dotnet/articles/project-json">Find Visual Studio 2015/project.json version of the documentation</a></p>
                                 </div>
                             </li>
                         </ul>

--- a/index.md
+++ b/index.md
@@ -122,7 +122,7 @@ title: .NET Documentation
                                             <div class="cardText">
                                                 <h3><a href="/dotnet/articles/framework/">.NET Framework Guide</a></h3>
                                                 <p><a href="/dotnet/articles/framework/get-started/">Get Started</a></p>
-                                                <p><a href="/dotnet/articles/framework/development-guide">Tutorials</a></p>
+                                                <p><a href="/dotnet/articles/framework/development-guide">Development Guide</a></p>
                                                 <p><a href="/dotnet/articles/framework/develop-client-apps">Client Development</a></p>
                                                 <p><a href="/aspnet/#pivot=aspnet">ASP.NET</a></p>
                                             </div>

--- a/index.md
+++ b/index.md
@@ -81,7 +81,7 @@ title: .NET Documentation
                                                 </div>
                                             </div>
                                             <div class="cardText">
-                                                <h3><a href="/dotnet/articles/standard">.NET Platform Guide</a></h3>
+                                                <h3><a href="/dotnet/articles/standard/">.NET Platform Guide</a></h3>
                                                 <p><a href="/dotnet/articles/standard/get-started">Get Started</a></p>
                                                 <p><a href="/dotnet/articles/standard/tour">Tour of .NET</a></p>
                                                 <p><a href="/dotnet/articles/standard/components">.NET Architectural Concepts</a></p>


### PR DESCRIPTION
While resolving some merge conflicts in one of my PRs, I've noticed that some content of the main page has been rolled back to an earlier version or content that we still wanted has been removed.

/cc @cartermp @GuardRex 