### PR TITLE
Update get-started-visual-studio.md

### DIFF
--- a/docs/fsharp/get-started/get-started-visual-studio.md
+++ b/docs/fsharp/get-started/get-started-visual-studio.md
@@ -133,7 +133,7 @@ If you haven't already, check out the [Tour of F#](../tour.md), which covers som
 
 [Visual F#](index.md)
 
-[Tour of F#](tour.md)
+[Tour of F#](../tour.md)
 
 [F# language reference](../language-reference/index.md)
 


### PR DESCRIPTION
Fixing link to the "Tour of F#" page under "See also".