### PR TITLE
Mark tooling as preview

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -1,15 +1,15 @@
-| .NET Standard                     | [1.0] | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]  | [1.6]  | [2.0] |
-|-----------------------------------|-------|--------|-------|-------|-------|--------|--------|-------|
-| .NET Core                         | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0    | 1.0    | 2.0   |
-| .NET Framework (with tooling 1.0) | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2  |        |       |
-| .NET Framework (with tooling 2.0) | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1  | 4.6.1  | 4.6.1 |
-| Mono                              | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | vNext |
-| Xamarin.iOS                       | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | vNext |
-| Xamarin.Android                   | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | vNext |
-| Universal Windows Platform        | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | vNext  | vNext  | vNext |
-| Windows                           | 8.0   | 8.0    | 8.1   |       |       |        |        |       |
-| Windows Phone                     | 8.1   | 8.1    | 8.1   |       |       |        |        |       |
-| Windows Phone Silverlight         | 8.0   |        |       |       |       |        |        |       |
+| .NET Standard                             | [1.0] | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]  | [1.6]  | [2.0] |
+|-------------------------------------------|-------|--------|-------|-------|-------|--------|--------|-------|
+| .NET Core                                 | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0    | 1.0    | 2.0   |
+| .NET Framework (with tooling 1.0)         | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2  |        |       |
+| .NET Framework (with tooling 2.0 preview) | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1  | 4.6.1  | 4.6.1 |
+| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | vNext |
+| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | vNext |
+| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | vNext |
+| Universal Windows Platform                | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | vNext  | vNext  | vNext |
+| Windows                                   | 8.0   | 8.0    | 8.1   |       |       |        |        |       |
+| Windows Phone                             | 8.1   | 8.1    | 8.1   |       |       |        |        |       |
+| Windows Phone Silverlight                 | 8.0   |        |       |       |       |        |        |       |
 
 - The columns represent .NET Standard versions. Each header cell is a link to a document that shows which APIs got added in that version of .NET Standard.
 - The rows represent the different .NET platforms.


### PR DESCRIPTION
Based on [feedback we received here](https://github.com/dotnet/standard/issues/133#issuecomment-306971794) I've marked the .NET Standard 2.0 tooling as preview in the .NET Standard version table.

@mairaw 

/cc @Petermarcu @weshaggard @richlander 