### PR TITLE
[WIP] [2.0] Create CLI command preview topics

### DIFF
--- a/docs/core/preview/tools/custom-templates.md
+++ b/docs/core/preview/tools/custom-templates.md
@@ -1,0 +1,234 @@
+---
+title: Create custom templates for dotnet new (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: 
+keywords: dotnet-new, dotnet new, CLI, CLI command, .NET Core, template, templating
+author: guardrex
+ms.author: mairaw
+ms.date: 06/18/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: c28eb59d-4d18-4aba-bcd1-88bd887abc08
+---
+
+# Create custom templates for dotnet new
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+The [`dotnet new` command](dotnet-new.md) is built on top of a template engine. When you invoke the command and specify a template with `dotnet new <TEMPLATE>`, the template engine creates project files and folders on disk from the template you specify to the command.
+
+The [.NET Core SDK](https://www.microsoft.com/net/download/core) provides several useful templates, but you can create your own custom templates for any type of .NET project, such as a service, tool, class library, or even just one or more files, such as a configuration file. Templates work with any Microsoft framework, including .NET Core, .NET Framework, and Xamarin. After you've created a custom template, users install it from a NuGet package on any NuGet feed (or by referencing the *nupkg* file directly) or by specifying a file system directory that contains the template. The template engine has templating features that allow you to replace values, include and exclude files and regions of files, and execute custom processing operations.
+
+The template engine is open source, and the online code repository is at [dotnet/templating](https://github.com/dotnet/templating/) on GitHub. You can open an issue if you run into a problem or start a discussion for a new feature, possibly a feature that you contribute. Visit the [dotnet/dotnet-template-samples](https://github.com/dotnet/dotnet-template-samples) repo for samples of templates. More templates, including templates from third parties, are found at [Available templates for dotnet new](https://github.com/dotnet/templating/wiki/Available-templates-for-dotnet-new) at GitHub. A detailed pre-release blog post that describes how to create and install custom templates written by [Sayed Ibrahim Hashimi](https://github.com/sayedihashimi) is at [How to create your own templates for dotnet new](https://blogs.msdn.microsoft.com/dotnet/2017/04/02/how-to-create-your-own-templates-for-dotnet-new/).
+
+## Configuration
+
+A template is composed of the following components:
+
+- Source files and folders
+- Configuration file (*template.json*)
+
+### Source files and folders
+
+The source files and folders are composed of whatever files and folders you want the templating engine to use when the `dotnet new <TEMPLATE>` command is executed. The templating engine is designed to use *runnable projects* as source code to produce projects. This has several benefits:
+
+- The templating engine doesn't require you to inject special tokens into your project's source code.
+- The code files aren't special files or modified in any way to work with the templating system, so the tools you normally use when working with projects also work with template content.
+- You build, run, and debug your template projects just like you do for any of your projects.
+- You can create a template from an existing project quickly by merely adding a *template.json* configuration file to the project.
+
+Files and folders stored in the template aren't limited to formal .NET project types, such as a .NET Core or .NET Framework solutions. Source files and folders may consist of any content you wish to create when the template is used, even if the template engine produces just one file for its output. For example, you can create a template that consists of a single *web.config* file. When the template is used, it creates a modified *web.config* file in a project based on logic and settings you've provided in *template.json* along with values provided by the user passed as options to the `dotnet new <TEMPLATE>` command.
+
+### template.json
+
+The *template.json* file is placed in a *.template.config* folder in the root directory of the template. The file provides configuration to the template engine when creating output from the source files and folders. The minimum configuration requires the members shown in the following table, which is sufficient to add to a .NET Core app to produce a functional template.
+
+| Member            | Type          | Description |
+| ----------------- | ------------- | ----------- |
+| `author`          | string        | The author of the template. |
+| `classifications` | array(string) | Zero or more characteristics of the template that a user might search for it by. |
+| `identity`        | string        | A unique name for this template. |
+| `name`            | string        | The name for the template that users should see. |
+| `shortName`       | string        | A default shorthand for selecting the template (applies to environments where the template name is specified by the user - not selected via a GUI). |
+
+**Example**
+
+```json
+{
+  "author": "Catalina Garcia",
+  "classifications": [ "Common", "Console" ],
+  "identity": "GarciaSoftware.ConsoleTemplate.CSharp",
+  "name": "My first .NET Core template",
+  "shortName": "garciaconsole"
+}
+```
+
+The full schema for the *template.json* file is found at the [JSON Schema Store](http://json.schemastore.org/template).
+
+## .NET default templates
+
+When you install the [.NET Core SDK](https://www.microsoft.com/net/download/core), you receive over a dozen built-in templates for creating projects and files, including console apps, class libraries, unit test projects, ASP.NET Core apps (including [Angular](https://angular.io/) and [React](https://facebook.github.io/react/) projects), and configuration files. To list the built-in templates, execute the `dotnet new` command with the `-l|--list` option:
+
+```console
+dotnet new -l
+```
+
+## Packing a template into a NuGet package
+
+Currently, a custom template is packed with [nuget.exe](https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) (not [dotnet-pack](dotnet-pack.md)).
+
+The contents of the project folder, together with its *.template.config\template.json* file, is placed into a folder named *content*. Next to the *content* folder, add a [*nuspec* file](https://docs.microsoft.com/nuget/create-packages/creating-a-package), which is an XML manifest file that describes a package's contents and drives the process of creating the NuGet package.
+
+Include a **\<packageTypes>\<packageType>** element with a `name` attribute value of `Template` in the file. Both the *content* folder and the *nuspec* file should reside in the same directory. The table shows the minimum *nuspec* file elements required to produce a template as a NuGet package.
+
+| Element            | Type   | Description |
+| ------------------ | ------ | ----------- |
+| **\<authors>**     | string | A comma-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors. |
+| **\<description>** | string | A long description of the package for UI display. |
+| **\<id>**          | string | The case-insensitive package identifier, which must be unique across nuget.org or whatever gallery the package will reside in. IDs may not contain spaces or characters that are not valid for a URL, and generally follow .NET namespace rules. See Choosing a unique package identifier for guidance. |
+| **\<packageType>** | string | Place this element inside a **\<packageTypes>** element among the **\<metadata>** elements. Set the `name` attribute of the element to `Template`. |
+| **\<version>**     | string | The version of the package, following the major.minor.patch pattern. Version numbers may include a pre-release suffix as described in [Prerelease Packages](https://docs.microsoft.com/nuget/create-packages/prerelease-packages#semantic-versioning). |
+
+See the [.nuspec reference](https://docs.microsoft.com/nuget/schema/nuspec) for the complete *nuspec* file schema.
+
+**Example**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>GarciaSoftware.ConsoleTemplate.CSharp</id>
+    <version>1.0.0</version>
+    <description>
+      GarciaSoftware.ConsoleTemplate.CSharp is my first .NET Core template.
+    </description>
+    <authors>Catalina Garcia</authors>
+    <packageTypes>
+      <packageType name="Template" />
+    </packageTypes>
+  </metadata>
+</package>
+```
+
+[Create the package](https://docs.microsoft.com/nuget/create-packages/creating-a-package#creating-the-package) using the `nuget pack <your_nuspec_file>.nuspec` command.
+
+**Example**
+
+```console
+nuget pack C:\Users\<USER>\Documents\Templates\GarciaSoftware.ConsoleTemplate.CSharp\GarciaSoftware.ConsoleTemplate.CSharp.nuspec
+```
+
+## Installing a template
+
+You install a custom template from a NuGet package on any NuGet feed (or by referencing a *nupkg* file directly) or by specifying a file system directory that contains a templating configuration. Use the `-i|--install` install option with the `dotnet new` command.
+
+### To install a template from a NuGet package stored at [nuget.org](https://www.nuget.org/):
+
+```console
+dotnet new -i <NUGET_PACKAGE_ID>
+```
+
+**Example**
+
+```console
+dotnet new -i GarciaSoftware.ConsoleTemplate.CSharp
+```
+
+> [!NOTE]
+> The example is for demonstration purposes only. There isn't a `GarciaSoftware.ConsoleTemplate.CSharp` NuGet package at nuget.org. If you run the command, no template is installed. However, you can install a template that hasn't been published to nuget.org by referencing the *nupkg* file directly on your local file system.
+
+### To install a template from a local *nupkg* file:
+
+```console
+dotnet new -i <PATH_TO_NUPKG_FILE>
+```
+
+**Example**
+
+```console
+dotnet new -i C:/Users/Garcia/GarciaSoftware.ConsoleTemplate.CSharp.1.0.0.nupkg
+```
+
+### To install a template from a file system directory (the project folder containing the project and the *.template.config* folder):
+
+```console
+dotnet new -i <FILE_SYSTEM_DIRECTORY>
+```
+
+**Example**
+
+```console
+dotnet new -i C:/Users/Garcia/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp/content
+```
+
+## Uninstalling a template
+
+You uninstall a custom template by referencing a NuGet package by its `id` or by specifying a file system directory that contains a templating configuration. Use the `-u|--uninstall` install option with the `dotnet new` command.
+
+### To uninstall a template from a NuGet package stored at [nuget.org](https://www.nuget.org/):
+
+```console
+dotnet new -u <NUGET_PACKAGE_ID>
+```
+
+**Example**
+
+```console
+dotnet new -u GarciaSoftware.ConsoleTemplate.CSharp
+```
+
+> [!NOTE]
+> The example is for demonstration purposes only. There isn't a `GarciaSoftware.ConsoleTemplate.CSharp` NuGet package at nuget.org or installed with the .NET Core SDK. If you run the command, no package/template is uninstalled and you receive the following exception:
+> 
+> ```console
+> Could not find something to uninstall called 'GarciaSoftware.ConsoleTemplate.CSharp'.
+> ```
+
+### To uninstall a template from a local *nupkg* file:
+
+Although you can install a template from a *nupkg* file on your local file system by referecing the *nupkg* file directly with the `dotnet new -i <PATH_TO_NUPKG_FILE>` command; when you wish to uninstall the template, only reference it by it's `id` (for example, `dotnet new -u <NUGET_PACKAGE_ID>`). **Attempting to uninstall a template using `dotnet new -u <PATH_TO_NUPKG_FILE>` will fail.**
+
+```console
+dotnet new -u <NUGET_PACKAGE_ID>
+```
+
+**Example**
+
+```console
+dotnet new -u GarciaSoftware.ConsoleTemplate.CSharp.1.0.0
+```
+
+### To uninstall a template from a file system directory (the project folder containing the project and the *.template.config* folder):
+
+```console
+dotnet new -u <FILE_SYSTEM_DIRECTORY>
+```
+
+**Example**
+
+```console
+dotnet new -u C:/Users/Garcia/Documents/Templates/content
+```
+
+## Creating a project from a template
+
+After a template is installed, use the template by executing the `dotnet new <TEMPLATE>` command from the directory where you want to the template engine's output placed. Supply the template's short name directly to the command:
+
+```console
+dotnet new <TEMPLATE>
+```
+
+**Example**
+
+From a new project folder created at *C:/Users/Garcia/Documents/Projects/MyConsoleApp*, create a project from the `garciaconsole` template:
+
+```console
+dotnet new garciaconsole
+```
+
+## See also
+
+[dotnet/templating GitHub repo Wiki](https://github.com/dotnet/templating/wiki)   
+[How to create your own templates for dotnet new](https://blogs.msdn.microsoft.com/dotnet/2017/04/02/how-to-create-your-own-templates-for-dotnet-new/)   
+[*template.json* schema at the JSON Schema Store](http://json.schemastore.org/template)   

--- a/docs/core/preview/tools/dotnet-add-package.md
+++ b/docs/core/preview/tools/dotnet-add-package.md
@@ -1,0 +1,105 @@
+---
+title: dotnet-add package command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-add package command provides a convenient option to add a NuGet package reference to a project.
+keywords: dotnet-add package, dotnet add package, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 88e0da69-a5ea-46cc-8b46-5493242b7af9
+---
+
+# dotnet-add package (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-add package` - Adds a package reference to a project file.
+
+## Synopsis
+
+`dotnet add [<PROJECT>] package <PACKAGE_NAME> [-f|--framework] [-h|--help] [-n|--no-restore] [--package-directory] [-s|--source] [-v|--version]`
+
+## Description
+
+The `dotnet add package` command adds a package reference to a project file. After running the command, there's a compatibility check to ensure the package is compatible with the frameworks in the project. If the check passes, a **\<PackageReference>** element is added to the project file and [dotnet restore](dotnet-restore.md) is run.
+
+For example, adding `Newtonsoft.Json` to *ToDo.csproj* produces output similar to the following:
+
+```console
+Writing C:\Users\guard\AppData\Local\Temp\tmp9194.tmp
+info : Adding PackageReference for package 'Newtonsoft.Json' into project 'ToDo.csproj'.
+log  : Restoring packages for ToDo.csproj...
+info :   CACHE https://dotnet.myget.org/F/aspnetcore-dev/api/v2/FindPackagesById()?id='Newtonsoft.Json'
+info :   CACHE https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json
+info : Package 'Newtonsoft.Json' is compatible with all the specified frameworks in project 'ToDo.csproj'.
+info : PackageReference for package 'Newtonsoft.Json' version '10.0.2' added to file 'ToDo.csproj'.
+```
+
+The *ToDo.csproj* file now contains a [**\<PackageReference>**](https://docs.microsoft.com/nuget/consume-packages/package-references-in-project-files) element for the referenced package:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+  </ItemGroup>
+</Project>
+```
+
+## Arguments
+
+`PROJECT`
+
+Specifies the project file. If not specified, the command searches the current directory for one.
+
+`PACKAGE_NAME`
+
+The package reference to add. Only one package reference is added per `dotnet add package` command; use multiple commands to add multiple package references to a project.
+
+## Options
+
+`-f|--framework <FRAMEWORK>`
+
+Adds a package reference only when targeting a specific [framework](../../standard/frameworks.md).
+
+`-h|--help`
+
+Shows help information.
+
+`-n|--no-restore`
+
+Adds a package reference without performing a restore preview and compatibility check.
+
+`--package-directory <PACKAGE_DIRECTORY>`
+
+Restores the package to the specified directory.
+
+`-s|--source <SOURCE>`
+
+Uses a specific NuGet package source during the restore operation.
+
+`-v|--version <VERSION>`
+
+Version of the package.
+
+## Examples
+
+Add the `Newtonsoft.Json` NuGet package to a project:
+
+`dotnet add package Newtonsoft.Json`
+
+Add a specific version of a package to a project:
+
+`dotnet add ToDo.csproj package Microsoft.Azure.DocumentDB.Core -v 1.0.0`
+
+Add a package using a specific NuGet source:
+
+`dotnet add package Microsoft.AspNetCore.StaticFiles -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json`

--- a/docs/core/preview/tools/dotnet-add-reference.md
+++ b/docs/core/preview/tools/dotnet-add-reference.md
@@ -1,0 +1,77 @@
+---
+title: dotnet-add reference command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-add reference command provides a convenient option to add project to project references.
+keywords: dotnet-add reference, dotnet add reference, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 5e2a3efd-443c-4f23-a1b1-a662a5387879
+---
+
+# dotnet-add reference (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-add reference` - Adds project-to-project (P2P) references.
+
+## Synopsis
+
+`dotnet add [<PROJECT>] reference <PROJECT_REFERENCES> [-f|--framework] [-h|--help]`
+
+## Description
+
+The `dotnet add reference` command adds project references to a project. After running the command, a [**\<ProjectReference>**](https://docs.microsoft.com/visualstudio/msbuild/common-msbuild-project-items) element is added to the project file.
+
+For example, adding *lib1\lib1.csproj* to *ToDo.csproj* with `dotnet add reference lib1/lib1.csproj` produces:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="lib1\lib1.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+## Arguments
+
+`PROJECT`
+
+Specifies the project file. If not specified, the command searches the current directory for one.
+
+`PROJECT_REFERENCES`
+
+Project-to-project (P2P) references to add. Specify one or more projects. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux-based systems.
+
+## Options
+
+`-f|--framework <FRAMEWORK>`
+
+Adds project references only when targeting a specific [framework](../../standard/frameworks.md).
+
+`-h|--help`
+
+Shows help information.
+
+## Examples
+
+Add a library project reference:
+
+`dotnet add app/app.csproj reference lib/lib.csproj`
+
+Add multiple project references:
+
+`dotnet add reference lib1/lib1.csproj lib2/lib2.csproj`
+
+Add multiple project references using a globbing pattern on Linux/Unix:
+
+`dotnet add app/app.csproj reference **/*.csproj`

--- a/docs/core/preview/tools/dotnet-build.md
+++ b/docs/core/preview/tools/dotnet-build.md
@@ -1,0 +1,116 @@
+---
+title: dotnet-build command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-build command builds a project and all of its dependencies. 
+keywords: dotnet-build, dotnet build, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
+---
+
+# dotnet-build (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-build` - Builds a project and all of its dependencies.
+
+## Synopsis
+
+`dotnet build [<PROJECT>] [-c|--configuration] [-f|--framework] [-h|--help] [--no-dependencies] [--no-incremental] [-o|--output] [-r|--runtime] [-v|--verbosity] [--version-suffix]`
+
+## Description
+
+The `dotnet build` command builds the project and its dependencies into a set of binaries. The binaries include the project's code in Intermediate Language (IL) files with a *dll* extension (for example, *\<assembly_name>.dll*) and symbol files used for debugging with a *pdb* extension (for example, *\<assembly_name>.pdb*). A dependencies JSON file (*\<assembly_name>.deps.json*) is produced that lists the dependencies of the app. A *\<assembly_name>.runtimeconfig.json* file is produced, which specifies the shared runtime and its version for the app.
+
+If the project has third-party dependencies, such as libraries from NuGet, they're resolved from the NuGet cache and aren't available with the project's built output. With that in mind, the product of `dotnet build` isn't ready to be transferred to another machine to run. This is in contrast to the behavior of the .NET Framework in which building an executable project (an app) produces output that's runnable on any machine where the .NET Framework is installed. To have a similar experience with .NET Core, use the [dotnet publish](dotnet-publish.md) command. For more information, see [.NET Core Application Deployment](../deploying/index.md). 
+
+Building requires the *project.assets.json* file in the intermediate output folder (*obj*), which lists the dependencies of your app. The file is created when you execute [`dotnet restore`](dotnet-restore.md) before building the project. Without the assets file in place, the tooling can't resolve reference assemblies, which results in errors.
+
+`dotnet build` uses [MSBuild](https://docs.microsoft.com/visualstudio/msbuild/msbuild) to build the project, so it supports both parallel and incremental builds. Refer to [Incremental Builds](https://docs.microsoft.com/visualstudio/msbuild/incremental-builds) for more information. 
+
+In addition to its own options, the `dotnet build` command accepts MSBuild options, such as `/p` for setting properties or `/l` to define a logger. Learn more about these options in the [MSBuild Command-Line Reference](https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference). 
+
+The `<OutputType>` property in the project file determines if the build output is an executable app or a non-executable library. The following example shows a project file that produces executable code (a .NET Core console app):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+</Project>
+```
+
+In order to produce a library, omit the `<OutputType>` property or set `<OutputType>` to `Library`. The main difference in the output for a library is that the IL DLL for a library doesn't contain entry points and can't be executed. The following example shows a project file that produces a non-executable library:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+## Arguments
+
+`PROJECT`
+
+The project file to build. If a project file isn't specified, MSBuild searches the current working directory for a file with a *proj* file extension.
+
+## Options
+
+`-c|--configuration <CONFIGURATION>`
+
+Defines the build configuration. If omitted, the build configuration defaults to `Debug`. Use `Release` build a Release configuration.
+
+`-f|--framework <FRAMEWORK>`
+
+Compiles for a specific [framework](../../standard/frameworks.md). The framework must be defined in the [project file](csproj.md).
+
+`-h|--help`
+
+Shows help information.
+
+`--no-dependencies`
+
+Ignores project-to-project (P2P) references and only builds the root project specified to build.
+
+`--no-incremental`
+
+Marks the build as unsafe for incremental build. This turns off incremental compilation and forces a clean rebuild of the project's dependency graph.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Places the built binaries into a specific directory. You must define the framework (`-f|--framework <FRAMEWORK>`) when you specify this option.
+
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+Specifies the target runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
+
+`-v|--verbosity <LEVEL>`
+
+Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+`--version-suffix <VERSION_SUFFIX>`
+
+Defines the version suffix to replace the asterisk (`*`) in the version field (`$(VersionSuffix)`) of the project file. The format follows NuGet's version guidelines.
+
+## Examples
+
+Build a project and its dependencies:
+
+`dotnet build`
+
+Build a project and its dependencies using Release configuration:
+
+`dotnet build --configuration Release`
+
+Build a project and its dependencies for a specific runtime (in this example, Ubuntu 16.04):
+
+`dotnet build --runtime ubuntu.16.04-x64`

--- a/docs/core/preview/tools/dotnet-clean.md
+++ b/docs/core/preview/tools/dotnet-clean.md
@@ -1,0 +1,74 @@
+---
+title: dotnet-clean command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-clean command cleans the current directory.
+keywords: dotnet-clean, dotnet clean, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
+---
+
+# dotnet-clean (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-clean` - Cleans the output of a project. 
+
+## Synopsis
+
+`dotnet clean [<PROJECT>] [-c|--configuration] [-f|--framework] [-h|--help] [-o|--output] [-r|--runtime] [-v|--verbosity]`
+
+## Description
+
+The `dotnet clean` command cleans the output of the previous build. It's implemented as an [MSBuild target](https://docs.microsoft.com/visualstudio/msbuild/msbuild-targets), so the project is evaluated when the command is run. Only the outputs created from a build are cleaned. Both intermediate (*obj*) and final output (*bin*) folders are cleaned.
+
+> [!NOTE]
+> Deployments created with the `dotnet publish` command (*publish* folder contents) aren't cleaned by the `dotnet clean` command.
+
+## Arguments
+
+`PROJECT`
+
+The MSBuild project to clean. If a project file isn't specified, MSBuild searches the current working directory for a file with a *proj* file extension.
+
+## Options
+
+`-c|--configuration <CONFIGURATION>`
+
+Defines the configuration. If omitted, it defaults to `Debug`. This property is only required if you specified it when you built the project.
+
+`-f|--framework <FRAMEWORK>`
+
+The [framework](../../standard/frameworks.md) that was specified when you built the project. The framework must be defined in the [project file](csproj.md). If you specified the framework when you built the project, you must specify the framework when using `dotnet clean`.
+
+`-h|--help`
+
+Shows help information.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Directory in which the build outputs are placed. Specify the `-f|--framework <FRAMEWORK>` option with the `-o|--output <OUTPUT_DIRECTORY>` option if you specified the framework when the project was built.
+
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+The [runtime](../rid-catalog.md) specified when you built the project. If you specified the runtime when you built the project, you must specify the runtime when using `dotnet clean`.
+
+`-v|--verbosity <LEVEL>`
+
+Sets the verbosity level of the command. Allowed levels are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+## Examples
+
+Clean a default build of the project:
+
+`dotnet clean`
+
+Clean a project built using the Release configuration:
+
+`dotnet clean --configuration Release`

--- a/docs/core/preview/tools/dotnet-install-script.md
+++ b/docs/core/preview/tools/dotnet-install-script.md
@@ -1,0 +1,182 @@
+---
+title: dotnet-install scripts (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: Learn about the dotnet-install scripts to install the .NET Core CLI tools and the shared runtime. 
+keywords: dotnet-install, dotnet install script, dotnet-install scripts, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: b64e7e6f-ffb4-4fc8-b43b-5731c89479c2
+---
+
+# dotnet-install scripts (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-install.ps1` | `dotnet-install.sh` - Script used to install the .NET Core Command-line Interface (CLI) tools and the shared runtime.
+
+## Synopsis
+
+Windows:
+
+`dotnet-install.ps1 [-Architecture] [-AzureFeed] [-Channel] [-DryRun] [-InstallDir] [-NoPath] [-ProxyAddress] [-ProxyUseDefaultCredentials] [-SharedRuntime] [-UncachedFeed] [-Version]`
+
+macOS/Linux:
+
+`dotnet-install.sh [-arch|--architecture] [--azure-feed] [-c|--channel] [--debug-symbols] [--dry-run] [-h|--help] [-i|--install-dir] [--no-path] [--runtime-id] [--shared-runtime] [--uncached-feed] [--verbose] [-v|--version]`
+
+## Description
+
+The `dotnet-install` script is used to perform a non-admin install of the CLI toolchain and the shared runtime. Two scripts are available: One is a PowerShell script that works on Windows. The other script is a bash script that works on macOS/Linux. The bash script also reads PowerShell switches, so you can use PowerShell switches on macOS/Linux systems. Download the script for your platform from the [dotnet/cli GitHub repo](https://github.com/dotnet/cli/tree/release/2.0.0/scripts/obtain) (See NOTE). 
+
+> [!NOTE>
+> Install the required [dependencies](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md) before running the script.
+
+The installation script downloads the SDK ZIP/tarball file from the CLI build outputs and installs the SDK in either the default location or in a location specified by `-InstallDir` (Windows) or `--install-dir` (macOS/Linux). If you wish to only install the shared runtime, specify the `--shared-runtime` option.
+
+The script adds the install location to the PATH for the current session. Override the default behavior by specifying the `--no-path` option. 
+
+Install a specific version using the `--version` option. Specify the version as a three-part version (for example, 1.0.0-13232). If omitted, it defaults to the first [global.json](global-json.md) file found in the hierarchy above the folder where the script is invoked that contains the `version` property. If that isn't present, it uses the latest version.
+
+On macOS/Linux, obtain the SDK or shared runtime debug binaries with debug symbols by using the `--debug-symbols` option. If you fail to do this on first install and realize later that you need the debug symbols, re-run the script with the `--debug-symbols` option and the installed SDK version to obtain the debug symbols.
+
+> [!NOTE]
+> For the PowerShell (Windows) version of the script, obtaining the debug symbols using a `-DebugSymbols` switch isn't currently available but planned for a future release.
+
+## Options
+
+Options are different between script implementations. macOS/Linux users should refer to the [Bash (macOS/Linux) section](#bash-macoslinux), while Windows users should refer to the [PowerShell (Windows) section](#powershell-windows).
+
+### Bash (macOS/Linux)
+
+`dotnet-install.sh [-arch|--architecture] [--azure-feed] [-c|--channel] [--debug-symbols] [--dry-run] [-h|--help] [-i|--install-dir] [--no-path] [--runtime-id] [--shared-runtime] [--uncached-feed] [--verbose] [-v|--version]`
+
+`-arch|--architecture <ARCHITECTURE>`
+
+Specifies the architecture of the .NET Core binaries to install. Possible values are `auto`, `x64` and `amd64`. The default value is `auto`, which represents the currently running OS architecture.
+
+`--azure-feed`
+
+Indicates the URL for the Azure feed to the installer. We don't recommended that you change this value. The default is `https://dotnetcli.azureedge.net/dotnet`.
+
+`-c|--channel <CHANNEL>`
+
+Specifies the source channel for the installation. The values are: `future`, `dev`, and `production`. The default value is `production`.
+
+`--debug-symbols`
+
+If set, the installer includes debugging symbols in the installation.
+
+`--dry-run`
+
+If set, the script won't perform the installation. Instead, it displays the command-line command to use to consistently install the requested version of the CLI. For example if you specify version `latest`, it displays a link with the specific version, so you have a stable command to use in a build script. It also displays the binary's location if you prefer to install or download the binary yourself.
+
+`-h|--help`
+
+Shows help information.
+
+`-i|--install-dir <DIRECTORY>`
+
+Specifies the installation path. The directory is created if it doesn't exist. The default value is `$HOME/.dotnet`.
+
+`--no-path`
+
+If set, the prefix/installdir are not exported to the PATH for the current session. By default, the script modifies the PATH, which makes the CLI tools available immediately after install.
+
+`--runtime-id <RUNTIME_IDENTIFIER>`
+
+Installs the .NET tools for the given runtime.
+
+> [!NOTE]
+> For 64-bit portable Linux systems, use `linux-x64`.
+
+`--shared-runtime`
+
+If set, this option limits installation to the shared runtime. The entire SDK isn't installed.
+
+`--uncached-feed <FEED>`
+
+Allows you to change the URL for the uncached feed used by the installer. This parameter typically isn't changed by the user. It defaults to `https://dotnetcli.blob.core.windows.net/dotnet`.
+
+`--verbose`
+
+Display diagnostics information.
+
+`-v|--version <VERSION>`
+
+Specifies the version of CLI to install. You must specify the version as a three-part version (for example, 1.0.0-13232). If omitted, it defaults to the first [global.json](global-json.md) that contains the `version` property. If a *global.json* file isn't found with a `version` property, it uses the latest version.
+
+### PowerShell (Windows)
+
+`dotnet-install.ps1 [-Architecture] [-AzureFeed] [-Channel] [-DryRun] [-InstallDir] [-NoPath] [-ProxyAddress] [-ProxyUseDefaultCredentials] [-SharedRuntime] [-UncachedFeed] [-Version]`
+
+`-Architecture <ARCHITECTURE>`
+
+Specifies the architecture of the .NET Core binaries to install. Possible values are `auto`, `x64`, and `x86`. The default value is `auto`, which represents the currently running OS architecture.
+
+`-AzureFeed`
+
+Indicates the URL for the Azure feed to the installer. It isn't recommended that you change this value. The default is `https://dotnetcli.azureedge.net/dotnet`.
+
+`-Channel <CHANNEL>`
+
+Specifies the source channel for the installation. The values are: `future`, `preview`, and `production`. The default value is `production`.
+
+`-DryRun`
+
+If set, the script won't perform the installation; but instead, it displays what command line to use to consistently install the currently requested version of the .NET CLI. For example if you specify version `latest`, it displays a link with the specific version, so you can use the command deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
+
+`-InstallDir <DIRECTORY>`
+
+Specifies the installation path. The directory is created if it doesn't exist. The default value is *%LocalAppData%\.dotnet*.
+
+`-NoPath`
+
+If set, the prefix/installdir are not exported to the path for the current session. By default, the script modifies the PATH, which makes the CLI tools available immediately after install.
+
+`-ProxyAddress`
+
+If set, the installer uses the proxy when making web requests.
+
+`-ProxyUseDefaultCredentials`
+
+Indicates that when using a proxy address to use default credentials. Defaults to `false`.
+
+`-SharedRuntime`
+
+If set, this option limits installation to the shared runtime. The entire SDK isn't installed.
+
+`-UncachedFeed <FEED>`
+
+Allows you to change URL for the uncached feed used by the installer. It defaults to `https://dotnetcli.blob.core.windows.net/dotnet`. This parameter typically isn't changed by the user.
+
+`-Version <VERSION>`
+
+Specifies the version of CLI to install. You must specify the version as a three-part version (for example, 1.0.0-13232). If omitted, it defaults to the first [global.json](global-json.md) that contains the `version` property. If a *global.json* file isn't found with a `version` property, it uses the latest version.
+
+## Examples
+
+**Install the latest development version to the default location:**
+
+Windows:
+
+`./dotnet-install.ps1 -Channel Future`
+
+macOS/Linux:
+
+`./dotnet-install.sh --channel Future`
+
+**Install the latest preview to the specified location:**
+
+Windows:
+
+`./dotnet-install.ps1 -Channel preview -InstallDir C:\cli`
+
+macOS/Linux:
+
+`./dotnet-install.sh --channel preview --install-dir ~/cli`

--- a/docs/core/preview/tools/dotnet-list-reference.md
+++ b/docs/core/preview/tools/dotnet-list-reference.md
@@ -1,0 +1,51 @@
+---
+title: dotnet-list reference command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-list reference command provides a convenient option to list project to project references.
+keywords: dotnet-list, dotnet list reference, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 8f954a0c-03f8-4fbc-a529-b313ab12c623
+---
+
+# dotnet-list reference (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-list reference` - Lists project to project references.
+
+## Synopsis
+
+`dotnet list [<PROJECT>] reference [-h|--help]`
+
+## Description
+
+The `dotnet-list reference` command lists project references for a given project.
+
+## Arguments
+
+`PROJECT`
+
+Specifies the project file to use for listing references. If not specified, the command searches the current directory for a project file.
+
+## Options
+
+`-h|--help`
+
+Shows help information.
+
+## Examples
+
+List the project references for the specified project:
+
+`dotnet list app/app.csproj reference`
+
+List the project references for the project in the current directory:
+
+`dotnet list reference`

--- a/docs/core/preview/tools/dotnet-migrate.md
+++ b/docs/core/preview/tools/dotnet-migrate.md
@@ -1,0 +1,110 @@
+---
+title: dotnet-migrate command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-migrate command migrates a project and all of its dependencies. 
+keywords: dotnet-migrate, dotnet migrate, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 0da07253-5ae1-42e9-9455-bffee9950952
+---
+
+# dotnet-migrate (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-migrate` - Migrates a Preview 2 .NET Core project to a .NET Core SDK 1.0 (MSBuild/*csproj*) project.
+
+## Synopsis
+
+`dotnet migrate [<SOLUTION_FILE|PROJECT_DIR>] [--format-report-file-json] [-h|--help] [-r|--report-file] [--skip-backup] [-s|--skip-project-references] [-t|--template-file] [-v|--sdk-package-version] [-x|--xproj-file]`
+
+## Description
+
+The `dotnet migrate` command migrates a valid Preview 2 *project.json*-based project to a valid .NET Core SDK 1.0 (MSBuild/*csproj*) project. 
+
+By default, the command migrates the root project and any project references that the root project contains. This behavior is disabled using the `-s|--skip-project-references` option at runtime. 
+
+Migration is performed on the following:
+
+- A single project by specifying the *project.json* file to migrate.
+- All of the directories specified in the *global.json* file by passing in a path to the *global.json* file.
+- A *solution.sln* file, where it migrates the projects referenced in the solution.
+- On all sub-directories of the given directory recursively.
+
+The `dotnet migrate` command keeps the migrated *project.json* file in a *backup* directory, which it creates if the directory doesn't exist. This behavior is overriden using the `--skip-backup` option. 
+
+By default, the migration operation outputs the state of the migration process to standard output (STDOUT). If you use the `-r|--report-file <REPORT_FILE>` option, the output is saved to the file specified. 
+
+> [!NOTE]
+> `dotnet  migrate` only migrates a Preview 2 *project.json*-based project to a .NET Core SDK 1.0 (MSBuild/*csproj*) project.
+>
+> You can't use the `dotnet migrate` command to migrate DNX or Preview 1 *project.json*-based projects directly to MSBuild/*csproj* projects. For a project built before Preview 2 *project-json*, you first need to manually migrate the project to a Preview 2 *project.json*-based project and then use the `dotnet migrate` command to migrate the project.
+> 
+> The `dotnet-migrate` command only migrates a project to .NET Core SDK 1.0. To migrate from a Preview 2 *project.json*-based project to .NET Core SDK 2.0, use the `dotnet-migrate` command to migrate the project to 1.0 and then manually migrate the project to 2.0.
+
+## Arguments
+
+`PROJECT_JSON/GLOBAL_JSON/SOLUTION_FILE/PROJECT_DIR`
+
+The path to one of the following:
+
+- A *project.json* file to migrate.
+- A *global.json* file. It migrates the folders specified in *global.json*.
+- A *\<solution_name>.sln* file. It migrates the projects referenced in the solution.
+- A directory to migrate. It recursively searches for *project.json* files to migrate.
+
+If omitted, `dotnet-migrate` defaults the path to the current directory.
+
+## Options
+
+`--format-report-file-json <REPORT_FILE>`
+
+Outputs the migration report file as JSON rather than user messages.
+
+`-h|--help`
+
+Shows help information.
+
+`-r|--report-file <REPORT_FILE>`
+
+Outputs the migration report to a file in addition to the console.
+
+`--skip-backup`
+
+Skips moving *project.json*, *global.json*, and the *xproj* project file to a *backup* directory after successful migration.
+
+`-s|--skip-project-references [Debug|Release]`
+
+Skip migrating project references. By default, project references are migrated recursively.
+
+`-t|--template-file <TEMPLATE_FILE>`
+
+Template *csproj* file to use for the migration. By default, the template used for the migration operation is the same template as the one created by the `dotnet new console` commmand. 
+
+`-v|--sdk-package-version <VERSION>`
+
+The version of the SDK package that's referenced in the migrated app. The default is the version of the SDK used by `dotnet new`.
+
+`-x|--xproj-file <FILE>`
+
+The path to the *xproj* file to use. Required when there's more than one *xproj* file in a project directory.
+
+## Examples
+
+Migrate a project in the current directory and all of its project-to-project dependencies:
+
+`dotnet migrate`
+
+Migrate all projects that the *global.json* file includes:
+
+`dotnet migrate path/to/global.json`
+
+Migrate only the current project and no project-to-project (P2P) dependencies with a specific SDK version:
+
+`dotnet migrate -s -v 1.0.0-preview4`

--- a/docs/core/preview/tools/dotnet-msbuild.md
+++ b/docs/core/preview/tools/dotnet-msbuild.md
@@ -1,0 +1,53 @@
+---
+title: dotnet-msbuild command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-msbuild command provides access to the MSBuild command line.
+keywords: dotnet-msbuild, dotnet msbuild, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: ffdc40ba-ef33-463e-aa35-b0af1fe615a2
+---
+
+# dotnet-msbuild (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-msbuild` - Builds a project and all of its dependencies.
+
+## Synopsis
+
+`dotnet msbuild <msbuild_arguments> [-h|/help]`
+
+## Description
+
+The `dotnet msbuild` command allows access to [MSBuild](https://docs.microsoft.com/visualstudio/msbuild/msbuild). The command has the same capabilities and options as the MSBuild command-line client. For information on the available options, see the [MSBuild Command-Line Reference](https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference).
+
+## Options
+
+`-h|/help`
+
+Shows help information.
+
+## Examples
+
+Build a project and its dependencies:
+
+`dotnet msbuild`
+
+Build a project and its dependencies using Release configuration:
+
+`dotnet msbuild /p:Configuration=Release`
+
+Run the publish target and publish for the `osx.10.12-x64` [Runtime IDentifier (RID)](../rid-catalog.md):
+
+`dotnet msbuild /t:Publish /p:RuntimeIdentifiers=osx.10.12-x64`
+
+See the whole project with all targets included by the SDK:
+
+`dotnet msbuild /pp`

--- a/docs/core/preview/tools/dotnet-new.md
+++ b/docs/core/preview/tools/dotnet-new.md
@@ -1,0 +1,152 @@
+---
+title: dotnet-new command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-new command creates new .NET Core projects in the current directory.
+keywords: dotnet-new, dotnet new, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: fcc3ed2e-9265-4d50-b59e-dc2e5c190b34
+---
+
+# dotnet-new (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-new` - Creates a new project, configuration file, or solution based on the specified template.
+
+## Synopsis
+
+```
+dotnet new <TEMPLATE> [--force] [-h|--help] [-i|--install] [-lang|--language] [-n|--name] [-o|--output] [--type] [-u|--uninstall] [Template options]
+dotnet new <TEMPLATE> [-l|--list]
+dotnet new [-all|--show-all]
+dotnet new [-h|--help]
+```
+
+## Description
+
+The `dotnet new` command initializes a .NET Core project. The command calls the [template engine](https://github.com/dotnet/templating) to create the artifacts on disk based on the specified template and options.
+
+## Arguments
+
+`TEMPLATE`
+
+The template to use when the command is invoked. Each template might have specific options that you can provide to the command. For more information, see [Template options](#template-options).
+
+The command contains a default list of templates. Use `dotnet new -all` to obtain a list of the available templates. The following table shows the templates that come pre-installed with the SDK. The default language for the template is shown in brackets.
+
+| Template                                     | Name        | Languages    | Tags                |
+| -------------------------------------------- | ----------- | ------------ | ------------------- |
+| Console Application                          | console     | [C#], F#, VB | Common/Console      |
+| Class library                                | classlib    | [C#], F#, VB | Common/Library      |
+| Unit Test Project                            | mstest      | [C#], F#, VB | Test/MSTest         |
+| xUnit Test Project                           | xunit       | [C#], F#, VB | Test/xUnit          |
+| ASP.NET Core Empty                           | web         | [C#]         | Web/Empty           |
+| ASP.NET Core Web App (Model-View-Controller) | mvc         | [C#], F#     | Web/MVC             |
+| ASP.NET Core Web App (Razor Pages)           | razor       | [C#]         | Web/MVC/Razor Pages |
+| ASP.NET Core with Angular                    | angular     | [C#]         | Web/MVC/SPA         |
+| ASP.NET Core with React.js                   | react       | [C#]         | Web/MVC/SPA         |
+| ASP.NET Core with React.js and Redux         | reactredux  | [C#]         | Web/MVC/SPA         |
+| ASP.NET Core Web API                         | webapi      | [C#]         | Web/WebAPI          |
+| Nuget Config                                 | nugetconfig |              | Config              |
+| Web Config                                   | webconfig   |              | Config              |
+| Solution File                                | sln         |              | Solution            |
+| Razor Page                                   | page        |              | Web/ASP.NET         |
+| MVC ViewImports                              | viewimports |              | Web/ASP.NET         |
+| MVC ViewStart                                | viewstart   |              | Web/ASP.NET         |
+
+## Options
+
+`-all|--show-all`
+
+Shows all templates for a specific type of project when running in the context of the `dotnet new` command alone. When running in the context of a specific template, such as `dotnet new web -all`, `-all` is interpreted as a force creation flag. This is required when the output directory already contains a project.
+
+`--force`
+
+Forces content generation even if changes existing files.
+
+`-h|--help`
+
+Shows help information. Invoke for the `dotnet new` command itself or for any template, such as `dotnet new mvc --help`, which shows template-specific options.
+
+`-i|--install`
+
+Installs a source or template pack.
+
+`-l|--list`
+
+Lists templates containing the specified name. If invoked for the `dotnet new` command, it lists the possible templates available for the given directory. For example if the directory already contains a project, it doesn't list all project templates.
+
+`-lang|--language <C#|F#|VB>`
+
+The language of the template to create. The language accepted varies by template, and this option isn't valid for some templates. See the *Languages* column in the [Arguments](#arguments) section.
+
+`-n|--name <OUTPUT_NAME>`
+
+The name for the created output. If no name is specified, the name of the current directory is used.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Location to place the generated output. The default is the current directory.
+
+`--type`
+
+Filters templates based on available types. Predifined values are `project`, `item`, or `other`.
+
+`-u|--uninstall`
+
+Uninstalls a source or template pack.
+
+## Template options
+
+Each project template may have additional options. The core templates have the following options:
+
+**console, xunit, mstest, web, webapi**
+
+`-f|--framework <FRAMEWORK>`
+
+Specifies the [framework](../../standard/frameworks.md) to target. If omitted, the framework defaults to `netcoreapp2.0`.
+
+**mvc**
+
+`-f|--framework <FRAMEWORK>`
+
+Specifies the [framework](../../standard/frameworks.md) to target. If omitted, the framework defaults to `netcoreapp2.0`.
+
+`-au|--auth <None|Individual>`
+
+The type of authentication to use. If the option is omitted, the default is `None`.
+
+`-uld|--use-local-db <true|false>`
+
+Specifies whether or not to use LocalDB instead of SQLite. If this option is omitted, the default value is `false`.
+
+**classlib**
+
+`-f|--framework`
+
+Specifies the [framework](../../standard/frameworks.md) to target. If this option is omitted, the default value is `netstandard1.4`.
+
+## Examples
+
+Create an F# console app project in the current directory:
+
+`dotnet new console -lang F#` 
+   
+Create a new ASP.NET Core C# MVC app project in the current directory with no authentication targeting .NET Core 2.0:  
+
+`dotnet new mvc -au None -f netcoreapp2.0`
+ 
+Create a new xUnit app targeting .NET Core 1.1:
+
+`dotnet new xunit --framework netcoreapp1.1`
+
+List all templates available for MVC:
+
+`dotnet new mvc -l`

--- a/docs/core/preview/tools/dotnet-new.md
+++ b/docs/core/preview/tools/dotnet-new.md
@@ -75,9 +75,9 @@ Forces content generation even if changes existing files.
 
 Shows help information. Invoke for the `dotnet new` command itself or for any template, such as `dotnet new mvc --help`, which shows template-specific options.
 
-`-i|--install`
+`-i|--install <PATH|NUGET_ID>`
 
-Installs a source or template pack.
+Installs a source or template pack from the `PATH` provided. For information on creating custom templates, see [Create custom templates for dotnet new](custom-templates.md).
 
 `-l|--list`
 
@@ -99,9 +99,9 @@ Location to place the generated output. The default is the current directory.
 
 Filters templates based on available types. Predifined values are `project`, `item`, or `other`.
 
-`-u|--uninstall`
+`-u|--uninstall <PATH|NUGET_ID>`
 
-Uninstalls a source or template pack.
+Uninstalls a source or template pack at the `PATH|NUGET_ID` provided.
 
 ## Template options
 
@@ -150,3 +150,7 @@ Create a new xUnit app targeting .NET Core 1.1:
 List all templates available for MVC:
 
 `dotnet new mvc -l`
+
+## See also
+
+[Create custom templates for dotnet new](custom-templates.md)

--- a/docs/core/preview/tools/dotnet-nuget-delete.md
+++ b/docs/core/preview/tools/dotnet-nuget-delete.md
@@ -1,0 +1,74 @@
+---
+title: dotnet-nuget-delete command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-nuget-delete command deletes or unlists a package from the server. 
+keywords: dotnet-nuget-delete, dotnet nuget delete, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 6ddffde4-c789-4e90-990e-d35f6a6565d4
+---
+
+# dotnet-nuget delete (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-nuget-delete` - Deletes or unlists a package from the server.
+
+## Synopsis
+
+`dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [-h|--help] [-k|--api-key] [--non-interactive] [-s|--source]`
+
+## Description
+
+The `dotnet nuget delete` command deletes or unlists a package from the server. For [NuGet.org](https://www.nuget.org/), the action is to unlist the package (See NOTE).
+
+> [!NOTE]
+> It isn't possible to permanently delete a package from NuGet.org; you can only *unlist* a package. For more information, see the [Deleting packages](https://docs.microsoft.com/nuget/policies/deleting-packages) topic in the NuGet documentation.
+
+## Arguments
+
+`PACKAGE_NAME`
+
+The package to delete.
+
+`PACKAGE_VERSION`
+
+The version of the package to delete.
+
+## Options
+
+`--force-english-output`
+
+Forces command-line output in English.
+
+`-h|--help`
+
+Shows help information.
+
+`-k|--api-key <API_KEY>`
+
+The API key for the server.
+
+`--non-interactive`
+
+Don't prompt for user input or confirmations.
+
+`-s|--source <SOURCE>`
+
+Specifies the server URL. Supported URLs for [NuGet.org](https://www.nuget.org/) include `http://www.nuget.org`, `http://www.nuget.org/api/v3`, and `http://www.nuget.org/api/v2/package`. For private feeds, use the host name for `SOURCE` (for example, `%hostname%/api/v3`).
+
+## Examples
+
+Delete version 1.0 of package `Microsoft.AspNetCore.Mvc`:
+
+`dotnet nuget delete Microsoft.AspNetCore.Mvc 1.0` 
+
+Delete version 1.0 of package `Microsoft.AspNetCore.Mvc` and don't prompt the user for credentials or other input:
+
+`dotnet nuget delete Microsoft.AspNetCore.Mvc 1.0 --non-interactive`

--- a/docs/core/preview/tools/dotnet-nuget-locals.md
+++ b/docs/core/preview/tools/dotnet-nuget-locals.md
@@ -1,0 +1,84 @@
+---
+title: dotnet-nuget-locals command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-nuget-locals command clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder. 
+keywords: dotnet-nuget-locals, dotnet nuget locals, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 8440229e-317e-4dc1-9463-cba5fdb12c3b
+---
+
+# dotnet-nuget locals (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-nuget locals` - Clears or lists local NuGet resources. 
+
+## Synopsis
+
+`dotnet nuget locals <CACHE_LOCATION> [(-c|--clear)|(-l|--list)] [--force-english-output] [-h|--help]`
+
+## Description
+
+The `dotnet nuget locals` command clears or lists local NuGet resources in the http-request cache, temporary cache, or machine-wide global packages folder.
+
+## Arguments
+
+`CACHE_LOCATION`
+
+| Value             | Cache locations cleared or listed                                        |
+| ----------------- | ------------------------------------------------------------------------ |
+| `all`             | All cache locations: http-request, global packages, and temporary caches |
+| `global-packages` | Only the global packages cache                                           |
+| `http-cache`      | Only the http-request cache                                              |
+| `temp`            | Only the temporary cache                                                 |
+
+## Options
+
+`-c|--clear`
+
+The clear option performs a clear operation on the specified cache type. The contents of the cache directories are deleted recursively. The executing user/group must have permission to delete the files in the cache directories or an error is displayed indicating the files/folders not cleared. Use either `-c|--clear` or `-l|-list`; don't use both.
+
+`--force-english-output`
+
+Force command-line output in English.
+
+`-h|--help`
+
+Shows help information.
+
+`-l|--list`
+
+The list option is used to display the location of the specified cache type. Use either `-c|--clear` or `-l|-list`; don't use both.
+
+## Examples
+
+Display the paths of the local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
+
+`dotnet nuget locals all -l`
+
+Display the path for the local http-cache directory:
+
+`dotnet nuget locals http-cache --list`
+
+Clear the files from the local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
+
+`dotnet nuget locals all --clear`
+
+Clear the files in the local global-packages cache directory:
+
+`dotnet nuget locals global-packages -c`
+
+Clear the files in the local temporary cache directory:
+
+`dotnet nuget locals temp -c`
+
+## Troubleshooting
+
+For information on common problems and errors while using the `dotnet nuget locals` command, see [Managing the NuGet cache](https://docs.microsoft.com/nuget/consume-packages/managing-the-nuget-cache).

--- a/docs/core/preview/tools/dotnet-nuget-push.md
+++ b/docs/core/preview/tools/dotnet-nuget-push.md
@@ -1,0 +1,107 @@
+---
+title: dotnet-nuget-push command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-nuget-push command pushes a package to the server and publishes it. 
+keywords: dotnet-nuget-push, dotnet nuget push, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: f54d9adf-94f8-41cc-bb52-42f7ca3be6ff
+---
+
+# dotnet-nuget push (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-nuget push` - Pushes a package to the server and publishes it.
+
+## Synopsis
+
+`dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [-h|--help] [-k|--api-key] [-n|--no-symbols] [-s|--source] [-sk|--symbol-api-key] [-ss|--symbol-source] [-t|--timeout]`
+
+## Description
+
+The `dotnet nuget push` command pushes a package to the server and publishes it. The push command uses server and credential details found in the system's NuGet config file or chain of config files. For more information on config files, see [Configuring NuGet Behavior](https://docs.microsoft.com/nuget/consume-packages/configuring-nuget-behavior). NuGet's default configuration is obtained by loading *%AppData%\NuGet\NuGet.config* (Windows) or *$HOME/.local/share* (macOS/Linux), then loading any *nuget.config* or *.nuget\nuget.config* starting from the root of drive and ending in the current directory.
+
+## Arguments
+
+`ROOT`
+
+Specifies the path to the package and your API key to push the package to the server.
+
+## Options
+
+`-d|--disable-buffering`
+
+Disable buffering when pushing to an HTTP(S) server to decrease memory usage.
+
+`--force-english-output`
+
+Force command-line output in English.
+
+`-h|--help`
+
+Shows help information.
+
+`-k|--api-key <API_KEY>`
+
+The API key for the server.
+
+`-n|--no-symbols`
+
+Don't push symbols (even if present).
+
+`-s|--source <SOURCE>`
+
+Specifies the server URL. This option is required unless the `DefaultPushSource` config value is set in the NuGet config file.
+
+`-sk|--symbol-api-key <API_KEY>`
+
+The API key for the symbol server.
+
+`-ss|--symbols-source <SOURCE>`
+
+Specifies the symbol server URL.
+
+`-t|--timeout <TIMEOUT>`
+
+Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
+
+## Examples
+
+Push *foo.nupkg* to the default push source with an API key:
+
+`dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a`
+
+Push *foo.nupkg* to the custom push source `http://customsource` with an API key:
+
+`dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -s http://customsource/` 
+
+Push *foo.nupkg* to the default push source:
+
+`dotnet nuget push foo.nupkg` 
+
+Push *foo.symbols.nupkg* to the default symbols source:
+
+`dotnet nuget push foo.symbols.nupkg`
+
+Push *foo.nupkg* to the default push source with a 360 second timeout:
+
+`dotnet nuget push foo.nupkg --timeout 360`
+
+Push all *nupkg* files in the current directory to the default push source:
+
+`dotnet nuget push *.nupkg`
+
+Push all *nupkg* files in the current directory to the default push source with a custom config file *./config/My.Config*:
+
+`dotnet nuget push *.nupkg --config-file ./config/My.Config`
+
+Push all *nupkg* files in the current directory to the default push source with maximum verbosity:
+
+`dotnet nuget push *.nupkg --verbosity detailed`

--- a/docs/core/preview/tools/dotnet-pack.md
+++ b/docs/core/preview/tools/dotnet-pack.md
@@ -1,0 +1,105 @@
+---
+title: dotnet-pack command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-pack command creates NuGet packages for your .NET Core project.
+keywords: dotnet-pack, dotnet pack, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 8dbbb3f7-b817-4161-a6c8-a3489d05e051
+---
+
+# dotnet-pack (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-pack` - Packs the code into a NuGet package.
+
+## Synopsis
+
+`dotnet pack [<PROJECT>] [-c|--configuration] [-h|--help] [--include-source] [--include-symbols] [--no-build] [-o|--output] [-s|--serviceable] [-v|--verbosity] [--version-suffix]`
+
+## Description
+
+The `dotnet pack` command builds the project and creates NuGet packages. If the `--include-symbols` option is present, another package containing the debug symbols is created. 
+
+NuGet dependencies of the packed project are added to the *nuspec* file and properly resolved when the package is installed. Project-to-project references aren't packaged inside the project. Currently, you must have a package per project if you have project-to-project dependencies.
+
+By default, `dotnet pack` builds the project first. If you wish to avoid this behavior, pass the `--no-build` option. This is often useful in Continuous Integration (CI) build scenarios when the code was previously built.
+
+You can provide MSBuild properties to the `dotnet pack` command for the packing process. For more information, see [NuGet metadata properties](csproj.md#nuget-metadata-properties) and the [MSBuild Command-Line Reference](/visualstudio/msbuild/msbuild-command-line-reference).
+
+## Arguments
+
+`PROJECT` 
+    
+The project to pack. It's either a path to a [*csproj* file](csproj.md) or to a directory. If omitted, the command defaults to the project in the current directory. 
+
+## Options
+
+`-c|--configuration <CONFIGURATION>`
+
+Specifies the build configuration. If not specified, the configuration defaults to `Debug`.
+
+`-h|--help`
+
+Shows help information.
+
+`--include-source`
+
+Includes the source files in the NuGet package. The sources files are included in the *src* folder within the *nupkg*.
+
+`--include-symbols`
+
+Generates the symbols *nupkg*.
+
+`--no-build`
+
+Disables building the project before packing.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Places the built packages in the directory specified.
+
+`-s|--serviceable`
+
+Sets the serviceable flag in the package. For more information, see [.NET Blog: .NET 4.5.1 Supports Microsoft Security Updates for .NET NuGet Libraries](https://aka.ms/nupkgservicing).
+
+`-v|--verbosity <LEVEL>`
+
+Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+`--version-suffix <VERSION_SUFFIX>`
+
+Defines the value for the `$(VersionSuffix)` MSBuild property in the project.
+
+## Examples
+
+Pack the project in the current directory:
+
+`dotnet pack`
+
+Pack the `app1` project:
+
+`dotnet pack ~/projects/app1/project.csproj`
+	
+Pack the project in the current directory and place the resulting packages into the *nupkgs* folder:
+
+`dotnet pack --output nupkgs`
+
+Pack the project in the current directory into the *nupkgs* folder and skip the build step:
+
+`dotnet pack --no-build --output nupkgs`
+
+With the project's version suffix configured as `<VersionSuffix>$(VersionSuffix)</VersionSuffix>` in the *csproj* file, pack the current project and update the resulting package version with a suffix:
+
+`dotnet pack --version-suffix "ci-1234"`
+
+Set the package version to `2.1.0` with the `PackageVersion` MSBuild property:
+
+`dotnet pack /p:PackageVersion=2.1.0`

--- a/docs/core/preview/tools/dotnet-publish.md
+++ b/docs/core/preview/tools/dotnet-publish.md
@@ -1,10 +1,10 @@
 ---
 title: dotnet-publish command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
 description: The dotnet-publish command publishes your .NET Core project into a directory. 
-keywords: dotnet-publish, CLI, CLI command, .NET Core
+keywords: dotnet-publish, dotnet publish, CLI, CLI command, .NET Core
 author: guardrex
 ms.author: mairaw
-ms.date: 06/07/2017
+ms.date: 06/11/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
@@ -18,66 +18,58 @@ ms.assetid: ff2471cd-07ed-49cf-bc1c-2a6f20acbd3f
 
 ## Name
 
-`dotnet-publish` - Packs the application and its dependencies into a folder for deployment to a hosting system.
+`dotnet-publish` - Packs the app and its dependencies into a folder for deployment to a hosting system.
 
 ## Synopsis
 
 `dotnet publish [<PROJECT>] [-h|--help] [-c|--configuration] [-f|--framework] [--manifest] [-o|--output] [-r|--runtime] [--self-contained] [-v|--verbosity] [--version-suffix]`
 
-Optional arguments appear in brackets.
-
 ## Description
 
-`dotnet publish` compiles the application, reads through its dependencies specified in the project file, and publishes the resulting set of files to a directory. The output contains the following:
+`dotnet publish` compiles the app, reads through its dependencies specified in the project file, and publishes the resulting set of files to a directory. The output contains the following:
 
-- Intermediate Language (IL) code in an assembly with a *.dll* extension.
-- *\*.deps.json* file containing all of the dependencies of the project.
-- *\*.runtime.config.json* file specifying the shared runtime that the application expects and other configuration options for the runtime (for example, garbage collection type).
-- The application's dependencies. These are copied from the NuGet cache into the output folder.
+- Intermediate Language (IL) code in an assembly with a *dll* extension.
+- *\<assembly_name>.deps.json* file containing all of the dependencies of the project.
+- *\<assembly_name>.runtime.config.json* file specifying the shared runtime that the app expects and other configuration options for the runtime (for example, the garbage collection type).
+- The app's dependencies. These are copied from the NuGet cache into the output folder.
 
-The `dotnet publish` command's output is ready for deployment to a hosting system (for example, a server, PC, Mac, laptop) for execution and is the only officially supported way to prepare the application for deployment. The .NET Core shared runtime is required on the hosting system for framework-dependent deployments to run. Self-contained deployments include the runtime, so the hosting system doesn't require pre-installation of the shared runtime. For more information, see [.NET Core Application Deployment](../deploying/index.md). For the directory structure of a published application, see [Directory structure](https://docs.microsoft.com/aspnet/core/hosting/directory-structure).
+The `dotnet publish` command's output is ready for deployment to a hosting system (for example, a server, PC, Mac, laptop) for execution and is the only officially-supported way to prepare the app for deployment. The .NET Core shared runtime is required on the hosting system for framework-dependent deployments to run. Self-contained deployments include the runtime, so the hosting system doesn't require pre-installation of the shared runtime. For more information, see [.NET Core Application Deployment](../deploying/index.md). For the directory structure of a published app, see [Directory structure](https://docs.microsoft.com/aspnet/core/hosting/directory-structure). If you plan to deploy an ASP.NET Core app, see [Hosting and deployment overview for ASP.NET Core apps](https://docs.microsoft.com/aspnet/core/publishing/). 
 
 ## Arguments
-
-### Command parameters
 
 `PROJECT`
 
 Optional. The project to publish, which defaults to the current directory if not specified. 
 
-### Required options
-
-None
-
-### Optional options
+## Options
 
 `-h|--help`
 
-Show help information.
+Shows help information.
 
 `-c|--configuration <CONFIGURATION>`
 
-Configuration to use when building the project. The default value is `Debug`.
+Specifies the build configuration. The default is `Debug`.
 
 `-f|--framework <FRAMEWORK>`
 
-Publishes the application for the specified [target framework](../../standard/frameworks.md). You must specify the target framework in the project file.
+Specifies the [target framework](../../standard/frameworks.md). You must specify the target framework in the project file in either the **\<TargetFramework>** or **\<TargetFrameworks>** property. For more information, see [Additions to the csproj format for .NET Core](xref:~/docs/core/tools/csproj.md).
 
-`--manifest <manifest.xml>`
+`--manifest <MANIFEST_FILE>`
 
-Specifies one or several [target manifests](../deploying/runtime-package-store.md) to use to trim the set of packages that published with the application. The manifest file is part of the output of the [`dotnet store` command](dotnet-store.md). To specify multiple manifests, add a `--manifest` option for each manifest.
+Specifies one or several [target manifests](../deploying/runtime-package-store.md) to use to trim the set of packages published with the app. The manifest file is part of the output of the [`dotnet store` command](dotnet-store.md). To specify multiple manifests, add a `--manifest` option for each manifest.
 
 `-o|--output <OUTPUT_DIRECTORY>`
 
-Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]/* for a self-contained deployment.
+Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment (FDD) or *./bin/[configuration]/[framework]/[runtime]/* for a self-contained deployment (SCD). For more information on the two types of deployement, see [.NET Core application deployment](../deploying/index.md).
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 
-Publishes the application for a given runtime. This is used when creating a [self-contained deployment (SCD)](../deploying/index.md#self-contained-deployments-scd). For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). Default is to publish a [framework-dependent deployment (FDD)](../deploying/index.md#framework-dependent-deployments-fdd).
+Publishes the app for a given runtime. This is used when creating a [self-contained deployment (SCD)](../deploying/index.md#self-contained-deployments-scd). For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). The default is to publish a [framework-dependent deployment (FDD)](../deploying/index.md#framework-dependent-deployments-fdd).
 
-`--self-contained`
+`--self-contained [<true|false>]`
 
-Publish the .NET Core runtime with your application so the app can run on the hosting system without having the runtime installed. Defaults to `true` when a runtime identifier (RID) is specified.
+Publishes the .NET Core runtime with your app, so the app can run on hosting systems where the runtime isn't installed. Defaults to `true` if `false` isn't specified or when a runtime identifier (RID) is specified with the `-r|--runtime` option.
 
 `-v|--verbosity <LEVEL>`
 
@@ -85,7 +77,7 @@ Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal
 
 `--version-suffix <VERSION_SUFFIX>`
 
-Defines the version suffix to replace the asterisk (`*`) in the version field (`$(VersionSuffix)`) of the project file.
+Defines the version suffix to replace the asterisk (`*`) in the version field (`$(VersionSuffix)`) of the project file. The format follows NuGet's version guidelines. For more information, see [Specifying dependency versions for NuGet Packages](https://docs.microsoft.com/nuget/create-packages/dependency-versions#normalized-version-numbers).
 
 ## Examples
 
@@ -93,7 +85,7 @@ Publish the project in the current directory:
 
 `dotnet publish`
 
-Publish the application using the specified project file:
+Publish the app using the specified project file:
 
 `dotnet publish ~/projects/app1/app1.csproj`
 
@@ -101,11 +93,11 @@ Publish the project in the current directory using the `netcoreapp2.0` framework
 
 `dotnet publish --framework netcoreapp2.0`
 
-Publish the current application using the `netcoreapp2.0` framework and the runtime for `OS X 10.12` [you must list the runtime (RID) in the project file]:
+Publish the current app using the `netcoreapp2.0` framework and the runtime for `OS X 10.12` [you must list the runtime (RID) in the project file]:
 
 `dotnet publish --framework netcoreapp2.0 --runtime osx.10.12-x64`
 
-Publish the current application without the packages specified in the *main-manifest.xml* and *other-manifest.xml* target manifests:
+Publish the current app without the packages specified in the *main-manifest.xml* and *other-manifest.xml* target manifests:
 
 `dotnet publish --manifest main-manifest.xml --manifest other-manifest.xml`
 

--- a/docs/core/preview/tools/dotnet-publish.md
+++ b/docs/core/preview/tools/dotnet-publish.md
@@ -1,21 +1,20 @@
 ---
-title: dotnet-publish command (.NET Core SDK 2.0 Preview 1) | Microsoft Docs
+title: dotnet-publish command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
 description: The dotnet-publish command publishes your .NET Core project into a directory. 
 keywords: dotnet-publish, CLI, CLI command, .NET Core
-author: blackdwarf
+author: guardrex
 ms.author: mairaw
-ms.date: 05/18/2017
+ms.date: 06/07/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: ff2471cd-07ed-49cf-bc1c-2a6f20acbd3f
 ---
-# dotnet-publish (.NET Core SDK 2.0 Preview 1)
 
-> [!WARNING]
-> This topic applies to .NET Core SDK 2.0 Preview 1. For the .NET Core SDK 1.x version,
-> see the [dotnet-publish](../../tools/dotnet-publish.md) topic.
+# dotnet-publish (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
 
 ## Name
 
@@ -23,58 +22,70 @@ ms.assetid: ff2471cd-07ed-49cf-bc1c-2a6f20acbd3f
 
 ## Synopsis
 
-`dotnet publish [<PROJECT>] [-f|--framework] [-r|--runtime] [-o|--output] [-c|--configuration] [--version-suffix] [--manifest] [-v|--verbosity] [-h|--help]`
+`dotnet publish [<PROJECT>] [-h|--help] [-c|--configuration] [-f|--framework] [--manifest] [-o|--output] [-r|--runtime] [--self-contained] [-v|--verbosity] [--version-suffix]`
+
+Optional arguments appear in brackets.
 
 ## Description
 
-`dotnet publish` compiles the application, reads through its dependencies specified in the project file, and publishes the resulting set of files to a directory. The output will contain the following:
+`dotnet publish` compiles the application, reads through its dependencies specified in the project file, and publishes the resulting set of files to a directory. The output contains the following:
 
-* Intermediate Language (IL) code in an assembly with a `*.dll` extension.
-* *\*.deps.json* file that contains all of the dependencies of the project.
-* *\*.runtime.config.json* file that specifies the shared runtime that the application expects, as well as other configuration options for the runtime (for example, garbage collection type).
-* The application's dependencies. These are copied from the NuGet cache into the output folder.
+- Intermediate Language (IL) code in an assembly with a *.dll* extension.
+- *\*.deps.json* file containing all of the dependencies of the project.
+- *\*.runtime.config.json* file specifying the shared runtime that the application expects and other configuration options for the runtime (for example, garbage collection type).
+- The application's dependencies. These are copied from the NuGet cache into the output folder.
 
-The `dotnet publish` command's output is ready for deployment to a hosting system (for example, a server, PC, Mac, laptop) for execution and is the only officially supported way to prepare the application for deployment. Depending on the type of deployment that the project specifies, the hosting system may or may not have the .NET Core shared runtime installed on it. For more information, see [.NET Core Application Deployment](../deploying/index.md). For the directory structure of a published application, see [Directory structure](https://docs.microsoft.com/en-us/aspnet/core/hosting/directory-structure).
+The `dotnet publish` command's output is ready for deployment to a hosting system (for example, a server, PC, Mac, laptop) for execution and is the only officially supported way to prepare the application for deployment. The .NET Core shared runtime is required on the hosting system for framework-dependent deployments to run. Self-contained deployments include the runtime, so the hosting system doesn't require pre-installation of the shared runtime. For more information, see [.NET Core Application Deployment](../deploying/index.md). For the directory structure of a published application, see [Directory structure](https://docs.microsoft.com/aspnet/core/hosting/directory-structure).
 
 ## Arguments
 
+### Command parameters
+
 `PROJECT`
 
-The project to publish, which defaults to the current directory if not specified. 
+Optional. The project to publish, which defaults to the current directory if not specified. 
 
-## Options
+### Required options
+
+None
+
+### Optional options
 
 `-h|--help`
 
-Prints out a short help for the command.
-
-`-f|--framework <FRAMEWORK>`
-
-Publishes the application for the specified [target framework](../../standard/frameworks.md). You must specify the target framework in the project file.
-
-`-r|--runtime <RUNTIME_IDENTIFIER>`
-
-Publishes the application for a given runtime. This is used when creating a [self-contained deployment (SCD)](../deploying/index.md#self-contained-deployments-scd). For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). Default is to publish a [framework-dependent deployment (FDD)](../deploying/index.md#framework-dependent-deployments-fdd).
-
-`-o|--output <OUTPUT_DIRECTORY>`
-
-Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
+Show help information.
 
 `-c|--configuration <CONFIGURATION>`
 
 Configuration to use when building the project. The default value is `Debug`.
 
-`--version-suffix <VERSION_SUFFIX>`
+`-f|--framework <FRAMEWORK>`
 
-Defines the version suffix to replace the asterisk (`*`) in the version field of the project file.
+Publishes the application for the specified [target framework](../../standard/frameworks.md). You must specify the target framework in the project file.
 
-`--manifest`
+`--manifest <manifest.xml>`
 
-Specifies one or several [target manifests](../deploying/runtime-package-store.md) to use to trim the set of packages that will be published with the application. The manifest file is part of the output of the [`dotnet store` command](dotnet-store.md). To specify multiple manifests, add a `--manifest` option for each manifest.
+Specifies one or several [target manifests](../deploying/runtime-package-store.md) to use to trim the set of packages that published with the application. The manifest file is part of the output of the [`dotnet store` command](dotnet-store.md). To specify multiple manifests, add a `--manifest` option for each manifest.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]/* for a self-contained deployment.
+
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+Publishes the application for a given runtime. This is used when creating a [self-contained deployment (SCD)](../deploying/index.md#self-contained-deployments-scd). For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). Default is to publish a [framework-dependent deployment (FDD)](../deploying/index.md#framework-dependent-deployments-fdd).
+
+`--self-contained`
+
+Publish the .NET Core runtime with your application so the app can run on the hosting system without having the runtime installed. Defaults to `true` when a runtime identifier (RID) is specified.
 
 `-v|--verbosity <LEVEL>`
 
 Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+`--version-suffix <VERSION_SUFFIX>`
+
+Defines the version suffix to replace the asterisk (`*`) in the version field (`$(VersionSuffix)`) of the project file.
 
 ## Examples
 
@@ -86,19 +97,19 @@ Publish the application using the specified project file:
 
 `dotnet publish ~/projects/app1/app1.csproj`
 
-Publish the project in the current directory using the `netcoreapp1.1` framework:
+Publish the project in the current directory using the `netcoreapp2.0` framework:
 
-`dotnet publish --framework netcoreapp1.1`
+`dotnet publish --framework netcoreapp2.0`
 
-Publish the current application using the `netcoreapp1.1` framework and the runtime for `OS X 10.10` (you must list this RID in the project file).
+Publish the current application using the `netcoreapp2.0` framework and the runtime for `OS X 10.12` [you must list the runtime (RID) in the project file]:
 
-`dotnet publish --framework netcoreapp1.1 --runtime osx.10.11-x64`
+`dotnet publish --framework netcoreapp2.0 --runtime osx.10.12-x64`
 
-Publish the current application without the packages specified in the `manifest.xml` target manifest:
+Publish the current application without the packages specified in the *main-manifest.xml* and *other-manifest.xml* target manifests:
 
-`dotnet publish --manifest manifest.xml`
+`dotnet publish --manifest main-manifest.xml --manifest other-manifest.xml`
 
 ## See also
 
-* [Target frameworks](../../standard/frameworks.md)
-* [Runtime IDentifier (RID) catalog](../rid-catalog.md)
+[Target frameworks](../../standard/frameworks.md)   
+[Runtime IDentifier (RID) catalog](../rid-catalog.md)

--- a/docs/core/preview/tools/dotnet-remove-package.md
+++ b/docs/core/preview/tools/dotnet-remove-package.md
@@ -1,0 +1,51 @@
+---
+title: dotnet-remove package command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-remove package command provides a convenient option to remove NuGet package reference to a project.
+keywords: dotnet-remove package, dotnet remove package, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 2fcc8d37-16b3-4581-8038-832160e72d36
+---
+
+# dotnet-remove package (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-remove package` - Removes package reference from a project file.
+
+## Synopsis
+
+`dotnet remove [<PROJECT>] package <PACKAGE_NAME> [-h|--help]`
+
+## Description
+
+The `dotnet remove package` command removes a NuGet package reference from a project.
+
+## Arguments
+
+`PROJECT`
+
+Specifies the project file. If not specified, the command searches the current directory for one.
+
+`PACKAGE_NAME`
+
+The package reference to remove.
+
+## Options
+
+`-h|--help`
+
+Shows help information.
+
+## Examples
+
+Removes `Newtonsoft.Json` NuGet package from a project in the current directory:
+
+`dotnet remove package Newtonsoft.Json`

--- a/docs/core/preview/tools/dotnet-remove-reference.md
+++ b/docs/core/preview/tools/dotnet-remove-reference.md
@@ -1,0 +1,63 @@
+---
+title: dotnet-remove reference command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-remove reference command provides a convenient option to remove project to project references.
+keywords: dotnet-remove reference, dotnet remove reference, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 889c6b7e-a313-40b1-9fd3-6a6f4c52f1d0
+---
+
+# dotnet-remove reference (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-remove reference` - Removes project-to-project references.
+
+## Synopsis
+
+`dotnet remove [<PROJECT>] reference [-f|--framework] <PROJECT_REFERENCES> [-h|--help]`
+
+## Description
+
+The `dotnet remove reference` command removes project references from a project.
+
+## Arguments
+
+`PROJECT`
+
+Specifies the target project file. If not specified, the command searches the current directory for one.
+
+`PROJECT_REFERENCES`
+
+Project to project (P2P) references to remove. The command accepts one or multiple projects. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux systems.
+
+## Options
+
+`-f|--framework <FRAMEWORK>`
+
+Removes the reference only when targeting a specific [framework](../../standard/frameworks.md).
+
+`-h|--help`
+
+Shows help information.
+
+## Examples
+
+Remove a project reference from the specified project:
+
+`dotnet remove app/app.csproj reference lib/lib.csproj`
+
+Remove multiple project references from the project in the current directory:
+
+`dotnet remove reference lib1/lib1.csproj lib2/lib2.csproj`
+
+Remove multiple project references using a glob pattern on Unix/Linux:
+
+`dotnet remove app/app.csproj reference **/*.csproj`

--- a/docs/core/preview/tools/dotnet-restore.md
+++ b/docs/core/preview/tools/dotnet-restore.md
@@ -1,0 +1,122 @@
+---
+title: dotnet-restore command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: Learn how to restore dependencies and project-specific tools with the dotnet restore command.
+keywords: dotnet-restore, dotnet restore, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: fd7a5769-afbe-4838-bbaf-3ae0cfcbb914
+---
+
+# dotnet-restore (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-restore` - Restores the dependencies and tools of a project.
+
+## Synopsis
+
+`dotnet restore [<ROOT>] [--configfile] [--disable-parallel] [-h|--help] [--ignore-failed-sources] [--no-cache] [--no-dependencies] [--packages] [-r|--runtime] [-s|--source] [-v|--verbosity]`
+
+## Description
+
+The `dotnet restore` command uses NuGet to restore dependencies and project-specific tools that are specified in the project file. By default, the restoration of dependencies and tools are performed in parallel. The outputs of `dotnet restore` are placed in an intermediate outputs folder named *obj*.
+
+In order to restore dependencies, NuGet requires feed locations where the packages are located. Feeds are usually provided with the *NuGet.config* configuration file. A default configuration file is provided when the CLI tools are installed.
+
+You can specify additional feeds by creating your own *NuGet.config* file in the project directory. For example when you need to obtain packages from the "nightly" development feed for bleeding edge ASP.NET Core development, you can specify the ASP.NET Core "dev" branch feed (`aspnetcore-dev`) by placing a *NuGet.config* file in the project's directory that includes the development feed:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v2/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+You can also specify additional feeds when running the `dotnet-restore` command at a command prompt using the `--configfile <FILE>` or `-s|--source <SOURCE>` options. `--configfile <FILE>` specifies a config file, while `-s|--source <SOURCE>` specifies a NuGet package source.
+
+For dependencies, you specify where the restored packages are placed during the restore operation using the `--packages <PACKAGES_DIRECTORY>` option. If not specified, the default NuGet package cache is used, which is found in the `.nuget/packages` directory in the user's home directory on all operating systems (for example, */home/user1* on Linux or *C:\Users\user1* on Windows).
+
+For project-specific tooling, `dotnet restore` first restores the package in which the tool is packed and then proceeds to restore the tool's dependencies as specified in its project file.
+
+Settings in a *Nuget.Config* file affect the behavior of the `dotnet restore` command. For example, setting the `globalPackagesFolder` in *NuGet.Config* places the restored NuGet packages in the specified folder. This is an alternative to specifying the `--packages` option on the `dotnet restore` command. For more information, see the [NuGet.Config reference](https://docs.microsoft.com/nuget/schema/nuget-config-file).
+
+## Arguments
+
+`ROOT` 
+    
+Optional path to the project file to restore.
+
+## Options
+
+`--configfile <FILE>`
+
+Specifies the NuGet configuration file (*NuGet.config*) to use for the restore operation.
+
+`--disable-parallel`
+
+Disables restoring multiple projects in parallel. 
+
+`-h|--help`
+
+Shows help information.
+
+`--ignore-failed-sources`
+
+Treat package source failures as warnings.
+
+`--no-cache`
+
+Specifies to not cache packages and HTTP requests.
+
+`--no-dependencies`
+
+When restoring a project with project-to-project (P2P) references, restore the root project and not the references.
+
+`--packages <PACKAGES_DIRECTORY>`
+
+Specifies the directory for restored packages. 
+
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+Specifies a runtime for the package restore. This is used to restore packages for runtimes not explicitly listed in the `<RuntimeIdentifiers>` tag in the *csproj* file. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md). Provide multiple RIDs by specifying this option and value multiple times.
+
+`-s|--source <SOURCE>`
+
+Specifies a NuGet package source to use during the restore operation. This overrides the sources specified in the *NuGet.config* files. Specify multiple sources by specifying this option/value multiple times.
+
+`-v|--verbosity <LEVEL>`
+
+Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+## Examples
+
+Restore dependencies and tools for the project in the current directory:
+
+`dotnet restore` 
+
+Restore dependencies and tools for the `app1` project found on a path:
+
+`dotnet restore ~/projects/app1/app1.csproj`
+	
+Restore the dependencies and tools for the project in the current directory using the file path provided as the source:
+
+`dotnet restore -s c:\packages\mypackages` 
+
+Restore the dependencies and tools for the project in the current directory using two file paths provided as sources:
+
+`dotnet restore -s c:\packages\mypackages -s c:\packages\myotherpackages` 
+
+Restore dependencies and tools for the project in the current directory and show minimal output:
+
+`dotnet restore --verbosity minimal`

--- a/docs/core/preview/tools/dotnet-run.md
+++ b/docs/core/preview/tools/dotnet-run.md
@@ -1,0 +1,87 @@
+---
+title: dotnet-run command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-run command provides a convenient option to run your app from its source code.
+keywords: dotnet-run, dotnet run, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 40d4e60f-9900-4a48-b03c-0bae06792d91
+---
+
+# dotnet-run (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name 
+
+`dotnet-run` - Runs source code without explicit compile or launch commands.
+
+## Synopsis
+
+`dotnet run [-c|--configuration] [-f|--framework] [-h|--help] [--launch-profile] [--no-build] [--no-launch-profile] [-p|--project] [[--] [application arguments]]`
+
+## Description
+
+The `dotnet run` command runs your app from source code with one command. It's useful for fast iterative development from the command line. The command depends on the [`dotnet build`](dotnet-build.md) command to build the code. Any requirements for the build, such as that the project must be restored first, apply to `dotnet run`. 
+
+Output files are written into the default location, which is *bin/<configuration>/<target>*. For example if you have a `netcoreapp2.0` app and you run `dotnet run`, the output is placed in *bin/Debug/netcoreapp2.0*. Files are overwritten as needed. Temporary files are placed in the *obj* directory. 
+
+If the project specifies multiple frameworks, executing `dotnet run` results in an error unless the `-f|--framework <FRAMEWORK>` option is used to specify the framework.
+
+The `dotnet run` command is used in the context of projects, not built assemblies. If you're trying to run a framework-dependent app DLL instead, use [dotnet](dotnet.md) without a command. For example to run `myapp.dll`, use `dotnet myapp.dll`.
+
+In order to run the app, the `dotnet run` command resolves the dependencies of the app that are outside of the shared runtime from the NuGet cache. Because it uses cached dependencies, it's not recommended to use `dotnet run` for apps in production. Instead, [create a deployment](../deploying/index.md) using the [`dotnet publish`](dotnet-publish.md) command and deploy the published output.
+
+For more information on the `dotnet` driver, see the [.NET Core CLI Tools](index.md) topic.
+
+## Options
+
+`--`
+
+Separates arguments to `dotnet run` from arguments for the app. The arguments after the `--` argument are passed to the app. 
+
+`-c|--configuration <CONFIGURATION>`
+
+Configuration to use for building the project. The default value is `Debug`.
+
+`-f|--framework <FRAMEWORK>`
+
+Builds and runs the app using the specified [framework](../../standard/frameworks.md). The framework must be specified in the project file.
+
+`-h|--help`
+
+Shows help information.
+
+`--launch-profile <PROFILE>`
+
+The name of the launch profile to use when launching the app.
+
+`--no-build`
+
+Skips building the project prior to running. By default, the project is built.
+
+`--no-launch-profile`
+
+Avoids using *launchSettings.json* to configure the app.
+
+`-p|--project <PATH/PROJECT.csproj>`
+
+Specifies the path and name of the project file. If this option isn't specified, the path defaults to the current directory.
+
+## Examples
+
+Run the project in the current directory:
+
+`dotnet run` 
+
+Run the specified project:
+
+`dotnet run --project /projects/proj1/proj1.csproj`
+
+Run the project in the current directory with a Release configuarion (the `--help` argument in this example is passed to the app, since `--help` is placed after the `--` argument):
+
+`dotnet run --configuration Release -- --help`

--- a/docs/core/preview/tools/dotnet-sln.md
+++ b/docs/core/preview/tools/dotnet-sln.md
@@ -1,0 +1,92 @@
+---
+title: dotnet-sln command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-sln command provides a convenient option to add, remove, and list projects in a solution file.
+keywords: dotnet-sln, dotnet sln, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: e5a72d3e-c14b-4b0a-a978-c5e54a0988c6
+---
+
+# dotnet-sln (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-sln` - Modifies a .NET Core solution file.
+
+## Synopsis
+
+```console
+dotnet sln [<SOLUTION_NAME>] add <PROJECT> <PROJECT> ...
+dotnet sln [<SOLUTION_NAME>] add <GLOBBING_PATTERN>
+dotnet sln [<SOLUTION_NAME>] remove <PROJECT> <PROJECT> ...
+dotnet sln [<SOLUTION_NAME>] remove <GLOBBING_PATTERN>
+dotnet sln [<SOLUTION_NAME>] list
+dotnet sln [-h|--help]
+```
+
+## Description
+
+The `dotnet sln` command adds, removes, and lists projects in a solution file.
+
+## Commands
+
+`add <PROJECT> ...`
+
+`add <GLOBBING_PATTERN>`
+
+Adds a project or multiple projects to the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
+
+`remove <PROJECT> ...`
+
+`remove <GLOBBING_PATTERN>`
+
+Removes a project or multiple projects from the solution file. [Globbing patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux based terminals.
+
+`list`
+
+List all projects in a solution file.
+
+## Arguments
+
+`SOLUTION_NAME`
+
+Solution file to use. If not specified, the command searches the current directory for one. If there are multiple solution files in the directory, one must be specified.
+
+## Options
+
+`-h|--help`
+
+Shows help information.
+
+## Examples
+
+Add a C# project to a solution:
+
+`dotnet sln todo.sln add todo-app/todo-app.csproj`
+
+Remove a C# project from a solution:
+
+`dotnet sln todo.sln remove todo-app/todo-app.csproj`
+
+Add multiple C# projects to a solution:
+
+`dotnet sln todo.sln add todo-app/todo-app.csproj back-end/back-end.csproj`
+
+Remove multiple C# projects from a solution:
+
+`dotnet sln todo.sln remove todo-app/todo-app.csproj back-end/back-end.csproj`
+
+Add multiple C# projects to a solution using a globbing pattern:
+
+`dotnet sln todo.sln add **/*.csproj`
+
+Remove multiple C# projects from a solution using a globbing pattern:
+
+`dotnet sln todo.sln remove **/*.csproj`

--- a/docs/core/preview/tools/dotnet-store.md
+++ b/docs/core/preview/tools/dotnet-store.md
@@ -1,8 +1,8 @@
 ---
-title: dotnet-store command (.NET Core SDK 2.0 Preview 1) | .NET Core SDK
+title: dotnet-store command (.NET Core SDK 2.0 Preview 2) | .NET Core SDK
 description: The dotnet-store Stores the specified assemblies in the runtime package store.
 keywords: dotnet-store, dotnet-publish, CLI, CLI command, .NET Core
-author: bleroy
+author: beleroy
 ms.author: beleroy
 ms.date: 4/13/2017
 ms.topic: article
@@ -10,7 +10,8 @@ ms.prod: .net-core
 ms.devlang: dotnet
 ms.assetid: 1e8e4122-8110-4b48-afce-afffb6737776
 ---
-# dotnet-store (.NET Core SDK 2.0 Preview 1)
+
+# dotnet-store (.NET Core SDK 2.0 Preview 2)
 
 [!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
 
@@ -20,7 +21,9 @@ ms.assetid: 1e8e4122-8110-4b48-afce-afffb6737776
 
 ## Synopsis
 
-`dotnet store -m|--manifest -r|--runtime -f|--framework [--framework-version] [--output] [--working-dir] [--skip-optimization] [--skip-symbols] [-v|--verbosity] [-h|--help]`
+`dotnet store -m|--manifest -f|--framework -r|--runtime  [--framework-version] [-h|--help] [--output] [--skip-optimization] [--skip-symbols] [-v|--verbosity] [--working-dir]`
+
+Optional arguments appear in brackets.
 
 ## Description
 
@@ -30,36 +33,39 @@ By default, these assemblies are optimized for the target runtime and framework.
 
 For more information, see the [runtime package store](../deploying/runtime-package-store.md) topic.
 
-## Options
+## Arguments
 
-`-h|--help`
+### Command parameters
 
-Prints out a short help for the command.
+None
+
+### Required options
 
 `-m|--manifest <MANIFEST>`
 
-The XML file, or a list of XML files, that contain the list of packages to be stored. The format of the files is compatible with the `csproj` format, so a project file referencing the desired packages can be used. This parameter is mandatory.
+The XML file, or a list of XML files, that contain the list of packages to store. The format of the files is compatible with the `csproj` format, so a project file referencing the desired packages can be used.
 
-`-r|--runtime`
+`-f|--framework <FRAMEWORK>`
 
-The runtime identifier to target, for example `win7-x64`. This parameter is mandatory.
+The framework to target.
 
-`-f|--framework`
+`-r|--runtime <RUNTIME_IDENTIFIER>`
 
-The framework to target, for example `netcoreapp2.0`. This parameter is mandatory.
+The runtime identifier to target.
+
+### Optional options
 
 `--framework-version <FRAMEWORK_VERSION>`
 
-The .NET Core SDK version to use. This option enables to fine tune to a specific version beyond the one that is part of `-f|--framework`. 
-For example: `2.0.0-preview1-1234`.
+The .NET Core SDK version to use. This option enables you to select a specific framework version beyond framework specified by the `-f|--framework` option.
 
-`-o|--output <OUTPUT_PATH>`
+`-h|--help`
+
+Show help information.
+
+`-o|--output <OUTPUT_DIR>`
 
 Specify the path to the runtime package store. If not specified, it defaults to the *store* subdirectory of the user profile .NET Core installation directory.
-
-`--working-dir <WORKING_DIRECTORY>`
-
-The working directory used by the command to execute. If not specified, it works under the *obj* subdirectory of the current directory.
 
 `--skip-optimization`
 
@@ -67,19 +73,23 @@ Skips the optimization phase.
 
 `--skip-symbols`
 
-Skips symbol generation. Currently, symbols can only be generated on Windows and Linux.
+Skips symbol generation. Currently, you can only generate symbols on Windows and Linux.
 
 `-v|--verbosity <LEVEL>`
 
 Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
+`--working-dir <INTERMEDIATE_WORKING_DIRECTORY>`
+
+The working directory used by the command. If not specified, it uses the *obj* subdirectory of the current directory.
+
 ## Examples
 
-Store the packages specified in the `packages.csproj` for .NET Core 2.0.0:
+Store the packages specified in the *packages.csproj* for .NET Core 2.0.0:
 
-`dotnet store --manifest packages.csproj --framework-version 2.0.0`
+`dotnet store --manifest packages.csproj --framework-version 2.0.0-preview1-1234`
 
-Store the packages specified in the `packages.csproj` without optimization:
+Store the packages specified in the *packages.csproj* without optimization:
 
 `dotnet store --manifest packages.csproj --skip-optimization`
 

--- a/docs/core/preview/tools/dotnet-store.md
+++ b/docs/core/preview/tools/dotnet-store.md
@@ -1,12 +1,13 @@
 ---
-title: dotnet-store command (.NET Core SDK 2.0 Preview 2) | .NET Core SDK
+title: dotnet-store command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
 description: The dotnet-store Stores the specified assemblies in the runtime package store.
-keywords: dotnet-store, dotnet-publish, CLI, CLI command, .NET Core
-author: beleroy
+keywords: dotnet-store, dotnet store, CLI, CLI command, .NET Core
+author: guardrex
 ms.author: beleroy
-ms.date: 4/13/2017
+ms.date: 06/11/2017
 ms.topic: article
 ms.prod: .net-core
+ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 1e8e4122-8110-4b48-afce-afffb6737776
 ---
@@ -23,49 +24,35 @@ ms.assetid: 1e8e4122-8110-4b48-afce-afffb6737776
 
 `dotnet store -m|--manifest -f|--framework -r|--runtime  [--framework-version] [-h|--help] [--output] [--skip-optimization] [--skip-symbols] [-v|--verbosity] [--working-dir]`
 
-Optional arguments appear in brackets.
-
 ## Description
 
-`dotnet store` stores the specified assemblies in the [runtime package store](../deploying/runtime-package-store.md).
+`dotnet store` stores the specified assemblies in the [runtime package store](../deploying/runtime-package-store.md). By default, assemblies are optimized for the target runtime and framework. For more information, see the [runtime package store](../deploying/runtime-package-store.md) topic.
 
-By default, these assemblies are optimized for the target runtime and framework.
-
-For more information, see the [runtime package store](../deploying/runtime-package-store.md) topic.
-
-## Arguments
-
-### Command parameters
-
-None
-
-### Required options
-
-`-m|--manifest <MANIFEST>`
-
-The XML file, or a list of XML files, that contain the list of packages to store. The format of the files is compatible with the `csproj` format, so a project file referencing the desired packages can be used.
+## Options
 
 `-f|--framework <FRAMEWORK>`
 
-The framework to target.
-
-`-r|--runtime <RUNTIME_IDENTIFIER>`
-
-The runtime identifier to target.
-
-### Optional options
+Required. Specifies the [target framework](../../standard/frameworks.md).
 
 `--framework-version <FRAMEWORK_VERSION>`
 
-The .NET Core SDK version to use. This option enables you to select a specific framework version beyond framework specified by the `-f|--framework` option.
+Specifies the .NET Core SDK version. This option enables you to select a specific framework version beyond the framework specified by the `-f|--framework` option.
 
 `-h|--help`
 
-Show help information.
+Shows help information.
 
-`-o|--output <OUTPUT_DIR>`
+`-m|--manifest <MANIFEST_FILE>`
 
-Specify the path to the runtime package store. If not specified, it defaults to the *store* subdirectory of the user profile .NET Core installation directory.
+Required. The XML file, or a list of XML files, that contain the list of packages to store. The format of the manifest files is compatible with the *csproj* format, so a *csproj* project file referencing the desired packages can be used with the `-m|--manifest` option to store assemblies in the runtime package store.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Specifies the path to the runtime package store. If not specified, it defaults to the *store* subdirectory of the user profile .NET Core installation directory.
+
+`-r|--runtime <RUNTIME_IDENTIFIER>`
+
+Required. The runtime identifier to target.
 
 `--skip-optimization`
 
@@ -85,7 +72,7 @@ The working directory used by the command. If not specified, it uses the *obj* s
 
 ## Examples
 
-Store the packages specified in the *packages.csproj* for .NET Core 2.0.0:
+Store the packages specified in the *packages.csproj* project file for .NET Core 2.0.0:
 
 `dotnet store --manifest packages.csproj --framework-version 2.0.0-preview1-1234`
 
@@ -95,4 +82,4 @@ Store the packages specified in the *packages.csproj* without optimization:
 
 ## See also
 
- [Runtime package store](../deploying/runtime-package-store.md)   
+[Runtime package store](../deploying/runtime-package-store.md)   

--- a/docs/core/preview/tools/dotnet-test.md
+++ b/docs/core/preview/tools/dotnet-test.md
@@ -30,7 +30,7 @@ The `dotnet test` command is used to execute unit tests in a given project. Unit
 
 Test projects must specify the test runner. This is specified using an ordinary **\<PackageReference>** element, as seen in the following sample project file:
 
-[!code-xml[XUnit Basic Template](~/docs/samples/snippets/csharp/xunit-test/xunit-test.csproj)]
+[!code-xml[XUnit Basic Template](../../../../samples/snippets/csharp/xunit-test/xunit-test.csproj)]
 
 ## Arguments
 

--- a/docs/core/preview/tools/dotnet-test.md
+++ b/docs/core/preview/tools/dotnet-test.md
@@ -1,0 +1,140 @@
+---
+title: dotnet-test command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The `dotnet test` command is used to execute unit tests in a given project.
+keywords: dotnet-test, dotnet test, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 4bf0aef4-148a-41c6-bb95-0a9e1af8762e
+---
+
+#dotnet-test (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-test` - .NET test driver used to execute unit tests.
+
+## Synopsis
+
+`dotnet test [<PROJECT>] [-a|--test-adapter-path] [-c|--configuration] [-d|--diag] [--filter] [-f|--framework] [-h|--help] [-l|--logger] [--no-build] [-o|--output] [-s|--settings] [-t|--list-tests] [-v|--verbosity]`
+
+## Description
+
+The `dotnet test` command is used to execute unit tests in a given project. Unit tests are console app projects that have dependencies on a unit test framework (for example, MSTest or xUnit) and the dotnet test runner for the unit testing framework. These are packaged as NuGet packages and are restored as ordinary dependencies for the project.
+
+Test projects must specify the test runner. This is specified using an ordinary **\<PackageReference>** element, as seen in the following sample project file:
+
+[!code-xml[XUnit Basic Template](~/docs/samples/snippets/csharp/xunit-test/xunit-test.csproj)]
+
+## Arguments
+
+`PROJECT`
+    
+Specifies a path to the test project. If omitted, it defaults to current directory.
+
+## Options
+
+`-a|--test-adapter-path <PATH_TO_ADAPTER>`
+
+Use the custom test adapters from the specified path in the test run.
+
+`-c|--configuration <CONFIGURATION>`
+
+Configuration under which to build. The default value is `Debug`, but your project's configuration overrides the default SDK setting.
+
+`-d|--diag <PATH_TO_DIAGNOSTICS_FILE>`
+
+Enables diagnostic mode for the test platform and writes diagnostic messages to the specified file. 
+
+`--filter <EXPRESSION>`
+
+Filters out tests in the current project using the given expression. For more information, see the [Filter option details](#filter-option-details) section. For additional information and examples on how to use selective unit test filtering, see [Running selective unit tests](../testing/selective-unit-tests.md).
+
+`-f|--framework <FRAMEWORK>`
+
+Looks for test binaries for a specific [framework](../../standard/frameworks.md).
+
+`-h|--help`
+
+Shows help information.
+
+`-l|--logger <LoggerUri/FriendlyName>`
+
+Specifies a logger for test results.
+
+`--no-build` 
+
+Doesn't build the test project prior to running it.
+
+`-o|--output <OUTPUT_DIRECTORY>`
+
+Directory in which to find the binaries to run.
+
+`-s|--settings <SETTINGS_FILE>`
+
+Settings to use when running tests. 
+
+`-t|--list-tests`
+
+List the discovered tests in the current project. 
+
+`-v|--verbosity <LEVEL>`
+
+Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+## Examples
+
+Run the tests in the project in the current directory:
+
+`dotnet test` 
+
+Run the tests in the `test1` project:
+
+`dotnet test ~/projects/test1/test1.csproj`
+
+## Filter option details
+
+`--filter <EXPRESSION>`
+
+`<Expression>` has the format `<property><operator><value>[|&<Expression>]`.
+
+`<property>` is an attribute of the `Test Case`. The following table shows the properties supported by popular unit test frameworks.
+
+| Test Framework | Supported properties                                                                                      |
+| :------------: | --------------------------------------------------------------------------------------------------------- |
+| MSTest         | <ul><li>FullyQualifiedName</li><li>Name</li><li>ClassName</li><li>Priority</li><li>TestCategory</li></ul> |
+| xUnit          | <ul><li>FullyQualifiedName</li><li>DisplayName</li><li>Traits</li></ul>                                   |
+
+The `<operator>` describes the relationship between the property and the value:
+
+| Operator | Function        |
+| :------: | --------------- |
+| `=`      | Exact match     |
+| `!=`     | Not exact match |
+| `~`      | Contains        |
+
+`<value>` is a string. The lookups are case insensitive.
+
+An expression without an `<operator>` is automatically considered as a *contains* on `FullyQualifiedName` property (for example, `dotnet test --filter xyz` is same as `dotnet test --filter FullyQualifiedName~xyz`).
+
+Expressions can be joined with conditional operators:
+
+| Operator | Function |
+| :------: | :------: |
+| `|`      | OR       |
+| `&`      | AND      |
+
+You can enclose expressions in paranthesis when using conditional operators (for example, `(Name~TestMethod1) | (Name~TestMethod2)`).
+
+For a additional information and examples on how to use selective unit test filtering, see [Running selective unit tests](../testing/selective-unit-tests.md).
+
+## See also
+
+[Frameworks and Targets](../../standard/frameworks.md)   
+[.NET Core Runtime IDentifier (RID) catalog](../rid-catalog.md)

--- a/docs/core/preview/tools/dotnet-vstest.md
+++ b/docs/core/preview/tools/dotnet-vstest.md
@@ -1,0 +1,137 @@
+---
+title: dotnet-vstest command (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: The dotnet-vstest command builds a project and all of its dependencies. 
+keywords: dotnet-vstest, dotnet vstest, CLI, CLI command, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 0e36c070-2242-41d3-96f1-aea0aca48d4d
+---
+
+# dotnet-vstest (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet-vstest` - Runs tests from the specified files.
+
+## Synopsis
+
+`dotnet vstest [<TEST_FILE_NAMES>] [--Collect|/Collect] [--Diag|/Diag] [--Framework|/Framework] [-?|--Help|/?|/Help] [-lt|--ListTests|/lt|/ListTests] [--logger|/logger] [--Parallel|/Parallel] [--ParentProcessId|/ParentProcessId] [--Platform|/Platform] [--Port|/Port] [--ResultsDirectory|/ResultsDirectory] [--Settings|/Settings] [--TestAdapterPath|/TestAdapterPath] [--TestCaseFilter|/TestCaseFilter] [--Tests|/Tests] [[--] <args>...]]`
+
+## Description
+
+The `dotnet-vstest` command runs the `VSTest.Console` command-line app to run automated unit and coded UI app tests.
+
+## Arguments
+
+`TEST_FILE_NAMES`
+
+Run tests from the specified assemblies. Separate multiple test assembly names with spaces.
+
+## Options
+
+`[--] args`
+
+Specifies extra arguments to pass to the adapter. Arguments are specified as name-value pairs of the form `<n>=<v>`, where `<n>` is the argument name and `<v>` is the argument value. Use a space to separate multiple arguments.
+
+`--Collect|/Collect:<DataCollector friendlyName>`
+
+Enables data collector for the test run. For more information, see [Monitor and analyze test run](https://aka.ms/vstest-collect).
+
+`--Diag|/Diag:<Path to log file>`
+
+Enables verbose logs for the test platform. Logs are written to the provided file.
+
+`--Framework|/Framework:<Framework Version>`
+
+Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.7` and `.NETCoreApp,Version=v2.0`. Other supported values are `Framework35`, `Framework40`, `Framework45`, and `FrameworkCore10`.
+
+`-?|--Help|/?|/Help`
+
+Shows help information.
+
+`--logger|/logger:<Logger Uri/FriendlyName>`
+
+Specify a logger for test results.
+
+- To publish test results to Team Foundation Server, use the `TfsPublisher` logger provider:
+
+  ```console
+  /logger:TfsPublisher;
+      Collection=<team project collection url>;
+      BuildName=<build name>;
+      TeamProject=<team project name>
+      [;Platform=<Defaults to "Any CPU">]
+      [;Flavor=<Defaults to "Debug">]
+      [;RunTitle=<title>]
+  ```
+
+- To log results to a Visual Studio Test Results File (TRX), use the `trx` logger provider. This switch creates a file in the test results directory with given log file name. If `LogFileName` isn't provided, a unique file name is created to hold the test results.
+
+  ```console
+  /logger:trx [;LogFileName=<Defaults to unique file name>]
+  ```
+
+`-lt|--ListTests|/lt|/ListTests:<File Name>`
+
+Lists discovered tests from the given test container.
+
+`--Parallel|/Parallel`
+
+Execute tests in parallel. By default, all available cores on the machine are available for use. Set an explicit number of cores with a settings file.
+
+`--ParentProcessId|/ParentProcessId:<ParentProcessId>`
+
+Process Id of the parent process responsible for launching the current process.
+
+`--Platform|/Platform:<Platform type>`
+
+Target platform architecture used for test execution. Valid values are `x86`, `x64`, and `ARM`.
+
+`--Port|/Port:<Port>`
+
+Specifies the port for the socket connection and receiving the event messages.
+
+`--ResultsDirectory|/ResultsDirectory <DIRECTORY>`
+
+The test results directory is created on the specified path if it doesn't exist.
+
+`--Settings|/Settings:<Settings File>`
+
+Settings to use when running tests.
+
+`--TestAdapterPath|/TestAdapterPath`
+
+Use custom test adapters from a given path (if any) in the test run.
+
+`--TestCaseFilter|/TestCaseFilter:<Expression>`
+
+Run tests that match the given expression. `<Expression>` is of the format `<property>Operator<value>[|&<Expression>]`, where Operator is one of `=`, `!=`, or `~`.  Operator `~` has *contains* semantics and is applicable to string properties like `DisplayName`. Parenthesis `()` are used to group sub-expressions.
+
+`--Tests|/Tests:<Test Names>`
+
+Run tests with names that match the provided values. Separate multiple values with commas.
+
+## Examples
+
+Run tests in `mytestproject.dll`:
+
+`dotnet vstest mytestproject.dll`
+
+Run tests in `mytestproject.dll` and `myothertestproject.exe`:
+
+`dotnet vstest mytestproject.dll myothertestproject.exe`
+
+Run `TestMethod1` tests:
+
+`dotnet vstest /Tests:TestMethod1`
+
+Run `TestMethod1` and `TestMethod2` tests:
+
+`dotnet vstest /Tests:TestMethod1,TestMethod2`

--- a/docs/core/preview/tools/dotnet.md
+++ b/docs/core/preview/tools/dotnet.md
@@ -1,0 +1,153 @@
+---
+title: dotnet command - .NET Core CLI(.NET Core SDK 2.0 Preview 2) | Microsoft Docs
+description: Learn about the dotnet command (the generic driver for the .NET Core CLI tools) and its usage.  
+keywords: dotnet, CLI, CLI commands, .NET Core
+author: guardrex
+ms.author: mairaw
+ms.date: 06/11/2017
+ms.topic: article
+ms.prod: .net-core
+ms.technology: dotnet-cli
+ms.devlang: dotnet
+ms.assetid: 256e468e-eaaa-4715-b5fb-8cbddcf80e69
+---
+
+# dotnet command (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+## Name
+
+`dotnet` - General driver for running the command-line commands.
+
+## Synopsis
+
+`dotnet [command] [arguments] [--additional-deps] [--additionalprobingpath] [-d|--diagnostics] [--depsfile] [--fx-version] [-h|--help] [--info] [--roll-forward-on-no-candidate-fx] [--runtimeconfig] [-v|--verbose] [--version]`
+
+## Description
+
+`dotnet` is a generic driver for the Command-Line Interface (CLI) toolchain. Invoked on its own, it provides usage instructions.
+
+Each feature is implemented as a command. In order to use a feature, the command is specified after `dotnet`. For example, you build a .NET Core project with the *build* feature by executing [`dotnet build`](dotnet-build.md) at a command prompt.
+
+The only time `dotnet` is used as a command on its own is to run [framework-dependent apps](../deploying/index.md). Specify an app DLL after `dotnet` to execute the app (for example, `dotnet myapp.dll`).
+
+## Options
+
+`--additional-deps <PATH>`
+
+Path to an additonal *\<assembly_name>.deps.json* file.
+
+`--additionalprobingpath <PATH>`
+
+Path containing probing policy and assemblies to probe.
+
+`-d|--diagnostics`
+
+Enables diagnostic output.
+
+`--depsfile <PATH>`
+
+Path to the *\<assembly_name>.deps.json* file.
+
+`--fx-version <VERSION>`
+
+Specifies the version of the installed shared framework used to run the app.
+
+`-h|--help`
+
+Shows help information. If using with `dotnet`, it shows a list of the available commands.
+
+`--info`
+
+Shows detailed information about the CLI tooling and the environment, such as the current operating system and the commit SHA for the version.
+
+`--roll-forward-on-no-candidate-fx`
+
+Specifies roll forward behavior when no candidate shared framework is enabled.
+
+`--runtimeconfig <PATH>`
+
+Path to the *\<assembly_name>.runtimeconfig.json* file.
+
+`-v|--verbose`
+
+Enables verbose output.
+
+`--version`
+
+Shows the version of the CLI tooling.
+
+## dotnet commands
+
+### General
+
+| Command                             | Function                                                            |
+| ----------------------------------- | ------------------------------------------------------------------- |
+| [dotnet-build](dotnet-build.md)     | Builds a .NET Core app.                                             |
+| [dotnet-clean](dotnet-clean.md)     | Cleans build outputs.                                               |
+| [dotnet-migrate](dotnet-migrate.md) | Migrates a valid Preview 2 project to a .NET Core SDK 1.0 project.  |
+| [dotnet-msbuild](dotnet-msbuild.md) | Provides access to the MSBuild command line.                        |
+| [dotnet-new](dotnet-new.md)         | Initializes a C# or F# project for a given template.                |
+| [dotnet-pack](dotnet-pack.md)       | Creates a NuGet package of your code.                               |
+| [dotnet-publish](dotnet-publish.md) | Publishes a .NET framework-dependent or self-contained deployment.  |
+| [dotnet-restore](dotnet-restore.md) | Restores the dependencies of an app.                                |
+| [dotnet-run](dotnet-run.md)         | Runs an app from source code.                                       |
+| [dotnet-sln](dotnet-sln.md)         | Options to add, remove, and list projects in a solution file.       |
+| [dotnet-test](dotnet-test.md)       | Runs tests using a test runner.                                     |
+| [dotnet-vstest](dotnet-vstest.md)   | Runs tests from the specified files.                                |
+
+### Project references
+
+| Command                                               | Function                     |
+| ----------------------------------------------------- | ---------------------------- |
+| [dotnet-add reference](dotnet-add-reference.md)       | Adds a project reference.    |
+| [dotnet-list reference](dotnet-list-reference.md)     | Lists project references.    |
+| [dotnet-remove reference](dotnet-remove-reference.md) | Removes a project reference. |
+
+### NuGet packages
+
+| Command                                           | Function                 |
+| ------------------------------------------------- | ------------------------ |
+| [dotnet-add package](dotnet-add-package.md)       | Adds a NuGet package.    |
+| [dotnet-remove package](dotnet-remove-package.md) | Removes a NuGet package. |
+
+### NuGet commands
+
+| Command                                       | Function                                                                                                                   |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [dotnet-nuget delete](dotnet-nuget-delete.md) | Deletes or unlists a package from the server.                                                                              |
+| [dotnet-nuget locals](dotnet-nuget-locals.md) | Clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder. |
+| [dotnet-nuget push](dotnet-nuget-push.md)     | Pushes a package to the server and publishes it.                                                                           |
+
+## Examples
+
+Initialize a sample .NET Core console app:
+
+`dotnet new console`
+
+Restore dependencies for an app:
+
+`dotnet restore`
+
+Build a project and its dependencies:
+
+`dotnet build`
+
+Run a framework-dependent app named *myapp.dll*:
+
+`dotnet myapp.dll`
+
+## Environment variables
+
+`DOTNET_PACKAGES`
+
+The primary package cache. If not set, it defaults to *$HOME/.nuget/packages* on Unix or *%HOME%\NuGet\Packages* on Windows.
+
+`DOTNET_SERVICING`
+
+Specifies the location of the servicing index to use by the shared host when loading the runtime.
+
+`DOTNET_CLI_TELEMETRY_OPTOUT`
+
+Specifies whether data about the .NET Core tools usage is collected and sent to Microsoft. Set to `true` to opt-out of the telemetry feature (valid values: `true`, `1`, or `yes`). Set to `false` to opt-in to the telemetry features (valid values: `false`, `0`, or `no`). If not set, the default is `false`, and the telemetry feature is active.

--- a/docs/core/preview/tools/index.md
+++ b/docs/core/preview/tools/index.md
@@ -1,28 +1,32 @@
 ---
-title: .NET Core CLI Tools (.NET Core SDK 2.0 Preview 1) | Microsoft Docs
+title: .NET Core CLI Tools (.NET Core SDK 2.0 Preview 2) | Microsoft Docs
 description: An overview of the Command-Line Interface (CLI) tools and features.
 keywords: CLI, CLI tools, .NET, .NET Core
-author: blackdwarf
+author: guardrex
 ms.author: mairaw
-ms.date: 04/18/2017
+ms.date: 06/11/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: f32707d4-4c70-4125-a466-02e6b35fb03f
 ---
-# .NET Core command-line interface (CLI) tools (.NET Core SDK 2.0 Preview 1)
 
-The .NET Core command-line interface (CLI) is a new cross-platform toolchain for developing .NET applications. The CLI is a foundation upon which higher-level tools, such as Integrated Development Environments (IDEs), editors, and build orchestrators, can rest.
+# .NET Core command-line interface (CLI) tools (.NET Core SDK 2.0 Preview 2)
+
+[!INCLUDE [core-preview-warning](~/includes/core-preview-warning.md)]
+
+The .NET Core command-line interface (CLI) is a new cross-platform toolchain for developing .NET apps. The CLI is a foundation upon which higher-level tools, such as Integrated Development Environments (IDEs), editors, and build orchestrators, can rest.
 
 ## Installation
 
 Either use the native installers or use the installation shell scripts:
 
-* The native installers are primarily used on developer's machines and use each supported platform's native install mechanism, for instance, DEB packages on Ubuntu or MSI bundles on Windows. These installers install and configure the environment for immediate use by the developer but require administrative privileges on the machine. You can view the installation instructions in the [.NET Core installation guide](https://aka.ms/dotnetcoregs).
-* Shell scripts are primarily used for setting up build servers or when you wish to install the tools without administrative privileges. Install scripts don't install prerequisites on the machine, which must be installed manually. For more information, see the [install script reference topic](dotnet-install-script.md). For information on how to set up CLI on your continuous integration (CI) build server, see [Using .NET Core SDK and tools in Continuous Integration (CI)](using-ci-with-cli.md).
+- The native installers are primarily used on developer's machines and use each supported platform's native install mechanism, for instance, DEB packages on Ubuntu or MSI bundles on Windows. These installers install and configure the environment for immediate use by the developer but require administrative privileges on the machine. You can view the installation instructions in the [.NET Core installation guide](https://aka.ms/dotnetcoregs).
 
-By default, the CLI installs in a side-by-side (SxS) manner, so multiple versions of the CLI tools can coexist on a single machine. Determining which version is used on a machine where multiple versions are installed is explained in more detail in the [Driver](#driver) section.
+- Shell scripts are primarily used for setting up build servers or when you wish to install the tools without administrative privileges. Install scripts don't install prerequisites on the machine, which must be installed manually. For more information, see the [install script reference topic](dotnet-install-script.md). For information on how to set up CLI on your continuous integration (CI) build server, see [Using .NET Core SDK and tools in Continuous Integration (CI)](using-ci-with-cli.md).
+
+By default, the CLI installs in a side-by-side manner without conflicts among installed SDKs, so multiple versions of the CLI tools can coexist on a single machine. Determining which version is used on a machine where multiple versions are installed is explained in more detail in the [Driver](#driver) section.
 
 ## CLI commands
 
@@ -30,34 +34,34 @@ The following commands are installed by default:
 
 ### Basic commands
 
-* [new](dotnet-new.md)
-* [restore](dotnet-restore.md)
-* [build](dotnet-build.md)
-* [publish](dotnet-publish.md)
-* [run](dotnet-run.md)
-* [test](dotnet-test.md)
-* [vstest](dotnet-vstest.md)
-* [pack](dotnet-pack.md)
-* [migrate](dotnet-migrate.md)
-* [clean](dotnet-clean.md)
-* [sln](dotnet-sln.md)
-* [store](dotnet-store.md)
+- [new](dotnet-new.md)
+- [restore](dotnet-restore.md)
+- [build](dotnet-build.md)
+- [publish](dotnet-publish.md)
+- [run](dotnet-run.md)
+- [test](dotnet-test.md)
+- [vstest](dotnet-vstest.md)
+- [pack](dotnet-pack.md)
+- [migrate](dotnet-migrate.md)
+- [clean](dotnet-clean.md)
+- [sln](dotnet-sln.md)
+- [store](dotnet-store.md)
 
 ### Project modification commands
 
-* [add package](dotnet-add-package.md)
-* [add reference](dotnet-add-reference.md)
-* [remove package](dotnet-remove-package.md)
-* [remove reference](dotnet-remove-reference.md)
-* [list reference](dotnet-list-reference.md)
+- [add package](dotnet-add-package.md)
+- [add reference](dotnet-add-reference.md)
+- [remove package](dotnet-remove-package.md)
+- [remove reference](dotnet-remove-reference.md)
+- [list reference](dotnet-list-reference.md)
 
 ### Advanced commands
 
-* [nuget delete](dotnet-nuget-delete.md)
-* [nuget locals](dotnet-nuget-locals.md)
-* [nuget push](dotnet-nuget-push.md)
-* [msbuild](dotnet-msbuild.md)
-* [dotnet install script](dotnet-install-script.md)
+- [nuget delete](dotnet-nuget-delete.md)
+- [nuget locals](dotnet-nuget-locals.md)
+- [nuget push](dotnet-nuget-push.md)
+- [msbuild](dotnet-msbuild.md)
+- [install script](dotnet-install-script.md)
 
 The CLI adopts an extensibility model that allows you to specify additional tools for your projects. For more information, see the [.NET Core CLI extensibility model](extensibility.md) topic.
 
@@ -74,15 +78,13 @@ dotnet /build_output/my_app.dll
 
 ### Driver
 
-The driver is named [dotnet](dotnet.md) and has two responsibilities, either running a [framework-dependent app](../deploying/index.md) or executing a command. The only time `dotnet` is used without a command is when it's used to start an application.
-
-To run a framework-dependent app, specify the app after the driver, for example, `dotnet /path/to/my_app.dll`. When executing the command from the folder where the app's DLL resides, simply execute `dotnet my_app.dll`.
+The driver is named [dotnet](dotnet.md) and has two responsibilities, either running a [framework-dependent app](../deploying/index.md) or executing a command. The only time `dotnet` is used without a command is when it's used to start an app. To run a framework-dependent app, specify the app after the driver, for example, `dotnet /path/to/my_app.dll`. When executing the command from the folder where the app's DLL resides, execute `dotnet my_app.dll`.
 
 When you supply a command to the driver, `dotnet.exe` starts the CLI command execution process. First, the driver determines the version of the tooling to use. If the version isn't specified in the command options, the driver uses the latest version available. To specify a version other than the latest installed version, use the `--fx-version <VERSION>` option (see the [dotnet command](dotnet.md) reference). Once the SDK version is determined, the driver executes the command.
 
 ### Command ("verb")
 
-The command (or "verb") is simply a command that performs an action. For example, `dotnet build` builds your code. `dotnet publish` publishes your code. The commands are implemented as a console application using a `dotnet-{verb}` convention. 
+The command (or "verb") is simply a command that performs an action. For example, `dotnet build` builds your code. `dotnet publish` publishes your code. The commands are implemented as console apps using a `dotnet-{verb}` convention. 
 
 ### Arguments
 
@@ -94,9 +96,13 @@ The options you pass on the command line are the options to the command invoked.
 
 ## Migration from project.json
 
-If you used Preview 2 tooling to produce *project.json*-based projects, consult the [dotnet migrate](dotnet-migrate.md) topic for information on migrating your project to MSBuild/*.csproj* for use with release tooling. For .NET Core projects created prior to the release of Preview 2 tooling, either manually update the the project following the guidance in [Migrating from DNX to .NET Core CLI (project.json)](../migration/from-dnx.md) and then use `dotnet migrate` or directly upgrade your projects.
+If you used Preview 2 tooling to produce *project.json*-based projects, consult the [`dotnet migrate`](dotnet-migrate.md) topic for information on migrating your project to MSBuild/*csproj* (SDK 1.0) and then migrate manually to 2.0. For .NET Core projects created prior to the release of Preview 2 tooling:
 
-## Additional resources
+- Manually update the the project following the guidance in [Migrating from DNX to .NET Core CLI (project.json)](../migration/from-dnx.md), use [`dotnet migrate`](dotnet-migrate.md) to move the project to 1.0, and manually update from 1.0 to 2.0.
 
-* [dotnet/CLI GitHub Repository](https://github.com/dotnet/cli/)
-* [.NET Core installation guide](https://aka.ms/dotnetcoregs)
+- Directly upgrade your DNX project to SDK 2.0.
+
+## See also
+
+[dotnet/CLI GitHub Repository](https://github.com/dotnet/cli/)   
+[.NET Core installation guide](https://aka.ms/dotnetcoregs)

--- a/includes/core-preview-warning.md
+++ b/includes/core-preview-warning.md
@@ -1,3 +1,2 @@
 > [!WARNING]
-> This topic applies to .NET Core SDK 2.0 Preview 1. For the .NET Core 1.x documentation,
-> see the [.NET Core Tools](/dotnet/articles/core/tools/index) section.
+> This topic applies to .NET Core SDK 2.0 Preview 2. For the .NET Core 1.x documentation, see [.NET Core Tools](/dotnet/articles/core/tools/index).


### PR DESCRIPTION
**WIP** to add the work for https://github.com/dotnet/docs/issues/2405.

Fixes #2139
Fixes #1780

As @cartermp stated, there weren't a large number of updates for command deltas. However ...

* There were many *guidelines-adherence* problems to address.
* Passive voice required significant updates.
* "Command x is a 'convenient way' of doing y." language only made sense relative to hand-editing project files, so those instances were converted to simply "Command x does y."
* Some of the examples were updated: Instead of only showing a single section of a project file to illustrate a command's effect, the entire console app project file is shown, which seems to provide a better frame of reference for the change produced by the command. This change didn't add much length to those docs.
* Some additional cross-reference links are added, sometimes added to external resources that devs will likely find helpful.
* In addition to adding new 2.0 options, options are alphabetized. This makes it easier to track down an option with commands that have many options.
* I moved the macOS/Linux coverage above the Windows coverage in the `dotnet install scripts` command seeking parity between showing the Windows-way first and showing the macOS/Linux-way first.
* I cleaned up tables and lists.