### PR TITLE
Clarified decription of AssemblyBuilderAccess.RunAndCollect

### DIFF
--- a/xml/System.Reflection.Emit/AssemblyBuilderAccess.xml
+++ b/xml/System.Reflection.Emit/AssemblyBuilderAccess.xml
@@ -86,7 +86,7 @@
         <ReturnType>System.Reflection.Emit.AssemblyBuilderAccess</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The dynamic assembly can be unloaded and its memory reclaimed, subject to the restrictions described in [Collectible Assemblies for Dynamic Type Generation](http://msdn.microsoft.com/en-us/4c3432e6-0dfd-453a-88a7-533979ec5d2b).</summary>
+        <summary>The dynamic assembly will be automatically unloaded and its memory reclaimed, when it's no longer accessible.</summary>
       </Docs>
     </Member>
     <Member MemberName="RunAndSave">


### PR DESCRIPTION
This was prompted by [this SO question](https://stackoverflow.com/q/44632891/41071), which pointed out that the link is dead.

Is it correct that [the linked article](https://msdn.microsoft.com/en-us/library/dd554932(vs.100).aspx) is no longer easily accessible and that the information seems to have effectively been lost?