### PR TITLE
PATH-based extensibility - macOS symbolic link

### DIFF
--- a/docs/core/tools/extensibility.md
+++ b/docs/core/tools/extensibility.md
@@ -180,7 +180,7 @@ echo "Hello World"
 ```
 
 On macOS, we can save this script as `dotnet-hello` and set its executable bit with `chmod +x dotnet-hello`. We can then
-create a symbolic link to it in `/usr/local/bin` using the command `ln -s dotnet-hello /usr/local/bin/`. This will make
+create a symbolic link to it in `/usr/local/bin` using the command `ln -s <full_path>/dotnet-hello /usr/local/bin/`. This will make
 it possible to invoke the command using the `dotnet hello` syntax.
 
 On Windows, we can save this script as `dotnet-hello.cmd` and put it in a location that is in a system path (or you can


### PR DESCRIPTION
# Title

PATH-based extensibility - macOS symbolic link

## Summary

The path to the original file/folder  can use . or ~ or other relative paths:
`ln -s /path/to/original /path/to/symlink`

## Details

Symbolic link created with the command `ln -s dotnet-hello /usr/local/bin/` returns error on execution.

```
$ dotnet hello
System.ComponentModel.Win32Exception (0x80004005): Too many levels of symbolic links
   at Interop.Sys.ForkAndExecProcess(String filename, String[] argv, String[] envp, String cwd, Boolean redirectStdin, Boolean redirectStdout, Boolean redirectStderr, Int32& lpChildPid, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at Microsoft.DotNet.Cli.Utils.Command.Execute()
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
```
