### PR TITLE
Add description to hub page

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,6 +2,7 @@
 layout: HubPage
 hide_bc: true
 title: .NET Documentation
+description: Learn how to use .NET to create a variety of apps using the language, platforms and tools of your choice.
 ---
 <div id="main" class="v2">
     <div class="container">

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: HubPage
 hide_bc: true
 title: .NET Documentation
-description: Learn how to use .NET to create a variety of applications on any platform using C#, Visual Basic, and F#.
+description: Learn how to use .NET to create a variety of applications on any platform using C#, Visual Basic, and F#. Browse API reference, sample code, tutorials, and more.”
 ---
 <div id="main" class="v2">
     <div class="container">

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: HubPage
 hide_bc: true
 title: .NET Documentation
-description: Learn how to use .NET to create a variety of apps using the language, platforms and tools of your choice.
+description: Learn how to use .NET to create a variety of applications on any platform using C#, Visual Basic, and F#.
 ---
 <div id="main" class="v2">
     <div class="container">


### PR DESCRIPTION
SEO team has requested us to add a meta description to our main .NET docs page.

This will replace the auto-generated description on search engines:
![image](https://user-images.githubusercontent.com/12971179/26998410-227bb868-4d38-11e7-8bf8-40dae374c2c5.png)

/cc @richlander @BethMassi 