### PR TITLE
Fix reference to non-existent binding

### DIFF
--- a/docs/framework/wcf/feature-details/grouping-queued-messages-in-a-session.md
+++ b/docs/framework/wcf/feature-details/grouping-queued-messages-in-a-session.md
@@ -54,7 +54,7 @@ manager: "erikre"
     [OperationBehavior(TransactionScopeRequired = true, TransactionAutoComplete = true)]   
     ```  
   
-5.  Configure an endpoint that uses the system-provided `NetProfileMsmqBinding` binding.  
+5.  Configure an endpoint that uses the system-provided `NetMsmqBinding` binding.  
   
 6.  Create a transactional queue using <xref:System.Messaging>. You can also create the queue by using Message Queuing (MSMQ) or MMC. If you do, create a transactional queue.  
   


### PR DESCRIPTION
# Fixed reference to non-existent binding

## Summary

As far as I know, the NetProfileMsmqBinding does not exist. Judging from [this post](https://blogs.msdn.microsoft.com/edpinto/2005/12/14/wcf-beta-1-to-nov-ctp-breaking-changes/), it looks like this was the old name for NetMsmqBinding.