### PR TITLE
Escape OR pipe in table

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -123,7 +123,7 @@ Expressions can be joined with conditional operators:
 
 | Operator | Function |
 | :------: | :------: |
-| `|`      | OR       |
+| <code>&#124;</code>      | OR       |
 | `&`      | AND      |
 
 You can enclose expressions in paranthesis when using conditional operators (for example, `(Name~TestMethod1) | (Name~TestMethod2)`).


### PR DESCRIPTION
Use HTML escaping as a workaround.
Markdown parser does not handle pipes inside table cells correctly.
