### PR TITLE
GetHostEntry sample using wrong overload

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Dns/CPP/dnsnewmethods.cpp
+++ b/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Dns/CPP/dnsnewmethods.cpp
@@ -11,135 +11,135 @@ ref class DNSChanges
 
 //<Snippet1>
 public:
-        static void DoGetHostEntry(String^ hostname)
-        {
-            IPHostEntry^ host = Dns::GetHostEntry(hostname);
+    static void DoGetHostEntry(String^ hostname)
+    {
+        IPHostEntry^ host = Dns::GetHostEntry(hostname);
 
-            Console::WriteLine("GetHostEntry({0}) returns:", host->HostName);
-            
-            for (int i = 0; i < host->AddressList->Length; i++)
-            {				
-				Console::WriteLine("    {0}", host->AddressList[i]->ToString());			
-            }
+        Console::WriteLine("GetHostEntry({0}) returns:", host->HostName);
+
+        for (int i = 0; i < host->AddressList->Length; i++)
+        {
+            Console::WriteLine("    {0}", host->AddressList[i]->ToString());			
         }
+    }
 //</Snippet1>
 
 //<Snippet4>
 public:
-        static void DoGetHostEntry(IPAddress^ address)
-        {
-            IPHostEntry^ host = Dns::GetHostEntry(address);
+    static void DoGetHostEntry(IPAddress^ address)
+    {
+        IPHostEntry^ host = Dns::GetHostEntry(address);
 
-            Console::WriteLine("GetHostEntry({0}) returns HostName: {1}", address->ToString(), host->HostName);
-        }
+        Console::WriteLine("GetHostEntry({0}) returns HostName: {1}", address->ToString(), host->HostName);
+    }
 //</Snippet4>
 
 //<Snippet3>
-   // Determine the Internet Protocol(IP) addresses for a host.
+    // Determine the Internet Protocol(IP) addresses for a host.
 public:
-   static void DoGetHostAddress(String^ hostname)
-   {
-      array<IPAddress^>^ ips;
-      ips = Dns::GetHostAddresses(hostname);
+    static void DoGetHostAddress(String^ hostname)
+    {
+        array<IPAddress^>^ addresses;
+        addresses = Dns::GetHostAddresses(hostname);
 
-      Console::WriteLine("GetHostAddresses({0}) returns:", hostname);
-      for each ( IPAddress^ ip in ips )
-      {
-         Console::Write( "{0} ", ip );
-      }
-      Console::WriteLine( "" );
+        Console::WriteLine("GetHostAddresses({0}) returns:", hostname);
+        for each (IPAddress^ address in addresses)
+        {
+            Console::Write("{0} ", address);
+        }
+        Console::WriteLine("");
    }
-  
 //</Snippet3>
 
 //<Snippet2>
-   // Signals when the resolve has finished.
+    // Signals when the resolve has finished.
 public:
-   static ManualResetEvent^ GetHostEntryFinished =
-      gcnew ManualResetEvent( false );
+    static ManualResetEvent^ GetHostEntryFinished =
+        gcnew ManualResetEvent(false);
 
-   // define the state object for the callback. 
-   // use hostName to correlate calls with the proper result.
-   ref class ResolveState
-   {
-   public:
-      String^ hostName;
-      IPHostEntry^ resolvedIPs;
+    // define the state object for the callback. 
+    // use hostName to correlate calls with the proper result.
+    ref class ResolveState
+    {
+    public:
+        String^ hostName;
+        IPHostEntry^ resolvedIPs;
 
-      ResolveState( String^ host )
-      {
-         hostName = host;
-      }
-
-      property IPHostEntry^ IPs 
-      {
-         IPHostEntry^ get()
-         {
-            return resolvedIPs;
-         }
-         void set( IPHostEntry^ IPs )
-         {
-            resolvedIPs = IPs;
-         }
-      }
-
-      property String^ host 
-      {
-         String^ get()
-         {
-            return hostName;
-         }
-         void set( String^ host )
-         {
+        ResolveState(String^ host)
+        {
             hostName = host;
-         }
-      }
-   };
+        }
 
-   // Record the IPs in the state object for later use.
-   static void GetHostEntryCallback( IAsyncResult^ ar )
-   {	  
-      ResolveState^ ioContext = (ResolveState^)( ar->AsyncState );
+        property IPHostEntry^ IPs 
+        {
+            IPHostEntry^ get()
+            {
+                return resolvedIPs;
+            }
 
-      ioContext->IPs = Dns::EndGetHostEntry( ar );
-      GetHostEntryFinished->Set();
-   }
+            void set(IPHostEntry^ IPs)
+            {
+                resolvedIPs = IPs;
+            }
+        }
+
+        property String^ host 
+        {
+            String^ get()
+            {
+                return hostName;
+            }
+
+            void set(String^ host)
+            {
+                hostName = host;
+            }
+        }
+    };
+
+    // Record the IPs in the state object for later use.
+    static void GetHostEntryCallback(IAsyncResult^ ar)
+    {
+        ResolveState^ ioContext = (ResolveState^)(ar->AsyncState);
+
+        ioContext->IPs = Dns::EndGetHostEntry(ar);
+        GetHostEntryFinished->Set();
+    }
 
 
-   // Determine the Internet Protocol(IP) addresses for this 
-   // host asynchronously.
+    // Determine the Internet Protocol(IP) addresses for this 
+    // host asynchronously.
 public:
-   static void DoGetHostEntryAsync( String^ hostName )
-   {
-      GetHostEntryFinished->Reset();
-      ResolveState^ ioContext = gcnew ResolveState( hostName );
+    static void DoGetHostEntryAsync(String^ hostName)
+    {
+        GetHostEntryFinished->Reset();
+        ResolveState^ ioContext = gcnew ResolveState(hostName);
 
-      Dns::BeginGetHostEntry( ioContext->host,
-         gcnew AsyncCallback( GetHostEntryCallback ), ioContext );
-      // Wait here until the resolve completes 
-      // (the callback calls .Set())
-      GetHostEntryFinished->WaitOne();
+        Dns::BeginGetHostEntry(ioContext->host,
+            gcnew AsyncCallback(GetHostEntryCallback), ioContext);
+        // Wait here until the resolve completes 
+        // (the callback calls .Set())
+        GetHostEntryFinished->WaitOne();
 
-      Console::WriteLine("EndGetHostEntry({0}) returns:", ioContext->host);
+        Console::WriteLine("EndGetHostEntry({0}) returns:", ioContext->host);
       
-      for (int i = 0; i < ioContext->IPs->AddressList->Length; i++)
-      {				
-		Console::WriteLine("    {0}", ioContext->IPs->AddressList[i]->ToString());			
-      }
-      
+        for (int i = 0; i < ioContext->IPs->AddressList->Length; i++)
+        {
+            Console::WriteLine("    {0}", ioContext->IPs->AddressList[i]->ToString());
+        }
 
-//      for each ( IPAddress^ ip in ioContext->IPs )
- //     {
- //        Console::WriteLine( "{0} ", ip );
- //     }
-   }
+//      for each (IPAddress^ address in ioContext->IPs)
+//      {
+//          Console::WriteLine("{0} ", address);
+//      }
+    }
 //</Snippet2>
 };
 
 int main()
 {
-   DNSChanges::DoGetHostEntry("www.contoso.com");
-   DNSChanges::DoGetHostEntry(IPAddress.Parse("127.0.0.1"));
-   DNSChanges::DoGetHostAddress("www.contoso.com");
-   DNSChanges::DoGetHostEntryAsync("");
+    DNSChanges::DoGetHostEntry("www.contoso.com");
+    DNSChanges::DoGetHostEntry(IPAddress::Parse("127.0.0.1"));
+    DNSChanges::DoGetHostAddress("www.contoso.com");
+    DNSChanges::DoGetHostEntryAsync("");
 }

--- a/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Dns/CPP/dnsnewmethods.cpp
+++ b/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Dns/CPP/dnsnewmethods.cpp
@@ -24,6 +24,15 @@ public:
         }
 //</Snippet1>
 
+//<Snippet4>
+public:
+        static void DoGetHostEntry(IPAddress^ address)
+        {
+            IPHostEntry^ host = Dns::GetHostEntry(address);
+
+            Console::WriteLine("GetHostEntry({0}) returns HostName: {1}", address->ToString(), host->HostName);
+        }
+//</Snippet4>
 
 //<Snippet3>
    // Determine the Internet Protocol(IP) addresses for a host.
@@ -130,6 +139,7 @@ public:
 int main()
 {
    DNSChanges::DoGetHostEntry("www.contoso.com");
+   DNSChanges::DoGetHostEntry(IPAddress.Parse("127.0.0.1"));
    DNSChanges::DoGetHostAddress("www.contoso.com");
    DNSChanges::DoGetHostEntryAsync("");
 }

--- a/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Dns/CS/dnsnewmethods.cs
+++ b/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Dns/CS/dnsnewmethods.cs
@@ -22,6 +22,17 @@ namespace DNSChanges
         }
 //</Snippet1>
 
+//<Snippet4>
+        public static void DoGetHostEntry(IPAddress address)
+        {
+            IPHostEntry host;
+
+            host = Dns.GetHostEntry(address);
+
+            Console.WriteLine("GetHostEntry({0}) returns HostName: {1}", address, host.HostName);
+        }
+//</Snippet4>
+
 //<Snippet3>
         public static void DoGetHostAddresses(string hostname)
         {
@@ -102,9 +113,9 @@ namespace DNSChanges
 	{
 
         DoGetHostEntry("www.contoso.com");
+        DoGetHostEntry(IPAddress.Parse("127.0.0.1"));
         DoGetHostAddresses("www.contoso.com");
         DoGetHostEntryAsync("www.contoso.com");
-
         }
 	}
 }

--- a/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Dns/CS/dnsnewmethods.cs
+++ b/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Dns/CS/dnsnewmethods.cs
@@ -9,15 +9,13 @@ namespace DNSChanges
 //<Snippet1>
         public static void DoGetHostEntry(string hostname)
         {
-            IPHostEntry host;
+            IPHostEntry host = Dns.GetHostEntry(hostname);
 
-            host = Dns.GetHostEntry(hostname);
+            Console.WriteLine($"GetHostEntry({hostname}) returns:");
 
-            Console.WriteLine("GetHostEntry({0}) returns:", hostname);
-
-            foreach (IPAddress ip in host.AddressList)
+            foreach (IPAddress address in host.AddressList)
             {
-                Console.WriteLine("    {0}", ip);
+                Console.WriteLine($"    {address}");
             }
         }
 //</Snippet1>
@@ -25,26 +23,22 @@ namespace DNSChanges
 //<Snippet4>
         public static void DoGetHostEntry(IPAddress address)
         {
-            IPHostEntry host;
+            IPHostEntry host = Dns.GetHostEntry(address);
 
-            host = Dns.GetHostEntry(address);
-
-            Console.WriteLine("GetHostEntry({0}) returns HostName: {1}", address, host.HostName);
+            Console.WriteLine($"GetHostEntry({address}) returns HostName: {host.HostName}");
         }
 //</Snippet4>
 
 //<Snippet3>
         public static void DoGetHostAddresses(string hostname)
         {
-            IPAddress[] ips;
+            IPAddress[] addresses = Dns.GetHostAddresses(hostname);
 
-            ips = Dns.GetHostAddresses(hostname);
+            Console.WriteLine($"GetHostAddresses({hostname}) returns:");
 
-            Console.WriteLine("GetHostAddresses({0}) returns:", hostname);
-
-            foreach (IPAddress ip in ips)
+            foreach (IPAddress address in addresses)
             {
-                Console.WriteLine("    {0}", ip);
+                Console.WriteLine($"    {address}");
             }
         }
 //</Snippet3>
@@ -68,20 +62,24 @@ namespace DNSChanges
 
             public IPHostEntry IPs
             {
-                get { return resolvedIPs; } 
-                set {resolvedIPs = value;}}
-            public string host {get {return hostName;} 
-                set {hostName = value;}}
+                get { return resolvedIPs; }
+                set { resolvedIPs = value; }
+            }
+
+            public string host
+            {
+                get { return hostName; }
+                set { hostName = value; }
+            }
         }
 
         // Record the IPs in the state object for later use.
         public static void GetHostEntryCallback(IAsyncResult ar)
         {
             ResolveState ioContext = (ResolveState)ar.AsyncState;
-
             ioContext.IPs = Dns.EndGetHostEntry(ar);
             GetHostEntryFinished.Set();
-        }       
+        }
         
         // Determine the Internet Protocol (IP) addresses for 
         // this host asynchronously.
@@ -99,23 +97,20 @@ namespace DNSChanges
 
             Console.WriteLine("EndGetHostEntry({0}) returns:", ioContext.host);
 
-            foreach (IPAddress ip in ioContext.IPs.AddressList)
+            foreach (IPAddress address in ioContext.IPs.AddressList)
             {
-                Console.WriteLine("    {0}", ip);
+                Console.WriteLine($"    {address}");
             }
- 
         }
-  
 //</Snippet2>
 
-    [STAThread]
-	static void Main(string[] args)
-	{
-
-        DoGetHostEntry("www.contoso.com");
-        DoGetHostEntry(IPAddress.Parse("127.0.0.1"));
-        DoGetHostAddresses("www.contoso.com");
-        DoGetHostEntryAsync("www.contoso.com");
+        [STAThread]
+        static void Main(string[] args)
+        {
+            DoGetHostEntry("www.contoso.com");
+            DoGetHostEntry(IPAddress.Parse("127.0.0.1"));
+            DoGetHostAddresses("www.contoso.com");
+            DoGetHostEntryAsync("www.contoso.com");
         }
-	}
+    }
 }

--- a/samples/snippets/visualbasic/VS_Snippets_Remoting/System.Net.Dns/vb/dnsnewmethods.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Remoting/System.Net.Dns/vb/dnsnewmethods.vb
@@ -15,6 +15,7 @@ Namespace DnsNew
 '        Dim hostName As [String] = "www.contoso.com"
 
         myDns.DoGetHostEntry("www.contoso.com")
+        myDns.DoGetHostEntry(IPAddress.Parse("127.0.0.1"))
         myDns.DoGetHostAddresses("www.contoso.com")
         myDns.DoGetHostAddresses("www.contoso.com")
 
@@ -24,7 +25,7 @@ Namespace DnsNew
 ' <Snippet1>
     Public Sub DoGetHostEntry(hostName As [String])
 
-        DIM host as IPHostEntry = Dns.GetHostEntry(hostname)
+        Dim host as IPHostEntry = Dns.GetHostEntry(hostname)
 
         Console.WriteLine("GetHostEntry(" + hostname + ") returns: ")
 
@@ -53,6 +54,15 @@ Namespace DnsNew
     End Sub    
 ' </Snippet3>
 
+' <Snippet4>
+    Public Sub DoGetHostEntry(address As [IPAddress])
+
+        Dim host as IPHostEntry = Dns.GetHostEntry(address)
+
+        Console.WriteLine("GetHostEntry(" + address.ToString() + ") returns HostName: " + host.HostName)
+
+    End Sub    
+' </Snippet4>
 
 ' <Snippet2>
     ' Signals when the resolve has finished.

--- a/samples/snippets/visualbasic/VS_Snippets_Remoting/System.Net.Dns/vb/dnsnewmethods.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Remoting/System.Net.Dns/vb/dnsnewmethods.vb
@@ -6,133 +6,133 @@ Imports Microsoft.VisualBasic
 
 Namespace DnsNew
 
-  Class DnsChanges
+    Class DnsChanges
     
-    Public Shared Sub Main()
+        Public Shared Sub Main()
+
+            Dim myDns As New DnsChanges()
+
+            Dim hostName As String = "www.contoso.com"
+
+            myDns.DoGetHostEntry(hostName)
+            myDns.DoGetHostEntry(IPAddress.Parse("127.0.0.1"))
+            myDns.DoGetHostAddresses(hostName)
+
+        End Sub 'Main
         
-        Dim myDns As New DnsChanges()
-        
-'        Dim hostName As [String] = "www.contoso.com"
 
-        myDns.DoGetHostEntry("www.contoso.com")
-        myDns.DoGetHostEntry(IPAddress.Parse("127.0.0.1"))
-        myDns.DoGetHostAddresses("www.contoso.com")
-        myDns.DoGetHostAddresses("www.contoso.com")
+    ' <Snippet1>
+        Public Sub DoGetHostEntry(hostName As String)
 
-    End Sub 'Main
-     
+            Dim host as IPHostEntry = Dns.GetHostEntry(hostname)
 
-' <Snippet1>
-    Public Sub DoGetHostEntry(hostName As [String])
+            Console.WriteLine($"GetHostEntry({hostname}) returns:")
 
-        Dim host as IPHostEntry = Dns.GetHostEntry(hostname)
+            Dim addresses As IPAddress() = host.AddressList
 
-        Console.WriteLine("GetHostEntry(" + hostname + ") returns: ")
+            Dim index As Integer
+            For index = 0 To addresses.Length - 1
+                Console.WriteLine($"    {addresses(index)}")
+            Next index
 
-        Dim ip As IPAddress() = host.AddressList
+        End Sub
+    ' </Snippet1>
 
-        Dim index As Integer
-        For index = 0 To ip.Length - 1
-             Console.WriteLine(ip(index))
-        Next index
-    End Sub    
-' </Snippet1>
+    ' <Snippet3>
+        Public Sub DoGetHostAddresses(hostName As String)
 
-' <Snippet3>
-    Public Sub DoGetHostAddresses(hostName As [String])
+            Dim addresses As IPAddress() = Dns.GetHostAddresses(hostname)
 
-        Dim ips As IPAddress()
- 
-        ips = Dns.GetHostAddresses(hostname)
+            Console.WriteLine($"GetHostAddresses({hostname}) returns:")
 
-        Console.WriteLine("GetHostAddresses(" + hostname + ") returns: ")
+            Dim index As Integer
+            For index = 0 To addresses.Length - 1
+                Console.WriteLine($"    {addresses(index)}")
+            Next index
 
-        Dim index As Integer
-        For index = 0 To ips.Length - 1
-             Console.WriteLine(ips(index))
-        Next index
-    End Sub    
-' </Snippet3>
+        End Sub
+    ' </Snippet3>
 
-' <Snippet4>
-    Public Sub DoGetHostEntry(address As [IPAddress])
+    ' <Snippet4>
+        Public Sub DoGetHostEntry(address As IPAddress)
 
-        Dim host as IPHostEntry = Dns.GetHostEntry(address)
+            Dim host as IPHostEntry = Dns.GetHostEntry(address)
 
-        Console.WriteLine("GetHostEntry(" + address.ToString() + ") returns HostName: " + host.HostName)
+            Console.WriteLine($"GetHostEntry({address}) returns HostName: {host.HostName}")
 
-    End Sub    
-' </Snippet4>
+        End Sub
+    ' </Snippet4>
 
-' <Snippet2>
-    ' Signals when the resolve has finished.
-    Dim Shared GetHostEntryFinished As ManualResetEvent = New ManualResetEvent(False)
+    ' <Snippet2>
+        ' Signals when the resolve has finished.
+        Dim Shared GetHostEntryFinished As ManualResetEvent = New ManualResetEvent(False)
 
-    ' Define the state object for the callback. 
-    ' Use hostName to correlate calls with the proper result.
-    Class ResolveState
-        
-        Dim hostName As String
-        Dim resolvedIPs As IPHostEntry
+        ' Define the state object for the callback. 
+        ' Use hostName to correlate calls with the proper result.
+        Class ResolveState
+            
+            Dim hostName As String
+            Dim resolvedIPs As IPHostEntry
 
-        Public Sub New(host As String)
-            hostName = host
+            Public Sub New(host As String)
+                hostName = host
+            End Sub
+
+            Public Property IPs AS IPHostEntry
+                Get
+                    Return resolvedIPs
+                End Get
+                Set
+                    resolvedIPs = value
+                End Set
+            End Property
+
+            Public Property host As String
+                Get
+                    Return hostName
+                End Get
+                Set
+                    hostName = value
+                End Set
+            End Property
+
+        End Class
+
+        ' Record the IPs in the state object for later use.
+        Shared Sub GetHostEntryCallback(ar As IAsyncResult)
+
+            Dim ioContext As ResolveState = ar.AsyncState
+
+            ioContext.IPs = Dns.EndGetHostEntry(ar)
+            GetHostEntryFinished.Set()
+
         End Sub
 
-        Public Property IPs AS IPHostEntry
-            Get
-                Return resolvedIPs 
-            End Get
-            Set
-                resolvedIPs = value
-            End Set
-        End Property
+        ' Determine the Internet Protocol (IP) addresses for 
+        ' this host asynchronously.
+        Shared Sub DoGetHostEntryAsync(hostname As String)
             
-        Public Property host As [String]
-            Get
-                Return hostName
-            End Get     
-            Set
-                hostName = value
-            End Set    
-        End Property
+            GetHostEntryFinished.Reset()
+            Dim ioContext As ResolveState = New ResolveState(hostname)
+
+            Dns.BeginGetHostEntry(ioContext.host,AddressOf GetHostEntryCallback, ioContext)
+
+            ' Wait here until the resolve completes (the callback 
+            ' calls .Set())
+            GetHostEntryFinished.WaitOne()
+
+            Console.WriteLine($"EndGetHostEntry({ioContext.host}) returns:")
+
+            Dim addresses As IPAddress() = ioContext.IPs.AddressList
+
+            Dim index As Integer
+            For index = 0 To addresses.Length - 1
+                Console.WriteLine($"    {addresses(index)}")
+            Next index
+
+        End Sub
+    ' </Snippet2>
+
     End Class
 
-
-    ' Record the IPs in the state object for later use.
-    Shared Sub GetHostEntryCallback(ar As IAsyncResult)
-        
-        Dim ioContext As ResolveState = ar.AsyncState
-
-        ioContext.IPs = Dns.EndGetHostEntry(ar)
-        GetHostEntryFinished.Set()
-    End Sub       
-
-    ' Determine the Internet Protocol (IP) addresses for 
-    ' this host asynchronously.
-    Shared Sub DoGetHostEntryAsync(hostname As String)
-        
-        GetHostEntryFinished.Reset()
-        Dim ioContext As ResolveState = New ResolveState(hostname)
-        
-        Dns.BeginGetHostEntry(ioContext.host,AddressOf GetHostEntryCallback, ioContext)
-
-        ' Wait here until the resolve completes (the callback 
-        ' calls .Set())
-        GetHostEntryFinished.WaitOne()
-
-        Console.WriteLine("EndGetHostEntry(" + ioContext.host + ") returns:")
-
-        Dim ip As IPAddress() = ioContext.IPs.AddressList
-        Dim index As Integer
-        For index = 0 To ip.Length - 1
-            Console.WriteLine(ip(index))
-        Next index
-          
-    End Sub
-  
-' </Snippet2>
-
-
-  End Class
 End Namespace

--- a/xml/System.Net/Dns.xml
+++ b/xml/System.Net/Dns.xml
@@ -887,15 +887,13 @@
   
 > [!NOTE]
 >  This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](~/docs/framework/network-programming/network-tracing.md).  
-  
-   
-  
+
 ## Examples  
  The following code example uses the <xref:System.Net.Dns.GetHostEntry%2A> method to resolve an IP address to an <xref:System.Net.IPHostEntry> instance.  
   
- [!code-cpp[System.Net.Dns#1](~/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Dns/CPP/dnsnewmethods.cpp#1)]
- [!code-csharp[System.Net.Dns#1](~/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Dns/CS/dnsnewmethods.cs#1)]
- [!code-vb[System.Net.Dns#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/System.Net.Dns/vb/dnsnewmethods.vb#1)]  
+ [!code-cpp[System.Net.Dns#4](~/samples/snippets/cpp/VS_Snippets_Remoting/System.Net.Dns/CPP/dnsnewmethods.cpp#4)]
+ [!code-csharp[System.Net.Dns#4](~/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Dns/CS/dnsnewmethods.cs#4)]
+ [!code-vb[System.Net.Dns#4](~/samples/snippets/visualbasic/VS_Snippets_Remoting/System.Net.Dns/vb/dnsnewmethods.vb#4)]  
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
Fixes #2548 OPS ... not MSDN.

Validated for C#, VB, & C++ locally ...

```console
GetHostEntry(10.254.80.85) returns HostName: DESKTOP-RexPC
```

