### PR TITLE
Clarify explanation in .NET Standard platform table

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -14,7 +14,7 @@
 
 - The columns represent .NET Standard versions. Each header cell is a link to a document that shows which APIs got added in that version of .NET Standard.
 - The rows represent the different .NET platforms.
-- The version number in each cell indicates the *minimum* version of the platform you'll need to implement that .NET Standard version.
+- The version number in each cell indicates the *minimum* version of the platform you'll need in order to target that .NET Standard version.
 
 [1.0]: https://github.com/dotnet/standard/blob/master/docs/versions/netstandard1.0.md
 [1.1]: https://github.com/dotnet/standard/blob/master/docs/versions/netstandard1.1.md


### PR DESCRIPTION
"Implement" sounds wrong in this context. As a library/app author I care about targeting a specific .NET Standard version.
