### PR TITLE
IronPython is now on GitHub

### DIFF
--- a/docs/framework/reflection-and-codedom/dynamic-language-runtime-overview.md
+++ b/docs/framework/reflection-and-codedom/dynamic-language-runtime-overview.md
@@ -54,7 +54,7 @@ The *dynamic language runtime* (DLR) is a runtime environment that adds a set of
   
  Examples of languages developed by using the DLR include the following:  
   
--   IronPython. Available as open-source software from the [CodePlex](http://go.microsoft.com/fwlink/?LinkId=141040) Web site.  
+-   IronPython. Available as open-source software from the [GitHub](https://github.com/IronLanguages/ironpython2) Web site.  
   
 -   IronRuby. Available as open-source software from the [RubyForge](http://go.microsoft.com/fwlink/?LinkId=141044) Web site.  
   


### PR DESCRIPTION
The IronPython repository has been moved from CodePlex to GitHub.