### PR TITLE
exporting namespace descriptions

### DIFF
--- a/xml/ns-System.EnterpriseServices.CompensatingResourceManager.xml
+++ b/xml/ns-System.EnterpriseServices.CompensatingResourceManager.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.EnterpriseServices.CompensatingResourceManager">
   <Docs>
-    <summary>To be added.</summary>
+    <summary>The <see cref="N:System.EnterpriseServices.CompensatingResourceManager" /> namespace provides classes that allow you to use a Compensating Resource Manager (CRM) in managed code. A CRM is a service provided by COM+ that enables you to include non transactional objects in Microsoft Distributed Transaction Coordinator (DTC) transactions. Although CRMs do not provide the capabilities of a full resource manager, they do provide transactional atomicity (all or nothing behavior) and durability through the recovery log.</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>

--- a/xml/ns-System.EnterpriseServices.Internal.xml
+++ b/xml/ns-System.EnterpriseServices.Internal.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.EnterpriseServices.Internal">
   <Docs>
-    <summary>To be added.</summary>
+    <summary>The <see cref="N:System.EnterpriseServices.Internal" /> namespace provides infrastructure support for COM+ services. The classes and interfaces in this namespace are specifically intended to support calls into <see cref="N:System.EnterpriseServices" /> from the unmanaged COM+ classes.</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>

--- a/xml/ns-System.EnterpriseServices.xml
+++ b/xml/ns-System.EnterpriseServices.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.EnterpriseServices">
   <Docs>
-    <summary>To be added.</summary>
+    <summary>The <see cref="N:System.EnterpriseServices" /> namespace provides an important infrastructure for enterprise applications. COM+ provides a services architecture for component programming models deployed in an enterprise environment. This namespace provides .NET objects with access to COM+ services making the .NET Framework objects more practical for enterprise applications.</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
When we brought the System.EnterpriseServices* namespaces, we didn't bring the namespace descriptions. So doing that now.