### PR TITLE
Wrong heading on the "service side timeouts" section

### DIFF
--- a/docs/framework/wcf/feature-details/configuring-timeout-values-on-a-binding.md
+++ b/docs/framework/wcf/feature-details/configuring-timeout-values-on-a-binding.md
@@ -91,7 +91,7 @@ public static void Main()
   
 4.  ReceiveTimeout – is not used  
   
-### Client-side Timeouts  
+### Service-side Timeouts  
  On the service side:  
   
 1.  SendTimeout, OpentTimeout, CloseTimeout are the same as on the client  


### PR DESCRIPTION
# Fixed heading on the "service side timeouts" section

## Summary

The heading on the "service side timeouts" section should read "Service-side Timeouts" instead of "Client-side Timeouts".