### PR TITLE
Document Signature APIs in the System.​Reflection.​Metadata Namespace.

### DIFF
--- a/xml/System.Reflection.Metadata/ArrayShape.xml
+++ b/xml/System.Reflection.Metadata/ArrayShape.xml
@@ -91,9 +91,16 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Int32&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the sizes of each dimension. Length may be smaller than rank, in which case the trailing dimensions have unspecified sizes.</summary>
+        <summary>Gets the sizes of each dimension.</summary>
         <value>A collection of size values.</value>
-        <remarks></remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The number of elements in the returned array may be fewer than the number of dimensions of the array type (its rank). In that case, the trailing dimensions have unspecified sizes.
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/ArrayShape.xml
+++ b/xml/System.Reflection.Metadata/ArrayShape.xml
@@ -33,8 +33,8 @@
       </Parameters>
       <Docs>
         <param name="rank">The number of dimensions in the array.</param>
-        <param name="sizes">The sizes of each dimension.</param>
-        <param name="lowerBounds">The lower-bounds of each dimension.</param>
+        <param name="sizes">The size of each dimension.</param>
+        <param name="lowerBounds">The lower-bound of each dimension.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.ArrayShape"/> structure.</summary>
         <remarks></remarks>
       </Docs>
@@ -53,8 +53,8 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Int32&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the lower-bounds of each dimension. Length may be smaller than rank, in which case the trailing dimensions have unspecified lower bounds.</summary>
-        <value>A collection of lower-bounds values.</value>
+        <summary>Gets the lower-bounds of all dimensions. Length may be smaller than rank, in which case the trailing dimensions have unspecified lower bounds.</summary>
+        <value>An array of lower-bounds.</value>
         <remarks></remarks>
       </Docs>
     </Member>
@@ -91,13 +91,13 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Int32&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the sizes of each dimension.</summary>
-        <value>A collection of size values.</value>
+        <summary>Gets the sizes of all dimensions.</summary>
+        <value>An array of sizes.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The number of elements in the returned array may be fewer than the number of dimensions of the array type (its rank). In that case, the trailing dimensions have unspecified sizes.
+ The number of elements in the returned array may be smaller than the number of dimensions of the array type (its rank). In that case, the trailing dimensions have unspecified sizes.
   
  ]]></format>
         </remarks>

--- a/xml/System.Reflection.Metadata/ArrayShape.xml
+++ b/xml/System.Reflection.Metadata/ArrayShape.xml
@@ -12,8 +12,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents the shape of an array type.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,11 +32,11 @@
         <Parameter Name="lowerBounds" Type="System.Collections.Immutable.ImmutableArray&lt;System.Int32&gt;" />
       </Parameters>
       <Docs>
-        <param name="rank">To be added.</param>
-        <param name="sizes">To be added.</param>
-        <param name="lowerBounds">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="rank">The number of dimensions in the array.</param>
+        <param name="sizes">The sizes of each dimension.</param>
+        <param name="lowerBounds">The lower-bounds of each dimension.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.ArrayShape"/> structure.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="LowerBounds">
@@ -53,9 +53,9 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Int32&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the lower-bounds of each dimension. Length may be smaller than rank, in which case the trailing dimensions have unspecified lower bounds.</summary>
+        <value>A collection of lower-bounds values.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Rank">
@@ -72,9 +72,9 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the number of dimensions in the array.</summary>
+        <value>The number of dimensions.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Sizes">
@@ -91,9 +91,9 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Int32&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the sizes of each dimension. Length may be smaller than rank, in which case the trailing dimensions have unspecified sizes.</summary>
+        <value>A collection of size values.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/ConstantTypeCode.xml
+++ b/xml/System.Reflection.Metadata/ConstantTypeCode.xml
@@ -175,7 +175,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A class type modifier.</summary>
+        <summary>A null.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">

--- a/xml/System.Reflection.Metadata/ConstantTypeCode.xml
+++ b/xml/System.Reflection.Metadata/ConstantTypeCode.xml
@@ -12,7 +12,7 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>Specifies constants that define types in a metadata type signature.</summary>
+    <summary>Specifies values that represent types of metadata constants.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A <see cref="System.Boolean"/> type.</summary>
+        <summary>A Boolean type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Byte">
@@ -67,7 +67,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A <see cref="System.Char"/> type.</summary>
+        <summary>A character type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -175,7 +175,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A null.</summary>
+        <summary>A null reference.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">

--- a/xml/System.Reflection.Metadata/ConstantTypeCode.xml
+++ b/xml/System.Reflection.Metadata/ConstantTypeCode.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies constants that define types in a metadata type signature.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Boolean">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Boolean"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Byte">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 1-byte integer.</summary>
       </Docs>
     </Member>
     <Member MemberName="Char">
@@ -67,7 +67,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Char"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -85,7 +85,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An 8-byte floating point type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int16">
@@ -103,7 +103,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 2-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int32">
@@ -121,7 +121,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 4-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int64">
@@ -139,7 +139,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 8-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Invalid">
@@ -157,7 +157,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An invalid type.</summary>
       </Docs>
     </Member>
     <Member MemberName="NullReference">
@@ -175,7 +175,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A class type modifier.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">
@@ -193,7 +193,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 1-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Single">
@@ -211,7 +211,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A 4-byte floating point type.</summary>
       </Docs>
     </Member>
     <Member MemberName="String">
@@ -229,7 +229,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.String"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt16">
@@ -247,7 +247,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 2-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt32">
@@ -265,7 +265,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 4-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt64">
@@ -283,7 +283,7 @@
         <ReturnType>System.Reflection.Metadata.ConstantTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 8-byte integer type.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/CustomAttributeNamedArgumentKind.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeNamedArgumentKind.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies constants that define the kinds of arguments in a custom metadata attribute.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Field">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.CustomAttributeNamedArgumentKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A field argument.</summary>
       </Docs>
     </Member>
     <Member MemberName="Property">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.CustomAttributeNamedArgumentKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A property argument.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/CustomAttributeNamedArgumentKind.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeNamedArgumentKind.xml
@@ -12,7 +12,7 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>Specifies constants that define the kinds of arguments in a custom metadata attribute.</summary>
+    <summary>Specifies constants that define the kinds of arguments in a custom attribute signature.</summary>
     <remarks></remarks>
   </Docs>
   <Members>

--- a/xml/System.Reflection.Metadata/CustomAttributeNamedArgument`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeNamedArgument`1.xml
@@ -15,8 +15,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="TType">The type of the argument.</typeparam>
-    <summary>Represents a named argument of the specified generic type for a custom metadata attribute.</summary>
+    <typeparam name="TType">The type used to represent types of values decoded from the custom attribute signature.</typeparam>
+    <summary>Represents a named argument decoded from a custom attribute signature.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -38,8 +38,8 @@
       </Parameters>
       <Docs>
         <param name="name">The name of the argument.</param>
-        <param name="kind">The kind of argument.</param>
-        <param name="type">The type of argument.</param>
+        <param name="kind">The kind of the argument.</param>
+        <param name="type">The type of the argument.</param>
         <param name="value">The value of the argument.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.CustomAttributeNamedArgument`1" /> structure using the specified name, kind, type, and value.</summary>
         <remarks></remarks>

--- a/xml/System.Reflection.Metadata/CustomAttributeNamedArgument`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeNamedArgument`1.xml
@@ -98,8 +98,8 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the type of the argument.</summary>
-        <value>the argument type.</value>
-        <remarks>T</remarks>
+        <value>The argument type.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">

--- a/xml/System.Reflection.Metadata/CustomAttributeNamedArgument`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeNamedArgument`1.xml
@@ -15,9 +15,9 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="TType">To be added.</typeparam>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <typeparam name="TType">The type of the argument.</typeparam>
+    <summary>Represents a named argument of the specified generic type for a custom metadata attribute.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -37,12 +37,12 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="name">To be added.</param>
-        <param name="kind">To be added.</param>
-        <param name="type">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="name">The name of the argument.</param>
+        <param name="kind">The kind of argument.</param>
+        <param name="type">The type of argument.</param>
+        <param name="value">The value of the argument.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.CustomAttributeNamedArgument`1" /> structure using the specified name, kind, type, and value.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Kind">
@@ -59,9 +59,9 @@
         <ReturnType>System.Reflection.Metadata.CustomAttributeNamedArgumentKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the kind of argument.</summary>
+        <value>The argument kind.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -78,9 +78,9 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the name of the argument.</summary>
+        <value>The argument name.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Type">
@@ -97,9 +97,9 @@
         <ReturnType>TType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the type of the argument.</summary>
+        <value>the argument type.</value>
+        <remarks>T</remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -116,9 +116,9 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the value of the argument.</summary>
+        <value>An object containing the argument value.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/CustomAttributeTypedArgument`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeTypedArgument`1.xml
@@ -15,9 +15,9 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="TType">To be added.</typeparam>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <typeparam name="TType">The type of the argument.</typeparam>
+    <summary>Represents a typed argument for a custom metadata attribute.</summary>
+    <remarks</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,10 +35,10 @@
         <Parameter Name="value" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="type">To be added.</param>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="type">The type of the argument.</param>
+        <param name="value">The argument value.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.CustomAttributeTypedArgument`1" /> structure using the specified argument type and value.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Type">
@@ -55,9 +55,9 @@
         <ReturnType>TType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the type of the argument.</summary>
+        <value>The argument type.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Value">
@@ -74,9 +74,9 @@
         <ReturnType>System.Object</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the value of the argument.</summary>
+        <value>An object containing the argument value.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/CustomAttributeTypedArgument`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeTypedArgument`1.xml
@@ -17,7 +17,7 @@
   <Docs>
     <typeparam name="TType">The type of the argument.</typeparam>
     <summary>Represents a typed argument for a custom metadata attribute.</summary>
-    <remarks</remarks>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Reflection.Metadata/CustomAttributeTypedArgument`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeTypedArgument`1.xml
@@ -75,7 +75,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the value of the argument.</summary>
-        <value>An object containing the argument value.</value>
+        <value>The argument value.</value>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Reflection.Metadata/CustomAttributeValue`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeValue`1.xml
@@ -15,9 +15,9 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="TType">To be added.</typeparam>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <typeparam name="TType">The value type.</typeparam>
+    <summary>Represents a custom metadata atttribute value of the specified generic type.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -35,10 +35,10 @@
         <Parameter Name="namedArguments" Type="System.Collections.Immutable.ImmutableArray&lt;System.Reflection.Metadata.CustomAttributeNamedArgument&lt;TType&gt;&gt;" />
       </Parameters>
       <Docs>
-        <param name="fixedArguments">To be added.</param>
-        <param name="namedArguments">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="fixedArguments">The fixed arguments.</param>
+        <param name="namedArguments">The named arguments.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.CustomAttributeValue`1" /> structure using the specified fixed arguments and named arguments.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="FixedArguments">
@@ -55,9 +55,9 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Reflection.Metadata.CustomAttributeTypedArgument&lt;TType&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the fixed arguments for the custom attribute value.</summary>
+        <value>An immutable array of arguments.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="NamedArguments">
@@ -74,9 +74,9 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Reflection.Metadata.CustomAttributeNamedArgument&lt;TType&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the named arguments for the custom attribute value.</summary>
+        <value>An immutable array of arguments.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/CustomAttributeValue`1.xml
+++ b/xml/System.Reflection.Metadata/CustomAttributeValue`1.xml
@@ -15,8 +15,8 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="TType">The value type.</typeparam>
-    <summary>Represents a custom metadata atttribute value of the specified generic type.</summary>
+    <typeparam name="TType">The attribute type.</typeparam>
+    <summary>Represents a custom atttribute of the type specified by <paramref name="TType"/>.</summary>
     <remarks></remarks>
   </Docs>
   <Members>
@@ -55,7 +55,7 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;System.Reflection.Metadata.CustomAttributeTypedArgument&lt;TType&gt;&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the fixed arguments for the custom attribute value.</summary>
+        <summary>Gets the fixed arguments for the custom attribute.</summary>
         <value>An immutable array of arguments.</value>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Reflection.Metadata/MemberReferenceKind.xml
+++ b/xml/System.Reflection.Metadata/MemberReferenceKind.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies constants that indicate whether a <see cref="T:System.Reflection.Metadata.MemberReference"/> references a method or field.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Field">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.MemberReferenceKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a method.</summary>
       </Docs>
     </Member>
     <Member MemberName="Method">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.MemberReferenceKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a field.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/MemberReferenceKind.xml
+++ b/xml/System.Reflection.Metadata/MemberReferenceKind.xml
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.MemberReferenceKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a method.</summary>
+        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a field.</summary>
       </Docs>
     </Member>
     <Member MemberName="Method">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.MemberReferenceKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a field.</summary>
+        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a method.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/MethodSignature`1.xml
+++ b/xml/System.Reflection.Metadata/MethodSignature`1.xml
@@ -15,9 +15,9 @@
   </Base>
   <Interfaces />
   <Docs>
-    <typeparam name="TType">To be added.</typeparam>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <typeparam name="TType">The method type.</typeparam>
+    <summary>Represents a method (definition, reference, or standalone) or property signature. In the case of properties, the signature matches that of a getter with a distinguishing <see cref="T:System.Reflection.Metadata.SignatureHeader"/>.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -38,13 +38,13 @@
         <Parameter Name="parameterTypes" Type="System.Collections.Immutable.ImmutableArray&lt;TType&gt;" />
       </Parameters>
       <Docs>
-        <param name="header">To be added.</param>
-        <param name="returnType">To be added.</param>
-        <param name="requiredParameterCount">To be added.</param>
-        <param name="genericParameterCount">To be added.</param>
-        <param name="parameterTypes">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="header">The information in the leading byte of the signature (kind, calling convention, flags).</param>
+        <param name="returnType">The return type of the method.</param>
+        <param name="requiredParameterCount">The number of required parameters.</param>
+        <param name="genericParameterCount">The number of generic type parameters.</param>
+        <param name="parameterTypes">The paramter types.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.MethodSignature`1" /> structure using the specified header, return type, and parameter information.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GenericParameterCount">
@@ -61,9 +61,9 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the number of generic type parameters for the method.</summary>
+        <value>The number of generic type parameters, or 0 for non-generic methods.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Header">
@@ -80,9 +80,9 @@
         <ReturnType>System.Reflection.Metadata.SignatureHeader</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the information in the leading byte of the signature (kind, calling convention, flags).</summary>
+        <value>The header signature.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ParameterTypes">
@@ -99,9 +99,9 @@
         <ReturnType>System.Collections.Immutable.ImmutableArray&lt;TType&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the method's parameter types.</summary>
+        <value>An immutable collection of parameter types.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="RequiredParameterCount">
@@ -118,9 +118,9 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the number of parameters that are required for the method. This value will be equal to the length of the <see cref="ParameterTypes"/> property, unless this method signature represents the standalone call site of a vararg method, in which case, the extra entries in <see cref="ParameterTypes"/> are the types used for the optional parameters.</summary>
+        <value>The number of required parameters.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ReturnType">
@@ -137,9 +137,9 @@
         <ReturnType>TType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the return type of the method.</summary>
+        <value>The return type.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/MethodSignature`1.xml
+++ b/xml/System.Reflection.Metadata/MethodSignature`1.xml
@@ -124,7 +124,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This value will be equal to the length of the <xref:System.Reflection.Metadata.MethodSignature`1.ParameterTypes> property, unless this method signature represents the standalone call site of a vararg method, in which case, the extra entries in <xref:System.Reflection.Metadata.MethodSignature`1.ParameterTypes> are the types used for the optional parameters.
+ This value is equal to the length of the <xref:System.Reflection.Metadata.MethodSignature`1.ParameterTypes> property, unless this method signature represents the standalone call site of a `vararg` method, in which case, the extra entries in <xref:System.Reflection.Metadata.MethodSignature`1.ParameterTypes> are the types used for the optional parameters.
   
  ]]></format>
       </remarks>

--- a/xml/System.Reflection.Metadata/MethodSignature`1.xml
+++ b/xml/System.Reflection.Metadata/MethodSignature`1.xml
@@ -42,7 +42,7 @@
         <param name="returnType">The return type of the method.</param>
         <param name="requiredParameterCount">The number of required parameters.</param>
         <param name="genericParameterCount">The number of generic type parameters.</param>
-        <param name="parameterTypes">The paramter types.</param>
+        <param name="parameterTypes">The parameter types.</param>
         <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.MethodSignature`1" /> structure using the specified header, return type, and parameter information.</summary>
         <remarks></remarks>
       </Docs>
@@ -118,9 +118,16 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the number of parameters that are required for the method. This value will be equal to the length of the <see cref="ParameterTypes"/> property, unless this method signature represents the standalone call site of a vararg method, in which case, the extra entries in <see cref="ParameterTypes"/> are the types used for the optional parameters.</summary>
+        <summary>Gets the number of parameters that are required for the method.</summary>
         <value>The number of required parameters.</value>
-        <remarks></remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This value will be equal to the length of the <xref:System.Reflection.Metadata.MethodSignature`1.ParameterTypes> property, unless this method signature represents the standalone call site of a vararg method, in which case, the extra entries in <xref:System.Reflection.Metadata.MethodSignature`1.ParameterTypes> are the types used for the optional parameters.
+  
+ ]]></format>
+      </remarks>
       </Docs>
     </Member>
     <Member MemberName="ReturnType">

--- a/xml/System.Reflection.Metadata/PrimitiveSerializationTypeCode.xml
+++ b/xml/System.Reflection.Metadata/PrimitiveSerializationTypeCode.xml
@@ -11,8 +11,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies constants that define the type codes used to encode types of primitive values in a <see cref="T:System.Reflection.Metadata.CustomAttribute"/> value blob.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Boolean">
@@ -29,7 +29,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Boolean"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Byte">
@@ -46,7 +46,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 1-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Char">
@@ -63,7 +63,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Char"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -80,7 +80,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An 8-byte floating point type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int16">
@@ -97,7 +97,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 2-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int32">
@@ -114,7 +114,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 4-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int64">
@@ -131,7 +131,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 8-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">
@@ -148,7 +148,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A signed 1-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Single">
@@ -165,7 +165,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A 4-byte floating point type.</summary>
       </Docs>
     </Member>
     <Member MemberName="String">
@@ -182,7 +182,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.String"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt16">
@@ -199,7 +199,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 2-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt32">
@@ -216,7 +216,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 4-byte integer type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt64">
@@ -233,7 +233,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveSerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unsigned 8-byte integer type.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/PrimitiveTypeCode.xml
+++ b/xml/System.Reflection.Metadata/PrimitiveTypeCode.xml
@@ -11,8 +11,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies constants that define primitive types found in metadata signatures.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Boolean">
@@ -29,7 +29,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Boolean"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Byte">
@@ -46,7 +46,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Byte"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Char">
@@ -63,7 +63,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Char"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -80,7 +80,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Double"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int16">
@@ -97,7 +97,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Int16"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int32">
@@ -114,7 +114,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Int32"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int64">
@@ -131,7 +131,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Int64"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="IntPtr">
@@ -148,7 +148,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.IntPtr"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Object">
@@ -165,7 +165,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An <see cref="System.Object"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">
@@ -182,7 +182,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An <see cref="System.SByte"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Single">
@@ -199,7 +199,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Single"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="String">
@@ -216,7 +216,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An <see cref="System.Single"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="TypedReference">
@@ -233,7 +233,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A typed reference.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt16">
@@ -250,7 +250,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.UInt16"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt32">
@@ -267,7 +267,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.UInt32"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt64">
@@ -284,7 +284,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.UInt64"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="UIntPtr">
@@ -301,7 +301,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.UIntPtr"/> type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Void">
@@ -318,7 +318,7 @@
         <ReturnType>System.Reflection.Metadata.PrimitiveTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A <see cref="System.Void"/> type.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SerializationTypeCode.xml
+++ b/xml/System.Reflection.Metadata/SerializationTypeCode.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies type codes used to encode the types of values in a <see cref="T:System.Reflection.Metadata.CustomAttributeValue`1" /> blob.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Boolean">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Boolean"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Byte">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Byte"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Char">
@@ -67,7 +67,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Char"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -85,7 +85,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Double"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Enum">
@@ -103,7 +103,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The attribute argument is an Enum instance.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int16">
@@ -121,7 +121,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Int16"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int32">
@@ -139,7 +139,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Int32"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int64">
@@ -157,7 +157,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Int64"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Invalid">
@@ -175,7 +175,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Invalid"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">
@@ -193,7 +193,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.SByte"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="Single">
@@ -211,7 +211,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.Single"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="String">
@@ -229,7 +229,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.String"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="SZArray">
@@ -247,7 +247,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.SZArray"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="TaggedObject">
@@ -265,7 +265,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The attribute argument is "boxed" (passed to a parameter, field, or property of type object) and carries type information in the attribute blob.</summary>
       </Docs>
     </Member>
     <Member MemberName="Type">
@@ -283,7 +283,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The attribute argument is a <see cref="System.Type"/> instance.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt16">
@@ -301,7 +301,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.UInt16"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt32">
@@ -319,7 +319,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.UInt32"/>.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt64">
@@ -337,7 +337,7 @@
         <ReturnType>System.Reflection.Metadata.SerializationTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A value equivalent to <see cref="SignatureTypeCode.UInt64"/>.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureAttributes.xml
+++ b/xml/System.Reflection.Metadata/SignatureAttributes.xml
@@ -17,8 +17,8 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies additional flags that can be applied to method signatures. The underlying values of the fields in this type correspond to the representation in the leading signature byte represented by a <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="ExplicitThis">
@@ -36,7 +36,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Indicates the first explicitly declared parameter that represents the instance pointer.</summary>
       </Docs>
     </Member>
     <Member MemberName="Generic">
@@ -54,7 +54,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A generic method.</summary>
       </Docs>
     </Member>
     <Member MemberName="Instance">
@@ -72,7 +72,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An instance method.</summary>
       </Docs>
     </Member>
     <Member MemberName="None">
@@ -90,7 +90,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>No flags.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureCallingConvention.xml
+++ b/xml/System.Reflection.Metadata/SignatureCallingConvention.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies how arguments in a given signature are passed from the caller to the callee. The underlying values of the fields in this type correspond to the representation in the leading signature byte represented by a <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="CDecl">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unmanaged C/C++ style calling convention where the call stack is cleaned by the caller.</summary>
       </Docs>
     </Member>
     <Member MemberName="Default">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A managed calling convention with a fixed-length argument list.</summary>
       </Docs>
     </Member>
     <Member MemberName="FastCall">
@@ -67,7 +67,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unmanaged calling convention where arguments are passed in registers when possible.</summary>
       </Docs>
     </Member>
     <Member MemberName="StdCall">
@@ -85,7 +85,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unmanaged calling convention where the call stack is cleaned up by the callee.</summary>
       </Docs>
     </Member>
     <Member MemberName="ThisCall">
@@ -103,7 +103,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>An unmanaged C++ style calling convention for calling instance member functions with a fixed argument list.</summary>
       </Docs>
     </Member>
     <Member MemberName="VarArgs">
@@ -121,7 +121,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A managed calling convention for passing extra arguments.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureHeader.xml
+++ b/xml/System.Reflection.Metadata/SignatureHeader.xml
@@ -348,8 +348,8 @@
         <ReturnType>System.Byte</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets the raw value.</summary>
-        <value>The raw value.</value>
+        <summary>Gets the raw value of the header byte.</summary>
+        <value>The raw value of the header byte.</value>
         <remarks></remarks>
       </Docs>
     </Member>

--- a/xml/System.Reflection.Metadata/SignatureHeader.xml
+++ b/xml/System.Reflection.Metadata/SignatureHeader.xml
@@ -216,7 +216,7 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> signature attribute.</summary>
+        <summary>Gets a value that indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> signature attribute.</summary>
         <value><see langword="true" /> if the <see cref="T:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> attribute is present; otherwise, <see langword="false" />.</value>
         <remarks></remarks>
       </Docs>
@@ -236,7 +236,7 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Generic"/> signature attribute.</summary>
+        <summary>Gets a value that indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Generic"/> signature attribute.</summary>
         <value><see langword="true" /> if the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Generic"/> attribute is present; otherwise, <see langword="false" />.</value>
         <remarks></remarks>
       </Docs>
@@ -256,7 +256,7 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Instance"/> signature attribute.</summary>
+        <summary>Gets a value that indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Instance"/> signature attribute.</summary>
         <value><see langword="true" /> if the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Instance"/> attribute is present; otherwise, <see langword="false" />.</value>
         <remarks></remarks>
       </Docs>
@@ -328,7 +328,7 @@
       <Docs>
         <param name="left">The first value to compare.</param>
         <param name="right">The second value to compare.</param>
-        <summary>Determines whether two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values are unequal</summary>
+        <summary>Determines whether two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values are unequal.</summary>
         <returns><see langword="true" /> if the values are unequal; otherwise, <see langword="false" />.</returns>
         <remarks></remarks>
       </Docs>

--- a/xml/System.Reflection.Metadata/SignatureHeader.xml
+++ b/xml/System.Reflection.Metadata/SignatureHeader.xml
@@ -17,8 +17,15 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents the signature characteristics specified by the leading byte of signature blobs.</summary>
+    <remarks>          
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This header byte is present in all method definition, method reference, standalone method, field, property, and local variable signatures, but not in type specification signatures.
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -36,9 +43,9 @@
         <Parameter Name="rawValue" Type="System.Byte" />
       </Parameters>
       <Docs>
-        <param name="rawValue">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="rawValue">The byte.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure using the specified byte value.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName=".ctor">
@@ -58,11 +65,11 @@
         <Parameter Name="attributes" Type="System.Reflection.Metadata.SignatureAttributes" />
       </Parameters>
       <Docs>
-        <param name="kind">To be added.</param>
-        <param name="convention">To be added.</param>
-        <param name="attributes">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="kind">The signature kind.</param>
+        <param name="convention">The calling convention.</param>
+        <param name="attributes">The signature attributes.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure using the specified signature kind, calling convention and signature attributes.</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Attributes">
@@ -80,9 +87,9 @@
         <ReturnType>System.Reflection.Metadata.SignatureAttributes</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the signature attributes.</summary>
+        <value>The attributes.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="CallingConvention">
@@ -100,9 +107,9 @@
         <ReturnType>System.Reflection.Metadata.SignatureCallingConvention</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the calling convention.</summary>
+        <value>The calling convention.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="CallingConventionOrKindMask">
@@ -121,8 +128,8 @@
       </ReturnValue>
       <MemberValue>15</MemberValue>
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Gets the mask value for the calling convention or signature kind. The default <see cref="F:System.Reflection.Metadata.SignatureHeader.CallingConventionOrKindMask"/> value is 15 (0x0F).</summary>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -143,10 +150,10 @@
         <Parameter Name="obj" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="obj">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="obj">The object to compare.</param>
+        <summary>Compares the specified object with this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> for equality.</summary>
+        <returns><see langword="true" /> if the objects are equal; otherwise, <see langword="false" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -167,10 +174,10 @@
         <Parameter Name="other" Type="System.Reflection.Metadata.SignatureHeader" />
       </Parameters>
       <Docs>
-        <param name="other">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="other">The value to compare.</param>
+        <summary>Compares two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values for equality.</summary>
+        <returns><see langword="true" /> if the values are equal; otherwise, <see langword="false" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -189,9 +196,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Gets a hash code for the current object.</summary>
+        <returns>A hash code for the current object.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="HasExplicitThis">
@@ -209,9 +216,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> signature attribute.</summary>
+        <value><see langword="true" /> if the <see cref="T:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> attribute is present; otherwise, <see langword="false" />.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="IsGeneric">
@@ -229,9 +236,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Generic"/> signature attribute.</summary>
+        <value><see langword="true" /> if the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Generic"/> attribute is present; otherwise, <see langword="false" />.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="IsInstance">
@@ -249,9 +256,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Instance"/> signature attribute.</summary>
+        <value><see langword="true" /> if the <see cref="T:System.Reflection.Metadata.SignatureAttributes.Instance"/> attribute is present; otherwise, <see langword="false" />.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="Kind">
@@ -269,9 +276,9 @@
         <ReturnType>System.Reflection.Metadata.SignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the signature kind.</summary>
+        <value>The signature kind.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Equality">
@@ -293,11 +300,11 @@
         <Parameter Name="right" Type="System.Reflection.Metadata.SignatureHeader" />
       </Parameters>
       <Docs>
-        <param name="left">To be added.</param>
-        <param name="right">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="left">The first value to compare.</param>
+        <param name="right">The second value to compare.</param>
+        <summary>Compares two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values for equality.</summary>
+        <returns><see langword="true" /> if the values are equal; otherwise, <see langword="false" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Inequality">
@@ -319,11 +326,11 @@
         <Parameter Name="right" Type="System.Reflection.Metadata.SignatureHeader" />
       </Parameters>
       <Docs>
-        <param name="left">To be added.</param>
-        <param name="right">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="left">The first value to compare.</param>
+        <param name="right">The second value to compare.</param>
+        <summary>Determines whether two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values are unequal</summary>
+        <returns><see langword="true" /> if the values are unequal; otherwise, <see langword="false" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="RawValue">
@@ -341,9 +348,9 @@
         <ReturnType>System.Byte</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the raw value.</summary>
+        <value>The raw value.</value>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="ToString">
@@ -362,9 +369,9 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Returns a string that represents the current object.</summary>
+        <returns>A string that represents the current object.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureKind.xml
+++ b/xml/System.Reflection.Metadata/SignatureKind.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies the signature kind. The underlying values of the fields in this type correspond to the representation in the leading signature byte represented by a <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Field">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A field signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="LocalVariables">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A local variables signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="Method">
@@ -67,7 +67,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A method reference, method definition, or standalone method signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="MethodSpecification">
@@ -85,7 +85,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A method specification signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="Property">
@@ -103,7 +103,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>A property signature.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureTypeCode.xml
+++ b/xml/System.Reflection.Metadata/SignatureTypeCode.xml
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Boolean"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.Boolean"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="ByReference">
@@ -85,7 +85,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Byte"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.Byte"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Char">
@@ -103,7 +103,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Char"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.Char"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -121,7 +121,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Double"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.Double"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="FunctionPointer">
@@ -211,7 +211,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Int16"/> in signatures.</summary>
+        <summary>Represents an <see cref="System.Int16"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int32">
@@ -229,7 +229,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Int32"/> in signatures.</summary>
+        <summary>Represents an <see cref="System.Int32"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int64">
@@ -247,7 +247,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Int64"/> in signatures.</summary>
+        <summary>Represents an <see cref="System.Int64"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="IntPtr">
@@ -265,7 +265,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents a <see cref="System.IntPtr"/> in signatures.</summary>
+        <summary>Represents an <see cref="System.IntPtr"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Invalid">
@@ -301,7 +301,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents a <see cref="System.Object"/> in signatures.</summary>
+        <summary>Represents an <see cref="System.Object"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="OptionalModifier">
@@ -427,7 +427,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.Single"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.Single"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="String">
@@ -445,7 +445,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.String"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.String"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="SZArray">
@@ -525,7 +525,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.UInt16"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.UInt16"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt32">
@@ -543,7 +543,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.UInt32"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.UInt32"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt64">
@@ -561,7 +561,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Represents <see cref="System.UInt64"/> in signatures.</summary>
+        <summary>Represents a <see cref="System.UInt64"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="UIntPtr">

--- a/xml/System.Reflection.Metadata/SignatureTypeCode.xml
+++ b/xml/System.Reflection.Metadata/SignatureTypeCode.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Specifies constants that define type codes used in signature encoding.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Array">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a generalized <see cref="System.Array"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Boolean">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Boolean"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="ByReference">
@@ -67,7 +67,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents managed pointers (byref return values and parameters) in signatures. It is followed in the blob by the signature encoding of the underlying type.</summary>
       </Docs>
     </Member>
     <Member MemberName="Byte">
@@ -85,7 +85,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Byte"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Char">
@@ -103,7 +103,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Char"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Double">
@@ -121,7 +121,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Double"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="FunctionPointer">
@@ -139,7 +139,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents function pointer types in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="GenericMethodParameter">
@@ -157,7 +157,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a generic method parameter used within a signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="GenericTypeInstance">
@@ -175,7 +175,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents the instantiation of a generic type in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="GenericTypeParameter">
@@ -193,7 +193,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a generic type parameter used within a signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int16">
@@ -211,7 +211,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Int16"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int32">
@@ -229,7 +229,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Int32"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Int64">
@@ -247,7 +247,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Int64"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="IntPtr">
@@ -265,7 +265,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a <see cref="System.IntPtr"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Invalid">
@@ -283,7 +283,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents an invalid or uninitialized type code. It will not appear in valid signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Object">
@@ -301,7 +301,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a <see cref="System.Object"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="OptionalModifier">
@@ -319,7 +319,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a custom modifier applied to a type within a signature that the caller can ignore.</summary>
       </Docs>
     </Member>
     <Member MemberName="Pinned">
@@ -337,7 +337,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a local variable that is pinned by garbage collector.</summary>
       </Docs>
     </Member>
     <Member MemberName="Pointer">
@@ -355,7 +355,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents an unmanaged pointer in signatures. It is followed in the blob by the signature encoding of the underlying type.</summary>
       </Docs>
     </Member>
     <Member MemberName="RequiredModifier">
@@ -373,7 +373,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a custom modifier applied to a type within a signature that the caller must understand.</summary>
       </Docs>
     </Member>
     <Member MemberName="SByte">
@@ -391,7 +391,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents an <see cref="System.SByte"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Sentinel">
@@ -409,7 +409,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a marker to indicate the end of fixed arguments and the beginning of variable arguments.</summary>
       </Docs>
     </Member>
     <Member MemberName="Single">
@@ -427,7 +427,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Single"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="String">
@@ -445,7 +445,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.String"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="SZArray">
@@ -463,7 +463,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a single dimensional <see cref="System.Array"/> with a lower bound of 0.</summary>
       </Docs>
     </Member>
     <Member MemberName="TypedReference">
@@ -481,7 +481,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a typed reference in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="TypeHandle">
@@ -499,7 +499,15 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Precedes a type <see cref="EntityHandle"/> in signatures.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ In raw metadata, this will be encoded as either ELEMENT_TYPE_CLASS (0x12) for reference types and ELEMENT_TYPE_VALUETYPE (0x11) for value types. This is collapsed to a single code because Windows Runtime projections can project from class to value type or vice-versa and the raw code is misleading in those cases.
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="UInt16">
@@ -517,7 +525,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.UInt16"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt32">
@@ -535,7 +543,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.UInt32"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="UInt64">
@@ -553,7 +561,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.UInt64"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="UIntPtr">
@@ -571,7 +579,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents a <see cref="System.UIntPtr"/> in signatures.</summary>
       </Docs>
     </Member>
     <Member MemberName="Void">
@@ -589,7 +597,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Represents <see cref="System.Void"/> in signatures.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureTypeKind.xml
+++ b/xml/System.Reflection.Metadata/SignatureTypeKind.xml
@@ -11,8 +11,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Indicates the type definition of the signature.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="Class">
@@ -29,7 +29,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The type definition or reference refers to a class.</summary>
       </Docs>
     </Member>
     <Member MemberName="Unknown">
@@ -46,7 +46,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>It is not known in the current context if the type reference or definition is a class or value type.</summary>
       </Docs>
     </Member>
     <Member MemberName="ValueType">
@@ -63,7 +63,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The type definition or reference refers to a value type.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Reflection.Metadata/SignatureTypeKind.xml
+++ b/xml/System.Reflection.Metadata/SignatureTypeKind.xml
@@ -46,7 +46,7 @@
         <ReturnType>System.Reflection.Metadata.SignatureTypeKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>It is not known in the current context if the type reference or definition is a class or value type.</summary>
+        <summary>It isn't known in the current context if the type reference or definition is a class or value type.</summary>
       </Docs>
     </Member>
     <Member MemberName="ValueType">

--- a/xml/System.Reflection.Metadata/StandaloneSignatureKind.xml
+++ b/xml/System.Reflection.Metadata/StandaloneSignatureKind.xml
@@ -12,8 +12,8 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Indicates whether a <see cref="T:System.Reflection.Metadata.StandaloneSignature"/> represents a standalone method or local variable signature.</summary>
+    <remarks></remarks>
   </Docs>
   <Members>
     <Member MemberName="LocalVariables">
@@ -31,7 +31,7 @@
         <ReturnType>System.Reflection.Metadata.StandaloneSignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The <see cref="T:System.Reflection.Metadata.MemberReference"/> references a local variable signature.</summary>
       </Docs>
     </Member>
     <Member MemberName="Method">
@@ -49,7 +49,7 @@
         <ReturnType>System.Reflection.Metadata.StandaloneSignatureKind</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>The <see cref="T:System.Reflection.Metadata.StandaloneSignature"/> represents a standalone method signature.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/ns-System.Reflection.Metadata.xml
+++ b/xml/ns-System.Reflection.Metadata.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Reflection.Metadata">
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>The <see cref="N:System.Reflection.Metadata" /> namespace contains types that represent metadata information about assemblies, modules, members, parameters, and other entities in managed code.</summary>
+    <remarks></remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
# Title
Add Undocumented APIs: System.​Reflection.​Metadata Namespace - Signature APIs

## Summary
Added missing documentation for the group of Signature APIs in the System.​Reflection.​Metadata Namespace. This group contains the following topics:

- ConstantTypeCode.xml
- CustomAttributeNamedArgument`1.xml
- CustomAttributeNamedArgumentKind.xml
- CustomAttributeTypedArgument`1.xml
- CustomAttributeValue`1.xml
- MemberReferenceKind.xml
- MethodSignature`1.xml
- PrimitiveSerializationTypeCode.xml
- PrimitiveTypeCode.xml
- SerializationTypeCode.xml
- SignatureAttributes.xml
- SignatureCallingConvention.xml
- SignatureHeader.xml
- SignatureKind.xml
- SignatureTypeCode.xml
- SignatureTypeKind.xml
- StandaloneSignatureKind.xml

The source code for these topics is located at:
https://github.com/dotnet/corefx/blob/master/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures

Issue #2487 

## Suggested Reviewers
@mairaw 

