### PR TITLE
added missing snippet

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Winforms/System.ComponentModel.IPropertyChangeExample/CS/Form1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Winforms/System.ComponentModel.IPropertyChangeExample/CS/Form1.cs
@@ -76,6 +76,7 @@ namespace TestNotifyPropertyChangedCS
 
     }
 
+    // <snippet9>
     // This is a simple customer class that 
     // implements the IPropertyChange interface.
     public class DemoCustomer : INotifyPropertyChanged
@@ -155,5 +156,6 @@ namespace TestNotifyPropertyChangedCS
             }
         }
     }
+    // </snippet9>
 }
 // </snippet1>

--- a/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.IPropertyChangeExample/VB/Form1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.IPropertyChangeExample/VB/Form1.vb
@@ -70,9 +70,9 @@ Public Class Form1
     End Sub
 End Class
 
+' <snippet9>
 ' This class implements a simple customer type 
 ' that implements the IPropertyChange interface.
-
 Public Class DemoCustomer
     Implements INotifyPropertyChanged
 
@@ -110,7 +110,6 @@ Public Class DemoCustomer
         End Get
     End Property
 
-
     Public Property CustomerName() As String
         Get
             Return Me.customerNameValue
@@ -123,7 +122,6 @@ Public Class DemoCustomer
             End If
         End Set
     End Property
-
 
     Public Property PhoneNumber() As String
         Get
@@ -138,4 +136,5 @@ Public Class DemoCustomer
         End Set
     End Property
 End Class
+' </snippet9>
 ' </snippet1>

--- a/xml/System.ComponentModel/INotifyPropertyChanged.xml
+++ b/xml/System.ComponentModel/INotifyPropertyChanged.xml
@@ -383,8 +383,9 @@ End Class
 ## Examples  
  The following code example demonstrates how to implement the <xref:System.ComponentModel.INotifyPropertyChanged.PropertyChanged> event of the <xref:System.ComponentModel.INotifyPropertyChanged> interface.  
   
-  
-  
+ [!code-csharp[System.ComponentModel.IPropertyChangeExample#9](~/samples/snippets/csharp/VS_Snippets_Winforms/System.ComponentModel.IPropertyChangeExample/CS/Form1.cs#9)]
+ [!code-vb[System.ComponentModel.IPropertyChangeExample#9](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.IPropertyChangeExample/VB/Form1.vb#9)]
+    
  ]]></format>
         </remarks>
       </Docs>


### PR DESCRIPTION
A dev manager reported internally that snippet was missing at https://msdn.microsoft.com/en-us/library/system.componentmodel.inotifypropertychanged.propertychanged(v=vs.110).aspx. Fixed on msdn and fixing it here too.

Interestingly, the code snippet reference lines were not migrated. Not sure why.