### PR TITLE
Add Xamarin.Mac to net-standard support table

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -5,6 +5,7 @@
 | .NET Framework (with tooling 2.0 preview) | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1  | 4.6.1  | 4.6.1 |
 | Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | vNext |
 | Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | vNext |
+| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0    | 3.0    | vNext |
 | Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | vNext |
 | Universal Windows Platform                | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | vNext  | vNext  | vNext |
 | Windows                                   | 8.0   | 8.0    | 8.1   |       |       |        |        |       |


### PR DESCRIPTION
# Title

Xamarin.Mac supports netstandard by leveraging mono just as Xamarin.iOS.

## Summary

Fixed https://github.com/dotnet/standard/issues/419

## Details

As the lead of Xamarin.Mac, I can claim support. :)

If it regresses file a bug at https://bugzilla.xamarin.com/index.cgi