### PR TITLE
Fixed typo in CS example

### DIFF
--- a/samples/snippets/csharp/concepts/linq/how-to-perform-custom-join-operations_1.cs
+++ b/samples/snippets/csharp/concepts/linq/how-to-perform-custom-join-operations_1.cs
@@ -58,7 +58,7 @@
                     Console.WriteLine("Cross Join Query:");
                     foreach (var v in crossJoinQuery)
                     {
-                        Console.WriteLine($"v.ID:-5}{v.Name});
+                        Console.WriteLine($"{v.ID:-5}{v.Name}");
                     }
                 }
 


### PR DESCRIPTION
# Fix typo in CS example

## Summary

Missing quote in example.
