### PR TITLE
Corrected comment - VB.NET code

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_CLR/DPAPI-HowTO/vb/sample.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/DPAPI-HowTO/vb/sample.vb
@@ -190,7 +190,7 @@ Public Module MemoryProtectionSample
             Throw New IOException("Could not read the stream.")
         End If
 
-        ' Return the length that was written to the stream. 
+        ' Return the unencrypted data as byte array. 
         Return outBuffer
 
     End Function 'DecryptDataFromStream 


### PR DESCRIPTION
The method returns the unprotected byte array from the stream. Most likely a copy-paste error.

# Corrected comment

In relation with C# code: https://github.com/kdaveid/docs-1/commit/8f6f82392cf2c3db23fd05c05bd25f26921b91b4

## Summary

Just changed a code comment.

## Suggested Reviewers

Initial file owner: @yishengjin1413