### PR TITLE
Drop include down one line

### DIFF
--- a/docs/framework/misc/security-transparent-code.md
+++ b/docs/framework/misc/security-transparent-code.md
@@ -24,7 +24,8 @@ ms.author: "mairaw"
 manager: "wpickett"
 ---
 # Security-Transparent Code
-<a name="top"></a> [!INCLUDE[net_security_note](../../../includes/net-security-note-md.md)]  
+<a name="top"></a>
+[!INCLUDE[net_security_note](../../../includes/net-security-note-md.md)]  
   
  Security involves three interacting pieces: sandboxing, permissions, and enforcement. Sandboxing refers to the practice of creating isolated domains where some code is treated as fully trusted and other code is restricted to the permissions in the grant set for the sandbox. The application code that runs within the grant set of the sandbox is considered to be transparent; that is, it cannot perform any operations that can affect security. The grant set for the sandbox is determined by evidence (<xref:System.Security.Policy.Evidence> class). Evidence identifies what specific permissions are required by sandboxes, and what kinds of sandboxes can be created. Enforcement refers to allowing transparent code to execute only within its grant set.  
   


### PR DESCRIPTION
See: https://docs.microsoft.com/en-us/dotnet/framework/misc/security-transparent-code

Looks like the anchor on the same line as the include is breaking the caution here. This exact include renders fine in other docs, e.g. https://docs.microsoft.com/en-us/dotnet/framework/misc/code-access-security-basics

![capture](https://user-images.githubusercontent.com/1622880/27393524-2578d4c0-566f-11e7-84ec-52ba80269a44.PNG)