### PR TITLE
Correct documented SortedList insert performance

### DIFF
--- a/docs/standard/collections/sorted-collection-types.md
+++ b/docs/standard/collections/sorted-collection-types.md
@@ -40,7 +40,7 @@ The <xref:System.Collections.SortedList?displayProperty=fullName> class, the <xr
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|  
 |The properties that return keys and values are indexed, allowing efficient indexed retrieval.|No indexed retrieval.|  
 |Retrieval is O(log `n`).|Retrieval is O(log `n`).|  
-|Insertion and removal are generally O(`n`); however, insertion is O(1) for data that are already in sort order, so that each element is added to the end of the list. (This assumes that a resize is not required.)|Insertion and removal are O(log `n`).|  
+|Insertion and removal are generally O(`n`); however, insertion is O(log `n`) for data that are already in sort order, so that each element is added to the end of the list. (This assumes that a resize is not required.)|Insertion and removal are O(log `n`).|  
 |Uses less memory than a <xref:System.Collections.Generic.SortedDictionary%602>.|Uses more memory than the <xref:System.Collections.SortedList> nongeneric class and the <xref:System.Collections.Generic.SortedList%602> generic class.|  
   
  For sorted lists or dictionaries that must be accessible concurrently from multiple threads, you can add sorting logic to a class that derives from <xref:System.Collections.Concurrent.ConcurrentDictionary%602>.  


### PR DESCRIPTION
# Correct documented SortedList insert performance

## Summary

This page states:
> insertion is O(1) for data that are already in sort order, so that each element is added to the end of the list. (This assumes that a resize is not required.)

which sadly doesn't seem to be true as explained in the details.

## Details

According to API specific doc pages and the code itself, insert as well as remove performance will be O(log n) instead of O(1) in the best case scenario:

> This method is an O(n) operation for unsorted data, where n is Count. It is an O(log n) operation if the new element is added at the end of the list. If insertion causes a resize, the operation is O(n).

stated here: https://msdn.microsoft.com/en-us/library/ms132330(v=vs.110).aspx and here: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.sortedlist-2.add?view=netframework-4.7#System_Collections_Generic_SortedList_2_Add__0__1_

The implementation of add also shows that it always starts with a binary search (being O(log n) in the best case) [SortedList .NET Core implementation](https://github.com/dotnet/corefx/blob/master/src/System.Collections/src/System/Collections/Generic/SortedList.cs#L185) and [SortedList .NET Framework implementation](https://referencesource.microsoft.com/#System/compmod/system/collections/generic/sortedlist.cs,177)