### PR TITLE
Simplify the invoke of delegate in the example

### DIFF
--- a/xml/System.ComponentModel/INotifyPropertyChanged.xml
+++ b/xml/System.ComponentModel/INotifyPropertyChanged.xml
@@ -140,10 +140,7 @@ namespace TestNotifyPropertyChangedCS
         // parameter causes the property name of the caller to be substituted as an argument.  
         private void NotifyPropertyChanged([CallerMemberName] String propertyName = "")  
         {  
-            if (PropertyChanged != null)  
-            {  
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));  
-            }  
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }  
   
         // The constructor is private to enforce the factory pattern.  


### PR DESCRIPTION
# Title

Simplify the invoke of delegate in the example using a new C# feature

## Summary

Simplify the invoke of delegate in the example section of INotifyPropertyChanged interface documentation. This change is suggested by Visual Studio.