### PR TITLE
Replace C# Developer Center broken link with new one

### DIFF
--- a/docs/csharp/programming-guide/index.md
+++ b/docs/csharp/programming-guide/index.md
@@ -41,7 +41,7 @@ translation.priority.ht:
 # C# programming guide
 This section provides detailed information on key C# language features and features accessible to C# through the .NET Framework.  
   
- Most of this section assumes that you already know something about C# and general programming concepts. If you are a complete beginner with programming or with C#, you might want to visit the [C# Developer Center](http://go.microsoft.com/fwlink/?linkid=95125), where you can find many tutorials, samples and videos to help you get started.  
+ Most of this section assumes that you already know something about C# and general programming concepts. If you are a complete beginner with programming or with C#, you might want to visit the [Getting Started with C#](https://www.microsoft.com/net/tutorials/csharp/getting-started) interactive tutorial, where no prior programming knowledge is required.  
   
  For information about specific keywords, operators and preprocessor directives, see [C# Reference](../../csharp/language-reference/index.md). For information about the C# Language Specification, see [C# Language Specification](../../csharp/language-reference/language-specification/index.md).  
   


### PR DESCRIPTION
The C# Developer Center link is broken. This commit replaces the link with the interactive tutorial.

I suggest we use the "Getting Started with C#" interactive tutorial instead which is aimed at people who are learning C# for the first time.
