### PR TITLE
Removed autoTopLevelSectionsOUTLINE

### DIFF
--- a/docs/framework/wpf/advanced/annotations-schema.md
+++ b/docs/framework/wpf/advanced/annotations-schema.md
@@ -34,15 +34,6 @@ This topic describes the XML schema definition (XSD) used by the Microsoft Annot
   
  The Base Schema described in this topic defines the extensions for the <xref:System.Windows.Annotations.Annotation.Authors%2A>, <xref:System.Windows.Annotations.ContentLocatorPart>, and Content types included with the initial [!INCLUDE[TLA#tla_wpf](../../../../includes/tlasharptla-wpf-md.md)] release.  
   
- This topic contains the following sections:  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
--   [Annotations XML Core Schema](#CoreSchema)  
-  
--   [Annotations XML Base Schema](#BaseSchema)  
-  
--   [Sample XML Created by Annotations XmlStreamStore](#SampleXML)  
-  
 <a name="CoreSchema"></a>   
 ## Annotations XML Core Schema  
  The Annotations XML Core Schema defines the XML structure that is used to store <xref:System.Windows.Annotations.Annotation> objects.  

--- a/docs/framework/wpf/advanced/freezable-objects-overview.md
+++ b/docs/framework/wpf/advanced/freezable-objects-overview.md
@@ -22,9 +22,6 @@ manager: "wpickett"
 # Freezable Objects Overview
 This topic describes how to effectively use and create <xref:System.Windows.Freezable> objects, which provide special features that can help improve application performance. Examples of freezable objects include brushes, pens, transformations, geometries, and animations.  
   
- This topic contains the following sections:  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="whatisafreezable"></a>   
 ## What Is a Freezable?  
  A <xref:System.Windows.Freezable> is a special type of object that has two states: unfrozen and frozen. When unfrozen, a <xref:System.Windows.Freezable> appears to behave like any other object. When frozen, a <xref:System.Windows.Freezable> can no longer be modified.  

--- a/docs/framework/wpf/advanced/use-automatic-layout-overview.md
+++ b/docs/framework/wpf/advanced/use-automatic-layout-overview.md
@@ -21,19 +21,6 @@ manager: "wpickett"
 # Use Automatic Layout Overview
 This topic introduces guidelines for developers on how to write              [!INCLUDE[TLA#tla_winclient](../../../../includes/tlasharptla-winclient-md.md)] applications with localizable              [!INCLUDE[TLA#tla_ui#plural](../../../../includes/tlasharptla-uisharpplural-md.md)]. In the past, localization of a              [!INCLUDE[TLA2#tla_ui](../../../../includes/tla2sharptla-ui-md.md)] was a time consuming process. Each language that the              [!INCLUDE[TLA2#tla_ui](../../../../includes/tla2sharptla-ui-md.md)] was adapted for required a pixel by pixel adjustment. Today with the right design and right coding standards,              [!INCLUDE[TLA2#tla_ui#plural](../../../../includes/tla2sharptla-uisharpplural-md.md)] can be constructed so that localizers have less resizing and repositioning to do. The approach to writing applications that can be more easily resized and repositioned is called automatic layout, and can be achieved by using              [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] application design.  
   
- This topic contains the following sections.  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
--   [Advantages of Using Automatic Layout](#advantages_of_autolayout)  
-  
--   [Automatic Layout and Controls](#autolayout_controls)  
-  
--   [Automatic Layout and Coding Standards](#autolayout_coding)  
-  
--   [Automatic Layout and Grids](#autolay_grids)  
-  
--   [Automatic Layout and Grids Using the IsSharedSizeScope Property](#autolay_grids_issharedsizescope)  
-  
 <a name="advantages_of_autolayout"></a>   
 ## Advantages of Using Automatic Layout  
  Because the                  [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] presentation system is powerful and flexible, it provides the ability to layout elements in an application that can be adjusted to fit the requirements of different languages. The following list points out some of the advantages of automatic layout.  

--- a/docs/framework/wpf/controls/scrollviewer-overview.md
+++ b/docs/framework/wpf/controls/scrollviewer-overview.md
@@ -21,19 +21,6 @@ manager: "wpickett"
 # ScrollViewer Overview
 Content within a user interface is often larger than a computer screen's display area. The <xref:System.Windows.Controls.ScrollViewer> control provides a convenient way to enable scrolling of content in [!INCLUDE[TLA#tla_winclient](../../../../includes/tlasharptla-winclient-md.md)] applications. This topic introduces the <xref:System.Windows.Controls.ScrollViewer> element and provides several usage examples.  
   
- This topic contains the following sections:  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
--   [The ScrollViewer Control](#what_is_a_scrollviewer_element)  
-  
--   [Physical vs. Logical Scrolling](#scrollviewer_physical_vs_logical)  
-  
--   [Defining and Using a ScrollViewer Element](#scrollviewer_markup_syntax_and_sample)  
-  
--   [Styling a ScrollViewer](#scrollviewer_styling_scrollviewer)  
-  
--   [Paginating Documents](#scrollviewer_scroll_vs_paginate)  
-  
 <a name="what_is_a_scrollviewer_element"></a>   
 ## The ScrollViewer Control  
  There are two predefined elements that enable scrolling in [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] applications: <xref:System.Windows.Controls.Primitives.ScrollBar> and <xref:System.Windows.Controls.ScrollViewer>. The <xref:System.Windows.Controls.ScrollViewer> control encapsulates horizontal and vertical <xref:System.Windows.Controls.Primitives.ScrollBar> elements and a content container (such as a <xref:System.Windows.Controls.Panel> element) in order to display other visible elements in a scrollable area. You must build a custom object in order to use the <xref:System.Windows.Controls.Primitives.ScrollBar> element for content scrolling. However, you can use the <xref:System.Windows.Controls.ScrollViewer> element by itself because it is a composite control that encapsulates <xref:System.Windows.Controls.Primitives.ScrollBar> functionality.  

--- a/docs/framework/wpf/graphics-multimedia/animation-and-timing-system-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/animation-and-timing-system-overview.md
@@ -21,7 +21,6 @@ manager: "wpickett"
 # Animation and Timing System Overview
 This topic describes how the timing system uses the animation, <xref:System.Windows.Media.Animation.Timeline>, and <xref:System.Windows.Media.Animation.Clock> classes to animate properties.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be able to use [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] animations to animate properties, as described in the [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md). It also helps to be familiar with dependency properties; for more information, see the [Dependency Properties Overview](../../../../docs/framework/wpf/advanced/dependency-properties-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/animation-tips-and-tricks.md
+++ b/docs/framework/wpf/graphics-multimedia/animation-tips-and-tricks.md
@@ -27,7 +27,6 @@ manager: "wpickett"
 # Animation Tips and Tricks
 When working with animations in              [!INCLUDE[TLA2#tla_wpf](../../../../includes/tla2sharptla-wpf-md.md)], there are a number of tips and tricks that can make your animations perform better and save you frustration.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="generalissuessection"></a>   
 ## General Issues  
   

--- a/docs/framework/wpf/graphics-multimedia/brush-transformation-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/brush-transformation-overview.md
@@ -22,7 +22,6 @@ manager: "wpickett"
 # Brush Transformation Overview
 The Brush class provides two transformation properties: <xref:System.Windows.Media.Brush.Transform%2A> and <xref:System.Windows.Media.Brush.RelativeTransform%2A>. The properties enable you to rotate, scale, skew, and translate a brush's contents. This topic describes the differences between these two properties and provides examples of their usage.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should understand the features of the brush that you are transforming. For <xref:System.Windows.Media.LinearGradientBrush> and <xref:System.Windows.Media.RadialGradientBrush>, see the [Painting with Solid Colors and Gradients Overview](../../../../docs/framework/wpf/graphics-multimedia/painting-with-solid-colors-and-gradients-overview.md). For <xref:System.Windows.Media.ImageBrush>, <xref:System.Windows.Media.DrawingBrush>, or <xref:System.Windows.Media.VisualBrush>, see  [Painting with Images, Drawings, and Visuals](../../../../docs/framework/wpf/graphics-multimedia/painting-with-images-drawings-and-visuals.md). You should also be familiar with the 2D transforms described in the  [Transforms Overview](../../../../docs/framework/wpf/graphics-multimedia/transforms-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/custom-animations-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/custom-animations-overview.md
@@ -24,7 +24,6 @@ manager: "wpickett"
 # Custom Animations Overview
 This topic describes how and when to extend the [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] animation system by creating custom key frames, animation classes, or by using per-frame callback to bypass it.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with the different types of animations provided by the [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)]. For more information, see the From/To/By Animations Overview, the [Key-Frame Animations Overview](../../../../docs/framework/wpf/graphics-multimedia/key-frame-animations-overview.md), and the [Path Animations Overview](../../../../docs/framework/wpf/graphics-multimedia/path-animations-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/from-to-by-animations-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/from-to-by-animations-overview.md
@@ -21,9 +21,6 @@ manager: "wpickett"
 # From/To/By Animations Overview
 This topic describes how to use From/To/By animations to animate dependency properties. A From/To/By animation creates a transition between two values.  
   
- This topic contains the following sections.  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prereq"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with                  [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] animations features. For an introduction to animation features, see the                  [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/opacity-masks-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/opacity-masks-overview.md
@@ -22,23 +22,6 @@ manager: "wpickett"
 # Opacity Masks Overview
 Opacity masks enable you to make portions of an element or visual either transparent or partially transparent. To create an opacity mask, you apply a <xref:System.Windows.Media.Brush> to the <xref:System.Windows.UIElement.OpacityMask%2A> property of an element or <xref:System.Windows.Media.Visual>.  The brush is mapped to the element or visual, and the opacity value of each brush pixel is used to determine the resulting opacity of each corresponding pixel of the element or visual.  
   
- This topic contains the following sections.  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
--   [Prerequisites](#prereqs)  
-  
--   [Creating Visual Effects with Opacity Masks](#opacitymasks)  
-  
--   [Creating an Opacity Mask](#creatingopacitymasks)  
-  
--   [Using a Gradient as an Opacity Mask](#creatingopacitymaskswithgradients)  
-  
--   [Specifying Gradient Stops for an Opacity Mask](#specifyinggradientcolors)  
-  
--   [Using an Image as an Opacity Mask](#usingimageasopacitymask)  
-  
--   [Creating an Opacity Mask from a Drawing](#drawingbrushasopacitymask)  
-  
 <a name="prereqs"></a>   
 ## Prerequisites  
  This overview assumes that you are familiar with <xref:System.Windows.Media.Brush> objects. For an introduction to using brushes, see [Painting with Solid Colors and Gradients Overview](../../../../docs/framework/wpf/graphics-multimedia/painting-with-solid-colors-and-gradients-overview.md). For information about <xref:System.Windows.Media.ImageBrush> and <xref:System.Windows.Media.DrawingBrush>, see [Painting with Images, Drawings, and Visuals](../../../../docs/framework/wpf/graphics-multimedia/painting-with-images-drawings-and-visuals.md).  

--- a/docs/framework/wpf/graphics-multimedia/path-animations-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/path-animations-overview.md
@@ -21,7 +21,6 @@ manager: "wpickett"
 # Path Animations Overview
 <a name="introduction"></a> This topic introduces path animations, which enable you to use a geometric path to generate output values. Path animations are useful for moving and rotating objects along complex paths.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with                  [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] animations features. For an introduction to animation features, see the                  [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/path-markup-syntax.md
+++ b/docs/framework/wpf/graphics-multimedia/path-markup-syntax.md
@@ -25,9 +25,6 @@ manager: "wpickett"
 # Path Markup Syntax
 Paths are discussed in              [Shapes and Basic Drawing in WPF Overview](../../../../docs/framework/wpf/graphics-multimedia/shapes-and-basic-drawing-in-wpf-overview.md) and the              [Geometry Overview](../../../../docs/framework/wpf/graphics-multimedia/geometry-overview.md), however, this topic describes in detail the powerful and complex mini-language you can use to specify path geometries more compactly using              [!INCLUDE[TLA#tla_xaml](../../../../includes/tlasharptla-xaml-md.md)].  
   
- This topic contains the following sections.  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with the basic features of                  <xref:System.Windows.Media.Geometry> objects. For more information, see the                  [Geometry Overview](../../../../docs/framework/wpf/graphics-multimedia/geometry-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/property-animation-techniques-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/property-animation-techniques-overview.md
@@ -21,7 +21,6 @@ manager: "wpickett"
 # Property Animation Techniques Overview
 This topic describes the different approaches for animating properties: storyboards, local animations, clocks, and per-frame animations.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with the basic animation features described in the [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/storyboards-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/storyboards-overview.md
@@ -22,7 +22,6 @@ manager: "wpickett"
 # Storyboards Overview
 This topic shows how to use              <xref:System.Windows.Media.Animation.Storyboard> objects to organize and apply animations. It describes how to interactively manipulate              <xref:System.Windows.Media.Animation.Storyboard> objects and describes indirect property targeting syntax.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with the different animation types and their basic features. For an introduction to animation, see the [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md). You should also know how to use attached properties. For more information about attached properties, see the [Attached Properties Overview](../../../../docs/framework/wpf/advanced/attached-properties-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/timing-behaviors-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/timing-behaviors-overview.md
@@ -21,7 +21,6 @@ manager: "wpickett"
 # Timing Behaviors Overview
 This topic describes the timing behaviors of animations and other              <xref:System.Windows.Media.Animation.Timeline> objects.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 <a name="prerequisites"></a>   
 ## Prerequisites  
  To understand this topic, you should be familiar with basic animation features. For more information, see the                  [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md).  

--- a/docs/framework/wpf/graphics-multimedia/timing-events-overview.md
+++ b/docs/framework/wpf/graphics-multimedia/timing-events-overview.md
@@ -23,7 +23,6 @@ manager: "wpickett"
 # Timing Events Overview
 This topic describes how to use the five timing events available on              <xref:System.Windows.Media.Animation.Timeline> and              <xref:System.Windows.Media.Animation.Clock> objects.  
   
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
 ## Prerequisites  
  To understand this topic, you should understand how to create and use animations. To get started with animation, see the                  [Animation Overview](../../../../docs/framework/wpf/graphics-multimedia/animation-overview.md).  
   

--- a/docs/framework/wpf/graphics-multimedia/using-drawingvisual-objects.md
+++ b/docs/framework/wpf/graphics-multimedia/using-drawingvisual-objects.md
@@ -21,19 +21,6 @@ manager: "wpickett"
 # Using DrawingVisual Objects
 This topic provides an overview of how to use <xref:System.Windows.Media.DrawingVisual> objects in the [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] visual layer.  
   
- This topic contains the following sections.  
-  
-<a name="autoTopLevelSectionsOUTLINE0"></a>   
--   [Drawing Visual Object](#drawingvisual_object)  
-  
--   [DrawingVisual Host Container](#drawingvisual_host_container)  
-  
--   [Creating DrawingVisual Objects](#creating_drawingvisual_objects)  
-  
--   [Creating Overrides for FrameworkElement Members](#creating_overrides)  
-  
--   [Providing Hit Testing Support](#providing_hit_testing_support)  
-  
 <a name="drawingvisual_object"></a>   
 ## DrawingVisual Object  
  The <xref:System.Windows.Media.DrawingVisual> is a lightweight drawing class that is used to render shapes, images, or text. This class is considered lightweight because it does not provide layout or event handling, which improves its performance. For this reason, drawings are ideal for backgrounds and clip art.  


### PR DESCRIPTION
Removed `<a name="autoTopLevelSectionsOUTLINE0"></a>`, since it doesn't do anything.

Also removed hardcoded TOCs and text pointing to the TOC nearby.