### PR TITLE
Update buttonstages.xaml

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Wpf/vsmbuttontemplate/csharp/buttonstages.xaml
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/vsmbuttontemplate/csharp/buttonstages.xaml
@@ -104,15 +104,15 @@
                     <!--Define the states and transitions for the common states.
                         The states in the VisualStateGroup are mutually exclusive to
                         each other.-->
-                    <VisualStateGroup Name="CommonStates">
+                    <VisualStateGroup x:Name="CommonStates">
 
                       <!--The Normal state is the state the button is in
                           when it is not in another state from this VisualStateGroup.-->
-                      <VisualState Name="Normal" />
+                      <VisualState x:Name="Normal" />
 
                       <!--Change the SolidColorBrush, BorderBrush, to red when the
                           mouse is over the button.-->
-                      <VisualState Name="MouseOver">
+                      <VisualState x:Name="MouseOver">
                         <Storyboard>
                           <ColorAnimation Storyboard.TargetName="BorderBrush" 
                                           Storyboard.TargetProperty="Color" 
@@ -122,7 +122,7 @@
 
                       <!--Change the SolidColorBrush, BorderBrush, to Transparent when the
                           button is pressed.-->
-                      <VisualState Name="Pressed">
+                      <VisualState x:Name="Pressed">
                         <Storyboard>
                           <ColorAnimation Storyboard.TargetName="BorderBrush" 
                                           Storyboard.TargetProperty="Color"
@@ -185,7 +185,7 @@
                 <Border x:Name="RootElement">
                   <VisualStateManager.VisualStateGroups>
                     <!--<SnippetVisualTransitions>-->
-                    <VisualStateGroup Name="CommonStates">
+                    <VisualStateGroup x:Name="CommonStates">
 
                       <!--Define the VisualTransitions that
                           can be used when the control transitions 
@@ -237,9 +237,9 @@
                       <!--The remainder of the VisualStateGroup is the
                           same as the previous example.-->
 
-                      <VisualState Name="Normal" />
+                      <VisualState x:Name="Normal" />
 
-                      <VisualState Name="MouseOver">
+                      <VisualState x:Name="MouseOver">
                         <Storyboard>
                           <ColorAnimation 
                             Storyboard.TargetName="BorderBrush" 
@@ -249,7 +249,7 @@
                         </Storyboard>
                       </VisualState>
 
-                      <VisualState Name="Pressed">
+                      <VisualState x:Name="Pressed">
                         <Storyboard>
                           <ColorAnimation 
                             Storyboard.TargetName="BorderBrush" 


### PR DESCRIPTION
# Title
appending "x:" in front of Name attributes

## Summary
Without appending "x:" in front of Name, user will get error - "Cannot assign CommonStates into the read only property "CommonStates".

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Without appending "x:" in front of Name, user will get error - "Cannot assign CommonStates into the read only property "CommonStates".

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
