### PR TITLE
fix writeline formatting

### DIFF
--- a/samples/snippets/csharp/concepts/linq/how-to-perform-left-outer-joins_1.cs
+++ b/samples/snippets/csharp/concepts/linq/how-to-perform-left-outer-joins_1.cs
@@ -34,15 +34,15 @@
 
             foreach (var v in query)
             {
-                Console.WriteLine($"{v.FirstName:-15}{v.PetName}");
+                Console.WriteLine($"{v.FirstName+":",-15}{v.PetName}");
             }
         }
 
         // This code produces the following output:
         //
-        // Magnus:         Daisy
-        // Terry:          Barley
-        // Terry:          Boots
-        // Terry:          Blue Moon
-        // Charlotte:      Whiskers
+        // Magnus:        Daisy
+        // Terry:         Barley
+        // Terry:         Boots
+        // Terry:         Blue Moon
+        // Charlotte:     Whiskers
         // Arlene:


### PR DESCRIPTION
I was looking at this code because of a customer comment and an earlier PR.
not sure if this is the right approach to fix this issue, however previous code was not rendering the results tabbed as the output was showing. my change produces the tabbed output but not sure if it's the right approach.

Previous results looked like this:
![image](https://user-images.githubusercontent.com/12971179/27062109-a601c026-4f9d-11e7-93d3-f3c381ad324f.png)

/cc @BillWagner 