### PR TITLE
fix snippet language order

### DIFF
--- a/docs/framework/data/adonet/ado-net-code-examples.md
+++ b/docs/framework/data/adonet/ado-net-code-examples.md
@@ -1,13 +1,9 @@
 ---
-title: "ADO.NET Code Examples | Microsoft Docs"
-ms.custom: ""
+title: "ADO.NET code examples | Microsoft Docs"
 ms.date: "03/30/2017"
 ms.prod: ".net-framework"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "dotnet-ado"
-ms.tgt_pltfrm: ""
 ms.topic: "article"
 ms.assetid: c119657a-9ce6-4940-91e4-ac1d5f0d9584
 caps.latest.revision: 7
@@ -15,365 +11,341 @@ author: "JennieHubbard"
 ms.author: "jhubbard"
 manager: "jhubbard"
 ---
-# ADO.NET Code Examples
-The code listings in this topic demonstrate how to retrieve data from a database by using the following ADO.NET technologies:  
-  
--   ADO.NET data providers:  
-  
-    -   [SqlClient](#_SqlClient) (`System.Data.SqlClient`)  
-  
-    -   [OleDb](#_OleDb) (`System.Data.OleDb`)  
-  
-    -   [Odbc](#_Odbc) (`System.Data.Odbc`)  
-  
-    -   [OracleClient](#_OracleClient) (`System.Data.OracleClient`)  
-  
--   ADO.NET Entity Framework:  
-  
-    -   [LINQ to Entities](#_LINQ)  
-  
-    -   [Typed ObjectQuery](#_QBM)  
-  
-    -   [EntityClient](#_EntityClient) (`System.Data.EntityClient`)  
-  
--   [LINQ to SQL](#_LINQ2SQL)  
-  
-## ADO.NET Data Provider Examples  
- The following code listings demonstrate how to retrieve data from a database using ADO.NET data providers. The data is returned in a `DataReader`. For more information, see [Retrieving Data Using a DataReader](../../../../docs/framework/data/adonet/retrieving-data-using-a-datareader.md).  
-  
-<a name="_SqlClient"></a>   
-### SqlClient  
- The code in this example assumes that you can connect to the `Northwind` sample database on Microsoft [!INCLUDE[ssNoVersion](../../../../includes/ssnoversion-md.md)]. The code creates a <xref:System.Data.SqlClient.SqlCommand> to select rows from the Products table, adding a <xref:System.Data.SqlClient.SqlParameter> to restrict the results to rows with a UnitPrice greater than the specified parameter value, in this case 5. The <xref:System.Data.SqlClient.SqlConnection> is opened inside of a `using` block, which ensures that resources are closed and disposed when the code exits. The code executes the command by using a <xref:System.Data.SqlClient.SqlDataReader>, and displays the results in the console window.  
-  
- [!code-csharp[DataWorks SampleApp.SqlClient#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.SqlClient/CS/source.cs#1)]
- [!code-vb[DataWorks SampleApp.SqlClient#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.SqlClient/VB/source.vb#1)]  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-<a name="_OleDb"></a>   
-### OleDb  
- The code in this example assumes that you can connect to the Microsoft Access Northwind sample database. The code creates a <xref:System.Data.OleDb.OleDbCommand> to select rows from the Products table, adding a <xref:System.Data.OleDb.OleDbParameter> to restrict the results to rows with a UnitPrice greater than the specified parameter value, in this case 5. The <xref:System.Data.OleDb.OleDbConnection> is opened inside of a `using` block, which ensures that resources are closed and disposed when the code exits. The code executes the command by using a <xref:System.Data.OleDb.OleDbDataReader>, and displays the results in the console window.  
-  
- [!code-csharp[DataWorks SampleApp.OleDb#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.OleDb/CS/source.cs#1)]
- [!code-vb[DataWorks SampleApp.OleDb#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.OleDb/VB/source.vb#1)]  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-<a name="_Odbc"></a>   
-### Odbc  
- The code in this example assumes that you can connect to the Microsoft Access Northwind sample database. The code creates a <xref:System.Data.Odbc.OdbcCommand> to select rows from the Products table, adding a <xref:System.Data.Odbc.OdbcParameter> to restrict the results to rows with a UnitPrice greater than the specified parameter value, in this case 5. The <xref:System.Data.Odbc.OdbcConnection> is opened inside of a `using` block, which ensures that resources are closed and disposed when the code exits. The executes the command by using a <xref:System.Data.Odbc.OdbcDataReader>, and displays the results in the console window.  
-  
-[!code-csharp[DataWorks SampleApp.Odbc#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.Odbc/CS/source.cs#1)]   
-[!code-vb[DataWorks SampleApp.Odbc#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.Odbc/VB/source.vb#1)]   
+# ADO.NET code examples
+The code listings in this topic demonstrate how to retrieve data from a database by using the following ADO.NET technologies:
 
- [&#91;Top&#93;](#_TOP)  
-  
-<a name="_OracleClient"></a>   
-### OracleClient  
- The code in this example assumes a connection to DEMO.CUSTOMER on an Oracle server. You must also add a reference to the System.Data.OracleClient.dll. The code returns the data in an <xref:System.Data.OracleClient.OracleDataReader>.  
-  
+- ADO.NET data providers:
+
+  - [SqlClient](#sqlclient) (`System.Data.SqlClient`)
+
+  - [OleDb](#oledb) (`System.Data.OleDb`)
+
+  - [Odbc](#odbc) (`System.Data.Odbc`)
+
+  - [OracleClient](#oracleclient) (`System.Data.OracleClient`)
+
+- ADO.NET Entity Framework:
+
+  - [LINQ to Entities](#linq-to-entities)
+
+  - [Typed ObjectQuery](#typed-objectquery)
+
+  - [EntityClient](#entityclient) (`System.Data.EntityClient`)
+
+- [LINQ to SQL](#linq-to-sql)
+
+## ADO.NET data provider examples
+The following code listings demonstrate how to retrieve data from a database using ADO.NET data providers. The data is returned in a `DataReader`. For more information, see [Retrieving Data Using a DataReader](../../../../docs/framework/data/adonet/retrieving-data-using-a-datareader.md).
+
+### SqlClient
+The code in this example assumes that you can connect to the `Northwind` sample database on Microsoft [!INCLUDE[ssNoVersion](../../../../includes/ssnoversion-md.md)]. The code creates a <xref:System.Data.SqlClient.SqlCommand> to select rows from the Products table, adding a <xref:System.Data.SqlClient.SqlParameter> to restrict the results to rows with a UnitPrice greater than the specified parameter value, in this case 5. The <xref:System.Data.SqlClient.SqlConnection> is opened inside a `using` block, which ensures that resources are closed and disposed when the code exits. The code executes the command by using a <xref:System.Data.SqlClient.SqlDataReader>, and displays the results in the console window.
+
+ [!code-csharp[DataWorks SampleApp.SqlClient#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.SqlClient/CS/source.cs#1)]
+ [!code-vb[DataWorks SampleApp.SqlClient#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.SqlClient/VB/source.vb#1)]
+
+### OleDb
+The code in this example assumes that you can connect to the Microsoft Access Northwind sample database. The code creates a <xref:System.Data.OleDb.OleDbCommand> to select rows from the Products table, adding a <xref:System.Data.OleDb.OleDbParameter> to restrict the results to rows with a UnitPrice greater than the specified parameter value, in this case 5. The <xref:System.Data.OleDb.OleDbConnection> is opened inside of a `using` block, which ensures that resources are closed and disposed when the code exits. The code executes the command by using a <xref:System.Data.OleDb.OleDbDataReader>, and displays the results in the console window.
+
+ [!code-csharp[DataWorks SampleApp.OleDb#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.OleDb/CS/source.cs#1)]
+ [!code-vb[DataWorks SampleApp.OleDb#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.OleDb/VB/source.vb#1)]
+
+### Odbc
+The code in this example assumes that you can connect to the Microsoft Access Northwind sample database. The code creates a <xref:System.Data.Odbc.OdbcCommand> to select rows from the Products table, adding a <xref:System.Data.Odbc.OdbcParameter> to restrict the results to rows with a UnitPrice greater than the specified parameter value, in this case 5. The <xref:System.Data.Odbc.OdbcConnection> is opened inside a `using` block, which ensures that resources are closed and disposed when the code exits. The code executes the command by using a <xref:System.Data.Odbc.OdbcDataReader>, and displays the results in the console window.
+
+[!code-csharp[DataWorks SampleApp.Odbc#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.Odbc/CS/source.cs#1)] 
+[!code-vb[DataWorks SampleApp.Odbc#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.Odbc/VB/source.vb#1)] 
+
+### OracleClient
+The code in this example assumes a connection to DEMO.CUSTOMER on an Oracle server. You must also add a reference to the System.Data.OracleClient.dll. The code returns the data in an <xref:System.Data.OracleClient.OracleDataReader>.
+
  [!code-csharp[DataWorks SampleApp.Oracle#1](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DataWorks SampleApp.Oracle/CS/source.cs#1)]
- [!code-vb[DataWorks SampleApp.Oracle#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.Oracle/VB/source.vb#1)]  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-## Entity Framework Examples  
- The following code listings demonstrate how to retrieve data from a data source by querying entities in an Entity Data Model (EDM). These examples use the [Northwind model](http://msdn.microsoft.com/en-us/74521f8c-e974-48cb-8858-c08deff52638). For more information, see [Entity Framework Overview](../../../../docs/framework/data/adonet/ef/overview.md).  
-  
-<a name="_LINQ"></a>   
-### LINQ to Entities  
- The code in this example uses a LINQ query to return data as Categories objects, which are projected as an anonymous type that contains only the CategoryID and CategoryName properties. For more information, see [LINQ to Entities Overview](http://msdn.microsoft.com/en-us/86d87a27-c17a-45ac-b28d-72c8500333c6).  
-  
-```vb  
-Option Explicit On  
-Option Strict On  
-  
-Imports System  
-Imports System.Linq  
-Imports System.Data.Objects  
-Imports NorthwindModel  
-  
-Class LinqSample  
-    Public Shared Sub ExecuteQuery()  
-        Using context As NorthwindEntities = New NorthwindEntities()  
-            Try  
-                Dim query = From category In context.Categories _  
-                            Select New With _  
-                            { _  
-                                .categoryID = category.CategoryID, _  
-                                .categoryName = category.CategoryName _  
-                            }  
-  
-                For Each categoryInfo In query  
-                    Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _  
-                        categoryInfo.categoryID, categoryInfo.categoryName)  
-                Next  
-            Catch ex As Exception  
-                Console.WriteLine(ex.Message)  
-            End Try  
-        End Using  
-    End Sub  
-End Class  
-```  
-  
-```csharp  
-using System;  
-using System.Linq;  
-using System.Data.Objects;  
-using NorthwindModel;  
-  
-class LinqSample  
-{  
-    public static void ExecuteQuery()  
-    {  
-        using (NorthwindEntities context = new NorthwindEntities())  
-        {  
-            try  
-            {  
-                var query = from category in context.Categories  
-                            select new  
-                            {  
-                                categoryID = category.CategoryID,  
-                                categoryName = category.CategoryName  
-                            };  
-  
-                foreach (var categoryInfo in query)  
-                {  
-                    Console.WriteLine("\t{0}\t{1}",  
-                        categoryInfo.categoryID, categoryInfo.categoryName);  
-                }  
-            }  
-            catch (Exception ex)  
-            {  
-                Console.WriteLine(ex.Message);  
-            }  
-        }  
-    }  
-}  
-```  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-<a name="_QBM"></a>   
-### Typed ObjectQuery  
- The code in this example uses an <xref:System.Data.Objects.ObjectQuery%601> to return data as Categories objects. For more information, see [Object Queries](http://msdn.microsoft.com/en-us/0768033c-876f-471d-85d5-264884349276).  
-  
-```vb  
-Option Explicit On  
-Option Strict On  
-  
-Imports System  
-Imports System.Data.Objects  
-Imports NorthwindModel  
-  
-Class ObjectQuerySample  
-    Public Shared Sub ExecuteQuery()  
-        Using context As NorthwindEntities = New NorthwindEntities()  
-            Dim categoryQuery As ObjectQuery(Of Categories) = context.Categories  
-  
-            For Each category As Categories In _  
-                categoryQuery.Execute(MergeOption.AppendOnly)  
-                Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _  
-                    category.CategoryID, category.CategoryName)  
-            Next  
-        End Using  
-    End Sub  
-End Class  
-```  
-  
-```csharp  
-using System;  
-using System.Data.Objects;  
-using NorthwindModel;  
-  
-class ObjectQuerySample  
-{  
-    public static void ExecuteQuery()  
-    {  
-        using (NorthwindEntities context = new NorthwindEntities())  
-        {  
-            ObjectQuery<Categories> categoryQuery = context.Categories;  
-  
-            foreach (Categories category in   
-                categoryQuery.Execute(MergeOption.AppendOnly))  
-            {  
-                Console.WriteLine("\t{0}\t{1}",  
-                    category.CategoryID, category.CategoryName);  
-            }  
-        }  
-    }  
-}  
-```  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-<a name="_EntityClient"></a>   
-### EntityClient  
- The code in this example uses an <xref:System.Data.EntityClient.EntityCommand> to execute an Entity SQL query. This query returns a list of records that represent instances of the Categories entity type. An <xref:System.Data.EntityClient.EntityDataReader> is used to access data records in the result set. For more information, see [EntityClient Provider for the Entity Framework](../../../../docs/framework/data/adonet/ef/entityclient-provider-for-the-entity-framework.md).  
-  
-```vb  
-Option Explicit On  
-Option Strict On  
-  
-Imports System  
-Imports System.Data  
-Imports System.Data.Common  
-Imports System.Data.EntityClient  
-Imports NorthwindModel  
-  
-Class EntityClientSample  
-    Public Shared Sub ExecuteQuery()  
-        Dim queryString As String = _  
-            "SELECT c.CategoryID, c.CategoryName " & _  
-                "FROM NorthwindEntities.Categories AS c"  
-  
-        Using conn As EntityConnection = _  
-            New EntityConnection("name=NorthwindEntities")  
-  
-            Try  
-                conn.Open()  
-                Using query As EntityCommand = _  
-                New EntityCommand(queryString, conn)  
-                    Using rdr As DbDataReader = _  
-                        query.ExecuteReader(CommandBehavior.SequentialAccess)  
-                        While rdr.Read()  
-                            Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _  
-                                              rdr(0), rdr(1))  
-                        End While  
-                    End Using  
-                End Using  
-            Catch ex As Exception  
-                Console.WriteLine(ex.Message)  
-            End Try  
-        End Using   
-    End Sub  
-End Class  
-```  
-  
-```csharp  
-using System;  
-using System.Data;  
-using System.Data.Common;  
-using System.Data.EntityClient;  
-using NorthwindModel;  
-  
-class EntityClientSample  
-{  
-    public static void ExecuteQuery()  
-    {  
-        string queryString =  
-            @"SELECT c.CategoryID, c.CategoryName   
-                FROM NorthwindEntities.Categories AS c";  
-  
-        using (EntityConnection conn =  
-            new EntityConnection("name=NorthwindEntities"))  
-        {  
-            try  
-            {  
-                conn.Open();  
-                using (EntityCommand query = new EntityCommand(queryString, conn))  
-                {  
-                    using (DbDataReader rdr =   
-                        query.ExecuteReader(CommandBehavior.SequentialAccess))  
-                    {  
-                        while (rdr.Read())  
-                        {  
-                            Console.WriteLine("\t{0}\t{1}", rdr[0], rdr[1]);  
-                        }  
-                    }  
-                }  
-            }  
-            catch (Exception ex)  
-            {  
-                Console.WriteLine(ex.Message);  
-            }  
-        }  
-    }  
-}  
-```  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-<a name="_LINQ2SQL"></a>   
-## LINQ to SQL  
- The code in this example uses a LINQ query to return data as Categories objects, which are projected as an anonymous type that contains only the CategoryID and CategoryName properties. This example is based on the Northwind data context. For more information, see [Getting Started](../../../../docs/framework/data/adonet/sql/linq/getting-started.md).  
-  
-```vb  
-Option Explicit On  
-Option Strict On  
-  
-Imports System  
-Imports System.Collections.Generic  
-Imports System.Linq  
-Imports System.Text  
-Imports Northwind  
-  
-Class LinqSqlSample  
-    Public Shared Sub ExecuteQuery()  
-        Using db As NorthwindDataContext = New NorthwindDataContext()  
-            Try  
-                Dim query = From category In db.Categories _  
-                                Select New With _  
-                                { _  
-                                    .categoryID = category.CategoryID, _  
-                                    .categoryName = category.CategoryName _  
-                                }  
-  
-                For Each categoryInfo In query  
-                    Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _  
-                            categoryInfo.categoryID, categoryInfo.categoryName)  
-                Next  
-            Catch ex As Exception  
-                Console.WriteLine(ex.Message)  
-            End Try  
-            End Using   
-    End Sub  
-End Class  
-```  
-  
-```csharp  
-using System;  
-using System.Collections.Generic;  
-using System.Linq;  
-using System.Text;  
-using Northwind;  
-  
-    class LinqSqlSample  
-    {  
-        public static void ExecuteQuery()  
-        {  
-            using (NorthwindDataContext db = new NorthwindDataContext())  
-            {  
-                try  
-                {  
-                    var query = from category in db.Categories  
-                                select new  
-                                {  
-                                    categoryID = category.CategoryID,  
-                                    categoryName = category.CategoryName  
-                                };  
-  
-                    foreach (var categoryInfo in query)  
-                    {  
-                        Console.WriteLine("vbTab {0} vbTab {1}",  
-                            categoryInfo.categoryID, categoryInfo.categoryName);  
-                    }  
-                }  
-                catch (Exception ex)  
-                {  
-                    Console.WriteLine(ex.Message);  
-                }  
-            }  
-        }  
-    }  
-```  
-  
- [&#91;Top&#93;](#_TOP)  
-  
-## See Also  
- [ADO.NET Overview](../../../../docs/framework/data/adonet/ado-net-overview.md)   
- [Retrieving and Modifying Data in ADO.NET](../../../../docs/framework/data/adonet/retrieving-and-modifying-data.md)   
- [Creating Data Applications](http://msdn.microsoft.com/library/ab334d5f-4f49-4346-bce0-3325d6130b3e)   
- [Querying an Entity Data Model (Entity Framework Tasks)](http://msdn.microsoft.com/en-us/187f1caa-e4d3-4e31-bd99-5d5c2b329c77)   
- [How to: Execute a Query that Returns Anonymous Type Objects](http://msdn.microsoft.com/en-us/3b264025-e911-4d73-90ce-992d2b9d189d)   
- [ADO.NET Managed Providers and DataSet Developer Center](http://go.microsoft.com/fwlink/?LinkId=217917)
+ [!code-vb[DataWorks SampleApp.Oracle#1](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DataWorks SampleApp.Oracle/VB/source.vb#1)]
+
+## Entity Framework examples
+The following code listings demonstrate how to retrieve data from a data source by querying entities in an Entity Data Model (EDM). These examples use the [Northwind model](http://msdn.microsoft.com/74521f8c-e974-48cb-8858-c08deff52638). For more information, see [Entity Framework Overview](../../../../docs/framework/data/adonet/ef/overview.md).
+
+### LINQ to Entities
+The code in this example uses a LINQ query to return data as Categories objects, which are projected as an anonymous type that contains only the CategoryID and CategoryName properties. For more information, see [LINQ to Entities Overview](http://msdn.microsoft.com/86d87a27-c17a-45ac-b28d-72c8500333c6).
+
+```csharp
+using System;
+using System.Linq;
+using System.Data.Objects;
+using NorthwindModel;
+
+class LinqSample
+{
+    public static void ExecuteQuery()
+    {
+        using (NorthwindEntities context = new NorthwindEntities())
+        {
+            try
+            {
+                var query = from category in context.Categories
+                            select new
+                            {
+                                categoryID = category.CategoryID,
+                                categoryName = category.CategoryName
+                            };
+
+                foreach (var categoryInfo in query)
+                {
+                    Console.WriteLine("\t{0}\t{1}",
+                        categoryInfo.categoryID, categoryInfo.categoryName);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+        }
+    }
+}
+```
+
+```vb
+Option Explicit On
+Option Strict On
+
+Imports System
+Imports System.Linq
+Imports System.Data.Objects
+Imports NorthwindModel
+
+Class LinqSample
+    Public Shared Sub ExecuteQuery()
+        Using context As NorthwindEntities = New NorthwindEntities()
+            Try
+                Dim query = From category In context.Categories _
+                            Select New With _
+                            { _
+                                .categoryID = category.CategoryID, _
+                                .categoryName = category.CategoryName _
+                            }
+
+                For Each categoryInfo In query
+                    Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _
+                        categoryInfo.categoryID, categoryInfo.categoryName)
+                Next
+            Catch ex As Exception
+                Console.WriteLine(ex.Message)
+            End Try
+        End Using
+    End Sub
+End Class
+```
+
+### Typed ObjectQuery
+The code in this example uses an <xref:System.Data.Objects.ObjectQuery%601> to return data as Categories objects. For more information, see [Object Queries](http://msdn.microsoft.com/0768033c-876f-471d-85d5-264884349276).
+
+```csharp
+using System;
+using System.Data.Objects;
+using NorthwindModel;
+
+class ObjectQuerySample
+{
+    public static void ExecuteQuery()
+    {
+        using (NorthwindEntities context = new NorthwindEntities())
+        {
+            ObjectQuery<Categories> categoryQuery = context.Categories;
+
+            foreach (Categories category in 
+                categoryQuery.Execute(MergeOption.AppendOnly))
+            {
+                Console.WriteLine("\t{0}\t{1}",
+                    category.CategoryID, category.CategoryName);
+            }
+        }
+    }
+}
+```
+
+```vb
+Option Explicit On
+Option Strict On
+
+Imports System
+Imports System.Data.Objects
+Imports NorthwindModel
+
+Class ObjectQuerySample
+    Public Shared Sub ExecuteQuery()
+        Using context As NorthwindEntities = New NorthwindEntities()
+            Dim categoryQuery As ObjectQuery(Of Categories) = context.Categories
+
+            For Each category As Categories In _
+                categoryQuery.Execute(MergeOption.AppendOnly)
+                Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _
+                    category.CategoryID, category.CategoryName)
+            Next
+        End Using
+    End Sub
+End Class
+```
+
+### EntityClient
+The code in this example uses an <xref:System.Data.EntityClient.EntityCommand> to execute an Entity SQL query. This query returns a list of records that represent instances of the Categories entity type. An <xref:System.Data.EntityClient.EntityDataReader> is used to access data records in the result set. For more information, see [EntityClient Provider for the Entity Framework](../../../../docs/framework/data/adonet/ef/entityclient-provider-for-the-entity-framework.md).
+
+```csharp
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Data.EntityClient;
+using NorthwindModel;
+
+class EntityClientSample
+{
+    public static void ExecuteQuery()
+    {
+        string queryString =
+            @"SELECT c.CategoryID, c.CategoryName 
+                FROM NorthwindEntities.Categories AS c";
+
+        using (EntityConnection conn =
+            new EntityConnection("name=NorthwindEntities"))
+        {
+            try
+            {
+                conn.Open();
+                using (EntityCommand query = new EntityCommand(queryString, conn))
+                {
+                    using (DbDataReader rdr = 
+                        query.ExecuteReader(CommandBehavior.SequentialAccess))
+                    {
+                        while (rdr.Read())
+                        {
+                            Console.WriteLine("\t{0}\t{1}", rdr[0], rdr[1]);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+        }
+    }
+}
+```
+
+```vb
+Option Explicit On
+Option Strict On
+
+Imports System
+Imports System.Data
+Imports System.Data.Common
+Imports System.Data.EntityClient
+Imports NorthwindModel
+
+Class EntityClientSample
+    Public Shared Sub ExecuteQuery()
+        Dim queryString As String = _
+            "SELECT c.CategoryID, c.CategoryName " & _
+                "FROM NorthwindEntities.Categories AS c"
+
+        Using conn As EntityConnection = _
+            New EntityConnection("name=NorthwindEntities")
+
+            Try
+                conn.Open()
+                Using query As EntityCommand = _
+                New EntityCommand(queryString, conn)
+                    Using rdr As DbDataReader = _
+                        query.ExecuteReader(CommandBehavior.SequentialAccess)
+                        While rdr.Read()
+                            Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _
+                                              rdr(0), rdr(1))
+                        End While
+                    End Using
+                End Using
+            Catch ex As Exception
+                Console.WriteLine(ex.Message)
+            End Try
+        End Using 
+    End Sub
+End Class
+```
+
+## LINQ to SQL
+The code in this example uses a LINQ query to return data as Categories objects, which are projected as an anonymous type that contains only the CategoryID and CategoryName properties. This example is based on the Northwind data context. For more information, see [Getting Started](../../../../docs/framework/data/adonet/sql/linq/getting-started.md).
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Northwind;
+
+    class LinqSqlSample
+    {
+        public static void ExecuteQuery()
+        {
+            using (NorthwindDataContext db = new NorthwindDataContext())
+            {
+                try
+                {
+                    var query = from category in db.Categories
+                                select new
+                                {
+                                    categoryID = category.CategoryID,
+                                    categoryName = category.CategoryName
+                                };
+
+                    foreach (var categoryInfo in query)
+                    {
+                        Console.WriteLine("vbTab {0} vbTab {1}",
+                            categoryInfo.categoryID, categoryInfo.categoryName);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
+            }
+        }
+    }
+```
+
+```vb
+Option Explicit On
+Option Strict On
+
+Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Text
+Imports Northwind
+
+Class LinqSqlSample
+    Public Shared Sub ExecuteQuery()
+        Using db As NorthwindDataContext = New NorthwindDataContext()
+            Try
+                Dim query = From category In db.Categories _
+                                Select New With _
+                                { _
+                                    .categoryID = category.CategoryID, _
+                                    .categoryName = category.CategoryName _
+                                }
+
+                For Each categoryInfo In query
+                    Console.WriteLine(vbTab & "{0}" & vbTab & "{1}", _
+                            categoryInfo.categoryID, categoryInfo.categoryName)
+                Next
+            Catch ex As Exception
+                Console.WriteLine(ex.Message)
+            End Try
+            End Using 
+    End Sub
+End Class
+```
+
+## See also
+ [ADO.NET Overview](../../../../docs/framework/data/adonet/ado-net-overview.md)  
+ [Retrieving and Modifying Data in ADO.NET](../../../../docs/framework/data/adonet/retrieving-and-modifying-data.md)  
+ [Creating Data Applications](http://msdn.microsoft.com/library/ab334d5f-4f49-4346-bce0-3325d6130b3e)  
+ [Querying an Entity Data Model (Entity Framework Tasks)](http://msdn.microsoft.com/187f1caa-e4d3-4e31-bd99-5d5c2b329c77)  
+ [How to: Execute a Query that Returns Anonymous Type Objects](http://msdn.microsoft.com/3b264025-e911-4d73-90ce-992d2b9d189d)  
+ [ADO.NET Managed Providers and DataSet Developer Center](http://go.microsoft.com/fwlink/?LinkId=217917)  


### PR DESCRIPTION
Re. https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/ado-net-code-examples#comments-container

Addressing customer comment that we start showing C# first and then switch in the middle of the topic to show VB first + some formatting. Use rich diff to see the changes.

