### PR TITLE
adding F# selector

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -114,9 +114,9 @@
         "api/**.yml": "managed-reference",
         "_csharplang/spec/*.md": "language-reference"
      },
-      "dev_langs": {
-        "api/System.Convert.yml": ["csharp", "vb", "cpp", "fsharp"],
-        "api/**.yml": ["csharp", "vb", "cpp"]
+      "langs": {
+        "api/**.yml": ["csharp", "vb", "cpp"],
+        "api/System.Convert.yml": ["csharp", "vb", "cpp", "fsharp"]        
       },
       "ROBOTS": {
         "api/**.yml": "NOINDEX, NOFOLLOW"

--- a/docfx.json
+++ b/docfx.json
@@ -115,6 +115,7 @@
         "_csharplang/spec/*.md": "language-reference"
      },
       "langs": {
+        "api/System.Convert.yml": ["csharp", "vb", "cpp", "fsharp"],
         "api/**.yml": ["csharp", "vb", "cpp"]
       },
       "ROBOTS": {

--- a/docfx.json
+++ b/docfx.json
@@ -114,7 +114,7 @@
         "api/**.yml": "managed-reference",
         "_csharplang/spec/*.md": "language-reference"
      },
-      "langs": {
+      "dev_langs": {
         "api/System.Convert.yml": ["csharp", "vb", "cpp", "fsharp"],
         "api/**.yml": ["csharp", "vb", "cpp"]
       },


### PR DESCRIPTION
With the new samples added by PR #2641, I'd like to see how we can add the F# selector to the applicable pages.

For example: https://docs.microsoft.com/en-us/dotnet/api/system.convert.tostring?view=netframework-4.7#System_Convert_ToString_System_Boolean_

/cc @cartermp 