### PR TITLE
Remove the Xamarin.Forms workload

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -59,7 +59,6 @@ By itself, .NET Core includes a single application model -- console apps -- whic
 
 - [ASP.NET Core](https://docs.microsoft.com/aspnet/core/)
 - [Windows 10 Universal Windows Platform (UWP)](https://developer.microsoft.com/windows)
-- [Xamarin.Forms](https://www.xamarin.com/forms)
 
 ### Open Source
 


### PR DESCRIPTION
I haven't seen any evidence besides this line that there is a relationship between .NET Core and Xamarin.Forms. Therefore, I doubt that this is an actual target workload for .NET Core. If I'm wrong, I'd love to know how to create a Xamarin.Forms project that uses the .NET Core runtime.
