### PR TITLE
Memory Limit attribute should be 'physicalMemoryLimitPercentage'

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md
+++ b/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md
@@ -84,7 +84,7 @@ Defines an element that is used to configure a cache that is based on the <xref:
 ## Example  
  The following example shows how to set the name of the <xref:System.Runtime.Caching.MemoryCache> object to the default cache object name by setting the `name` attribute to "default".  
   
- The `cacheMemoryLimitMegabytes` attribute and the `physicalMemoryPercentage` attribute are set to zero. Setting these attributes to zero means that the <xref:System.Runtime.Caching.MemoryCache> autosizing heuristics are used by default. The cache implementation should compare the current memory load against the absolute and percentage-based memory limits every two minutes.  
+ The `cacheMemoryLimitMegabytes` attribute and the `physicalMemoryLimitPercentage` attribute are set to zero. Setting these attributes to zero means that the <xref:System.Runtime.Caching.MemoryCache> autosizing heuristics are used by default. The cache implementation should compare the current memory load against the absolute and percentage-based memory limits every two minutes.  
   
 ```xml  
 <configuration>  
@@ -93,7 +93,7 @@ Defines an element that is used to configure a cache that is based on the <xref:
       <namedCaches>  
           <add name="default"   
                cacheMemoryLimitMegabytes="0"   
-               physicalMemoryPercentage="0"  
+               physicalMemoryLimitPercentage="0"  
                pollingInterval="00:02:00" />  
       </namedCaches>  
     </memoryCache>  


### PR DESCRIPTION
# Physical Memory Limit Percentage attribute should be `physicalMemoryLimitPercentage`


## Summary

The attribute name on the `namedCaches` example is not correct.


