### PR TITLE
Update how-to-perform-left-outer-joins_1.cs

### DIFF
--- a/samples/snippets/csharp/concepts/linq/how-to-perform-left-outer-joins_1.cs
+++ b/samples/snippets/csharp/concepts/linq/how-to-perform-left-outer-joins_1.cs
@@ -30,7 +30,7 @@
             var query = from person in people
                         join pet in pets on person equals pet.Owner into gj
                         from subpet in gj.DefaultIfEmpty()
-                        select new { person.FirstName, PetName = subpet?.Name ?? String.Empty : subpet.Name) };
+                        select new { person.FirstName, PetName = subpet?.Name ?? String.Empty };
 
             foreach (var v in query)
             {


### PR DESCRIPTION
Typo correction in line 33, the current code does not compile.  
Ternary operator not necessary.

# Title

Fix the code not compiling anymore

## Summary

Deleted the old ternary operator not needed.

## Details

Fix typo, a parenthesis and a part of the ternary operator was still there in how-to-perform-left-outer-join_1.cs
