### PR TITLE
Syntax highlight lock statement

### DIFF
--- a/docs/csharp/language-reference/keywords/lock-statement.md
+++ b/docs/csharp/language-reference/keywords/lock-statement.md
@@ -34,7 +34,7 @@ translation.priority.ht:
 # lock Statement (C# Reference)
 The `lock` keyword marks a statement block as a critical section by obtaining the mutual-exclusion lock for a given object, executing a statement, and then releasing the lock. The following example includes a `lock` statement.  
   
-```  
+```csharp  
 class Account  
 {  
     decimal balance;  


### PR DESCRIPTION
The code displayed on the lock statement page does not have syntax highlighting.
