### PR TITLE
Clarified C# language support for the compiler

### DIFF
--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -49,7 +49,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |------------|-------------|  
 |default|The compiler accepts all valid language syntax that it can support.|  
 |ISO-1|The compiler accepts only syntax that is included in the ISO/IEC 23270:2003 C# language specification. (net 2.x or newer)|  
-|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. This specification is available on the [ISO](http://go.microsoft.com/fwlink/? LinkId=144406) Web site. (net 3.x or newer)|
+|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. This specification is available on the [ISO](http://go.microsoft.com/fwlink/?LinkId=144406) Web site. (net 3.x or newer)|
 |3|The compiler accepts only syntax that is included in the version 3.0 [C# Language Specification](../../../csharp/language-reference/language-specification.md). (net 4.x or newer)|
 |4|The compiler accepts only syntax that is included in the version 4.0 (net 4.x or newer)|
 |5|The compiler accepts only syntax that is included in the version 5.0 (net 4.x or newer)|
@@ -61,7 +61,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
  
  While newer versions of the C# syntax do not explicitly depend on a specific version of the net framework runtime, compilers on older versions of the framework are not updated to support newer langauge syntax without additional configuration (which is beyond the scope of this article.) The above table lists the minimum net framework compiler version needed to compile for a given language version without any additional configuration needed.
  
- Additionally, C# 6 and newer are not supported at all with this compiler, they require migrating to the newer .NET Compiler Platform ("Roslyn")
+ Additionally, C# 6 and newer are not supported at all with the compiler included with the net framework as it is no longer being updated for features, they require migrating to the newer [.NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn)
   
  Regardless of which **/langversion** setting you use, you will use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [/moduleassemblyname (C# Compiler Option)](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md), which work under **/langversion:ISO-1**.  
   
@@ -81,4 +81,4 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
  [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)   
  [NIB How to: Modify Project Properties and Configuration Settings](http://msdn.microsoft.com/en-us/e7184bc5-2f2b-4b4f-aa9a-3ecfcbc48b67)   
  [C# Language Specification](../../../csharp/language-reference/language-specification.md)   
- [.NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn)    
+     

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -55,7 +55,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |5|The compiler accepts only syntax that is included in C# 5.0 or lower <sup id="TCS5">[CS5](#FCS5)</sup>|
 |6|The compiler accepts only syntax that is included in C# 6.0 or lower <sup id="TCS6">[CS6](#FCS6)</sup>|
 |7|The compiler accepts only syntax that is included in C# 7.0 or lower <sup id="TCS7">[CS7](#FCS7)</sup>|
-|latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</su
+|latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</sup>|
 <!--- Uncomment and move these above |latest| once they're officially released
 |7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
 |7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS71">[CS72](#FCS72)</sup>|

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -48,22 +48,27 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |Option|Meaning|  
 |------------|-------------|  
 |default|The compiler accepts all valid language syntax that it can support. <sup id="TDefault">[Default](#FDefault)</sup>| 
-|ISO-1|The compiler accepts only syntax that is included in the ISO/IEC 23270:2003 C# language specification. <sup id="TISO1">[ISO1](#FISO1)</sup>|  
-|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. <sup id="TISO2">[ISO2](#FISO2)</sup>|
+|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.1) <sup id="TISO1">[ISO1](#FISO1)</sup>|  
+|ISO-2|The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0) <sup id="TISO2">[ISO2](#FISO2)</sup>|
 |3|The compiler accepts only syntax that is included in C# 3.0 or lower <sup id="TCS3">[CS3](#FCS3)</sup>|
 |4|The compiler accepts only syntax that is included in C# 4.0 or lower <sup id="TCS4">[CS4](#FCS4)</sup>|
 |5|The compiler accepts only syntax that is included in C# 5.0 or lower <sup id="TCS5">[CS5](#FCS5)</sup>|
 |6|The compiler accepts only syntax that is included in C# 6.0 or lower <sup id="TCS6">[CS6](#FCS6)</sup>|
 |7|The compiler accepts only syntax that is included in C# 7.0 or lower <sup id="TCS7">[CS7](#FCS7)</sup>|
-|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
 |latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</sup>|  
+<!--- Uncomment and move these above |latest| once they're officially released
+|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
+|7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS71">[CS72](#FCS72)</sup>|
+|8|The compiler accepts only syntax that is included in C# 8 or lower <sup id="TCS71">[CS8](#FCS8)</sup>|
+-->
+
   
 ## Remarks  
  Metadata referenced by your C# application is not subject to **/langversion** compiler option.  
   
  Because each version of the C# compiler contains extensions to the language specification, **/langversion** does not give you the equivalent functionality of an earlier version of the compiler.  
  
- Additionally, while newer C# versions and features do necessarily not explicitly depend on the .Net Framework version they were released with, individual features/packages may have varying minimum API requirements.
+ Additionally, while C# version updates generally coincide with major .Net Framework releases, the new syntax and features are not necessarily tied to that specific framework version. While the new features will definitely require a new compiler update that is also released alongside the C# revision, each specific feature has it's own minimum .Net API or common language runtime requirements that may allow it to run on downlevel runtimes.
   
  Regardless of which **/langversion** setting you use, you will use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [/moduleassemblyname (C# Compiler Option)](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md), which work under **/langversion:ISO-1**.  
   
@@ -78,7 +83,28 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 4.  Modify the **Language Version** property.  
   
  For information about how to set this compiler option programmatically, see <xref:VSLangProj80.CSharpProjectConfigurationProperties3.LanguageVersion%2A>.  
-  
+    
+## See Also  
+ [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)   
+ [NIB How to: Modify Project Properties and Configuration Settings](http://msdn.microsoft.com/en-us/e7184bc5-2f2b-4b4f-aa9a-3ecfcbc48b67)   
+ 
+### C# Language Specification
+ [C# Language Specification Reference](../../../csharp/language-reference/language-specification.md) : .NET Foundation   
+ C# 1.0/1.1 [ISO/IEC 23270:2003](https://www.iso.org/standard/36768.html) Information technology -- C# Language Specification : ISO Catalogue   
+ C# 2.0 [ISO/IEC 23270:2006](https://www.iso.org/standard/42926.html) Information technology -- C# Language Specification : ISO Catalogue   
+ C# 2.0 [c042926_ISO_IEC_23270_2006(E).zip](http://go.microsoft.com/fwlink/?LinkId=144406) ISO/IEC 23270:2006 in PDF format : ISO Freely Available Standards   
+ C# 3.0 [CSharp Language Specification.doc](http://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc) C# Language Specification Version 3.0 : Microsoft Corporation   
+ C# 4.0 [Ecma-334.pdf](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf) Standard ECMA-334 4th Edition    
+ C# 5.0 [CSharp Language Specification.docx](www.microsoft.com/en-us/download/details.aspx?id=7029) C# Language Specification Version 5.0 : Microsoft Corporation   
+ C# 6.0 [README.md](https://github.com/dotnet/csharplang/blob/master/spec/README.md) C# Language Specification Version 6 - Unofficial Draft : .NET Foundation   
+ C# 7.0 (not currently available)   
+
+<!--- Uncomment and add to the above when they become officially released
+ C# 7.1 (spec is not yet finished)   
+ C# 7.2 (spec is not yet finished)   
+ C# 8.0 (spec is not yet finished)   
+-->
+
 ### Minimum compiler version needed to support all language features   
 [↩](#TDefault)<a name="FDefault">Default</a>, <a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler     
 [↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler    
@@ -86,14 +112,10 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 [↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler    
 [↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler    
 [↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015    
-[↩](#TCS7)<a name="FCS7">CS7</a>,<a name="FCS71">CS71</a>, <a name="FLatest">Latest</a>: Microsoft Visual Studio/Build Tools 2017   
-  
-  
-## See Also  
- [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)   
- [NIB How to: Modify Project Properties and Configuration Settings](http://msdn.microsoft.com/en-us/e7184bc5-2f2b-4b4f-aa9a-3ecfcbc48b67)   
- 
-### C# Language Specification
- [C# Language Specification](../../../csharp/language-reference/language-specification.md)   
- This specification is available on the [ISO](http://go.microsoft.com/fwlink/?LinkId=144406) Web site.  
- [C# Language Specification](../../../csharp/language-reference/language-specification.md).
+[↩](#TCS7)<a name="FCS7">CS7</a>, <a name="FLatest">Latest</a>: Microsoft Visual Studio/Build Tools 2017   
+
+<!--- Uncomment and add to the above when they become officially released
+[↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 20??    
+[↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 20??    
+[↩](#TCS8)<a name="FCS71">CS8</a>: Microsoft Visual Studio/Build Tools 20??    
+-->

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -47,21 +47,23 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
 |Option|Meaning|  
 |------------|-------------|  
-|default|The compiler accepts all valid language syntax that it can support.|  
-|ISO-1|The compiler accepts only syntax that is included in the ISO/IEC 23270:2003 C# language specification. (net 2.x or newer)|  
-|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. This specification is available on the [ISO](http://go.microsoft.com/fwlink/?LinkId=144406) Web site. (net 3.x or newer)|
-|3|The compiler accepts only syntax that is included in the version 3.0 [C# Language Specification](../../../csharp/language-reference/language-specification.md). (net 4.x or newer)|
-|4|The compiler accepts only syntax that is included in the version 4.0 (net 4.x or newer)|
-|5|The compiler accepts only syntax that is included in the version 5.0 (net 4.x or newer)|
+|default|The compiler accepts all valid language syntax that it can support. <sup id="TDefault">[Default](#FDefault)</sup>| 
+|ISO-1|The compiler accepts only syntax that is included in the ISO/IEC 23270:2003 C# language specification. <sup id="TISO1">[ISO1](#FISO1)</sup>|  
+|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. <sup id="TISO2">[ISO2](#FISO2)</sup>|
+|3|The compiler accepts only syntax that is included in C# 3.0 or lower <sup id="TCS3">[CS3](#FCS3)</sup>|
+|4|The compiler accepts only syntax that is included in C# 4.0 or lower <sup id="TCS4">[CS4](#FCS4)</sup>|
+|5|The compiler accepts only syntax that is included in C# 5.0 or lower <sup id="TCS5">[CS5](#FCS5)</sup>|
+|6|The compiler accepts only syntax that is included in C# 6.0 or lower <sup id="TCS6">[CS6](#FCS6)</sup>|
+|7|The compiler accepts only syntax that is included in C# 7.0 or lower <sup id="TCS7">[CS7](#FCS7)</sup>|
+|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
+|latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</sup>|  
   
 ## Remarks  
  Metadata referenced by your C# application is not subject to **/langversion** compiler option.  
   
  Because each version of the C# compiler contains extensions to the language specification, **/langversion** does not give you the equivalent functionality of an earlier version of the compiler.  
  
- While newer versions of the C# syntax do not explicitly depend on a specific version of the net framework runtime, compilers on older versions of the framework are not updated to support newer langauge syntax without additional configuration (which is beyond the scope of this article.) The above table lists the minimum net framework compiler version needed to compile for a given language version without any additional configuration needed.
- 
- Additionally, C# 6 and newer are not supported at all with the compiler included with the net framework as it is no longer being updated for features, they require migrating to the newer [.NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn)
+ Additionally, while newer C# versions and features do necessarily not explicitly depend on the .Net Framework version they were released with, individual features/packages may have varying minimum API requirements.
   
  Regardless of which **/langversion** setting you use, you will use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [/moduleassemblyname (C# Compiler Option)](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md), which work under **/langversion:ISO-1**.  
   
@@ -77,8 +79,21 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
  For information about how to set this compiler option programmatically, see <xref:VSLangProj80.CSharpProjectConfigurationProperties3.LanguageVersion%2A>.  
   
+### Minimum compiler version needed to support all language features   
+[↩](#TDefault)<a name="FDefault">Default</a>, <a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler     
+[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler    
+[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler    
+[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler    
+[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler    
+[↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015    
+[↩](#TCS7)<a name="FCS7">CS7</a>,<a name="FCS71">CS71</a>, <a name="FLatest">Latest</a>: Microsoft Visual Studio/Build Tools 2017   
+  
+  
 ## See Also  
  [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)   
  [NIB How to: Modify Project Properties and Configuration Settings](http://msdn.microsoft.com/en-us/e7184bc5-2f2b-4b4f-aa9a-3ecfcbc48b67)   
+ 
+### C# Language Specification
  [C# Language Specification](../../../csharp/language-reference/language-specification.md)   
-     
+ This specification is available on the [ISO](http://go.microsoft.com/fwlink/?LinkId=144406) Web site.  
+ [C# Language Specification](../../../csharp/language-reference/language-specification.md).

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -55,7 +55,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |5|The compiler accepts only syntax that is included in C# 5.0 or lower <sup id="TCS5">[CS5](#FCS5)</sup>|
 |6|The compiler accepts only syntax that is included in C# 6.0 or lower <sup id="TCS6">[CS6](#FCS6)</sup>|
 |7|The compiler accepts only syntax that is included in C# 7.0 or lower <sup id="TCS7">[CS7](#FCS7)</sup>|
-|latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</sup>|  
+|latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</su
 <!--- Uncomment and move these above |latest| once they're officially released
 |7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
 |7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS71">[CS72](#FCS72)</sup>|
@@ -68,7 +68,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
  Because each version of the C# compiler contains extensions to the language specification, **/langversion** does not give you the equivalent functionality of an earlier version of the compiler.  
  
- Additionally, while C# version updates generally coincide with major .Net Framework releases, the new syntax and features are not necessarily tied to that specific framework version. While the new features will definitely require a new compiler update that is also released alongside the C# revision, each specific feature has it's own minimum .Net API or common language runtime requirements that may allow it to run on downlevel runtimes.
+ Additionally, while C# version updates generally coincide with major .Net Framework releases, the new syntax and features are not necessarily tied to that specific framework version. While the new features will definitely require a new compiler update that is also released alongside the C# revision, each specific feature has it's own minimum .Net API or common language runtime requirements that may allow it to run on downlevel frameworks by including NuGet packages or other libraries.
   
  Regardless of which **/langversion** setting you use, you will use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [/moduleassemblyname (C# Compiler Option)](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md), which work under **/langversion:ISO-1**.  
   

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -47,15 +47,21 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
 |Option|Meaning|  
 |------------|-------------|  
-|default|The compiler accepts all valid language syntax.|  
-|ISO-1|The compiler accepts only syntax that is included in the ISO/IEC 23270:2003 C# language specification.|  
-|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. This specification is available on the [ISO](http://go.microsoft.com/fwlink/?LinkId=144406) Web site.|  
-|3|The compiler accepts only syntax that is included in the version 3.0 [C# Language Specification](../../../csharp/language-reference/language-specification.md).|  
+|default|The compiler accepts all valid language syntax that it can support.|  
+|ISO-1|The compiler accepts only syntax that is included in the ISO/IEC 23270:2003 C# language specification. (net 2.x or newer)|  
+|ISO-2|The compiler accepts only syntax that is included in the ISO/IEC 23270:2006 C# language specification. This specification is available on the [ISO](http://go.microsoft.com/fwlink/? LinkId=144406) Web site. (net 3.x or newer)|
+|3|The compiler accepts only syntax that is included in the version 3.0 [C# Language Specification](../../../csharp/language-reference/language-specification.md). (net 4.x or newer)|
+|4|The compiler accepts only syntax that is included in the version 4.0 (net 4.x or newer)|
+|5|The compiler accepts only syntax that is included in the version 5.0 (net 4.x or newer)|
   
 ## Remarks  
  Metadata referenced by your C# application is not subject to **/langversion** compiler option.  
   
  Because each version of the C# compiler contains extensions to the language specification, **/langversion** does not give you the equivalent functionality of an earlier version of the compiler.  
+ 
+ While newer versions of the C# syntax do not explicitly depend on a specific version of the net framework runtime, compilers on older versions of the framework are not updated to support newer langauge syntax without additional configuration (which is beyond the scope of this article.) The above table lists the minimum net framework compiler version needed to compile for a given language version without any additional configuration needed.
+ 
+ Additionally, C# 6 and newer are not supported at all with this compiler, they require migrating to the newer .NET Compiler Platform ("Roslyn")
   
  Regardless of which **/langversion** setting you use, you will use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [/moduleassemblyname (C# Compiler Option)](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md), which work under **/langversion:ISO-1**.  
   
@@ -74,4 +80,5 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 ## See Also  
  [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)   
  [NIB How to: Modify Project Properties and Configuration Settings](http://msdn.microsoft.com/en-us/e7184bc5-2f2b-4b4f-aa9a-3ecfcbc48b67)   
- [C# Language Specification](../../../csharp/language-reference/language-specification.md)
+ [C# Language Specification](../../../csharp/language-reference/language-specification.md)   
+ [.NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn)    

--- a/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
+++ b/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
@@ -59,7 +59,7 @@ The following compiler options are sorted alphabetically. For a categorical list
 |**/incremental**|Enables incremental compilation [obsolete].|  
 |[/keycontainer](../../../csharp/language-reference/compiler-options/keycontainer-compiler-option.md)|Specifies a strong name key container.|  
 |[/keyfile](../../../csharp/language-reference/compiler-options/keyfile-compiler-option.md)|Specifies a strong name key file.|  
-|[/langversion:\<string>](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: ISO-1, ISO-2, 3, 4, 5, 6, or Default|  
+|[/langversion:\<string>](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: ISO-1, ISO-2, 3, 4, 5, or Default|  
 |[/lib](../../../csharp/language-reference/compiler-options/lib-compiler-option.md)|Specifies additional directories in which to search for references.|  
 |[/link](../../../csharp/language-reference/compiler-options/link-compiler-option.md)|Makes COM type information in specified assemblies available to the project.|  
 |[/linkresource](../../../csharp/language-reference/compiler-options/linkresource-compiler-option.md)|Links the specified resource to this assembly.|  

--- a/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
+++ b/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
@@ -59,7 +59,7 @@ The following compiler options are sorted alphabetically. For a categorical list
 |**/incremental**|Enables incremental compilation [obsolete].|  
 |[/keycontainer](../../../csharp/language-reference/compiler-options/keycontainer-compiler-option.md)|Specifies a strong name key container.|  
 |[/keyfile](../../../csharp/language-reference/compiler-options/keyfile-compiler-option.md)|Specifies a strong name key file.|  
-|[/langversion:\<string>](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: ISO-1, ISO-2, 3, 4, 5, or Default|  
+|[/langversion:\<string>](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, or Latest |  
 |[/lib](../../../csharp/language-reference/compiler-options/lib-compiler-option.md)|Specifies additional directories in which to search for references.|  
 |[/link](../../../csharp/language-reference/compiler-options/link-compiler-option.md)|Makes COM type information in specified assemblies available to the project.|  
 |[/linkresource](../../../csharp/language-reference/compiler-options/linkresource-compiler-option.md)|Links the specified resource to this assembly.|  

--- a/docs/csharp/language-reference/compiler-options/listed-by-category.md
+++ b/docs/csharp/language-reference/compiler-options/listed-by-category.md
@@ -106,7 +106,7 @@ The following compiler options are sorted by category. For an alphabetical list,
 |[/codepage](../../../csharp/language-reference/compiler-options/codepage-compiler-option.md)|Specifies the code page to use for all source code files in the compilation.|  
 |[/help](../../../csharp/language-reference/compiler-options/help-compiler-option.md)|Lists compiler options to stdout.|  
 |[/highentropyva](../../../csharp/language-reference/compiler-options/highentropyva-compiler-option.md)|Specifies that the executable file supports address space layout randomization (ASLR).|  
-|[/langversion](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: ISO-1, ISO-2, 3, 4, 5, 6, or Default|  
+|[/langversion](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, or Latest |  
 |[/main](../../../csharp/language-reference/compiler-options/main-compiler-option.md)|Specifies the location of the **Main** method.|  
 |[/noconfig](../../../csharp/language-reference/compiler-options/noconfig-compiler-option.md)|Instructs the compiler not to compile with csc.rsp.|  
 |[/nologo](../../../csharp/language-reference/compiler-options/nologo-compiler-option.md)|Suppresses compiler banner information.|  


### PR DESCRIPTION
## Summary

Update the C# support for the latest compilers included out of the box in the net framework
## Details

Added details for C# 4 though C# 7 (the latest version as of this PR)

As of net 4.7 (also the latest as of this PR), the legacy version of csc (and the codedomprovider it uses by default) included in it can only handle C# 5 syntax (and older). 

Anything above C# 5 requires using the roslyn compiler, which is not included out of the box in any version of the net framework. The roslyn based version of csc is located in a different file path then the one listed here: [Command-line build with csc.exe](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/command-line-building-with-csc-exe) when installed globally as part of VS2017

Due to this, unless there is specific references to VS 2017+ (which uses roslyn by default) or manually adding roslyn to a project as the compiler, I assume that we are talking about the legacy csc compiler.
