### PR TITLE
exclude System.MonoTODo from API syntax

### DIFF
--- a/xml/_filter.xml
+++ b/xml/_filter.xml
@@ -104,7 +104,7 @@
       <typeFilter name="*" expose="true" />
     </namespaceFilter>
     <namespaceFilter name="System">
-      <typeFilter name="MonoTODO" expose="false" />
+      <typeFilter name="MonoTODOAttribute" expose="false" />
       <typeFilter name="*" expose="true" />
     </namespaceFilter>    
     <namespaceFilter name="*">

--- a/xml/_filter.xml
+++ b/xml/_filter.xml
@@ -73,7 +73,7 @@
     <namespaceFilter name="System.Web.Compilation">
       <typeFilter name="*" expose="false" />
     </namespaceFilter>
-    <!-- The ASP.NET team only wants these attributes exposed from their namespace. Their logic ecscapes me, but here it is. -->
+    <!-- The ASP.NET team only wants these attributes exposed from their namespace. -->
     <namespaceFilter name="System.Web.UI">
       <typeFilter name="ControlValuePropertyAttribute" expose="true" />
       <typeFilter name="PersistenceModeAttribute" expose="true" />
@@ -103,6 +103,10 @@
       <typeFilter name="GeneratedCodeAttribute" expose="false" />
       <typeFilter name="*" expose="true" />
     </namespaceFilter>
+    <namespaceFilter name="System">
+      <typeFilter name="MonoTODO" expose="false" />
+      <typeFilter name="*" expose="true" />
+    </namespaceFilter>    
     <namespaceFilter name="*">
       <typeFilter name="*" expose="true" />
     </namespaceFilter>


### PR DESCRIPTION
I don't think we should be displaying that attribute in the syntax blocks for API docs.

Here's an example: https://docs.microsoft.com/en-us/dotnet/api/system.net.mail.mailaddress.-ctor?view=netframework-4.7#System_Net_Mail_MailAddress__ctor_System_String_System_String_System_Text_Encoding_