### PR TITLE
Replace note for types that don't have to be disposed

### DIFF
--- a/includes/note-unnecessary-dispose.md
+++ b/includes/note-unnecessary-dispose.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> This type implements the @System.IDisposable interface, but does not actually have any resources to dispose. This means that disposing it by directly calling @System.IDisposable.Dispose or by using a language construct such as `using` (in C#) or `Using` (in Visual Basic) is not necessary.

--- a/xml/System.IO/MemoryStream.xml
+++ b/xml/System.IO/MemoryStream.xml
@@ -42,8 +42,7 @@
   
  The current position of a stream is the position at which the next read or write operation could take place. The current position can be retrieved or set through the <xref:System.IO.MemoryStream.Seek%2A> method. When a new instance of <xref:System.IO.MemoryStream> is created, the current position is set to zero.  
   
-> [!IMPORTANT]
->  This type implements the <xref:System.IDisposable> interface. When you have finished using the type, you should dispose of it either directly or indirectly. To dispose of the type directly, call its <xref:System.IDisposable.Dispose%2A> method in a `try`/`catch` block. To dispose of it indirectly, use a language construct such as `using` (in C#) or `Using` (in Visual Basic). For more information, see the "Using an Object that Implements IDisposable" section in the <xref:System.IDisposable> interface topic.  
+[!INCLUDE[note_unnecessary_dispose](~/includes/note-unnecessary-dispose.md)]
   
  Memory streams created with an unsigned byte array provide a non-resizable stream of the data. When using a byte array, you can neither append to nor shrink the stream, although you might be able to modify the existing contents depending on the parameters passed into the constructor. Empty memory streams are resizable, and can be written to and read from.  
   

--- a/xml/System.IO/StringReader.xml
+++ b/xml/System.IO/StringReader.xml
@@ -38,8 +38,7 @@
 ## Remarks  
  <xref:System.IO.StringReader> enables you to read a string synchronously or asynchronously. You can read a character at a time with the <xref:System.IO.StringReader.Read%2A> or the <xref:System.IO.StringReader.ReadAsync%2A> method, a line at a time using the <xref:System.IO.StringReader.ReadLine%2A> or the <xref:System.IO.StringReader.ReadLineAsync%2A> method and an entire string using the <xref:System.IO.StringReader.ReadToEnd%2A> or the <xref:System.IO.StringReader.ReadToEndAsync%2A> method.  
   
-> [!IMPORTANT]
->  This type implements the <xref:System.IDisposable> interface. When you have finished using the type, you should dispose of it either directly or indirectly. To dispose of the type directly, call its <xref:System.IDisposable.Dispose%2A> method in a `try`/`catch` block. To dispose of it indirectly, use a language construct such as `using` (in C#) or `Using` (in Visual Basic). For more information, see the "Using an Object that Implements IDisposable" section in the <xref:System.IDisposable> interface topic.  
+[!INCLUDE[note_unnecessary_dispose](~/includes/note-unnecessary-dispose.md)]
   
  The following table lists examples of other typical or related I/O tasks.  
   

--- a/xml/System.IO/StringWriter.xml
+++ b/xml/System.IO/StringWriter.xml
@@ -38,8 +38,7 @@
 ## Remarks  
  <xref:System.IO.StringWriter> enables you to write to a string synchronously or asynchronously. You can write a character at a time with the <xref:System.IO.StringWriter.Write%28System.Char%29> or the <xref:System.IO.StringWriter.WriteAsync%28System.Char%29> method, a string at a time using the <xref:System.IO.StringWriter.Write%28System.String%29> or the <xref:System.IO.StringWriter.WriteAsync%28System.String%29> method. In addition, you can write a character, an array of characters or a string followed by the line terminator asynchronously with one of the <xref:System.IO.StringWriter.WriteLineAsync%2A> methods.  
   
-> [!IMPORTANT]
->  This type implements the <xref:System.IDisposable> interface. When you have finished using the type, you should dispose of it either directly or indirectly. To dispose of the type directly, call its <xref:System.IDisposable.Dispose%2A> method in a `try` /`catch` block. To dispose of it indirectly, use a language construct such as `using` (in C#) or `Using` (in Visual Basic). For more information, see the "Using an Object that Implements IDisposable" section in the <xref:System.IDisposable> interface topic.  
+[!INCLUDE[note_unnecessary_dispose](~/includes/note-unnecessary-dispose.md)]
   
  The following table lists examples of other typical or related I/O tasks.  
   

--- a/xml/System.IO/UnmanagedMemoryAccessor.xml
+++ b/xml/System.IO/UnmanagedMemoryAccessor.xml
@@ -35,8 +35,7 @@
 ## Remarks  
  The <xref:System.IO.MemoryMappedFiles.MemoryMappedFile.CreateViewAccessor%2A> method of a <xref:System.IO.MemoryMappedFiles.MemoryMappedFile> object returns the unmanaged blocks of memory for working with views of memory-mapped files.  
   
-> [!IMPORTANT]
->  This type implements the <xref:System.IDisposable> interface. When you have finished using the type, you should dispose of it either directly or indirectly. To dispose of the type directly, call its <xref:System.IDisposable.Dispose%2A> method in a `try`/`catch` block. To dispose of it indirectly, use a language construct such as `using` (in C#) or `Using` (in Visual Basic). For more information, see the "Using an Object that Implements IDisposable" section in the <xref:System.IDisposable> interface topic.  
+[!INCLUDE[note_unnecessary_dispose](~/includes/note-unnecessary-dispose.md)]
   
  ]]></format>
     </remarks>

--- a/xml/System.IO/UnmanagedMemoryStream.xml
+++ b/xml/System.IO/UnmanagedMemoryStream.xml
@@ -31,10 +31,7 @@
 ## Remarks  
  This class supports access to unmanaged memory using the existing stream-based model and does not require that the contents in the unmanaged memory be copied to the heap.  
   
-> [!IMPORTANT]
->  This type implements the <xref:System.IDisposable> interface. When you have finished using the type, you should dispose of it either directly or indirectly. To dispose of the type directly, call its <xref:System.IDisposable.Dispose%2A> method in a `try`/`catch` block. To dispose of it indirectly, use a language construct such as `using` (in C#) or `Using` (in Visual Basic). For more information, see the "Using an Object that Implements IDisposable" section in the <xref:System.IDisposable> interface topic.  
-  
-   
+[!INCLUDE[note_unnecessary_dispose](~/includes/note-unnecessary-dispose.md)]
   
 ## Examples  
  The following code example demonstrates how to read from and write to unmanaged memory using the <xref:System.IO.UnmanagedMemoryStream> class.  A block of unmanaged memory is allocated and de-allocated using the <xref:System.Runtime.InteropServices.Marshal> class.  


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/2385.

Since it's the same note in multiple places, I have put it into a `includes` file, so that any future changes can be made in a single place. Is that that right approach?

cc: @rpetrusha 