### PR TITLE
Document APIs for the System.Composition.Hosting.Core Namespace.

### DIFF
--- a/xml/System.Composition.Hosting.Core/CompositeActivator.xml
+++ b/xml/System.Composition.Hosting.Core/CompositeActivator.xml
@@ -20,7 +20,7 @@
   <Docs>
     <param name="context">The context in which the part or export is being accessed.</param>
     <param name="operation">The operation within which the activation is occurring.</param>
-    <summary>The delegate signature that allows instances of parts and exports to be accessed during composition.</summary>
+    <summary>The delegate that allows instances of parts and exports to be accessed during composition.</summary>
     <returns>The activated part or export.</returns>
     <remarks></remarks>
   </Docs>

--- a/xml/System.Composition.Hosting.Core/CompositeActivator.xml
+++ b/xml/System.Composition.Hosting.Core/CompositeActivator.xml
@@ -18,10 +18,10 @@
     <ReturnType>System.Object</ReturnType>
   </ReturnValue>
   <Docs>
-    <param name="context">To be added.</param>
-    <param name="operation">To be added.</param>
-    <summary>To be added.</summary>
-    <returns>To be added.</returns>
-    <remarks>To be added.</remarks>
+    <param name="context">The context in which the part or export is being accessed.</param>
+    <param name="operation">The operation within which the activation is occurring.</param>
+    <summary>Represents a signature that allows instances of parts and exports to be accessed during composition.</summary>
+    <returns>The activated part or export.</returns>
+    <remarks></remarks>
   </Docs>
 </Type>

--- a/xml/System.Composition.Hosting.Core/CompositeActivator.xml
+++ b/xml/System.Composition.Hosting.Core/CompositeActivator.xml
@@ -20,7 +20,7 @@
   <Docs>
     <param name="context">The context in which the part or export is being accessed.</param>
     <param name="operation">The operation within which the activation is occurring.</param>
-    <summary>Represents a signature that allows instances of parts and exports to be accessed during composition.</summary>
+    <summary>The delegate signature that allows instances of parts and exports to be accessed during composition.</summary>
     <returns>The activated part or export.</returns>
     <remarks></remarks>
   </Docs>

--- a/xml/System.Composition.Hosting.Core/CompositionContract.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionContract.xml
@@ -31,7 +31,7 @@
       </Parameters>
       <Docs>
         <param name="contractType">The contract type.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"/> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -52,7 +52,7 @@
       <Docs>
         <param name="contractType">The contract type.</param>
         <param name="contractName">The contract name.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"/> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -75,7 +75,7 @@
         <param name="contractType">The contract type.</param>
         <param name="contractName">The contract name.</param>
         <param name="metadataConstraints">The metadata constraints for this contract.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"/> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -158,7 +158,7 @@
       </Parameters>
       <Docs>
         <param name="obj">The object to compare with this object.</param>
-        <summary>Determines whether the specified object is equal to this instance of <see cref="T:System.CompositionContract">.</summary>
+        <summary>Determines whether the specified object is equal to this instance of <see cref="T:System.CompositionContract"/>.</summary>
         <returns><see langword="true" /> if the specified object is equal to the current object; otherwise, <see langword="false" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -186,7 +186,7 @@
       <Parameters />
       <Docs>
         <summary>Serves as the default hash function.</summary>
-        <returns>A hash code for the current instance of <see cref="T:System.CompositionContract">.</returns>
+        <returns>A hash code for the current instance of <see cref="T:System.CompositionContract"/>.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -204,7 +204,7 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the metadata constraints for this instance of <see cref="T:System.CompositionContract">.</summary>
+        <summary>Gets the metadata constraints for this instance of <see cref="T:System.CompositionContract"/>.</summary>
         <value>The metadata constraints.</value>
         <remarks></remarks>
       </Docs>
@@ -224,7 +224,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Returns a string that represents the current instance of <see cref="T:System.CompositionContract">.</summary>
+        <summary>Returns a string that represents the current instance of <see cref="T:System.CompositionContract"/>.</summary>
         <returns>A string that represents the current object.</returns>
         <remarks></remarks>
       </Docs>
@@ -251,11 +251,11 @@
         <Parameter Name="remainingContract" Type="System.Composition.Hosting.Core.CompositionContract&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The type of the value of the constrained metadata item that will be returned in <param name="constraintValue">.</typeparam>
+        <typeparam name="T">The type of the value of the constrained metadata item that will be returned in <paramref name="constraintValue"/>.</typeparam>
         <param name="constraintName">The name of the constrained metadata item.</param>
-        <param name="constraintValue">When this method returns, contains a value of the type specified by <typeparam name="T"> that is the constraint value for the metadata item. This parameter is treated as uninitialized.</param>
-        <param name="remainingContract">When this method returns, contains a <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object that holds the remainder of the contract excluding the value returned in <param name="constraintValue">. This parameter is treated as uninitialized.</param>
-        <summary>Tries to extract the constraint value for the metadata item specified by <param name="constraintName">.</summary>
+        <param name="constraintValue">When this method returns, contains a value of the type specified by <typeparamref name="T"/> that is the constraint value for the metadata item. This parameter is treated as uninitialized.</param>
+        <param name="remainingContract">When this method returns, contains a <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object that holds the remainder of the contract excluding the value returned in <paramref name="constraintValue"/>. This parameter is treated as uninitialized.</param>
+        <summary>Tries to extract the constraint value for the metadata item specified by <paramref name="constraintName"/>.</summary>
         <returns><see langword="true" /> if the constrained metadata item was unwrapped and the value extracted; otherwise, <see langword="false" />.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Hosting.Core/CompositionContract.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionContract.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents an agreement between parts that allows the composition engine to match imports with exports.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -30,9 +30,9 @@
         <Parameter Name="contractType" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="contractType">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="contractType">The contract type.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -50,10 +50,10 @@
         <Parameter Name="contractName" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="contractType">To be added.</param>
-        <param name="contractName">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="contractType">The contract type.</param>
+        <param name="contractName">The contract name.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -72,11 +72,11 @@
         <Parameter Name="metadataConstraints" Type="System.Collections.Generic.IDictionary&lt;System.String,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="contractType">To be added.</param>
-        <param name="contractName">To be added.</param>
-        <param name="metadataConstraints">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="contractType">The contract type.</param>
+        <param name="contractName">The contract name.</param>
+        <param name="metadataConstraints">The metadata constraints for this contract.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ChangeType">
@@ -96,10 +96,10 @@
         <Parameter Name="newContractType" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="newContractType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="newContractType">The contract type to change to.</param>
+        <summary>Changes the contract to the specified type.</summary>
+        <returns>The modified contract.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ContractName">
@@ -116,9 +116,9 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the name of the contract.</summary>
+        <value>The contract name.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ContractType">
@@ -135,9 +135,9 @@
         <ReturnType>System.Type</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the contract type.</summary>
+        <value>The contract type.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -157,10 +157,17 @@
         <Parameter Name="obj" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="obj">The object to compare with this object.</param>
+        <summary>Determines whether the specified object is equal to this instance of <see cref="T:System.CompositionContract">.</summary>
+        <returns><see langword="true" /> if the specified object is equal to the current object; otherwise, <see langword="false" />.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The type of comparison between the current instance and the <paramref name="obj"/> parameter depends on whether the current instance is a reference type or a value type.
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -178,9 +185,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Serves as the default hash function.</summary>
+        <returns>A hash code for the current instance of <see cref="T:System.CompositionContract">.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="MetadataConstraints">
@@ -197,9 +204,9 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the metadata constraints for this instance of <see cref="T:System.CompositionContract">.</summary>
+        <value>The metadata constraints.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -217,9 +224,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Returns a string that represents the current instance of <see cref="T:System.CompositionContract">.</summary>
+        <returns>A string that represents the current object.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="TryUnwrapMetadataConstraint&lt;T&gt;">
@@ -244,13 +251,13 @@
         <Parameter Name="remainingContract" Type="System.Composition.Hosting.Core.CompositionContract&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <typeparam name="T">To be added.</typeparam>
-        <param name="constraintName">To be added.</param>
-        <param name="constraintValue">To be added.</param>
-        <param name="remainingContract">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="T">The type of the value of the constrained metadata item that will be returned in <param name="constraintValue">.</typeparam>
+        <param name="constraintName">The name of the constrained metadata item.</param>
+        <param name="constraintValue">When this method returns, contains a value of the type specified by <typeparam name="T"> that is the constraint value for the metadata item. This parameter is treated as uninitialized.</param>
+        <param name="remainingContract">When this method returns, contains a <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object that holds the remainder of the contract excluding the value returned in <param name="constraintValue">. This parameter is treated as uninitialized.</param>
+        <summary>Tries to extract the constraint value for the metadata item specified by <param name="constraintName">.</summary>
+        <returns><see langword="true" /> if the constrained metadata item was unwrapped and the value extracted; otherwise, <see langword="false" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/CompositionContract.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionContract.xml
@@ -31,7 +31,7 @@
       </Parameters>
       <Docs>
         <param name="contractType">The contract type.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> class with the specified contract type.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -52,7 +52,7 @@
       <Docs>
         <param name="contractType">The contract type.</param>
         <param name="contractName">The contract name.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> class with the specified contract name and type.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -74,8 +74,8 @@
       <Docs>
         <param name="contractType">The contract type.</param>
         <param name="contractName">The contract name.</param>
-        <param name="metadataConstraints">The metadata constraints for this contract.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.CompositionContract"/> class.</summary>
+        <param name="metadataConstraints">A collection of metadata constraints for the contract.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> class with the specified contract name, type, and metadata constraints.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -96,9 +96,9 @@
         <Parameter Name="newContractType" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="newContractType">The contract type to change to.</param>
-        <summary>Changes the contract to the specified type.</summary>
-        <returns>The modified contract.</returns>
+        <param name="newContractType">The new contract type.</param>
+        <summary>Creates a new contract that has the specified type but the same name and constraints as this object.</summary>
+        <returns>The created contract.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -158,16 +158,9 @@
       </Parameters>
       <Docs>
         <param name="obj">The object to compare with this object.</param>
-        <summary>Determines whether the specified object is equal to this instance of <see cref="T:System.CompositionContract"/>.</summary>
+        <summary>Determines whether the specified object is equal to this instance of <see cref="T:System.Composition.Hosting.Core.CompositionContract"/>.</summary>
         <returns><see langword="true" /> if the specified object is equal to the current object; otherwise, <see langword="false" />.</returns>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The type of comparison between the current instance and the <paramref name="obj"/> parameter depends on whether the current instance is a reference type or a value type.
-  
- ]]></format>
-        </remarks>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -185,8 +178,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Serves as the default hash function.</summary>
-        <returns>A hash code for the current instance of <see cref="T:System.CompositionContract"/>.</returns>
+        <summary>Returns the hash code for this <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object.</summary>
+        <returns>The hash code for the current object.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -204,8 +197,8 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Collections.Generic.KeyValuePair&lt;System.String,System.Object&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the metadata constraints for this instance of <see cref="T:System.CompositionContract"/>.</summary>
-        <value>The metadata constraints.</value>
+        <summary>Gets a collection of metadata constraints for the contract.</summary>
+        <value>A collection of metadata constraints.</value>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -224,8 +217,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Returns a string that represents the current instance of <see cref="T:System.CompositionContract"/>.</summary>
-        <returns>A string that represents the current object.</returns>
+        <summary>Returns the string representation of this <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object.</summary>
+        <returns>The string representation of this <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -251,11 +244,11 @@
         <Parameter Name="remainingContract" Type="System.Composition.Hosting.Core.CompositionContract&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <typeparam name="T">The type of the value of the constrained metadata item that will be returned in <paramref name="constraintValue"/>.</typeparam>
-        <param name="constraintName">The name of the constrained metadata item.</param>
-        <param name="constraintValue">When this method returns, contains a value of the type specified by <typeparamref name="T"/> that is the constraint value for the metadata item. This parameter is treated as uninitialized.</param>
-        <param name="remainingContract">When this method returns, contains a <see cref="T:System.Composition.Hosting.Core.CompositionContract"/> object that holds the remainder of the contract excluding the value returned in <paramref name="constraintValue"/>. This parameter is treated as uninitialized.</param>
-        <summary>Tries to extract the constraint value for the metadata item specified by <paramref name="constraintName"/>.</summary>
+        <typeparam name="T">The type of the metadata constraint value.</typeparam>
+        <param name="constraintName">The name of the metadata constraint.</param>
+        <param name="constraintValue">When this method returns, contains the value of the constraint if it was found. This parameter is treated as uninitialized.</param>
+        <param name="remainingContract">When this method returns, holds the contract with the constraint removed, if the constraint was found. This parameter is treated as uninitialized.</param>
+        <summary>Gets a metadata constraint that has the specified type and name, if it exists.</summary>
         <returns><see langword="true" /> if the constrained metadata item was unwrapped and the value extracted; otherwise, <see langword="false" />.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Hosting.Core/CompositionDependency.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionDependency.xml
@@ -80,7 +80,7 @@
         <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- A missing dependency is an error, and is different from an optional dependency.
+ A missing dependency is an error. A missing dependency is different from an optional dependency.
   
  ]]></format>
        </remarks>

--- a/xml/System.Composition.Hosting.Core/CompositionDependency.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionDependency.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents a dependency that a part must have in order to fulfill an <see cref="T:ExportDescriptorPromise"/>. This class is used by the composition engine during initialization to determine whether the composition can be made, and if not, what error to provide.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Contract">
@@ -30,9 +30,9 @@
         <ReturnType>System.Composition.Hosting.Core.CompositionContract</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the contract required by the dependency.</summary>
+        <value>The contract required by the dependency.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="IsPrerequisite">
@@ -49,9 +49,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a value indicating whether the dependency is a prerequisite that must be satisfied before any exports can be retrieved from the dependent part.</summary>
+        <value><see langword="true" /> if the dependency is a prerequisite; otherwise, <see langword="false" />.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Missing">
@@ -72,11 +72,18 @@
         <Parameter Name="site" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="site">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contract">">The contract required by the dependency.</param>
+        <param name="site">A marker used to identify the individual dependency among those on the dependent part.</param>
+        <summary>Constructs a placeholder for a missing dependency.</summary>
+        <returns>The dependency that acts as a placeholder.</returns>
+        <remarks>
+        <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ A missing dependency is an error, and is different from an optional dependency.
+  
+ ]]></format>
+       </remarks>
       </Docs>
     </Member>
     <Member MemberName="Oversupplied">
@@ -98,12 +105,12 @@
         <Parameter Name="site" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="targets">To be added.</param>
-        <param name="site">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contract">The contract required by the dependency.</param>
+        <param name="targets">The multiple targets found when only one is expected.</param>
+        <param name="site">A marker used to identify the individual dependency among those on the dependent part.</param>
+        <summary>Constructs a placeholder for an "exactly one" dependency that cannot be configured because multiple target implementations exist.</summary>
+        <returns>The dependency that acts as a placeholder.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Satisfied">
@@ -126,13 +133,13 @@
         <Parameter Name="site" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="target">To be added.</param>
-        <param name="isPrerequisite">To be added.</param>
-        <param name="site">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contract">The contract required by the dependency.</param>
+        <param name="target">The <see cref="T:ExportDescriptorPromise"/> from another part that this part is dependent on.</param>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency is a prerequisite that must be satisfied before any exports can be retrieved from the dependent part; otherwise, <see langword="false" />.</param>
+        <param name="site">A marker used to identify the individual dependency among those on the dependent part.</param>
+        <summary>Constructs a dependency on the specified target.</summary>
+        <returns>The dependency constructed for the specified target.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Site">
@@ -149,9 +156,9 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a marker used to identify the individual dependency among those on the dependent part.</summary>
+        <value>The marker that identifies the dependency.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Target">
@@ -168,9 +175,9 @@
         <ReturnType>System.Composition.Hosting.Core.ExportDescriptorPromise</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the export descriptor promise from another part that this part is dependent on.</summary>
+        <value>The export descriptor promise.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -188,9 +195,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Creates a human-readable explanation of the dependency.</summary>
+        <returns>The dependency represented as a string.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/CompositionDependency.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionDependency.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Represents a dependency that a part must have in order to fulfill an <see cref="T:ExportDescriptorPromise"/>. This class is used by the composition engine during initialization to determine whether the composition can be made, and if not, what error to provide.</summary>
+    <summary>Represents a dependency that a part must have in order to fulfill an <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/>. This class is used by the composition engine during initialization to determine whether the composition can be made, and if not, what error to provide.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -106,10 +106,10 @@
       </Parameters>
       <Docs>
         <param name="contract">The contract required by the dependency.</param>
-        <param name="targets">The multiple targets found when only one is expected.</param>
-        <param name="site">A marker used to identify the individual dependency among those on the dependent part.</param>
-        <summary>Constructs a placeholder for an "exactly one" dependency that cannot be configured because multiple target implementations exist.</summary>
-        <returns>The dependency that acts as a placeholder.</returns>
+        <param name="targets">A collection of the supplied values.</param>
+        <param name="site">A marker for the dependency.</param>
+        <summary>Constructs a placeholder for a dependency that has too many supplied values.</summary>
+        <returns>The placeholder dependency.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -134,11 +134,11 @@
       </Parameters>
       <Docs>
         <param name="contract">The contract required by the dependency.</param>
-        <param name="target">The <see cref="T:ExportDescriptorPromise"/> from another part that this part is dependent on.</param>
+        <param name="target">The dependency target. A <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/> from another part that this part is dependent on.</param>
         <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency is a prerequisite that must be satisfied before any exports can be retrieved from the dependent part; otherwise, <see langword="false" />.</param>
         <param name="site">A marker used to identify the individual dependency among those on the dependent part.</param>
         <summary>Constructs a dependency on the specified target.</summary>
-        <returns>The dependency constructed for the specified target.</returns>
+        <returns>The constructed dependency.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -156,8 +156,8 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a marker used to identify the individual dependency among those on the dependent part.</summary>
-        <value>The marker that identifies the dependency.</value>
+        <summary>Gets a marker used to identify the dependency among those on the dependent part.</summary>
+        <value>The marker.</value>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -175,7 +175,7 @@
         <ReturnType>System.Composition.Hosting.Core.ExportDescriptorPromise</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the export descriptor promise from another part that this part is dependent on.</summary>
+        <summary>Gets the export descriptor promise that the dependecy is on.</summary>
         <value>The export descriptor promise.</value>
         <remarks></remarks>
       </Docs>
@@ -195,8 +195,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Creates a human-readable explanation of the dependency.</summary>
-        <returns>The dependency represented as a string.</returns>
+        <summary>Returns the string representation of this <see cref="T:System.Composition.Hosting.Core.CompositionDependency"/> object.</summary>
+        <returns>The string representation of <see cref="T:System.Composition.Hosting.Core.CompositionDependency"/>.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/CompositionOperation.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionOperation.xml
@@ -16,15 +16,8 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Represents a single logical graph-building operation.</summary>
-    <remarks>
-    <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Instances of this class are not safe for access by multiple threads.
-  
- ]]></format>
-    </remarks>
+    <summary>Represents a single composition operation.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="AddNonPrerequisiteAction">
@@ -75,12 +68,13 @@
       </Parameters>
       <Docs>
         <param name="action">The action to run.</param>
-        <summary>Specifies an action to run during the activation process, after all composition has completed.</summary>
+        <summary>Specifies an action to run after all composition has completed, as indicated by the <see cref="T:System.Composition.OnImportsSatisfiedAttribute"/>.
+        </summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- For an indication of when composition has completed, see <xref:System.Composition.OnImportsSatisfiedAttribute>.
+ This method is called during the activation process.
   
  ]]></format>        
         </remarks>
@@ -101,7 +95,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Releases locks held during the composition operation.</summary>
+        <summary>Releases all locks held during the composition operation.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -125,7 +119,7 @@
       <Docs>
         <param name="outermostLifetimeContext">The context in which to begin the operation (the operation can flow to the parents of the context if required).</param>
         <param name="compositionRootActivator">The activator that drives the operation.</param>
-        <summary>Executes a new composition operation starting within the specified lifetime context, for the specified activator.</summary>
+        <summary>Runs the composition operation starting within the specified lifetime context, driven by the specified activator.</summary>
         <returns>The composed object graph.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Hosting.Core/CompositionOperation.xml
+++ b/xml/System.Composition.Hosting.Core/CompositionOperation.xml
@@ -16,8 +16,15 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents a single logical graph-building operation.</summary>
+    <remarks>
+    <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Instances of this class are not safe for access by multiple threads.
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName="AddNonPrerequisiteAction">
@@ -37,9 +44,17 @@
         <Parameter Name="action" Type="System.Action" />
       </Parameters>
       <Docs>
-        <param name="action">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="action">The action to run.</param>
+        <summary>Specifies an action that can run after all prerequisite part dependencies have been satisfied.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This method is called during the activation process.
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ArgumentNullException"><paramref name="action"/> is <see langword="null" />.</exception>
       </Docs>
     </Member>
     <Member MemberName="AddPostCompositionAction">
@@ -59,9 +74,16 @@
         <Parameter Name="action" Type="System.Action" />
       </Parameters>
       <Docs>
-        <param name="action">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="action">The action to run.</param>
+        <summary>Specifies an action to run during the activation process, after all composition has completed.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ For an indication of when composition has completed, see <xref:System.Composition.OnImportsSatisfiedAttribute>.
+  
+ ]]></format>        
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -79,8 +101,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Releases locks held during the composition operation.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Run">
@@ -101,11 +123,11 @@
         <Parameter Name="compositionRootActivator" Type="System.Composition.Hosting.Core.CompositeActivator" />
       </Parameters>
       <Docs>
-        <param name="outermostLifetimeContext">To be added.</param>
-        <param name="compositionRootActivator">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="outermostLifetimeContext">The context in which to begin the operation (the operation can flow to the parents of the context if required).</param>
+        <param name="compositionRootActivator">The activator that drives the operation.</param>
+        <summary>Executes a new composition operation starting within the specified lifetime context, for the specified activator.</summary>
+        <returns>The composed object graph.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/DependencyAccessor.xml
+++ b/xml/System.Composition.Hosting.Core/DependencyAccessor.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Represents an accessor that allows <see cref="T:System.Composition.Hosting.Core.ExportDescriptorProvider"/> objects to locate dependencies.</summary>
+    <summary>Allows <see cref="T:System.Composition.Hosting.Core.ExportDescriptorProvider"/> objects to locate their dependencies.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -28,7 +28,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="T:DependencyAccessor"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.DependencyAccessor"/> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -56,9 +56,9 @@
         <Parameter Name="exportKey" Type="System.Composition.Hosting.Core.CompositionContract" />
       </Parameters>
       <Docs>
-        <param name="exportKey">The export key that the definitions must supply.</param>
-        <summary>Retrieves all definitions for the specified export key (a <see cref="T:System.Composition.Hosting.Core.CompositionContract"/>).</summary>
-        <returns>The available definitions that match the export key.</returns>
+        <param name="exportKey">The export key that the promises must supply.</param>
+        <summary>Retrieves all promises for the specified contract.</summary>
+        <returns>A collection of promises for the contract.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -81,11 +81,11 @@
         <Parameter Name="isPrerequisite" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="site">A tag describing the dependency site.</param>
+        <param name="site">A tag that describes the dependency site.</param>
         <param name="contract">The contract required by the site.</param>
-        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before corresponding exports can be retrieved; otherwise, <see langword="false" />.</param>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before exports are made available; otherwise, <see langword="false" />.</param>
         <summary>Resolves dependencies on all implementations of a contract.</summary>
-        <returns>Dependencies for all implementations of the contact.</returns>
+        <returns>A collection of resolved dependencies.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -108,11 +108,11 @@
         <Parameter Name="isPrerequisite" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="site">A tag describing the dependency site.</param>
+        <param name="site">A tag that describes the dependency site.</param>
         <param name="contract">The contract required by the site.</param>
-        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before corresponding exports can be retrieved; otherwise, <see langword="false" />.</param>
-        <summary>Resolves a required dependency on exactly one implementation of a contract.</summary>
-        <returns>The dependency.</returns>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before exports are made available; otherwise, <see langword="false" />.</param>
+        <summary>Resolves a required dependency on one implementation of a contract.</summary>
+        <returns>The resolved dependency.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -136,12 +136,12 @@
         <Parameter Name="dependency" Type="System.Composition.Hosting.Core.CompositionDependency&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="site">A tag describing the dependency site.</param>
+        <param name="site">A tag that describes the dependency site.</param>
         <param name="contract">The contract required by the site.</param>
-        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before corresponding exports can be retrieved; otherwise, <see langword="false" />.</param>
-        <param name="dependency">The dependency, or <see langword="null" />.</param>
-        <summary>Resolves an optional dependency on exactly one implementation of a contract.</summary>
-        <returns><see langword="true" /> if the dependency could be resolved; otherwise, <see langword="false"/>.</returns>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before exports are made available; otherwise, <see langword="false" />.</param>
+        <param name="dependency">After this method returns, contains the resolved dependency or <see langword="null" />.</param>
+        <summary>Resolves an optional dependency on one implementation of a contract.</summary>
+        <returns><see langword="true" /> if the dependency was resolved; otherwise, <see langword="false"/>.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/DependencyAccessor.xml
+++ b/xml/System.Composition.Hosting.Core/DependencyAccessor.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents an accessor that allows <see cref="T:ExportDescriptorProvider"/> objects to locate dependencies.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -28,8 +28,15 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Creates a new instance of the <see cref="DependencyAccessor"/> class.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This is a protected constructor that can only be called from derived classes.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetPromises">
@@ -49,10 +56,10 @@
         <Parameter Name="exportKey" Type="System.Composition.Hosting.Core.CompositionContract" />
       </Parameters>
       <Docs>
-        <param name="exportKey">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="exportKey">The export key that the definitions must supply.</param>
+        <summary>Retrieves all definitions for the specified export key (a <see cref="CompositionContract"/>).</summary>
+        <returns>The available definitions that match the export key.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ResolveDependencies">
@@ -74,12 +81,12 @@
         <Parameter Name="isPrerequisite" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="site">To be added.</param>
-        <param name="contract">To be added.</param>
-        <param name="isPrerequisite">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="site">A tag describing the dependency site.</param>
+        <param name="contract">The contract required by the site.</param>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before corresponding exports can be retrieved; otherwise, <see langword="false" />.</param>
+        <summary>Resolves dependencies on all implementations of a contract.</summary>
+        <returns>Dependencies for all implementations of the contact.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ResolveRequiredDependency">
@@ -101,12 +108,12 @@
         <Parameter Name="isPrerequisite" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="site">To be added.</param>
-        <param name="contract">To be added.</param>
-        <param name="isPrerequisite">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="site">A tag describing the dependency site.</param>
+        <param name="contract">The contract required by the site.</param>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before corresponding exports can be retrieved; otherwise, <see langword="false" />.</param>
+        <summary>Resolves a required dependency on exactly one implementation of a contract.</summary>
+        <returns>The dependency.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="TryResolveOptionalDependency">
@@ -129,13 +136,13 @@
         <Parameter Name="dependency" Type="System.Composition.Hosting.Core.CompositionDependency&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="site">To be added.</param>
-        <param name="contract">To be added.</param>
-        <param name="isPrerequisite">To be added.</param>
-        <param name="dependency">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="site">A tag describing the dependency site.</param>
+        <param name="contract">The contract required by the site.</param>
+        <param name="isPrerequisite"><see langword="true" /> to indicate that the dependency must be satisfied before corresponding exports can be retrieved; otherwise, <see langword="false" />.</param>
+        <param name="dependency">The dependency, or <see langword="null" />.</param>
+        <summary>Resolves an optional dependency on exactly one implementation of a contract.</summary>
+        <returns><see langword="true" /> if the dependency could be resolved; otherwise, <see langword="false"/>.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/DependencyAccessor.xml
+++ b/xml/System.Composition.Hosting.Core/DependencyAccessor.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Represents an accessor that allows <see cref="T:ExportDescriptorProvider"/> objects to locate dependencies.</summary>
+    <summary>Represents an accessor that allows <see cref="T:System.Composition.Hosting.Core.ExportDescriptorProvider"/> objects to locate dependencies.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -28,7 +28,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="DependencyAccessor"/> class.</summary>
+        <summary>Creates a new instance of the <see cref="T:DependencyAccessor"/> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -57,7 +57,7 @@
       </Parameters>
       <Docs>
         <param name="exportKey">The export key that the definitions must supply.</param>
-        <summary>Retrieves all definitions for the specified export key (a <see cref="CompositionContract"/>).</summary>
+        <summary>Retrieves all definitions for the specified export key (a <see cref="T:System.Composition.Hosting.Core.CompositionContract"/>).</summary>
         <returns>The available definitions that match the export key.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptor.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptor.xml
@@ -12,8 +12,15 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Describes the export of a part known to the composition engine.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This is the only runtime overhead that is maintained per-part; all other part-specific information must be discarded once its export descriptors have been retrieved.  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -28,8 +35,15 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Creates a new instance of the <see cref="ExportDescriptor"/> class.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This is a protected constructor that can only be called from derived classes.  
+  
+ ]]></format>
+        </remarks>      
       </Docs>
     </Member>
     <Member MemberName="Activator">
@@ -46,9 +60,9 @@
         <ReturnType>System.Composition.Hosting.Core.CompositeActivator</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the activator used to retrieve instances of the export.</summary>
+        <value>The activator.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Create">
@@ -69,11 +83,11 @@
         <Parameter Name="metadata" Type="System.Collections.Generic.IDictionary&lt;System.String,System.Object&gt;" />
       </Parameters>
       <Docs>
-        <param name="activator">To be added.</param>
-        <param name="metadata">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="activator">The activator used to retrieve instances of the export.</param>
+        <param name="metadata">The metadata associated with the export.</param>
+        <summary>Constructs an <see cref="ExportDescriptor"/>.</summary>
+        <returns>The export descriptor.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Metadata">
@@ -90,9 +104,9 @@
         <ReturnType>System.Collections.Generic.IDictionary&lt;System.String,System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the metadata associated with the export.</summary>
+        <value>The export metadata./value>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptor.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptor.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Describes the export of a part known to the composition engine.</summary>
+    <summary>Describes an export of a part known to the composition engine.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
@@ -35,7 +35,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="T:ExportDescriptor"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.ExportDescriptor"/> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -85,8 +85,8 @@
       <Docs>
         <param name="activator">The activator used to retrieve instances of the export.</param>
         <param name="metadata">The metadata associated with the export.</param>
-        <summary>Constructs an <see cref="T:ExportDescriptor"/>.</summary>
-        <returns>The export descriptor.</returns>
+        <summary>Creates an export descriptor that has the specified activator and metadata.</summary>
+        <returns>The created descriptor.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -104,8 +104,8 @@
         <ReturnType>System.Collections.Generic.IDictionary&lt;System.String,System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the metadata associated with the export.</summary>
-        <value>The export metadata.</value>
+        <summary>Gets the metadata for the export.</summary>
+        <value>A collection of metadata.</value>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptor.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptor.xml
@@ -35,7 +35,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="ExportDescriptor"/> class.</summary>
+        <summary>Creates a new instance of the <see cref="T:ExportDescriptor"/> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -85,7 +85,7 @@
       <Docs>
         <param name="activator">The activator used to retrieve instances of the export.</param>
         <param name="metadata">The metadata associated with the export.</param>
-        <summary>Constructs an <see cref="ExportDescriptor"/>.</summary>
+        <summary>Constructs an <see cref="T:ExportDescriptor"/>.</summary>
         <returns>The export descriptor.</returns>
         <remarks></remarks>
       </Docs>
@@ -105,7 +105,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the metadata associated with the export.</summary>
-        <value>The export metadata./value>
+        <value>The export metadata.</value>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptorPromise.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptorPromise.xml
@@ -41,12 +41,12 @@
         <Parameter Name="getDescriptor" Type="System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.CompositionDependency&gt;,System.Composition.Hosting.Core.ExportDescriptor&gt;" />
       </Parameters>
       <Docs>
-        <param name="contract">The contract fulfilled by this promise.</param>
-        <param name="origin">The description of where the export is being provided from. For example, the part type.</param>
-        <param name="isShared"><see langword="true" /> if the export is shared within some context, otherwise <see langword="false" />.</param>
-        <param name="dependencies">A function providing dependencies required in order to fulfill the promise.</param>
-        <param name="getDescriptor">A function providing the promise.</param>
-        <summary>Creates a promise for an export descriptor.</summary>
+        <param name="contract">The promised contract.</param>
+        <param name="origin">A description of the promise's origin. For example, a part type.</param>
+        <param name="isShared"><see langword="true" /> if the promise is shared, otherwise <see langword="false" />.</param>
+        <param name="dependencies">A function that provides the dependencies required to fulfill the promise.</param>
+        <param name="getDescriptor">A function that provides the promised descriptor.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -83,8 +83,8 @@
         <ReturnType>System.Collections.ObjectModel.ReadOnlyCollection&lt;System.Composition.Hosting.Core.CompositionDependency&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the dependencies that are required to fulfill the promise.</summary>
-        <value>The dependecies.</value>
+        <summary>Gets the dependencies that are required to fulfill this promise.</summary>
+        <value>A collection of dependencies.</value>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -103,8 +103,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Retrieves the promised export descriptor.</summary>
-        <returns>The export descriptor.</returns>
+        <summary>Retrieves the promised descriptor.</summary>
+        <returns>The descriptor.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -122,16 +122,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a value that indicates whether the export is shared within some context.</summary>
-        <value><see langword="true"/> if the export is shared within some context; otherwise, <see langword="false"/>.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The description contained in this property is used in cycle checking.
-  
- ]]></format>
-        </remarks>
+        <summary>Gets a value that indicates whether the promise is shared.</summary>
+        <value><see langword="true"/> if the promise is shared within some context; otherwise, <see langword="false"/>.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Origin">
@@ -148,16 +141,9 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a description of where the export is being provided from. For example, the part type.</summary>
-        <value>The description.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- The description contained in this property is used to provide friendly errors.
-  
- ]]></format>
-        </remarks>
+        <summary>Gets a description of where the promise originates (for example, a part type), used to provide readable errors.</summary>
+        <value>A description of the promise's origin.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -175,8 +161,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Describes the promise.</summary>
-        <returns>A description of the promise.</returns>
+        <summary>Returns the string representation of this <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"> object.</summary>
+        <returns>The string representation of this <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"> object.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptorPromise.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptorPromise.xml
@@ -12,8 +12,15 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents an export descriptor that an available part can provide.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This type is central to the cycle-checking, adaptation, and compilation features of the container.  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -34,13 +41,13 @@
         <Parameter Name="getDescriptor" Type="System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.CompositionDependency&gt;,System.Composition.Hosting.Core.ExportDescriptor&gt;" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="origin">To be added.</param>
-        <param name="isShared">To be added.</param>
-        <param name="dependencies">To be added.</param>
-        <param name="getDescriptor">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="contract">The contract fulfilled by this promise.</param>
+        <param name="origin">The description of where the export is being provided from. For example, the part type.</param>
+        <param name="isShared"><see langword="true" /> if the export is shared within some context, otherwise <see langword="false" />.</param>
+        <param name="dependencies">A function providing dependencies required in order to fulfill the promise.</param>
+        <param name="getDescriptor">A function providing the promise.</param>
+        <summary>Creates a promise for an export descriptor.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Contract">
@@ -57,9 +64,9 @@
         <ReturnType>System.Composition.Hosting.Core.CompositionContract</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the contract fulfilled by this promise.</summary>
+        <value>The contract</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Dependencies">
@@ -76,9 +83,9 @@
         <ReturnType>System.Collections.ObjectModel.ReadOnlyCollection&lt;System.Composition.Hosting.Core.CompositionDependency&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the dependencies that are required to fulfill the promise.</summary>
+        <value>The dependecies.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetDescriptor">
@@ -96,9 +103,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Retrieves the promised export descriptor.</summary>
+        <returns>The export descriptor.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="IsShared">
@@ -115,9 +122,16 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a value that indicates whether the export is shared within some context.</summary>
+        <value><see langword="true"/> if the export is shared within some context; otherwise, <see langword="false"/>.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The description contained in this property is used in cycle checking.
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Origin">
@@ -134,9 +148,16 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a description of where the export is being provided from. For example, the part type.</summary>
+        <value>The description.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The description contained in this property is used to provide friendly errors.
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -154,9 +175,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Describes the promise.</summary>
+        <returns>A description of the promise.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptorPromise.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptorPromise.xml
@@ -46,7 +46,7 @@
         <param name="isShared"><see langword="true" /> if the promise is shared, otherwise <see langword="false" />.</param>
         <param name="dependencies">A function that provides the dependencies required to fulfill the promise.</param>
         <param name="getDescriptor">A function that provides the promised descriptor.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -161,8 +161,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Returns the string representation of this <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"> object.</summary>
-        <returns>The string representation of this <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"> object.</returns>
+        <summary>Returns the string representation of this <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/> object.</summary>
+        <returns>The string representation of this <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/> object.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptorProvider.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptorProvider.xml
@@ -13,14 +13,7 @@
   <Interfaces />
   <Docs>
     <summary>Provides the description of an export for a part known to the composition engine.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- Instances of this class are not required to be safe for concurrent access by multiple threads.  
-  
- ]]></format>
-    </remarks>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,7 +28,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="T:ExportDescriptorProvider"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.Core.ExportDescriptorProvider"/> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -65,14 +58,14 @@
       </Parameters>
       <Docs>
         <param name="contract">The export key required by another component.</param>
-        <param name="descriptorAccessor">The accessor that accesses the other export descriptors present in the composition.</param>
+        <param name="descriptorAccessor">An accessor for the other descriptors in the composition.</param>
         <summary>Retrieves promise export descriptors for the specified export key.</summary>
-        <returns>Promises for new export descriptors.</returns>
+        <returns>A collection of promises for new export descriptors.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- A provider will only be queried once for each unique export key. The descriptor accessor can only be queried immediately if the descriptor being promised is an adapter, such as <see cref="Lazy{T}"/>; otherwise, dependencies should only be queried within execution of the function provided to the <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/>. The actual descriptors provided by this method, must not close over or reference any aspect of the dependency/promise structure, as this would prevent the structure from being garbage collected.  
+ A provider will only be queried once for each unique export key. The descriptor accessor can only be queried immediately if the descriptor being promised is an adapter, such as <see cref="Lazy{T}"/>; otherwise, dependencies should only be queried within execution of the function provided to the <xref:System.Composition.Hosting.Core.ExportDescriptorPromise>. The actual descriptors provided by this method, must not close over or reference any aspect of the dependency/promise structure, as this would prevent the structure from being garbage collected.  
   
  ]]></format>
         </remarks>
@@ -92,7 +85,7 @@
         <ReturnType>System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.CompositionDependency&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Provides a constant value so that subclasses can avoid creating additional duplicate values.</summary>
+        <summary>Indicates a lack of dependencies.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -110,7 +103,7 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.ExportDescriptorPromise&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Provides a constant value so that subclasses can avoid creating additional duplicate values.</summary>
+        <summary>Indicates a lack of export descriptors.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -128,7 +121,7 @@
         <ReturnType>System.Collections.Generic.IDictionary&lt;System.String,System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Provides a constant value so that subclasses can avoid creating additional duplicate values.</summary>
+        <summary>Indicates a lack of metadata.</summary>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptorProvider.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptorProvider.xml
@@ -35,7 +35,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="ExportDescriptorProvider"/> class.</summary>
+        <summary>Creates a new instance of the <see cref="T:ExportDescriptorProvider"/> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -72,7 +72,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- A provider will only be queried once for each unique export key. The descriptor accessor can only be queried immediately if the descriptor being promised is an adapter, such as <see cref="Lazy{T}"/>; otherwise, dependencies should only be queried within execution of the function provided to the <see cref="T:ExportDescriptorPromise"/>. The actual descriptors provided by this method, must not close over or reference any aspect of the dependency/promise structure, as this would prevent the structure from being garbage collected.  
+ A provider will only be queried once for each unique export key. The descriptor accessor can only be queried immediately if the descriptor being promised is an adapter, such as <see cref="Lazy{T}"/>; otherwise, dependencies should only be queried within execution of the function provided to the <see cref="T:System.Composition.Hosting.Core.ExportDescriptorPromise"/>. The actual descriptors provided by this method, must not close over or reference any aspect of the dependency/promise structure, as this would prevent the structure from being garbage collected.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Composition.Hosting.Core/ExportDescriptorProvider.xml
+++ b/xml/System.Composition.Hosting.Core/ExportDescriptorProvider.xml
@@ -12,8 +12,15 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Provides the description of an export for a part known to the composition engine.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Instances of this class are not required to be safe for concurrent access by multiple threads.  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -28,8 +35,15 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Creates a new instance of the <see cref="ExportDescriptorProvider"/> class.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This is a protected constructor that can only be called from derived classes.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetExportDescriptors">
@@ -50,11 +64,18 @@
         <Parameter Name="descriptorAccessor" Type="System.Composition.Hosting.Core.DependencyAccessor" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="descriptorAccessor">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contract">The export key required by another component.</param>
+        <param name="descriptorAccessor">The accessor that accesses the other export descriptors present in the composition.</param>
+        <summary>Retrieves promise export descriptors for the specified export key.</summary>
+        <returns>Promises for new export descriptors.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ A provider will only be queried once for each unique export key. The descriptor accessor can only be queried immediately if the descriptor being promised is an adapter, such as <see cref="Lazy{T}"/>; otherwise, dependencies should only be queried within execution of the function provided to the <see cref="T:ExportDescriptorPromise"/>. The actual descriptors provided by this method, must not close over or reference any aspect of the dependency/promise structure, as this would prevent the structure from being garbage collected.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="NoDependencies">
@@ -71,8 +92,8 @@
         <ReturnType>System.Func&lt;System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.CompositionDependency&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Provides a constant value so that subclasses can avoid creating additional duplicate values.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="NoExportDescriptors">
@@ -89,8 +110,8 @@
         <ReturnType>System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.ExportDescriptorPromise&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Provides a constant value so that subclasses can avoid creating additional duplicate values.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="NoMetadata">
@@ -107,8 +128,8 @@
         <ReturnType>System.Collections.Generic.IDictionary&lt;System.String,System.Object&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Provides a constant value so that subclasses can avoid creating additional duplicate values.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting.Core/LifetimeContext.xml
+++ b/xml/System.Composition.Hosting.Core/LifetimeContext.xml
@@ -24,7 +24,7 @@
 The <xref:System.Composition.Hosting.Core.LifetimeContext> object is the unit of sharing for shared parts. It controls the disposal of bound parts and can be used to retrieve instances, either as part of an existing composition operation or as the basis of a new composition operation. An individual lifetime context can be marked to contain parts that are constrained by particular sharing boundaries.
 
 This object contains two pieces of independently protected shared state: shared part instances and bound part instances. 
-A shared part instance is lock-free readable and does not result in issues if it is added to during disposal. It is protected by being locked itself. Activation logic is unavoidably called under this lock. 
+A shared part instance is lock-free, readable, and does not result in issues if it is added to during disposal. It is protected by being locked itself. Activation logic is unavoidably called under this lock. 
 A bound part instance is always protected by locking <see langword="this" />, and should never be written to after disposal. A bound part instance is set to <see langword="null" /> under a lock in the <xref:System.Composition.Hosting.Core.LifetimeContext.Dispose> method. If writing were allowed after disposal for a bound part instance, it would result in disposable parts not being released. The dispose method on a bound part is called outside of the lock. 
   
  ]]></format>

--- a/xml/System.Composition.Hosting.Core/LifetimeContext.xml
+++ b/xml/System.Composition.Hosting.Core/LifetimeContext.xml
@@ -143,7 +143,7 @@ A bound part instance is always protected by locking <see langword="this" />, an
         <param name="sharingId">The identifier of the part instance to search for.</param>
         <param name="operation">The operation in which a new part instance is activated, if necessary.</param>
         <param name="creator">The activator of a new part instance, if necessary.</param>
-        <summary>Retrieves an existing part instance with the specified <param name="sharingId"> or, if the part instance can not be found, creates and shares a new part instance using the specified <paramref name="creator"/> within the specified <paramref name="operation"/>.</summary>
+        <summary>Retrieves an existing part instance with the specified <param name="sharingId"/> or, if the part instance can not be found, creates and shares a new part instance using the specified <paramref name="creator"/> within the specified <paramref name="operation"/>.</summary>
         <returns>The part instance.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  

--- a/xml/System.Composition.Hosting.Core/LifetimeContext.xml
+++ b/xml/System.Composition.Hosting.Core/LifetimeContext.xml
@@ -16,14 +16,16 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Represents a node in the lifetime tree. The <see cref="LifetimeContext"/> object is the unit of sharing for shared parts. It controls the disposal of bound parts and can be used to retrieve instances, either as part of an existing <see cref="CompositionOperation"/> or as the basis of a new composition operation. An individual lifetime context can be marked to contain parts that are constrained by particular sharing boundaries.</summary>
+    <summary>Represents a node in the lifetime tree.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-The <see cref="T:System.Composition.Hosting.Core.LifetimeContext"/> object contains two pieces of independently protected shared state: shared part instances and bound part instances. 
+The <xref:System.Composition.Hosting.Core.LifetimeContext> object is the unit of sharing for shared parts. It controls the disposal of bound parts and can be used to retrieve instances, either as part of an existing composition operation or as the basis of a new composition operation. An individual lifetime context can be marked to contain parts that are constrained by particular sharing boundaries.
+
+This object contains two pieces of independently protected shared state: shared part instances and bound part instances. 
 A shared part instance is lock-free readable and does not result in issues if it is added to during disposal. It is protected by being locked itself. Activation logic is unavoidably called under this lock. 
-A bound part instance is always protected by locking <see langword="this" />, and should never be written to after disposal. A bound part instance is set to <see langword="null" /> under a lock in the <see cref="M:System.Composition.Hosting.Core.LifetimeContext.Dispose"/> method. If writing were allowed after disposal for a bound part instance, it would result in disposable parts not being released. The dispose method on a bound part is called outside of the lock. 
+A bound part instance is always protected by locking <see langword="this" />, and should never be written to after disposal. A bound part instance is set to <see langword="null" /> under a lock in the <xref:System.Composition.Hosting.Core.LifetimeContext.Dispose> method. If writing were allowed after disposal for a bound part instance, it would result in disposable parts not being released. The dispose method on a bound part is called outside of the lock. 
   
  ]]></format>
     </remarks>
@@ -46,8 +48,8 @@ A bound part instance is always protected by locking <see langword="this" />, an
         <Parameter Name="instance" Type="System.IDisposable" />
       </Parameters>
       <Docs>
-        <param name="instance">The disposable part to bind.</param>
-        <summary>Binds the lifetime of a disposable part to the current lifetime context.</summary>
+        <param name="instance">The part.</param>
+        <summary>Binds the lifetime of a disposable part to this lifetime context.</summary>
         <remarks></remarks>
         <exception cref="T:System.ObjectDisposedException">The operation was performed on a disposed object.</exception>
       </Docs>
@@ -87,7 +89,7 @@ A bound part instance is always protected by locking <see langword="this" />, an
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Releases the lifetime context and any disposable part instances that are bound to it.</summary>
+        <summary>Releases the lifetime context and any part instances bound to it.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -110,7 +112,7 @@ A bound part instance is always protected by locking <see langword="this" />, an
       <Docs>
         <param name="sharingBoundary">The sharing boundary to find a lifetime context within.</param>
         <summary>Finds the broadest lifetime context within all of the specified sharing boundaries.</summary>
-        <returns>The lifetime context.</returns>
+        <returns>The broadest lifetime context within all of the specified sharing boundaries.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -140,11 +142,11 @@ A bound part instance is always protected by locking <see langword="this" />, an
         <Parameter Name="creator" Type="System.Composition.Hosting.Core.CompositeActivator" />
       </Parameters>
       <Docs>
-        <param name="sharingId">The identifier of the part instance to search for.</param>
-        <param name="operation">The operation in which a new part instance is activated, if necessary.</param>
-        <param name="creator">The activator of a new part instance, if necessary.</param>
-        <summary>Retrieves an existing part instance with the specified <param name="sharingId"/> or, if the part instance can not be found, creates and shares a new part instance using the specified <paramref name="creator"/> within the specified <paramref name="operation"/>.</summary>
-        <returns>The part instance.</returns>
+        <param name="sharingId">The ID of the shared part.</param>
+        <param name="operation">An operation in which to create a part, if necessary.</param>
+        <param name="creator">An activator that can activate a new part instance, if necessary.</param>
+        <summary>Retrieves a shared part instance with the specified ID, or if the part instance can not be found, creates and shares a part instance using the specified creator within the specified operation.</summary>
+        <returns>The new or retrieved part.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -170,8 +172,8 @@ A bound part instance is always protected by locking <see langword="this" />, an
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Describes this lifetime context.</summary>
-        <returns>A string description.</returns>
+        <summary>Returns the string representation of this <see cref="T:System.Composition.Hosting.Core.LifetimeContext"/> object.</summary>
+        <returns>The string representation of this <see cref="T:System.Composition.Hosting.Core.LifetimeContext"/> object.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -193,10 +195,10 @@ A bound part instance is always protected by locking <see langword="this" />, an
         <Parameter Name="export" Type="System.Object&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="contract">The contract to retrieve.</param>
-        <param name="export">The export if available; otherwise, <see langword="null" />.</param>
-        <summary>Retrieves the single <paramref name="contract"/> instance from the <see cref="CompositionContext"/>.</summary>
-        <returns>An instance of the export.</returns>
+        <param name="contract">The contract.</param>
+        <param name="export">After this method returns, contains the contract instance if available; otherwise, <see langword="null" />.</param>
+        <summary>Retrieves a contract instance from the composition context.</summary>
+        <returns><see langword="true" /> if the instance was retrieved; otherwise, <see langword="false" />.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting.Core/LifetimeContext.xml
+++ b/xml/System.Composition.Hosting.Core/LifetimeContext.xml
@@ -16,8 +16,17 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents a node in the lifetime tree. The <see cref="LifetimeContext"/> object is the unit of sharing for shared parts. It controls the disposal of bound parts and can be used to retrieve instances, either as part of an existing <see cref="CompositionOperation"/> or as the basis of a new composition operation. An individual lifetime context can be marked to contain parts that are constrained by particular sharing boundaries.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+The <see cref="T:System.Composition.Hosting.Core.LifetimeContext"/> object contains two pieces of independently protected shared state: shared part instances and bound part instances. 
+A shared part instance is lock-free readable and does not result in issues if it is added to during disposal. It is protected by being locked itself. Activation logic is unavoidably called under this lock. 
+A bound part instance is always protected by locking <see langword="this" />, and should never be written to after disposal. A bound part instance is set to <see langword="null" /> under a lock in the <see cref="M:System.Composition.Hosting.Core.LifetimeContext.Dispose"/> method. If writing were allowed after disposal for a bound part instance, it would result in disposable parts not being released. The dispose method on a bound part is called outside of the lock. 
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName="AddBoundInstance">
@@ -37,9 +46,10 @@
         <Parameter Name="instance" Type="System.IDisposable" />
       </Parameters>
       <Docs>
-        <param name="instance">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="instance">The disposable part to bind.</param>
+        <summary>Binds the lifetime of a disposable part to the current lifetime context.</summary>
+        <remarks></remarks>
+        <exception cref="T:System.ObjectDisposedException">The operation was performed on a disposed object.</exception>
       </Docs>
     </Member>
     <Member MemberName="AllocateSharingId">
@@ -57,9 +67,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Generates an identifier that can be used to locate shared part instances.</summary>
+        <returns>A new unique identifier.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -77,8 +87,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Releases the lifetime context and any disposable part instances that are bound to it.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="FindContextWithin">
@@ -98,10 +108,17 @@
         <Parameter Name="sharingBoundary" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="sharingBoundary">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="sharingBoundary">The sharing boundary to find a lifetime context within.</param>
+        <summary>Finds the broadest lifetime context within all of the specified sharing boundaries.</summary>
+        <returns>The lifetime context.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Currently, the root cannot be a boundary.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetOrCreate">
@@ -123,12 +140,19 @@
         <Parameter Name="creator" Type="System.Composition.Hosting.Core.CompositeActivator" />
       </Parameters>
       <Docs>
-        <param name="sharingId">To be added.</param>
-        <param name="operation">To be added.</param>
-        <param name="creator">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="sharingId">The identifier of the part instance to search for.</param>
+        <param name="operation">The operation in which a new part instance is activated, if necessary.</param>
+        <param name="creator">The activator of a new part instance, if necessary.</param>
+        <summary>Retrieves an existing part instance with the specified <param name="sharingId"> or, if the part instance can not be found, creates and shares a new part instance using the specified <paramref name="creator"/> within the specified <paramref name="operation"/>.</summary>
+        <returns>The part instance.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This method is lock-free if the part instance already exists. If the part instance must be created, a lock will be taken that will serialize other writes that use this method (concurrent reads will continue to be safe and lock-free). It is important that the composition, and thus lock acquisition, is strictly leaf-to-root in the lifetime tree.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -146,9 +170,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Describes this lifetime context.</summary>
+        <returns>A string description.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="TryGetExport">
@@ -169,11 +193,11 @@
         <Parameter Name="export" Type="System.Object&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="export">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contract">The contract to retrieve.</param>
+        <param name="export">The export if available; otherwise, <see langword="null" />.</param>
+        <summary>Retrieves the single <paramref name="contract"/> instance from the <see cref="CompositionContext"/>.</summary>
+        <returns>An instance of the export.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/ns-System.Composition.Hosting.Core.xml
+++ b/xml/ns-System.Composition.Hosting.Core.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Composition.Hosting.Core">
   <Docs>
-    <summary>The <see cref="N:System.Composition.Hosting.Core" /> namespace contains classes that represent core functionality of the composition engine; including, composition operations, contracts, part dependencies, export descriptions, and the lifetime context of a sdhared part that governs how it can be disposed.</summary>
+    <summary>The <see cref="N:System.Composition.Hosting.Core" /> namespace contains classes that represent core functionality of the composition engine, including composition operations, contracts, part dependencies, export descriptions, and the lifetime context of a shared part that governs how it can be disposed.</summary>
     <remarks></remarks>
   </Docs>
 </Namespace>

--- a/xml/ns-System.Composition.Hosting.Core.xml
+++ b/xml/ns-System.Composition.Hosting.Core.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Composition.Hosting.Core">
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>The <see cref="N:System.Composition.Hosting.Core" /> namespace contains classes that represent core functionality of the composition engine; including, composition operations, contracts, part dependencies, export descriptions, and the lifetime context of a sdhared part that governs how it can be disposed.</summary>
+    <remarks></remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
# Title
Add missing documentation for the System.Composition.Hosting.Core Namespace

This namespace contains the following classes and delegates:

- CompositeActivator 
- CompositionContract  **(NOTE:  There was no code file for this class)**
- CompositionDependency
- CompositionOperation
- DependencyAccessor
- ExportDescriptor
- ExportDescriptorPromise
- ExportDescriptorProvider
- LifetimeContext

Information was pulled from the source code at:
https://github.com/dotnet/corefx/tree/master/src/System.Composition.Hosting/src/System/Composition/Hosting/Core

Fixes #2349

## Suggested Reviewers
@mairaw 

