### PR TITLE
Update ProviderBase.Initialize() description

### DIFF
--- a/xml/System.Configuration.Provider/ProviderBase.xml
+++ b/xml/System.Configuration.Provider/ProviderBase.xml
@@ -108,7 +108,7 @@
       <Docs>
         <param name="name">The friendly name of the provider.</param>
         <param name="config">A collection of the name/value pairs representing the provider-specific attributes specified in the configuration for this provider.</param>
-        <summary>Initializes the provider.</summary>
+        <summary>Initializes the configuration builder.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
Per dev team directive, the description should be changed from ...

> Initializes the provider.

to

> Initializes the configuration builder.

... to accompany updates that will appear with the next netfx release.