### PR TITLE
Replace 'En Dash' character with 'Hyphen-Minus'

### DIFF
--- a/docs/csharp/language-reference/keywords/long.md
+++ b/docs/csharp/language-reference/keywords/long.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
 |Type|Range|Size|.NET Framework type|  
 |----------|-----------|----------|-------------------------|  
-|`long`|–9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|<xref:System.Int64?displayProperty=fullName>|  
+|`long`|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|<xref:System.Int64?displayProperty=fullName>|  
   
 ## Literals 
 


### PR DESCRIPTION
The value range for long uses an ['En Dash'](https://unicode-table.com/en/2013/) character instead of a ['Hyphen-Minus'](https://unicode-table.com/en/002D/).  

This means when the value is copied and used in a context which expects a number, the 'En Dash' is likely to not be understood. Also an 'En Dash' is punctuation and is the wrong character to be using.

