### PR TITLE
Supply missing language identifiers to code blocks

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0019.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0019.md
@@ -40,7 +40,7 @@ Operator 'operator' cannot be applied to operands of type 'type' and 'type'
 ## Example  
  In the following example, CS0019 is generated in two places because [bool](../../../csharp/language-reference/keywords/bool.md) in C# is not convertible to [int](../../../csharp/language-reference/keywords/int.md). CS0019 also is generated when the subtraction operator is applied to a string. The addition operator (+) can be used with string operands because that operator is overloaded by the `String` class to perform string concatenation.  
   
-```  
+```csharp  
 static void Main()  
 {  
     bool result = true;  
@@ -74,7 +74,7 @@ static void Main()
   
  The following sample generates CS0019.  
   
-```  
+```csharp  
 // CS0019_a.cs  
 // compile with: /target:library  
 using System.Diagnostics;  

--- a/docs/csharp/language-reference/compiler-messages/cs0029.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0029.md
@@ -37,7 +37,7 @@ Cannot implicitly convert type 'type' to 'type'
   
  Conversions must occur when assigning a variable of one type to a variable of a different type. When making an assignment between variables of different types, the compiler must convert the type on the right-hand side of the assignment operator to the type on the left-hand side of the assignment operator. Take the following the code:  
   
-```  
+```csharp  
 int i = 50;  
 long lng = 100;  
 i = lng;  
@@ -47,7 +47,7 @@ i = lng;
   
  A narrowing conversion exists when converting to a data type that occupies less storage space in memory than the data type we are converting from. For example, converting a long to an int would be considered a narrowing conversion. A long occupies 8 bytes of memory while an int occupies 4 bytes. To see how data loss can occur, consider the following sample:  
   
-```  
+```csharp  
 int i = 50;  
 long lng = 3147483647;  
 i = lng;  
@@ -57,7 +57,7 @@ i = lng;
   
  A widening conversion would be the opposite of a narrowing conversion. With widening conversions, we are converting to a data type that occupies more storage space in memory than the data type we are converting from. Here is an example of a widening conversion:  
   
-```  
+```csharp  
 int i = 50;  
 long lng = 100;  
 lng = i;  
@@ -67,7 +67,7 @@ lng = i;
   
  We know that implicit narrowing conversions are not allowed, so to be able to compile this code we need to explicitly convert the data type. Explicit conversions are done using casting. Casting is the term used in C# to describe converting one data type to another. To get the code to compile we would need to use the following syntax:  
   
-```  
+```csharp  
 int i = 50;  
 long lng = 100;  
 i = (int) lng;   // cast to int  
@@ -79,7 +79,7 @@ i = (int) lng;   // cast to int
   
  The following sample generates CS0029:  
   
-```  
+```csharp  
 // CS0029.cs  
 public class MyInt  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0034.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0034.md
@@ -37,7 +37,7 @@ Operator 'operator' is ambiguous on operands of type 'type1' and 'type2'
   
  The following sample generates CS0034:  
   
-```  
+```csharp  
 // CS0034.cs  
 public class A  
 {  
@@ -93,7 +93,7 @@ public class C
   
  In C# 1.1 a compiler bug made it possible to define a class that has implicit user-defined conversions to both `int` and `bool`, and to use a bitwise `AND` operator (`&`) on objects of that type. In C# 2.0, this bug was fixed to bring the compiler into compliance with the C# specification, and therefore the following code will now cause CS0034:  
   
-```  
+```csharp  
 namespace CS0034  
 {  
     class TestClass2  

--- a/docs/csharp/language-reference/compiler-messages/cs0038.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0038.md
@@ -37,7 +37,7 @@ Cannot access a nonstatic member of outer type 'type1' via nested type 'type2'
   
  The following sample generates CS0038:  
   
-```  
+```csharp  
 // CS0038.cs  
 class OuterClass  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0039.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0039.md
@@ -38,7 +38,7 @@ Cannot convert type 'type1' to 'type2' via a reference conversion, boxing conver
 ## Example  
  The following example generates CS0039.  
   
-```  
+```csharp  
 // CS0039.cs  
 using System;  
 class A  

--- a/docs/csharp/language-reference/compiler-messages/cs0050.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0050.md
@@ -38,7 +38,7 @@ Inconsistent accessibility: return type 'type' is less accessible than method 'm
 ## Example  
  The following sample generates CS0050 because no accessiblity modifier is supplied for `MyClass` and its accessibility therefore defaults to `private`.  
   
-```  
+```csharp  
 // CS0050.cs  
 class MyClass //accessibility defaults to private  
 // try the following line instead  

--- a/docs/csharp/language-reference/compiler-messages/cs0051.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0051.md
@@ -38,7 +38,7 @@ Inconsistent accessibility: parameter type 'type' is less accessible than method
 ## Example  
  The following sample generates CS0051:  
   
-```  
+```csharp  
 // CS0051.cs  
 public class A  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0071.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0071.md
@@ -38,7 +38,7 @@ An explicit interface implementation of an event must use event accessor syntax
 ## Example  
  The following sample generates CS0071.  
   
-```  
+```csharp  
 // CS0071.cs  
 public delegate void MyEvent(object sender);  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0106.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0106.md
@@ -48,7 +48,7 @@ The modifier 'modifier' is not valid for this item
 ## Example  
  The following sample generates CS0106.  
   
-```  
+```csharp  
 // CS0106.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0108.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0108.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
  The following sample generates CS0108:  
   
-```  
+```csharp  
 // CS0108.cs  
 // compile with: /W:2  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0115.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0115.md
@@ -42,7 +42,7 @@ translation.priority.ht:
   
 -   Use `MyClass1` as a base class for `MyClass2`.  
   
-```  
+```csharp  
 // CS0115.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0116.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0116.md
@@ -38,7 +38,7 @@ A namespace does not directly contain members such as fields or methods
 ## Example  
  The following sample generates CS0116:  
   
-```  
+```csharp  
 // CS0116.cs  
 namespace x  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0120.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0120.md
@@ -37,7 +37,7 @@ An object reference is required for the nonstatic field, method, or property 'me
   
  The following sample generates CS0120:  
   
-```  
+```csharp  
 // CS0120_1.cs  
 public class MyClass  
 {  
@@ -70,7 +70,7 @@ public class MyClass
   
  CS0120 will also be generated if there is a call to a non-static method from a static method, as follows:  
   
-```  
+```csharp  
 // CS0120_2.cs  
 // CS0120 expected  
 using System;  
@@ -95,7 +95,7 @@ public class MyClass
   
  Similarly, a static method cannot call an instance method unless you explicitly give it an instance of the class, as follows:  
   
-```  
+```csharp  
 // CS0120_3.cs  
 using System;  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0122.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0122.md
@@ -40,7 +40,7 @@ translation.priority.ht:
 ## Example  
  The following sample generates CS0122:  
   
-```  
+```csharp  
 // CS0122.cs  
 public class MyClass  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0134.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0134.md
@@ -40,7 +40,7 @@ translation.priority.ht:
 ## Example  
  The following example generates CS0134.  
   
-```  
+```csharp  
 // CS0134.cs  
 // compile with: /target:library  
 class MyTest {}   

--- a/docs/csharp/language-reference/compiler-messages/cs0151.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0151.md
@@ -38,7 +38,7 @@ A value of an integral type expected
 ## Example  
  This error can occur when there is no conversion or if the available implicit conversions result in an ambiguous situation. The following sample generates CS0151.  
   
-```  
+```csharp  
 // CS0151.cs  
 public class MyClass  
 {  
@@ -71,7 +71,7 @@ public class MyClass
 ## Example  
  In Visual Studio 2008 and later, a [void](../../../csharp/language-reference/keywords/void.md) method invocation generates CS0151. You can fix the error by calling a method that returns an integral type such as [int](../../../csharp/language-reference/keywords/int.md) or [long](../../../csharp/language-reference/keywords/long.md).  
   
-```  
+```csharp  
 class C  
 {  
     static void Main()  

--- a/docs/csharp/language-reference/compiler-messages/cs0178.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0178.md
@@ -46,7 +46,7 @@ Invalid rank specifier: expected ',' or ']'
 ## Example  
  The following sample generates CS0178.  
   
-```  
+```csharp  
 // CS0178.cs  
 class MyClass  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0188.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0188.md
@@ -42,7 +42,7 @@ The 'this' object cannot be used before all of its fields are assigned to
 ## Example  
  The following sample generates CS0188:  
   
-```  
+```csharp  
 // CS0188.cs  
 // compile with: /t:library  
 namespace MyNamespace  

--- a/docs/csharp/language-reference/compiler-messages/cs0201.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0201.md
@@ -38,7 +38,7 @@ Only assignment, call, increment, decrement, and new object expressions can be u
 ## Example  
  The following sample generates CS0201 because 2 * 3 is an expression, not a statement. To make the code compile, try assigning the value of the expression to a  variable.  
   
-```  
+```csharp  
 // CS0201.cs  
 public class MainClass  
 {  
@@ -54,7 +54,7 @@ public class MainClass
 ## Example  
  The following sample generates CS0201 because checked by itself is not a statement, even though it is parameterized by an increment operation.  
   
-```  
+```csharp  
 // CS0201_b.cs  
 // compile with: /target:library  
 public class MyList<T>   

--- a/docs/csharp/language-reference/compiler-messages/cs0229.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0229.md
@@ -41,7 +41,7 @@ Ambiguity between 'member1' and 'member2'
 ## Example  
  The following example generates CS0229:  
   
-```  
+```csharp  
 // CS0229.cs  
   
 interface IList  

--- a/docs/csharp/language-reference/compiler-messages/cs0233.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0233.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following example generates CS0233:  
   
-```  
+```csharp  
 // CS0233.cs  
 using System;  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/language-reference/compiler-messages/cs0234.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0234.md
@@ -45,7 +45,7 @@ The type or namespace name 'name' does not exist in the namespace 'namespace' (a
   
  The following sample generates CS0234:  
   
-```  
+```csharp  
 // CS0234.cs  
 public class C  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0270.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0270.md
@@ -37,7 +37,7 @@ Array size cannot be specified in a variable declaration (try initializing with 
   
  The following example generates CS0270:  
   
-```  
+```csharp  
 // CS0270.cs  
 // compile with: /t:module  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0310.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0310.md
@@ -38,7 +38,7 @@ The type 'typename' must be a non-abstract type with a public parameterless cons
 ## Example  
  The following sample generates CS0310:  
   
-```  
+```csharp  
 // CS0310.cs  
 using System;  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0311.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0311.md
@@ -43,7 +43,7 @@ The type 'type1' cannot be used as type parameter 'T' in the generic type or met
   
 ## Example  
   
-```  
+```csharp  
 // cs0311.cs  
 class B{}  
 class C{}  

--- a/docs/csharp/language-reference/compiler-messages/cs0413.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0413.md
@@ -41,7 +41,7 @@ The type parameter 'type parameter' cannot be used with the 'as' operator becaus
 ## Example  
  The following sample generates CS0413.  
   
-```  
+```csharp  
 // CS0413.cs  
 // compile with: /target:library  
 class A {}  

--- a/docs/csharp/language-reference/compiler-messages/cs0420.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0420.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
  The following sample generates CS0420:  
   
-```  
+```csharp  
 // CS0420.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0429.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0429.md
@@ -38,7 +38,7 @@ Unreachable expression code detected
 ## Example  
  The following code generates CS0429.  
   
-```  
+```csharp  
 // CS0429.cs  
 public class cs0429   
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0433.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0433.md
@@ -40,7 +40,7 @@ The type TypeName1 exists in both TypeName2 and TypeName3
 ## Example  
  This code creates the DLL with the first copy of the ambiguous type.  
   
-```  
+```csharp  
 // CS0433_1.cs  
 // compile with: /target:library  
 namespace TypeBindConflicts   
@@ -52,7 +52,7 @@ namespace TypeBindConflicts
 ## Example  
  This code creates the DLL with the second copy of the ambiguous type.  
   
-```  
+```csharp  
 // CS0433_2.cs  
 // compile with: /target:library  
 namespace TypeBindConflicts   
@@ -64,7 +64,7 @@ namespace TypeBindConflicts
 ## Example  
  The following example generates CS0433.  
   
-```  
+```csharp  
 // CS0433_3.cs  
 // compile with: /reference:cs0433_1.dll /reference:cs0433_2.dll  
 using TypeBindConflicts;  
@@ -80,7 +80,7 @@ public class Test
 ## Example  
  The following example shows how you can use the alias feature of the **/reference** compiler option to resolve this CS0433 error.  
   
-```  
+```csharp  
 // CS0433_4.cs  
 // compile with: /reference:cs0433_1.dll /reference:TypeBindConflicts=cs0433_2.dll  
 using TypeBindConflicts;  

--- a/docs/csharp/language-reference/compiler-messages/cs0446.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0446.md
@@ -38,7 +38,7 @@ Foreach cannot operate on a 'Method or Delegate'. Did you intend to invoke the '
 ## Example  
  The following code will generate CS0446.  
   
-```  
+```csharp  
 // CS0446.cs  
 using System;  
 class Tester   

--- a/docs/csharp/language-reference/compiler-messages/cs0465.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0465.md
@@ -40,7 +40,7 @@ Introducing a 'Finalize' method can interfere with destructor invocation. Did yo
 ## Example  
  The following sample generates CS0465.  
   
-```  
+```csharp  
 // CS0465.cs  
 // compile with: /target:library  
 class A  

--- a/docs/csharp/language-reference/compiler-messages/cs0504.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0504.md
@@ -37,7 +37,7 @@ The constant 'variable' cannot be marked static
   
  The following sample generates CS0504:  
   
-```  
+```csharp  
 // CS0504.cs  
 namespace x  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0507.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0507.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following sample generates CS0507.  
   
-```  
+```csharp  
 // CS0507.cs  
 abstract public class clx  
 {  
@@ -55,7 +55,7 @@ public class cly : clx
 ## Example  
  CS0507 can also occur if a class attempts to override a method marked as `protected internal` defined in referenced metadata. In this situation, the overriding method should be marked as `protected`.  
   
-```  
+```csharp  
 // CS0507_b.cs  
 // compile with: /target:library  
 abstract public class clx  
@@ -67,7 +67,7 @@ abstract public class clx
 ## Example  
  The following sample generates CS0507.  
   
-```  
+```csharp  
 // CS0507_c.cs  
 // compile with: /reference:cs0507_b.dll  
 public class cly : clx  

--- a/docs/csharp/language-reference/compiler-messages/cs0523.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0523.md
@@ -37,7 +37,7 @@ Struct member 'struct2 field' of type 'struct1' causes a cycle in the struct lay
   
  The following sample generates CS0523:  
   
-```  
+```csharp  
 // CS0523.cs  
 // compile with: /target:library  
 struct RecursiveLayoutStruct1  

--- a/docs/csharp/language-reference/compiler-messages/cs0545.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0545.md
@@ -48,7 +48,7 @@ translation.priority.ht:
 ## Example  
  The following sample generates CS0545.  
   
-```  
+```csharp  
 // CS0545.cs  
 // compile with: /target:library  
 // CS0545  

--- a/docs/csharp/language-reference/compiler-messages/cs0552.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0552.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
  The following sample generates CS0552:  
   
-```  
+```csharp  
 // CS0552.cs  
 public interface ii  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0563.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0563.md
@@ -38,7 +38,7 @@ One of the parameters of a binary operator must be the containing type
 ## Example  
  The following sample generates CS0563:  
   
-```  
+```csharp  
 // CS0563.cs  
 public class iii  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0570.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0570.md
@@ -38,7 +38,7 @@ Property, indexer, or event 'name' is not supported by the language; try directl
 ## Example  
  The following C++ program uses an attribute, RequiredAttributeAttribute, which may not be consumed by other languages.  
   
-```  
+```csharp  
 // CPP0570.cpp  
 // compile with: /clr /LD  
   
@@ -66,7 +66,7 @@ namespace CS0570_Server {
 ## Example  
  The following sample generates CS0570.  
   
-```  
+```csharp  
 // CS0570.cs  
 // compile with: /reference:CPP0570.dll  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0571.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0571.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
  The following sample generates CS0571:  
   
-```  
+```csharp  
 // CS0571.cs  
 public class MyClass  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0592.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0592.md
@@ -38,7 +38,7 @@ Attribute 'attribute' is not valid on this declaration type. It is valid on 'typ
 ## Example  
  The following sample generates CS0592:  
   
-```  
+```csharp  
 // CS0592.cs  
 using System;  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0616.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0616.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following sample generates CS0616.  
   
-```  
+```csharp  
 // CS0616.cs  
 // compile with: /target:library  
 [CMyClass(i = 5)]   // CS0616  
@@ -48,7 +48,7 @@ public class CMyClass {}
 ## Example  
  The following sample shows how you might define an attribute:  
   
-```  
+```csharp  
 // CreateAttrib.cs  
 // compile with: /target:library  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0618.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0618.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
  The following sample generates CS0618:  
   
-```  
+```csharp  
 // CS0618.cs  
 // compile with: /W:2  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0650.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0650.md
@@ -38,7 +38,7 @@ Bad array declarator: To declare a managed array the rank specifier precedes the
 ## Example  
  The following example code generates CS0650.  
   
-```  
+```csharp  
 // CS0650.cs  
 public class MyClass  
 {  
@@ -62,7 +62,7 @@ public class MyClass
 ## Example  
  The following example shows how to use the `fixed` keyword when you create a fixed size buffer:  
   
-```  
+```csharp  
 // This code must appear in an unsafe block.   
 public struct MyArray   
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0675.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0675.md
@@ -37,7 +37,7 @@ Bitwise-or operator used on a sign-extended operand; consider casting to a small
   
  The following sample generates CS0675:  
   
-```  
+```csharp  
 // CS0675.cs  
 // compile with: /W:3  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0686.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0686.md
@@ -36,7 +36,7 @@ Accessor 'accessor' cannot implement interface member 'member' for type 'type'. 
  Suggested: This error can occur when implementing an interface that contains method names which conflict with the auto-generated methods associated with a property or event. The get/set methods for properties are generated as get_property and set_property, and the add/remove methods for events are generated as add_event and remove_event. If an interface contains either of these methods, a conflict occurs. To avoid this error, implement the methods using an explicit interface implementation. To do this, specify the function as:  
   
 ```csharp  
-      Interface.get_property() { /* */ }  
+Interface.get_property() { /* */ }  
 Interface.set_property() { /* */ }  
 ```  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0686.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0686.md
@@ -35,7 +35,7 @@ Accessor 'accessor' cannot implement interface member 'member' for type 'type'. 
   
  Suggested: This error can occur when implementing an interface that contains method names which conflict with the auto-generated methods associated with a property or event. The get/set methods for properties are generated as get_property and set_property, and the add/remove methods for events are generated as add_event and remove_event. If an interface contains either of these methods, a conflict occurs. To avoid this error, implement the methods using an explicit interface implementation. To do this, specify the function as:  
   
-```  
+```csharp  
       Interface.get_property() { /* */ }  
 Interface.set_property() { /* */ }  
 ```  
@@ -43,7 +43,7 @@ Interface.set_property() { /* */ }
 ## Example  
  The following sample generates CS0686:  
   
-```  
+```csharp  
 // CS0686.cs  
 interface I  
 {  
@@ -68,7 +68,7 @@ class D : I
 ## Example  
  This error can also occur when declaring events.  The event construct automatically generates the `add_``event` and `remove_``event` methods, which could conflict with the methods of the same name in an interface, as in the following sample:  
   
-```  
+```csharp  
 // CS0686b.cs  
 using System;  
   

--- a/docs/csharp/language-reference/compiler-messages/cs0702.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0702.md
@@ -38,7 +38,7 @@ Constraint cannot be special class 'identifier'
 ## Example  
  The following sample generates CS0702:  
   
-```  
+```csharp  
 // CS0702.cs  
 class C<T> where T : System.Array  // CS0702  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0703.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0703.md
@@ -39,7 +39,7 @@ Inconsistent accessibility: constraint type 'identifier' is less accessible than
   
  The following sample generates CS0703:  
   
-```  
+```csharp  
 // CS0703.cs  
 internal interface I {}  
 public class C<T> where T : I  // CS0703 – I is internal; C<T> is public  

--- a/docs/csharp/language-reference/compiler-messages/cs0826.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0826.md
@@ -46,7 +46,7 @@ No best type found for implicitly typed array.
 ## Example  
  The following code generates CS0826 because the array elements are not all the same type, and the compiler's type inference logic does not find a single best type:  
   
-```  
+```csharp  
 // cs0826.cs  
 public class C  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0834.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0834.md
@@ -42,7 +42,7 @@ A lambda expression must have an expression body to be converted to an expressio
 ## Example  
  The following example generates CS0834:  
   
-```  
+```csharp  
 // cs0834.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/language-reference/compiler-messages/cs0840.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0840.md
@@ -42,7 +42,7 @@ translation.priority.ht:
 ## Example  
  The following example generates CS0840:  
   
-```  
+```csharp  
 // cs0840.cs  
 // Compile with /target:library  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs0843.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0843.md
@@ -42,7 +42,7 @@ Backing field for automatically implemented property 'name' must be fully assign
 ## Example  
  The following code generates CS0843:  
   
-```  
+```csharp  
 // cs0843.cs  
 struct S  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs0845.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0845.md
@@ -42,7 +42,7 @@ An expression tree lambda may not contain a coalescing operator with a null lite
 ## Example  
  The following code generates CS0845:  
   
-```  
+```csharp  
 // cs0845.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/language-reference/compiler-messages/cs1001.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1001.md
@@ -37,7 +37,7 @@ Identifier expected
   
  The following example declares a simple class but does not give the class a name:  
   
-```  
+```csharp  
 //cs1001.cs  
 public class              //CS1001  
     {  
@@ -48,7 +48,7 @@ public class              //CS1001
   
  The following sample generates CS1001 because, when declaring an enum, you must specify members:  
   
-```  
+```csharp  
 // CS1001.cs  
 public class clx  
 {  
@@ -67,7 +67,7 @@ public class clx
   
  Parameter names are required even if the compiler doesn't use them, for example, in an interface definition. These parameters are required so that programmers who are consuming the interface know something about the what the parameters mean.  
   
-```  
+```csharp  
 // CS1001-2.cs  
 // compile with: /target:library  
 interface IMyTest  

--- a/docs/csharp/language-reference/compiler-messages/cs1018.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1018.md
@@ -38,7 +38,7 @@ Keyword 'this' or 'base' expected
 ## Example  
  The following example generates CS1018, and suggests several ways to resolve the error:  
   
-```  
+```csharp  
 // CS1018.cs  
 public class C  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs1026.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1026.md
@@ -55,7 +55,7 @@ translation.priority.ht:
   
  The following example generates CS1026:  
   
-```  
+```csharp  
 // CS1026.cs  
 #if (a == b   // CS1026, add closing )  
 #endif  

--- a/docs/csharp/language-reference/compiler-messages/cs1029.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1029.md
@@ -37,7 +37,7 @@ translation.priority.ht:
   
  The following sample shows how to create a user-defined error:  
   
-```  
+```csharp  
 // CS1029.cs  
 class Sample  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs1058.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1058.md
@@ -40,7 +40,7 @@ A previous catch clause already catches all exceptions. All exceptions thrown wi
 ## Example  
  The following example generates CS1058.  
   
-```  
+```csharp  
 // CS1058.cs  
 // CS1058 expected  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/language-reference/compiler-messages/cs1060.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1060.md
@@ -42,7 +42,7 @@ Use of possibly unassigned field 'name'. Struct instance variables are initially
 ## Example  
  The following code generates CS1060 because the class type `U` is a member of the `struct S` but is never initialized.  
   
-```  
+```csharp  
 // cs1060.cs  
 namespace CS1060  
 {      

--- a/docs/csharp/language-reference/compiler-messages/cs1112.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1112.md
@@ -44,7 +44,7 @@ Do not use 'System.Runtime.CompilerServices.ExtensionAttribute'. Use the 'this' 
 ## Example  
  The following example generates CS1112:  
   
-```  
+```csharp  
 // cs1112.cs  
 [System.Runtime.CompilerServices.ExtensionAttribute] // CS1112  
 public class Extensions  

--- a/docs/csharp/language-reference/compiler-messages/cs1502.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1502.md
@@ -47,7 +47,7 @@ The best overloaded method match for 'name' has some invalid arguments
   
  The following sample generates CS1502:  
   
-```  
+```csharp  
 // CS1502.cs  
 namespace x  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs1546.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1546.md
@@ -40,7 +40,7 @@ Property, indexer, or event 'property' is not supported by the language; try dir
 ## Example  
  This code sample consists of a .cpp file, which compiles to a .dll, and a .cs file, which uses that .dll. The following code is for the .dll file, and defines a property to be accessed by the code in the .cs file.  
   
-```  
+```cpp  
 // CPP1546.cpp  
 // compile with: /clr /LD  
 using namespace System;  
@@ -60,7 +60,7 @@ public:
 ## Example  
  This is the C# file.  
   
-```  
+```csharp  
 // CS1546.cs  
 // compile with: /r:CPP1546.dll   
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs1546.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1546.md
@@ -38,7 +38,7 @@ Property, indexer, or event 'property' is not supported by the language; try dir
  The following sample generates CS1546.  
   
 ## Example  
- This code sample consists of a .cpp file, which compiles to a .dll, and a .cs file, which uses that .dll. The following code is for the .dll file, and defines a property to be accessed by the code in the .cs file.  
+ This code sample consists of a .cpp file, which compiles to a .dll, and a .cs file, which uses that .dll. The following code is for the .dll file and defines a property to be accessed by the code in the .cs file.  
   
 ```cpp  
 // CPP1546.cpp  

--- a/docs/csharp/language-reference/compiler-messages/cs1564.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1564.md
@@ -42,7 +42,7 @@ Conflicting options specified: Win32 resource file; Win32 manifest.
 ## Example  
  The following example produces CS1564 if it is compiled with the **/Win32res** option and no manifest is included in the resource file.  
   
-```  
+```csharp  
 // cs1564.cs  
 // Compile with: /Win32res  
 public class Test  

--- a/docs/csharp/language-reference/compiler-messages/cs1579.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1579.md
@@ -48,7 +48,7 @@ foreach statement cannot operate on variables of type 'type1' because 'type2' do
   
  The following sample generates CS1579.  
   
-```  
+```csharp  
 // CS1579.cs  
 using System;  
 public class MyCollection   

--- a/docs/csharp/language-reference/compiler-messages/cs1591.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1591.md
@@ -37,7 +37,7 @@ Missing XML comment for publicly visible type or member 'Type_or_Member'
   
  The following sample generates CS1591:  
   
-```  
+```csharp  
 // CS1591.cs  
 // compile with: /W:4 /doc:x.xml  
   

--- a/docs/csharp/language-reference/compiler-messages/cs1614.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1614.md
@@ -39,7 +39,7 @@ translation.priority.ht:
   
  The following sample generates CS1614:  
   
-```  
+```csharp  
 // CS1614.cs  
 using System;  
   

--- a/docs/csharp/language-reference/compiler-messages/cs1616.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1616.md
@@ -35,10 +35,10 @@ Option 'option' overrides attribute 'attribute' given in a source file or added 
   
  This warning occurs if the assembly attributes <xref:System.Reflection.AssemblyKeyFileAttribute> or <xref:System.Reflection.AssemblyKeyNameAttribute> found in source conflict with the [/keyfile](../../../csharp/language-reference/compiler-options/keyfile-compiler-option.md) or [/keycontainer](../../../csharp/language-reference/compiler-options/keycontainer-compiler-option.md) command line option or key file name or key container specified in the Project Properties.  
   
- For the example below, assume you have a key file  named `cs1616.snk`. This file could be generated with the command line:  
+ For the example below, assume you have a key file named `cs1616.snk`. Generate this file with the command line:  
   
 ```console  
-sn –k CS1616.snk  
+sn -k CS1616.snk  
 ```  
   
  The following sample generates CS1616:  

--- a/docs/csharp/language-reference/compiler-messages/cs1616.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1616.md
@@ -37,13 +37,13 @@ Option 'option' overrides attribute 'attribute' given in a source file or added 
   
  For the example below, assume you have a key file  named `cs1616.snk`. This file could be generated with the command line:  
   
-```  
+```console  
 sn –k CS1616.snk  
 ```  
   
  The following sample generates CS1616:  
   
-```  
+```csharp  
 // CS1616.cs  
 // compile with: /keyfile:cs1616.snk  
 using System.Reflection;  

--- a/docs/csharp/language-reference/compiler-messages/cs1640.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1640.md
@@ -38,7 +38,7 @@ foreach statement cannot operate on variables of type 'type' because it implemen
 ## Example  
  The following sample generates CS1640:  
   
-```  
+```csharp  
 // CS1640.cs  
   
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs1644.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1644.md
@@ -37,7 +37,7 @@ Feature 'feature' is not part of the standardized ISO C# language specification,
   
  The following sample generates CS1644:  
   
-```  
+```csharp  
 // CS1644.cs  
 // compile with: /langversion:ISO-1 /target:library  
 class C<T> {}   // CS1644  

--- a/docs/csharp/language-reference/compiler-messages/cs1656.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1656.md
@@ -38,7 +38,7 @@ Cannot assign to 'variable' because it is a 'read-only variable type'
 ## Example  
  The following example generates error CS1656 because it tries to replace complete elements of a collection inside a `foreach` loop. One way to work around the error is to change the `foreach` loop to a [for](../../../csharp/language-reference/keywords/for.md) loop. Another way, not shown here, is to modify the members of the existing element; this is possible with classes, but not with structs.  
   
-```  
+```csharp  
 using System;  
 using System.Collections;  
 using System.Collections.Generic;  
@@ -105,7 +105,7 @@ namespace CS1656_2
 ## Example  
  The following sample demonstrates how CS1656 can be generated in other contexts besides a `foreach` loop:  
   
-```  
+```csharp  
 // CS1656.cs  
 // compile with: /unsafe  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs1658.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1658.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following example generates CS1658.  
   
-```  
+```csharp  
 // CS1658.cs  
 // compile with: /doc:x.xml  
 // CS1584 expected  

--- a/docs/csharp/language-reference/compiler-messages/cs1674.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1674.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following sample generates CS1674.  
   
-```  
+```csharp  
 // CS1674.cs  
 class C  
 {  
@@ -55,7 +55,7 @@ class C
 ## Example  
  The following sample generates CS1674.  
   
-```  
+```csharp  
 // CS1674_b.cs  
 using System;  
 class C {  
@@ -78,7 +78,7 @@ class D : IDisposable {
 ## Example  
  The following case illustrates the need for a class type constraint to guarantee that an unknown type parameter is disposable. The following sample generates CS1674.  
   
-```  
+```csharp  
 // CS1674_c.cs  
 // compile with: /target:library  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs1690.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1690.md
@@ -37,7 +37,7 @@ Accessing a member on 'member' may cause a runtime exception because it is a fie
   
  The following sample generates CS1690:  
   
-```  
+```csharp  
 // CS1690.cs  
 using System;  
   

--- a/docs/csharp/language-reference/compiler-messages/cs1691.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1691.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following example generates CS1691.  
   
-```  
+```csharp  
 // CS1691.cs  
 public class C  
 {  

--- a/docs/csharp/language-reference/compiler-messages/cs1699.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1699.md
@@ -58,7 +58,7 @@ Use command line option "compiler_option" or appropriate project settings instea
 ## Example  
  The following sample generates CS1699. To resolve the error, remove the attribute and compile with **/delaysign**.  
   
-```  
+```csharp  
 // CS1699.cs  
 // compile with: /target:library  
 [assembly:System.Reflection.AssemblyDelaySign(true)]   // CS1699  

--- a/docs/csharp/language-reference/compiler-messages/cs1700.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1700.md
@@ -40,7 +40,7 @@ Assembly reference Assembly Name is invalid and cannot be resolved
 ## Example  
  The following sample generates CS1700.  
   
-```  
+```csharp  
 // CS1700.cs  
 // compile with: /target:library  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/language-reference/compiler-messages/cs1701.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1701.md
@@ -38,7 +38,7 @@ Assuming assembly reference "Assembly Name #1" matches "Assembly Name #2", you m
 ## Example  
  The following multifile sample references an assembly using two different external aliases. This first sample builds the older version of the code that creates assembly CS1701_d.  
   
-```  
+```csharp  
 // CS1701_a.cs  
 // compile with: /target:library /out:cs1701_d.dll /keyfile:mykey.snk  
 using System.Reflection;  
@@ -53,7 +53,7 @@ public class C1 {}
 ## Example  
  This is the code that creates the newer version of assembly CS1701_d. Note that it compiles into a different directory than the older version, necessary since the output files have the same names.  
   
-```  
+```csharp  
 // CS1701_b.cs  
 // compile with: /target:library /out:c:\\cs1701_d.dll /keyfile:mykey.snk  
 using System.Reflection;  
@@ -70,7 +70,7 @@ public class C1 {}
 ## Example  
  This sample sets up the external aliases A1 and A2.  
   
-```  
+```csharp  
 // CS1701_c.cs  
 // compile with: /target:library /reference:A2=c:\\cs1701_d.dll /reference:A1=cs1701_d.dll  
   
@@ -92,7 +92,7 @@ public class Ref {
 ## Example  
  This sample calls methods using two different aliases of A. The following sample generates C1701.  
   
-```  
+```csharp  
 // CS1701_d.cs  
 // compile with: /reference:c:\\CS1701_d.dll /reference:CS1701_c.dll  
 // CS1701 expected  

--- a/docs/csharp/language-reference/compiler-messages/cs1703.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1703.md
@@ -42,7 +42,7 @@ An assembly with the same simple name 'name' has already been imported. Try remo
   
  Save this example in a file named CS1703a1.cs, and compile it with the following flags: `/t:library /out:.\bin1\cs1703.dll /keyfile:key.snk`  
   
-```  
+```csharp  
 using System;  
 public class A { }  
 ```  
@@ -52,7 +52,7 @@ public class A { }
   
  Save this example in a file named CS1703a2.cs, and compile it with the following flags: `/t:library /out:.\bin2\cs1703.dll /keyfile:key.snk`  
   
-```  
+```csharp  
 using System;  
 public class A { }  
 ```  
@@ -62,7 +62,7 @@ public class A { }
   
  Save this example in a file named CS1703ref.cs, and compile it with the following flags: `/t:library /r:A2=.\bin2\cs1703.dll /r:A1=.\bin1\cs1703.dll`  
   
-```  
+```csharp  
 extern alias A1;  
 extern alias A2;  
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs1704.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1704.md
@@ -38,7 +38,7 @@ An assembly with the same simple name 'Assembly Name' has already been imported.
 ## Example  
  This sample creates an assembly and saves it to the root directory.  
   
-```  
+```csharp  
 // CS1704_a.cs  
 // compile with: /target:library /out:c:\\cs1704.dll  
 public class A {}  
@@ -47,7 +47,7 @@ public class A {}
 ## Example  
  This sample creates an assembly with the same name as the previous sample, but saves it to a different location.  
   
-```  
+```csharp  
 // CS1704_b.cs  
 // compile with: /target:library /out:cs1704.dll  
 public class A {}  
@@ -56,7 +56,7 @@ public class A {}
 ## Example  
  This sample attempts to reference both assemblies. The following sample generates CS1704.  
   
-```  
+```csharp  
 // CS1704_c.cs  
 // compile with: /target:library /r:A2=cs1704.dll /r:A1=c:\\cs1704.dll  
 // CS1704 expected  

--- a/docs/csharp/language-reference/compiler-messages/cs1716.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1716.md
@@ -38,7 +38,7 @@ Do not use 'System.Runtime.CompilerServices.FixedBuffer' attribute. Use the 'fix
 ## Example  
  The following example generates CS1716.  
   
-```  
+```csharp  
 // CS1716.cs  
 // compile with: /unsafe  
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs1721.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1721.md
@@ -38,7 +38,7 @@ Class 'class' cannot have multiple base classes: 'class_1' and 'class_2'
 ## Example  
  The following example shows one way in which SC1721 is generated, and then shows two possible ways to avoid the error.  
   
-```  
+```csharp  
 // CS1721.cs  
 public class A {}  
 public class B {}  

--- a/docs/csharp/language-reference/compiler-messages/cs1726.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1726.md
@@ -42,7 +42,7 @@ Friend assembly reference 'reference' is invalid. Strong-name signed assemblies 
 ## Example  
  The following sample generates CS1726.  
   
-```  
+```csharp  
 // Save this code as CS1726.cs  
   
 // Run the following command to create CS1726.key:  

--- a/docs/csharp/language-reference/compiler-messages/cs1919.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1919.md
@@ -44,7 +44,7 @@ Unsafe type 'type name' cannot be used in object creation.
 ## Example  
  The following example generates CS1919 because a pointer type is unsafe:  
   
-```  
+```csharp  
 // cs1919.cs  
 // Compile with: /unsafe  
 unsafe public class C  

--- a/docs/csharp/language-reference/compiler-messages/cs1921.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1921.md
@@ -38,7 +38,7 @@ The best overloaded method match for 'method' has wrong signature for the initia
 ## Example  
  The following example generates CS1921:  
   
-```  
+```csharp  
 // cs1921.cs  
 using System.Collections;  
 public class C : CollectionBase  

--- a/docs/csharp/language-reference/compiler-messages/cs1926.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1926.md
@@ -48,7 +48,7 @@ Error reading Win32 manifest file 'filename' -- 'error'.
 ## Example  
  The following example generates CS1926 when it is compiled with a corrupted for missing win32 manifest file:  
   
-```  
+```csharp  
 // cs1926.cs  
 // Compile with: /win32manifest: ../../app.manifest  
 // CS1926  

--- a/docs/csharp/language-reference/compiler-messages/cs1933.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1933.md
@@ -42,7 +42,7 @@ Expression cannot contain query expressions
 ## Example  
  The following example generates CS1933:  
   
-```  
+```csharp  
 // cs1933.cs  
 using System.Linq;  
 using System.Collections;  

--- a/docs/csharp/language-reference/compiler-messages/cs1936.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1936.md
@@ -44,7 +44,7 @@ Could not find an implementation of the query pattern for source type 'type'.  '
 ## Example  
  The following example produces CS1936:  
   
-```  
+```csharp  
 // cs1936.cs  
 using System.Collections;  
 using System.Linq;  

--- a/docs/csharp/language-reference/compiler-messages/cs1941.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1941.md
@@ -42,7 +42,7 @@ The type of one of the expressions in the 'clause' clause is incorrect. Type inf
 ## Example  
  The following code generates CS1941 because the `equals` operator is being asked to compare an `int` to a `string`.  
   
-```  
+```csharp  
 // cs1941.cs  
 using System.Collections;  
 using System.Linq;  

--- a/docs/csharp/language-reference/compiler-messages/cs1942.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1942.md
@@ -42,7 +42,7 @@ The type of the expression in the 'clause' clause is incorrect. Type inference f
 ## Example  
  The following code generates CS1942:  
   
-```  
+```csharp  
 // cs1942.cs  
 class Program  
     {  

--- a/docs/csharp/language-reference/compiler-messages/cs1943.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1943.md
@@ -44,7 +44,7 @@ An expression of type 'type' is not allowed in a subsequent from clause in a que
 ## Example  
  The following code generates CS1943:  
   
-```  
+```csharp  
 // cs1943.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/language-reference/compiler-messages/cs1946.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1946.md
@@ -42,7 +42,7 @@ An anonymous method expression cannot be converted to an expression tree.
 ## Example  
  The following example generates CS1946:  
   
-```  
+```csharp  
 // cs1946.cs  
 using System;  
     using System.Linq.Expressions;  

--- a/docs/csharp/language-reference/compiler-messages/cs3003.md
+++ b/docs/csharp/language-reference/compiler-messages/cs3003.md
@@ -38,7 +38,7 @@ Type of 'variable' is not CLS-compliant
 ## Example  
  The following example generates CS3003:  
   
-```  
+```csharp  
 // CS3003.cs  
   
 [assembly:System.CLSCompliant(true)]  

--- a/docs/csharp/language-reference/compiler-messages/cs3007.md
+++ b/docs/csharp/language-reference/compiler-messages/cs3007.md
@@ -38,7 +38,7 @@ Overloaded method 'method' differing only by unnamed array types is not CLS-comp
 ## Example  
  The following example generates CS3007:  
   
-```  
+```csharp  
 // CS3007.cs  
 [assembly: System.CLSCompliant(true)]  
 public struct S  

--- a/docs/csharp/language-reference/compiler-messages/cs3009.md
+++ b/docs/csharp/language-reference/compiler-messages/cs3009.md
@@ -38,7 +38,7 @@ translation.priority.ht:
 ## Example  
  The following example generates CS3009:  
   
-```  
+```csharp  
 // CS3009.cs  
   
 using System;  

--- a/docs/csharp/language-reference/compiler-messages/cs4014.md
+++ b/docs/csharp/language-reference/compiler-messages/cs4014.md
@@ -98,7 +98,7 @@ async Task CalledMethodAsync(int howLong)
   
  In the example, if you choose Call #1 or Call #2, the unawaited async method (`CalledMethodAsync`) finishes after both its caller (`CallingMethodAsync`) and the caller's caller (`startButton_Click`) are complete. The last line in the following output shows you when the called method finishes. Entry to and exit from the event handler that calls `CallingMethodAsync` in the full example are marked in the output.  
   
-```  
+```console  
 Entering the Click event handler.  
   Entering calling method.  
     Entering called method, starting and awaiting Task.Delay.  

--- a/docs/csharp/language-reference/compiler-options/addmodule-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/addmodule-compiler-option.md
@@ -37,7 +37,7 @@ This option adds a module that was created with the target:module switch to the 
   
 ## Syntax  
   
-```  
+```console  
 /addmodule:file[;file2]  
 ```  
   
@@ -57,7 +57,7 @@ This option adds a module that was created with the target:module switch to the 
 ## Example  
  Compile source file `input.cs` and add metadata from `metad1.netmodule` and `metad2.netmodule` to produce `out.exe`:  
   
-```  
+```console  
 csc /addmodule:metad1.netmodule;metad2.netmodule /out:out.exe input.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/appconfig-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/appconfig-compiler-option.md
@@ -35,7 +35,7 @@ The **/appconfig** compiler option enables a C# application to specify the locat
   
 ## Syntax  
   
-```  
+```console  
 /appconfig:file  
 ```  
   
@@ -58,7 +58,7 @@ The **/appconfig** compiler option enables a C# application to specify the locat
 ## Example  
  The following example shows an app.config file that enables an application to have references to both the .NET Framework implementation and the .NET Framework for Silverlight implementation of any .NET Framework assembly that exists in both implementations. The **/appconfig** compiler option specifies the location of this app.config file.  
   
-```  
+```xml  
 <configuration>  
       <runtime>  
       <assemblyBinding>  

--- a/docs/csharp/language-reference/compiler-options/baseaddress-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/baseaddress-compiler-option.md
@@ -37,7 +37,7 @@ The **/baseaddress** option lets you specify the preferred base address at which
   
 ## Syntax  
   
-```  
+```console  
 /baseaddress:address  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/bugreport-compiler-option.md
@@ -37,7 +37,7 @@ Specifies that debug information should be placed in a file for later analysis.
   
 ## Syntax  
   
-```  
+```console  
 /bugreport:file  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/checked-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/checked-compiler-option.md
@@ -37,7 +37,7 @@ The **/checked** option specifies whether an integer arithmetic statement that r
   
 ## Syntax  
   
-```  
+```console  
 /checked[+ | -]  
 ```  
   
@@ -63,7 +63,7 @@ The **/checked** option specifies whether an integer arithmetic statement that r
 ## Example  
  The following command compiles `t2.cs`. The use of `/checked` in the command specifies that any integer arithmetic statement in the file that is not in the scope of a `checked` or `unchecked` keyword, and that results in a value that is outside the range of the data type, causes an exception at run time.  
   
-```  
+```console  
 csc t2.cs /checked  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
@@ -37,7 +37,7 @@ This option specifies which codepage to use during compilation if the required p
   
 ## Syntax  
   
-```  
+```console  
 /codepage:id  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/command-line-building-with-csc-exe.md
+++ b/docs/csharp/language-reference/compiler-options/command-line-building-with-csc-exe.md
@@ -75,37 +75,37 @@ The C# compiler uses the following rules when it interprets arguments given on t
 
 - Compiles *File.cs* producing *File.exe*:
 
-```
+```console
 csc File.cs 
 ```
 
 - Compiles *File.cs* producing *File.dll*:
 
-```
+```console
 csc /target:library File.cs
 ```
 
 - Compiles *File.cs* and creates *My.exe*:
 
-```
+```console
 csc /out:My.exe File.cs
 ```
 
 - Compiles all the C# files in the current directory with optimizations enabled and defines the DEBUG symbol. The output is *File2.exe*:
 
-```
+```console
 csc /define:DEBUG /optimize /out:File2.exe *.cs
 ```
 
 - Compiles all the C# files in the current directory producing a debug version of *File2.dll*. No logo and no warnings are displayed:
 
-```
+```console
 csc /target:library /out:File2.dll /warn:0 /nologo /debug *.cs
 ```
 
 - Compiles all the C# files in the current directory to *Something.xyz* (a DLL):
 
-```
+```console
 csc /target:library /out:Something.xyz *.cs
 ```
 

--- a/docs/csharp/language-reference/compiler-options/debug-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/debug-compiler-option.md
@@ -37,7 +37,7 @@ The **/debug** option causes the compiler to generate debugging information and 
   
 ## Syntax  
   
-```  
+```console  
 /debug[+ | -]  
 /debug:{full | pdbonly}  
 ```  
@@ -76,7 +76,7 @@ The **/debug** option causes the compiler to generate debugging information and 
 ## Example  
  Place debugging information in output file `app.pdb`:  
   
-```  
+```console  
 csc /debug /pdb:app.pdb test.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/define-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/define-compiler-option.md
@@ -40,7 +40,7 @@ The **/define** option defines `name` as a symbol in all source code files your 
   
 ## Syntax  
   
-```  
+```console  
 /define:name[;name2]  
 ```  
   
@@ -57,7 +57,7 @@ The **/define** option defines `name` as a symbol in all source code files your 
   
  You can define multiple symbols with **/define** by using a semicolon or comma to separate symbol names. For example:  
   
-```  
+```console  
 /define:DEBUG;TUESDAY  
 ```  
   
@@ -76,7 +76,7 @@ The **/define** option defines `name` as a symbol in all source code files your 
   
 ## Example  
   
-```  
+```csharp  
 // preprocessor_define.cs  
 // compile with: /define:xx  
 // or uncomment the next line  

--- a/docs/csharp/language-reference/compiler-options/delaysign-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/delaysign-compiler-option.md
@@ -37,7 +37,7 @@ This option causes the compiler to reserve space in the output file so that a di
   
 ## Syntax  
   
-```  
+```console  
 /delaysign[ + | - ]  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/doc-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/doc-compiler-option.md
@@ -41,7 +41,7 @@ The **/doc** option allows you to place documentation comments in an XML file.
   
 ## Syntax  
   
-```  
+```console  
 /doc:file  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md
@@ -40,7 +40,7 @@ This option provides a convenient way to report a C# internal compiler error to 
   
 ## Syntax  
   
-```  
+```console  
 /errorreport:{ none | prompt | queue | send }  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/filealign-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/filealign-compiler-option.md
@@ -45,7 +45,7 @@ The **/filealign** option lets you specify the size of sections in your output f
   
 ## Syntax  
   
-```  
+```console  
 /filealign:number  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/fullpaths-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/fullpaths-compiler-option.md
@@ -39,7 +39,7 @@ The **/fullpaths** option causes the compiler to specify the full path to the fi
   
 ## Syntax  
   
-```  
+```console  
 /fullpaths  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/help-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/help-compiler-option.md
@@ -41,7 +41,7 @@ This option sends a listing of compiler options, and a brief description of each
   
 ## Syntax  
   
-```  
+```console  
 /help  
 /?  
 ```  

--- a/docs/csharp/language-reference/compiler-options/highentropyva-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/highentropyva-compiler-option.md
@@ -37,7 +37,7 @@ The **/highentropyva** compiler option tells the Windows kernel whether a partic
   
 ## Syntax  
   
-```  
+```console  
 /highentropyva[+ | -]  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/keycontainer-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/keycontainer-compiler-option.md
@@ -37,7 +37,7 @@ Specifies the name of the cryptographic key container.
   
 ## Syntax  
   
-```  
+```console  
 /keycontainer:string  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/keyfile-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/keyfile-compiler-option.md
@@ -37,7 +37,7 @@ Specifies the filename containing the cryptographic key.
   
 ## Syntax  
   
-```  
+```console  
 /keyfile:file  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -37,7 +37,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
 ## Syntax  
   
-```  
+```console  
 /langversion:option  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/lib-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/lib-compiler-option.md
@@ -37,7 +37,7 @@ The **/lib** option specifies the location of assemblies referenced by means of 
   
 ## Syntax  
   
-```  
+```console  
 /lib:dir1[,dir2]  
 ```  
   
@@ -80,7 +80,7 @@ The **/lib** option specifies the location of assemblies referenced by means of 
 ## Example  
  Compile t2.cs to create an .exe file. The compiler will look in the working directory and in the root directory of the C drive for assembly references.  
   
-```  
+```console  
 csc /lib:c:\ /reference:t2.dll t2.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/link-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/link-compiler-option.md
@@ -40,7 +40,7 @@ Causes the compiler to make COM type information in the specified assemblies ava
   
 ## Syntax  
   
-```  
+```console  
 /link:fileList  
 // -or-  
 /l:fileList  

--- a/docs/csharp/language-reference/compiler-options/linkresource-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/linkresource-compiler-option.md
@@ -40,7 +40,7 @@ Creates a link to a .NET Framework resource in the output file. The resource fil
   
 ## Syntax  
   
-```  
+```console  
 /linkresource:filename[,identifier[,accessibility-modifier]]  
 ```  
   
@@ -70,14 +70,14 @@ Creates a link to a .NET Framework resource in the output file. The resource fil
 ## Example  
  Compile `in.cs` and link to resource file `rf.resource`:  
   
-```  
+```console  
 csc /linkresource:rf.resource in.cs  
 ```  
   
 ## Example  
  Compile `A.cs` into a DLL, link to a native DLL N.dll, and put the output in the Global Assembly Cache (GAC). In this example, both A.dll and N.dll will reside in the GAC.  
   
-```  
+```console  
 csc /linkresource:N.dll /t:library A.cs  
 gacutil -i A.dll  
 ```  
@@ -85,7 +85,7 @@ gacutil -i A.dll
 ## Example  
  This example does the same thing as the previous one, but by using Assembly Linker options.  
   
-```  
+```console  
 csc /t:module A.cs  
 al /out:A.dll A.netmodule /link:N.dll   
 gacutil -i A.dll  

--- a/docs/csharp/language-reference/compiler-options/main-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/main-compiler-option.md
@@ -37,7 +37,7 @@ This option specifies the class that contains the entry point to the program, if
   
 ## Syntax  
   
-```  
+```console  
 /main:class  
 ```  
   
@@ -63,7 +63,7 @@ This option specifies the class that contains the entry point to the program, if
 ## Example  
  Compile `t2.cs` and `t3.cs`, specifying that the **Main** method will be found in `Test2`:  
   
-```  
+```console  
 csc t2.cs t3.cs /main:Test2  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md
@@ -37,7 +37,7 @@ Specifies an assembly whose non-public types a .netmodule can access.
   
 ## Syntax  
   
-```  
+```console  
 /moduleassemblyname:assembly_name  
 ```  
   
@@ -65,7 +65,7 @@ Specifies an assembly whose non-public types a .netmodule can access.
 ## Example  
  This sample builds an assembly with a private type, and that gives friend assembly access to an assembly called csman_an_assembly.  
   
-```  
+```csharp  
 // moduleassemblyname_1.cs  
 // compile with: /target:library  
 using System;  
@@ -85,7 +85,7 @@ class An_Internal_Class
 ## Example  
  This sample builds a .netmodule that accesses a non-public type in the assembly moduleassemblyname_1.dll. By knowing that this .netmodule will be built into an assembly called csman_an_assembly, we can specify **/moduleassemblyname**, allowing the .netmodule to access non-public types in an assembly that has granted friend assembly access to csman_an_assembly.  
   
-```  
+```csharp  
 // moduleassemblyname_2.cs  
 // compile with: /moduleassemblyname:csman_an_assembly /target:module /reference:moduleassemblyname_1.dll  
 class B {  
@@ -99,7 +99,7 @@ class B {
 ## Example  
  This code sample builds the assembly csman_an_assembly, referencing the previously-built assembly and .netmodule.  
   
-```  
+```csharp  
 // csman_an_assembly.cs  
 // compile with: /addmodule:moduleassemblyname_2.netmodule /reference:moduleassemblyname_1.dll  
 class A {  

--- a/docs/csharp/language-reference/compiler-options/noconfig-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/noconfig-compiler-option.md
@@ -38,7 +38,7 @@ The **/noconfig** option tells the compiler not to compile with the csc.rsp file
   
 ## Syntax  
   
-```  
+```console  
 /noconfig  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/nologo-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/nologo-compiler-option.md
@@ -38,7 +38,7 @@ The **/nologo** option suppresses display of the sign-on banner when the compile
   
 ## Syntax  
   
-```  
+```console  
 /nologo  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/nostdlib-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/nostdlib-compiler-option.md
@@ -38,7 +38,7 @@ translation.priority.mt:
   
 ## Syntax  
   
-```  
+```console  
 /nostdlib[+ | -]  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/nowarn-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/nowarn-compiler-option.md
@@ -37,7 +37,7 @@ The **/nowarn** option lets you suppress the compiler from displaying one or mor
   
 ## Syntax  
   
-```  
+```console  
 /nowarn:number1[,number2,...]  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/nowin32manifest-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/nowin32manifest-compiler-option.md
@@ -37,7 +37,7 @@ Use the **/nowin32manifest** option to instruct the compiler not to embed any ap
   
 ## Syntax  
   
-```  
+```console  
 /nowin32manifest  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/optimize-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/optimize-compiler-option.md
@@ -41,7 +41,7 @@ The **/optimize** option enables or disables optimizations performed by the comp
   
 ## Syntax  
   
-```  
+```console  
 /optimize[+ | -]  
 ```  
   
@@ -69,7 +69,7 @@ The **/optimize** option enables or disables optimizations performed by the comp
 ## Example  
  Compile `t2.cs` and enable compiler optimizations:  
   
-```  
+```console  
 csc t2.cs /optimize  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/out-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/out-compiler-option.md
@@ -37,7 +37,7 @@ The **/out** option specifies the name of the output file.
   
 ## Syntax  
   
-```  
+```console  
 /out:filename  
 ```  
   
@@ -77,7 +77,7 @@ The **/out** option specifies the name of the output file.
 ## Example  
  Compile `t.cs` and create output file `t.exe`, as well as build `t2.cs` and create module output file `mymodule.netmodule`:  
   
-```  
+```console  
 csc t.cs /out:mymodule.netmodule /target:module t2.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/pdb-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/pdb-compiler-option.md
@@ -37,7 +37,7 @@ The **/pdb** compiler option specifies the name and location of the debug symbol
   
 ## Syntax  
   
-```  
+```console  
 /pdb:filename  
 ```  
   
@@ -55,7 +55,7 @@ The **/pdb** compiler option specifies the name and location of the debug symbol
 ## Example  
  Compile `t.cs` and create a .pdb file called tt.pdb:  
   
-```  
+```console  
 csc /debug /pdb:tt t.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/platform-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/platform-compiler-option.md
@@ -37,7 +37,7 @@ Specifies which version of the common language runtime (CLR) can run the assembl
   
 ## Syntax  
   
-```  
+```console  
 /platform:string  
 ```  
   
@@ -88,7 +88,7 @@ Specifies which version of the common language runtime (CLR) can run the assembl
 ## Example  
  The following example shows how to use the **/platform** option to specify that the application should be run by the 64-bit CLR on a 64-bit Windows operating system.  
   
-```  
+```console  
 csc /platform:anycpu filename.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/preferreduilang-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/preferreduilang-compiler-option.md
@@ -37,7 +37,7 @@ By using the `/preferreduilang` compiler option, you can specify the language in
   
 ## Syntax  
   
-```  
+```console  
 /preferreduilang: language  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/recurse-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/recurse-compiler-option.md
@@ -37,7 +37,7 @@ The /recurse option enables you to compile source code files in all child direct
   
 ## Syntax  
   
-```  
+```console  
 /recurse:[dir\]file  
 ```  
   
@@ -58,13 +58,13 @@ The /recurse option enables you to compile source code files in all child direct
 ## Example  
  Compiles all C# files in the current directory:  
   
-```  
+```console  
 csc *.cs  
 ```  
   
  Compiles all of the C# files in the dir1\dir2 directory and any directories below it and generates dir2.dll:  
   
-```  
+```console  
 csc /target:library /out:dir2.dll /recurse:dir1\dir2\*.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/reference-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/reference-compiler-option.md
@@ -42,7 +42,7 @@ The **/reference** option causes the compiler to import [public](../../../csharp
   
 ## Syntax  
   
-```  
+```console  
 /reference:[alias=]filename  
 /reference:filename  
 ```  
@@ -89,7 +89,7 @@ The **/reference** option causes the compiler to import [public](../../../csharp
   
  This sets up the external aliases "GridV1" and "GridV2," which you use in your program by means of an extern statement:  
   
-```  
+```csharp  
 extern alias GridV1;  
 extern alias GridV2;  
 // Using statements go here.  
@@ -97,13 +97,13 @@ extern alias GridV2;
   
  Once this is done, you can refer to the grid control from grid.dll by prefixing the control name with GridV1, like this:  
   
-```  
+```csharp  
 GridV1::Grid  
 ```  
   
  In addition, you can refer to the grid control from grid20.dll by prefixing the control name with GridV2 like this:  
   
-```  
+```csharp  
 GridV2::Grid   
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/resource-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/resource-compiler-option.md
@@ -40,7 +40,7 @@ Embeds the specified resource into the output file.
   
 ## Syntax  
   
-```  
+```console  
 /resource:filename[,identifier[,accessibility-modifier]]  
 ```  
   
@@ -80,7 +80,7 @@ Embeds the specified resource into the output file.
 ## Example  
  Compile `in.cs` and attach resource file `rf.resource`:  
   
-```  
+```console  
 csc /resource:rf.resource in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/response-file-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/response-file-compiler-option.md
@@ -66,7 +66,7 @@ The @ option lets you specify a file that contains compiler options and source c
 ## Example  
  The following are a few lines from a sample response file:  
   
-```  
+```console  
 # build the first output file  
 /target:exe /out:MyExe.exe source1.cs source2.cs  
 ```  

--- a/docs/csharp/language-reference/compiler-options/subsystemversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/subsystemversion-compiler-option.md
@@ -34,7 +34,7 @@ Specifies the minimum version of the subsystem on which the generated executable
   
 ## Syntax  
   
-```  
+```console  
 /subsystemversion:major.minor  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/target-appcontainerexe-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-appcontainerexe-compiler-option.md
@@ -32,7 +32,7 @@ If you use the **/target:appcontainerexe** compiler option, the compiler creates
   
 ## Syntax  
   
-```  
+```console  
 /target:appcontainerexe  
 ```  
   
@@ -56,7 +56,7 @@ If you use the **/target:appcontainerexe** compiler option, the compiler creates
 ## Example  
  The following command compiles `filename.cs` into a Windows executable file that can be run only in an app container.  
   
-```  
+```console  
 csc /target:appcontainerexe filename.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/target-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-compiler-option.md
@@ -58,7 +58,7 @@ The **/target** compiler option can be specified in one of four forms:
   
  The assembly manifest is placed in the first .exe output file in the compilation or in the first DLL, if there is no .exe output file. For example, in the following command line, the manifest will be placed in `1.exe`:  
   
-```  
+```console  
 csc /out:1.exe t1.cs /out:2.netmodule t2.cs  
 ```  
   
@@ -66,7 +66,7 @@ csc /out:1.exe t1.cs /out:2.netmodule t2.cs
   
  If you create an assembly, you can indicate that all or part of your code is CLS compliant with the <xref:System.CLSCompliantAttribute> attribute.  
   
-```  
+```csharp  
 // target_clscompliant.cs  
 [assembly:System.CLSCompliant(true)]   // specify assembly compliance  
   

--- a/docs/csharp/language-reference/compiler-options/target-exe-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-exe-compiler-option.md
@@ -37,7 +37,7 @@ The **/target:exe** option causes the compiler to create an executable (EXE), co
   
 ## Syntax  
   
-```  
+```console  
 /target:exe  
 ```  
   
@@ -65,7 +65,7 @@ The **/target:exe** option causes the compiler to create an executable (EXE), co
 ## Example  
  Each of the following command lines will compile `in.cs`, creating `in.exe`:  
   
-```  
+```console  
 csc /target:exe in.cs  
 csc in.cs  
 ```  

--- a/docs/csharp/language-reference/compiler-options/target-library-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-library-compiler-option.md
@@ -37,7 +37,7 @@ The **/target:library** option causes the compiler to create a dynamic-link libr
   
 ## Syntax  
   
-```  
+```console  
 /target:library  
 ```  
   
@@ -63,7 +63,7 @@ The **/target:library** option causes the compiler to create a dynamic-link libr
 ## Example  
  Compile `in.cs`, creating `in.dll`:  
   
-```  
+```console  
 csc /target:library in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/target-module-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-module-compiler-option.md
@@ -37,7 +37,7 @@ This option causes the compiler to not generate an assembly manifest.
   
 ## Syntax  
   
-```  
+```console  
 /target:module  
 ```  
   
@@ -55,7 +55,7 @@ This option causes the compiler to not generate an assembly manifest.
 ## Example  
  Compile `in.cs`, creating `in.netmodule`:  
   
-```  
+```console  
 csc /target:module in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/target-winexe-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-winexe-compiler-option.md
@@ -37,7 +37,7 @@ The **/target:winexe** option causes the compiler to create an executable (EXE),
   
 ## Syntax  
   
-```  
+```console  
 /target:winexe  
 ```  
   
@@ -65,7 +65,7 @@ The **/target:winexe** option causes the compiler to create an executable (EXE),
 ## Example  
  Compile `in.cs` into a Windows program:  
   
-```  
+```console  
 csc /target:winexe in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/target-winmdobj-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-winmdobj-compiler-option.md
@@ -32,7 +32,7 @@ If you use the **/target:winmdobj** compiler option, the compiler creates an int
   
 ## Syntax  
   
-```  
+```console  
 /target:winmdobj  
 ```  
   
@@ -60,7 +60,7 @@ If you use the **/target:winmdobj** compiler option, the compiler creates an int
 ## Example  
  The following command compiles `filename.cs` into an intermediate .winmdobj file.  
   
-```  
+```console  
 csc /target:winmdobj filename.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/unsafe-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/unsafe-compiler-option.md
@@ -37,7 +37,7 @@ The **/unsafe** compiler option allows code that uses the [unsafe](../../../csha
   
 ## Syntax  
   
-```  
+```console  
 /unsafe  
 ```  
   
@@ -57,7 +57,7 @@ The **/unsafe** compiler option allows code that uses the [unsafe](../../../csha
 ## Example  
  Compile `in.cs` for unsafe mode:  
   
-```  
+```console  
 csc /unsafe in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/utf8output-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/utf8output-compiler-option.md
@@ -37,7 +37,7 @@ The **/utf8output** option displays compiler output using UTF-8 encoding.
   
 ## Syntax  
   
-```  
+```console  
 /utf8output  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/warn-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/warn-compiler-option.md
@@ -41,7 +41,7 @@ The **/warn** option specifies the warning level for the compiler to display.
   
 ## Syntax  
   
-```  
+```console  
 /warn:option  
 ```  
   
@@ -77,7 +77,7 @@ The **/warn** option specifies the warning level for the compiler to display.
 ## Example  
  Compile `in.cs` and have the compiler only display level 1 warnings:  
   
-```  
+```console  
 csc /warn:1 in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/warnaserror-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/warnaserror-compiler-option.md
@@ -37,7 +37,7 @@ The **/warnaserror+** option treats all warnings as errors
   
 ## Syntax  
   
-```  
+```console  
 /warnaserror[<U>+</U> | -][:warning-list]  
 ```  
   
@@ -63,7 +63,7 @@ The **/warnaserror+** option treats all warnings as errors
 ## Example  
  Compile `in.cs` and have the compiler display no warnings:  
   
-```  
+```console  
 csc /warnaserror in.cs  
 csc /warnaserror:642,649,652 in.cs  
 ```  

--- a/docs/csharp/language-reference/compiler-options/win32icon-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/win32icon-compiler-option.md
@@ -37,7 +37,7 @@ The **/win32icon** option inserts an .ico file in the output file, which gives t
   
 ## Syntax  
   
-```  
+```console  
 /win32icon:filename  
 ```  
   
@@ -63,7 +63,7 @@ The **/win32icon** option inserts an .ico file in the output file, which gives t
 ## Example  
  Compile `in.cs` and attach an .ico file `rf.ico` to produce `in.exe`:  
   
-```  
+```console  
 csc /win32icon:rf.ico in.cs  
 ```  
   

--- a/docs/csharp/language-reference/compiler-options/win32manifest-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/win32manifest-compiler-option.md
@@ -37,7 +37,7 @@ Use the **/win32manifest** option to specify a user-defined Win32 application ma
   
 ## Syntax  
   
-```  
+```console  
 /win32manifest: filename  
 ```  
   
@@ -69,7 +69,7 @@ Use the **/win32manifest** option to specify a user-defined Win32 application ma
 > [!NOTE]
 >  The compiler inserts a standard application name " MyApplication.app " into the xml. This is a workaround to enable applications to run on Windows Server 2003 Service Pack 3.  
   
-```  
+```xml  
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>  
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">  
   <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>  

--- a/docs/csharp/language-reference/compiler-options/win32res-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/win32res-compiler-option.md
@@ -38,7 +38,7 @@ The **/win32res** option inserts a Win32 resource in the output file.
   
 ## Syntax  
   
-```  
+```console  
 /win32res:filename  
 ```  
   
@@ -64,7 +64,7 @@ The **/win32res** option inserts a Win32 resource in the output file.
 ## Example  
  Compile `in.cs` and attach a Win32 resource file `rf.res` to produce `in.exe`:  
   
-```  
+```console  
 csc /win32res:rf.res in.cs  
 ```  
   


### PR DESCRIPTION
Addresses #2192

@mairaw There are 4,847 markdown topics with missing lang idents on code blocks. 😓

I started working the problem from the manual side first. Both scripts were going to have the same basic structure ... a person looks :eyes: and picks the ident for one script, while an algorithm will look and choose for the next one (and I'm considering a machine learning approach for that :smile:). I wrote the one to handle manual changes first:

https://gist.github.com/GuardRex/d6a8c2dc4dab0053ceeb1c7848ec6045

... However, I'm going set that one aside now and work on the automatic one. I want to get as many done :sparkles: auto-magically :sparkles: as I can before invoking the manual option.

Since there are so many code blocks that need help, I think it best to break these down into bite-size groups, such as I do on this PR. This PR is also a test of the manual process. It worked well. It only took about ten minutes to update these 147 files! Not bad ... not bad at all. 🍰 

Note that I'm tagging switch idents as "console." Let me know if you want to reverse that, but I felt that since they're used in console commands, it made the most sense.