### PR TITLE
Add the missing SettingsProvider attribute

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Winforms/ApplicationSettings.Architecture/CS/DummyClass.cs
+++ b/samples/snippets/csharp/VS_Snippets_Winforms/ApplicationSettings.Architecture/CS/DummyClass.cs
@@ -6,6 +6,7 @@ using System.Configuration;
 
 namespace ApplicationSettingsArchitectureCS
 {
+    [SettingsProvider("SqlSettingsProvider")]
     class CustomSettings : ApplicationSettingsBase
     {
         // Implementation goes here.


### PR DESCRIPTION
# Added the missing SettingProvider attribute in C# sample

In the documentation about Application Settings Architecture, illustration of use of custom `SettingProvider` shown does not include the attribute in C# sample (included in VB sample).

## Some useful links
- [Microsoft Docs Page](https://docs.microsoft.com/en-us/dotnet/framework/winforms/advanced/application-settings-architecture#custom-settings-providers)
- [VB snippet](https://github.com/dotnet/docs/blob/master/samples/snippets/visualbasic/VS_Snippets_Winforms/ApplicationSettings.Architecture/VB/DummyProviderClass.vb#1)