### PR TITLE
Document Explicit/Implicit operators for IntPtr, UIntPtr, BigInteger

### DIFF
--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -2737,7 +2737,7 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
 
 ## Examples
@@ -2794,7 +2794,7 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
 
 ## Examples
@@ -2845,7 +2845,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type. There is no loss of precision in the resulting <xref:System.Byte> value if the conversion is successful.
 
@@ -2897,7 +2897,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type. 
 
@@ -2949,7 +2949,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
 
  Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Double> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Double.MinValue?displayProperty=fullName>, the resulting <xref:System.Double> value is <xref:System.Double.NegativeInfinity?displayProperty=fullName>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Double.MaxValue?displayProperty=fullName>, the resulting <xref:System.Double> value is <xref:System.Double.PositiveInfinity?displayProperty=fullName>.
  
@@ -3008,7 +3008,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
 
@@ -3065,7 +3065,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
 
@@ -3122,7 +3122,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type. 
 
@@ -3179,7 +3179,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type. There is no loss of precision in the resulting <xref:System.SByte> value if the conversion is successful.
 
@@ -3226,7 +3226,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Single> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Single.MinValue?displayProperty=fullName>, the resulting <xref:System.Single> value is <xref:System.Single.NegativeInfinity?displayProperty=fullName>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Single.MaxValue?displayProperty=fullName>, the resulting <xref:System.Single> value is <xref:System.Single.PositiveInfinity?displayProperty=fullName>.
 
@@ -3290,7 +3290,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type. There is no loss of precision in the resulting <xref:System.UInt16> value if the conversion is successful.
 
@@ -3347,7 +3347,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type. There is no loss of precision in the resulting <xref:System.UInt32> value if the conversion is successful.
 
@@ -3404,7 +3404,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type. There is no loss of precision in the resulting <xref:System.UInt64> value if the conversion is successful.
 
@@ -3462,7 +3462,7 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
  
- The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
 
 ## Examples

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -4081,7 +4081,7 @@ value Mod 2 = 0
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
  [!code-csharp[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#2)]
- [!code-vb[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigIntegerImplicit/vb/Implicit1.vb#2)]  
+ [!code-vb[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#2)]  
 
  ]]></format>
         </remarks>

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -2852,8 +2852,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Byte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#1)]
- [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#1)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#1)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#1)]  
 
  ]]></format>
         </remarks>
@@ -2904,8 +2904,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Decimal> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#2)]
- [!code-vb[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#2)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#2)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#2)]  
 
  ]]></format>
         </remarks>
@@ -2962,8 +2962,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Double> values.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#3)]
- [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#3)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#3)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#3)]  
 
  ]]></format>
         </remarks>
@@ -3014,8 +3014,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#4)]
- [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#4)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#4)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#4)]  
 
  ]]></format>
         </remarks>
@@ -3071,8 +3071,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#5)]
- [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#5)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#5)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#5)]  
 
  ]]></format>
         </remarks>
@@ -3128,8 +3128,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#6)]
- [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#6)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#6)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#6)]  
 
  ]]></format>
         </remarks>
@@ -3185,8 +3185,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.SByte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#7)]
- [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#7)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#7)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#7)]  
 
  ]]></format>
         </remarks>
@@ -3238,8 +3238,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Single> values. 
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#8)]
- [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#8)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#8)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#8)]  
 
  ]]></format>
         </remarks>
@@ -3295,8 +3295,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#9)]
- [!code-vb[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#9)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#9)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#9)]  
 
  ]]></format>
         </remarks>
@@ -3352,8 +3352,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#10)]
- [!code-vb[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#10)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#10)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#10)]  
 
  ]]></format>
         </remarks>
@@ -3409,8 +3409,8 @@ value Mod 2 = 0
 ## Examples
  The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type.
 
- [!code-csharp[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#11)]
- [!code-vb[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#11)]  
+ [!code-csharp[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#11)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#11)]  
 
  ]]></format>
         </remarks>
@@ -4038,8 +4038,8 @@ value Mod 2 = 0
 
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Byte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#1)]
- [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#1)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#1)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#1)]  
 
  ]]></format>
         </remarks>
@@ -4080,8 +4080,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#2)]
- [!code-vb[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#2)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#2)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigIntegerImplicit/vb/Implicit1.vb#2)]  
 
  ]]></format>
         </remarks>
@@ -4122,8 +4122,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#3)]
- [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#3)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#3)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#3)]  
 
  ]]></format>
         </remarks>
@@ -4164,8 +4164,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#4)]
- [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#4)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#4)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#4)]  
 
  ]]></format>
         </remarks>
@@ -4211,8 +4211,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.SByte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#5)]
- [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#5)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#5)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#5)]  
 
  ]]></format>
         </remarks>
@@ -4258,8 +4258,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#6)]
- [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#6)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#6)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#6)]  
 
  ]]></format>
         </remarks>
@@ -4305,8 +4305,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#7)]
- [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#7)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#7)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#7)]  
 
  ]]></format>
         </remarks>
@@ -4352,8 +4352,8 @@ value Mod 2 = 0
 ## Remarks  
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
  
- [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#8)]
- [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#8)]  
+ [!code-csharp[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#8)]
+ [!code-vb[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#8)]  
 
  ]]></format>
         </remarks>

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -2737,7 +2737,9 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.   
+
+ For languages that do not support explicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Decimal%29displayProperty=fullName>.
 
 
 ## Examples
@@ -2795,6 +2797,8 @@ value Mod 2 = 0
  Any fractional part of the `value` parameter is truncated before conversion.
 
  The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+
+  For languages that do not support explicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Double%29displayProperty=fullName>.
 
 
 ## Examples
@@ -3168,7 +3172,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to a signed 8-bit value.</param>
-        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a signed 8-bit value.</summary>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a signed 8-bit value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="T:System.Int16" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.SByte.MinValue" />.  
   
@@ -3279,7 +3285,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to an unsigned 16-bit integer.</param>
-        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 16-bit integer value.</summary>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 16-bit integer value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="T:System.Int32" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.UInt16.MinValue" />.  
   
@@ -3336,7 +3344,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to an unsigned 32-bit integer.</param>
-        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 32-bit integer value.</summary>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 32-bit integer value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="T:System.Int64" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.UInt32.MinValue" />.  
   
@@ -3393,7 +3403,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to an unsigned 64-bit integer.</param>
-        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 64-bit integer value.</summary>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 64-bit integer value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="T:System.Double" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.UInt64.MinValue" />.  
   
@@ -3463,6 +3475,8 @@ value Mod 2 = 0
  Any fractional part of the `value` parameter is truncated before conversion.
  
  The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+
+ For languages that do not support explicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Single%29displayProperty=fullName>.
 
 
 ## Examples
@@ -4205,7 +4219,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
-        <summary>Defines an implicit conversion of an 8-bit signed integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <summary>Defines an implicit conversion of an 8-bit signed integer to a <see cref="T:System.Numerics.BigInteger" /> value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="M:System.Numerics.BigInteger.#ctor(System.Int32)" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -4252,7 +4268,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
-        <summary>Defines an implicit conversion of a 16-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <summary>Defines an implicit conversion of a 16-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="M:System.Numerics.BigInteger.op_Implicit(System.Int32)~System.Numerics.BigInteger" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -4299,7 +4317,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
-        <summary>Defines an implicit conversion of a 32-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <summary>Defines an implicit conversion of a 32-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="M:System.Numerics.BigInteger.op_Implicit(System.Int64)~System.Numerics.BigInteger" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -4346,7 +4366,9 @@ value Mod 2 = 0
       </Parameters>
       <Docs>
         <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
-        <summary>Defines an implicit conversion of a 64-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <summary>Defines an implicit conversion of a 64-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.  
+  
+ This API is not CLS-compliant. The compliant alternative is <see cref="T:System.Double" />.</summary>
         <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -2737,14 +2737,14 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the Explicit(Decimal to BigInteger) method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
 
 ## Examples
- The following example converts the individual elements in an array of <xref:System.Decimal> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Decimal> value is truncated during the conversion.
- 
- [!code-csharp[System.Numerics.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#1)]
- [!code-vb[System.Numerics.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#1)]  
+ The following example converts the individual elements in an array of <xref:System.Decimal> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Decimal> value is truncated during the conversion.   
+
+ [!code-csharp[System.Numerics.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#1)]   
+ [!code-vb[System.Numerics.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#1)]   
 
  ]]></format>
         </remarks>
@@ -2794,14 +2794,14 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
 
 ## Examples
- The following example converts the individual elements in an array of <xref:System.Double> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Double> value is truncated during the conversion.
- 
- [!code-csharp[System.Numerics.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#2)]
- [!code-vb[System.Numerics.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#2)]  
+ The following example converts the individual elements in an array of <xref:System.Double> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Double> value is truncated during the conversion.   
+    
+ [!code-csharp[System.Numerics.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#2)]   
+ [!code-vb[System.Numerics.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#2)]   
 
  ]]></format>
         </remarks>
@@ -2845,15 +2845,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type. There is no loss of precision in the resulting <xref:System.Byte> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Byte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#1)]
- [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#1)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Byte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#1)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#1)]   
 
  ]]></format>
         </remarks>
@@ -2897,13 +2897,13 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type. 
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Decimal> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type.
-
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Decimal> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type.   
+    
  [!code-csharp[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#2)]
  [!code-vb[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#2)]  
 
@@ -2949,21 +2949,22 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
 
- Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Double> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Double.MinValue>, the resulting <xref:System.Double> value is <xref:System.Double.NegativeInfinity>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Numerics.BigInteger>, the resulting <xref:System.Double> value is <xref:System.Double.PositiveInfinity>.
+ Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Double> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Double.MinValue?displayProperty=fullName>, the resulting <xref:System.Double> value is <xref:System.Double.NegativeInfinity?displayProperty=fullName>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Double.MaxValue?displayProperty=fullName>, the resulting <xref:System.Double> value is <xref:System.Double.PositiveInfinity?displayProperty=fullName>.
  
- The conversion of a <xref:System.Numerics.BigInteger> to a <xref:System.Double> may involve a loss of precision. In some cases, the loss of precision may cause the casting or conversion operation to succeed even if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Double> data type. The following example provides an illustration. It assigns the maximum value of a <xref:System.Double> to two <xref:System.Numerics.BigInteger> variables, increments one <xref:System.Numerics.BigInteger> variable by 9.999e291, and tests the two variables for equality. As expected, the call to the <xref:System.Numerics.BigInteger.Equals%28System.Numerics.BigInteger%29?displayProperty=fullName> method shows that they are unequal. However, the conversion of the larger <xref:System.Numerics.BigInteger> value back to a <xref:System.Double> succeeds, although the <xref:System.Numerics.BigInteger> value now exceeds <xref:System.Double.MaxValue>.
+ The conversion of a <xref:System.Numerics.BigInteger> to a <xref:System.Double> may involve a loss of precision. In some cases, the loss of precision may cause the casting or conversion operation to succeed even if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Double> data type. The following example provides an illustration. It assigns the maximum value of a <xref:System.Double> to two <xref:System.Numerics.BigInteger> variables, increments one <xref:System.Numerics.BigInteger> variable by 9.999e291, and tests the two variables for equality. As expected, the call to the <xref:System.Numerics.BigInteger.Equals%28System.Numerics.BigInteger%29?displayProperty=fullName> method shows that they are unequal. However, the conversion of the larger <xref:System.Numerics.BigInteger> value back to a <xref:System.Double> succeeds, although the <xref:System.Numerics.BigInteger> value now exceeds <xref:System.Double.MaxValue?displayProperty=fullName>.   
+    
+ [!code-csharp[System.Numerics.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#4)]   
+ [!code-vb[System.Numerics.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#4)]   
 
- [!code-csharp[System.Numerics.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#4)]
- [!code-vb[System.Numerics.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#4)]  
 
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Double> values.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#3)]
- [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#3)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Double> values.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#3)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#3)]   
 
  ]]></format>
         </remarks>
@@ -3007,15 +3008,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#4)]
- [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#4)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#4)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#4)]   
 
  ]]></format>
         </remarks>
@@ -3064,15 +3065,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#5)]
- [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#5)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#5)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#5)]   
 
  ]]></format>
         </remarks>
@@ -3121,15 +3122,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type. 
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#6)]
- [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#6)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#6)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#6)]   
 
  ]]></format>
         </remarks>
@@ -3178,15 +3179,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type. There is no loss of precision in the resulting <xref:System.SByte> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.SByte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#7)]
- [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#7)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.SByte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#7)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#7)]   
 
  ]]></format>
         </remarks>
@@ -3225,21 +3226,22 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
- Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Single> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Single.MinValue>, the resulting <xref:System.Single> value is <xref:System.Single.NegativeInfinity>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Single.MaxValue>, the resulting <xref:System.Single> value is <xref:System.Single.PositiveInfinity>.
+ Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Single> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Single.MinValue?displayProperty=fullName>, the resulting <xref:System.Single> value is <xref:System.Single.NegativeInfinity?displayProperty=fullName>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Single.MaxValue?displayProperty=fullName>, the resulting <xref:System.Single> value is <xref:System.Single.PositiveInfinity?displayProperty=fullName>.
 
- The conversion of a <xref:System.Numerics.BigInteger> to a <xref:System.Single> may involve a loss of precision. In some cases, the loss of precision may cause the casting or conversion operation to succeed even if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Single> data type. The following example provides an illustration. It assigns the maximum value of a <xref:System.Single> to two <xref:System.Numerics.BigInteger> variables, increments one <xref:System.Numerics.BigInteger> variable by 9.999e291, and tests the two variables for equality. As expected, the call to the <xref:System.Numerics.BigInteger.Equals%28System.Numerics.BigInteger%29?displayProperty=fullName> method shows that they are unequal. However, the conversion of the larger <xref:System.Numerics.BigInteger> value back to a <xref:System.Single> succeeds, although the <xref:System.Numerics.BigInteger> value now exceeds <xref:System.Single.MaxValue>.
+ The conversion of a <xref:System.Numerics.BigInteger> to a <xref:System.Single> may involve a loss of precision. In some cases, the loss of precision may cause the casting or conversion operation to succeed even if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Single> data type. The following example provides an illustration. It assigns the maximum value of a <xref:System.Single> to two <xref:System.Numerics.BigInteger> variables, increments one <xref:System.Numerics.BigInteger> variable by 9.999e291, and tests the two variables for equality. As expected, the call to the <xref:System.Numerics.BigInteger.Equals%28System.Numerics.BigInteger%29?displayProperty=fullName> method shows that they are unequal. However, the conversion of the larger <xref:System.Numerics.BigInteger> value back to a <xref:System.Single> succeeds, although the <xref:System.Numerics.BigInteger> value now exceeds <xref:System.Single.MaxValue?displayProperty=fullName>.   
+    
+ [!code-csharp[System.Numerics.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#5)]   
+ [!code-vb[System.Numerics.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#5)]   
 
- [!code-csharp[System.Numerics.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#5)]
- [!code-vb[System.Numerics.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#5)]  
 
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Single> values. 
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#8)]
- [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#8)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Single> values.   
+     
+ [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#8)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#8)]   
 
  ]]></format>
         </remarks>
@@ -3288,15 +3290,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type. There is no loss of precision in the resulting <xref:System.UInt16> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#9)]
- [!code-vb[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#9)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#9)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#9)]   
 
  ]]></format>
         </remarks>
@@ -3345,15 +3347,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type. There is no loss of precision in the resulting <xref:System.UInt32> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#10)]
- [!code-vb[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#10)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#10)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#10)]   
 
  ]]></format>
         </remarks>
@@ -3402,15 +3404,15 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type. There is no loss of precision in the resulting <xref:System.UInt64> value if the conversion is successful.
 
 ## Examples
- The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type.
-
- [!code-csharp[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#11)]
- [!code-vb[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#11)]  
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type.   
+    
+ [!code-csharp[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/System.Numeric.BigInteger.Explicit.cs#11)]   
+ [!code-vb[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/System.Numeric.BigInteger.Explicit.vb#11)]   
 
  ]]></format>
         </remarks>
@@ -3460,14 +3462,14 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numbers.BigInteger.op_Explicit%2A> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
 
 ## Examples
  The following example converts the individual elements in an array of <xref:System.Single> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Single> value is truncated during the conversion.
  
- [!code-csharp[System.Numerics.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#3)]
- [!code-vb[System.Numerics.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#3)]  
+ [!code-csharp[System.Numerics.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#3)]   
+ [!code-vb[System.Numerics.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#3)]   
 
  ]]></format>
         </remarks>
@@ -4034,12 +4036,12 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Any fractional part of the `value` parameter is truncated before conversion.
+ Any fractional part of the `value` parameter is truncated before conversion.   
 
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Byte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#1)]
- [!code-vb[System.Numeric.BigInteger.Implicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#1)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Byte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#1)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#1)]   
 
  ]]></format>
         </remarks>
@@ -4078,10 +4080,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#2)]
- [!code-vb[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#2)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#2)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#2)]   
 
  ]]></format>
         </remarks>
@@ -4120,10 +4122,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#3)]
- [!code-vb[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#3)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#3)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#3)]   
 
  ]]></format>
         </remarks>
@@ -4162,10 +4164,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#4)]
- [!code-vb[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#4)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#4)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#4)]   
 
  ]]></format>
         </remarks>
@@ -4209,10 +4211,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.SByte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#5)]
- [!code-vb[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#5)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.SByte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#5)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#5)]   
 
  ]]></format>
         </remarks>
@@ -4256,10 +4258,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#6)]
- [!code-vb[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#6)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#6)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#6)]   
 
  ]]></format>
         </remarks>
@@ -4303,10 +4305,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#7)]
- [!code-vb[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#7)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#7)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#7)]   
 
  ]]></format>
         </remarks>
@@ -4350,10 +4352,10 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
- 
- [!code-csharp[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#8)]
- [!code-vb[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#8)]  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
+   
+ [!code-csharp[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#8)]   
+ [!code-vb[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/vb/Implicit1.vb#8)]   
 
  ]]></format>
         </remarks>

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -2737,9 +2737,9 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
- For languages that do not support explicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Decimal%29displayProperty=fullName>.
+ For languages that do not support custom operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Decimal%29?displayProperty=fullName>.
 
 
 ## Examples
@@ -2796,9 +2796,9 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
 
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
-  For languages that do not support explicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Double%29displayProperty=fullName>.
+ For languages that do not support custom operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Double%29?displayProperty=fullName>.
 
 
 ## Examples
@@ -2849,7 +2849,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type. There is no loss of precision in the resulting <xref:System.Byte> value if the conversion is successful.
 
@@ -2901,7 +2901,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type. 
 
@@ -2953,7 +2953,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
 
  Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Double> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Double.MinValue?displayProperty=fullName>, the resulting <xref:System.Double> value is <xref:System.Double.NegativeInfinity?displayProperty=fullName>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Double.MaxValue?displayProperty=fullName>, the resulting <xref:System.Double> value is <xref:System.Double.PositiveInfinity?displayProperty=fullName>.
  
@@ -3012,7 +3012,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
 
@@ -3069,7 +3069,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
 
@@ -3126,7 +3126,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type. 
 
@@ -3185,7 +3185,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type. There is no loss of precision in the resulting <xref:System.SByte> value if the conversion is successful.
 
@@ -3232,7 +3232,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Single> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Single.MinValue?displayProperty=fullName>, the resulting <xref:System.Single> value is <xref:System.Single.NegativeInfinity?displayProperty=fullName>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Single.MaxValue?displayProperty=fullName>, the resulting <xref:System.Single> value is <xref:System.Single.PositiveInfinity?displayProperty=fullName>.
 
@@ -3298,7 +3298,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type. There is no loss of precision in the resulting <xref:System.UInt16> value if the conversion is successful.
 
@@ -3357,7 +3357,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type. There is no loss of precision in the resulting <xref:System.UInt32> value if the conversion is successful.
 
@@ -3416,7 +3416,7 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
 
  Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type. There is no loss of precision in the resulting <xref:System.UInt64> value if the conversion is successful.
 
@@ -3474,9 +3474,9 @@ value Mod 2 = 0
 ## Remarks  
  Any fractional part of the `value` parameter is truncated before conversion.
  
- The overloads of the <xref:System.Numerics.BigInteger.op_Explicit%28System.Decimal%29?displayProperty=fullName> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
 
- For languages that do not support explicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Single%29displayProperty=fullName>.
+ For languages that do not support custom operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Single%29?displayProperty=fullName>.
 
 
 ## Examples

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -4050,7 +4050,9 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Any fractional part of the `value` parameter is truncated before conversion.   
+ Any fractional part of the `value` parameter is truncated before conversion.
+
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Int32%29?displayProperty=fullName>.   
 
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Byte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
@@ -4094,6 +4096,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Int32%29?displayProperty=fullName>.   
+
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#2)]   
@@ -4136,6 +4140,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Int32%29?displayProperty=fullName>.  
+
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#3)]   
@@ -4178,6 +4184,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Int64%29?displayProperty=fullName>.   
+ 
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#4)]   
@@ -4227,6 +4235,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.Int32%29?displayProperty=fullName>.   
+
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.SByte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#5)]   
@@ -4276,6 +4286,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.UInt32%29?displayProperty=fullName>.   
+
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#6)]   
@@ -4325,6 +4337,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.UInt32%29?displayProperty=fullName>.   
+
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#7)]   
@@ -4374,6 +4388,8 @@ value Mod 2 = 0
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ For languages that do not support implicit operators, the alternative method is <xref:System.Numerics.BigInteger.%23ctor%28System.UInt64%29?displayProperty=fullName>.   
+
  The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows.   
    
  [!code-csharp[System.Numeric.BigInteger.Implicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Implicit/cs/Implicit1.cs#8)]   

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -2728,10 +2728,26 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Decimal" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Decimal" /> object to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Any fractional part of the `value` parameter is truncated before conversion.
+
+ The overloads of the Explicit(Decimal to BigInteger) method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Decimal> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+
+
+## Examples
+ The following example converts the individual elements in an array of <xref:System.Decimal> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Decimal> value is truncated during the conversion.
+ 
+ [!code-csharp[System.Numerics.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#1)]
+ [!code-vb[System.Numerics.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#1)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2760,10 +2776,35 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Double" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Double" /> value to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is <see cref="F:System.Double.NaN" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is <see cref="F:System.Double.PositiveInfinity" />.
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is <see cref="F:System.Double.NegativeInfinity" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Any fractional part of the `value` parameter is truncated before conversion.
+
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Double> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+
+
+## Examples
+ The following example converts the individual elements in an array of <xref:System.Double> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Double> value is truncated during the conversion.
+ 
+ [!code-csharp[System.Numerics.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#2)]
+ [!code-vb[System.Numerics.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#2)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2792,10 +2833,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Byte" />.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned byte value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.Byte.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.Byte.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CByte` in Visual Basic) is used. Otherwise, they display a compiler error.   
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type. There is no loss of precision in the resulting <xref:System.Byte> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Byte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Byte> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#1)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#1)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2824,10 +2885,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Decimal" />.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a <see cref="T:System.Decimal" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.Decimal.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.Decimal.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDec` in Visual Basic) is used.   
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type. 
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Decimal> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Decimal> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#2)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#2)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2861,10 +2942,31 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Double" />.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a <see cref="T:System.Double" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CDbl` in Visual Basic) is used.   
+
+ Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Double> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Double.MinValue>, the resulting <xref:System.Double> value is <xref:System.Double.NegativeInfinity>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Numerics.BigInteger>, the resulting <xref:System.Double> value is <xref:System.Double.PositiveInfinity>.
+ 
+ The conversion of a <xref:System.Numerics.BigInteger> to a <xref:System.Double> may involve a loss of precision. In some cases, the loss of precision may cause the casting or conversion operation to succeed even if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Double> data type. The following example provides an illustration. It assigns the maximum value of a <xref:System.Double> to two <xref:System.Numerics.BigInteger> variables, increments one <xref:System.Numerics.BigInteger> variable by 9.999e291, and tests the two variables for equality. As expected, the call to the <xref:System.Numerics.BigInteger.Equals%28System.Numerics.BigInteger%29?displayProperty=fullName> method shows that they are unequal. However, the conversion of the larger <xref:System.Numerics.BigInteger> value back to a <xref:System.Double> succeeds, although the <xref:System.Numerics.BigInteger> value now exceeds <xref:System.Double.MaxValue>.
+
+ [!code-csharp[System.Numerics.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#4)]
+ [!code-vb[System.Numerics.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#4)]  
+
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Double> values.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#3)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#3)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2893,10 +2995,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a 16-bit signed integer.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a 16-bit signed integer value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.Int16.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.Int16.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CShort` in Visual Basic) is used. Otherwise, they display a compiler error.   
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int16> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#4)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#4)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2930,10 +3052,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a 32-bit signed integer.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a 32-bit signed integer value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.Int32.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.Int32.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CInt` in Visual Basic) is used. Otherwise, they display a compiler error.   
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type. There is no loss of precision in the resulting <xref:System.Int16> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int32> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#5)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#5)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -2967,10 +3109,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a 64-bit signed integer.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a 64-bit signed integer value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.Int64.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.Int64.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CLng` in Visual Basic) is used. Otherwise, they display a compiler error.  
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type. 
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Int64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Int64> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#6)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#6)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -3004,10 +3166,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a signed 8-bit value.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a signed 8-bit value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.SByte.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.SByte.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSByte` in Visual Basic) is used. Otherwise, they display a compiler error.  
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type. There is no loss of precision in the resulting <xref:System.SByte> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.SByte> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.SByte> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#7)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#7)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -3036,10 +3218,31 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a single-precision floating-point value.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to a single-precision floating-point value.</summary>
+        <returns>An object that contains the closest possible representation of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss or a loss of precision. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CSng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+
+ Because the <xref:System.Numerics.BigInteger> value can be outside the range of the <xref:System.Single> data type, this operation is a narrowing conversion. If the conversion is unsuccessful, it does not throw an <xref:System.OverflowException>. Instead, if the <xref:System.Numerics.BigInteger> value is less than <xref:System.Single.MinValue>, the resulting <xref:System.Single> value is <xref:System.Single.NegativeInfinity>. If the <xref:System.Numerics.BigInteger> value is greater than <xref:System.Single.MaxValue>, the resulting <xref:System.Single> value is <xref:System.Single.PositiveInfinity>.
+
+ The conversion of a <xref:System.Numerics.BigInteger> to a <xref:System.Single> may involve a loss of precision. In some cases, the loss of precision may cause the casting or conversion operation to succeed even if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.Single> data type. The following example provides an illustration. It assigns the maximum value of a <xref:System.Single> to two <xref:System.Numerics.BigInteger> variables, increments one <xref:System.Numerics.BigInteger> variable by 9.999e291, and tests the two variables for equality. As expected, the call to the <xref:System.Numerics.BigInteger.Equals%28System.Numerics.BigInteger%29?displayProperty=fullName> method shows that they are unequal. However, the conversion of the larger <xref:System.Numerics.BigInteger> value back to a <xref:System.Single> succeeds, although the <xref:System.Numerics.BigInteger> value now exceeds <xref:System.Single.MaxValue>.
+
+ [!code-csharp[System.Numerics.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#5)]
+ [!code-vb[System.Numerics.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#5)]  
+
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.Single> values. 
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#8)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#8)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -3073,10 +3276,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to an unsigned 16-bit integer.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 16-bit integer value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.UInt16.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.UInt16.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUShort` in Visual Basic) is used. Otherwise, they display a compiler error.    
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type. There is no loss of precision in the resulting <xref:System.UInt16> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt16> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt16> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#9)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#9](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#9)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -3110,10 +3333,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to an unsigned 32-bit integer.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 32-bit integer value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.UInt32.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.UInt32.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CUInt` in Visual Basic) is used. Otherwise, they display a compiler error.    
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type. There is no loss of precision in the resulting <xref:System.UInt32> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt32> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt32> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#10)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#10)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -3147,10 +3390,30 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Numerics.BigInteger" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to an unsigned 64-bit integer.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Numerics.BigInteger" /> object to an unsigned 64-bit integer value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is less than <see cref="F:System.UInt64.MinValue" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is greater than <see cref="F:System.UInt64.MaxValue" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Language compilers do not perform this conversion automatically because it can involve data loss. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` or `CULng` in Visual Basic) is used. Otherwise, they display a compiler error.    
+
+ Because this operation defines a narrowing conversion, it can throw an <xref:System.OverflowException> at run time if the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type. There is no loss of precision in the resulting <xref:System.UInt64> value if the conversion is successful.
+
+## Examples
+ The following example illustrates the conversion of <xref:System.Numerics.BigInteger> to <xref:System.UInt64> values. It also handles an <xref:System.OverflowException> that is thrown because the <xref:System.Numerics.BigInteger> value is outside the range of the <xref:System.UInt64> data type.
+
+ [!code-csharp[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Explicit.cs#11)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Explicit.vb#11)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -3179,10 +3442,35 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Single" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an explicit conversion of a <see cref="T:System.Single" /> value to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <exception cref="T:System.OverflowException">The value of <paramref name="value" /> is <see cref="F:System.Single.NaN" />.  
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is <see cref="F:System.Single.PositiveInfinity" />.
+  
+ -or-  
+  
+ The value of <paramref name="value" /> is <see cref="F:System.Single.NegativeInfinity" />.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Any fractional part of the `value` parameter is truncated before conversion.
+ 
+ The overloads of the <xref:System.Numerics.BigInteger.op_Explicit(System.Decimal)~System.Numerics.BigInteger> method define the types to which or from which a <xref:System.Numerics.BigInteger> object can be converted. Because the conversion from <xref:System.Single> to <xref:System.Numerics.BigInteger> can involve truncating any fractional part of `value`, language compilers do not perform this conversion automatically. Instead, they perform the conversion only if a casting operator (in C#) or a conversion function (such as `CType` in Visual Basic) is used. Otherwise, they display a compiler error.
+
+
+## Examples
+ The following example converts the individual elements in an array of <xref:System.Single> values to <xref:System.Numerics.BigInteger> objects, and then displays the result of each conversion. Note that any fractional part of a <xref:System.Single> value is truncated during the conversion.
+ 
+ [!code-csharp[System.Numerics.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/cs/Explicit1.cs#3)]
+ [!code-vb[System.Numerics.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numerics.BigInteger.Explicit/vb/Explicit1.vb#3)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_GreaterThan">
@@ -3739,10 +4027,22 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Byte" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of an unsigned byte to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Any fractional part of the `value` parameter is truncated before conversion.
+
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Byte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#1)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#1)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3771,10 +4071,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Int16" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of a signed 16-bit integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#2)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#2)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3803,10 +4113,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of a signed 32-bit integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#3)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#3](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#3)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3835,10 +4155,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.Int64" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of a signed 64-bit integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.Int64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#4)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#4)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3872,10 +4202,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.SByte" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of an 8-bit signed integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.SByte> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#5)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#5)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3909,10 +4249,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.UInt16" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of a 16-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt16> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#6)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#6)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3946,10 +4296,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.UInt32" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of a 32-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt32> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#7)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#7)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Implicit">
@@ -3983,10 +4343,20 @@ value Mod 2 = 0
         <Parameter Name="value" Type="System.UInt64" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The value to convert to a <see cref="T:System.Numerics.BigInteger" />.</param>
+        <summary>Defines an implicit conversion of a 64-bit unsigned integer to a <see cref="T:System.Numerics.BigInteger" /> value.</summary>
+        <returns>An object that contains the value of the <paramref name="value" /> parameter.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The overloads of the <xref:System.Numerics.BigInteger.op_Implicit(System.Byte)~System.Numerics.BigInteger> method define the types to which or from which a compiler can automatically convert a <xref:System.Numerics.BigInteger> value without an explicit casting operator (in C#) or a call to a conversion function (in Visual Basic). They are widening conversions that do not involve data loss and do not throw an <xref:System.OverflowException>. This overload lets the compiler handle conversions from a <xref:System.UInt64> value to a <xref:System.Numerics.BigInteger> value, as the following example shows. 
+ 
+ [!code-csharp[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/cs/Implicit1.cs#8)]
+ [!code-vb[System.Numeric.BigInteger.Explicit#8](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Numeric.BigInteger.Explicit/vb/Implicit1.vb#8)]  
+
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Increment">

--- a/xml/System/IntPtr.xml
+++ b/xml/System/IntPtr.xml
@@ -462,10 +462,10 @@
         <Parameter Name="value" Type="System.Int32" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">A 32-bit signed integer.</param>
+        <summary>Converts the value of a 32-bit signed integer to an <see cref="T:System.IntPtr" />.</summary>
+        <returns>A new instance of <see cref="T:System.IntPtr" /> initialized to <paramref name="value" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -502,10 +502,11 @@
         <Parameter Name="value" Type="System.Int64" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">A 64-bit signed integer.</param>
+        <summary>Converts the value of a 64-bit signed integer to an <see cref="T:System.IntPtr" />.</summary>
+        <returns>A new instance of <see cref="T:System.IntPtr" /> initialized to <paramref name="value" />.</returns>
+        <exception cref="T:System.OverflowException">On a 32-bit platform, <paramref name="value" /> is too large to represent as an <see cref="T:System.IntPtr" />.</exception>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -537,10 +538,17 @@
         <Parameter Name="value" Type="System.IntPtr" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The pointer or handle to convert.</param>
+        <summary>Converts the value of the specified <see cref="T:System.IntPtr" /> to a 32-bit signed integer.</summary>
+        <returns>The contents of <paramref name="value" />.</returns>
+        <exception cref="T:System.OverflowException">On a 64-bit platform, the value of <paramref name="value" /> is too large to represent as a 32-bit signed integer.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ An exception is only thrown if the value of `value` requires more bits than the current platform supports.
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -572,10 +580,10 @@
         <Parameter Name="value" Type="System.IntPtr" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The pointer or handle to convert.</param>
+        <summary>Converts the value of the specified <see cref="T:System.IntPtr" /> to a 64-bit signed integer.</summary>
+        <returns>The contents of <paramref name="value" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -612,10 +620,10 @@
         <Parameter Name="value" Type="System.IntPtr" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The pointer or handle to convert.</param>
+        <summary>Converts the value of the specified <see cref="T:System.IntPtr" /> to a pointer to an unspecified type.</summary>
+        <returns>The contents of <paramref name="value" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -655,10 +663,11 @@
         <Parameter Name="value" Type="System.Void*" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">A pointer to an unspecified type.</param>
+        <summary>Converts the specified pointer to an unspecified type to an <see cref="T:System.IntPtr" />.</summary>
+        <returns>A new instance of <see cref="T:System.IntPtr" /> initialized to <paramref name="value" />.</returns>
+        <remarks></remarks>
+        <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
       </Docs>
     </Member>
     <Member MemberName="op_Inequality">
@@ -912,7 +921,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This  method populates the `info` parameter with the value of the current <xref:System.IntPtr> object.  
+ This method populates the `info` parameter with the value of the current <xref:System.IntPtr> object.  
   
  ]]></format>
         </remarks>

--- a/xml/System/IntPtr.xml
+++ b/xml/System/IntPtr.xml
@@ -621,7 +621,9 @@
       </Parameters>
       <Docs>
         <param name="value">The pointer or handle to convert.</param>
-        <summary>Converts the value of the specified <see cref="T:System.IntPtr" /> to a pointer to an unspecified type.</summary>
+        <summary>Converts the value of the specified <see cref="T:System.IntPtr" /> to a pointer to an unspecified type.  
+  
+ This API is not CLS-compliant.</summary>
         <returns>The contents of <paramref name="value" />.</returns>
         <remarks></remarks>
       </Docs>
@@ -664,7 +666,9 @@
       </Parameters>
       <Docs>
         <param name="value">A pointer to an unspecified type.</param>
-        <summary>Converts the specified pointer to an unspecified type to an <see cref="T:System.IntPtr" />.</summary>
+        <summary>Converts the specified pointer to an unspecified type to an <see cref="T:System.IntPtr" />.  
+  
+ This API is not CLS-compliant.</summary>
         <returns>A new instance of <see cref="T:System.IntPtr" /> initialized to <paramref name="value" />.</returns>
         <remarks></remarks>
         <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>

--- a/xml/System/UIntPtr.xml
+++ b/xml/System/UIntPtr.xml
@@ -404,10 +404,10 @@
         <Parameter Name="value" Type="System.UInt32" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">A 32-bit unsigned integer. </param>
+        <summary>Converts the value of a 32-bit unsigned integer to an <see cref="T:System.UIntPtr" />.</summary>
+        <returns>A new instance of <see cref="T:System.UIntPtr" /> initialized to <paramref name="value" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -439,10 +439,11 @@
         <Parameter Name="value" Type="System.UInt64" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">A 64-bit unsigned integer.</param>
+        <summary>Converts the value of a 64-bit unsigned integer to an <see cref="T:System.UIntPtr" />.</summary>
+        <returns>A new instance of <see cref="T:System.UIntPtr" /> initialized to <paramref name="value" />.</returns>
+        <exception cref="T:System.OverflowException">On a 32-bit platform, <paramref name="value" /> is too large to represent as an <see cref="T:System.UIntPtr" />.</exception>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -474,10 +475,17 @@
         <Parameter Name="value" Type="System.UIntPtr" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The pointer or handle to convert.</param>
+        <summary>Converts the value of the specified <see cref="T:System.UIntPtr" /> to a 32-bit unsigned integer.</summary>
+        <returns>The contents of <paramref name="value" />.</returns>
+        <exception cref="T:System.OverflowException">On a 64-bit platform, the value of <paramref name="value" /> is too large to represent as a 32-bit unsigned integer.</exception>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ An exception is only thrown if the value of `value` requires more bits than the current platform supports.
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -509,10 +517,10 @@
         <Parameter Name="value" Type="System.UIntPtr" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The pointer or handle to convert.</param>
+        <summary>Converts the value of the specified <see cref="T:System.UIntPtr" /> to a 64-bit unsigned integer.</summary>
+        <returns>The contents of <paramref name="value" />.</returns>
+        <remarks></remarks>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -549,10 +557,11 @@
         <Parameter Name="value" Type="System.UIntPtr" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">The pointer or handle to convert.</param>
+        <summary>Converts the value of the specified <see cref="T:System.UIntPtr" /> to a pointer to an unspecified type.</summary>
+        <returns>The contents of <paramref name="value" />.</returns>
+        <remarks></remarks>
+        <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
       </Docs>
     </Member>
     <Member MemberName="op_Explicit">
@@ -589,10 +598,11 @@
         <Parameter Name="value" Type="System.Void*" />
       </Parameters>
       <Docs>
-        <param name="value">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="value">A pointer to an unspecified type.</param>
+        <summary>Converts the specified pointer to an unspecified type to an <see cref="T:System.UIntPtr" />.</summary>
+        <returns>A new instance of <see cref="T:System.UIntPtr" /> initialized to <paramref name="value" />.</returns>
+        <remarks></remarks>
+        <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
       </Docs>
     </Member>
     <Member MemberName="op_Inequality">

--- a/xml/System/UIntPtr.xml
+++ b/xml/System/UIntPtr.xml
@@ -558,7 +558,9 @@
       </Parameters>
       <Docs>
         <param name="value">The pointer or handle to convert.</param>
-        <summary>Converts the value of the specified <see cref="T:System.UIntPtr" /> to a pointer to an unspecified type.</summary>
+        <summary>Converts the value of the specified <see cref="T:System.UIntPtr" /> to a pointer to an unspecified type.  
+  
+ This API is not CLS-compliant.</summary>
         <returns>The contents of <paramref name="value" />.</returns>
         <remarks></remarks>
         <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
@@ -599,7 +601,9 @@
       </Parameters>
       <Docs>
         <param name="value">A pointer to an unspecified type.</param>
-        <summary>Converts the specified pointer to an unspecified type to an <see cref="T:System.UIntPtr" />.</summary>
+        <summary>Converts the specified pointer to an unspecified type to an <see cref="T:System.UIntPtr" />.  
+  
+ This API is not CLS-compliant.</summary>
         <returns>A new instance of <see cref="T:System.UIntPtr" /> initialized to <paramref name="value" />.</returns>
         <remarks></remarks>
         <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>

--- a/xml/System/UIntPtr.xml
+++ b/xml/System/UIntPtr.xml
@@ -331,7 +331,7 @@
   
  The addition operation does not throw an exception if the result is too large to represent as a pointer on the specified platform. Instead, it is performed in an unchecked context.  
   
- The equivalent method for this operator is <xref:System.%2A> U IntPtr.Add(System. U IntPtr,System.Int32)?qualifyHint=True&autoUpgrade=False]]></format>
+ The equivalent method for this operator is <xref:System.UIntPtr.Add%28System.UIntPtr%2CSystem.Int32%29?displayProperty=fullName>. ]]></format>
         </remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
# Title
Document all Explicit and Implicit operators for IntPtr, UIntPtr, and BigInteger.

## Summary
Pulled information from MSDN to document all Explicit and Implicit operators in:
- System.IntPtr  (6 Explicit)
- System.UIntPtr  (6 Explicit)
- System.Numerics.BigInteger  (14 Explicit and 8 Implicit)

## Suggested Reviewers
@rpetrusha 

**Question for reviewer**
A few of these methods had the following message as part of the description on MSDN:
"This API is not CLS-compliant. "

Does this message need to be added to our description?  Or is it generated?

