### PR TITLE
Fixed note about overriding in RandomNumberGenerator

### DIFF
--- a/xml/System.Security.Cryptography/RandomNumberGenerator.xml
+++ b/xml/System.Security.Cryptography/RandomNumberGenerator.xml
@@ -107,7 +107,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>When overridden in a derived class, creates an instance of the default implementation of a cryptographic random number generator that can be used to generate random data.</summary>
+        <summary>Creates an instance of the default implementation of a cryptographic random number generator that can be used to generate random data.</summary>
         <returns>A new instance of a cryptographic random number generator.</returns>
         <remarks>To be added.</remarks>
       </Docs>
@@ -138,7 +138,7 @@
       </Parameters>
       <Docs>
         <param name="rngName">The name of the random number generator implementation to use.</param>
-        <summary>When overridden in a derived class, creates an instance of the specified implementation of a cryptographic random number generator.</summary>
+        <summary>Creates an instance of the specified implementation of a cryptographic random number generator.</summary>
         <returns>A new instance of a cryptographic random number generator.</returns>
         <remarks>To be added.</remarks>
       </Docs>


### PR DESCRIPTION
Static methods cannot be overridden, so the old text doesn't make sense.