### PR TITLE
Typo / Clarity

### DIFF
--- a/docs/framework/security/how-to-build-claims-aware-aspnet-web-forms-app-using-wif.md
+++ b/docs/framework/security/how-to-build-claims-aware-aspnet-web-forms-app-using-wif.md
@@ -134,7 +134,7 @@ manager: "mbaldwin"
   
 6.  Add reference to the <xref:System.IdentityModel> assembly.  
   
-7.  Compile the solution to make sure there are errors.  
+7.  Compile the solution to make sure there are no errors.  
   
 ## Step 3 – Test Your Solution  
  In this step you will test your ASP.NET Web Forms application configured for claims-based authentication. To perform a basic test, you will add code that displays claims in the token issued by the Security Token Service (STS).  


### PR DESCRIPTION
Adding 'no'. The user does _not_ want any errors.

# Typo

Small typo.

## Summary

Sentence was incorrect. 

## Details

Fixed typo. User does not expect any errors after compilation of code.
