### PR TITLE
Add a symbol for NET47

### DIFF
--- a/docs/core/porting/libraries.md
+++ b/docs/core/porting/libraries.md
@@ -193,6 +193,7 @@ Note that all of the .NET Framework and .NET Standard targets have names recogni
 .NET Framework 4.6   --> NET46
 .NET Framework 4.6.1 --> NET461
 .NET Framework 4.6.2 --> NET462
+.NET Framework 4.7   --> NET47
 .NET Standard 1.0    --> NETSTANDARD1_0
 .NET Standard 1.1    --> NETSTANDARD1_1
 .NET Standard 1.2    --> NETSTANDARD1_2


### PR DESCRIPTION
The table is missing a valid symbol for `NET47`.