### PR TITLE
Fix minor formatting error

### DIFF
--- a/docs/csharp/language-reference/keywords/internal.md
+++ b/docs/csharp/language-reference/keywords/internal.md
@@ -53,7 +53,7 @@ public class BaseClass
  It is an error to reference a type or a member with internal access outside the assembly within which it was defined.  
   
 ## Example  
- This example contains two files, `Assembly1.cs` and `Assembly1`_`a.cs`. The first file contains an internal base class, `BaseClass`. In the second file, an attempt to instantiate `BaseClass` will produce an error.  
+ This example contains two files, `Assembly1.cs` and `Assembly1_a.cs`. The first file contains an internal base class, `BaseClass`. In the second file, an attempt to instantiate `BaseClass` will produce an error.  
   
 ```  
 // Assembly1.cs  


### PR DESCRIPTION
Found a weird-looking formatting error on line 56 for the filename "Assembly1_a.cs", where the underscore was written in regular font instead of code font.
