### PR TITLE
Fixed metadata formatting

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
+++ b/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
@@ -1,7 +1,6 @@
 ---
-title: "Ref return values and ref locals (C# Guide) |  | Microsoft Docs"
+title: "Ref return values and ref locals (C# Guide) | Microsoft Docs"
 description: "Learn how to define and use ref return and ref local values"
-keywords: "ref returns, C#", "reference return values, C#", "ref return values, C#", "ref locals, C#", "ref local values, C#" 
 author: "rpetrusha"
 ms.author: "ronpet"
 ms.date: "05/30/2017"


### PR DESCRIPTION
# Fixed metadata formatting

## Summary

The topic's metadata appears on [docs.microsoft.com](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/ref-returns). I didn't see anything obvious that caused it, but I'm hoping that the changes I made fixed the issue.

Fixes #2650 

## Suggested Reviewers

@Billwagner, @Daniel15
