### PR TITLE
Minor F# corrections

### DIFF
--- a/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
+++ b/docs/fsharp/language-reference/symbol-and-operator-reference/nullable-operators.md
@@ -42,7 +42,7 @@ In query expressions, nullable types arise when selecting data from a data sourc
 Nullable types may be converted to non-nullable primitive types using the usual conversion operators such as `int` or `float`. It is also possible to convert from one nullable type to another nullable type by using the conversion operators for nullable types. The appropriate conversion operators have the same name as the standard ones, but they are in a separate module, the [Nullable](https://msdn.microsoft.com/library/e7a4ea13-28cc-462e-bc3a-33131ace976e) module in the [Microsoft.FSharp.Linq](https://msdn.microsoft.com/library/4765b4e8-4006-4d8c-a405-39c218b3c82d) namespace. Typically, you open this namespace when working with query expressions. In that case, you can use the nullable conversion operators by adding the prefix `Nullable.` to the appropriate conversion operator, as shown in the following code.
 
 ```fsharp
-open Microsoft.Fsharp.Linq
+open Microsoft.FSharp.Linq
 
 let nullableInt = new System.Nullable<int>(10)
 

--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -21,7 +21,7 @@ There are two primary concepts in F#: functions and types.  This tour will empha
 ## How to Run the Code Samples
 
 >[!NOTE]
-Two options for running the code samples are [TryFsharp](http://www.tryfsharp.org/Create) (requires Silverlight) and [F# for Azure Notebooks](https://notebooks.azure.com/Microsoft/libraries/fsharp/html/FSharp%20for%20Azure%20Notebooks.ipynb) on Microsoft Azure.
+Two options for running the code samples are [Try F#](http://www.tryfsharp.org/Create) (requires Silverlight) and [F# for Azure Notebooks](https://notebooks.azure.com/Microsoft/libraries/fsharp/html/FSharp%20for%20Azure%20Notebooks.ipynb) on Microsoft Azure.
 
 The quickest way to run these code samples is to use [F# Interactive](tutorials/fsharp-interactive/index.md).  Just copy/paste the code samples and run them there.  Alternatively you can set up a project to compile and run the code as a Console Application in [Visual Studio](tutorials/getting-started/getting-started-visual-studio.md) or [Visual Studio Code and Ionide](tutorials/getting-started/getting-started-vscode.md).
 

--- a/docs/fsharp/tutorials/getting-started/getting-started-vscode.md
+++ b/docs/fsharp/tutorials/getting-started/getting-started-vscode.md
@@ -281,7 +281,7 @@ Here are a few ways you can troubleshoot certain problems that you might run int
 5. If none of the Ionide commands are working, check your [Visual Studio Code keybindings](https://code.visualstudio.com/docs/customization/keybindings#_customizing-shortcuts) to see if you're overriding them by accident.
 6. If Ionide is broken on your machine and none of the above has fixed your problem, try removing the `ionide-fsharp` directory on your machine and reinstall the plugin suite.
 
-Ionide is an open source project built and maintained by members of the F# community.  Please report issues and feel free to contribute at the [Ionide-Vscode-Fsharp GitHub repository](https://github.com/ionide/ionide-vscode-fsharp).
+Ionide is an open source project built and maintained by members of the F# community.  Please report issues and feel free to contribute at the [Ionide-VSCode: FSharp GitHub repository](https://github.com/ionide/ionide-vscode-fsharp).
 
 If you have an issue to report, please follow [the instructions for getting logs to use when reporting an issue](https://github.com/ionide/ionide-vscode-fsharp#how-to-get-logs-for-debugging--issue-reporting).
 
@@ -303,4 +303,4 @@ To learn more about F# and the features of the language, check out [Tour of F#](
 
 [Namespaces](../../language-reference/namespaces.md)
 
-[Ionide-Vscode-Fsharp](https://github.com/ionide/ionide-vscode-fsharp)
+[Ionide-VSCode: FSharp](https://github.com/ionide/ionide-vscode-fsharp)


### PR DESCRIPTION
I've made some very minor corrections around the F# docs.

I noticed when c/p from a snippet that it was referring to `Fsharp` not `FSharp`, so I've fix that and found some links that I have changed to their proper titles.