### PR TITLE
Document APIs for the System.Composition.Convention Namespace

### DIFF
--- a/xml/System.Composition.Convention/AttributedModelProvider.xml
+++ b/xml/System.Composition.Convention/AttributedModelProvider.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Defines the core behavior of methods used to retrieve metadata attributes for a type, and provides a base for derived classes.</summary>
+    <summary>Serves as the base class that defines the core behavior of methods used to retrieve metadata attributes for a type.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -28,8 +28,15 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Called from constructors in derived classes to initialize the <see cref="AttributedModelProvider"/> class.</summary>
-        <remarks></remarks>
+        <summary>Creates a new instance of the <see cref="AttributedModelProvider"/> class.</summary>
+        <remarks>
+         <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This is a protected constructor that can only be called from derived classes.
+  
+ ]]></format>        
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCustomAttributes">

--- a/xml/System.Composition.Convention/AttributedModelProvider.xml
+++ b/xml/System.Composition.Convention/AttributedModelProvider.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Defines the core behavior of methods used to retrieve metadata attributes for a type, and provides a base for derived classes.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -28,8 +28,8 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Called from constructors in derived classes to initialize the <see cref="AttributedModelProvider"/> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCustomAttributes">
@@ -50,11 +50,11 @@
         <Parameter Name="member" Type="System.Reflection.MemberInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">To be added.</param>
-        <param name="member">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="reflectedType">The type used to retrieve attributes from the member.</param>
+        <param name="member">The member whose attributes are to be retrieved.</param>
+        <summary>Provides the list of attributes applied to the specified member.</summary>
+        <returns>The list of applied attributes.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCustomAttributes">
@@ -75,11 +75,11 @@
         <Parameter Name="parameter" Type="System.Reflection.ParameterInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">To be added.</param>
-        <param name="parameter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="reflectedType">The type used to retrieve attributes from the parameter.</param>
+        <param name="parameter">The parameter whose attributes are to be retrieved.</param>
+        <summary>Provides the list of attributes applied to the specified parameter.</summary>
+        <returns>The list of applied attributes.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/AttributedModelProvider.xml
+++ b/xml/System.Composition.Convention/AttributedModelProvider.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Serves as the base class that defines the core behavior of methods used to retrieve metadata attributes for a type.</summary>
+    <summary>Provides augmented reflection data to support convention-based models.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -28,7 +28,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="AttributedModelProvider"/> class.</summary>
+        <summary>Creates a new instance of the <see cref="T:System.Composition.Convention.AttributedModelProvider"/> class.</summary>
         <remarks>
          <format type="text/markdown"><![CDATA[  
   
@@ -57,10 +57,10 @@
         <Parameter Name="member" Type="System.Reflection.MemberInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">The type used to retrieve attributes from the member.</param>
-        <param name="member">The member whose attributes are to be retrieved.</param>
-        <summary>Provides the list of attributes applied to the specified member.</summary>
-        <returns>The list of applied attributes.</returns>
+        <param name="reflectedType">The type.</param>
+        <param name="member">The member to inspect.</param>
+        <summary>Provides the list of attributes applied to the specified member of the specified type.</summary>
+        <returns>A collection of the attributes applied to the specified member.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -82,10 +82,10 @@
         <Parameter Name="parameter" Type="System.Reflection.ParameterInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">The type used to retrieve attributes from the parameter.</param>
-        <param name="parameter">The parameter whose attributes are to be retrieved.</param>
-        <summary>Provides the list of attributes applied to the specified parameter.</summary>
-        <returns>The list of applied attributes.</returns>
+        <param name="reflectedType">The type.</param>
+        <param name="parameter">The parameter to inspect.</param>
+        <summary>Provides the list of attributes applied to the specified parameter of the specified type.</summary>
+        <returns>A collection of the attributes applied to the specified parameter.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Convention/ConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ConventionBuilder.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Provides methods for building a convention by defining rules for configuring plain old CLR objects as Managed Extensibility Framework (MEF) parts.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -28,8 +28,8 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Initializes a new instance of the <see cref="ConventionBuilder"/> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ForType">
@@ -49,10 +49,10 @@
         <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="type">The type to which the rule applies.</param>
+        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that will apply to the specified type.</summary>
+        <returns>The builder that must be used to specify the rule.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ForType&lt;T&gt;">
@@ -73,10 +73,10 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type to which the rule applies.</typeparam>
+        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that will apply to the types specified by <typeparamref name="T"/>.</summary>
+        <returns>The builder that must be used to specify the rule.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ForTypesDerivedFrom">
@@ -96,10 +96,10 @@
         <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="type">The type from which matching types derive.</param>
+        <summary>Creates an instance of the <see cref="PartConventionBuilder"/> class for defining a rule that will apply to all types that derive from (or implement) the specified type.</summary>
+        <returns>The builder for constructing the rule.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ForTypesDerivedFrom&lt;T&gt;">
@@ -120,10 +120,10 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type from which the matching types derive.</typeparam>
+        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that will apply to all types that derive from (or implement) the specified type.</summary>
+        <returns>The builder that must be used to specify the rule.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ForTypesMatching">
@@ -143,10 +143,10 @@
         <Parameter Name="typeFilter" Type="System.Predicate&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <param name="typeFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="typeFilter">A predicate that selects matching types.</param>
+        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that will apply to types that match the specified predicate.</summary>
+        <returns>The builder that must be used to specify the rule.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ForTypesMatching&lt;T&gt;">
@@ -169,11 +169,11 @@
         <Parameter Name="typeFilter" Type="System.Predicate&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="typeFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type to which the rule applies.</typeparam>
+        <param name="typeFilter">A predicate that selects matching types.</param>
+        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that will apply to types assignable to <typeparamref name="T"/> matching the specified predicate.</summary>
+        <returns>The builder that must be used to specify the rule.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCustomAttributes">
@@ -194,11 +194,11 @@
         <Parameter Name="member" Type="System.Reflection.MemberInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">To be added.</param>
-        <param name="member">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="reflectedType">The type used to retrieve attributes from the member.</param>
+        <param name="member">The member to supply attributes for.</param>
+        <summary>Provides the list of attributes applied to the specified member.</summary>
+        <returns>The list of applied attributes.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCustomAttributes">
@@ -219,11 +219,11 @@
         <Parameter Name="parameter" Type="System.Reflection.ParameterInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">To be added.</param>
-        <param name="parameter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="reflectedType">The type used to retrieve attributes from the parameter.</param>
+        <param name="parameter">The parameter to supply attributes for.</param>
+        <summary>Provides the list of attributes applied to the specified parameter.</summary>
+        <returns>The list of applied attributes.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/ConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ConventionBuilder.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Provides methods for building a convention by defining rules for configuring CLR objects as Managed Extensibility Framework (MEF) parts.</summary>
+    <summary>Provides methods for creating and configuring rules to define CLR objects as Managed Extensibility Framework (MEF) parts.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -28,7 +28,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Initializes a new instance of the <see cref="ConventionBuilder"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Convention.ConventionBuilder"/> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -49,9 +49,9 @@
         <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="type">The type to which the rule applies.</param>
-        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that applies to the specified type.</summary>
-        <returns>The builder for constructing the rule.</returns>
+        <param name="type">The type.</param>
+        <summary>Creates a rule that applies to the specified type.</summary>
+        <returns>An object that can be used to further configure the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -73,9 +73,9 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">The type to which the rule applies.</typeparam>
-        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that applies to the type specified by <typeparamref name="T"/>.</summary>
-        <returns>The builder for constructing the rule.</returns>
+        <typeparam name="T">The generic type.</typeparam>
+        <summary>Creates a rule that applies to the specified generic type.</summary>
+        <returns>An object that can be used to further configure the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -96,9 +96,9 @@
         <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="type">The type from which matching types derive.</param>
-        <summary>Creates an instance of the <see cref="PartConventionBuilder"/> class for defining a rule that applies to all types that derive from (or implement) the specified type.</summary>
-        <returns>The builder for constructing the rule.</returns>
+        <param name="type">The type.</param>
+        <summary>Creates a rule that applies to all types that implement, or are derived from, the specified type.</summary>
+        <returns>An object that can be used to further configure the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -120,9 +120,9 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">The type from which the matching types derive.</typeparam>
-        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that applies to all types that derive from (or implement) the specified type.</summary>
-        <returns>The builder for constructing the rule.</returns>
+        <typeparam name="T">The generic type.</typeparam>
+        <summary>Creates a rule that applies to all types that implement, or are derived from, the specified generic type.</summary>
+        <returns>An object that can be used to further configure the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -143,9 +143,9 @@
         <Parameter Name="typeFilter" Type="System.Predicate&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <param name="typeFilter">A predicate that selects matching types.</param>
-        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that applies to types that match the specified predicate.</summary>
-        <returns>The builder for constructing the rule.</returns>
+        <param name="typeFilter">The predicate to match.</param>
+        <summary>Creates a rule that applies to types that match the specified predicate.</summary>
+        <returns>An object that can be used to further configure the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -169,10 +169,10 @@
         <Parameter Name="typeFilter" Type="System.Predicate&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The type to which the rule applies.</typeparam>
-        <param name="typeFilter">A predicate that selects matching types.</param>
-        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that applies to types assignable to <typeparamref name="T"/> that match the specified predicate.</summary>
-        <returns>The builder for constructing the rule.</returns>
+        <typeparam name="T">The type to match.</typeparam>
+        <param name="typeFilter">The predicate to match.</param>
+        <summary>Creates a rule that applies to types that match the specified predicate and generic type.</summary>
+        <returns>An object that can be used to further configure the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -194,10 +194,10 @@
         <Parameter Name="member" Type="System.Reflection.MemberInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">The type used to retrieve attributes from the member.</param>
-        <param name="member">The member whose attributes are to be retrieved.</param>
-        <summary>Provides the list of attributes applied to the specified member.</summary>
-        <returns>The list of applied attributes.</returns>
+        <param name="reflectedType">The type.</param>
+        <param name="member">The member to inspect.</param>
+        <summary>Retrieves the list of custom attributes applied to the specified member of the specified type.</summary>
+        <returns>A collection of custom attributes.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -219,10 +219,10 @@
         <Parameter Name="parameter" Type="System.Reflection.ParameterInfo" />
       </Parameters>
       <Docs>
-        <param name="reflectedType">The type used to retrieve attributes from the parameter.</param>
-        <param name="parameter">The parameter whose attributes are to be retrieved.</param>
-        <summary>Provides the list of attributes applied to the specified parameter.</summary>
-        <returns>The list of applied attributes.</returns>
+        <param name="reflectedType">The type.</param>
+        <param name="parameter">The parameter to inspect.</param>
+        <summary>Retrieves the list of custom attributes applied to the specified parameter of the specified type.</summary>
+        <returns>A collection of custom attributes.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Convention/ConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ConventionBuilder.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Provides methods for building a convention by defining rules for configuring plain old CLR objects as Managed Extensibility Framework (MEF) parts.</summary>
+    <summary>Provides methods for building a convention by defining rules for configuring CLR objects as Managed Extensibility Framework (MEF) parts.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -50,8 +50,8 @@
       </Parameters>
       <Docs>
         <param name="type">The type to which the rule applies.</param>
-        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that will apply to the specified type.</summary>
-        <returns>The builder that must be used to specify the rule.</returns>
+        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that applies to the specified type.</summary>
+        <returns>The builder for constructing the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -74,8 +74,8 @@
       <Parameters />
       <Docs>
         <typeparam name="T">The type to which the rule applies.</typeparam>
-        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that will apply to the types specified by <typeparamref name="T"/>.</summary>
-        <returns>The builder that must be used to specify the rule.</returns>
+        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that applies to the type specified by <typeparamref name="T"/>.</summary>
+        <returns>The builder for constructing the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -97,7 +97,7 @@
       </Parameters>
       <Docs>
         <param name="type">The type from which matching types derive.</param>
-        <summary>Creates an instance of the <see cref="PartConventionBuilder"/> class for defining a rule that will apply to all types that derive from (or implement) the specified type.</summary>
+        <summary>Creates an instance of the <see cref="PartConventionBuilder"/> class for defining a rule that applies to all types that derive from (or implement) the specified type.</summary>
         <returns>The builder for constructing the rule.</returns>
         <remarks></remarks>
       </Docs>
@@ -121,8 +121,8 @@
       <Parameters />
       <Docs>
         <typeparam name="T">The type from which the matching types derive.</typeparam>
-        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that will apply to all types that derive from (or implement) the specified type.</summary>
-        <returns>The builder that must be used to specify the rule.</returns>
+        <summary>Creates an instance of <see cref="PartConventionBuilder"/> for defining a rule that applies to all types that derive from (or implement) the specified type.</summary>
+        <returns>The builder for constructing the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -144,8 +144,8 @@
       </Parameters>
       <Docs>
         <param name="typeFilter">A predicate that selects matching types.</param>
-        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that will apply to types that match the specified predicate.</summary>
-        <returns>The builder that must be used to specify the rule.</returns>
+        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that applies to types that match the specified predicate.</summary>
+        <returns>The builder for constructing the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -171,8 +171,8 @@
       <Docs>
         <typeparam name="T">The type to which the rule applies.</typeparam>
         <param name="typeFilter">A predicate that selects matching types.</param>
-        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that will apply to types assignable to <typeparamref name="T"/> matching the specified predicate.</summary>
-        <returns>The builder that must be used to specify the rule.</returns>
+        <summary>Creates an instance of <see cref="PartConventionBuilder{T}"/> for defining a rule that applies to types assignable to <typeparamref name="T"/> that match the specified predicate.</summary>
+        <returns>The builder for constructing the rule.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -195,7 +195,7 @@
       </Parameters>
       <Docs>
         <param name="reflectedType">The type used to retrieve attributes from the member.</param>
-        <param name="member">The member to supply attributes for.</param>
+        <param name="member">The member whose attributes are to be retrieved.</param>
         <summary>Provides the list of attributes applied to the specified member.</summary>
         <returns>The list of applied attributes.</returns>
         <remarks></remarks>
@@ -220,7 +220,7 @@
       </Parameters>
       <Docs>
         <param name="reflectedType">The type used to retrieve attributes from the parameter.</param>
-        <param name="parameter">The parameter to supply attributes for.</param>
+        <param name="parameter">The parameter whose attributes are to be retrieved.</param>
         <summary>Provides the list of attributes applied to the specified parameter.</summary>
         <returns>The list of applied attributes.</returns>
         <remarks></remarks>

--- a/xml/System.Composition.Convention/ExportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ExportConventionBuilder.xml
@@ -35,7 +35,7 @@
       </Parameters>
       <Docs>
         <param name="name">The name of the metadata item.</param>
-        <param name="getValueFromPartType">A function that calculates the metadata value based on the type.</param>
+        <param name="getValueFromPartType">A function that determines the metadata value based on the type.</param>
         <summary>Adds export metadata to the export.</summary>
         <returns>An export builder containing the metadata that allows for further export configuration.</returns>
         <remarks></remarks>

--- a/xml/System.Composition.Convention/ExportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ExportConventionBuilder.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Configures an export associated with a part.</summary>
+    <summary>Configures an export that is associated with a part.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -34,10 +34,10 @@
         <Parameter Name="getValueFromPartType" Type="System.Func&lt;System.Type,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="name">The name of the metadata item.</param>
-        <param name="getValueFromPartType">A function that determines the metadata value based on the type.</param>
-        <summary>Adds export metadata to the export.</summary>
-        <returns>An export builder containing the metadata that allows for further export configuration.</returns>
+        <param name="name">The name of the metadata to add.</param>
+        <param name="getValueFromPartType">A function that provides the value of the metadata to add.</param>
+        <summary>Adds metadata that has the specified name and value to the export.</summary>
+        <returns>An export builder containing the metadata that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -59,10 +59,10 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="name">The name of the metadata item.</param>
-        <param name="value">The value of the metadata item.</param>
-        <summary>Adds export metadata to the export.</summary>
-        <returns>An export builder containing the metadata that allows for further export configuration.</returns>
+        <param name="name">The name of the metadata to add.</param>
+        <param name="value">The value of the metadata to add.</param>
+        <summary>Adds metadata that has the specified name and value to the export.</summary>
+        <returns>An export builder containing the metadata that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -83,9 +83,9 @@
         <Parameter Name="getContractNameFromPartType" Type="System.Func&lt;System.Type,System.String&gt;" />
       </Parameters>
       <Docs>
-        <param name="getContractNameFromPartType">A function that retrieves the contract name from the part type.</param>
-        <summary>Specifies the contract name for the export.</summary>
-        <returns>An export builder containing the contract name that allows for further export configuration.</returns>
+        <param name="getContractNameFromPartType">The function that provides the contract name.</param>
+        <summary>Specifies the contract name for the export based on the result of the specified function on the export type.</summary>
+        <returns>An export builder containing the contract name that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -108,7 +108,7 @@
       <Docs>
         <param name="contractName">The contract name.</param>
         <summary>Specifies the contract name for the export.</summary>
-        <returns>An export builder containing the contract name that allows for further export configuration.</returns>
+        <returns>An export builder containing the contract name that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -129,9 +129,9 @@
         <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="type">The contract type.</param>
+        <param name="type">The type.</param>
         <summary>Specifies the contract type for the export.</summary>
-        <returns>An export builder containing the contract type that allows for further export configuration.</returns>
+        <returns>An export builder containing the contract type that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -153,9 +153,9 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">The contract type.</typeparam>
-        <summary>Specifies the contract type for the export.</summary>
-        <returns>An export builder containing the contract type that allows for further export configuration.</returns>
+        <typeparam name="T">The generic type.</typeparam>
+        <summary>Specifies the contract type for the export as a generic type.</summary>
+        <returns>An export builder containing the contract type that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Convention/ExportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ExportConventionBuilder.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Configures an export associated with a part.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="AddMetadata">
@@ -34,11 +34,11 @@
         <Parameter Name="getValueFromPartType" Type="System.Func&lt;System.Type,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="getValueFromPartType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="name">The name of the metadata item.</param>
+        <param name="getValueFromPartType">A function that calculates the metadata value based on the type.</param>
+        <summary>Adds export metadata to the export.</summary>
+        <returns>An export builder containing the metadata that allows for further export configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AddMetadata">
@@ -59,11 +59,11 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="name">The name of the metadata item.</param>
+        <param name="value">The value of the metadata item.</param>
+        <summary>Adds export metadata to the export.</summary>
+        <returns>An export builder containing the metadata that allows for further export configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsContractName">
@@ -83,10 +83,10 @@
         <Parameter Name="getContractNameFromPartType" Type="System.Func&lt;System.Type,System.String&gt;" />
       </Parameters>
       <Docs>
-        <param name="getContractNameFromPartType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="getContractNameFromPartType">A function that retrieves the contract name from the part type.</param>
+        <summary>Specifies the contract name for the export.</summary>
+        <returns>An export builder containing the contract name that allows for further export configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsContractName">
@@ -106,10 +106,10 @@
         <Parameter Name="contractName" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="contractName">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contractName">The contract name.</param>
+        <summary>Specifies the contract name for the export.</summary>
+        <returns>An export builder containing the contract name that allows for further export configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsContractType">
@@ -129,10 +129,10 @@
         <Parameter Name="type" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="type">The contract type.</param>
+        <summary>Specifies the contract type for the export.</summary>
+        <returns>An export builder containing the contract type that allows for further export configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsContractType&lt;T&gt;">
@@ -153,10 +153,10 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The contract type.</typeparam>
+        <summary>Specifies the contract type for the export.</summary>
+        <returns>An export builder containing the contract type that allows for further export configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/ImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ImportConventionBuilder.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Configures an import associated with a part.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="AddMetadataConstraint">
@@ -34,11 +34,11 @@
         <Parameter Name="getConstraintValueFromPartType" Type="System.Func&lt;System.Type,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="getConstraintValueFromPartType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="name">The name of the metadata item to be constrained.</param>
+        <param name="getConstraintValueFromPartType">A function that calculates the constraint value to match the specified type.</param>
+        <summary>Adds an import constraint.</summary>
+        <returns>An import builder containing the constraint that allows for further configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AddMetadataConstraint">
@@ -59,11 +59,11 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="name">The name of the metadata item to be constrained.</param>
+        <param name="value">The constraint value to match the specified name.</param>
+        <summary>Adds an import constraint.</summary>
+        <returns>An import builder containing the metadata constraint that allows for further import configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AllowDefault">
@@ -81,9 +81,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Allows the import to receive the default value for its type if the contract cannot be supplied by another part.</summary>
+        <returns>An import builder that allows default values and can be further configured.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsContractName">
@@ -103,10 +103,10 @@
         <Parameter Name="getContractNameFromPartType" Type="System.Func&lt;System.Type,System.String&gt;" />
       </Parameters>
       <Docs>
-        <param name="getContractNameFromPartType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="getContractNameFromPartType">A function that retrieves the contract name from the specified part type.</param>
+        <summary>Specifies the contract name for the import.</summary>
+        <returns>An import builder containing the contract name that allows for further import configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsContractName">
@@ -126,10 +126,10 @@
         <Parameter Name="contractName" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="contractName">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contractName">The contract name.</param>
+        <summary>Specifies the contract name for the import.</summary>
+        <returns>An import builder containing the contract name that allows for further import configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsMany">
@@ -147,9 +147,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Configures the import to receive all exports of the contract.</summary>
+        <returns>An import builder that is configured to receive all exports of the contract, and allows for further import configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AsMany">
@@ -169,10 +169,10 @@
         <Parameter Name="isMany" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="isMany">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="isMany">Indicates whether the import will receive all values from the export.</param>
+        <summary>Configures a flag in the import that indicates whether it will receive all exports of the contract.</summary>
+        <returns>An import builder that allows further import configuration.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/ImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ImportConventionBuilder.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Configures an import associated with a part.</summary>
+    <summary>Configures an import that is associated with a part.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -34,9 +34,9 @@
         <Parameter Name="getConstraintValueFromPartType" Type="System.Func&lt;System.Type,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="name">The name of the metadata item to be constrained.</param>
-        <param name="getConstraintValueFromPartType">A function that calculates the constraint value to match the specified type.</param>
-        <summary>Adds an import constraint.</summary>
+        <param name="name">The required metadata name.</param>
+        <param name="getConstraintValueFromPartType">A function that provides the required metadata value.</param>
+        <summary>Adds a constraint to the import requiring the specified metadata name and the value provided by the specified function on the part type.</summary>
         <returns>An import builder containing the constraint that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
@@ -59,10 +59,10 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="name">The name of the metadata item to be constrained.</param>
-        <param name="value">The constraint value to match the specified name.</param>
-        <summary>Adds an import constraint.</summary>
-        <returns>An import builder containing the metadata constraint that allows for further import configuration.</returns>
+        <param name="name">The required metadata name.</param>
+        <param name="value">The required metadata value.</param>
+        <summary>Adds a constraint to the import requiring the specified metadata name and value.</summary>
+        <returns>An import builder containing the constraint that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -103,9 +103,9 @@
         <Parameter Name="getContractNameFromPartType" Type="System.Func&lt;System.Type,System.String&gt;" />
       </Parameters>
       <Docs>
-        <param name="getContractNameFromPartType">A function that retrieves the contract name from the specified part type.</param>
-        <summary>Specifies the contract name for the import.</summary>
-        <returns>An import builder containing the contract name that allows for further import configuration.</returns>
+        <param name="getContractNameFromPartType">A function that provides the contract name of the import.</param>
+        <summary>Sets the contract name of the import to the value provided by the specified function on the part type.</summary>
+        <returns>An import builder containing the contract name that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -126,9 +126,9 @@
         <Parameter Name="contractName" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="contractName">The contract name.</param>
-        <summary>Specifies the contract name for the import.</summary>
-        <returns>An import builder containing the contract name that allows for further import configuration.</returns>
+        <param name="contractName">The contract name of the import.</param>
+        <summary>Sets the contract name of the import to the specified string.</summary>
+        <returns>An import builder containing the contract name that allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -147,8 +147,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Configures the import to receive all exports of the contract.</summary>
-        <returns>An import builder that is configured to receive all exports of the contract and allows for further import configuration.</returns>
+        <summary>Configures the import to receive a collection of exports.</summary>
+        <returns>An import builder that can receive a collection of exports and allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -169,9 +169,9 @@
         <Parameter Name="isMany" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="isMany">Indicates whether the import will receive all values from the export.</param>
-        <summary>Configures a flag in the import that indicates whether it will receive all exports of the contract.</summary>
-        <returns>An import builder that allows further import configuration.</returns>
+        <param name="isMany"><langword="true"/> to provide all available matching exports; otherwise, <langword="false"/>.</param>
+        <summary>Configures the import to receive a collection of exports, possibly representing all available matching exports.</summary>
+        <returns>An import builder that can receive a collection of exports and allows for further configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Convention/ImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ImportConventionBuilder.xml
@@ -148,7 +148,7 @@
       <Parameters />
       <Docs>
         <summary>Configures the import to receive all exports of the contract.</summary>
-        <returns>An import builder that is configured to receive all exports of the contract, and allows for further import configuration.</returns>
+        <returns>An import builder that is configured to receive all exports of the contract and allows for further import configuration.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Convention/ImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ImportConventionBuilder.xml
@@ -169,7 +169,7 @@
         <Parameter Name="isMany" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="isMany"><langword="true"/> to provide all available matching exports; otherwise, <langword="false"/>.</param>
+        <param name="isMany"><see langword="true" /> to provide all available matching exports; otherwise, <see langword="false" />.</param>
         <summary>Configures the import to receive a collection of exports, possibly representing all available matching exports.</summary>
         <returns>An import builder that can receive a collection of exports and allows for further configuration.</returns>
         <remarks></remarks>

--- a/xml/System.Composition.Convention/ParameterImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ParameterImportConventionBuilder.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Contains methods used when configuring a <see cref="PartConventionBuilder{T}"/>.</summary>
+    <summary>Represents a helper type that is used when configuring a <see cref="T:System.Composition.Convention.PartConventionBuilder`1"/>.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
@@ -41,8 +41,8 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">The type of the parameter.</typeparam>
-        <summary>Specifies an import with a contract of type <typeparamref name="T"/>.</summary>
+        <typeparam name="T">The type to import.</typeparam>
+        <summary>Imports the specified type.</summary>
         <returns>The imported instance.</returns>
         <remarks></remarks>
       </Docs>
@@ -67,9 +67,9 @@
         <Parameter Name="configure" Type="System.Action&lt;System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The type of the parameter.</typeparam>
-        <param name="configure">Configuration for the import.</param>
-        <summary>Specifies an import with a contract of type <typeparamref name="T"/>.</summary>
+        <typeparam name="T">The type to import.</typeparam>
+        <param name="configure">The configuration for the import.</param>
+        <summary>Imports the specified generic type by using the specified configuration.</summary>
         <returns>The imported instance.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Convention/ParameterImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ParameterImportConventionBuilder.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Contains methods used when configuring a <see cref="PartConventionBuilder{T}"/>. This class is used only in expressions, instances of this type are never created.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Import&lt;T&gt;">
@@ -34,10 +34,10 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type of the parameter.</typeparam>
+        <summary>Specifies an import with a contract of type <typeparamref name="T"/>.</summary>
+        <returns>The imported instance.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Import&lt;T&gt;">
@@ -60,11 +60,11 @@
         <Parameter Name="configure" Type="System.Action&lt;System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="configure">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type of the parameter.</typeparam>
+        <param name="configure">Configuration for the import.</param>
+        <summary>Specifies an import with a contract of type <typeparamref name="T"/>.</summary>
+        <returns>The imported instance.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/ParameterImportConventionBuilder.xml
+++ b/xml/System.Composition.Convention/ParameterImportConventionBuilder.xml
@@ -12,8 +12,15 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Contains methods used when configuring a <see cref="PartConventionBuilder{T}"/>. This class is used only in expressions, instances of this type are never created.</summary>
-    <remarks></remarks>
+    <summary>Contains methods used when configuring a <see cref="PartConventionBuilder{T}"/>.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This class is used only in expressions; instances of this type are never created.
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName="Import&lt;T&gt;">

--- a/xml/System.Composition.Convention/PartConventionBuilder.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Configures a type as a Managed Extensibility Framework (MEF) part.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="AddPartMetadata">
@@ -34,11 +34,11 @@
         <Parameter Name="getValueFromPartType" Type="System.Func&lt;System.Type,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="getValueFromPartType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="name">The metadata name.</param>
+        <param name="getValueFromPartType">A function that calculates the metadata value based on the type.</param>
+        <summary>Adds the specified metadata to the part.</summary>
+        <returns>A part builder containing the metadata that allows further configuration of the part.</returns>
+        <remarks</remarks>
       </Docs>
     </Member>
     <Member MemberName="AddPartMetadata">
@@ -59,11 +59,11 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="name">The metadata name.</param>
+        <param name="value">The metadata value.</param>
+        <summary> Add the specified metadata to the part.</summary>
+        <returns>A part builder containing the metadata that allows further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Export">
@@ -81,9 +81,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Exports the part using its own concrete type as the contract.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Export">
@@ -103,10 +103,10 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="exportConfiguration">Configuration action for the export.</param>
+        <summary>Exports the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Export&lt;T&gt;">
@@ -127,10 +127,10 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type of the contract.</typeparam>
+        <summary>Exports the part using type <typeparamref name="T"/> as the contract.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Export&lt;T&gt;">
@@ -153,11 +153,11 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type of the contract.</typeparam>
+        <param name="exportConfiguration">Configuration action for the export.</param>
+        <summary>Exports the class using type <typeparamref name="T"/> as the contract.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportInterfaces">
@@ -175,9 +175,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Exports all interfaces implemented by the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportInterfaces">
@@ -197,10 +197,10 @@
         <Parameter Name="interfaceFilter" Type="System.Predicate&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <param name="interfaceFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="interfaceFilter">The filter for selecting the interfaces.</param>
+        <summary>Selects the interfaces on the part type that will be exported.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportInterfaces">
@@ -221,11 +221,11 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Type,System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="interfaceFilter">To be added.</param>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="interfaceFilter">The filter for selecting the interfaces.</param>
+        <param name="exportConfiguration">The action to configure the selected interfaces.</param>
+        <summary>Selects the interfaces on the part type that will be exported.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperties">
@@ -245,10 +245,10 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertyFilter">The filter for selecting the properites to export.</param>
+        <summary>Selects the properties of the part to export.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperties">
@@ -269,11 +269,11 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">To be added.</param>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertyFilter">The filter for selecting the properites to export.</param>
+        <param name="exportConfiguration">The action to configure the selected properties.</param>
+        <summary>Selects the properties of the part to export.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperties&lt;T&gt;">
@@ -296,11 +296,11 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="propertyFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The contract type to export.</typeparam>
+        <param name="propertyFilter">The filter for selecting the properites to export.</param>
+        <summary>Selects the properties of the part to export.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperties&lt;T&gt;">
@@ -324,12 +324,12 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="propertyFilter">To be added.</param>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The contract type to export.</typeparam>
+        <param name="propertyFilter">The filter for selecting the properites to export.</param>
+        <param name="exportConfiguration">The action to configure the selected properties.</param>
+        <summary>Selects the properties of the part to export.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperties">
@@ -349,10 +349,10 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertyFilter">The filter for selecting the properites to import.</param>
+        <summary>Selects properties to import into the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperties">
@@ -373,11 +373,11 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">To be added.</param>
-        <param name="importConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertyFilter">The filter for selecting the properites to import.</param>
+        <param name="importConfiguration">The action to configure the selected properties.</param>
+        <summary>Selects properties to import into the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperties&lt;T&gt;">
@@ -400,11 +400,11 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="propertyFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The property type to import.</typeparam>
+        <param name="propertyFilter">The filter for selecting the properites to import.</param>
+        <summary>Selects properties to import into the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperties&lt;T&gt;">
@@ -428,12 +428,12 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="propertyFilter">To be added.</param>
-        <param name="importConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The property type to import.</typeparam>
+        <param name="propertyFilter">The filter for selecting the properites to import.</param>
+        <param name="importConfiguration">The action to configure the selected properties.</param>
+        <summary>Selects properties to import into the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="NotifyImportsSatisfied">
@@ -453,10 +453,10 @@
         <Parameter Name="methodFilter" Type="System.Predicate&lt;System.Reflection.MethodInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="methodFilter">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="methodFilter">The filter for selecting matching methods.</param>
+        <summary>Marks the part as being shared within the entire composition.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectConstructor">
@@ -476,10 +476,10 @@
         <Parameter Name="constructorSelector" Type="System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Reflection.ConstructorInfo&gt;,System.Reflection.ConstructorInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="constructorSelector">Filter that selects a single constructor.</param>
+        <summary>Selects which of the available constructors will be used to instantiate the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectConstructor">
@@ -500,11 +500,11 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Reflection.ParameterInfo,System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">To be added.</param>
-        <param name="importConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="constructorSelector">A filter that selects a single constructor.</param>
+        <param name="importConfiguration">The action configuring the parameters of the selected constructor.</param>
+        <summary>Selects which of the available constructors will be used to instantiate the part.</summary>
+        <returns>>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Shared">
@@ -522,9 +522,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Marks the part as being shared within the entire composition.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Shared">
@@ -544,10 +544,10 @@
         <Parameter Name="sharingBoundary" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="sharingBoundary">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="sharingBoundary">The name of the sharing boundary.</param>
+        <summary>Marks the part as being shared within the specified boundary.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/PartConventionBuilder.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder.xml
@@ -38,7 +38,7 @@
         <param name="getValueFromPartType">A function that calculates the metadata value based on the type.</param>
         <summary>Adds the specified metadata to the part.</summary>
         <returns>A part builder containing the metadata that allows further configuration of the part.</returns>
-        <remarks</remarks>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="AddPartMetadata">

--- a/xml/System.Composition.Convention/PartConventionBuilder.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder.xml
@@ -35,7 +35,7 @@
       </Parameters>
       <Docs>
         <param name="name">The metadata name.</param>
-        <param name="getValueFromPartType">A function that calculates the metadata value based on the type.</param>
+        <param name="getValueFromPartType">A function that determines the metadata value based on the type.</param>
         <summary>Adds the specified metadata to the part.</summary>
         <returns>A part builder containing the metadata that allows further configuration of the part.</returns>
         <remarks></remarks>
@@ -198,7 +198,7 @@
       </Parameters>
       <Docs>
         <param name="interfaceFilter">The filter for selecting the interfaces.</param>
-        <summary>Selects the interfaces on the part type that will be exported.</summary>
+        <summary>Selects the interfaces on the part type to export.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
       </Docs>
@@ -223,7 +223,7 @@
       <Docs>
         <param name="interfaceFilter">The filter for selecting the interfaces.</param>
         <param name="exportConfiguration">The action to configure the selected interfaces.</param>
-        <summary>Selects the interfaces on the part type that will be exported.</summary>
+        <summary>Selects the interfaces on the part type to export.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
       </Docs>
@@ -476,8 +476,8 @@
         <Parameter Name="constructorSelector" Type="System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Reflection.ConstructorInfo&gt;,System.Reflection.ConstructorInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">Filter that selects a single constructor.</param>
-        <summary>Selects which of the available constructors will be used to instantiate the part.</summary>
+        <param name="constructorSelector">A filter that selects a single constructor.</param>
+        <summary>Selects which constructors is used to instantiate the part.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
       </Docs>
@@ -502,7 +502,7 @@
       <Docs>
         <param name="constructorSelector">A filter that selects a single constructor.</param>
         <param name="importConfiguration">The action configuring the parameters of the selected constructor.</param>
-        <summary>Selects which of the available constructors will be used to instantiate the part.</summary>
+        <summary>Selects which constructor is used to instantiate the part.</summary>
         <returns>>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Convention/PartConventionBuilder.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder.xml
@@ -34,10 +34,10 @@
         <Parameter Name="getValueFromPartType" Type="System.Func&lt;System.Type,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="name">The metadata name.</param>
-        <param name="getValueFromPartType">A function that determines the metadata value based on the type.</param>
-        <summary>Adds the specified metadata to the part.</summary>
-        <returns>A part builder containing the metadata that allows further configuration of the part.</returns>
+        <param name="name">The name of the metadata to add.</param>
+        <param name="getValueFromPartType">A function that returns the metadata value on the part type.</param>
+        <summary>Adds metadata that has the specified name and value to the part. The value is returned by a function that maps the part type to the metadata value.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -61,8 +61,8 @@
       <Docs>
         <param name="name">The metadata name.</param>
         <param name="value">The metadata value.</param>
-        <summary> Add the specified metadata to the part.</summary>
-        <returns>A part builder containing the metadata that allows further configuration of the part.</returns>
+        <summary>Adds metadata that has the specified name and value to the part.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -81,8 +81,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Exports the part using its own concrete type as the contract.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <summary>Exports the part with its concrete type as the contract type.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -103,9 +103,9 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="exportConfiguration">Configuration action for the export.</param>
-        <summary>Exports the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="exportConfiguration">An action that configures the part.</param>
+        <summary>Exports the part that has the specified configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -127,9 +127,9 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="T">The type of the contract.</typeparam>
-        <summary>Exports the part using type <typeparamref name="T"/> as the contract.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="T">The contract type.</typeparam>
+        <summary>Exports the part that has the specified contract type.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -153,10 +153,10 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The type of the contract.</typeparam>
-        <param name="exportConfiguration">Configuration action for the export.</param>
-        <summary>Exports the class using type <typeparamref name="T"/> as the contract.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="T">The contract type.</typeparam>
+        <param name="exportConfiguration">An action that configures the part.</param>
+        <summary>Exports the part that has the specified contract type by using the specified configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -175,8 +175,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Exports all interfaces implemented by the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <summary>Selects all interfaces on the part type to be exported.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -197,9 +197,9 @@
         <Parameter Name="interfaceFilter" Type="System.Predicate&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <param name="interfaceFilter">The filter for selecting the interfaces.</param>
-        <summary>Selects the interfaces on the part type to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="interfaceFilter">A predicate that specifies the interfaces to be selected.</param>
+        <summary>Selects interfaces on the part type to be exported according to the specified filter.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -221,10 +221,10 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Type,System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="interfaceFilter">The filter for selecting the interfaces.</param>
-        <param name="exportConfiguration">The action to configure the selected interfaces.</param>
-        <summary>Selects the interfaces on the part type to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="interfaceFilter">A predicate that specifies the interfaces to be selected.</param>
+        <param name="exportConfiguration">An action that configures the exports.</param>
+        <summary>Selects interfaces on the part type to be exported according to the specified filter, using the specified export configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -245,9 +245,9 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">The filter for selecting the properites to export.</param>
-        <summary>Selects the properties of the part to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertyFilter">A predicate that specifies the properites to export.</param>
+        <summary>Selects the properties on the part to export according to the specified predicate.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -269,10 +269,10 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">The filter for selecting the properites to export.</param>
-        <param name="exportConfiguration">The action to configure the selected properties.</param>
-        <summary>Selects the properties of the part to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertyFilter">A predicate that specifies the properites to export.</param>
+        <param name="exportConfiguration">An action that configures the exports.</param>
+        <summary>Selects the properties on the part to export according to the specified predicate, using the specified export configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -296,10 +296,10 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The contract type to export.</typeparam>
-        <param name="propertyFilter">The filter for selecting the properites to export.</param>
-        <summary>Selects the properties of the part to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="T">The contract type.</typeparam>
+        <param name="propertyFilter">A predicate that specifies the properites to export.</param>
+        <summary>Selects the properties on the part to export according to the specified predicate, using the specified contract type.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -324,11 +324,11 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The contract type to export.</typeparam>
-        <param name="propertyFilter">The filter for selecting the properites to export.</param>
-        <param name="exportConfiguration">The action to configure the selected properties.</param>
-        <summary>Selects the properties of the part to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="T">The contract type.</typeparam>
+        <param name="propertyFilter">A predicate that specifies the properites to export.</param>
+        <param name="exportConfiguration">An action that configures the exports.</param>
+        <summary>Selects the properties on the part to export according to the specified predicate, using the specified contract type and export configuration. </summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -349,9 +349,9 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">The filter for selecting the properites to import.</param>
-        <summary>Selects properties to import into the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertyFilter">A predicate that specifies the properites to import.</param>
+        <summary>Selects the properties on the part to import according to the specified predicate.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -373,10 +373,10 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertyFilter">The filter for selecting the properites to import.</param>
-        <param name="importConfiguration">The action to configure the selected properties.</param>
-        <summary>Selects properties to import into the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertyFilter">A predicate that specifies the properites to import.</param>
+        <param name="importConfiguration">An action that configures the imports.</param>
+        <summary>Selects the properties on the part to import according to the specified predicate, using the specified import configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -400,10 +400,10 @@
         <Parameter Name="propertyFilter" Type="System.Predicate&lt;System.Reflection.PropertyInfo&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The property type to import.</typeparam>
-        <param name="propertyFilter">The filter for selecting the properites to import.</param>
-        <summary>Selects properties to import into the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="T">The contract type.</typeparam>
+        <param name="propertyFilter">A predicate that specifies the properties to import.</param>
+        <summary>Selects the properties on the part to import according to the specified predicate, using the specified contract type.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -428,11 +428,11 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Reflection.PropertyInfo,System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The property type to import.</typeparam>
-        <param name="propertyFilter">The filter for selecting the properites to import.</param>
-        <param name="importConfiguration">The action to configure the selected properties.</param>
-        <summary>Selects properties to import into the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="T">The contract type.</typeparam>
+        <param name="propertyFilter">A predicate that specifies the properties to import.</param>
+        <param name="importConfiguration">An action that configures the imports.</param>
+        <summary>Selects the properties on the part to import according to the specified predicate, using the specified contract type and import configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -453,9 +453,9 @@
         <Parameter Name="methodFilter" Type="System.Predicate&lt;System.Reflection.MethodInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="methodFilter">The filter for selecting matching methods.</param>
-        <summary>Marks the part as being shared within the entire composition.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="methodFilter">A predicate that selects the methods.</param>
+        <summary>Select methods to be used as a notification when composition is complete.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -476,9 +476,9 @@
         <Parameter Name="constructorSelector" Type="System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Reflection.ConstructorInfo&gt;,System.Reflection.ConstructorInfo&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">A filter that selects a single constructor.</param>
-        <summary>Selects which constructors is used to instantiate the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="constructorSelector">A function that returns a single constructor.</param>
+        <summary>Selects the constructor used to initialize the part by using the specified function.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -500,10 +500,10 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Reflection.ParameterInfo,System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">A filter that selects a single constructor.</param>
-        <param name="importConfiguration">The action configuring the parameters of the selected constructor.</param>
-        <summary>Selects which constructor is used to instantiate the part.</summary>
-        <returns>>A part builder allowing further configuration of the part.</returns>
+        <param name="constructorSelector">A function that returns a single constructor.</param>
+        <param name="importConfiguration">A method that configures the constructor's imports.</param>
+        <summary>Selects the constructor used to initialize the part by using the specified function and import configuration.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -522,8 +522,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Marks the part as being shared within the entire composition.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <summary>Marks the part as being shared throughout the entire composition.</summary>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -544,9 +544,9 @@
         <Parameter Name="sharingBoundary" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="sharingBoundary">The name of the sharing boundary.</param>
+        <param name="sharingBoundary">The boundary.</param>
         <summary>Marks the part as being shared within the specified boundary.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <returns>A part builder that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Convention/PartConventionBuilder`1.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder`1.xml
@@ -16,7 +16,7 @@
   <Interfaces />
   <Docs>
     <typeparam name="T">The type of the part, or a type to which the part is assignable.</typeparam>
-    <summaryConfigures a type as a Managed Extensibility Framework (MEF) part.</summary>
+    <summary>Configures a type as a Managed Extensibility Framework (MEF) part.</summary>
     <remarks></remarks>
   </Docs>
   <Members>

--- a/xml/System.Composition.Convention/PartConventionBuilder`1.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder`1.xml
@@ -66,6 +66,7 @@
         <summary>Selects a property on the part to export.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
+        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty&lt;TContract&gt;">
@@ -93,6 +94,7 @@
         <summary>Selects a property to export from the part.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
+        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty&lt;TContract&gt;">
@@ -170,6 +172,7 @@
         <summary>Selects a property on the part to import.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
+        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="ImportProperty&lt;TContract&gt;">
@@ -226,6 +229,7 @@
         <summary>Selects a property on the part to import.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
+        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="NotifyImportsSatisfied">
@@ -249,6 +253,7 @@
         <summary>Marks the part as being shared within the entire composition.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
+        <exception cref="T:System.Argument"><paramref name="methodSelector" /> The expression must be a <see langword="void" /> method with no arguments.</exception>
       </Docs>
     </Member>
     <Member MemberName="SelectConstructor">
@@ -272,6 +277,7 @@
         <summary>Selects which constructor is used to instantiate the part.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
+        <exception cref="T:System.Argument"><paramref name="constructorSelector" /> The expression must be new.</exception>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/PartConventionBuilder`1.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder`1.xml
@@ -269,7 +269,7 @@
       </Parameters>
       <Docs>
         <param name="constructorSelector">An <see cref="T:System.Linq.Expressions.Expression"/> that selects a single constructor.</param>
-        <summary>Selects which of the available constructors will be used to instantiate the part.</summary>
+        <summary>Selects which constructor is used to instantiate the part.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Convention/PartConventionBuilder`1.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder`1.xml
@@ -15,8 +15,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="T">The type of the part, or a type to which the part is assignable.</typeparam>
-    <summary>Configures a type as a Managed Extensibility Framework (MEF) part.</summary>
+    <typeparam name="T">The type of the part.</typeparam>
+    <summary>Configures a type as a Managed Extensibility Framework (MEF) part, with strongly typed return values.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -37,9 +37,9 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <summary>Selects a property on the part to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertySelector">A function that selects the property to export.</param>
+        <summary>Exports a specified property.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -61,10 +61,10 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <param name="exportConfiguration">The action to configure the selected property.</param>
-        <summary>Selects a property on the part to export.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertySelector">A function that selects the property to export.</param>
+        <param name="exportConfiguration">An action that configures the exported property.</param>
+        <summary>Exports a specified property with the specified configuration.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
         <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
@@ -89,10 +89,10 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">The contract type to export.</typeparam>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <summary>Selects a property to export from the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="TContract">The contract type.</typeparam>
+        <param name="propertySelector">A function that selects the property to export.</param>
+        <summary>Exports a specified property as a specified contract type.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
         <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
@@ -118,11 +118,11 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">The contract type to export.</typeparam>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the matching property.</param>
-        <param name="exportConfiguration">The action to configure the selected properties.</param>
-        <summary>Selects a property to export from the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="TContract">The contract type.</typeparam>
+        <param name="propertySelector">A function that selects the property to export.</param>
+        <param name="exportConfiguration">An action that configures the exported property.</param>
+        <summary>Exports a specified property as a specified contract type by using the specified configuration.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -143,9 +143,9 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <summary>Selects a property on the part to import.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertySelector">A function that selects the property to import.</param>
+        <summary>Imports a specified property.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -167,10 +167,10 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <param name="importConfiguration">The action configuring the imported property.</param>
-        <summary>Selects a property on the part to import.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="propertySelector">A function that selects the property to import.</param>
+        <param name="importConfiguration">An action that configures the imported property.</param>
+        <summary>Imports a specified property by using the specified configuration.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
         <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
@@ -195,10 +195,10 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">The contract type to import.</typeparam>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <summary>Selects a property on the part to import.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="TContract">The contract type.</typeparam>
+        <param name="propertySelector">A function that selects the property to import.</param>
+        <summary>Imports a specified property with the specified contract type.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -223,11 +223,11 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">The contract type to import.</typeparam>
-        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
-        <param name="importConfiguration">The action configuring the imported property.</param>
-        <summary>Selects a property on the part to import.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <typeparam name="TContract">The contract type.</typeparam>
+        <param name="propertySelector">A function that selects the property to import.</param>
+        <param name="importConfiguration">An action that configures the imported property.</param>
+        <summary>Imports a specified property with the specified contract type and configuration.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
         <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
@@ -249,9 +249,9 @@
         <Parameter Name="methodSelector" Type="System.Linq.Expressions.Expression&lt;System.Action&lt;T&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="methodSelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the method.</param>
-        <summary>Marks the part as being shared within the entire composition.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="methodSelector">An action that selects the method to call.</param>
+        <summary>Selects a method to be called when composition is complete.</summary>
+        <returns>An object that can be used to further configure the part.</returns>
         <remarks></remarks>
         <exception cref="T:System.Argument">The <paramref name="methodSelector" /> expression must be a <see langword="void" /> method with no arguments.</exception>
       </Docs>
@@ -273,9 +273,9 @@
         <Parameter Name="constructorSelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;System.Composition.Convention.ParameterImportConventionBuilder,T&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">An <see cref="T:System.Linq.Expressions.Expression"/> that selects a single constructor.</param>
-        <summary>Selects which constructor is used to instantiate the part.</summary>
-        <returns>A part builder allowing further configuration of the part.</returns>
+        <param name="constructorSelector">A function that selects a constructor.</param>
+        <summary>Selects a constructor to be used in composition.</summary>
+        <returns>An object that can be used to further configure the part. </returns>
         <remarks></remarks>
         <exception cref="T:System.Argument">The <paramref name="constructorSelector" /> expression must use the <see langword="new" /> operator.</exception>
       </Docs>

--- a/xml/System.Composition.Convention/PartConventionBuilder`1.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder`1.xml
@@ -66,7 +66,7 @@
         <summary>Selects a property on the part to export.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
-        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
+        <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty&lt;TContract&gt;">
@@ -94,7 +94,7 @@
         <summary>Selects a property to export from the part.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
-        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
+        <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty&lt;TContract&gt;">
@@ -172,7 +172,7 @@
         <summary>Selects a property on the part to import.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
-        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
+        <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="ImportProperty&lt;TContract&gt;">
@@ -229,7 +229,7 @@
         <summary>Selects a property on the part to import.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
-        <exception cref="T:System.Argument"><paramref name="propertySelector" /> The expression must be <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
+        <exception cref="T:System.Argument">The <paramref name="propertySelector" /> expression must be a <see cref="T:System.Linq.Expressions.MemberExpression"/> for accessing a property.</exception>
       </Docs>
     </Member>
     <Member MemberName="NotifyImportsSatisfied">
@@ -253,7 +253,7 @@
         <summary>Marks the part as being shared within the entire composition.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
-        <exception cref="T:System.Argument"><paramref name="methodSelector" /> The expression must be a <see langword="void" /> method with no arguments.</exception>
+        <exception cref="T:System.Argument">The <paramref name="methodSelector" /> expression must be a <see langword="void" /> method with no arguments.</exception>
       </Docs>
     </Member>
     <Member MemberName="SelectConstructor">
@@ -277,7 +277,7 @@
         <summary>Selects which constructor is used to instantiate the part.</summary>
         <returns>A part builder allowing further configuration of the part.</returns>
         <remarks></remarks>
-        <exception cref="T:System.Argument"><paramref name="constructorSelector" /> The expression must be new.</exception>
+        <exception cref="T:System.Argument">The <paramref name="constructorSelector" /> expression must use the <see langword="new" /> operator.</exception>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Convention/PartConventionBuilder`1.xml
+++ b/xml/System.Composition.Convention/PartConventionBuilder`1.xml
@@ -15,9 +15,9 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="T">To be added.</typeparam>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <typeparam name="T">The type of the part, or a type to which the part is assignable.</typeparam>
+    <summaryConfigures a type as a Managed Extensibility Framework (MEF) part.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="ExportProperty">
@@ -37,10 +37,10 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <summary>Selects a property on the part to export.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty">
@@ -61,11 +61,11 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">To be added.</param>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <param name="exportConfiguration">The action to configure the selected property.</param>
+        <summary>Selects a property on the part to export.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty&lt;TContract&gt;">
@@ -88,11 +88,11 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">To be added.</typeparam>
-        <param name="propertySelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="TContract">The contract type to export.</typeparam>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <summary>Selects a property to export from the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ExportProperty&lt;TContract&gt;">
@@ -116,12 +116,12 @@
         <Parameter Name="exportConfiguration" Type="System.Action&lt;System.Composition.Convention.ExportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">To be added.</typeparam>
-        <param name="propertySelector">To be added.</param>
-        <param name="exportConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="TContract">The contract type to export.</typeparam>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the matching property.</param>
+        <param name="exportConfiguration">The action to configure the selected properties.</param>
+        <summary>Selects a property to export from the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperty">
@@ -141,10 +141,10 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <summary>Selects a property on the part to import.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperty">
@@ -165,11 +165,11 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <param name="propertySelector">To be added.</param>
-        <param name="importConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <param name="importConfiguration">The action configuring the imported property.</param>
+        <summary>Selects a property on the part to import.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperty&lt;TContract&gt;">
@@ -192,11 +192,11 @@
         <Parameter Name="propertySelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;T,System.Object&gt;&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">To be added.</typeparam>
-        <param name="propertySelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="TContract">The contract type to import.</typeparam>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <summary>Selects a property on the part to import.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ImportProperty&lt;TContract&gt;">
@@ -220,12 +220,12 @@
         <Parameter Name="importConfiguration" Type="System.Action&lt;System.Composition.Convention.ImportConventionBuilder&gt;" />
       </Parameters>
       <Docs>
-        <typeparam name="TContract">To be added.</typeparam>
-        <param name="propertySelector">To be added.</param>
-        <param name="importConfiguration">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="TContract">The contract type to import.</typeparam>
+        <param name="propertySelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the property.</param>
+        <param name="importConfiguration">The action configuring the imported property.</param>
+        <summary>Selects a property on the part to import.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="NotifyImportsSatisfied">
@@ -245,10 +245,10 @@
         <Parameter Name="methodSelector" Type="System.Linq.Expressions.Expression&lt;System.Action&lt;T&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="methodSelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="methodSelector">The <see cref="T:System.Linq.Expressions.Expression"/> that selects the method.</param>
+        <summary>Marks the part as being shared within the entire composition.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="SelectConstructor">
@@ -268,10 +268,10 @@
         <Parameter Name="constructorSelector" Type="System.Linq.Expressions.Expression&lt;System.Func&lt;System.Composition.Convention.ParameterImportConventionBuilder,T&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="constructorSelector">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="constructorSelector">An <see cref="T:System.Linq.Expressions.Expression"/> that selects a single constructor.</param>
+        <summary>Selects which of the available constructors will be used to instantiate the part.</summary>
+        <returns>A part builder allowing further configuration of the part.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/ns-System.Composition.Convention.xml
+++ b/xml/ns-System.Composition.Convention.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Composition.Convention">
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>The <see cref="N:System.Composition.Convention" /> namespace contains classes that represent convention builders for constructing rules used to configure CLR objects as MEF parts.</summary>
+    <remarks></remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
# Title
Document APIs for the System.Composition.Convention Namespace

## Summary
Added documentation for "To be added." fields in all classes of the System.Composition.Convention Namespace:

- ConventionBuilder 
- ExportConventionBuilder 
- ImportConventionBuilder 
- ParameterImportConventionBuilder 
- PartConventionBuilder 
- PartConventionBuilderOfT 

**Note:** I will be adding two more files for this namespace in another commit:
The AttributedModelProvider base class, and the namespace file ns-System.Composition.Convention.xml

Fixes #2261 

## Suggested Reviewers
@rpetrusha 
