### PR TITLE
Document APIs for the System.Buffers Namespace

### DIFF
--- a/xml/System.Buffers/ArrayPool`1.xml
+++ b/xml/System.Buffers/ArrayPool`1.xml
@@ -23,10 +23,10 @@
 ## Remarks  
   
  Using the <see cref="T:System.Buffers.ArrayPool{T}"/> class to rent and return buffers (using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> and <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> methods) can improve performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.
-
- This class is thread-safe.  All members may be used by multiple threads concurrently. 
+  
  ]]></format>
     </remarks>
+    <threadsafe>This class is thread-safe. All members may be used by multiple threads concurrently.</threadsafe>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -42,8 +42,8 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Invokes the static constructor when a new instance of the <see cref="ArrayPool{T}"/> class is instantiated.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Create">
@@ -151,7 +151,7 @@ This buffer is loaned to the caller and should be returned to the same pool usin
       </Parameters>
       <Docs>
         <param name="array">A buffer to return to the pool that was previously obtained using the <see cref="Rent"/> method.</param>
-        <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse. If <paramref name="bufferLength"/> is set to <see langword="true" />, and if the pool will store the buffer to enable subsequent reuse, the <see cref="Return"/> method will clear the <paramref name="array"/> of its contents so that a subsequent consumer using the <see cref="Rent"/> method will not see the previous consumer's content. If <paramref name="bufferLength"/> is set to <see langword="false" /> or if the pool will release the buffer, the array's contents are left unchanged.</param>
+        <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse. If <paramref name="bufferLength"/> is set to <see langword="true" />, and if the pool will store the buffer to enable subsequent reuse, the <see cref="Return"/> method will clear the <paramref name="array"/> of its contents so that a subsequent caller using the <see cref="Rent"/> method will not see the content of the previous caller. If <paramref name="bufferLength"/> is set to <see langword="false" /> or if the pool will release the buffer, the array's contents are left unchanged.</param>
         <summary>Returns an array to the pool that was previously obtained using the <see cref="Rent"/> method on the same <see cref="ArrayPool{T}"/> instance.</summary>
         <remarks>
         <format type="text/markdown"><![CDATA[  

--- a/xml/System.Buffers/ArrayPool`1.xml
+++ b/xml/System.Buffers/ArrayPool`1.xml
@@ -16,9 +16,17 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="T">To be added.</typeparam>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <typeparam name="T">The type of the objects that are in the resource pool.</typeparam>
+    <summary>Provides a resource pool that enables the reusing of instances of type <see cref="T:T[]"/>.</summary>
+    <remarks><format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+  
+ Using the <see cref="T:System.Buffers.ArrayPool{T}"/> class to rent and return buffers (using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> and <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> methods) can increase performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.
+
+ This class is thread-safe.  All members may be used by multiple threads concurrently. 
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -54,9 +62,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Creates a new instance of the <see cref="ArrayPool{T}"/> class.</summary>
+        <returns>A new instance of the <see cref="ArrayPool{T}"/> class.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Create">
@@ -78,11 +86,18 @@
         <Parameter Name="maxArraysPerBucket" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="maxArrayLength">To be added.</param>
-        <param name="maxArraysPerBucket">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="maxArrayLength">The maximum length of an array instance that may be stored in the pool.</param>
+        <param name="maxArraysPerBucket">The maximum number of array instances that may be stored in each bucket in the pool. The pool groups arrays of similar lengths into buckets for faster access.</param>
+        <summary>Creates a new instance of the <see cref="ArrayPool{T}"/> class using the specifed configuration options.</summary>
+        <returns>A new instance of the <see cref="ArrayPool{T}"/> class with the specified configuration options.</returns>
+        <remarks>
+        <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+  
+The instance of the <see cref="ArrayPool{T}"/> class created by this method will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/> in each bucket and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Rent">
@@ -103,10 +118,17 @@
         <Parameter Name="minimumLength" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="minimumLength">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="minimumLength">The minimum length of the array.</param>
+        <summary>Retrieves a buffer that is at least the requested length.</summary>
+        <returns>An array of type <see cref="T:T[]"/> that is at least <paramref name="minimumLength"/> in length.</returns>
+        <remarks>
+        <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+
+This buffer is loaned to the caller and should be returned to the same pool using the <see cref="Return"/> method, so that it can be reused in subsequent calls to the <see cref="Rent"/> method. Failure to return a rented buffer is not a fatal error. However, it may lead to decreased application performance, as the pool may need to create a new buffer to replace the lost one.
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Return">
@@ -128,10 +150,17 @@
         <Parameter Name="clearArray" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="array">To be added.</param>
-        <param name="clearArray">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="array">A buffer to return to the pool that was previously obtained using the <see cref="Rent"/> method.</param>
+        <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse. If <paramref name="bufferLength"/> is set to <see langword="true" />, and if the pool will store the buffer to enable subsequent reuse, the <see cref="Return"/> method will clear the <paramref name="array"/> of its contents so that a subsequent consumer using the <see cref="Rent"/> method will not see the previous consumer's content. If <paramref name="bufferLength"/> is set to <see langword="false" /> or if the pool will release the buffer, the array's contents are left unchanged.</param>
+        <summary>Returns an array to the pool that was previously obtained using the <see cref="Rent"/> method on the same <see cref="ArrayPool{T}"/> instance.</summary>
+        <remarks>
+        <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+
+Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer and must not use it. The reference returned from a given call to the <see cref="Rent"/> method must only be returned using the <see cref="Return"/> method once. The default <see cref="ArrayPool{T}"/> may hold onto the returned buffer in order to rent it again, or it may release the returned buffer if it's determined that the pool already has enough buffers stored.
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Shared">
@@ -149,9 +178,16 @@
         <ReturnType>System.Buffers.ArrayPool&lt;T&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a shared <see cref="ArrayPool{T}"/> instance.</summary>
+        <value>A shared <see cref="ArrayPool{T}"/> instance.</value>
+        <remarks>
+        <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+
+The shared pool provides a default implementation of the <see cref="ArrayPool{T}"/> class that's intended for general applicability. A shared class maintains arrays of multiple sizes, and may hand back a larger array than was actually requested, but will never hand back a smaller array than was requested. Renting a buffer from a shared class using the <see cref="Rent"/> method will result in an existing buffer being taken from the pool if an appropriate buffer is available or in a new buffer being allocated if one is not available.
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Buffers/ArrayPool`1.xml
+++ b/xml/System.Buffers/ArrayPool`1.xml
@@ -42,8 +42,15 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Invokes the static constructor when a new instance of the <see cref="ArrayPool{T}"/> class is instantiated.</summary>
-        <remarks></remarks>
+        <summary>Initializes a new instance of the <see cref="ArrayPool{T}"/> class.</summary>
+        <remarks>
+        <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+  
+Note that this constructor is protected; it can only be called by classes derived from the <see cref="ArrayPool{T}"/> class. 
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Create">

--- a/xml/System.Buffers/ArrayPool`1.xml
+++ b/xml/System.Buffers/ArrayPool`1.xml
@@ -17,12 +17,12 @@
   <Interfaces />
   <Docs>
     <typeparam name="T">The type of the objects that are in the resource pool.</typeparam>
-    <summary>Provides a resource pool that enables the reusing of instances of type <see cref="T:T[]"/>.</summary>
+    <summary>Provides a resource pool that enables reusing instances of type <see cref="T:T[]"/>.</summary>
     <remarks><format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
- Using the <see cref="T:System.Buffers.ArrayPool{T}"/> class to rent and return buffers (using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> and <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> methods) can increase performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.
+ Using the <see cref="T:System.Buffers.ArrayPool{T}"/> class to rent and return buffers (using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> and <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> methods) can improve performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.
 
  This class is thread-safe.  All members may be used by multiple threads concurrently. 
  ]]></format>
@@ -88,14 +88,14 @@
       <Docs>
         <param name="maxArrayLength">The maximum length of an array instance that may be stored in the pool.</param>
         <param name="maxArraysPerBucket">The maximum number of array instances that may be stored in each bucket in the pool. The pool groups arrays of similar lengths into buckets for faster access.</param>
-        <summary>Creates a new instance of the <see cref="ArrayPool{T}"/> class using the specifed configuration options.</summary>
-        <returns>A new instance of the <see cref="ArrayPool{T}"/> class with the specified configuration options.</returns>
+        <summary>Creates a new instance of the <see cref="ArrayPool{T}"/> class using the specifed configuration.</summary>
+        <returns>A new instance of the <see cref="ArrayPool{T}"/> class with the specified configuration.</returns>
         <remarks>
         <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
-The instance of the <see cref="ArrayPool{T}"/> class created by this method will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/> in each bucket and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
+The instance of the <see cref="ArrayPool{T}"/> class created by this method will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/> in each bucket, and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
  ]]></format>
         </remarks>
       </Docs>
@@ -185,7 +185,7 @@ Once a buffer has been returned to the pool, the caller gives up all ownership o
   
 ## Remarks  
 
-The shared pool provides a default implementation of the <see cref="ArrayPool{T}"/> class that's intended for general applicability. A shared class maintains arrays of multiple sizes, and may hand back a larger array than was actually requested, but will never hand back a smaller array than was requested. Renting a buffer from a shared class using the <see cref="Rent"/> method will result in an existing buffer being taken from the pool if an appropriate buffer is available or in a new buffer being allocated if one is not available.
+The shared pool provides a default implementation of the <see cref="ArrayPool{T}"/> class that's intended for general applicability. A shared class maintains arrays of multiple sizes, and may hand back a larger array than was actually requested, but it will never hand back a smaller array than was requested. Renting a buffer from a shared class using the <see cref="Rent"/> method will result in an existing buffer being taken from the pool if an appropriate buffer is available or in a new buffer being allocated if one is not available.
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/ns-System.Buffers.xml
+++ b/xml/ns-System.Buffers.xml
@@ -1,6 +1,13 @@
 <Namespace Name="System.Buffers">
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class that represents a shared resource pool of resusable instances of type <see cref="T:T[]"/>.</summary>
+    <remarks>
+       <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+  
+Resources of the <see cref="ArrayPool{T}"/> class are obtained by calling the <cref="Rent"/> method, and must be returned to the pool using the <see cref="Return"/> method so that they can be safely reused. By allocating shared buffer resources in this way, the <see cref="ArrayPool{T}"/> class can improve performance by relieving memory pressure on the garbage collector in situations where arrays are created and destroyed frequently.
+ ]]></format>
+    </remarks>
   </Docs>
-</Namespace>
+</Namespace> 

--- a/xml/ns-System.Buffers.xml
+++ b/xml/ns-System.Buffers.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Buffers">
   <Docs>
-    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class which represents a shared resource pool of resusable instances of type <see cref="T:T[]"/>.</summary>
+    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class, which represents a shared resource pool of resusable instances of type <see cref="T:T[]"/>.</summary>
     <remarks>
        <format type="text/markdown"><![CDATA[  
   

--- a/xml/ns-System.Buffers.xml
+++ b/xml/ns-System.Buffers.xml
@@ -1,12 +1,12 @@
 <Namespace Name="System.Buffers">
   <Docs>
-    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class that represents a shared resource pool of resusable instances of type <see cref="T:T[]"/>.</summary>
+    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class which represents a shared resource pool of resusable instances of type <see cref="T:T[]"/>.</summary>
     <remarks>
        <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
-Resources of the <see cref="ArrayPool{T}"/> class are obtained by calling the <cref="Rent"/> method, and must be returned to the pool using the <see cref="Return"/> method so that they can be safely reused. By allocating shared buffer resources in this way, the <see cref="ArrayPool{T}"/> class can improve performance by relieving memory pressure on the garbage collector in situations where arrays are created and destroyed frequently.
+The <see cref="ArrayPool{T}"/> class, by allocating a shared buffer for array values, can offer significant improvements in performance for apps that make extensive use of arrays.
  ]]></format>
     </remarks>
   </Docs>


### PR DESCRIPTION
# Title
Document APIs for the System.Buffers Namespace

## Summary
Added documentation for "To be added." fields in all classes of the System.Buffers Namespace:

- System.Buffers.ArrayPool

Fixes #2242 

## Suggested Reviewers
@mairaw 

Questions for reviewer:

1. A "protected ArrayPool ();" constructor is listed in the topic, but is not in the code. In fact, it doesn't really make sense to have this type of constructior for this object. Should I delete this Member? Or should I add a generic description for the summary field?
2. Please be sure and review the description of the clearArray parameter in the Return method. The indication that a buffer's contents might not be cleared and that another "consumer" might see the contents, sounds like a security issue. 
