### PR TITLE
Fix the path of tags

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-create-a-duplex-federated-binding.md
+++ b/docs/framework/wcf/feature-details/how-to-create-a-duplex-federated-binding.md
@@ -38,11 +38,11 @@ manager: "erikre"
   
 ### To create a duplex federated custom binding with TCP message security mode  
   
-1.  In the [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) node of the configuration file, create a [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element.  
+1.  In the [\<bindings>](../../../../docs/framework/configure-apps/file-schema/wcf/bindings.md) node of the configuration file, create a [\<customBinding>](../../../../docs/framework/configure-apps/file-schema/wcf/custombinding.md) element.   
   
-2.  Inside the [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element, create a [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element with the `name` attribute set to `FederationDuplexTcpMessageSecurityBinding`.  
+2.  Inside the [\<customBinding>](../../../../docs/framework/configure-apps/file-schema/wcf/custombinding.md) element, create a [\<binding>](../../../../docs/framework/misc/binding.md) element with the `name` attribute set to `FederationDuplexTcpMessageSecurityBinding`.  
   
-3.  Inside the [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element, create a [\<security>](../../../../docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md) element with the `authenticationMode` attribute set to `SecureConversation`.  
+3.  Inside the [\<binding>](../../../../docs/framework/misc/binding.md) element, create a [\<security>](../../../../docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md) element with the `authenticationMode` attribute set to `SecureConversation`.  
   
 4.  Inside the [\<security>](../../../../docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md) element, create a [\<secureConversationBootstrap>](../../../../docs/framework/configure-apps/file-schema/wcf/secureconversationbootstrap.md) element with the `authenticationMode` attribute set to `IssuedTokenForCertificate` or `IssuedTokenForSslNegotiated`.  
   
@@ -50,11 +50,11 @@ manager: "erikre"
   
 ### To create a duplex federated custom binding with TCP mixed security mode  
   
-1.  In the [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) node of the configuration file, create a [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element.  
+1.  In the [\<bindings>](../../../../docs/framework/configure-apps/file-schema/wcf/bindings.md) node of the configuration file, create a [\<customBinding>](../../../../docs/framework/configure-apps/file-schema/wcf/custombinding.md) element.   
   
-2.  Inside the [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element, create a [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element with the `name` attribute set to `FederationDuplexTcpTransportSecurityWithMessageCredentialBinding`.  
+2.  Inside the [\<customBinding>](../../../../docs/framework/configure-apps/file-schema/wcf/custombinding.md) element, create a [\<binding>](../../../../docs/framework/misc/binding.md) element with the `name` attribute set to `FederationDuplexTcpTransportSecurityWithMessageCredentialBinding`.  
   
-3.  Inside the [\<oneWay>](../../../../docs/framework/configure-apps/file-schema/wcf/oneway.md) element, create a [\<security>](../../../../docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md) element with the `authenticationMode` attribute set to `SecureConversation`.  
+3.  Inside the [\<binding>](../../../../docs/framework/misc/binding.md) element, create a [\<security>](../../../../docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md) element with the `authenticationMode` attribute set to `SecureConversation`.  
   
 4.  Inside the [\<security>](../../../../docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md) element, create a [\<secureConversationBootstrap>](../../../../docs/framework/configure-apps/file-schema/wcf/secureconversationbootstrap.md) element with the `authenticationMode` attribute set to `IssuedTokenForCertificate` or `IssuedTokenForSslNegotiated`.  
   


### PR DESCRIPTION
The path of tags was wrong from the second configuration.

# Fix the path of tags

Change the old path from the second configuration, its start from `<oneWay>` element and not from `<bindings>`

## Summary

The path was fixed to match with the expected schema

@mairaw @yishengjin1413 @GuardRex  
