### PR TITLE
Fix misspelling

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_Misc/ls_queries/vb/data/applicationdefinition.lsml
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/ls_queries/vb/data/applicationdefinition.lsml
@@ -4369,7 +4369,7 @@
             </BinaryExpression.Left>
             <BinaryExpression.Right>
               <ConstantExpression ResultType=":String?"
-                                  Value="Fuck You" />
+                                  Value="Forget You" />
             </BinaryExpression.Right>
           </BinaryExpression>
         </QueryFilterExpressionTree>


### PR DESCRIPTION
Fixing a minor misspelling.

# Fixing a small misspelling.

## Summary

One word was misspelled in our examples.