### PR TITLE
Document APIs for the System.Composition.Hosting Namespace.

### DIFF
--- a/xml/System.Composition.Hosting/CompositionFailedException.xml
+++ b/xml/System.Composition.Hosting/CompositionFailedException.xml
@@ -47,7 +47,7 @@
       </Parameters>
       <Docs>
         <param name="message">A message that contains information about the exception.</param>
-        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class with the specified message.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.CompositionFailedException"/> class with the specified message.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -68,7 +68,7 @@
       <Docs>
         <param name="message">A message that contains information about the exception.</param>
         <param name="innerException">The inner exception to wrap in this exception.</param>
-        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class with the specified message and inner exception.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.CompositionFailedException"/> class with the specified message and inner exception.</summary>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting/CompositionFailedException.xml
+++ b/xml/System.Composition.Hosting/CompositionFailedException.xml
@@ -12,7 +12,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Represents an exception for a failed composition.</summary>
+    <summary>The exception that is thrown when composition problems occur.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -46,8 +46,8 @@
         <Parameter Name="message" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="message">The exception message.</param>
-        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class using the specified message.</summary>
+        <param name="message">A message that contains information about the exception.</param>
+        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class with the specified message.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -66,11 +66,11 @@
         <Parameter Name="innerException" Type="System.Exception" />
       </Parameters>
       <Docs>
-        <param name="message">The exception message.</param>
-        <param name="innerException">The inner exception.</param>
-        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class using the specified message and inner exception.</summary>
+        <param name="message">A message that contains information about the exception.</param>
+        <param name="innerException">The inner exception to wrap in this exception.</param>
+        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class with the specified message and inner exception.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
   </Members>
-</Type>
+</Type> 

--- a/xml/System.Composition.Hosting/CompositionFailedException.xml
+++ b/xml/System.Composition.Hosting/CompositionFailedException.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents an exception for a failed composition.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -28,8 +28,8 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -46,9 +46,9 @@
         <Parameter Name="message" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="message">The exception message.</param>
+        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class using the specified message.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -66,10 +66,10 @@
         <Parameter Name="innerException" Type="System.Exception" />
       </Parameters>
       <Docs>
-        <param name="message">To be added.</param>
-        <param name="innerException">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="message">The exception message.</param>
+        <param name="innerException">The inner exception.</param>
+        <summary>Initializes a new instance of the <see cref="T:CompositionFailedException"/> class using the specified message and inner exception.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting/CompositionHost.xml
+++ b/xml/System.Composition.Hosting/CompositionHost.xml
@@ -37,7 +37,7 @@
         <Parameter Name="providers" Type="System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.ExportDescriptorProvider&gt;" />
       </Parameters>
       <Docs>
-        <param name="providers">The providers, containing export descriptions for the parts being composed.</param>
+        <param name="providers">The providers, which contain export descriptions for the parts being composed.</param>
         <summary>Creates the composition host with the specified collection of providers.</summary>
         <returns>The created composition host.</returns>
         <remarks></remarks>
@@ -66,8 +66,8 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="providers">The providers, containing export descriptions for the parts being composed.</param>
-        <summary>Creates the composition host with the specified collection of providers.</summary>
+        <param name="providers">The providers, which contain export descriptions for the parts being composed.</param>
+        <summary>Creates the composition host with the specified array of providers.</summary>
         <returns>The created composition host.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Hosting/CompositionHost.xml
+++ b/xml/System.Composition.Hosting/CompositionHost.xml
@@ -16,8 +16,8 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents a composition host; a container that is assembled from configured providers.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="CreateCompositionHost">
@@ -37,10 +37,10 @@
         <Parameter Name="providers" Type="System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.ExportDescriptorProvider&gt;" />
       </Parameters>
       <Docs>
-        <param name="providers">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="providers">The export descriptions for the parts being composed.</param>
+        <summary>Creates a composition container based on the specified providers.</summary>
+        <returns>The composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateCompositionHost">
@@ -66,10 +66,10 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="providers">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="providers">The export descriptions for the parts being composed.</param>
+        <summary>Creates a composition container based on the specified providers.</summary>
+        <returns>The composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -87,8 +87,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Releases the composition host and any globally-shared parts.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="TryGetExport">
@@ -109,11 +109,11 @@
         <Parameter Name="export" Type="System.Object&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="contract">To be added.</param>
-        <param name="export">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="contract">The contract to retrieve.</param>
+        <param name="export">When this method returns, contains an instance of the export if available, otherwise, <see langword="null" />.</param>
+        <summary>Retrieves the single <paramref name="contract"/> instance from the <see cref="T:System.CompositionContext"/>.</summary>
+        <returns><see langword="true" /> if a contract was retrieved, otherwise <see langword="false" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting/CompositionHost.xml
+++ b/xml/System.Composition.Hosting/CompositionHost.xml
@@ -16,7 +16,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Represents a composition host; a container that is assembled from configured providers.</summary>
+    <summary>A lightweight composition container that is assembled from specified providers.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -37,9 +37,9 @@
         <Parameter Name="providers" Type="System.Collections.Generic.IEnumerable&lt;System.Composition.Hosting.Core.ExportDescriptorProvider&gt;" />
       </Parameters>
       <Docs>
-        <param name="providers">The export descriptions for the parts being composed.</param>
-        <summary>Creates a composition container based on the specified providers.</summary>
-        <returns>The composition container.</returns>
+        <param name="providers">The providers, containing export descriptions for the parts being composed.</param>
+        <summary>Creates the composition host with the specified collection of providers.</summary>
+        <returns>The created composition host.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -66,9 +66,9 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="providers">The export descriptions for the parts being composed.</param>
-        <summary>Creates a composition container based on the specified providers.</summary>
-        <returns>The composition container.</returns>
+        <param name="providers">The providers, containing export descriptions for the parts being composed.</param>
+        <summary>Creates the composition host with the specified collection of providers.</summary>
+        <returns>The created composition host.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -87,7 +87,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Releases the composition host and any globally-shared parts.</summary>
+        <summary>Releases the composition host and any globally shared parts.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -109,12 +109,12 @@
         <Parameter Name="export" Type="System.Object&amp;" RefType="out" />
       </Parameters>
       <Docs>
-        <param name="contract">The contract to retrieve.</param>
-        <param name="export">When this method returns, contains an instance of the export if available, otherwise, <see langword="null" />.</param>
-        <summary>Retrieves the single <paramref name="contract"/> instance from the <see cref="T:System.CompositionContext"/>.</summary>
-        <returns><see langword="true" /> if a contract was retrieved, otherwise <see langword="false" />.</returns>
+        <param name="contract">The export to retrieve.</param>
+        <param name="export">When this method returns, contains an instance of the export if available; otherwise, <see langword="null" />.</param>
+        <summary>Retrieves the specified export from the composition context.</summary>
+        <returns><see langword="true" /> if the export was retrieved; otherwise, <see langword="false" />.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
   </Members>
-</Type>
+</Type> 

--- a/xml/System.Composition.Hosting/ContainerConfiguration.xml
+++ b/xml/System.Composition.Hosting/ContainerConfiguration.xml
@@ -33,7 +33,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Initializes a new instance of the <see cref="T:ContainerConfiguration"/> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Composition.Hosting.ContainerConfiguration"/> class.</summary>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -243,7 +243,7 @@
       <Parameters />
       <Docs>
         <typeparam name="TPart">The type to add.</typeparam>
-        <summary>Adds the specified generic type to the container.</summary>
+        <summary>Adds the specified type to the container.</summary>
         <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
@@ -270,7 +270,7 @@
       <Docs>
         <typeparam name="TPart">The type to add.</typeparam>
         <param name="conventions">The conventions to use for the part type.</param>
-        <summary>Adds the specified generic type to the container.</summary>
+        <summary>Adds the specified type to the container using the specified conventions.</summary>
         <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
@@ -347,7 +347,7 @@
       <Docs>
         <param name="partTypes">A collection of part types to add.</param>
         <param name="conventions">The conventions to use for part types.</param>
-        <summary>Adds the specified part types to the container.</summary>
+        <summary>Adds the specified part types to the container using the specified conventions.</summary>
         <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Composition.Hosting/ContainerConfiguration.xml
+++ b/xml/System.Composition.Hosting/ContainerConfiguration.xml
@@ -17,7 +17,7 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>Represents a configuration for a composition container.</summary>
+    <summary>Configures and constructs a lightweight container.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -52,8 +52,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Creates a composition container.</summary>
-        <returns>The composition container.</returns>
+        <summary>Creates the container.</summary>
+        <returns>The created container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -74,9 +74,9 @@
         <Parameter Name="assemblies" Type="System.Collections.Generic.IEnumerable&lt;System.Reflection.Assembly&gt;" />
       </Parameters>
       <Docs>
-        <param name="assemblies">The assemblies used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container using the specfied assemblies.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="assemblies">The assemblies to add part types from.</param>
+        <summary>Adds part types from the specified collection of assemblies to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -98,10 +98,10 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="assemblies">The assemblies used to configure the composition container.</param>
-        <param name="conventions">The conventions used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container using the specfied assemblies and conventions.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="assemblies">The assemblies to add part types from.</param>
+        <param name="conventions">The conventions to use for part types.</param>
+        <summary>Adds part types from the specified collection of assemblies to the container, using the specified conventions.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -122,9 +122,9 @@
         <Parameter Name="assembly" Type="System.Reflection.Assembly" />
       </Parameters>
       <Docs>
-        <param name="assembly">The assembly used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container using the specfied assembly.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="assembly">The assembly to add part types from.</param>
+        <summary>Adds part types from the specified assembly to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -146,10 +146,10 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="assembly">The assembly used to configure the composition container.</param>
-        <param name="conventions">The conventions used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container using the specfied assembly and conventions.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="assembly">The assembly to add part types from.</param>
+        <param name="conventions">The conventions to use for part types.</param>
+        <summary>Adds part types from the specified assembly to the container, using the specified conventions.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -170,9 +170,9 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="conventions">The conventions used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container the specified conventions.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="conventions">The conventions to use for part types.</param>
+        <summary>Specifies the default conventions to use for added parts.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -193,9 +193,9 @@
         <Parameter Name="partType" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="partType">The type of the part used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container using the specified type.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="partType">The part type to add.</param>
+        <summary>Adds a specified part type to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -217,10 +217,10 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="partType">The type of the part used to configure the composition container.</param>
-        <param name="conventions">The conventions used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container using the specified type and conventions.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="partType">The part type to add.</param>
+        <param name="conventions">The conventions to use for the part type.</param>
+        <summary>Adds a specified part type to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -242,9 +242,9 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="TPart">The type of the part used to configure the composition container.</typeparam>
-        <summary>Builds a configuration for a composition container using the type specified by <TypeParameter Name="TPart" />.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <typeparam name="TPart">The type to add.</typeparam>
+        <summary>Adds the specified generic type to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -268,10 +268,10 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <typeparam name="TPart">The type of the part used to configure the composition container.</typeparam>
-        <param name="conventions">The conventions used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container of type <TypeParameter Name="TPart" /> using the type specified conventions.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <typeparam name="TPart">The type to add.</typeparam>
+        <param name="conventions">The conventions to use for the part type.</param>
+        <summary>Adds the specified generic type to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -292,9 +292,9 @@
         <Parameter Name="partTypes" Type="System.Collections.Generic.IEnumerable&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <param name="partTypes">The types of the parts used to configure the container.</param>
-        <summary>Builds a configuration for a composition container based on the specified part types.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="partTypes">A collection of part types to add.</param>
+        <summary>Adds the specified part types to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -321,9 +321,9 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="partTypes">The types of the parts used to configure the container.</param>
-        <summary>Builds a configuration for a composition container based on the specified part types.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="partTypes">An array of part types to add.</param>
+        <summary>Adds the specified array of part types to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -345,10 +345,10 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="partTypes">The types of the parts used to configure the container.</param>
-        <param name="conventions">The conventions used to configure the composition container.</param>
-        <summary>Builds a configuration for a composition container based on the specified part types and conventions.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="partTypes">A collection of part types to add.</param>
+        <param name="conventions">The conventions to use for part types.</param>
+        <summary>Adds the specified part types to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -369,9 +369,9 @@
         <Parameter Name="exportDescriptorProvider" Type="System.Composition.Hosting.Core.ExportDescriptorProvider" />
       </Parameters>
       <Docs>
-        <param name="exportDescriptorProvider">The description of an export for a part.</param>
-        <summary>Builds a configuration for a composition container based on the specified description of an export for a part.</summary>
-        <returns>The configuration for a composition container.</returns>
+        <param name="exportDescriptorProvider">The provider to add.</param>
+        <summary>Adds the specified provider to the container.</summary>
+        <returns>An object that can be used to further configure the container.</returns>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Composition.Hosting/ContainerConfiguration.xml
+++ b/xml/System.Composition.Hosting/ContainerConfiguration.xml
@@ -17,8 +17,8 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents a configuration for a composition container.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -33,8 +33,8 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Initializes a new instance of the <see cref="T:ContainerConfiguration"/> class.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateContainer">
@@ -52,9 +52,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Creates a composition container.</summary>
+        <returns>The composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithAssemblies">
@@ -74,10 +74,10 @@
         <Parameter Name="assemblies" Type="System.Collections.Generic.IEnumerable&lt;System.Reflection.Assembly&gt;" />
       </Parameters>
       <Docs>
-        <param name="assemblies">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="assemblies">The assemblies used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container using the specfied assemblies.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithAssemblies">
@@ -98,11 +98,11 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="assemblies">To be added.</param>
-        <param name="conventions">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="assemblies">The assemblies used to configure the composition container.</param>
+        <param name="conventions">The conventions used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container using the specfied assemblies and conventions.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithAssembly">
@@ -122,10 +122,10 @@
         <Parameter Name="assembly" Type="System.Reflection.Assembly" />
       </Parameters>
       <Docs>
-        <param name="assembly">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="assembly">The assembly used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container using the specfied assembly.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithAssembly">
@@ -146,11 +146,11 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="assembly">To be added.</param>
-        <param name="conventions">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="assembly">The assembly used to configure the composition container.<</param>
+        <param name="conventions">The conventions used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container using the specfied assembly and conventions.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithDefaultConventions">
@@ -170,10 +170,10 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="conventions">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="conventions">The conventions used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container the specified conventions.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithPart">
@@ -193,10 +193,10 @@
         <Parameter Name="partType" Type="System.Type" />
       </Parameters>
       <Docs>
-        <param name="partType">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="partType">The type of the part used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container using the specified type.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithPart">
@@ -217,11 +217,11 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="partType">To be added.</param>
-        <param name="conventions">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="partType">The type of the part used to configure the composition container.</param>
+        <param name="conventions">The conventions used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container using the specified type and conventions.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithPart&lt;TPart&gt;">
@@ -242,10 +242,10 @@
       </TypeParameters>
       <Parameters />
       <Docs>
-        <typeparam name="TPart">To be added.</typeparam>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="TPart">The type of the part used to configure the composition container.</typeparam>
+        <summary>Builds a configuration for a composition container using the type specified by <TypeParameter Name="TPart" />.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithPart&lt;TPart&gt;">
@@ -268,11 +268,11 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <typeparam name="TPart">To be added.</typeparam>
-        <param name="conventions">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <typeparam name="TPart">The type of the part used to configure the composition container.</typeparam>
+        <param name="conventions">The conventions used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container of type <TypeParameter Name="TPart" /> using the type specified conventions.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithParts">
@@ -292,10 +292,10 @@
         <Parameter Name="partTypes" Type="System.Collections.Generic.IEnumerable&lt;System.Type&gt;" />
       </Parameters>
       <Docs>
-        <param name="partTypes">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="partTypes">The types of the parts used to configure the container.</param>
+        <summary>Builds a configuration for a composition container based on the specified part types.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithParts">
@@ -321,10 +321,10 @@
         </Parameter>
       </Parameters>
       <Docs>
-        <param name="partTypes">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="partTypes">The types of the parts used to configure the container.</param>
+        <summary>Builds a configuration for a composition container based on the specified part types.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithParts">
@@ -345,11 +345,11 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="partTypes">To be added.</param>
-        <param name="conventions">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="partTypes">The types of the parts used to configure the container.</param>
+        <param name="conventions">The conventions used to configure the composition container.</param>
+        <summary>Builds a configuration for a composition container based on the specified part types and conventions.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="WithProvider">
@@ -369,10 +369,10 @@
         <Parameter Name="exportDescriptorProvider" Type="System.Composition.Hosting.Core.ExportDescriptorProvider" />
       </Parameters>
       <Docs>
-        <param name="exportDescriptorProvider">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="exportDescriptorProvider">The description of an export for a part.</param>
+        <summary>Builds a configuration for a composition container based on the specified description of an export for a part.</summary>
+        <returns>The configuration for a composition container.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Composition.Hosting/ContainerConfiguration.xml
+++ b/xml/System.Composition.Hosting/ContainerConfiguration.xml
@@ -146,7 +146,7 @@
         <Parameter Name="conventions" Type="System.Composition.Convention.AttributedModelProvider" />
       </Parameters>
       <Docs>
-        <param name="assembly">The assembly used to configure the composition container.<</param>
+        <param name="assembly">The assembly used to configure the composition container.</param>
         <param name="conventions">The conventions used to configure the composition container.</param>
         <summary>Builds a configuration for a composition container using the specfied assembly and conventions.</summary>
         <returns>The configuration for a composition container.</returns>

--- a/xml/ns-System.Composition.Hosting.xml
+++ b/xml/ns-System.Composition.Hosting.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Composition.Hosting">
   <Docs>
-    <summary>To be added.</summary>
+    <summary>The <see cref="N:System.Composition.Hosting" /> namespace contains classes for building and configuring a composition container and for reporting exceptions from a failed composition.</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
Add missing documentation for the System.Composition.Hosting Namespace

This namespace contains the following classes:
CompositionFailedException
CompositionHost
ContainerConfiguration

Information was pulled from the source code at:
https://github.com/dotnet/corefx/tree/master/src/System.Composition.Hosting/src/System/Composition/Hosting

Fixes #2389 

## Suggested Reviewers
@mairaw 

