### PR TITLE
Issue 1846: goto must go to a constant label

### DIFF
--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -94,7 +94,7 @@ This requirement is usually met by explicitly exiting the switch section by usin
   
  [!code-cs[switch#4](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch4.cs#1)]    
   
- Execution of the statement list in the switch section with a case label that matches the match expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label.  
+ Execution of the statement list in the switch section with a case label that matches the match expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `goto label`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label. A `goto` statement, if it is used, must transfer control to a constant label. This restriction is necessary, since attempting to transfer control to a non-constant label can have undesirable side-effects, such transferring control to an unintended location in code or creating an endless loop.
 
 ## Case labels
 


### PR DESCRIPTION
# goto must go to a constant label

Fixes #1846 

## Suggested Reviewers
@BillWagner 
