### PR TITLE
Add explanation of library and language dependency

### DIFF
--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -14,6 +14,12 @@ ms.assetid: 77deec51-a14d-46d4-9bb3-faf449477149
 
 # What's new in C# #
 
+This page provides a roadmap of new features in each major release of
+the C# language. The links below provide detailed information on the
+major features added in each release.
+
+> [!IMPORTANT]
+> The C# language relies on types and methods in a *standard library* for some of the features. To use the latest language features in older environments, you may need to install specific libraries. These are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency.
 
 * [C# 7](csharp-7.md):
     - This page describes the latest features in the C# language. This covers C# 7, currently available in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/).

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -19,7 +19,7 @@ the C# language. The links below provide detailed information on the
 major features added in each release.
 
 > [!IMPORTANT]
-> The C# language relies on types and methods in a *standard library* for some of the features. To use the latest language features in older environments, you may need to install specific libraries. These are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency.
+> The C# language relies on types and methods in a *standard library* for some of the features. One example is exception processing. Every `throw` statement or expression is checked to ensure the object being thrown is derived from @System.Exception. Similarly, every `catch` is checked to ensure that the type being caught is derived from @System.Exception. Each version may add new requirements. To use the latest language features in older environments, you may need to install specific libraries. These are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency. 
 
 * [C# 7](csharp-7.md):
     - This page describes the latest features in the C# language. This covers C# 7, currently available in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/).

--- a/docs/csharp/whats-new/relationships-between-language-and-library.md
+++ b/docs/csharp/whats-new/relationships-between-language-and-library.md
@@ -13,29 +13,32 @@ ms.devlang: devlang-csharp
 # Relationships between language features and library types
 
 The C# language definition requires a standard library to have certain
-types, and certain accessible members on those types. The compiler generates
+types and certain accessible members on those types. The compiler generates
 code that uses these required types and members for many different language
 features. When necessary, there are NuGet packages that contain types
 needed for newer versions of the language when writing code for environments
 where those types or members have not been deployed yet.
 
 This dependency on standard library functionality has been part of the
-C# language since its first version. In that version, examples included
-`System.Exception`, `System.String`, `System.Int32` and more. That first
+C# language since its first version. In that version, examples included:
+
+* @System.Exception - used for all compiler generated exceptions.
+* @System.String - the C# `string` type is a synonym for @System.String.
+* @System.Int32 - synonym of `int`.
+
+That first
 version was simple: the compiler and the standard library shipped together,
 and there was only one version of each.
 
 Subsequent versions of C# have occasionally added new types or members to
-the dependencies. Examples include `System.Runtime.CompilerServices.INotifyCompletion`,
-`System.Runtime.CompilerServices.CallerFilePathAttribute` and
-`System.Runtime.CompilerServices.CallerMemberNameAttribute`.
-
-C# 7.0 continues this by adding a dependency on `System.ValueTuple` to
+the dependencies. Examples include: @System.Runtime.CompilerServices.INotifyCompletion,
+@System.Runtime.CompilerServices.CallerFilePathAttribute and
+@System.Runtime.CompilerServices.CallerMemberNameAttribute. C# 7.0 continues this by adding a dependency on @System.ValueTuple to
 implement the [tuples](../tuples.md) language feature.
 
 The language design team works to minimize the surface area of the types
 and members required in a compliant standard library. That goal is balanced
-against a clean design where new library features are incorporated cleanly
+against a clean design where new library features are incorporated seamlessly
 into the language. There will be new features in future versions of C# that
 require new types and members in a standard library. It's important to understand
 how to manage those dependencies in your work.
@@ -43,15 +46,15 @@ how to manage those dependencies in your work.
 ## Managing your dependencies
 
 C# compiler tools are now decoupled from the release cycle of the .NET libraries
-on the many supported platforms. In fact, different .NET libraries have different release
-cycles: the .NET Framework on Windows is relesed as a Windows Update. .NET Core ships on
-its schedule, and the Xamarin versions of library updates ship with the Xamarin tools
+on supported platforms. In fact, different .NET libraries have different release
+cycles: the .NET Framework on Windows is relesed as a Windows Update, .NET Core ships on
+a separate schedule, and the Xamarin versions of library updates ship with the Xamarin tools
 for each target platform.
 
 The majority of time, you won't notice these changes. However, when you are working
 with a newer version of the language that requires features not yet in the .NET libraries
 on that platform, you'll reference the NuGet packages to provide those new types.
-As all the platforms your app supports are updated with new framework installations,
+As the platforms your app supports are updated with new framework installations,
 you can remove the extra reference.
 
 This separation means you can use new language features even when you are targeting

--- a/docs/csharp/whats-new/relationships-between-language-and-library.md
+++ b/docs/csharp/whats-new/relationships-between-language-and-library.md
@@ -1,0 +1,58 @@
+---
+title: The relationship between language features and library types | Microsoft Docs 
+description: Language features often rely on library types for implementation. Understand that relationship.
+keywords: C# language design, standard library
+author: billwagner
+ms.author: wiwagn
+ms.date: 07/20/2017
+ms.topic: article
+ms.prod: .net
+ms.devlang: devlang-csharp
+---
+
+# Relationships between language features and library types
+
+The C# language definition requires a standard library to have certain
+types, and certain accessible members on those types. The compiler generates
+code that uses these required types and members for many different language
+features. When necessary, there are NuGet packages that contain types
+needed for newer versions of the language when writing code for environments
+where those types or members have not been deployed yet.
+
+This dependency on standard library functionality has been part of the
+C# language since its first version. In that version, examples included
+`System.Exception`, `System.String`, `System.Int32` and more. That first
+version was simple: the compiler and the standard library shipped together,
+and there was only one version of each.
+
+Subsequent versions of C# have occasionally added new types or members to
+the dependencies. Examples include `System.Runtime.CompilerServices.INotifyCompletion`,
+`System.Runtime.CompilerServices.CallerFilePathAttribute` and
+`System.Runtime.CompilerServices.CallerMemberNameAttribute`.
+
+C# 7.0 continues this by adding a dependency on `System.ValueTuple` to
+implement the [tuples](../tuples.md) language feature.
+
+The language design team works to minimize the surface area of the types
+and members required in a compliant standard library. That goal is balanced
+against a clean design where new library features are incorporated cleanly
+into the language. There will be new features in future versions of C# that
+require new types and members in a standard library. It's important to understand
+how to manage those dependencies in your work.
+
+## Managing your dependencies
+
+C# compiler tools are now decoupled from the release cycle of the .NET libraries
+on the many supported platforms. In fact, different .NET libraries have different release
+cycles: the .NET Framework on Windows is relesed as a Windows Update. .NET Core ships on
+its schedule, and the Xamarin versions of library updates ship with the Xamarin tools
+for each target platform.
+
+The majority of time, you won't notice these changes. However, when you are working
+with a newer version of the language that requires features not yet in the .NET libraries
+on that platform, you'll reference the NuGet packages to provide those new types.
+As all the platforms your app supports are updated with new framework installations,
+you can remove the extra reference.
+
+This separation means you can use new language features even when you are targeting
+machines that may not have the corresponding framework.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -182,6 +182,7 @@
 ## [What's new in C#](csharp/whats-new/index.md) 
 ### [What's new in C# 7](csharp/whats-new/csharp-7.md)
 ### [What's new in C# 6](csharp/whats-new/csharp-6.md)
+### [Relationships between language and framework](csharp/whats-new/relationships-between-language-and-library.md)
 <!-- End What's New -->
 <!--## [🔧 C# Interactive](csharp/interactive/)-->
 <!-- Do this section later, once master redirects are in place -->


### PR DESCRIPTION
Fixes #1760

The C# language maps syntax to methods and types. This expalins what to
do when you have a newer compiler than framework.