### PR TITLE
Better code formatting in how-to-serialize-an-object-as-a-soap-encoded-xml-stream

### DIFF
--- a/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
+++ b/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
@@ -23,7 +23,6 @@ ms.author: "erikre"
 manager: "erikre"
 ---
 # How to: Serialize an Object as a SOAP-Encoded XML Stream
-[Code Example](#cpconxmlserializationusingsoapprotocolanchor1)  
   
  Because a SOAP message is built using XML, the [XmlSerializer](https://msdn.microsoft.com/library/system.xml.serialization.xmlserializer.aspx) can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to section 5 of the World Wide Web Consortium (www.w3.org) document "Simple Object Access Protocol (SOAP) 1.1". When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
   
@@ -39,14 +38,14 @@ manager: "erikre"
   
     ```vb  
     ' Serializes a class named Group as a SOAP message.  
-    Dim myTypeMapping As XmlTypeMapping = (New SoapReflectionImporter(). _  
-    ImportTypeMapping(GetType(Group))  
+    Dim myTypeMapping As XmlTypeMapping =
+        New SoapReflectionImporter().ImportTypeMapping(GetType(Group))  
     ```  
   
     ```csharp  
     // Serializes a class named Group as a SOAP message.  
-    XmlTypeMapping myTypeMapping = (new SoapReflectionImporter().  
-    ImportTypeMapping(typeof(Group));  
+    XmlTypeMapping myTypeMapping =
+        new SoapReflectionImporter().ImportTypeMapping(typeof(Group));
     ```  
   
 4.  Create an instance of the `XmlSerializer` class by passing the `XmlTypeMapping` to the <xref:System.Xml.Serialization.XmlSerializer.%23ctor%28System.Xml.Serialization.XmlTypeMapping%29> constructor.  
@@ -65,14 +64,15 @@ manager: "erikre"
   
 ```vb  
 ' Serializes a class named Group as a SOAP message.  
-Dim myTypeMapping As XmlTypeMapping = New SoapReflectionImporter(). _  
-ImportTypeMapping(GetType(Group))  
+Dim myTypeMapping As XmlTypeMapping =
+    New SoapReflectionImporter().ImportTypeMapping(GetType(Group))
 Dim mySerializer As XmlSerializer = New XmlSerializer(myTypeMapping)  
 ```  
   
 ```csharp  
 // Serializes a class named Group as a SOAP message.  
-XmlTypeMapping myTypeMapping = new SoapReflectionImporter().ImportTypeMapping(typeof(Group));  
+XmlTypeMapping myTypeMapping =
+    new SoapReflectionImporter().ImportTypeMapping(typeof(Group));
 XmlSerializer mySerializer = new XmlSerializer(myTypeMapping);  
 ```  
   

--- a/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
+++ b/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
@@ -24,7 +24,7 @@ manager: "erikre"
 ---
 # How to: Serialize an Object as a SOAP-Encoded XML Stream
   
- Because a SOAP message is built using XML, the [XmlSerializer](https://msdn.microsoft.com/library/system.xml.serialization.xmlserializer.aspx) can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to section 5 of the World Wide Web Consortium (www.w3.org) document "Simple Object Access Protocol (SOAP) 1.1". When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
+ Because a SOAP message is built using XML, the [XmlSerializer](https://msdn.microsoft.com/library/system.xml.serialization.xmlserializer.aspx) can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to [section 5 of the World Wide Web Consortium document "Simple Object Access Protocol (SOAP) 1.1"](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383512). When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
   
 ### To serialize an object as a SOAP-encoded XML stream  
   

--- a/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
+++ b/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
@@ -24,7 +24,7 @@ manager: "erikre"
 ---
 # How to: Serialize an Object as a SOAP-Encoded XML Stream
   
- Because a SOAP message is built using XML, the <xref:System.Xml.Serialization.XmlSerializer> class  can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to [section 5 of the World Wide Web Consortium document "Simple Object Access Protocol (SOAP) 1.1"](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383512). When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
+ Because a SOAP message is built using XML, the <xref:System.Xml.Serialization.XmlSerializer> class can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to [section 5 of the World Wide Web Consortium document "Simple Object Access Protocol (SOAP) 1.1"](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383512). When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
   
 ### To serialize an object as a SOAP-encoded XML stream  
   

--- a/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
+++ b/docs/framework/serialization/how-to-serialize-an-object-as-a-soap-encoded-xml-stream.md
@@ -24,7 +24,7 @@ manager: "erikre"
 ---
 # How to: Serialize an Object as a SOAP-Encoded XML Stream
   
- Because a SOAP message is built using XML, the [XmlSerializer](https://msdn.microsoft.com/library/system.xml.serialization.xmlserializer.aspx) can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to [section 5 of the World Wide Web Consortium document "Simple Object Access Protocol (SOAP) 1.1"](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383512). When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
+ Because a SOAP message is built using XML, the <xref:System.Xml.Serialization.XmlSerializer> class  can be used to serialize classes and generate encoded SOAP messages. The resulting XML conforms to [section 5 of the World Wide Web Consortium document "Simple Object Access Protocol (SOAP) 1.1"](https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383512). When you are creating an XML Web service that communicates through SOAP messages, you can customize the XML stream by applying a set of special SOAP attributes to classes and members of classes. For a list of attributes, see [Attributes That Control Encoded SOAP Serialization](../../../docs/framework/serialization/attributes-that-control-encoded-soap-serialization.md).  
   
 ### To serialize an object as a SOAP-encoded XML stream  
   


### PR DESCRIPTION
Followup to https://github.com/dotnet/docs/pull/2474. Fixes https://github.com/dotnet/docs/issues/2475.

* Removed some more extra opening parens.
* Better line break positions and indentation in code, including using implicit line continuation for VB.
* Removed non-working mini-TOC (no need to duplicate the actual article TOC).
* Also added link to the SOAP spec.

cc: @hakito, @GuardRex 