### PR TITLE
fix reference to Visual Studio IDE

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
@@ -31,7 +31,7 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # #region (C# Reference)
-`#region` lets you specify a block of code that you can expand or collapse when using the [outlining](https://docs.microsoft.com/visualstudio/ide/outlining) feature of the Visual Studio Code Editor. In longer code files, it is convenient to be able to collapse or hide one or more regions so that you can focus on the part of the file that you are currently working on. The following example shows how to define a region:  
+`#region` lets you specify a block of code that you can expand or collapse when using the [outlining](https://docs.microsoft.com/visualstudio/ide/outlining) feature of the Visual Studio Editor. In longer code files, it is convenient to be able to collapse or hide one or more regions so that you can focus on the part of the file that you are currently working on. The following example shows how to define a region:  
   
 ```  
 #region MyClass definition  


### PR DESCRIPTION


# fix reference to Visual Studio IDE

## Summary

I believe the reference to Visual Studio Code is actually intended to be a reference to the Visual Studio IDE.
The outlining feature doesn't appear to be work OOTB for the `#region` preprocessor directive in VS Code.
(I don't think VS Code recognizes C# syntax w/o the use of an add-on)
