### PR TITLE
Corrected accessibility of nested types

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -45,7 +45,8 @@ You can also specify an access modifier to define the accessibility of a nested 
 
 - Nested types of a **class** can be [public](../../../csharp/language-reference/keywords/public.md), [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md), protected internal, or [private](../../../csharp/language-reference/keywords/private.md).
 
-- Nested types of a **struct** can be [public](../../../csharp/language-reference/keywords/public.md), [internal](../../../csharp/language-reference/keywords/internal.md), or [private](../../../csharp/language-reference/keywords/private.md).   
+- Nested types of a **struct** can be [public](../../../csharp/language-reference/keywords/public.md), [internal](../../../csharp/language-reference/keywords/internal.md), or [private](../../../csharp/language-reference/keywords/private.md).
+  
 The following example makes the `Nested` class public:
   
 [!code-cs[csProgGuideObjects#69](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/nested-types_2.cs)]  

--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -41,10 +41,12 @@ A type defined within a [class](../../../csharp/language-reference/keywords/clas
   
 Regardless of whether the outer type is a class or a struct, nested types default to [private](../../../csharp/language-reference/keywords/private.md); they are accessible only from their containing type. In the previous example, the `Nested` class is inaccessible to external types. 
 
-You can also specify an access modifier to define the accessibility of a nested type, as follows:
+You can also specify an [access modifier](../../language-reference/keywords/access-modifiers.md) to define the accessibility of a nested type, as follows:
 
-- Nested types of a **class** can be [public](../../../csharp/language-reference/keywords/public.md), [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md), protected internal, or [private](../../../csharp/language-reference/keywords/private.md).
+- Nested types of a **class** can be [public](../../../csharp/language-reference/keywords/public.md), [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md), `protected internal`, or [private](../../../csharp/language-reference/keywords/private.md). 
 
+   However, defining a `protected` or `protected internal` nested class inside a [sealed class](../../language-reference/keywords/sealed.md) generates compiler warning [CS0628](../../misc/cs0628.md), "new protected member declared in sealed class."
+  
 - Nested types of a **struct** can be [public](../../../csharp/language-reference/keywords/public.md), [internal](../../../csharp/language-reference/keywords/internal.md), or [private](../../../csharp/language-reference/keywords/private.md).
   
 The following example makes the `Nested` class public:

--- a/docs/csharp/programming-guide/classes-and-structs/nested-types.md
+++ b/docs/csharp/programming-guide/classes-and-structs/nested-types.md
@@ -1,7 +1,7 @@
 ---
 title: "Nested Types (C# Programming Guide) | Microsoft Docs"
 
-ms.date: "2015-07-20"
+ms.date: "2017-07-10"
 ms.prod: .net
 
 
@@ -37,13 +37,20 @@ translation.priority.mt:
 # Nested Types (C# Programming Guide)
 A type defined within a [class](../../../csharp/language-reference/keywords/class.md) or [struct](../../../csharp/language-reference/keywords/struct.md) is called a nested type. For example:  
   
- [!code-cs[csProgGuideObjects#68](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/nested-types_1.cs)]  
+[!code-cs[csProgGuideObjects#68](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/nested-types_1.cs)]  
   
- Regardless of whether the outer type is a class or a struct, nested types default to [private](../../../csharp/language-reference/keywords/private.md), but can be made [public](../../../csharp/language-reference/keywords/public.md), protected internal, [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md), or [private](../../../csharp/language-reference/keywords/private.md). In the previous example, `Nested` is inaccessible to external types, but can be made public like this:  
+Regardless of whether the outer type is a class or a struct, nested types default to [private](../../../csharp/language-reference/keywords/private.md); they are accessible only from their containing type. In the previous example, the `Nested` class is inaccessible to external types. 
+
+You can also specify an access modifier to define the accessibility of a nested type, as follows:
+
+- Nested types of a **class** can be [public](../../../csharp/language-reference/keywords/public.md), [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md), protected internal, or [private](../../../csharp/language-reference/keywords/private.md).
+
+- Nested types of a **struct** can be [public](../../../csharp/language-reference/keywords/public.md), [internal](../../../csharp/language-reference/keywords/internal.md), or [private](../../../csharp/language-reference/keywords/private.md).   
+The following example makes the `Nested` class public:
   
- [!code-cs[csProgGuideObjects#69](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/nested-types_2.cs)]  
+[!code-cs[csProgGuideObjects#69](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/nested-types_2.cs)]  
   
- The nested, or inner type can access the containing, or outer type. To access the containing type, pass it as a constructor to the nested type. For example:  
+ The nested, or inner, type can access the containing, or outer, type. To access the containing type, pass it as an argument to the constructor of the nested type. For example:  
   
  [!code-cs[csProgGuideObjects#70](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/nested-types_3.cs)]  
   


### PR DESCRIPTION
# Corrected accessibility of nested types

## Summary

Nested types of a struct cannot be protected or protected internal.

Fixes #2564 

## Suggested Reviewers

@BillWagner @justcurious

 
