### PR TITLE
Add info about MSBuild /pp option to show the whole project as seen by MSBuild

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -4,7 +4,7 @@ description: Learn about the differences between existing and .NET Core csproj f
 keywords: reference, csproj, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 03/03/2017
+ms.date: 05/24/2017
 ms.topic: article
 ms.prod: .net-core
 ms.devlang: dotnet
@@ -67,7 +67,7 @@ Setting this property to `false` will override implicit inclusion and the behavi
 This change does not modify the main mechanics of other includes. However, if you wish to specify, for example, some files to get published with your app, you can still use the known mechanisms in *csproj* for that (for example, the `<Content>` element).
 
 ### Recommendation
-With csproj, we recommend that you remove the default globs from your project and only add file paths with globs for those artifacts that your app/library needs for various scenarios (runtime, NuGet packaging, etc.)
+With csproj, we recommend that you remove the default globs from your project and only add file paths with globs for those artifacts that your app/library needs for various scenarios (for example, runtime and NuGet packaging).
 
 ## How to see the whole project as MSBuild sees it
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -71,13 +71,13 @@ With csproj, we recommend that you remove the default globs from your project an
 
 ## How to see the whole project as MSBuild sees it
 
-While those csproj changes greatly simplify project files, you might want to see the fully expanded project as MSBuild sees it once the SDK and its targets are included. Preprocess the project with the `/pp` switch of the [`dotnet msbuild`](dotnet-msbuild.md) command, which shows which files are imported, their sources, and their contributions to the build without actually building the project:
-
-`dotnet msbuild /pp`
-
-Direct the output of this command to a file by specifying it as the value of the `/pp` option:
+While those csproj changes greatly simplify project files, you might want to see the fully expanded project as MSBuild sees it once the SDK and its targets are included. Preprocess the project with [the `/pp` switch](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference#preprocess) of the [`dotnet msbuild`](dotnet-msbuild.md) command, which shows which files are imported, their sources, and their contributions to the build without actually building the project:
 
 `dotnet msbuild /pp:fullproject.xml`
+
+If the project has multiple target frameworks, the results of the command should be focused on only one of them by specifying it as an MSBuild property:
+
+`dotnet msbuild /p:TargetFramework=netcoreapp2.0 /pp:fullproject.xml`
 
 ## Additions
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -69,6 +69,13 @@ This change does not modify the main mechanics of other includes. However, if yo
 ### Recommendation
 With csproj, we recommend that you remove the default globs from your project and only add file paths with globs for those artifacts that your app/library needs for various scenarios (runtime, NuGet packaging, etc.)
 
+## How to see the whole project as MSBuild sees it
+
+While those csproj changes greatly simplify project files, it is sometimes useful to be able to look at the fully expanded project as MSBuild sees it once the SDK and its targets are included. This can be done by simply typing the following in the command-line:
+
+```
+dotnet msbuild /pp
+```
 
 ## Additions
 

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -71,7 +71,7 @@ With csproj, we recommend that you remove the default globs from your project an
 
 ## How to see the whole project as MSBuild sees it
 
-While those csproj changes greatly simplify project files, it is sometimes useful to be able to look at the fully expanded project as MSBuild sees it once the SDK and its targets are included. This can be done by simply typing the following in the command-line:
+While those csproj changes greatly simplify project files, it's sometimes useful to be able to look at the fully expanded project as MSBuild sees it once the SDK and its targets are included. Preprocess the project with the following command and switch, which shows which files are imported, their sources, and their contributions to the build without actually building the project:
 
 ```
 dotnet msbuild /pp

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -71,11 +71,13 @@ With csproj, we recommend that you remove the default globs from your project an
 
 ## How to see the whole project as MSBuild sees it
 
-While those csproj changes greatly simplify project files, it's sometimes useful to be able to look at the fully expanded project as MSBuild sees it once the SDK and its targets are included. Preprocess the project with the following command and switch, which shows which files are imported, their sources, and their contributions to the build without actually building the project:
+While those csproj changes greatly simplify project files, you might want to see the fully expanded project as MSBuild sees it once the SDK and its targets are included. Preprocess the project with the `/pp` switch of the [`dotnet msbuild`](dotnet-msbuild.md) command, which shows which files are imported, their sources, and their contributions to the build without actually building the project:
 
-```
-dotnet msbuild /pp
-```
+`dotnet msbuild /pp`
+
+Direct the output of this command to a file by specifying it as the value of the `/pp` option:
+
+`dotnet msbuild /pp:fullproject.xml`
 
 ## Additions
 

--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -4,7 +4,7 @@ description: The dotnet-msbuild command provides access to the MSBuild command l
 keywords: dotnet-msmsbuild, CLI, CLI command, .NET Core
 author: blackdwarf
 ms.author: mairaw
-ms.date: 03/15/2017
+ms.date: 05/24/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli

--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -41,3 +41,7 @@ Build a project and its dependencies using Release configuration:
 Run the publish target and publish for the `osx.10.11-x64` RID:
 
 `dotnet msbuild /t:Publish /p:RuntimeIdentifiers=osx.10.11-x64`
+
+See the whole project with all targets included by the SDK:
+
+`dotnet msbuild /pp`


### PR DESCRIPTION
With the new simplified csproj format, a lot of information that used to be explicit has been pushed into the SDK and its targets. As a result, it's hard to track some of them. This change shows how to see the whole csproj as MSBuild sees it.

## Suggested Reviewers

@mairaw @ellismg 
