### PR TITLE
Missing semi-colon in synchronous-client-socket-example.md

### DIFF
--- a/docs/framework/network-programming/synchronous-client-socket-example.md
+++ b/docs/framework/network-programming/synchronous-client-socket-example.md
@@ -91,7 +91,7 @@ public class SynchronousSocketClient {
         try {  
             // Establish the remote endpoint for the socket.  
             // This example uses port 11000 on the local computer.  
-            IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName())  
+            IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName());  
             IPAddress ipAddress = ipHostInfo.AddressList[0];  
             IPEndPoint remoteEP = new IPEndPoint(ipAddress,11000);  
   


### PR DESCRIPTION
C# code example was missing a semi-colon at line 19 so I added a semi-colon.