### PR TITLE
Remove self referential link in "See Also" section

### DIFF
--- a/docs/framework/wcf/wcf-and-aspnet-web-api.md
+++ b/docs/framework/wcf/wcf-and-aspnet-web-api.md
@@ -35,4 +35,3 @@ WCF is Microsoft’s unified programming model for building service-oriented app
 ## See Also  
  [What Is Windows Communication Foundation](../../../docs/framework/wcf/whats-wcf.md)   
  [Fundamental Windows Communication Foundation Concepts](../../../docs/framework/wcf/fundamental-concepts.md)   
- [WCF and ASP.NET Web API](../../../docs/framework/wcf/wcf-and-aspnet-web-api.md)


### PR DESCRIPTION
# Title

Removed extraneous self referential link

## Summary

In the "See Also" section, there is a link to the same article. This should be removed
