### PR TITLE
branding fix

### DIFF
--- a/docs/core/build/index.md
+++ b/docs/core/build/index.md
@@ -83,7 +83,7 @@ There are two basic techniques for using your new runtime:
 
 The source code for the .NET Core CLI can be found in [the `dotnet/cli` repository on GitHub](https://github.com/dotnet/cli/).
 
-In order to build the .NET CLI, you need the following installed on your machine.
+In order to build the .NET Core CLI, you need the following installed on your machine.
 
 * Windows & Linux:
     - git on the PATH

--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -26,8 +26,8 @@ When writing unit tests, be careful you don’t accidentally introduce dependenc
 
 Learn more about unit testing in .NET Core projects:
 
-* Try this [walkthrough creating unit tests with xUnit and the .NET CLI](unit-testing-with-dotnet-test.md). 
+* Try this [walkthrough creating unit tests with xUnit and the .NET Core CLI](unit-testing-with-dotnet-test.md). 
 * The XUnit team has written a tutorial that shows
 [how to use xUnit with .NET Core and Visual Studio](http://xunit.github.io/docs/getting-started-dotnet-core.html).
-* If you prefer using MSTest, try the [walkthrough creating unit tests with MSTest and the .NET CLI](unit-testing-with-mstest.md).
+* If you prefer using MSTest, try the [walkthrough creating unit tests with MSTest and the .NET Core CLI](unit-testing-with-mstest.md).
 * For a additional information and examples on how to use selective unit test filtering, see [Running selective unit tests](../testing/selective-unit-tests.md).

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -92,7 +92,7 @@ If set, the installer includes debugging symbols in the installation.
 
 `-DryRun`
 
-If set, the script won't perform the installation; but instead, it displays what command line to use to consistently install the currently requested version of the .NET CLI. For example if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
+If set, the script won't perform the installation; but instead, it displays what command line to use to consistently install the currently requested version of the .NET Core CLI. For example if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
 
 `-NoPath`
 
@@ -152,7 +152,7 @@ If set, the installer includes debugging symbols in the installation.
 
 `--dry-run`
 
-If set, the script won't perform the installation; but instead, it displays what command line to use to consistently install the currently requested version of the .NET CLI. For example if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
+If set, the script won't perform the installation; but instead, it displays what command line to use to consistently install the currently requested version of the .NET Core CLI. For example if you specify version `latest`, it displays a link with the specific version so that this command can be used deterministically in a build script. It also displays the binary's location if you prefer to install or download it yourself.
 
 `--no-path`
 

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -217,7 +217,7 @@ Each of these contain the `.dll` files for each target.
 It's important to be able to test across platforms. You can use either [xUnit](http://xunit.github.io/) or MSTest out of the box. Both are perfectly suitable for unit testing your library on .NET Core. How you set up your solution with test projects will depend on the [structure of your solution](#structuring-a-solution). The following example assumes that the test and source directories live in the same top-level directory.
 
 > [!NOTE]
-> This uses some [.NET CLI commands](../tools/index.md). See [dotnet new](../tools/dotnet-new.md) and [dotnet sln](../tools/dotnet-sln.md) for more information.
+> This uses some [.NET Core CLI commands](../tools/index.md). See [dotnet new](../tools/dotnet-new.md) and [dotnet sln](../tools/dotnet-sln.md) for more information.
 
 1. Set up your solution. You can do so with the following commands:
 
@@ -317,7 +317,7 @@ This will add the three projects above and a solution file which links them toge
 
 ### Project-to-project referencing
 
-The best way to reference a project is to use the .NET CLI to add a project reference. From the **AwesomeLibrary.CSharp** and **AwesomeLibrary.FSharp** project directories, you can run the following command:
+The best way to reference a project is to use the .NET Core CLI to add a project reference. From the **AwesomeLibrary.CSharp** and **AwesomeLibrary.FSharp** project directories, you can run the following command:
 
 ```console
 $ dotnet add reference ../AwesomeLibrary.Core/AwesomeLibrary.Core.csproj
@@ -331,7 +331,7 @@ The project files for both **AwesomeLibrary.CSharp** and **AwesomeLibrary.FSharp
 </ItemGroup>
 ```
 
-You can add this section to each project file manually if you prefer not to use the .NET CLI.
+You can add this section to each project file manually if you prefer not to use the .NET Core CLI.
 
 ### Structuring a solution
 

--- a/docs/core/tutorials/testing-with-cli.md
+++ b/docs/core/tutorials/testing-with-cli.md
@@ -1,7 +1,7 @@
 ---
 title: Organizing and testing projects with the .NET Core command line | Microsoft Docs
 description: This tutorial explains how to organize and test .NET Core projects from the command line.
-keywords: .NET, .NET Core, unit testing, .NET CLI, xUnit
+keywords: .NET, .NET Core, unit testing, .NET Core CLI, xUnit
 author: cartermp
 ms.author: mairaw
 ms.date: 05/16/2017

--- a/docs/fsharp/get-started/get-started-command-line.md
+++ b/docs/fsharp/get-started/get-started-command-line.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with F# with command-line tools | Microsoft Docs
-description: Learn how to use F# with the cross-platform .NET CLI.
+description: Learn how to use F# with the cross-platform .NET Core CLI.
 keywords: visual f#, f#, functional programming, .NET, .NET Core
 author: cartermp
 ms.author: phcart
@@ -12,7 +12,7 @@ ms.devlang: fsharp
 ms.assetid: 615db1ec-6ef3-4de2-bae6-4586affa9771
 ---
 
-# Get started with F# with the .NET CLI
+# Get started with F# with the .NET Core CLI
 
 This article covers how you can get started with using F# on .NET Core. It will go through building a multi-project solution with a Class Library that is called by a Console Application.
 

--- a/docs/fsharp/get-started/index.md
+++ b/docs/fsharp/get-started/index.md
@@ -18,8 +18,8 @@ There are multiple ways to get started with F#.  We have multiple articles writt
 
 | OS | Prefer Visual Studio | Prefer Visual Studio Code | Prefer a command line |
 | -- |------------------------|--------------------------|-----------------------------|-------------------------|
-| Windows | [Get started with Visual Studio](get-started-visual-studio.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET CLI](get-started-vscode.md) |
-| macOS | [Get started with VS for Mac](get-started-with-visual-studio-for-mac.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET CLI](get-started-command-line.md) |
-| Linux | N/A | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET CLI](get-started-command-line.md) |
+| Windows | [Get started with Visual Studio](get-started-visual-studio.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-vscode.md) |
+| macOS | [Get started with VS for Mac](get-started-with-visual-studio-for-mac.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-command-line.md) |
+| Linux | N/A | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-command-line.md) |
 
 In general, there is no specific way to get started which is better than the rest.  We recommend trying all ways to use F# on your machine to see what you like the best!

--- a/docs/standard/components.md
+++ b/docs/standard/components.md
@@ -63,7 +63,7 @@ Tooling for .NET is also common across each implementation of .NET.  These inclu
 * .NET project system (sometimes known as "csproj", "vbproj", or "fsproj")
 * MSBuild, the build engine used to build projects
 * NuGet, Microsoft's package manager for .NET
-* The .NET CLI, a cross-platform command-line interface for building .NET projects
+* The .NET Core CLI, a cross-platform command-line interface for building .NET projects
 * Open Source build orchestration tools, such as CAKE and FAKE
 
 The main takeaway here should be that there is a vast amount of tooling and infrastructure which is common for any "flavor" of .NET you choose to build your apps with.

--- a/docs/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow.md
+++ b/docs/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow.md
@@ -114,7 +114,7 @@ ENTRYPOINT ["dotnet", " MySingleContainerWebApp.dll "]
 
 In this case, the container is based on version 1.1 of the official ASP.NET Core Docker image for Linux; this is the setting FROM microsoft/aspnetcore:1.1. (For further details about this base image, see the [ASP.NET Core Docker Image](https://hub.docker.com/r/microsoft/aspnetcore/) page and the [.NET Core Docker Image](https://hub.docker.com/r/microsoft/dotnet/) page.) In the Dockerfile, you also need to instruct Docker to listen on the TCP port you will use at runtime (in this case, port 80, as configured with the EXPOSE setting).
 
-You can specify additional configuration settings in the Dockerfile, depending on the language and framework you are using. For instance, the ENTRYPOINT line with \["dotnet", "MySingleContainerWebApp.dll"\] tells Docker to run a .NET Core application. If you are using the SDK and the .NET CLI (dotnet CLI) to build and run the .NET application, this setting would be different. The bottom line is that the ENTRYPOINT line and other settings will be different depending on the language and platform you choose for your application.
+You can specify additional configuration settings in the Dockerfile, depending on the language and framework you are using. For instance, the ENTRYPOINT line with \["dotnet", "MySingleContainerWebApp.dll"\] tells Docker to run a .NET Core application. If you are using the SDK and the .NET Core CLI (dotnet CLI) to build and run the .NET application, this setting would be different. The bottom line is that the ENTRYPOINT line and other settings will be different depending on the language and platform you choose for your application.
 
 ### Additional resources
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,7 @@ you can read more about the concepts covered in each sample.
 
 ## Building a sample
 
-You build the samples using the .NET CLI. You can download the CLI from
+You build the samples using the .NET Core CLI. You can download the CLI from
 [the .NET Core home page](http://microsoft.com/net/core). Then, execute
 these commands from the CLI in the directory of any sample:
 


### PR DESCRIPTION
For now, the branding for CLI is .NET Core CLI. So standardizing on that across the board.