### PR TITLE
Encoding provider-related revisions

### DIFF
--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -858,15 +858,15 @@
         <ReturnType>System.Text.Encoding</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets an encoding for the system's active code page.</summary>
-        <value>An encoding for the system's active code page.</value>
+        <summary>Gets the default encoding for this .NET implementation.</summary>
+        <value>The default encoding for this .NET implementation.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
 > [!WARNING]
->  Different computers can use different encodings as the default, and the default encoding can change on a single computer. If you use the <xref:System.Text.Encoding.Default%2A> encoding to encode and decode data streamed between computers or retrieved at different times on the same computer, it may translate that data incorrectly. In addition, the encoding returned by the <xref:System.Text.Encoding.Default%2A> property uses best-fit fallback to map unsupported characters to characters supported by the code page. For these reasons, using the default encoding is not recommended. To ensure that encoded bytes are decoded properly, you should use a Unicode encoding, such as <xref:System.Text.UTF8Encoding> or <xref:System.Text.UnicodeEncoding> with a preamble. You could alsouse a higher-level protocol to ensure that the same format is used for encoding and decoding.  
+>  Different computers can use different encodings as the default, and the default encoding can change on a single computer. If you use the <xref:System.Text.Encoding.Default%2A> encoding to encode and decode data streamed between computers or retrieved at different times on the same computer, it may translate that data incorrectly. In addition, the encoding returned by the <xref:System.Text.Encoding.Default%2A> property uses best-fit fallback to map unsupported characters to characters supported by the code page. For these reasons, using the default encoding is not recommended. To ensure that encoded bytes are decoded properly, you should use a Unicode encoding, such as <xref:System.Text.UTF8Encoding> or <xref:System.Text.UnicodeEncoding>. You could also use a higher-level protocol to ensure that the same format is used for encoding and decoding.  
 
 ### The Default property in the .NET Framework
 
@@ -2661,7 +2661,7 @@ You can also supply a value of 0 for the `codepage` argument. Its precise behavi
 
 - On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the operating system's active code page. To determine the active code page on Windows systems, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the .NET Framework on the Windows desktop.
 
-- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding>.
+- On .NET Core, if no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding>.
   
 > [!NOTE]
 >  Some unsupported code pages cause an <xref:System.ArgumentException> to be thrown, whereas others cause a <xref:System.NotSupportedException>. Therefore, your code must catch all exceptions indicated in the Exceptions section.  
@@ -2814,7 +2814,7 @@ You can also supply a value of 0 for the `codepage` argument. Its precise behavi
 
 - On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the active code page.
 
-- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding> encoding.
+- On .NET Core, if no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding> encoding.
 
 > [!NOTE]
 >  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, if the active code page is an ANSI code page, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page. 

--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -858,12 +858,10 @@
         <ReturnType>System.Text.Encoding</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets an encoding for the operating system's current ANSI code page.</summary>
-        <value>An encoding for the operating system's current ANSI code page.</value>
+        <summary>Gets an encoding for the system's active code page.</summary>
+        <value>An encoding for the system's active code page.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
   
 ## Remarks  
   
@@ -872,11 +870,11 @@
 
 ### The Default property in the .NET Framework
 
-In the .NET Framework on the Windows desktop, the <xref:System.Text.Encoding.Default%2A> property always gets the system's active code page and creates a <xref:System.Text.Encoding> object that corresponds to it. This ANSI code page includes the ASCII character set along with additional characters, which vary by code page. Because all <xref:System.Text.Encoding.Default%2A> encodings lose data, consider using the <xref:System.Text.Encoding.UTF8%2A> encoding instead. UTF-8 is often identical in the U+00 to U+7F range, but can encode characters outside the ASCII range without loss.
+In the .NET Framework on the Windows desktop, the <xref:System.Text.Encoding.Default%2A> property always gets the system's active code page and creates a <xref:System.Text.Encoding> object that corresponds to it. The active code page may be an ANSI code page, which includes the ASCII character set along with additional characters that vary by code page. Because all <xref:System.Text.Encoding.Default%2A> encodings based on ANSI code pages lose data, consider using the <xref:System.Text.Encoding.UTF8%2A?displayProperty=fullName> encoding instead. UTF-8 is often identical in the U+00 to U+7F range, but can encode characters outside the ASCII range without loss.
 
 ## The Default property on .NET Core
 
-On .NET Core, the <xref:System.Text.Encoding.Default%2A> property always returns the <xref:System.Text.UTF8> encoding. UTF-8 is supported on all the operating systems (Windows, Linux, and Max OS X) on which .NET Core applications run.
+On .NET Core, the <xref:System.Text.Encoding.Default%2A> property always returns the <xref:System.Text.UTF8Encoding>. UTF-8 is supported on all the operating systems (Windows, Linux, and Max OS X) on which .NET Core applications run.
   
  ]]></format>
         </remarks>
@@ -2661,17 +2659,15 @@ You can also supply a value of 0 for the `codepage` argument. Its precise behavi
 
 - If one or more encoding providers have been registered, it returns the encoding of the last registered provider that has chosen to return a encoding when the <xref:System.Text.Encoding.GetEncoding%2A> method is passed a `codepage` argument of 0.     
 
-- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.Encoding.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the default ANSI code page in the operating system's regional and language settings.
+- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.Encoding.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the operating system's active code page. To determine the active code page on Windows systems, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the .NET Framework on the Windows desktop.
 
-- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8> encoding.
-
-To determine the default code pages used on Windows systems, call the Windows [GetSystemDefaultLangID](http://msdn.microsoft.com/library/windows/desktop/dd318120.aspx) function from the full .NET Framework on the WIndows desktop. To determine the current ANSI code page on Windows systems, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the full .NET Framework on the Windows desktop.  
+- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding>.
   
 > [!NOTE]
 >  Some unsupported code pages cause an <xref:System.ArgumentException> to be thrown, whereas others cause a <xref:System.NotSupportedException>. Therefore, your code must catch all exceptions indicated in the Exceptions section.  
   
 > [!NOTE]
->  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use a Unicode encoding, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
+>  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, if the active code page is an ANSI code page, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use a Unicode encoding, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
   
  <xref:System.Text.Encoding.GetEncoding%2A> returns a cached instance with default settings. You should use the constructors of derived classes to get an instance with different settings. For example, the <xref:System.Text.UTF32Encoding> class provides a constructor that lets you enable error detection.  
 
@@ -2816,15 +2812,14 @@ You can also supply a value of 0 for the `codepage` argument. Its precise behavi
 
 - If one or more encoding providers have been registered, it returns the encoding of the last registered provider that has chosen to return a encoding when the <xref:System.Text.Encoding.GetEncoding%2A> method is passed a `codepage` argument of 0.     
 
-- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.Encoding.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the default ANSI code page in the operating system's regional and language settings.
+- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the active code page.
 
-- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8> encoding.
+- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding> encoding.
 
 > [!NOTE]
->  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
- 
+>  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, if the active code page is an ANSI code page, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page. 
   
- To get the encoding associated with the default ANSI code page in the operating system's regional and language settings, you can either supply a value of 0 for the `codepage` argument or, if your code is running on the full .NET Framework on the Windows desktop, retrieve the value of the <xref:System.Text.Encoding.Default%2A?displayProperty=fullName> property. To determine the default code pages used on the system, use the Windows [GetSystemDefaultLangID](http://msdn.microsoft.com/library/windows/desktop/dd318120.aspx) function. To determine the current ANSI code page, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the full .NET Framework on the Windows desktop.  
+ To get the encoding associated with the active code page, you can either supply a value of 0 for the `codepage` argument or, if your code is running on the full .NET Framework on the Windows desktop, retrieve the value of the <xref:System.Text.Encoding.Default%2A?displayProperty=fullName> property. To determine the current active code page, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the .NET Framework on the Windows desktop.  
   
  <xref:System.Text.Encoding.GetEncoding%2A> returns a cached instance with default settings. You should use the constructors of derived classes to get an instance with different settings. For example, the <xref:System.Text.UTF32Encoding> class provides a constructor that lets you enable error detection.  
   
@@ -3885,9 +3880,9 @@ The goal is to save this file, then open and decode it as a binary stream.
 
 Registering an encoding provider by using the <xref:System.Text.Encoding.RegisterProvider%2A> method also modifies the behavior of the [Encoding.GetEncoding(Int32)](<xref:System.Text.Encoding.GetEncoding(System.Int32)>) and [EncodingProvider.GetEncoding(Int32, EncoderFallback, DecoderFallback)](xref:System.Text.Encoding.GetEncoding(System.Int32,System.Text.EncoderFallback,System.Text.DecoderFallback)) methods when passed an argument of `0`:
 
-- If the registered provider is the <xref:System.Text.CodePagesEncodingProvider>, the method returns the encoding that matches the system ANSI code page when running on the Windows operating system.
+- If the registered provider is the <xref:System.Text.CodePagesEncodingProvider>, the method returns the encoding that matches the system active code page when running on the Windows operating system.
 
-- A custom encoding provider can choose which encoding to return when either of these <xref:Encoding.GetEncoding%2A> method overloads is passed an argument of `0`. The provider can also choose to not return an encoding by having the <xref:System.Text.EncodingProvider.GetEncoding%2A?displayProperty=fullName> method return `null`. 
+- A custom encoding provider can choose which encoding to return when either of these <xref:System.Text.Encoding.GetEncoding%2A> method overloads is passed an argument of `0`. The provider can also choose to not return an encoding by having the <xref:System.Text.EncodingProvider.GetEncoding%2A?displayProperty=fullName> method return `null`. 
   
  [!INCLUDE[net_v46](~/includes/net-v46-md.md)] includes one encoding provider, <xref:System.Text.CodePagesEncodingProvider>, that makes the encodings available that are present in the full .NET Framework but are not available in [!INCLUDE[net_v46](~/includes/net-v46-md.md)]. By default, [!INCLUDE[net_v46](~/includes/net-v46-md.md)] only supports the Unicode encodings, ASCII, and code page 28591.  
   

--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -2659,7 +2659,7 @@ You can also supply a value of 0 for the `codepage` argument. Its precise behavi
 
 - If one or more encoding providers have been registered, it returns the encoding of the last registered provider that has chosen to return a encoding when the <xref:System.Text.Encoding.GetEncoding%2A> method is passed a `codepage` argument of 0.     
 
-- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.Encoding.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the operating system's active code page. To determine the active code page on Windows systems, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the .NET Framework on the Windows desktop.
+- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the operating system's active code page. To determine the active code page on Windows systems, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the .NET Framework on the Windows desktop.
 
 - On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8Encoding>.
   

--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -865,10 +865,18 @@
   
 ## Remarks  
   
-> [!WARNING]
->  Different computers can use different encodings as the default, and the default encoding can even change on a single computer. Therefore, data streamed from one computer to another or even retrieved at different times on the same computer might be translated incorrectly. In addition, the encoding returned by the <xref:System.Text.Encoding.Default%2A> property uses best-fit fallback to map unsupported characters to characters supported by the code page. For these two reasons, using the default encoding is generally not recommended. To ensure that encoded bytes are decoded properly, you should use a Unicode encoding, such as <xref:System.Text.UTF8Encoding> or <xref:System.Text.UnicodeEncoding>, with a preamble. Another option is to use a higher-level protocol to ensure that the same format is used for encoding and decoding.  
+## Remarks  
   
- The system ANSI code page defined by <xref:System.Text.Encoding.Default%2A> covers the ASCII set of characters, but the encoding is different from the encoding for ASCII. Because all <xref:System.Text.Encoding.Default%2A> encodings lose data, you might use <xref:System.Text.Encoding.UTF8%2A> instead. UTF-8 is often identical in the U+00 to U+7F range, but can encode other characters without loss.  
+> [!WARNING]
+>  Different computers can use different encodings as the default, and the default encoding can change on a single computer. If you use the <xref:System.Text.Encoding.Default%2A> encoding to encode and decode data streamed between computers or retrieved at different times on the same computer, it may translate that data incorrectly. In addition, the encoding returned by the <xref:System.Text.Encoding.Default%2A> property uses best-fit fallback to map unsupported characters to characters supported by the code page. For these reasons, using the default encoding is not recommended. To ensure that encoded bytes are decoded properly, you should use a Unicode encoding, such as <xref:System.Text.UTF8Encoding> or <xref:System.Text.UnicodeEncoding> with a preamble. You could alsouse a higher-level protocol to ensure that the same format is used for encoding and decoding.  
+
+### The Default property in the .NET Framework
+
+In the .NET Framework on the Windows desktop, the <xref:System.Text.Encoding.Default%2A> property always gets the system's active code page and creates a <xref:System.Text.Encoding> object that corresponds to it. This ANSI code page includes the ASCII character set along with additional characters, which vary by code page. Because all <xref:System.Text.Encoding.Default%2A> encodings lose data, consider using the <xref:System.Text.Encoding.UTF8%2A> encoding instead. UTF-8 is often identical in the U+00 to U+7F range, but can encode characters outside the ASCII range without loss.
+
+## The Default property on .NET Core
+
+On .NET Core, the <xref:System.Text.Encoding.Default%2A> property always returns the <xref:System.Text.UTF8> encoding. UTF-8 is supported on all the operating systems (Windows, Linux, and Max OS X) on which .NET Core applications run.
   
  ]]></format>
         </remarks>
@@ -2647,18 +2655,26 @@
   
  The <xref:System.Text.Encoding.GetEncoding%2A> method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings. For a list of code pages, see the <xref:System.Text.Encoding> class topic. Alternatively, you can call the <xref:System.Text.Encoding.GetEncodings%2A> method to get an array of <xref:System.Text.EncodingInfo> objects that contains information about all encodings.  
   
- In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%28System.Int32%29> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object.  
-  
- To get the encoding associated with the default ANSI code page in the operating system's regional and language settings, you can either supply a value 0 for the `codepage` argument or, on the full .NET Framework on the Windows desktop, retrieve the value of the <xref:System.Text.Encoding.Default%2A> property. To determine the default code pages used on the system, use the Windows [GetSystemDefaultLangID](http://msdn.microsoft.com/library/windows/desktop/dd318120.aspx) function. To determine the current ANSI code page, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the full .NET Framework on the Windows desktop.  
+ In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%2A> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object. If the same encoding has been registered by multiple <xref:System.Text.EncodingProvider> objects, this method returns the last one registered.  
+
+You can also supply a value of 0 for the `codepage` argument. Its precise behavior depends on whether any encodings have been made available by registering an <xref:System.Text.EncodingProvider> object:
+
+- If one or more encoding providers have been registered, it returns the encoding of the last registered provider that has chosen to return a encoding when the <xref:System.Text.Encoding.GetEncoding%2A> method is passed a `codepage` argument of 0.     
+
+- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.Encoding.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the default ANSI code page in the operating system's regional and language settings.
+
+- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8> encoding.
+
+To determine the default code pages used on Windows systems, call the Windows [GetSystemDefaultLangID](http://msdn.microsoft.com/library/windows/desktop/dd318120.aspx) function from the full .NET Framework on the WIndows desktop. To determine the current ANSI code page on Windows systems, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the full .NET Framework on the Windows desktop.  
   
 > [!NOTE]
->  Some unsupported code pages cause the exception <xref:System.ArgumentException> to be thrown, whereas others cause <xref:System.NotSupportedException>. Therefore, your code must catch all exceptions indicated in the Exceptions section.  
+>  Some unsupported code pages cause an <xref:System.ArgumentException> to be thrown, whereas others cause a <xref:System.NotSupportedException>. Therefore, your code must catch all exceptions indicated in the Exceptions section.  
   
 > [!NOTE]
->  The ANSI code pages can be different on different computers, or can be changed for a single computer, leading to data corruption. For this reason, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
+>  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use a Unicode encoding, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
   
  <xref:System.Text.Encoding.GetEncoding%2A> returns a cached instance with default settings. You should use the constructors of derived classes to get an instance with different settings. For example, the <xref:System.Text.UTF32Encoding> class provides a constructor that lets you enable error detection.  
-  
+
    
   
 ## Examples  
@@ -2717,18 +2733,15 @@
 ## Remarks  
  The fallback handler depends on the encoding type of `name`. If `name` is a code page or double-byte character set (DBCS) encoding, a best-fit fallback handler is used. Otherwise, a replacement fallback handler is used. These fallback handlers may not be appropriate for your app. To specify the fallback handler used by the encoding specified by `name`, you can call the <xref:System.Text.Encoding.GetEncoding%28System.String%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29> overload.  
   
- The `GetEncoding` method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings.  
+ The <xref:System.Text.Encoding.GetEncoding%2A> method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings. For a list of code pages, see the <xref:System.Text.Encoding> class topic. Alternatively, you can call the <xref:System.Text.Encoding.GetEncodings%2A> method to get an array of <xref:System.Text.EncodingInfo> objects that contains information about all encodings. 
   
- In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%28System.String%29> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object.  
-  
+ In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%2A> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object. If the same encoding has been registered by multiple <xref:System.Text.EncodingProvider> objects, this method returns the last one registered.  
+   
 > [!NOTE]
 >  The ANSI code pages can be different on different computers, or can be changed for a single computer, leading to data corruption. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
-  
- For a list of code pages, see the <xref:System.Text.Encoding> class topic. You can call the <xref:System.Text.Encoding.GetEncodings%2A> method in the full .NET Framework on the Windows desktop to get a list of all encodings.  
+ 
   
  <xref:System.Text.Encoding.GetEncoding%2A> returns a cached instance with default settings. You should use the constructors of derived classes to get an instance with different settings. For example, the <xref:System.Text.UTF32Encoding> class provides a constructor that lets you enable error detection.  
-  
-   
   
 ## Examples  
  The following example gets two instances of the same encoding (one by code page and another by name), and checks their equality.  
@@ -2795,14 +2808,21 @@
 > [!NOTE]
 >  Some unsupported code pages cause the exception <xref:System.ArgumentException> to be thrown, whereas others cause <xref:System.NotSupportedException>. Therefore, your code must catch all exceptions indicated in the Exceptions section.  
   
- The <xref:System.Text.Encoding.GetEncoding%2A> method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings.  
+ The <xref:System.Text.Encoding.GetEncoding%2A> method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings. For a list of code pages, see the <xref:System.Text.Encoding> class topic. You can call the <xref:System.Text.Encoding.GetEncodings%2A> method in the full .NET Framework on the Windows desktop to get a list of all encodings.   
   
- In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%28System.Int32%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object.  
-  
+ In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%2A> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object.  If the same encoding has been registered by multiple <xref:System.Text.EncodingProvider> objects, this method returns the last one registered.  
+
+You can also supply a value of 0 for the `codepage` argument. Its precise behavior depends on whether any encodings have been made available by registering an <xref:System.Text.EncodingProvider> object:
+
+- If one or more encoding providers have been registered, it returns the encoding of the last registered provider that has chosen to return a encoding when the <xref:System.Text.Encoding.GetEncoding%2A> method is passed a `codepage` argument of 0.     
+
+- On the .NET Framework, if no encoding provider has been registered, if the <xref:System.Text.Encoding.CodePagesEncodingProvider> is the registered encoding provider, or if no registered encoding provider handles a `codepage` value of 0, it returns the default ANSI code page in the operating system's regional and language settings.
+
+- On .NET Core, if no no encoding provider has been registered or if no registered encoding provider handles a `codepage` value of 0, it returns the <xref:System.Text.UTF8> encoding.
+
 > [!NOTE]
->  The ANSI code pages can be different on different computers, or can be changed for a single computer, leading to data corruption. For this reason, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
-  
- For a list of code pages, see the <xref:System.Text.Encoding> class topic. You can call the <xref:System.Text.Encoding.GetEncodings%2A> method in the full .NET Framework on the Windows desktop to get a list of all encodings.  
+>  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For this reason, encoding and decoding data using the default code page returned by `Encoding.GetEncoding(0)` is not recommended. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
+ 
   
  To get the encoding associated with the default ANSI code page in the operating system's regional and language settings, you can either supply a value of 0 for the `codepage` argument or, if your code is running on the full .NET Framework on the Windows desktop, retrieve the value of the <xref:System.Text.Encoding.Default%2A?displayProperty=fullName> property. To determine the default code pages used on the system, use the Windows [GetSystemDefaultLangID](http://msdn.microsoft.com/library/windows/desktop/dd318120.aspx) function. To determine the current ANSI code page, call the Windows [GetACP](http://msdn.microsoft.com/library/windows/desktop/dd318070.aspx) function from the full .NET Framework on the Windows desktop.  
   
@@ -2867,12 +2887,12 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The `GetEncoding` method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings.  
+ The <xref:System.Text.Encoding.GetEncoding%2A> method relies on the underlying platform to support most code pages. However, the .NET Framework natively supports some encodings.  
   
- In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%28System.Int32%29> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object.  
+ In addition to the encodings that are intrinsically supported on a specific platform version of the .NET Framework, the <xref:System.Text.Encoding.GetEncoding%2A> method returns any additional encodings that are made available by registering an <xref:System.Text.EncodingProvider> object. If the same encoding has been registered by multiple <xref:System.Text.EncodingProvider> objects, this method returns the last one registered. 
   
 > [!NOTE]
->  The ANSI code pages can be different on different computers, or can be changed for a single computer, leading to data corruption. For the most consistent results, you should use Unicode, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
+>  The ANSI code pages can be different on different computers and can change on a single computer, leading to data corruption. For the most consistent results, you should use a Unicode encoding, such as UTF-8 (code page 65001) or UTF-16, instead of a specific code page.  
   
  For a list of code pages, see the <xref:System.Text.Encoding> class topic. You can call the <xref:System.Text.Encoding.GetEncodings%2A> method on the full .NET Framework on the Windows desktop to get a list of all encodings.  
   

--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -3861,7 +3861,13 @@ The goal is to save this file, then open and decode it as a binary stream.
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Text.Encoding.RegisterProvider%2A> method allows you to register a class derived from <xref:System.Text.EncodingProvider> that makes character encodings available on a platform that does not otherwise support them. Once the encoding provider is registered, the encodings that it supports can be retrieved by calling any <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=fullName> overload.  
+ The <xref:System.Text.Encoding.RegisterProvider%2A> method allows you to register a class derived from <xref:System.Text.EncodingProvider> that makes character encodings available on a platform that does not otherwise support them. Once the encoding provider is registered, the encodings that it supports can be retrieved by calling any <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=fullName> overload. If there are multiple encoding providers, the <xref:System.Text.Encoding.GetEncoding%2A?displayProperty=fullName> method attempts to retrieve a specified encoding from each provider starting with the one most recently registered.
+
+Registering an encoding provider by using the <xref:System.Text.Encoding.RegisterProvider%2A> method also modifies the behavior of the [Encoding.GetEncoding(Int32)](<xref:System.Text.Encoding.GetEncoding(System.Int32)>) and [EncodingProvider.GetEncoding(Int32, EncoderFallback, DecoderFallback)](xref:System.Text.Encoding.GetEncoding(System.Int32,System.Text.EncoderFallback,System.Text.DecoderFallback)) methods when passed an argument of `0`:
+
+- If the registered provider is the <xref:System.Text.CodePagesEncodingProvider>, the method returns the encoding that matches the system ANSI code page when running on the Windows operating system.
+
+- A custom encoding provider can choose which encoding to return when either of these <xref:Encoding.GetEncoding%2A> method overloads is passed an argument of `0`. The provider can also choose to not return an encoding by having the <xref:System.Text.EncodingProvider.GetEncoding%2A?displayProperty=fullName> method return `null`. 
   
  [!INCLUDE[net_v46](~/includes/net-v46-md.md)] includes one encoding provider, <xref:System.Text.CodePagesEncodingProvider>, that makes the encodings available that are present in the full .NET Framework but are not available in [!INCLUDE[net_v46](~/includes/net-v46-md.md)]. By default, [!INCLUDE[net_v46](~/includes/net-v46-md.md)] only supports the Unicode encodings, ASCII, and code page 28591.  
   

--- a/xml/System.Text/EncodingProvider.xml
+++ b/xml/System.Text/EncodingProvider.xml
@@ -137,13 +137,13 @@
 
 ### Notes to inheritors
 
-You override the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method, the method passes the `codepage` identifier to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method attempts to retrieve a cached encoding whose code page identifier is `codepage`. Because of this, if `codepage` is not the code page identifier of an encoding that you support, the method should return `null`; it should never throw an exception.
+You override the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method to return the encoding or encodings supported by your <xref:System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method, the method passes the `codepage` identifier to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method attempts to retrieve a cached encoding whose code page identifier is `codepage`. Because of this, if `codepage` is not the code page identifier of an encoding that you support, the method should return `null`; it should never throw an exception.
         
 Note that you can also choose to return a default code page if the value of the `codepage` argument is 0.
 
 ## Notes to callers
         
-This method is called by the [Encoding.GetEncoding(Int32)](<xref=System.Text.Encoding.GetEncoding(System.Int32)>) method. You should not call it directly from user code.
+This method is called by the [Encoding.GetEncoding(Int32)](<xref:System.Text.Encoding.GetEncoding(System.Int32)>) method. You should not call it directly from user code.
 
         ]]></format>
         </remarks>
@@ -185,12 +185,12 @@ This method is called by the [Encoding.GetEncoding(Int32)](<xref=System.Text.Enc
            <format type="text/markdown"><![CDATA[ 
       
 ## Notes to inheritors 
-        
-You override the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method, the method passes the `name` argument to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method attempts to retrieve a cached encoding whose name is `name`. Because of this, if `name` is not the name of an encoding that you support, the method should return `null`. The only case in which the method should throw an exception is if `name` is `null`.
+                  
+You override the [GetEncoding(String)](<xref:System.Text.EncodingProvider.GetEncoding(System.String)>) method to return the encoding or encodings supported by your <xref:System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(String)](<xref:System.Text.EncodingProvider.GetEncoding(System.String)>) method, the method passes the `name` argument to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(String)](<xref:System.Text.EncodingProvider.GetEncoding(System.String)>) method attempts to retrieve a cached encoding whose name is `name`. Because of this, if `name` is not the name of an encoding that you support, the method should return `null`. The only case in which the method should throw an exception is if `name` is `null`.
 
 ## Notes to callers
 
-This method is called by the [Encoding.GetEncoding(String)](<xref=System.Text.Encoding.GetEncoding(System.String)>) method. You should not call it directly from user code.
+This method is called by the [Encoding.GetEncoding(String)](<xref:System.Text.Encoding.GetEncoding(System.String)>) method. You should not call it directly from user code.
         ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Text/EncodingProvider.xml
+++ b/xml/System.Text/EncodingProvider.xml
@@ -36,7 +36,7 @@
 ## Remarks  
  An encoding provider supplies encodings that are not otherwise available on a particular target platform.  
   
- The .NET Framework on the Windows desktop supports a large number of character encodings and code pages. You can get a complete list of encodings available in the .NET Framework on the Windows desktop by calling the <xref:System.Text.Encoding.GetEncodings%2A?displayProperty=fullName> method. [!INCLUDE[net_core](~/includes/net-core-md.md)], on the other hand, by default supports only the following encodings:  
+ The .NET Framework on the Windows desktop supports a large number of character encodings and code pages. You can get a complete list of encodings available in the .NET Framework on the Windows desktop by calling the <xref:System.Text.Encoding.GetEncodings%2A?displayProperty=fullName> method. .NET Core, on the other hand, by default supports only the following encodings:  
   
 -   ASCII (code page 20127), which is returned by the <xref:System.Text.Encoding.ASCII%2A?displayProperty=fullName> property.  
   
@@ -54,9 +54,9 @@
   
 -   UTF-32BE (code page 12001), which is instantiated by calling an <xref:System.Text.UTF32Encoding> constructor that has a `bigEndian` parameter and providing a value of `true` in the method call.  
   
- In [!INCLUDE[net_v46](~/includes/net-v46-md.md)], <xref:System.Text.EncodingProvider> is the base class that makes otherwise unavailable encodings available to the .NET Framework. This involves the following steps:  
+ Starting with the .NET Framework 4.6, <xref:System.Text.EncodingProvider> is the base class that makes otherwise unavailable encodings available to the .NET Framework. This involves the following steps:  
   
-1.  Define a subclass of <xref:System.Text.EncodingProvider> that overrides the two abstract <xref:System.Text.EncodingProvider.GetEncoding%2A> overloads, <xref:System.Text.EncodingProvider.GetEncoding%28System.Int32%29> and <xref:System.Text.EncodingProvider.GetEncoding%28System.String%29>. These overloads return the otherwise unsupported encoding by code page identifier and by name.  
+1.  Define a subclass of <xref:System.Text.EncodingProvider> that overrides the two abstract <xref:System.Text.EncodingProvider.GetEncoding%2A> overloads, <xref:System.Text.EncodingProvider.GetEncoding%28System.Int32%29> and <xref:System.Text.EncodingProvider.GetEncoding%28System.String%29>. These overloads return the otherwise unsupported encoding by code page identifier and by name. Note that you can also choose to return a default encoding if the <xref:System.Text.EncodingProvider.GetEncoding%28System.Int32%29> method is called with an argument of 0.  
   
 2.  Optionally, you can override the virtual <xref:System.Text.EncodingProvider.GetEncoding%28System.Int32%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29> and <xref:System.Text.EncodingProvider.GetEncoding%28System.String%2CSystem.Text.EncoderFallback%2CSystem.Text.DecoderFallback%29> methods. In most cases, this is not necessary, since the base class provides a default implementation.  
   

--- a/xml/System.Text/EncodingProvider.xml
+++ b/xml/System.Text/EncodingProvider.xml
@@ -133,17 +133,17 @@
         <remarks>
         <format type="text/markdown"><![CDATA[ 
 
-        ## Remarks
+## Remarks
 
-        ### Notes to inheritors
+### Notes to inheritors
 
-        You override the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method, the method passes the `codepage` identifier to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method attempts to retrieve a cached encoding whose code page identifier is `codepage`. Because of this, if `codepage` is not the code page identifier of an encoding that you support, the method should return `null`; it should never throw an exception.
+You override the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method, the method passes the `codepage` identifier to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method attempts to retrieve a cached encoding whose code page identifier is `codepage`. Because of this, if `codepage` is not the code page identifier of an encoding that you support, the method should return `null`; it should never throw an exception.
         
-        Note that you can also choose to return a default code page if the value of the `codepage` argument is 0.
+Note that you can also choose to return a default code page if the value of the `codepage` argument is 0.
 
-        ## Notes to callers
+## Notes to callers
         
-        This method is called by the [Encoding.GetEncoding(Int32)](<xref=System.Text.Encoding.GetEncoding(System.Int32)>) method. You should not call it directly from user code.
+This method is called by the [Encoding.GetEncoding(Int32)](<xref=System.Text.Encoding.GetEncoding(System.Int32)>) method. You should not call it directly from user code.
 
         ]]></format>
         </remarks>
@@ -183,16 +183,14 @@
         <returns>The encoding that is associated with the specified name, or <see langword="null" /> if this <see cref="T:System.Text.EncodingProvider" /> cannot return a valid encoding that corresponds to <paramref name="name" />.</returns>
         <remarks>
            <format type="text/markdown"><![CDATA[ 
+      
+## Notes to inheritors 
         
-        ## Remarks
-        
-        ### Notes to inheritors 
-        
-        You override the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method, the method passes the `name` argument to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method attempts to retrieve a cached encoding whose name is `name`. Because of this, if `name` is not the name of an encoding that you support, the method should return `null`. The only case in which the method should throw an exception is if `name` is `null`.
+You override the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method, the method passes the `name` argument to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method attempts to retrieve a cached encoding whose name is `name`. Because of this, if `name` is not the name of an encoding that you support, the method should return `null`. The only case in which the method should throw an exception is if `name` is `null`.
 
-      ### Notes to callers
+## Notes to callers
 
-      This method is called by the [Encoding.GetEncoding(String)](<xref=System.Text.Encoding.GetEncoding(System.String)>) method. You should not call it directly from user code.
+This method is called by the [Encoding.GetEncoding(String)](<xref=System.Text.Encoding.GetEncoding(System.String)>) method. You should not call it directly from user code.
         ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Text/EncodingProvider.xml
+++ b/xml/System.Text/EncodingProvider.xml
@@ -130,13 +130,23 @@
         <param name="codepage">The code page identifier of the requested encoding.</param>
         <summary>Returns the encoding associated with the specified code page identifier.</summary>
         <returns>The encoding that is associated with the specified code page, or <see langword="null" /> if this <see cref="T:System.Text.EncodingProvider" /> cannot return a valid encoding that corresponds to <paramref name="codepage" />.</returns>
-        <remarks>To be added.</remarks>
-        <block subset="none" type="overrides">
-          <para>You override the <see cref="M:System.Text.EncodingProvider.GetEncoding(System.Int32)" /> method to return the encoding or encodings supported by your <see cref="T:System.Text.EncodingProvider" /> subclass. When user code attempts to retrieve an encoding by calling the <see cref="M:System.Text.Encoding.GetEncoding(System.Int32)" /> method, the method passes the <paramref name="codepage" /> identifier to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the <see cref="M:System.Text.Encoding.GetEncoding(System.Int32)" /> method attempts to retrieve a cached encoding whose code page identifier is <paramref name="codepage" />. Because of this, if <paramref name="codepage" /> is not the code page identifier of an encoding that you support, the method should return <see langword="null" />; it should never throw an exception.</para>
-        </block>
-        <block subset="none" type="usage">
-          <para>This method is called by the <see cref="M:System.Text.Encoding.GetEncoding(System.Int32)" /> method. You should not call it directly from user code.</para>
-        </block>
+        <remarks>
+        <format type="text/markdown"><![CDATA[ 
+
+        ## Remarks
+
+        ### Notes to inheritors
+
+        You override the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method, the method passes the `codepage` identifier to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(Int32)](<xref:System.Text.EncodingProvider.GetEncoding(System.Int32)>) method attempts to retrieve a cached encoding whose code page identifier is `codepage`. Because of this, if `codepage` is not the code page identifier of an encoding that you support, the method should return `null`; it should never throw an exception.
+        
+        Note that you can also choose to return a default code page if the value of the `codepage` argument is 0.
+
+        ## Notes to callers
+        
+        This method is called by the [Encoding.GetEncoding(Int32)](<xref=System.Text.Encoding.GetEncoding(System.Int32)>) method. You should not call it directly from user code.
+
+        ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEncoding">
@@ -171,13 +181,20 @@
         <param name="name">The name of the requested encoding.</param>
         <summary>Returns the encoding with the specified name.</summary>
         <returns>The encoding that is associated with the specified name, or <see langword="null" /> if this <see cref="T:System.Text.EncodingProvider" /> cannot return a valid encoding that corresponds to <paramref name="name" />.</returns>
-        <remarks>To be added.</remarks>
-        <block subset="none" type="overrides">
-          <para>You override the <see cref="M:System.Text.EncodingProvider.GetEncoding(System.String)" /> method to return the encoding or encodings supported by your <see cref="T:System.Text.EncodingProvider" /> subclass. When user code attempts to retrieve an encoding by calling the <see cref="M:System.Text.Encoding.GetEncoding(System.String)" /> method, the method passes the <paramref name="name" /> argument to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the <see cref="M:System.Text.Encoding.GetEncoding(System.String)" /> method attempts to retrieve a cached encoding whose name is <paramref name="name" />. Because of this, if <paramref name="name" /> is not the name of an encoding that you support, the method should return <see langword="null" />. The only case in which the method should throw an exception is if <paramref name="name" /> is <see langword="null" />.</para>
-        </block>
-        <block subset="none" type="usage">
-          <para>This method is called by the <see cref="M:System.Text.Encoding.GetEncoding(System.String)" /> method. You should not call it directly from user code.</para>
-        </block>
+        <remarks>
+           <format type="text/markdown"><![CDATA[ 
+        
+        ## Remarks
+        
+        ### Notes to inheritors 
+        
+        You override the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method to return the encoding or encodings supported by your <xref=System.Text.EncodingProvider> subclass. When user code attempts to retrieve an encoding by calling the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method, the method passes the `name` argument to every registered encoding provider until one returns a valid encoding. If none returns a valid encoding, the [GetEncoding(String)](<xref=System.Text.EncodingProvider.GetEncoding(System.String)>) method attempts to retrieve a cached encoding whose name is `name`. Because of this, if `name` is not the name of an encoding that you support, the method should return `null`. The only case in which the method should throw an exception is if `name` is `null`.
+
+      ### Notes to callers
+
+      This method is called by the [Encoding.GetEncoding(String)](<xref=System.Text.Encoding.GetEncoding(System.String)>) method. You should not call it directly from user code.
+        ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetEncoding">


### PR DESCRIPTION
# Encoding provider-related revisions

## Summary

The documentation for `Encoding.GetEncoding` didn't clarify how encoding providers affected the method, nor did it indicate how it affected GetEncoding(0). 

In addition, the Encoding.Default property is implementation-specific.

There has also been some content loss from documentation migration from MSDN to GitHub. I've added some of it back.

Fixes #1837, #2531 

## Suggested Reviewers

@tarekgh @mklement0
