### PR TITLE
Add .NET Core app preprocessor symbols to the list

### DIFF
--- a/includes/preprocessor-symbols.md
+++ b/includes/preprocessor-symbols.md
@@ -1,19 +1,21 @@
  ```
-.NET Framework 2.0   --> NET20
-.NET Framework 3.5   --> NET35
-.NET Framework 4.0   --> NET40
-.NET Framework 4.5   --> NET45
-.NET Framework 4.5.1 --> NET451
-.NET Framework 4.5.2 --> NET452
-.NET Framework 4.6   --> NET46
-.NET Framework 4.6.1 --> NET461
-.NET Framework 4.6.2 --> NET462
-.NET Framework 4.7   --> NET47
-.NET Standard 1.0    --> NETSTANDARD1_0
-.NET Standard 1.1    --> NETSTANDARD1_1
-.NET Standard 1.2    --> NETSTANDARD1_2
-.NET Standard 1.3    --> NETSTANDARD1_3
-.NET Standard 1.4    --> NETSTANDARD1_4
-.NET Standard 1.5    --> NETSTANDARD1_5
-.NET Standard 1.6    --> NETSTANDARD1_6
+.NET Framework 2.0        --> NET20
+.NET Framework 3.5        --> NET35
+.NET Framework 4.0        --> NET40
+.NET Framework 4.5        --> NET45
+.NET Framework 4.5.1      --> NET451
+.NET Framework 4.5.2      --> NET452
+.NET Framework 4.6        --> NET46
+.NET Framework 4.6.1      --> NET461
+.NET Framework 4.6.2      --> NET462
+.NET Framework 4.7        --> NET47
+.NET Standard 1.0         --> NETSTANDARD1_0
+.NET Standard 1.1         --> NETSTANDARD1_1
+.NET Standard 1.2         --> NETSTANDARD1_2
+.NET Standard 1.3         --> NETSTANDARD1_3
+.NET Standard 1.4         --> NETSTANDARD1_4
+.NET Standard 1.5         --> NETSTANDARD1_5
+.NET Standard 1.6         --> NETSTANDARD1_6
+.NET Core Application 1.0 --> NETCOREAPP1_0
+.NET Core Application 1.1 --> NETCOREAPP1_1
 ```


### PR DESCRIPTION
Adding the `NETCOREAPPX_Y` ones to the list.