### PR TITLE
Update type-conversion.md

### DIFF
--- a/docs/standard/base-types/type-conversion.md
+++ b/docs/standard/base-types/type-conversion.md
@@ -5,7 +5,7 @@ ms.date: "03/30/2017"
 ms.prod: ".net"
 ms.reviewer: ""
 ms.suite: ""
-ms.technology:v
+ms.technology: v
 ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords: 

--- a/docs/standard/base-types/type-conversion.md
+++ b/docs/standard/base-types/type-conversion.md
@@ -5,7 +5,7 @@ ms.date: "03/30/2017"
 ms.prod: ".net"
 ms.reviewer: ""
 ms.suite: ""
-ms.technology: v
+ms.technology: dotnet-standard
 ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords: 


### PR DESCRIPTION
# Fixed a space in formatting causing page metadata to show at top of article.

## Details

Fix typo in type-conversion.md. 
