### PR TITLE
Titles: Add "| Microsoft Docs" + remove quotes

### DIFF
--- a/docs/core/deploying/creating-nuget-packages.md
+++ b/docs/core/deploying/creating-nuget-packages.md
@@ -1,5 +1,5 @@
 ---
-title: Creating a NuGet Package with Cross Platform Tools
+title: Creating a NuGet Package with Cross Platform Tools | Microsoft Docs
 description: Creating a NuGet Package with Cross Platform Tools
 keywords: .NET, .NET Core, NuGet
 author: cartermp

--- a/docs/core/deploying/reducing-dependencies.md
+++ b/docs/core/deploying/reducing-dependencies.md
@@ -1,5 +1,5 @@
 ---
-title: Reducing Package Dependencies with project.json
+title: Reducing Package Dependencies with project.json | Microsoft Docs
 description: Reducing Package Dependencies with project.json
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/core/docker/building-net-docker-images.md
+++ b/docs/core/docker/building-net-docker-images.md
@@ -1,5 +1,5 @@
 ---
-title: Building .NET Core Docker Images
+title: Building .NET Core Docker Images | Microsoft Docs
 description: Understanding Docker images and .NET Core
 keywords: .NET, .NET Core, Docker
 author: spboyer

--- a/docs/core/docker/index.md
+++ b/docs/core/docker/index.md
@@ -1,5 +1,5 @@
 ---
-title: Docker and .NET Core
+title: Docker and .NET Core | Microsoft Docs
 description: Docker and .NET Core
 keywords: Docker, .NET, .NET Core
 author: spboyer

--- a/docs/core/docker/visual-studio-tools-for-docker.md
+++ b/docs/core/docker/visual-studio-tools-for-docker.md
@@ -1,5 +1,5 @@
 ---
-title: Visual Studio Tools for Docker
+title: Visual Studio Tools for Docker | Microsoft Docs
 description: Using Visual Studio Tools for Docker 
 keywords: .NET, .NET Core, Docker, ASP.NET Core, Visual Studio
 author: spboyer

--- a/docs/core/get-started.md
+++ b/docs/core/get-started.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with .NET Core
+title: Get started with .NET Core | Microsoft Docs
 description: Find resources to learn how to build .NET Core applications on Windows, Linux and macOS.
 keywords: .NET, .NET Core
 author: mairaw

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core
+title: .NET Core | Microsoft Docs
 description: .NET Core
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/core/migration/from-dnx.md
+++ b/docs/core/migration/from-dnx.md
@@ -1,5 +1,5 @@
 ---
-title: Migrating from DNX to .NET Core CLI
+title: Migrating from DNX to .NET Core CLI | Microsoft Docs
 description: Migrating from DNX to .NET Core CLI
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/core/packages.md
+++ b/docs/core/packages.md
@@ -1,5 +1,5 @@
 ---
-title: Packages, Metapackages and Frameworks
+title: Packages, Metapackages and Frameworks | Microsoft Docs
 description: Packages, Metapackages and Frameworks
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -1,5 +1,5 @@
 ---
-title: Porting to .NET Core from .NET Framework
+title: Porting to .NET Core from .NET Framework | Microsoft Docs
 description: Porting to .NET Core from .NET Framework
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/core/porting/libraries.md
+++ b/docs/core/porting/libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Porting to .NET Core - Libraries
+title: Porting to .NET Core - Libraries | Microsoft Docs
 description: Porting to .NET Core - Libraries
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/core/porting/nuget-packages.md
+++ b/docs/core/porting/nuget-packages.md
@@ -1,5 +1,5 @@
 ---
-title: Porting to .NET Core - NuGet packages
+title: Porting to .NET Core - NuGet packages | Microsoft Docs
 description: Porting to .NET Core - NuGet packages
 keywords: .NET, .NET Core
 ms.date: 06/20/2016

--- a/docs/core/porting/project-structure.md
+++ b/docs/core/porting/project-structure.md
@@ -1,5 +1,5 @@
 ---
-title: Organizing your project to support .NET Framework and .NET Core
+title: Organizing your project to support .NET Framework and .NET Core | Microsoft Docs
 description: Help for project owners who want to compile their solution against .NET Framework and .NET Core side-by-side.
 keywords: .NET, .NET Core, .NET Framework, project layout, multiple frameworks
 author: conniey

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -1,5 +1,5 @@
 ---
-title: Porting to .NET Core - Analyzing your Third-Party Party Dependencies
+title: Porting to .NET Core - Analyzing your Third-Party Party Dependencies | Microsoft Docs
 description: Porting to .NET Core - Analyzing your Third-Party Dependencies
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core Runtime IDentifier (RID) catalog
+title: .NET Core Runtime IDentifier (RID) catalog | Microsoft Docs
 description: .NET Core Runtime IDentifier (RID) catalog
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/core/sdk.md
+++ b/docs/core/sdk.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core SDK Overview 
+title: .NET Core SDK Overview | Microsoft Docs
 description: .NET Core SDK Overview 
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -1,5 +1,5 @@
 ---
-title: Unit Testing in .NET Core
+title: Unit Testing in .NET Core | Microsoft Docs
 description: Unit Testing in .NET Core
 keywords: .NET, .NET Core
 author: ardalis

--- a/docs/core/tutorials/aspnet-core.md
+++ b/docs/core/tutorials/aspnet-core.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with ASP.NET Core 
+title: Getting started with ASP.NET Core | Microsoft Docs
 description: Getting started with ASP.NET Core    
 keywords: .NET, .NET Core
 author: tdykstra

--- a/docs/core/tutorials/cli-console-app-tutorial-advanced.md
+++ b/docs/core/tutorials/cli-console-app-tutorial-advanced.md
@@ -1,5 +1,5 @@
 ---
-title: "Writing .NET Core console apps using the CLI tools: An advanced step-by-step guide"
+title: Writing .NET Core console apps using the CLI tools: An advanced step-by-step guide | Microsoft Docs
 description: "Writing .NET Core console apps using the CLI tools: An advanced step-by-step guide"
 keywords: .NET, .NET Core
 ms.date: 06/20/2016

--- a/docs/core/tutorials/index.md
+++ b/docs/core/tutorials/index.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core Tutorials
+title: .NET Core Tutorials | Microsoft Docs
 description: .NET Core Tutorials
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Developing Libraries with Cross Platform Tools
+title: Developing Libraries with Cross Platform Tools | Microsoft Docs
 description: Developing Libraries with Cross Platform Tools
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/core/tutorials/managing-package-dependency-versions.md
+++ b/docs/core/tutorials/managing-package-dependency-versions.md
@@ -1,5 +1,5 @@
 ---
-title: How to Manage Package Dependency Versions for .NET Core 1.0
+title: How to Manage Package Dependency Versions for .NET Core 1.0 | Microsoft Docs
 description: How to Manage Package Dependency Versions for .NET Core 1.0
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/core/versions/index.md
+++ b/docs/core/versions/index.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core Versioning
+title: .NET Core Versioning | Microsoft Docs
 description: .NET Core Versioning
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/core/versions/servicing.md
+++ b/docs/core/versions/servicing.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core Servicing
+title: .NET Core Servicing | Microsoft Docs
 description: .NET Core Servicing
 keywords: .NET, .NET Core
 ms.date: 06/20/2016

--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -1,5 +1,5 @@
 ---
-title: Asynchronous programming
+title: Asynchronous programming | Microsoft Docs
 description: Asynchronous programming
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/csharp/basic-types.md
+++ b/docs/csharp/basic-types.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Types | C# Guide
+title: Basic Types | C# Guide | Microsoft Docs
 description: Learn about the core types (numerics, strings, and object) in all C# programs 
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/basic-types.md
+++ b/docs/csharp/basic-types.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Types | C# Guide | Microsoft Docs
+title: Basic Types - C# Guide | Microsoft Docs
 description: Learn about the core types (numerics, strings, and object) in all C# programs 
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/classes.md
+++ b/docs/csharp/classes.md
@@ -1,5 +1,5 @@
 ---
-title: Classes | C# Guide
+title: Classes | C# Guide | Microsoft Docs
 description: Learn about the class types and how you create them
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/classes.md
+++ b/docs/csharp/classes.md
@@ -1,5 +1,5 @@
 ---
-title: Classes | C# Guide | Microsoft Docs
+title: Classes - C# Guide | Microsoft Docs
 description: Learn about the class types and how you create them
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/codedoc.md
+++ b/docs/csharp/codedoc.md
@@ -1,5 +1,5 @@
 ---
-title: Documenting your code with XML comments
+title: Documenting your code with XML comments | Microsoft Docs
 description: Documenting your code
 keywords: .NET, .NET Core
 author: tsolarin

--- a/docs/csharp/delegate-class.md
+++ b/docs/csharp/delegate-class.md
@@ -1,5 +1,5 @@
 ---
-title: System.Delegate and the `delegate` keyword
+title: System.Delegate and the `delegate` keyword | Microsoft Docs
 description: System.Delegate and the `delegate` keyword
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/delegates-events.md
+++ b/docs/csharp/delegates-events.md
@@ -1,5 +1,5 @@
 ---
-title: Delegates & events
+title: Delegates & events | Microsoft Docs
 description: Delegates & events
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/delegates-overview.md
+++ b/docs/csharp/delegates-overview.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Delegates
+title: Introduction to Delegates | Microsoft Docs
 description: Introduction to Delegates
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/delegates-patterns.md
+++ b/docs/csharp/delegates-patterns.md
@@ -1,5 +1,5 @@
 ---
-title: Common Patterns for Delegates
+title: Common Patterns for Delegates | Microsoft Docs
 description: Common Patterns for Delegates
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/delegates-strongly-typed.md
+++ b/docs/csharp/delegates-strongly-typed.md
@@ -1,5 +1,5 @@
 ---
-title: Strongly Typed Delegates
+title: Strongly Typed Delegates | Microsoft Docs
 description: Strongly Typed Delegates
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/distinguish-delegates-events.md
+++ b/docs/csharp/distinguish-delegates-events.md
@@ -1,5 +1,5 @@
 ---
-title: Distinguising Delegates and Events
+title: Distinguising Delegates and Events | Microsoft Docs
 description: Distinguising Delegates and Events
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/event-pattern.md
+++ b/docs/csharp/event-pattern.md
@@ -1,5 +1,5 @@
 ---
-title: The Standard .NET Event Pattern
+title: The Standard .NET Event Pattern | Microsoft Docs
 description: The Standard .NET Event Pattern
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/events-overview.md
+++ b/docs/csharp/events-overview.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction to Events
+title: Introduction to Events | Microsoft Docs
 description: Introduction to Events
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-classes.md
+++ b/docs/csharp/expression-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Framework Types Supporting Expression Trees
+title: Framework Types Supporting Expression Trees | Microsoft Docs
 description: Framework Types Supporting Expression Trees
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees-building.md
+++ b/docs/csharp/expression-trees-building.md
@@ -1,5 +1,5 @@
 ---
-title: Building Expression Trees
+title: Building Expression Trees | Microsoft Docs
 description: Building Expression Trees
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees-execution.md
+++ b/docs/csharp/expression-trees-execution.md
@@ -1,5 +1,5 @@
 ---
-title: Executing Expression Trees
+title: Executing Expression Trees | Microsoft Docs
 description: Executing Expression Trees
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees-explained.md
+++ b/docs/csharp/expression-trees-explained.md
@@ -1,5 +1,5 @@
 ---
-title: Expression Trees Explained
+title: Expression Trees Explained | Microsoft Docs
 description: Expression Trees Explained
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees-interpreting.md
+++ b/docs/csharp/expression-trees-interpreting.md
@@ -1,5 +1,5 @@
 ---
-title: Interpreting Expressions
+title: Interpreting Expressions | Microsoft Docs
 description: Interpreting Expressions
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees-summary.md
+++ b/docs/csharp/expression-trees-summary.md
@@ -1,5 +1,5 @@
 ---
-title: Expression Trees Summary
+title: Expression Trees Summary | Microsoft Docs
 description: Expression Trees Summary
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees-translating.md
+++ b/docs/csharp/expression-trees-translating.md
@@ -1,5 +1,5 @@
 ---
-title: Translating Expression Trees
+title: Translating Expression Trees | Microsoft Docs
 description: Translating Expression Trees
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/expression-trees.md
+++ b/docs/csharp/expression-trees.md
@@ -1,5 +1,5 @@
 ---
-title: Expression Trees
+title: Expression Trees | Microsoft Docs
 description: Expression Trees
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/getting-started/consuming-library-with-visual-studio.md
+++ b/docs/csharp/getting-started/consuming-library-with-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Consuming a class library with .NET Core in Visual Studio 2017
+title: Consuming a class library with .NET Core in Visual Studio 2017 | Microsoft Docs
 description: Learn how to call the members in a class library with Visual Studio 2017.
 keywords: .NET Core, .NET Core class library, .NET Standard, .NET Standard class library distribution
 author: BillWagner

--- a/docs/csharp/getting-started/debugging-with-visual-studio.md
+++ b/docs/csharp/getting-started/debugging-with-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging your C# Hello World application with Visual Studio 2017
+title: Debugging your C# Hello World application with Visual Studio 2017 | Microsoft Docs
 description: Learn how to debug a Hello World app written in C# with Visual Studio 2017.
 keywords: .NET Core, .NET Core console application, .NET Core debugging
 author: BillWagner

--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -1,6 +1,6 @@
 ---
 
-title: Get Started | C# Guide | Microsoft Docs
+title: Get Started - C# Guide | Microsoft Docs
 description: Get Started with C#
 keywords: C#, Get Started, Acquisition, Install
 author: rpetrusha

--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -1,6 +1,6 @@
 ---
 
-title: Get Started | C# Guide
+title: Get Started | C# Guide | Microsoft Docs
 description: Get Started with C#
 keywords: C#, Get Started, Acquisition, Install
 author: rpetrusha

--- a/docs/csharp/getting-started/library-with-visual-studio.md
+++ b/docs/csharp/getting-started/library-with-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Building a class library with C# and .NET Core in Visual Studio 2017
+title: Building a class library with C# and .NET Core in Visual Studio 2017 | Microsoft Docs
 description: Learn how to build a class library written in C# using Visual Studio 2017
 keywords: .NET Core, .NET Standard class library, Visual Studio 2017
 author: BillWagner

--- a/docs/csharp/getting-started/publishing-with-visual-studio.md
+++ b/docs/csharp/getting-started/publishing-with-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Publishing your Hello World application with Visual Studio 2017
+title: Publishing your Hello World application with Visual Studio 2017 | Microsoft Docs
 description: Publishing creates the set of files that are needed to run your application.
 keywords: .NET, .NET Core, console application, publishing, deployment
 author: BillWagner

--- a/docs/csharp/getting-started/testing-library-with-visual-studio.md
+++ b/docs/csharp/getting-started/testing-library-with-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Testing a class library with .NET Core in Visual Studio 2017
+title: Testing a class library with .NET Core in Visual Studio 2017 | Microsoft Docs
 description: Learn how to test a class library written in C# using Visual Studio 2017
 keywords: .NET Core, .NET Standard class library, Visual Studio 2017, unit testing 
 author: BillWagner

--- a/docs/csharp/getting-started/with-cross-platform-tools.md
+++ b/docs/csharp/getting-started/with-cross-platform-tools.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with C# and the cross platform tools | C# Guide
+title: Getting started with C# and the cross platform tools | C# Guide | Microsoft Docs
 description: Getting Started with C# and the cross platform tools
 keywords: C#, Getting Started, Acquisition,  Cross Platform
 ms.date: 08/23/2016

--- a/docs/csharp/getting-started/with-cross-platform-tools.md
+++ b/docs/csharp/getting-started/with-cross-platform-tools.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with C# and the cross platform tools | C# Guide | Microsoft Docs
+title: Getting started with C# and the cross platform tools - C# Guide | Microsoft Docs
 description: Getting Started with C# and the cross platform tools
 keywords: C#, Getting Started, Acquisition,  Cross Platform
 ms.date: 08/23/2016

--- a/docs/csharp/getting-started/with-csharp-interactive.md
+++ b/docs/csharp/getting-started/with-csharp-interactive.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with C# Interactive | C# Guide | Microsoft Docs
+title: Getting started with C# Interactive - C# Guide | Microsoft Docs
 description: Getting Started with C# interactive
 keywords: C#, Getting Started, REPL,  Cross Platform
 ms.date: 08/23/2016

--- a/docs/csharp/getting-started/with-csharp-interactive.md
+++ b/docs/csharp/getting-started/with-csharp-interactive.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with C# Interactive | C# Guide
+title: Getting started with C# Interactive | C# Guide | Microsoft Docs
 description: Getting Started with C# interactive
 keywords: C#, Getting Started, REPL,  Cross Platform
 ms.date: 08/23/2016

--- a/docs/csharp/getting-started/with-visual-studio-code.md
+++ b/docs/csharp/getting-started/with-visual-studio-code.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Visual Studio Code | C# Guide | Microsoft Docs
+title: Get started with Visual Studio Code - C# Guide | Microsoft Docs
 description: Learn how to create and debug your first .NET Core application in C# using VS Code. 
 keywords: C#, Get Started, Acquisition, Install, Visual Studio Code, Cross Platform
 author: kendrahavens

--- a/docs/csharp/getting-started/with-visual-studio-code.md
+++ b/docs/csharp/getting-started/with-visual-studio-code.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Visual Studio Code | C# Guide
+title: Get started with Visual Studio Code | C# Guide | Microsoft Docs
 description: Learn how to create and debug your first .NET Core application in C# using VS Code. 
 keywords: C#, Get Started, Acquisition, Install, Visual Studio Code, Cross Platform
 author: kendrahavens

--- a/docs/csharp/getting-started/with-visual-studio.md
+++ b/docs/csharp/getting-started/with-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Building a C# Hello World application with .NET Core in Visual Studio 2017
+title: Building a C# Hello World application with .NET Core in Visual Studio 2017 | Microsoft Docs
 description: Learn how to build a simple .NET Core console application using Visual Studio 2017.
 keywords: .NET Core, .NET Core console application, Visual Studio 2017
 author: BillWagner

--- a/docs/csharp/implicitly-typed-lambda-expressions.md
+++ b/docs/csharp/implicitly-typed-lambda-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Implicitly typed lambda expressions
+title: Implicitly typed lambda expressions | Microsoft Docs
 description: Implicitly typed lambda expressions
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -1,5 +1,5 @@
 ---
-title: C# Guide
+title: C# Guide | Microsoft Docs
 description: C# Guide
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/indexers.md
+++ b/docs/csharp/indexers.md
@@ -1,5 +1,5 @@
 ---
-title: Indexers
+title: Indexers | Microsoft Docs
 description: Indexers
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/interactive/index.md
+++ b/docs/csharp/interactive/index.md
@@ -1,5 +1,5 @@
 ---
-title: C# Interactive | C# Guide
+title: C# Interactive | C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell and use it to explore APIs and frameworks
 keywords: .NET, .NET Core, C#
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/index.md
+++ b/docs/csharp/interactive/index.md
@@ -1,5 +1,5 @@
 ---
-title: C# Interactive | C# Guide | Microsoft Docs
+title: C# Interactive - C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell and use it to explore APIs and frameworks
 keywords: .NET, .NET Core, C#
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/with-bash.md
+++ b/docs/csharp/interactive/with-bash.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive with MacOS or Linux terminal | C# Guide | Microsoft Docs
+title: Using C# Interactive with MacOS or Linux terminal - C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell from the MacOS or Linux Command Line
 keywords: .NET, .NET Core, C#, REPL, cross-platform
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/with-bash.md
+++ b/docs/csharp/interactive/with-bash.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive with MacOS or Linux terminal | C# Guide
+title: Using C# Interactive with MacOS or Linux terminal | C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell from the MacOS or Linux Command Line
 keywords: .NET, .NET Core, C#, REPL, cross-platform
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/with-powershell.md
+++ b/docs/csharp/interactive/with-powershell.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive with Powershell | C# Guide | Microsoft Docs
+title: Using C# Interactive with Powershell - C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell from the Windows Command Line
 keywords: .NET, .NET Core, C#, REPL, 
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/with-powershell.md
+++ b/docs/csharp/interactive/with-powershell.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive with Powershell | C# Guide
+title: Using C# Interactive with Powershell | C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell from the Windows Command Line
 keywords: .NET, .NET Core, C#, REPL, 
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/with-visualstudio.md
+++ b/docs/csharp/interactive/with-visualstudio.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive with Visual Studio | C# Guide
+title: Using C# Interactive with Visual Studio | C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell inside Visual Studio
 keywords: .NET, .NET Core, C#
 ms.date: 06/25/2016

--- a/docs/csharp/interactive/with-visualstudio.md
+++ b/docs/csharp/interactive/with-visualstudio.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive with Visual Studio | C# Guide | Microsoft Docs
+title: Using C# Interactive with Visual Studio - C# Guide | Microsoft Docs
 description: Explore the C# Interactive Shell inside Visual Studio
 keywords: .NET, .NET Core, C#
 ms.date: 06/25/2016

--- a/docs/csharp/iterators.md
+++ b/docs/csharp/iterators.md
@@ -1,5 +1,5 @@
 ---
-title: Iterators
+title: Iterators | Microsoft Docs
 description: Iterators
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/lambda-expressions.md
+++ b/docs/csharp/lambda-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Lambda Expressions
+title: Lambda Expressions | Microsoft Docs
 description: Lean to use lambda expressions, which are executable code blocks that can be passed as arguments. 
 keywords: .NET, .NET Core, lambda expressions, lambdas, delegates 
 ms-author: ronpet

--- a/docs/csharp/language-reference/operators/conditional-or-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-or-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "|| Operator (C# Reference) | Microsoft Docs"
+title: "-| Operator (C# Reference) | Microsoft Docs"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 

--- a/docs/csharp/language-reference/operators/conditional-or-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-or-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "-| Operator (C# Reference) | Microsoft Docs"
+title: "|| Operator (C# Reference) | Microsoft Docs"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 

--- a/docs/csharp/language-reference/operators/or-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/or-assignment-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "-= Operator (C# Reference) | Microsoft Docs"
+title: "|= Operator (C# Reference) | Microsoft Docs"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 

--- a/docs/csharp/language-reference/operators/or-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/or-assignment-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "|= Operator (C# Reference) | Microsoft Docs"
+title: "-= Operator (C# Reference) | Microsoft Docs"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 

--- a/docs/csharp/language-reference/operators/or-operator.md
+++ b/docs/csharp/language-reference/operators/or-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "- Operator (C# Reference) | Microsoft Docs"
+title: "| Operator (C# Reference) | Microsoft Docs"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 

--- a/docs/csharp/language-reference/operators/or-operator.md
+++ b/docs/csharp/language-reference/operators/or-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "| Operator (C# Reference) | Microsoft Docs"
+title: "- Operator (C# Reference) | Microsoft Docs"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 

--- a/docs/csharp/linq/create-a-nested-group.md
+++ b/docs/csharp/linq/create-a-nested-group.md
@@ -1,5 +1,5 @@
 ---
-title: "Create a nested group"
+title: Create a nested group | Microsoft Docs
 description: How to create a nested group.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/dynamically-specify-predicate-filters-at-runtime.md
+++ b/docs/csharp/linq/dynamically-specify-predicate-filters-at-runtime.md
@@ -1,5 +1,5 @@
 ---
-title: "Dynamically specify predicate filters at runtime"
+title: Dynamically specify predicate filters at runtime | Microsoft Docs
 description: How to dynamically specify predicate filters at runtime.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/group-query-results.md
+++ b/docs/csharp/linq/group-query-results.md
@@ -1,5 +1,5 @@
 ---
-title: "Group query results"
+title: Group query results | Microsoft Docs
 description: How to group results.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/group-results-by-contiguous-keys.md
+++ b/docs/csharp/linq/group-results-by-contiguous-keys.md
@@ -1,5 +1,5 @@
 ---
-title: "Group results by contiguous keys"
+title: Group results by contiguous keys | Microsoft Docs
 description: How to group results by contiguous keys.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/handle-exceptions-in-query-expressions.md
+++ b/docs/csharp/linq/handle-exceptions-in-query-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: "Handle exceptions in query expressions"
+title: Handle exceptions in query expressions | Microsoft Docs
 description: How to handle exceptions in query expressions.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/handle-null-values-in-query-expressions.md
+++ b/docs/csharp/linq/handle-null-values-in-query-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: "Handle null values in query expressions"
+title: Handle null values in query expressions | Microsoft Docs
 description: How to handle null values in query expressions.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -1,5 +1,5 @@
 ---
-title: Language Integrated Query (LINQ)
+title: Language Integrated Query (LINQ) | Microsoft Docs
 description: Introduces Language Integrated Query (LINQ) in C#
 keywords: .NET, .NET Core, LINQ, C#
 author: BillWagner

--- a/docs/csharp/linq/join-by-using-composite-keys.md
+++ b/docs/csharp/linq/join-by-using-composite-keys.md
@@ -1,5 +1,5 @@
 ---
-title: "Join by using composite keys"
+title: Join by using composite keys | Microsoft Docs
 description: How to join by using composite keys.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/linq-in-csharp.md
+++ b/docs/csharp/linq/linq-in-csharp.md
@@ -1,5 +1,5 @@
 ---
-title: "LINQ in C#"
+title: LINQ in C# | Microsoft Docs
 description: Links to topics that provide more detailed information about LINQ.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/order-the-results-of-a-join-clause.md
+++ b/docs/csharp/linq/order-the-results-of-a-join-clause.md
@@ -1,5 +1,5 @@
 ---
-title: "Order the results of a join clause"
+title: Order the results of a join clause | Microsoft Docs
 description: How to order the results of a join clause.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/perform-a-subquery-on-a-grouping-operation.md
+++ b/docs/csharp/linq/perform-a-subquery-on-a-grouping-operation.md
@@ -1,5 +1,5 @@
 ---
-title: "Perform a subquery on a grouping operation"
+title: Perform a subquery on a grouping operation | Microsoft Docs
 description: How to perform a subquery on a grouping operation.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/perform-custom-join-operations.md
+++ b/docs/csharp/linq/perform-custom-join-operations.md
@@ -1,5 +1,5 @@
 ---
-title: "Perform custom join operations"
+title: Perform custom join operations | Microsoft Docs
 description: How to perform custom join operations.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/perform-grouped-joins.md
+++ b/docs/csharp/linq/perform-grouped-joins.md
@@ -1,5 +1,5 @@
 ---
-title: "Perform grouped joins"
+title: Perform grouped joins | Microsoft Docs
 description: How to perform grouped joins.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/perform-inner-joins.md
+++ b/docs/csharp/linq/perform-inner-joins.md
@@ -1,5 +1,5 @@
 ---
-title: "Perform inner joins"
+title: Perform inner joins | Microsoft Docs
 description: How to perform inner joins.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/perform-left-outer-joins.md
+++ b/docs/csharp/linq/perform-left-outer-joins.md
@@ -1,5 +1,5 @@
 ---
-title: "Perform left outer joins"
+title: Perform left outer joins | Microsoft Docs
 description: How to perform left outer joins.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/query-a-collection-of-objects.md
+++ b/docs/csharp/linq/query-a-collection-of-objects.md
@@ -1,5 +1,5 @@
 ---
-title: "Query a collection of objects"
+title: Query a collection of objects | Microsoft Docs
 description: How query collections.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/query-expression-basics.md
+++ b/docs/csharp/linq/query-expression-basics.md
@@ -1,5 +1,5 @@
 ---
-title: "Query expression basics"
+title: Query expression basics | Microsoft Docs
 description: Introduces concepts related to query expressions
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/return-a-query-from-a-method.md
+++ b/docs/csharp/linq/return-a-query-from-a-method.md
@@ -1,5 +1,5 @@
 ---
-title: "Return a query from a method"
+title: Return a query from a method | Microsoft Docs
 description: How to return a query.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/store-the-results-of-a-query-in-memory.md
+++ b/docs/csharp/linq/store-the-results-of-a-query-in-memory.md
@@ -1,5 +1,5 @@
 ---
-title: "Store the results of a query in memory"
+title: Store the results of a query in memory | Microsoft Docs
 description: How to store results.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/linq/write-linq-queries.md
+++ b/docs/csharp/linq/write-linq-queries.md
@@ -1,5 +1,5 @@
 ---
-title: "Write LINQ queries in C#"
+title: Write LINQ queries in C# | Microsoft Docs
 description: How to write queries.
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/local-functions-vs-lambdas.md
+++ b/docs/csharp/local-functions-vs-lambdas.md
@@ -1,5 +1,5 @@
 ---
-title: Local functions vs. lambda expressions 
+title: Local functions vs. lambda expressions | Microsoft Docs
 description: Why Local Functions might be a better choice than Lambda Expressions    
 keywords: C#, .NET, .NET Core, Latest Features, What's New, local functions, lambda expressions
 author: BillWagner

--- a/docs/csharp/methods-lambda-expressions.md
+++ b/docs/csharp/methods-lambda-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Methods and Lambda Expressions
+title: Methods and Lambda Expressions | Microsoft Docs
 description: Methods and Lamba expressions are the core of your algorithms. Learn more here.
 keywords: .NET, .NET Core
 ms.date: 06/20/2016

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -1,5 +1,5 @@
 ---
-title: Methods | C# Guide | Microsoft Docs
+title: Methods - C# Guide | Microsoft Docs
 description: Overview of methods, method parameters, and method return values
 keywords: .NET, .NET Core, C#
 author: rpetrusha

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -1,5 +1,5 @@
 ---
-title: Methods | C# Guide
+title: Methods | C# Guide | Microsoft Docs
 description: Overview of methods, method parameters, and method return values
 keywords: .NET, .NET Core, C#
 author: rpetrusha

--- a/docs/csharp/modern-events.md
+++ b/docs/csharp/modern-events.md
@@ -1,5 +1,5 @@
 ---
-title: The Updated .NET Core Event Pattern
+title: The Updated .NET Core Event Pattern | Microsoft Docs
 description: The Updated .NET Core Event Pattern
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/parallel.md
+++ b/docs/csharp/parallel.md
@@ -1,5 +1,5 @@
 ---
-title: Parallel programming
+title: Parallel programming | Microsoft Docs
 description: Parallel programming
 keywords: .NET, .NET Core
 ms.date: 06/20/2016

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-title: Pattern Matching | C# Guide | Microsoft Docs
+title: Pattern Matching - C# Guide | Microsoft Docs
 description: Learn about pattern matching expressions in C#
 keywords: .NET, .NET Core, C#
 ms.date: 01/24/2017

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-title: Pattern Matching | C# Guide
+title: Pattern Matching | C# Guide | Microsoft Docs
 description: Learn about pattern matching expressions in C#
 keywords: .NET, .NET Core, C#
 ms.date: 01/24/2017

--- a/docs/csharp/properties.md
+++ b/docs/csharp/properties.md
@@ -1,5 +1,5 @@
 ---
-title: Properties
+title: Properties | Microsoft Docs
 description: Properties
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/reflection.md
+++ b/docs/csharp/reflection.md
@@ -1,5 +1,5 @@
 ---
-title: Reflection & code generation
+title: Reflection & code generation | Microsoft Docs
 description: Reflection & code generation
 keywords: .NET, .NET Core
 ms.date: 06/20/2016

--- a/docs/csharp/roslyn/index.md
+++ b/docs/csharp/roslyn/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using the .NET Compiler SDK | C# Guide | Microsoft Docs
+title: Using the .NET Compiler SDK - C# Guide | Microsoft Docs
 description: Explore the the Roslyn APIs to create automatic diagnostics and code fixes
 keywords: .NET, .NET Core, C#, Roslyn, 
 ms.date: 06/25/2016

--- a/docs/csharp/roslyn/index.md
+++ b/docs/csharp/roslyn/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using the .NET Compiler SDK | C# Guide
+title: Using the .NET Compiler SDK | C# Guide | Microsoft Docs
 description: Explore the the Roslyn APIs to create automatic diagnostics and code fixes
 keywords: .NET, .NET Core, C#, Roslyn, 
 ms.date: 06/25/2016

--- a/docs/csharp/structs.md
+++ b/docs/csharp/structs.md
@@ -1,5 +1,5 @@
 ---
-title: Structs | C# Guide
+title: Structs | C# Guide | Microsoft Docs
 description: Learn about the struct type and how you create them
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/structs.md
+++ b/docs/csharp/structs.md
@@ -1,5 +1,5 @@
 ---
-title: Structs | C# Guide | Microsoft Docs
+title: Structs - C# Guide | Microsoft Docs
 description: Learn about the struct type and how you create them
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/arrays.md
+++ b/docs/csharp/tour-of-csharp/arrays.md
@@ -1,5 +1,5 @@
 ---
-title: C# Arrays | A tour of the C# language
+title: C# Arrays | A tour of the C# language | Microsoft Docs
 description: Arrays are the most basic collection type in the C# langauge
 keywords: .NET, csharp, array, collection
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/arrays.md
+++ b/docs/csharp/tour-of-csharp/arrays.md
@@ -1,5 +1,5 @@
 ---
-title: C# Arrays | A tour of the C# language | Microsoft Docs
+title: C# Arrays - A tour of the C# language | Microsoft Docs
 description: Arrays are the most basic collection type in the C# langauge
 keywords: .NET, csharp, array, collection
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/attributes.md
+++ b/docs/csharp/tour-of-csharp/attributes.md
@@ -1,5 +1,5 @@
 ---
-title: C# Attributes | A tour of the C# language | Microsoft Docs
+title: C# Attributes - A tour of the C# language | Microsoft Docs
 description: Learn about declarative programming using attributes in C#
 keywords: .NET, csharp
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/attributes.md
+++ b/docs/csharp/tour-of-csharp/attributes.md
@@ -1,5 +1,5 @@
 ---
-title: C# Attributes | A tour of the C# language
+title: C# Attributes | A tour of the C# language | Microsoft Docs
 description: Learn about declarative programming using attributes in C#
 keywords: .NET, csharp
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -1,5 +1,5 @@
 ---
-title: Classes and Objects in C# | A tour of the C# Language
+title: Classes and Objects in C# | A tour of the C# Language | Microsoft Docs
 description: New to C#? Read this overview of classes, objects and inheritance
 keywords: .NET, csharp, class, instance, object, inheritance, polymorphism
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -1,5 +1,5 @@
 ---
-title: Classes and Objects in C# | A tour of the C# Language | Microsoft Docs
+title: Classes and Objects in C# - A tour of the C# Language | Microsoft Docs
 description: New to C#? Read this overview of classes, objects and inheritance
 keywords: .NET, csharp, class, instance, object, inheritance, polymorphism
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/delegates.md
+++ b/docs/csharp/tour-of-csharp/delegates.md
@@ -1,5 +1,5 @@
 ---
-title: C# Delegates | A tour of the C# language | Microsoft Docs
+title: C# Delegates - A tour of the C# language | Microsoft Docs
 description: Learn late binding with C# delegates
 keywords: .NET, csharp, delegate, lambda, late binding
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/delegates.md
+++ b/docs/csharp/tour-of-csharp/delegates.md
@@ -1,5 +1,5 @@
 ---
-title: C# Delegates | A tour of the C# language
+title: C# Delegates | A tour of the C# language | Microsoft Docs
 description: Learn late binding with C# delegates
 keywords: .NET, csharp, delegate, lambda, late binding
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/enums.md
+++ b/docs/csharp/tour-of-csharp/enums.md
@@ -1,5 +1,5 @@
 ---
-title: C# Enums | A tour of the C# language
+title: C# Enums | A tour of the C# language | Microsoft Docs
 description: Learn about enums, discrete named constants in C#
 keywords: .NET, csharp 
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/enums.md
+++ b/docs/csharp/tour-of-csharp/enums.md
@@ -1,5 +1,5 @@
 ---
-title: C# Enums | A tour of the C# language | Microsoft Docs
+title: C# Enums - A tour of the C# language | Microsoft Docs
 description: Learn about enums, discrete named constants in C#
 keywords: .NET, csharp 
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/expressions.md
+++ b/docs/csharp/tour-of-csharp/expressions.md
@@ -1,5 +1,5 @@
 ---
-title: C# Expressions | A tour of the C# language | Microsoft Docs
+title: C# Expressions - A tour of the C# language | Microsoft Docs
 description: expressions, operands, and operators are building blocks of the C# language
 keywords: .NET, csharp, expression, operator, operand
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/expressions.md
+++ b/docs/csharp/tour-of-csharp/expressions.md
@@ -1,5 +1,5 @@
 ---
-title: C# Expressions | A tour of the C# language
+title: C# Expressions | A tour of the C# language | Microsoft Docs
 description: expressions, operands, and operators are building blocks of the C# language
 keywords: .NET, csharp, expression, operator, operand
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -1,5 +1,5 @@
 ---
-title: A Tour of C# | C# Guide
+title: A Tour of C# | C# Guide | Microsoft Docs
 description: New to C#? Learn the basics of the language.
 keywords: .NET, .NET Core, C#, C# Primer, C# Guide
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -1,5 +1,5 @@
 ---
-title: A Tour of C# | C# Guide | Microsoft Docs
+title: A Tour of C# - C# Guide | Microsoft Docs
 description: New to C#? Learn the basics of the language.
 keywords: .NET, .NET Core, C#, C# Primer, C# Guide
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/interfaces.md
+++ b/docs/csharp/tour-of-csharp/interfaces.md
@@ -1,5 +1,5 @@
 ---
-title: C# Interfaces | A tour of the C# language
+title: C# Interfaces | A tour of the C# language | Microsoft Docs
 description: Interfaces define contracts implemented by types in C#
 keywords: .NET, csharp, interfaces, multiple inheritance, polymorphism
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/interfaces.md
+++ b/docs/csharp/tour-of-csharp/interfaces.md
@@ -1,5 +1,5 @@
 ---
-title: C# Interfaces | A tour of the C# language | Microsoft Docs
+title: C# Interfaces - A tour of the C# language | Microsoft Docs
 description: Interfaces define contracts implemented by types in C#
 keywords: .NET, csharp, interfaces, multiple inheritance, polymorphism
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/program-structure.md
+++ b/docs/csharp/tour-of-csharp/program-structure.md
@@ -1,5 +1,5 @@
 ---
-title: C# Program Structure | A Tour of the C# Language | Microsoft Docs
+title: C# Program Structure - A Tour of the C# Language | Microsoft Docs
 description: Learn the basic building blocks of a C# program
 keywords: .NET .NET Core
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/program-structure.md
+++ b/docs/csharp/tour-of-csharp/program-structure.md
@@ -1,5 +1,5 @@
 ---
-title: C# Program Structure | A Tour of the C# Language
+title: C# Program Structure | A Tour of the C# Language | Microsoft Docs
 description: Learn the basic building blocks of a C# program
 keywords: .NET .NET Core
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/statements.md
+++ b/docs/csharp/tour-of-csharp/statements.md
@@ -1,5 +1,5 @@
 ---
-title: C# Statements | A tour of the C# language | Microsoft Docs
+title: C# Statements - A tour of the C# language | Microsoft Docs
 description: You create the actions of a C# program using statements
 keywords: .NET, csharp, statements, syntax
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/statements.md
+++ b/docs/csharp/tour-of-csharp/statements.md
@@ -1,5 +1,5 @@
 ---
-title: C# Statements | A tour of the C# language
+title: C# Statements | A tour of the C# language | Microsoft Docs
 description: You create the actions of a C# program using statements
 keywords: .NET, csharp, statements, syntax
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/structs.md
+++ b/docs/csharp/tour-of-csharp/structs.md
@@ -1,5 +1,5 @@
 ---
-title: C# structs | A tour of the C# language | Microsoft Docs
+title: C# structs - A tour of the C# language | Microsoft Docs
 description: Learn the basics of C# value types, called structs
 keywords: .NET, C#, struct, value type
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/structs.md
+++ b/docs/csharp/tour-of-csharp/structs.md
@@ -1,5 +1,5 @@
 ---
-title: C# structs | A tour of the C# language
+title: C# structs | A tour of the C# language | Microsoft Docs
 description: Learn the basics of C# value types, called structs
 keywords: .NET, C#, struct, value type
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/types-and-variables.md
+++ b/docs/csharp/tour-of-csharp/types-and-variables.md
@@ -1,5 +1,5 @@
 ---
-title: C# Types and Variables | A tour of the C# language | Microsoft Docs
+title: C# Types and Variables - A tour of the C# language | Microsoft Docs
 description: Learn about defining types and declaring variables in C#
 keywords: .NET, csharp, type, reference type, value type
 author: BillWagner

--- a/docs/csharp/tour-of-csharp/types-and-variables.md
+++ b/docs/csharp/tour-of-csharp/types-and-variables.md
@@ -1,5 +1,5 @@
 ---
-title: C# Types and Variables | A tour of the C# language
+title: C# Types and Variables | A tour of the C# language | Microsoft Docs
 description: Learn about defining types and declaring variables in C#
 keywords: .NET, csharp, type, reference type, value type
 author: BillWagner

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -1,5 +1,5 @@
 ---
-title: Tuples | C# Guide
+title: Tuples | C# Guide | Microsoft Docs
 description: Learn about unnamed and named tuple types in C#
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -1,5 +1,5 @@
 ---
-title: Tuples | C# Guide | Microsoft Docs
+title: Tuples - C# Guide | Microsoft Docs
 description: Learn about unnamed and named tuple types in C#
 keywords: .NET, .NET Core, C#
 author: BillWagner

--- a/docs/csharp/tutorials/asynchronous-server-programming.md
+++ b/docs/csharp/tutorials/asynchronous-server-programming.md
@@ -1,5 +1,5 @@
 ---
-title: Asynchronous Server Programming | C# Guide
+title: Asynchronous Server Programming | C# Guide | Microsoft Docs
 description: Learn techniques for offloading server workloads using asynchronous programming techniques
 keywords: C#, async, CPU bound, network bound
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/asynchronous-server-programming.md
+++ b/docs/csharp/tutorials/asynchronous-server-programming.md
@@ -1,5 +1,5 @@
 ---
-title: Asynchronous Server Programming | C# Guide | Microsoft Docs
+title: Asynchronous Server Programming - C# Guide | Microsoft Docs
 description: Learn techniques for offloading server workloads using asynchronous programming techniques
 keywords: C#, async, CPU bound, network bound
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/asynchronous-ui-programming.md
+++ b/docs/csharp/tutorials/asynchronous-ui-programming.md
@@ -1,5 +1,5 @@
 ---
-title: Asynchronous UI Programming | C# Guide | Microsoft Docs
+title: Asynchronous UI Programming - C# Guide | Microsoft Docs
 description: Learn techniques for keeping the UI responsive while a programming is working on asynchronous operations
 keywords: C#, UWP, XAML
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/asynchronous-ui-programming.md
+++ b/docs/csharp/tutorials/asynchronous-ui-programming.md
@@ -1,5 +1,5 @@
 ---
-title: Asynchronous UI Programming | C# Guide
+title: Asynchronous UI Programming | C# Guide | Microsoft Docs
 description: Learn techniques for keeping the UI responsive while a programming is working on asynchronous operations
 keywords: C#, UWP, XAML
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/attributes.md
+++ b/docs/csharp/tutorials/attributes.md
@@ -1,5 +1,5 @@
 ---
-title: Attributes | C# | Microsoft Docs
+title: Attributes - C# | Microsoft Docs
 description: Learn how attributes work in C#.
 keywords: .NET, .NET Core, C#, attributes
 author: mgroves

--- a/docs/csharp/tutorials/attributes.md
+++ b/docs/csharp/tutorials/attributes.md
@@ -1,5 +1,5 @@
 ---
-title: Attributes | C#
+title: Attributes | C# | Microsoft Docs
 description: Learn how attributes work in C#.
 keywords: .NET, .NET Core, C#, attributes
 author: mgroves

--- a/docs/csharp/tutorials/concurrent-programming.md
+++ b/docs/csharp/tutorials/concurrent-programming.md
@@ -1,5 +1,5 @@
 ---
-title: Concurrent Programming | C# Guide
+title: Concurrent Programming | C# Guide | Microsoft Docs
 description: Learn techniques for running (likely CPU bound) tasks in parallel
 keywords: C#, async, CPU bound, network bound
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/concurrent-programming.md
+++ b/docs/csharp/tutorials/concurrent-programming.md
@@ -1,5 +1,5 @@
 ---
-title: Concurrent Programming | C# Guide | Microsoft Docs
+title: Concurrent Programming - C# Guide | Microsoft Docs
 description: Learn techniques for running (likely CPU bound) tasks in parallel
 keywords: C#, async, CPU bound, network bound
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -1,5 +1,5 @@
 ---
-title: Console Application
+title: Console Application | Microsoft Docs
 description: This tutorial teaches you a number of features in .NET Core and the C# language.
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -1,5 +1,5 @@
 ---
-title: Creates a REST client using .NET Core
+title: Creates a REST client using .NET Core | Microsoft Docs
 description: This tutorial teaches you a number of features in .NET Core and the C# language. 
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/tutorials/creating-portable-libraries.md
+++ b/docs/csharp/tutorials/creating-portable-libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Creating Portable Libraries| C# Guide
+title: Creating Portable Libraries| C# Guide | Microsoft Docs
 description: Learn how to create portable libraries, and specify the platforms and versions your library supports.
 keywords: C#, UWP, Portable Assembly, Cross Platform
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/creating-portable-libraries.md
+++ b/docs/csharp/tutorials/creating-portable-libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Creating Portable Libraries- C# Guide | Microsoft Docs
+title: Creating Portable Libraries - C# Guide | Microsoft Docs
 description: Learn how to create portable libraries, and specify the platforms and versions your library supports.
 keywords: C#, UWP, Portable Assembly, Cross Platform
 ms.date: 08/24/2016
@@ -11,11 +11,11 @@ ms.assetid: 254836c0-3be7-4549-bd9a-40fc0f445c31
 redirect_url: /dotnet/articles/csharp/tutorials/index
 ---
 
-# 🔧 Creating Portable Libraries
+# Creating Portable Libraries
 
 > **Note**
 > 
-> This topic hasn’t been written yet! 
+> This topic hasn't been written yet! 
 >
 > We welcome your input to help shape the scope and approach. You can track the status and provide input on this
 > [issue](https://github.com/dotnet/docs/issues/950) at GitHub.

--- a/docs/csharp/tutorials/creating-portable-libraries.md
+++ b/docs/csharp/tutorials/creating-portable-libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Creating Portable Libraries| C# Guide | Microsoft Docs
+title: Creating Portable Libraries- C# Guide | Microsoft Docs
 description: Learn how to create portable libraries, and specify the platforms and versions your library supports.
 keywords: C#, UWP, Portable Assembly, Cross Platform
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/exploring-with-csharp-interactive.md
+++ b/docs/csharp/tutorials/exploring-with-csharp-interactive.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive to explore and experiment | C# Guide | Microsoft Docs
+title: Using C# Interactive to explore and experiment - C# Guide | Microsoft Docs
 description: C# interactive provides a great environment for learning about an API. You can explore interactively and quickly.
 keywords: C#, Getting Started, Cross Platform, REPL, Interactive
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/exploring-with-csharp-interactive.md
+++ b/docs/csharp/tutorials/exploring-with-csharp-interactive.md
@@ -1,5 +1,5 @@
 ---
-title: Using C# Interactive to explore and experiment | C# Guide
+title: Using C# Interactive to explore and experiment | C# Guide | Microsoft Docs
 description: C# interactive provides a great environment for learning about an API. You can explore interactively and quickly.
 keywords: C#, Getting Started, Cross Platform, REPL, Interactive
 ms.date: 08/24/2016

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -1,5 +1,5 @@
 ---
-title: C# Tutorials
+title: C# Tutorials | Microsoft Docs
 description: C# Tutorials
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/tutorials/inheritance.md
+++ b/docs/csharp/tutorials/inheritance.md
@@ -1,5 +1,5 @@
 ---
-title: Inheritance in C#
+title: Inheritance in C# | Microsoft Docs
 description: Learn to use inheritance in C# libraries and applications.
 keywords: inheritance (C#), base classes, derived classes, abstract base classes
 author: rpetrusha

--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -1,5 +1,5 @@
 ---
-title: Microservices hosted in Docker | C#
+title: Microservices hosted in Docker | C# | Microsoft Docs
 description: Learn to create asp.net core services that run in Docker containers
 keywords: .NET, .NET Core, Docker, C#, ASP.NET, Microservice
 author: BillWagner

--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -1,5 +1,5 @@
 ---
-title: Microservices hosted in Docker | C# | Microsoft Docs
+title: Microservices hosted in Docker - C# | Microsoft Docs
 description: Learn to create asp.net core services that run in Docker containers
 keywords: .NET, .NET Core, Docker, C#, ASP.NET, Microservice
 author: BillWagner

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -1,5 +1,5 @@
 ---
-title: String Interpolation | C#
+title: String Interpolation | C# | Microsoft Docs
 description: Learn how string interpolation works in C# 6
 keywords: .NET, .NET Core, C#, string
 author: mgroves

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -1,5 +1,5 @@
 ---
-title: String Interpolation | C# | Microsoft Docs
+title: String Interpolation - C# | Microsoft Docs
 description: Learn how string interpolation works in C# 6
 keywords: .NET, .NET Core, C#, string
 author: mgroves

--- a/docs/csharp/tutorials/working-with-linq.md
+++ b/docs/csharp/tutorials/working-with-linq.md
@@ -1,5 +1,5 @@
 ---
-title: Working with LINQ
+title: Working with LINQ | Microsoft Docs
 description: This tutorial teaches you how to generate sequences with LINQ, write methods for use in LINQ queries, and distinguish between eager and lazy evaluation.
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/versioning.md
+++ b/docs/csharp/versioning.md
@@ -1,5 +1,5 @@
 ---
-title: C# Versioning | C# Guide | Microsoft Docs
+title: C# Versioning - C# Guide | Microsoft Docs
 description: Understand how versioning works in C# and .NET
 keywords: .NET, .NET Core, C#
 author: tsolarin

--- a/docs/csharp/versioning.md
+++ b/docs/csharp/versioning.md
@@ -1,5 +1,5 @@
 ---
-title: C# Versioning | C# Guide
+title: C# Versioning | C# Guide | Microsoft Docs
 description: Understand how versioning works in C# and .NET
 keywords: .NET, .NET Core, C#
 author: tsolarin

--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in C# 6 | C# Guide | Microsoft Docs
+title: What's New in C# 6 - C# Guide | Microsoft Docs
 description: Learn the new features in C# Version 6    
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in C# 6 | C# Guide
+title: What's New in C# 6 | C# Guide | Microsoft Docs
 description: Learn the new features in C# Version 6    
 keywords: .NET, .NET Core
 author: BillWagner

--- a/docs/csharp/whats-new/csharp-7.md
+++ b/docs/csharp/whats-new/csharp-7.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in C# 7 | C# Guide | Microsoft Docs
+title: What's New in C# 7 - C# Guide | Microsoft Docs
 description: Get an overview of the new features coming in the upcoming version 7 of the C# language.    
 keywords: C#, .NET, .NET Core, Latest Features, What's New
 author: BillWagner

--- a/docs/csharp/whats-new/csharp-7.md
+++ b/docs/csharp/whats-new/csharp-7.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in C# 7 | C# Guide
+title: What's New in C# 7 | C# Guide | Microsoft Docs
 description: Get an overview of the new features coming in the upcoming version 7 of the C# language.    
 keywords: C#, .NET, .NET Core, Latest Features, What's New
 author: BillWagner

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in C# | C# Guide | Microsoft Docs
+title: What's New in C# - C# Guide | Microsoft Docs
 description: How is the C# language evolving
 keywords: C#, Latest Features, What's New, Roslyn
 author: BillWagner

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in C# | C# Guide
+title: What's New in C# | C# Guide | Microsoft Docs
 description: How is the C# language evolving
 keywords: C#, Latest Features, What's New, Roslyn
 author: BillWagner

--- a/docs/framework/data/adonet/ef/language-reference/or-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/or-entity-sql.md
@@ -1,5 +1,5 @@
 ---
-title: "|| (OR) (Entity SQL) | Microsoft Docs"
+title: "-| (OR) (Entity SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
 ms.prod: ".net-framework"

--- a/docs/framework/data/adonet/ef/language-reference/or-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/or-entity-sql.md
@@ -1,5 +1,5 @@
 ---
-title: "-| (OR) (Entity SQL) | Microsoft Docs"
+title: "|| (OR) (Entity SQL) | Microsoft Docs"
 ms.custom: ""
 ms.date: "03/30/2017"
 ms.prod: ".net-framework"

--- a/docs/framework/deployment/repair.md
+++ b/docs/framework/deployment/repair.md
@@ -1,5 +1,5 @@
 ---
-title: Repair the .NET Framework
+title: Repair the .NET Framework | Microsoft Docs
 description: Learn how to repair the .NET Framework
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/docker/console.md
+++ b/docs/framework/docker/console.md
@@ -1,5 +1,5 @@
 ---
-title: Running Console applications in Docker
+title: Running Console applications in Docker | Microsoft Docs
 description: Learn how to take an existing .NET Framework console application and run it in a Windows Docker container.
 author: spboyer
 keywords: .NET, Container, Console, Applications

--- a/docs/framework/docker/index.md
+++ b/docs/framework/docker/index.md
@@ -1,5 +1,5 @@
 ---
-title: Docker on .NET Framework
+title: Docker on .NET Framework | Microsoft Docs
 description: Docker on .NET Framework
 keywords: .NET, .NET Server, Docker, Windows Containers
 author: BillWagner

--- a/docs/framework/install/dotnet-35-windows-10.md
+++ b/docs/framework/install/dotnet-35-windows-10.md
@@ -1,5 +1,5 @@
 ---
-title: Install the .NET Framework 3.5 on Windows 10, Windows 8.1, and Windows 8
+title: Install the .NET Framework 3.5 on Windows 10, Windows 8.1, and Windows 8 | Microsoft Docs
 description: Learn how to install .NET Framework 3.5 on Windows 10, Windows 8.1 and Windows 8
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/index.md
+++ b/docs/framework/install/index.md
@@ -1,5 +1,5 @@
 ---
-title: Installation guide
+title: Installation guide | Microsoft Docs
 description: Learn how to install the .NET Framework on Windows.
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -1,5 +1,5 @@
 ---
-title: Install the .NET Framework on Windows 10
+title: Install the .NET Framework on Windows 10 | Microsoft Docs
 description: Learn how to install .NET Framework on Windows 10
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/on-windows-7.md
+++ b/docs/framework/install/on-windows-7.md
@@ -1,5 +1,5 @@
 ---
-title: Install the .NET Framework on Windows 7 SP1
+title: Install the .NET Framework on Windows 7 SP1 | Microsoft Docs
 description: Learn how to install .NET Framework on Windows 7 SP1
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/on-windows-8.md
+++ b/docs/framework/install/on-windows-8.md
@@ -1,5 +1,5 @@
 ---
-title: Install the .NET Framework on Windows 8
+title: Install the .NET Framework on Windows 8 | Microsoft Docs
 description: Learn how to install .NET Framework on Windows 8
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/on-windows-vista.md
+++ b/docs/framework/install/on-windows-vista.md
@@ -1,5 +1,5 @@
 ---
-title: Install the .NET Framework on Windows Vista
+title: Install the .NET Framework on Windows Vista | Microsoft Docs
 description: Learn how to install .NET Framework on Windows Vista
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/on-windows-xp.md
+++ b/docs/framework/install/on-windows-xp.md
@@ -1,5 +1,5 @@
 ---
-title: Install the .NET Framework on Windows XP
+title: Install the .NET Framework on Windows XP | Microsoft Docs
 description: Learn how to install .NET Framework on Windows XP
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/framework/install/repair.md
+++ b/docs/framework/install/repair.md
@@ -1,5 +1,5 @@
 ---
-title: Repair the .NET Framework
+title: Repair the .NET Framework | Microsoft Docs
 description: Learn how to repair the .NET Framework
 author: rlander
 keywords: .NET Framework, Install

--- a/docs/fsharp/index.md
+++ b/docs/fsharp/index.md
@@ -1,5 +1,5 @@
 ---
-title: F# Guide
+title: F# Guide | Microsoft Docs
 description: F# Guide 
 keywords: .NET, .NET Core
 author: jackfoxy

--- a/docs/fsharp/introduction-to-functional-programming/functions-as-first-class-values.md
+++ b/docs/fsharp/introduction-to-functional-programming/functions-as-first-class-values.md
@@ -1,5 +1,5 @@
 ---
-title: Functions as First-Class Values (F#)
+title: Functions as First-Class Values (F#) | Microsoft Docs
 description: Functions as First-Class Values (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/abstract-classes.md
+++ b/docs/fsharp/language-reference/abstract-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Abstract Classes (F#)
+title: Abstract Classes (F#) | Microsoft Docs
 description: Abstract Classes (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/access-control.md
+++ b/docs/fsharp/language-reference/access-control.md
@@ -1,5 +1,5 @@
 ---
-title: Access Control (F#)
+title: Access Control (F#) | Microsoft Docs
 description: Access Control (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/active-patterns.md
+++ b/docs/fsharp/language-reference/active-patterns.md
@@ -1,5 +1,5 @@
 ---
-title: Active Patterns (F#)
+title: Active Patterns (F#) | Microsoft Docs
 description: Active Patterns (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/arrays.md
+++ b/docs/fsharp/language-reference/arrays.md
@@ -1,5 +1,5 @@
 ---
-title: Arrays (F#)
+title: Arrays (F#) | Microsoft Docs
 description: Arrays (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/assertions.md
+++ b/docs/fsharp/language-reference/assertions.md
@@ -1,5 +1,5 @@
 ---
-title: Assertions (F#)
+title: Assertions (F#) | Microsoft Docs
 description: Assertions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/asynchronous-workflows.md
+++ b/docs/fsharp/language-reference/asynchronous-workflows.md
@@ -1,5 +1,5 @@
 ---
-title: Asynchronous Workflows (F#)
+title: Asynchronous Workflows (F#) | Microsoft Docs
 description: Asynchronous Workflows (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/attributes.md
+++ b/docs/fsharp/language-reference/attributes.md
@@ -1,5 +1,5 @@
 ---
-title: Attributes (F#)
+title: Attributes (F#) | Microsoft Docs
 description: Attributes (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/casting-and-conversions.md
+++ b/docs/fsharp/language-reference/casting-and-conversions.md
@@ -1,5 +1,5 @@
 ---
-title: Casting and Conversions (F#)
+title: Casting and Conversions (F#) | Microsoft Docs
 description: Casting and Conversions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/classes.md
+++ b/docs/fsharp/language-reference/classes.md
@@ -1,5 +1,5 @@
 ---
-title: Classes (F#)
+title: Classes (F#) | Microsoft Docs
 description: Classes (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/code-formatting-guidelines.md
+++ b/docs/fsharp/language-reference/code-formatting-guidelines.md
@@ -1,5 +1,5 @@
 ---
-title: Code Formatting Guidelines (F#)
+title: Code Formatting Guidelines (F#) | Microsoft Docs
 description: Code Formatting Guidelines (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/code-quotations.md
+++ b/docs/fsharp/language-reference/code-quotations.md
@@ -1,5 +1,5 @@
 ---
-title: Code Quotations (F#)
+title: Code Quotations (F#) | Microsoft Docs
 description: Code Quotations (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/compiler-directives.md
+++ b/docs/fsharp/language-reference/compiler-directives.md
@@ -1,5 +1,5 @@
 ---
-title: Compiler Directives (F#)
+title: Compiler Directives (F#) | Microsoft Docs
 description: Compiler Directives (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/compiler-options.md
+++ b/docs/fsharp/language-reference/compiler-options.md
@@ -1,5 +1,5 @@
 ---
-title: Compiler Options (F#)
+title: Compiler Options (F#) | Microsoft Docs
 description: Compiler Options (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/computation-expressions.md
+++ b/docs/fsharp/language-reference/computation-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Computation Expressions (F#)
+title: Computation Expressions (F#) | Microsoft Docs
 description: Computation Expressions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/conditional-expressions-if-then-else.md
+++ b/docs/fsharp/language-reference/conditional-expressions-if-then-else.md
@@ -1,5 +1,5 @@
 ---
-title: "Conditional Expressions: if... then...else (F#)"
+title: Conditional Expressions: if... then...else (F#) | Microsoft Docs
 description: "Conditional Expressions: if... then...else (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/copy-and-update-record-expressions.md
+++ b/docs/fsharp/language-reference/copy-and-update-record-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Copy and Update Record Expressions (F#)
+title: Copy and Update Record Expressions (F#) | Microsoft Docs
 description: Copy and Update Record Expressions (F#)
 keywords: visual f#, f#, functional programming
 author: ChrSteinert

--- a/docs/fsharp/language-reference/delegates.md
+++ b/docs/fsharp/language-reference/delegates.md
@@ -1,5 +1,5 @@
 ---
-title: Delegates (F#)
+title: Delegates (F#) | Microsoft Docs
 description: Delegates (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/discriminated-unions.md
+++ b/docs/fsharp/language-reference/discriminated-unions.md
@@ -1,5 +1,5 @@
 ---
-title: Discriminated Unions (F#)
+title: Discriminated Unions (F#) | Microsoft Docs
 description: Discriminated Unions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/enumerations.md
+++ b/docs/fsharp/language-reference/enumerations.md
@@ -1,5 +1,5 @@
 ---
-title: Enumerations (F#)
+title: Enumerations (F#) | Microsoft Docs
 description: Enumerations (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/exception-types.md
+++ b/docs/fsharp/language-reference/exception-handling/exception-types.md
@@ -1,5 +1,5 @@
 ---
-title: Exception Types (F#)
+title: Exception Types (F#) | Microsoft Docs
 description: Exception Types (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/index.md
+++ b/docs/fsharp/language-reference/exception-handling/index.md
@@ -1,5 +1,5 @@
 ---
-title: Exception Handling (F#)
+title: Exception Handling (F#) | Microsoft Docs
 description: Exception Handling (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/the-failwith-function.md
+++ b/docs/fsharp/language-reference/exception-handling/the-failwith-function.md
@@ -1,5 +1,5 @@
 ---
-title: "Exceptions: The failwith Function (F#)"
+title: Exceptions: The failwith Function (F#) | Microsoft Docs
 description: "Exceptions: The failwith Function (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/the-invalidArg-function.md
+++ b/docs/fsharp/language-reference/exception-handling/the-invalidArg-function.md
@@ -1,5 +1,5 @@
 ---
-title: "Exceptions: The invalidArg Function (F#)"
+title: Exceptions: The invalidArg Function (F#) | Microsoft Docs
 description: "Exceptions: The invalidArg Function (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/the-raise-function.md
+++ b/docs/fsharp/language-reference/exception-handling/the-raise-function.md
@@ -1,5 +1,5 @@
 ---
-title: "Exceptions: the raise Function (F#)"
+title: Exceptions: the raise Function (F#) | Microsoft Docs
 description: "Exceptions: the raise Function (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/the-try-finally-expression.md
+++ b/docs/fsharp/language-reference/exception-handling/the-try-finally-expression.md
@@ -1,5 +1,5 @@
 ---
-title: "Exceptions: The try...finally Expression (F#)"
+title: Exceptions: The try...finally Expression (F#) | Microsoft Docs
 description: "Exceptions: The try...finally Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/exception-handling/the-try-with-expression.md
+++ b/docs/fsharp/language-reference/exception-handling/the-try-with-expression.md
@@ -1,5 +1,5 @@
 ---
-title: "Exceptions: The try...with Expression (F#)"
+title: Exceptions: The try...with Expression (F#) | Microsoft Docs
 description: "Exceptions: The try...with Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/flexible-types.md
+++ b/docs/fsharp/language-reference/flexible-types.md
@@ -1,5 +1,5 @@
 ---
-title: Flexible Types (F#)
+title: Flexible Types (F#) | Microsoft Docs
 description: Flexible Types (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/fsharp-collection-types.md
+++ b/docs/fsharp/language-reference/fsharp-collection-types.md
@@ -1,5 +1,5 @@
 ---
-title: F# Collection Types
+title: F# Collection Types | Microsoft Docs
 description: F# Collection Types
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/fsharp-types.md
+++ b/docs/fsharp/language-reference/fsharp-types.md
@@ -1,5 +1,5 @@
 ---
-title: F# Types
+title: F# Types | Microsoft Docs
 description: F# Types
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/do-bindings.md
+++ b/docs/fsharp/language-reference/functions/do-bindings.md
@@ -1,5 +1,5 @@
 ---
-title: do Bindings (F#)
+title: do Bindings (F#) | Microsoft Docs
 description: do Bindings (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/entry-point.md
+++ b/docs/fsharp/language-reference/functions/entry-point.md
@@ -1,5 +1,5 @@
 ---
-title: Entry Point (F#)
+title: Entry Point (F#) | Microsoft Docs
 description: Entry Point (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/external-functions.md
+++ b/docs/fsharp/language-reference/functions/external-functions.md
@@ -1,5 +1,5 @@
 ---
-title: External Functions (F#)
+title: External Functions (F#) | Microsoft Docs
 description: External Functions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/index.md
+++ b/docs/fsharp/language-reference/functions/index.md
@@ -1,5 +1,5 @@
 ---
-title: Functions (F#)
+title: Functions (F#) | Microsoft Docs
 description: Functions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/inline-functions.md
+++ b/docs/fsharp/language-reference/functions/inline-functions.md
@@ -1,5 +1,5 @@
 ---
-title: Inline Functions (F#)
+title: Inline Functions (F#) | Microsoft Docs
 description: Inline Functions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
+++ b/docs/fsharp/language-reference/functions/lambda-expressions-the-fun-keyword.md
@@ -1,5 +1,5 @@
 ---
-title: "Lambda Expressions: The fun Keyword (F#)"
+title: Lambda Expressions: The fun Keyword (F#) | Microsoft Docs
 description: "Lambda Expressions: The fun Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/let-bindings.md
+++ b/docs/fsharp/language-reference/functions/let-bindings.md
@@ -1,5 +1,5 @@
 ---
-title: let Bindings (F#)
+title: let Bindings (F#) | Microsoft Docs
 description: let Bindings (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/functions/recursive-functions-the-rec-keyword.md
+++ b/docs/fsharp/language-reference/functions/recursive-functions-the-rec-keyword.md
@@ -1,5 +1,5 @@
 ---
-title: "Recursive Functions: The rec Keyword (F#)"
+title: Recursive Functions: The rec Keyword (F#) | Microsoft Docs
 description: "Recursive Functions: The rec Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/generics/automatic-generalization.md
+++ b/docs/fsharp/language-reference/generics/automatic-generalization.md
@@ -1,5 +1,5 @@
 ---
-title: Automatic Generalization (F#)
+title: Automatic Generalization (F#) | Microsoft Docs
 description: Automatic Generalization (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/generics/constraints.md
+++ b/docs/fsharp/language-reference/generics/constraints.md
@@ -1,5 +1,5 @@
 ---
-title: Constraints (F#)
+title: Constraints (F#) | Microsoft Docs
 description: Constraints (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/generics/index.md
+++ b/docs/fsharp/language-reference/generics/index.md
@@ -1,5 +1,5 @@
 ---
-title: Generics (F#)
+title: Generics (F#) | Microsoft Docs
 description: Generics (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md
+++ b/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md
@@ -1,5 +1,5 @@
 ---
-title: Statically Resolved Type Parameters (F#)
+title: Statically Resolved Type Parameters (F#) | Microsoft Docs
 description: Statically Resolved Type Parameters (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
+++ b/docs/fsharp/language-reference/import-declarations-the-open-keyword.md
@@ -1,5 +1,5 @@
 ---
-title: "Import Declarations: The open Keyword (F#)"
+title: Import Declarations: The open Keyword (F#) | Microsoft Docs
 description: "Import Declarations: The open Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/index.md
+++ b/docs/fsharp/language-reference/index.md
@@ -1,5 +1,5 @@
 ---
-title: F# Language Reference
+title: F# Language Reference | Microsoft Docs
 description: F# Language Reference
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/inheritance.md
+++ b/docs/fsharp/language-reference/inheritance.md
@@ -1,5 +1,5 @@
 ---
-title: Inheritance (F#)
+title: Inheritance (F#) | Microsoft Docs
 description: Inheritance (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/interfaces.md
+++ b/docs/fsharp/language-reference/interfaces.md
@@ -1,5 +1,5 @@
 ---
-title: Interfaces (F#)
+title: Interfaces (F#) | Microsoft Docs
 description: Interfaces (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/keyword-reference.md
+++ b/docs/fsharp/language-reference/keyword-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Keyword Reference (F#)
+title: Keyword Reference (F#) | Microsoft Docs
 description: Keyword Reference (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/lazy-computations.md
+++ b/docs/fsharp/language-reference/lazy-computations.md
@@ -1,5 +1,5 @@
 ---
-title: Lazy Computations (F#)
+title: Lazy Computations (F#) | Microsoft Docs
 description: Lazy Computations (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/lists.md
+++ b/docs/fsharp/language-reference/lists.md
@@ -1,5 +1,5 @@
 ---
-title: Lists (F#)
+title: Lists (F#) | Microsoft Docs
 description: Lists (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -1,5 +1,5 @@
 ---
-title: Literals (F#)
+title: Literals (F#) | Microsoft Docs
 description: Literals (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/loops-for-in-expression.md
+++ b/docs/fsharp/language-reference/loops-for-in-expression.md
@@ -1,5 +1,5 @@
 ---
-title: "Loops: for...in Expression (F#)"
+title: Loops: for...in Expression (F#) | Microsoft Docs
 description: "Loops: for...in Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/loops-for-to-expression.md
+++ b/docs/fsharp/language-reference/loops-for-to-expression.md
@@ -1,5 +1,5 @@
 ---
-title: "Loops: for...to Expression (F#)"
+title: Loops: for...to Expression (F#) | Microsoft Docs
 description: "Loops: for...to Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/loops-while-do-expression.md
+++ b/docs/fsharp/language-reference/loops-while-do-expression.md
@@ -1,5 +1,5 @@
 ---
-title: "Loops: while...do Expression (F#)"
+title: Loops: while...do Expression (F#) | Microsoft Docs
 description: "Loops: while...do Expression (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/match-expressions.md
+++ b/docs/fsharp/language-reference/match-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Match Expressions (F#)
+title: Match Expressions (F#) | Microsoft Docs
 description: Match Expressions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/constructors.md
+++ b/docs/fsharp/language-reference/members/constructors.md
@@ -1,5 +1,5 @@
 ---
-title: Constructors (F#)
+title: Constructors (F#) | Microsoft Docs
 description: Constructors (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/do-bindings-in-classes.md
+++ b/docs/fsharp/language-reference/members/do-bindings-in-classes.md
@@ -1,5 +1,5 @@
 ---
-title: do Bindings in Classes (F#)
+title: do Bindings in Classes (F#) | Microsoft Docs
 description: do Bindings in Classes (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/events.md
+++ b/docs/fsharp/language-reference/members/events.md
@@ -1,5 +1,5 @@
 ---
-title: Events (F#)
+title: Events (F#) | Microsoft Docs
 description: Events (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
+++ b/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
@@ -1,5 +1,5 @@
 ---
-title: "Explicit Fields: The val Keyword (F#)"
+title: Explicit Fields: The val Keyword (F#) | Microsoft Docs
 description: "Explicit Fields: The val Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/index.md
+++ b/docs/fsharp/language-reference/members/index.md
@@ -1,5 +1,5 @@
 ---
-title: Members (F#)
+title: Members (F#) | Microsoft Docs
 description: Members (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/indexed-properties.md
+++ b/docs/fsharp/language-reference/members/indexed-properties.md
@@ -1,5 +1,5 @@
 ---
-title: Indexed Properties (F#)
+title: Indexed Properties (F#) | Microsoft Docs
 description: Indexed Properties (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/let-bindings-in-classes.md
+++ b/docs/fsharp/language-reference/members/let-bindings-in-classes.md
@@ -1,5 +1,5 @@
 ---
-title: let Bindings in Classes (F#)
+title: let Bindings in Classes (F#) | Microsoft Docs
 description: let Bindings in Classes (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/methods.md
+++ b/docs/fsharp/language-reference/members/methods.md
@@ -1,5 +1,5 @@
 ---
-title: Methods (F#)
+title: Methods (F#) | Microsoft Docs
 description: Methods (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/members/properties.md
+++ b/docs/fsharp/language-reference/members/properties.md
@@ -1,5 +1,5 @@
 ---
-title: Properties (F#)
+title: Properties (F#) | Microsoft Docs
 description: Properties (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/modules.md
+++ b/docs/fsharp/language-reference/modules.md
@@ -1,5 +1,5 @@
 ---
-title: Modules (F#)
+title: Modules (F#) | Microsoft Docs
 description: Modules (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/namespaces.md
+++ b/docs/fsharp/language-reference/namespaces.md
@@ -1,5 +1,5 @@
 ---
-title: Namespaces (F#)
+title: Namespaces (F#) | Microsoft Docs
 description: Namespaces (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/object-expressions.md
+++ b/docs/fsharp/language-reference/object-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Object Expressions (F#)
+title: Object Expressions (F#) | Microsoft Docs
 description: Object Expressions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/operator-overloading.md
+++ b/docs/fsharp/language-reference/operator-overloading.md
@@ -1,5 +1,5 @@
 ---
-title: Operator Overloading (F#)
+title: Operator Overloading (F#) | Microsoft Docs
 description: Operator Overloading (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/options.md
+++ b/docs/fsharp/language-reference/options.md
@@ -1,5 +1,5 @@
 ---
-title: Options (F#)
+title: Options (F#) | Microsoft Docs
 description: Options (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -1,5 +1,5 @@
 ---
-title: Parameters and Arguments (F#)
+title: Parameters and Arguments (F#) | Microsoft Docs
 description: Parameters and Arguments (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/pattern-matching.md
+++ b/docs/fsharp/language-reference/pattern-matching.md
@@ -1,5 +1,5 @@
 ---
-title: Pattern Matching (F#)
+title: Pattern Matching (F#) | Microsoft Docs
 description: Pattern Matching (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/primitive-types.md
+++ b/docs/fsharp/language-reference/primitive-types.md
@@ -1,5 +1,5 @@
 ---
-title: Primitive Types (F#)
+title: Primitive Types (F#) | Microsoft Docs
 description: Primitive Types (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/query-expressions.md
+++ b/docs/fsharp/language-reference/query-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: Query Expressions (F#)
+title: Query Expressions (F#) | Microsoft Docs
 description: Query Expressions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -1,5 +1,5 @@
 ---
-title: Records (F#)
+title: Records (F#) | Microsoft Docs
 description: Records (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/reference-cells.md
+++ b/docs/fsharp/language-reference/reference-cells.md
@@ -1,5 +1,5 @@
 ---
-title: Reference Cells (F#)
+title: Reference Cells (F#) | Microsoft Docs
 description: Reference Cells (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/resource-management-the-use-keyword.md
+++ b/docs/fsharp/language-reference/resource-management-the-use-keyword.md
@@ -1,5 +1,5 @@
 ---
-title: "Resource Management: The use Keyword (F#)"
+title: Resource Management: The use Keyword (F#) | Microsoft Docs
 description: "Resource Management: The use Keyword (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/sequences.md
+++ b/docs/fsharp/language-reference/sequences.md
@@ -1,5 +1,5 @@
 ---
-title: Sequences (F#)
+title: Sequences (F#) | Microsoft Docs
 description: Sequences (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/signatures.md
+++ b/docs/fsharp/language-reference/signatures.md
@@ -1,5 +1,5 @@
 ---
-title: Signatures (F#)
+title: Signatures (F#) | Microsoft Docs
 description: Signatures (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/source-line-file-path-identifiers.md
+++ b/docs/fsharp/language-reference/source-line-file-path-identifiers.md
@@ -1,5 +1,5 @@
 ---
-title: Source Line, File, and Path Identifiers (F#)
+title: Source Line, File, and Path Identifiers (F#) | Microsoft Docs
 description: Source Line, File, and Path Identifiers (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/strings.md
+++ b/docs/fsharp/language-reference/strings.md
@@ -1,5 +1,5 @@
 ---
-title: Strings (F#)
+title: Strings (F#) | Microsoft Docs
 description: Strings (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/structures.md
+++ b/docs/fsharp/language-reference/structures.md
@@ -1,5 +1,5 @@
 ---
-title: Structures (F#)
+title: Structures (F#) | Microsoft Docs
 description: Structures (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators.md
@@ -1,5 +1,5 @@
 ---
-title: Arithmetic Operators (F#)
+title: Arithmetic Operators (F#) | Microsoft Docs
 description: Arithmetic Operators (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/bitwise-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/bitwise-operators.md
@@ -1,5 +1,5 @@
 ---
-title: Bitwise Operators (F#)
+title: Bitwise Operators (F#) | Microsoft Docs
 description: Bitwise Operators (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/boolean-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/boolean-operators.md
@@ -1,5 +1,5 @@
 ---
-title: Boolean Operators (F#)
+title: Boolean Operators (F#) | Microsoft Docs
 description: Boolean Operators (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/index.md
@@ -1,5 +1,5 @@
 ---
-title: Symbol and Operator Reference (F#)
+title: Symbol and Operator Reference (F#) | Microsoft Docs
 description: Symbol and Operator Reference (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -1,5 +1,5 @@
 ---
-title: Nullable Operators (F#)
+title: Nullable Operators (F#) | Microsoft Docs
 description: Nullable Operators (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/tuples.md
+++ b/docs/fsharp/language-reference/tuples.md
@@ -1,5 +1,5 @@
 ---
-title: Tuples (F#)
+title: Tuples (F#) | Microsoft Docs
 description: Tuples (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/type-abbreviations.md
+++ b/docs/fsharp/language-reference/type-abbreviations.md
@@ -1,5 +1,5 @@
 ---
-title: Type Abbreviations (F#)
+title: Type Abbreviations (F#) | Microsoft Docs
 description: Type Abbreviations (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/type-extensions.md
+++ b/docs/fsharp/language-reference/type-extensions.md
@@ -1,5 +1,5 @@
 ---
-title: Type Extensions (F#)
+title: Type Extensions (F#) | Microsoft Docs
 description: Type Extensions (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/type-inference.md
+++ b/docs/fsharp/language-reference/type-inference.md
@@ -1,5 +1,5 @@
 ---
-title: Type Inference (F#)
+title: Type Inference (F#) | Microsoft Docs
 description: Type Inference (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/unit-type.md
+++ b/docs/fsharp/language-reference/unit-type.md
@@ -1,5 +1,5 @@
 ---
-title: Unit Type (F#)
+title: Unit Type (F#) | Microsoft Docs
 description: Unit Type (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/units-of-measure.md
+++ b/docs/fsharp/language-reference/units-of-measure.md
@@ -1,5 +1,5 @@
 ---
-title: Units of Measure (F#)
+title: Units of Measure (F#) | Microsoft Docs
 description: Units of Measure (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/values/index.md
+++ b/docs/fsharp/language-reference/values/index.md
@@ -1,5 +1,5 @@
 ---
-title: Values (F#)
+title: Values (F#) | Microsoft Docs
 description: Values (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/values/null-values.md
+++ b/docs/fsharp/language-reference/values/null-values.md
@@ -1,5 +1,5 @@
 ---
-title: Null Values (F#)
+title: Null Values (F#) | Microsoft Docs
 description: Null Values (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/verbose-syntax.md
+++ b/docs/fsharp/language-reference/verbose-syntax.md
@@ -1,5 +1,5 @@
 ---
-title: Verbose Syntax (F#)
+title: Verbose Syntax (F#) | Microsoft Docs
 description: Verbose Syntax (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/language-reference/xml-documentation.md
+++ b/docs/fsharp/language-reference/xml-documentation.md
@@ -1,5 +1,5 @@
 ---
-title: XML Documentation (F#)
+title: XML Documentation (F#) | Microsoft Docs
 description: XML Documentation (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -1,5 +1,5 @@
 ---
-title: Tour of F#
+title: Tour of F# | Microsoft Docs
 description: Tour of F# 
 keywords: visual f#, f#, functional programming, .NET, tour
 author: cartermp

--- a/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
+++ b/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
@@ -1,5 +1,5 @@
 ---
-title: Async Programming in F#
+title: Async Programming in F# | Microsoft Docs
 description: Async Programming in F#
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/fsharp/tutorials/fsharp-interactive/fsharp-interactive-options.md
+++ b/docs/fsharp/tutorials/fsharp-interactive/fsharp-interactive-options.md
@@ -1,5 +1,5 @@
 ---
-title: F# Interactive Options
+title: F# Interactive Options | Microsoft Docs
 description: F# Interactive Options
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/fsharp-interactive/index.md
+++ b/docs/fsharp/tutorials/fsharp-interactive/index.md
@@ -1,5 +1,5 @@
 ---
-title: F# Interactive (fsi.exe) Reference
+title: F# Interactive (fsi.exe) Reference | Microsoft Docs
 description: F# Interactive (fsi.exe) Reference
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/getting-started/getting-started-command-line.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-command-line.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with F# with command-line tools
+title: Getting started with F# with command-line tools | Microsoft Docs
 description: Learn how to use F# with the cross-platform .NET CLI.
 keywords: visual f#, f#, functional programming, .NET, .NET Core
 author: cartermp

--- a/docs/fsharp/tutorials/getting-started/getting-started-visual-studio.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with F# in Visual Studio
+title: Getting Started with F# in Visual Studio | Microsoft Docs
 description: Learn how to use F# with Visual Studio.
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/getting-started/getting-started-vscode.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-vscode.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with F# in Visual Studio Code with Ionide
+title: Getting Started with F# in Visual Studio Code with Ionide | Microsoft Docs
 description: Learn how to use F# with Visual Studio Code and the Ionide plugin suite.
 keywords: visual f#, f#, functional programming, .NET, Visual Studio Code, vscode, Ionide
 author: cartermp

--- a/docs/fsharp/tutorials/getting-started/getting-started-with-visual-studio-for-mac.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-with-visual-studio-for-mac.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with F# in Visual Studio for Mac
+title: Getting Started with F# in Visual Studio for Mac | Microsoft Docs
 description: Learn how to use F# with Visual Studio for Mac.
 keywords: visual f#, f#, functional programming
 author: mizzle-mo

--- a/docs/fsharp/tutorials/getting-started/index.md
+++ b/docs/fsharp/tutorials/getting-started/index.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with F#
+title: Getting Started with F# | Microsoft Docs
 description: Getting Started with F#
 keywords: visual f#, f#, functional programming, .NET, .NET Core
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database-entities.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database-entities.md
@@ -1,5 +1,5 @@
 ---
-title: "Walkthrough: Accessing a SQL Database by Using Type Providers and Entities (F#)"
+title: Walkthrough: Accessing a SQL Database by Using Type Providers and Entities (F#) | Microsoft Docs
 description: "Walkthrough: Accessing a SQL Database by Using Type Providers and Entities (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
@@ -1,5 +1,5 @@
 ---
-title: "Walkthrough: Accessing a SQL Database by Using Type Providers (F#)"
+title: Walkthrough: Accessing a SQL Database by Using Type Providers (F#) | Microsoft Docs
 description: "Walkthrough: Accessing a SQL Database by Using Type Providers (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/accessing-a-web-service.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-web-service.md
@@ -1,5 +1,5 @@
 ---
-title: Walkthrough - Accessing a Web Service by Using Type Providers (F#)
+title: Walkthrough - Accessing a Web Service by Using Type Providers (F#) | Microsoft Docs
 description: Walkthrough - Accessing a Web Service by Using Type Providers (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/accessing-an-odata-service.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-an-odata-service.md
@@ -1,5 +1,5 @@
 ---
-title: "Walkthrough: Accessing an OData Service by Using Type Providers (F#)"
+title: Walkthrough: Accessing an OData Service by Using Type Providers (F#) | Microsoft Docs
 description: "Walkthrough: Accessing an OData Service by Using Type Providers (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
+++ b/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
@@ -1,5 +1,5 @@
 ---
-title: "Tutorial: Creating a Type Provider (F#)"
+title: Tutorial: Creating a Type Provider (F#) | Microsoft Docs
 description: "Tutorial: Creating a Type Provider (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
@@ -1,5 +1,5 @@
 ---
-title: "Walkthrough: Generating F# Types from a DBML File (F#)"
+title: Walkthrough: Generating F# Types from a DBML File (F#) | Microsoft Docs
 description: "Walkthrough: Generating F# Types from a DBML File (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-edmx.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-edmx.md
@@ -1,5 +1,5 @@
 ---
-title: "Walkthrough: Generating F# Types from an EDMX Schema File (F#)"
+title: Walkthrough: Generating F# Types from an EDMX Schema File (F#) | Microsoft Docs
 description: "Walkthrough: Generating F# Types from an EDMX Schema File (F#)"
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/index.md
+++ b/docs/fsharp/tutorials/type-providers/index.md
@@ -1,5 +1,5 @@
 ---
-title: Type Providers
+title: Type Providers | Microsoft Docs
 description: Type Providers
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/troubleshooting-type-providers.md
+++ b/docs/fsharp/tutorials/type-providers/troubleshooting-type-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting Type Providers
+title: Troubleshooting Type Providers | Microsoft Docs
 description: Troubleshooting Type Providers
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/tutorials/type-providers/type-provider-security.md
+++ b/docs/fsharp/tutorials/type-providers/type-provider-security.md
@@ -1,5 +1,5 @@
 ---
-title: Type Provider Security
+title: Type Provider Security | Microsoft Docs
 description: Type Provider Security
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/using-fsharp-in-visual-studio/configuring-projects.md
+++ b/docs/fsharp/using-fsharp-in-visual-studio/configuring-projects.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring Projects (F#)
+title: Configuring Projects (F#) | Microsoft Docs
 description: Configuring Projects (F#)
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/using-fsharp-in-visual-studio/targeting-older-versions-of-net.md
+++ b/docs/fsharp/using-fsharp-in-visual-studio/targeting-older-versions-of-net.md
@@ -1,5 +1,5 @@
 ---
-title: Targeting .NET Framework 2.0 on Windows 8
+title: Targeting .NET Framework 2.0 on Windows 8 | Microsoft Docs
 description: Targeting .NET Framework 2.0 on Windows 8
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/using-fsharp-in-visual-studio/visual-fsharp-development-environment-features.md
+++ b/docs/fsharp/using-fsharp-in-visual-studio/visual-fsharp-development-environment-features.md
@@ -1,5 +1,5 @@
 ---
-title: F# Development Environment Features
+title: F# Development Environment Features | Microsoft Docs
 description: F# Development Environment Features
 keywords: visual f#, f#, functional programming
 author: cartermp

--- a/docs/fsharp/using-fsharp-on-azure/blob-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/blob-storage.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Azure Blob storage using F#
+title: Get started with Azure Blob storage using F# | Microsoft Docs
 description: Store unstructured data in the cloud with Azure Blob storage.
 keywords: visual f#, f#, functional programming, .NET, .NET Core, Azure
 author: sylvanc

--- a/docs/fsharp/using-fsharp-on-azure/file-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/file-storage.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Azure File storage using F# 
+title: Get started with Azure File storage using F# | Microsoft Docs
 description: Store file data in the cloud with Azure File storage, and mount your cloud file share from an Azure virtual machine (VM) or from an on-premises application running Windows.
 keywords: visual f#, f#, functional programming, .NET, .NET Core, Azure
 author: sylvanc

--- a/docs/fsharp/using-fsharp-on-azure/index.md
+++ b/docs/fsharp/using-fsharp-on-azure/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using F# on Azure
+title: Using F# on Azure | Microsoft Docs
 description: Guide to using Azure services with F#
 keywords: Azure, cloud, visual f#, f#, functional programming, .NET, .NET Core
 author: sylvanc

--- a/docs/fsharp/using-fsharp-on-azure/package-management.md
+++ b/docs/fsharp/using-fsharp-on-azure/package-management.md
@@ -1,5 +1,5 @@
 ---
-title: Using Package Management with F# for Azure
+title: Using Package Management with F# for Azure | Microsoft Docs
 description: Use Paket or Nuget to manage F# Azure dependencies
 keywords: visual f#, f#, functional programming, .NET, .NET Core, Azure
 author: sylvanc

--- a/docs/fsharp/using-fsharp-on-azure/queue-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/queue-storage.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Azure Queue storage using F# 
+title: Get started with Azure Queue storage using F# | Microsoft Docs
 description: Azure Queues provide reliable, asynchronous messaging between application components. Cloud messaging enables your application components to scale independently.
 keywords: visual f#, f#, functional programming, .NET, .NET Core, Azure
 author: sylvanc

--- a/docs/fsharp/using-fsharp-on-azure/table-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/table-storage.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with Azure Table storage using F#
+title: Get started with Azure Table storage using F# | Microsoft Docs
 description: Store structured data in the cloud using Azure Table storage, a NoSQL data store.
 keywords: visual f#, f#, functional programming, .NET, .NET Core, Azure
 author: sylvanc

--- a/docs/samples-and-tutorials/index.md
+++ b/docs/samples-and-tutorials/index.md
@@ -1,5 +1,5 @@
 ---
-title: Samples and tutorials
+title: Samples and tutorials | Microsoft Docs
 description: Information on samples and tutorials for .NET Core, ASP.NET Core, and the C# language that help you learn about .NET.
 keywords: .NET, .NET Core, ASP.NET, C#, sample, tutorial
 author: BillWagner

--- a/docs/standard/assembly-format.md
+++ b/docs/standard/assembly-format.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Assembly File Format
+title: .NET Assembly File Format | Microsoft Docs
 description: .NET Assembly File Format
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -1,5 +1,5 @@
 ---
-title: Async in depth
+title: Async in depth | Microsoft Docs
 description: In-depth explanation of how asynchronous code works in .NET
 keywords: .NET, .NET Core, .NET Standard
 author: cartermp

--- a/docs/standard/async.md
+++ b/docs/standard/async.md
@@ -1,5 +1,5 @@
 ---
-title: Async Overview
+title: Async Overview | Microsoft Docs
 description: Async Overview
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -1,5 +1,5 @@
 ---
-title: Choosing between .NET Core and .NET Framework for server apps
+title: Choosing between .NET Core and .NET Framework for server apps | Microsoft Docs
 description: A guide on which flavor of .NET you should consider when building a server app in .NET.
 keywords: .NET, .NET Core, .NET Framework
 author: cartermp

--- a/docs/standard/class-libraries.md
+++ b/docs/standard/class-libraries.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Class Libraries
+title: .NET Class Libraries | Microsoft Docs
 description: .NET Class Libraries
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/standard/common-type-system.md
+++ b/docs/standard/common-type-system.md
@@ -1,5 +1,5 @@
 ---
-title: Common Type System & Common Language Specification
+title: Common Type System & Common Language Specification | Microsoft Docs
 description: Common Type System & Common Language Specification
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/standard/components.md
+++ b/docs/standard/components.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Architectural Components
+title: .NET Architectural Components | Microsoft Docs
 description: Describes key .NET architectural components such as the .NET Standard Library, .NET runtimes, and tooling.
 keywords: .NET, .NET Standard Library, .NET Standard, .NET Core, .NET Framework, Xamarin, MSBuild, C#, F#, VB, compilers
 author: cartermp

--- a/docs/standard/delegates-lambdas.md
+++ b/docs/standard/delegates-lambdas.md
@@ -1,5 +1,5 @@
 ---
-title: Delegates and lambdas
+title: Delegates and lambdas | Microsoft Docs
 description: Delegates and lambdas
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/standard/framework-libraries.md
+++ b/docs/standard/framework-libraries.md
@@ -1,5 +1,5 @@
 ---
-title: Framework Libraries
+title: Framework Libraries | Microsoft Docs
 description: Framework Libraries
 keywords: .NET, .NET Core
 author: richlander

--- a/docs/standard/garbage-collection/gc.md
+++ b/docs/standard/garbage-collection/gc.md
@@ -1,5 +1,5 @@
 ---
-title: Automatic memory management and garbage collection
+title: Automatic memory management and garbage collection | Microsoft Docs
 description: Automatic memory management and garbage collection
 keywords: .NET, .NET Core
 author: dotnet-bot

--- a/docs/standard/generics.md
+++ b/docs/standard/generics.md
@@ -1,5 +1,5 @@
 ---
-title: Generic Types (Generics) Overview
+title: Generic Types (Generics) Overview | Microsoft Docs
 description: Generic Types (Generics) Overview
 keywords: .NET, .NET Core
 author: kuhlenh

--- a/docs/standard/get-started.md
+++ b/docs/standard/get-started.md
@@ -1,5 +1,5 @@
 ---
-title: Get Started with .NET
+title: Get Started with .NET | Microsoft Docs
 description: Lists various articles for getting started with .NET, both from a language and platform perspective.
 keywords: .NET, Getting Started, C#, F#, Visual Basic
 author: cartermp

--- a/docs/standard/index.md
+++ b/docs/standard/index.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Platform Guide
+title: .NET Platform Guide | Microsoft Docs
 description: Learn about the .NET Platform.
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/standard/language-independence.md
+++ b/docs/standard/language-independence.md
@@ -1,5 +1,5 @@
 ---
-title: Language independence and language-independent components
+title: Language independence and language-independent components | Microsoft Docs
 description: Language independence and language-independent components
 keywords: .NET, .NET Core
 author: dotnet-bot

--- a/docs/standard/managed-code.md
+++ b/docs/standard/managed-code.md
@@ -1,5 +1,5 @@
 ---
-title: What is "managed code"?
+title: What is managed code? | Microsoft Docs
 description: What is "managed code"?
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/standard/native-interop.md
+++ b/docs/standard/native-interop.md
@@ -1,5 +1,5 @@
 ---
-title: Native interoperability
+title: Native interoperability | Microsoft Docs
 description: Native interoperability
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/standard/portability-analyzer.md
+++ b/docs/standard/portability-analyzer.md
@@ -1,5 +1,5 @@
 ---
-title: The .NET Portability Analyzer | .NET | Microsoft Docs
+title: The .NET Portability Analyzer - .NET | Microsoft Docs
 description: Learn how to use the .NET Portability Analyzer tool to evaluate how portable your code is among the various .NET Platforms.
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/standard/portability-analyzer.md
+++ b/docs/standard/portability-analyzer.md
@@ -1,5 +1,5 @@
 ---
-title: The .NET Portability Analyzer | .NET
+title: The .NET Portability Analyzer | .NET | Microsoft Docs
 description: Learn how to use the .NET Portability Analyzer tool to evaluate how portable your code is among the various .NET Platforms.
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -1,5 +1,5 @@
 ---
-title: Tour of .NET
+title: Tour of .NET | Microsoft Docs
 description: A guided tour through some of the prominent features of the .NET platform.
 keywords: .NET, .NET Core, Tour, Programming Languages, Unsafe, Memory Management, Type Safety, Async
 author: cartermp

--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -1,5 +1,5 @@
 ---
-title: LINQ (Language Integrated Query)
+title: LINQ (Language Integrated Query) | Microsoft Docs
 description: LINQ (Language Integrated Query)
 keywords: .NET, .NET Core
 author: cartermp

--- a/docs/visual-basic/misc/bc30932.md
+++ b/docs/visual-basic/misc/bc30932.md
@@ -1,5 +1,5 @@
 ---
-title: "Constraints for this type parameter do not match the constraints on the corresponding type parameter defined on one of the other partial types of &#39;|1&#39; | Microsoft Docs"
+title: "Constraints for this type parameter do not match the constraints on the corresponding type parameter defined on one of the other partial types of &#39;-1&#39; | Microsoft Docs"
 
 ms.date: "2015-07-20"
 ms.prod: .net

--- a/docs/visual-basic/misc/bc30932.md
+++ b/docs/visual-basic/misc/bc30932.md
@@ -1,5 +1,5 @@
 ---
-title: "Constraints for this type parameter do not match the constraints on the corresponding type parameter defined on one of the other partial types of &#39;-1&#39; | Microsoft Docs"
+title: "Constraints for this type parameter do not match the constraints on the corresponding type parameter defined on one of the other partial types of &#39;|1&#39; | Microsoft Docs"
 
 ms.date: "2015-07-20"
 ms.prod: .net

--- a/docs/visual-basic/misc/bc31513.md
+++ b/docs/visual-basic/misc/bc31513.md
@@ -1,5 +1,5 @@
 ---
-title: "&#39;System.STAThreadAttribute&#39; and &#39;System.MTAThreadAttribute&#39; cannot both be applied to &#39;-1&#39; | Microsoft Docs"
+title: "&#39;System.STAThreadAttribute&#39; and &#39;System.MTAThreadAttribute&#39; cannot both be applied to &#39;|1&#39; | Microsoft Docs"
 
 ms.date: "2015-07-20"
 ms.prod: .net

--- a/docs/visual-basic/misc/bc31513.md
+++ b/docs/visual-basic/misc/bc31513.md
@@ -1,5 +1,5 @@
 ---
-title: "&#39;System.STAThreadAttribute&#39; and &#39;System.MTAThreadAttribute&#39; cannot both be applied to &#39;|1&#39; | Microsoft Docs"
+title: "&#39;System.STAThreadAttribute&#39; and &#39;System.MTAThreadAttribute&#39; cannot both be applied to &#39;-1&#39; | Microsoft Docs"
 
 ms.date: "2015-07-20"
 ms.prod: .net

--- a/docs/visual-basic/misc/bc32304.md
+++ b/docs/visual-basic/misc/bc32304.md
@@ -1,5 +1,5 @@
 ---
-title: "Conflict between the default property and the &#39;DefaultMemberAttribute&#39; defined on &#39;|1&#39; | Microsoft Docs"
+title: "Conflict between the default property and the &#39;DefaultMemberAttribute&#39; defined on &#39;-1&#39; | Microsoft Docs"
 
 ms.date: "2015-07-20"
 ms.prod: .net

--- a/docs/visual-basic/misc/bc32304.md
+++ b/docs/visual-basic/misc/bc32304.md
@@ -1,5 +1,5 @@
 ---
-title: "Conflict between the default property and the &#39;DefaultMemberAttribute&#39; defined on &#39;-1&#39; | Microsoft Docs"
+title: "Conflict between the default property and the &#39;DefaultMemberAttribute&#39; defined on &#39;|1&#39; | Microsoft Docs"
 
 ms.date: "2015-07-20"
 ms.prod: .net

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -1,5 +1,5 @@
 ---
-title: Welcome to .NET
+title: Welcome to .NET | Microsoft Docs
 description: Getting started with the .NET family of technologies.
 keywords: .NET, .NET Core, getting started, news
 author: richlander


### PR DESCRIPTION
Fixes #1408 

[Change script](https://gist.github.com/GuardRex/6e91f66d4084022f0c8ca1e482bddf2e)

Adds ...

| Microsoft Docs

... to titles that don't have it. Also, removes quotes from titles.

@mairaw A handful ended up with a double-pipe due some existing piped text on the title. There aren't many of them. Here are a couple of examples:

* Using C# Interactive with Visual Studio | C# Guide | Microsoft Docs
* The .NET Portability Analyzer | .NET | Microsoft Docs

Let me know how you would like that situation handled.