### PR TITLE
Make it clear when the changes for csproj were introduced

### DIFF
--- a/docs/core/tools/cli-msbuild-architecture.md
+++ b/docs/core/tools/cli-msbuild-architecture.md
@@ -13,7 +13,7 @@ ms.assetid: 7fff0f61-ac23-42f0-9661-72a7240a4456
 
 # High-level overview of changes in the .NET Core tools
 
-This document will describe in high-level the changes that moving from *project.json* to MSBuild and *.csproj* project system bring. It will outline the new way the tooling is layered all-up and which new pieces are available and what is their place in the overall picture. After reading this article, you should have a better understanding of all of the pieces that make up .NET Core tooling after moving to MSBuild and *.csproj*. 
+This document describes the changes associated with moving from *project.json* to MSBuild and the *csproj* project system that occurred with the release of .NET Core Tools 1.0, .NET Core 1.0.4/1.1.1, and Visual Studio 2017 on March 7, 2017 (see the [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/03/07/announcing-net-core-tools-1-0/)).
 
 ## Moving away from project.json
 The biggest change in the tooling for .NET Core is certainly the [move away from project.json to csproj](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/) as the project system. The latest versions of the command-line tools don't support *project.json* files. That means that it cannot be used to build, run or publish project.json based applications and libraries. In order to use this version of the tools, you will need to migrate your existing projects or start new ones. 

--- a/docs/core/tools/cli-msbuild-architecture.md
+++ b/docs/core/tools/cli-msbuild-architecture.md
@@ -13,7 +13,7 @@ ms.assetid: 7fff0f61-ac23-42f0-9661-72a7240a4456
 
 # High-level overview of changes in the .NET Core tools
 
-This document describes the changes associated with moving from *project.json* to MSBuild and the *csproj* project system that occurred with the release of .NET Core Tools 1.0, .NET Core 1.0.4/1.1.1, and Visual Studio 2017 on March 7, 2017 (see the [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/03/07/announcing-net-core-tools-1-0/)).
+This document describes the changes associated with moving from *project.json* to MSBuild and the *csproj* project system with information on the changes to the layering of the .NET Core tooling and the implementation of the CLI commands. These changes occurred with the release of .NET Core SDK 1.0 and Visual Studio 2017 on March 7, 2017 (see the [announcement](https://blogs.msdn.microsoft.com/dotnet/2017/03/07/announcing-net-core-tools-1-0/)) but were initially implemented with the release of the .NET Core SDK Preview 3.
 
 ## Moving away from project.json
 The biggest change in the tooling for .NET Core is certainly the [move away from project.json to csproj](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/) as the project system. The latest versions of the command-line tools don't support *project.json* files. That means that it cannot be used to build, run or publish project.json based applications and libraries. In order to use this version of the tools, you will need to migrate your existing projects or start new ones. 
@@ -21,8 +21,7 @@ The biggest change in the tooling for .NET Core is certainly the [move away from
 As part of this move, the custom build engine that was developed to build project.json projects was replaced with a mature and fully capable build engine called [MSBuild](https://github.com/Microsoft/msbuild). MSBuild is a well-known engine in the .NET community, since it has been a key technology since the platform's first release. Of course, because it needs to build .NET Core applications, MSBuild has been ported to .NET Core and can be used on any platform that .NET Core runs on. One of the main promises of .NET Core is that of a cross-platform development stack, and we have made sure that this move does not break that promise.
 
 > [!NOTE]
-> If you are new to MSBuild and would like to learn more about it, you can start by reading 
-> the [MSBuild Concepts](https://docs.microsoft.com/visualstudio/msbuild/msbuild-concepts) article. 
+> If you are new to MSBuild and would like to learn more about it, you can start by reading the [MSBuild Concepts](https://docs.microsoft.com/visualstudio/msbuild/msbuild-concepts) article. 
 
 ## The tooling layers
 With the move away from the existing project system as well as with building engine switches, the question that naturally follows is do any of these changes change the overall "layering" of the whole .NET Core tooling ecosystem? Are there new bits and components?


### PR DESCRIPTION
Fixes #2479 

In addition to noting the versions and date, I link the announcement and kill two useless sentences.