### PR TITLE
Update Schema Collections docs to match Implementation

### DIFF
--- a/docs/framework/data/adonet/common-schema-collections.md
+++ b/docs/framework/data/adonet/common-schema-collections.md
@@ -28,7 +28,7 @@ The common schema collections are the schema collections that are implemented by
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
 |CollectionName|string|The name of the collection to pass to the **GetSchema** method to return the collection.|  
-|NumberOfRestriction|int|The number of restrictions that may be specified for the collection.|  
+|NumberOfRestrictions|int|The number of restrictions that may be specified for the collection.|  
 |NumberOfIdentifierParts|int|The number of parts in the composite identifier/database object name. For example, in SQL Server, this would be 3 for tables and 4 for columns. In Oracle, it would be 2 for tables and 3 for columns.|  
   
 ## DataSourceInformation  
@@ -78,9 +78,9 @@ The common schema collections are the schema collections that are implemented by
 |MaximumScale|short|If the type indicator is a numeric type, this is the maximum number of digits allowed to the right of the decimal point. Otherwise, this is DBNull.Value.|  
 |MinimumScale|short|If the type indicator is a numeric type, this is the minimum number of digits allowed to the right of the decimal point. Otherwise, this is DBNull.Value.|  
 |IsConcurrencyType|bool|true – the data type is updated by the database every time the row is changed and the value of the column is different from all previous values<br /><br /> false – the data type is note updated by the database every time the row is changed<br /><br /> DBNull.Value – the database does not support this type of data type|  
-|IsLiteralsSupported|bool|true – the data type can be expressed as a literal<br /><br /> false – the data type can not be expressed as a literal|  
+|IsLiteralSupported|bool|true – the data type can be expressed as a literal<br /><br /> false – the data type can not be expressed as a literal|  
 |LiteralPrefix|string|The prefix applied to a given literal.|  
-|LitteralSuffix|string|The suffix applied to a given literal.|  
+|LiteralSuffix|string|The suffix applied to a given literal.|  
 |NativeDataType|String|NativeDataType is an OLE DB specific column for exposing the OLE DB type of the data type .|  
   
 ## Restrictions  
@@ -98,7 +98,7 @@ The common schema collections are the schema collections that are implemented by
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|ReservedWords|string|Provider specific reserved words.|  
+|ReservedWord|string|Provider specific reserved word.|  
   
 ## See Also  
  [Retrieving Database Schema Information](../../../../docs/framework/data/adonet/retrieving-database-schema-information.md)   

--- a/docs/framework/data/adonet/sql-server-schema-collections.md
+++ b/docs/framework/data/adonet/sql-server-schema-collections.md
@@ -23,22 +23,22 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
 |database_name|String|Name of the database.|  
-|Dbid|Int16|Database ID.|  
+|dbid|Int16|Database ID.|  
 |create_date|DateTime|Creation Date of the database.|  
   
 ## Foreign Keys  
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|constraint_catalog|String|Catalog the constraint belongs to.|  
-|constraint_schema|String|Schema that contains the constraint.|  
-|constraint_name|String|Name.|  
-|table_catalog|String|Table Name constraint is part of.|  
-|table_schema|String|Schema that that contains the table.|  
-|table_name|String|Table Name|  
-|constraint_type|String|Type of constraint. Only "FOREIGN KEY" is allowed.|  
-|is_deferrable|String|Specifies whether the constraint is deferrable. Returns NO.|  
-|initially_deferred|String|Specifies whether the constraint is initially deferrable. Returns NO.|  
+|CONSTRAINT_CATALOG|String|Catalog the constraint belongs to.|  
+|CONSTRAINT_SCHEMA|String|Schema that contains the constraint.|  
+|CONSTRAINT_NAME|String|Name.|  
+|TABLE_CATALOG|String|Table Name constraint is part of.|  
+|TABLE_SCHEMA|String|Schema that that contains the table.|  
+|TABLE_NAME|String|Table Name|  
+|CONSTRAINT_TYPE|String|Type of constraint. Only "FOREIGN KEY" is allowed.|  
+|IS_DEFERRABLE|String|Specifies whether the constraint is deferrable. Returns NO.|  
+|INITIALLY_DEFERRED|String|Specifies whether the constraint is initially deferrable. Returns NO.|  
   
 ## Indexes  
   
@@ -78,75 +78,75 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|specific_catalog|String|Specific name for the catalog.|  
-|specific_schema|String|Specific name of the schema.|  
-|specific_name|String|Specific name of the catalog.|  
-|routine_catalog|String|Catalog the stored procedure belongs to.|  
-|routine_schema|String|Schema that contains the stored procedure.|  
-|routine_name|String|Name of the stored procedure.|  
-|routine_type|String|Returns PROCEDURE for stored procedures and FUNCTION for functions.|  
-|created|DateTime|Time the procedure was created.|  
-|last_altered|DateTime|The last time the procedure was modified.|  
+|SPECIFIC_CATALOG|String|Specific name for the catalog.|  
+|SPECIFIC_SCHEMA|String|Specific name of the schema.|  
+|SPECIFIC_NAME|String|Specific name of the catalog.|  
+|ROUTINE_CATALOG|String|Catalog the stored procedure belongs to.|  
+|ROUTINE_SCHEMA|String|Schema that contains the stored procedure.|  
+|ROUTINE_NAME|String|Name of the stored procedure.|  
+|ROUTINE_TYPE|String|Returns PROCEDURE for stored procedures and FUNCTION for functions.|  
+|CREATED|DateTime|Time the procedure was created.|  
+|LAST_ALTERED|DateTime|The last time the procedure was modified.|  
   
 ## Procedure Parameters  
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|specific_catalog|String|Catalog name of the procedure for which this is a parameter.|  
-|specific_schema|String|Schema that contains the procedure for which this parameter is part of.|  
-|specific_name|String|Name of the procedure for which this parameter is a part of.|  
-|ordinal_position|Int32|Ordinal position of the parameter starting at 1. For the return value of a procedure, this is a 0.|  
-|parameter_mode|String|Returns IN if an input parameter, OUT if an output parameter, and INOUT if an input/output parameter.|  
-|is_result|String|Returns YES if indicates result of the procedure that is a function. Otherwise, returns NO.|  
-|as_locator|String|Returns YES if declared as locator. Otherwise, returns NO.|  
-|parameter_name|String|Name of the parameter. NULL if this corresponds to the return value of a function.|  
-|data_type|String|System-supplied data type.|  
-|character_maximum_length|Int32|Maximum length in characters for binary or character data types. Otherwise, returns NULL.|  
-|character_octet_length|Int32|Maximum length, in bytes, for binary or character data types. Otherwise, returns NULL.|  
-|collation_catalog|String|Catalog name of the collation of the parameter. If not one of the character types, returns NULL.|  
-|collation_schema|String|Always returns NULL.|  
-|collation_name|String|Name of the collation of the parameter. If not one of the character types, returns NULL.|  
-|character_set_catalog|String|Catalog name of the character set of the parameter. If not one of the character types, returns NULL.|  
-|character_set_schema|String|Always returns NULL.|  
-|character_set_name|String|Name of the character set of the parameter. If not one of the character types, returns NULL.|  
-|numeric_precision|Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, returns NULL.|  
-|numeric_precision_radix|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, returns NULL.|  
-|numeric_scale|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, returns NULL.|  
-|datetime_precision|Int16|Precision in fractional seconds if the parameter type is datetime or smalldatetime. Otherwise, returns NULL.|  
-|interval_type|String|NULL. Reserved for future use by SQL Server.|  
-|interval_precision|Int16|NULL. Reserved for future use by SQL Server.|  
+|SPECIFIC_CATALOG|String|Catalog name of the procedure for which this is a parameter.|  
+|SPECIFIC_SCHEMA|String|Schema that contains the procedure for which this parameter is part of.|  
+|SPECIFIC_NAME|String|Name of the procedure for which this parameter is a part of.|  
+|ORDINAL_POSITION|Int32|Ordinal position of the parameter starting at 1. For the return value of a procedure, this is a 0.|  
+|PARAMETER_MODE|String|Returns IN if an input parameter, OUT if an output parameter, and INOUT if an input/output parameter.|  
+|IS_RESULT|String|Returns YES if indicates result of the procedure that is a function. Otherwise, returns NO.|  
+|AS_LOCATOR|String|Returns YES if declared as locator. Otherwise, returns NO.|  
+|PARAMETER_NAME|String|Name of the parameter. NULL if this corresponds to the return value of a function.|  
+|DATA_TYPE|String|System-supplied data type.|  
+|CHARACTER_MAXIMUM_LENGTH|Int32|Maximum length in characters for binary or character data types. Otherwise, returns NULL.|  
+|CHARACTER_OCTET_LENGTH|Int32|Maximum length, in bytes, for binary or character data types. Otherwise, returns NULL.|  
+|COLLATION_CATALOG|String|Catalog name of the collation of the parameter. If not one of the character types, returns NULL.|  
+|COLLATION_SCHEMA|String|Always returns NULL.|  
+|COLLATION_NAME|String|Name of the collation of the parameter. If not one of the character types, returns NULL.|  
+|CHARACTER_SET_CATALOG|String|Catalog name of the character set of the parameter. If not one of the character types, returns NULL.|  
+|CHARACTER_SET_SCHEMA|String|Always returns NULL.|  
+|CHARACTER_SET_NAME|String|Name of the character set of the parameter. If not one of the character types, returns NULL.|  
+|NUMERIC_PRECISION|Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, returns NULL.|  
+|NUMERIC_PRECISION_RADIX|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, returns NULL.|  
+|NUMERIC_SCALE|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, returns NULL.|  
+|DATETIME_PRECISION|Int16|Precision in fractional seconds if the parameter type is datetime or smalldatetime. Otherwise, returns NULL.|  
+|INTERVAL_TYPE|String|NULL. Reserved for future use by SQL Server.|  
+|INTERVAL_PRECISION|Int16|NULL. Reserved for future use by SQL Server.|  
   
 ## Tables  
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|table_catalog|String|Catalog of the table.|  
-|table_schema|String|Schema that contains the table.|  
-|table_name|String|Table name.|  
-|table_type|String|Type of table. Can be VIEW or BASE TABLE.|  
+|TABLE_CATALOG|String|Catalog of the table.|  
+|TABLE_SCHEMA|String|Schema that contains the table.|  
+|TABLE_NAME|String|Table name.|  
+|TABLE_TYPE|String|Type of table. Can be VIEW or BASE TABLE.|  
   
 ## Columns  
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|table_catalog|String|Catalog of the table.|  
-|table_schema|String|Schema that contains the table.|  
-|table_name|String|Table name.|  
-|column_name|String|Column name.|  
-|ordinal_position|Int32|Column identification number.|  
-|column_default|String|Default value of the column|  
-|is_nullable|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, No is returned.|  
-|data_type|String|System-supplied data type.|  
-|character_maximum_length|Int32 – Sql8, Int16 – Sql7|Maximum length, in characters, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
-|character_octet_length|Int32 – SQL8, Int16 – Sql7|Maximum length, in bytes, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
-|numeric_precision|Unsigned Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|numeric_precision_radix|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|numeric_scale|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|datetime_precision|Int16|Subtype code for datetime and SQL-92 interval data types. For other data types, NULL is returned.|  
-|character_set_catalog|String|Returns master, indicating the database in which the character set is located, if the column is character data or text data type. Otherwise, NULL is returned.|  
-|character_set_schema|String|Always returns NULL.|  
-|character_set_name|String|Returns the unique name for the character set if this column is character data or text data type. Otherwise, NULL is returned.|  
-|collation_catalog|String|Returns master, indicating the database in which the collation is defined, if the column is character data or text data type. Otherwise, this column is NULL.|  
+|TABLE_CATALOG|String|Catalog of the table.|  
+|TABLE_SCHEMA|String|Schema that contains the table.|  
+|TABLE_NAME|String|Table name.|  
+|COLUMN_NAME|String|Column name.|  
+|ORDINAL_POSITION|Int32|Column identification number.|  
+|COLUMN_DEFAULT|String|Default value of the column|  
+|IS_NULLABLE|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, No is returned.|  
+|DATA_TYPE|String|System-supplied data type.|  
+|CHARACTER_MAXIMUM_LENGTH|Int32 – Sql8, Int16 – Sql7|Maximum length, in characters, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
+|CHARACTER_OCTET_LENGTH|Int32 – SQL8, Int16 – Sql7|Maximum length, in bytes, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
+|NUMERIC_PRECISION|Unsigned Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|NUMERIC_PRECISION_RADIX|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|NUMERIC_SCALE|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|DATETIME_PRECISION|Int16|Subtype code for datetime and SQL-92 interval data types. For other data types, NULL is returned.|  
+|CHARACTER_SET_CATALOG|String|Returns master, indicating the database in which the character set is located, if the column is character data or text data type. Otherwise, NULL is returned.|  
+|CHARACTER_SET_SCHEMA|String|Always returns NULL.|  
+|CHARACTER_SET_NAME|String|Returns the unique name for the character set if this column is character data or text data type. Otherwise, NULL is returned.|  
+|COLLATION_CATALOG|String|Returns master, indicating the database in which the collation is defined, if the column is character data or text data type. Otherwise, this column is NULL.|  
   
 ### Columns (SQL Server 2008)  
  Beginning with the .NET Framework version 3.5 SP1 and SQL Server 2008, the following columns have been added to the Columns schema collection to support new spatial types, filestream and sparse columns. These columns are not supported in earlier versions of the .NET Framework and SQL Server.  
@@ -164,24 +164,24 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|table_catalog|String|Catalog of the table.|  
-|table_schema|String|Schema that contains the table.|  
-|table_name|String|Table name.|  
-|column_name|String|Column name.|  
-|ordinal_position|Int32|Column identification number.|  
-|column_default|String|Default value of the column|  
-|is_nullable|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, NO is returned.|  
-|data_type|String|System-supplied data type.|  
-|character_maximum_length|Int32|Maximum length, in characters, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
-|character_octet_length|Int32|Maximum length, in bytes, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
-|numeric_precision|Unsigned Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|numeric_precision_radix|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|numeric_scale|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|datetime_precision|Int16|Subtype code for datetime and SQL-92 interval data types. For other data types, NULL is returned.|  
-|character_set_catalog|String|Returns master, indicating the database in which the character set is located, if the column is character data or text data type. Otherwise, NULL is returned.|  
-|character_set_schema|String|Always returns NULL.|  
-|character_set_name|String|Returns the unique name for the character set if this column is character data or text data type. Otherwise, NULL is returned.|  
-|collation_catalog|String|Returns master, indicating the database in which the collation is defined, if the column is character data or text data type. Otherwise, this column is NULL.|  
+|TABLE_CATALOG|String|Catalog of the table.|  
+|TABLE_SCHEMA|String|Schema that contains the table.|  
+|TABLE_NAME|String|Table name.|  
+|COLUMN_NAME|String|Column name.|  
+|ORDINAL_POSITION|Int32|Column identification number.|  
+|COLUMN_DEFAULT|String|Default value of the column|  
+|IS_NULLABLE|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, NO is returned.|  
+|DATA_TYPE|String|System-supplied data type.|  
+|CHARACTER_MAXIMUM_LENGTH|Int32|Maximum length, in characters, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
+|CHARACTER_OCTET_LENGTH|Int32|Maximum length, in bytes, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
+|NUMERIC_PRECISION|Unsigned Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|NUMERIC_PRECISION_RADIX|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|NUMERIC_SCALE|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|DATETIME_PRECISION|Int16|Subtype code for datetime and SQL-92 interval data types. For other data types, NULL is returned.|  
+|CHARACTER_SET_CATALOG|String|Returns master, indicating the database in which the character set is located, if the column is character data or text data type. Otherwise, NULL is returned.|  
+|CHARACTER_SET_SCHEMA|String|Always returns NULL.|  
+|CHARACTER_SET_NAME|String|Returns the unique name for the character set if this column is character data or text data type. Otherwise, NULL is returned.|  
+|COLLATION_CATALOG|String|Returns master, indicating the database in which the collation is defined, if the column is character data or text data type. Otherwise, this column is NULL.|  
 |IS_FILESTREAM|String|YES if the column has FILESTREAM attribute.<br /><br /> NO if the column does not have FILESTREAM attribute.|  
 |IS_SPARSE|String|YES if the column is a sparse column.<br /><br /> NO if the column is not a sparse column.|  
 |IS_COLUMN_SET|String|YES if the column is a column set column.<br /><br /> NO if the column is not a column set column.|  
@@ -191,24 +191,24 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|table_catalog|String|Catalog of the table.|  
-|table_schema|String|Schema that contains the table.|  
-|table_name|String|Table name.|  
-|column_name|String|Column name.|  
-|ordinal_position|Int32|Column identification number.|  
-|column_default|String|Default value of the column|  
-|is_nullable|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, NO is returned.|  
-|data_type|String|System-supplied data type.|  
-|character_maximum_length|Int32|Maximum length, in characters, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
-|character_octet_length|Int32|Maximum length, in bytes, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
-|numeric_precision|Unsigned Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|numeric_precision_radix|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|numeric_scale|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
-|datetime_precision|Int16|Subtype code for datetime and SQL-92 interval data types. For other data types, NULL is returned.|  
-|character_set_catalog|String|Returns master, indicating the database in which the character set is located, if the column is character data or text data type. Otherwise, NULL is returned.|  
-|character_set_schema|String|Always returns NULL.|  
-|character_set_name|String|Returns the unique name for the character set if this column is character data or text data type. Otherwise, NULL is returned.|  
-|collation_catalog|String|Returns master, indicating the database in which the collation is defined, if the column is character data or text data type. Otherwise, this column is NULL.|  
+|TABLE_CATALOG|String|Catalog of the table.|  
+|TABLE_SCHEMA|String|Schema that contains the table.|  
+|TABLE_NAME|String|Table name.|  
+|COLUMN_NAME|String|Column name.|  
+|ORDINAL_POSITION|Int32|Column identification number.|  
+|COLUMN_DEFAULT|String|Default value of the column|  
+|IS_NULLABLE|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, NO is returned.|  
+|DATA_TYPE|String|System-supplied data type.|  
+|CHARACTER_MAXIMUM_LENGTH|Int32|Maximum length, in characters, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
+|CHARACTER_OCTET_LENGTH|Int32|Maximum length, in bytes, for binary data, character data, or text and image data. Otherwise, NULL is returned.|  
+|NUMERIC_PRECISION|Unsigned Byte|Precision of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|NUMERIC_PRECISION_RADIX|Int16|Precision radix of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|NUMERIC_SCALE|Int32|Scale of approximate numeric data, exact numeric data, integer data, or monetary data. Otherwise, NULL is returned.|  
+|DATETIME_PRECISION|Int16|Subtype code for datetime and SQL-92 interval data types. For other data types, NULL is returned.|  
+|CHARACTER_SET_CATALOG|String|Returns master, indicating the database in which the character set is located, if the column is character data or text data type. Otherwise, NULL is returned.|  
+|CHARACTER_SET_SCHEMA|String|Always returns NULL.|  
+|CHARACTER_SET_NAME|String|Returns the unique name for the character set if this column is character data or text data type. Otherwise, NULL is returned.|  
+|COLLATION_CATALOG|String|Returns master, indicating the database in which the collation is defined, if the column is character data or text data type. Otherwise, this column is NULL.|  
 |IS_FILESTREAM|String|YES if the column has FILESTREAM attribute.<br /><br /> NO if the column does not have FILESTREAM attribute.|  
 |IS_SPARSE|String|YES if the column is a sparse column.<br /><br /> NO if the column is not a sparse column.|  
 |IS_COLUMN_SET|String|YES if the column is a column set column.<br /><br /> NO if the column is not a column set column.|  
@@ -226,40 +226,40 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|table_catalog|String|Catalog of the view.|  
-|table_schema|String|Schema that contains the view.|  
-|table_name|String|View name.|  
-|check_option|String|Type of WITH CHECK OPTION. Is CASCADE if the original view was created using the WITH CHECK OPTION. Otherwise, NONE is returned.|  
-|is_updatable|String|Specifies whether the view is updatable. Always returns NO.|  
+|TABLE_CATALOG|String|Catalog of the view.|  
+|TABLE_SCHEMA|String|Schema that contains the view.|  
+|TABLE_NAME|String|View name.|  
+|CHECK_OPTION|String|Type of WITH CHECK OPTION. Is CASCADE if the original view was created using the WITH CHECK OPTION. Otherwise, NONE is returned.|  
+|IS_UPDATABLE|String|Specifies whether the view is updatable. Always returns NO.|  
   
 ## ViewColumns  
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
-|view_catalog|String|Catalog of the view.|  
-|view_schema|String|Schema that contains the view.|  
-|view_name|String|View name.|  
-|table_catalog|String|Catalog of the table that is associated with this view.|  
-|table_schema|String|Schema that contains the table that is associated with this view.|  
-|table_name|String|Name of the table that is associated with the view. Base Table.|  
-|column_name|String|Column name.|  
+|VIEW_CATALOG|String|Catalog of the view.|  
+|VIEW_SCHEMA|String|Schema that contains the view.|  
+|VIEW_NAME|String|View name.|  
+|TABLE_CATALOG|String|Catalog of the table that is associated with this view.|  
+|TABLE_SCHEMA|String|Schema that contains the table that is associated with this view.|  
+|TABLE_NAME|String|Name of the table that is associated with the view. Base Table.|  
+|COLUMN_NAME|String|Column name.|  
   
 ## UserDefinedTypes  
   
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
 |assembly_name|String|The name of the file for the assembly.|  
-|UDT_name|String|The class name for the assembly.|  
+|udt_name|String|The class name for the assembly.|  
 |version_major|Object|Major Version Number.|  
 |version_minor|Object|Minor Version Number.|  
 |version_build|Object|Build Number.|  
 |version_revision|Object|Revision Number.|  
-|Culture_info|Object|The culture information associated with this UDT.|  
-|Public_key|Object|The public key used by this Assembly.|  
-|Is_fixed_length|Boolean|Specifies whether length of type is always same as max_length.|  
+|culture_info|Object|The culture information associated with this UDT.|  
+|public_key|Object|The public key used by this Assembly.|  
+|is_fixed_length|Boolean|Specifies whether length of type is always same as max_length.|  
 |max_length|Int16|Maximum length of type in bytes.|  
-|permission_set_desc|String|The friendly name for the permission-set/security-level for the assembly.|  
-|create_date|DateTime|The date the assembly was created/registered.|  
+|Create_Date|DateTime|The date the assembly was created/registered.|  
+|Permission_set_desc|String|The friendly name for the permission-set/security-level for the assembly.|  
   
 ## See Also  
  [Retrieving Database Schema Information](../../../../docs/framework/data/adonet/retrieving-database-schema-information.md)   

--- a/docs/framework/data/adonet/sql-server-schema-collections.md
+++ b/docs/framework/data/adonet/sql-server-schema-collections.md
@@ -50,6 +50,7 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |table_catalog|String|Table name the index is associated with.|  
 |table_schema|String|Schema that contains the table the index is associated with.|  
 |table_name|String|Table Name.|  
+|index_name|String|Index Name.|  
   
 ### Indexes (SQL Server 2008)  
  Beginning with the .NET Framework version 3.5 SP1 and SQL Server 2008, the following columns have been added to the Indexes schema collection to support new spatial types, filestream and sparse columns. These columns are not supported in earlier versions of the .NET Framework and SQL Server.  
@@ -70,7 +71,8 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |table_name|String|Table Name.|  
 |column_name|String|Column name the index is associated with.|  
 |ordinal_position|Int32|Column ordinal position.|  
-|KeyType|UInt16|The type of object.|  
+|KeyType|Byte|The type of object.|  
+|index_name|String|Index Name.|  
   
 ## Procedures  
   
@@ -93,7 +95,7 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |specific_catalog|String|Catalog name of the procedure for which this is a parameter.|  
 |specific_schema|String|Schema that contains the procedure for which this parameter is part of.|  
 |specific_name|String|Name of the procedure for which this parameter is a part of.|  
-|ordinal_position|Int16|Ordinal position of the parameter starting at 1. For the return value of a procedure, this is a 0.|  
+|ordinal_position|Int32|Ordinal position of the parameter starting at 1. For the return value of a procedure, this is a 0.|  
 |parameter_mode|String|Returns IN if an input parameter, OUT if an output parameter, and INOUT if an input/output parameter.|  
 |is_result|String|Returns YES if indicates result of the procedure that is a function. Otherwise, returns NO.|  
 |as_locator|String|Returns YES if declared as locator. Otherwise, returns NO.|  
@@ -131,7 +133,7 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |table_schema|String|Schema that contains the table.|  
 |table_name|String|Table name.|  
 |column_name|String|Column name.|  
-|ordinal_position|Int16|Column identification number.|  
+|ordinal_position|Int32|Column identification number.|  
 |column_default|String|Default value of the column|  
 |is_nullable|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, No is returned.|  
 |data_type|String|System-supplied data type.|  
@@ -166,7 +168,7 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |table_schema|String|Schema that contains the table.|  
 |table_name|String|Table name.|  
 |column_name|String|Column name.|  
-|ordinal_position|Int16|Column identification number.|  
+|ordinal_position|Int32|Column identification number.|  
 |column_default|String|Default value of the column|  
 |is_nullable|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, NO is returned.|  
 |data_type|String|System-supplied data type.|  
@@ -193,7 +195,7 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |table_schema|String|Schema that contains the table.|  
 |table_name|String|Table name.|  
 |column_name|String|Column name.|  
-|ordinal_position|Int16|Column identification number.|  
+|ordinal_position|Int32|Column identification number.|  
 |column_default|String|Default value of the column|  
 |is_nullable|String|Nullability of the column. If this column allows NULL, this column returns YES. Otherwise, NO is returned.|  
 |data_type|String|System-supplied data type.|  
@@ -216,7 +218,7 @@ The Microsoft .NET Framework Data Provider for SQL Server supports additional sc
 |ColumnName|DataType|Description|  
 |----------------|--------------|-----------------|  
 |uid|Int16|User ID, unique in this database. 1 is the database owner.|  
-|name|String|Username or group name, unique in this database.|  
+|user_name|String|Username or group name, unique in this database.|  
 |createdate|DateTime|Date the account was added.|  
 |updatedate|DateTime|Date the account was last changed.|  
   


### PR DESCRIPTION
# Title

Update Schema Collections docs to match Implementation

## Summary

While working with schema collections I was working from the documentation and noticed it was different from what I was getting in the resulting `DataTable` objects. I've updated the documentation to match the schema of the `DataTable` objects.

## Details

The majority of the changes are minor. The changes I have made are:

* Adding missing columns.
* Updating types for a given column.
* Fixing typos for column names.

Additionally I have changed the case of the column names to exactly match what is provided by the `DataTable` collections.
