### PR TITLE
Add docs on the various HttpClient providers and their default handlers

### DIFF
--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -71,22 +71,21 @@ The <xref:System.Net.Http.HttpClient> is a high-level API that wraps the lower-l
 
 On each platform, <xref:System.Net.Http.HttpClient> tries to use the best available transport:
 
-| **Host/Runtime**  | **Backend**                                                                               |
-| ----------------- | ----------------------------------------------------------------------------------------- |
-| Windows/.NET      | <xref:System.Net.HttpWebRequest>                                                          |
-| Windows/Mono      | <xref:System.Net.HttpWebRequest>                                                          |
-| Windows/UWP       | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
-| Windows/.NET Core | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
-| Android/Xamarin   | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
-| iOS, tvOS/Xamarin | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
-| macOS/Xamarin     | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
-| macOS/Mono        | <xref:System.Net.HttpWebRequest>                                                                          |
-| macOS/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
-| Linux/Mono        | <xref:System.Net.HttpWebRequest>                                                          |
-| Linux/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
+| **Host/Runtime**            | **Backend**                                                                               |
+| --------------------------- | ----------------------------------------------------------------------------------------- |
+| Windows/.NET Framework      | <xref:System.Net.HttpWebRequest>                                                          |
+| Windows/Mono                | <xref:System.Net.HttpWebRequest>                                                          |
+| Windows/UWP                 | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
+| Windows/.NET Core           | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
+| Android/Xamarin             | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
+| iOS, tvOS, watchOS/Xamarin  | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Xamarin               | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Mono                  | <xref:System.Net.HttpWebRequest>                                                                          |
+| macOS/.NET Core             | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
+| Linux/Mono                  | <xref:System.Net.HttpWebRequest>                                                          |
+| Linux/.NET Core             | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
 
-Users can also configure a specific transport for <xref:System.Net.Http.HttpClient> by invoking the constructor that takes an 
-<xref:System.Net.Http.HttpMessageHandler>.
+Users can also configure a specific transport for <xref:System.Net.Http.HttpClient> by invoking the <xref:System.Net.Http.HttpClient.%23ctor*> constructor that takes an <xref:System.Net.Http.HttpMessageHandler>.
   
 ## Examples  
  [!code-csharp[System.Net.Http.HttpClient#1](~/samples/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclient/cs/source.cs#1)]  

--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -67,7 +67,29 @@ public class GoodController : ApiController
   
 ```  
   
-   
+The <xref:System.Net.Http.HttpClient> is a high-level API that wraps the lower-level functionality available on each platform where it runs.
+
+On each platform, <xref:System.Net.Http.HttpClient> tries to use the best available transport:
+
+| **Host/Runtime**  | **Backend**                                                                             |
+| ----------------- | --------------------------------------------------------------------------------------- |
+| Windows/.NET      | <xref:System.Net.HttpWebRequest>                                                        |
+| Windows/Mono      | <xref:System.Net.HttpWebRequest>                                                        |
+| Windows/UWP       | Windows native <xref:Syste.Net.Http.WinHttpHandler (HTTP 2.0 capable)                   |
+| Windows/.NET Core | Windows native <xref:Syste.Net.Http.WinHttpHandler (HTTP 2.0 capable)                   |
+| Android/Xamarin   | Build time selection;
+Can use either <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
+| iOS, tvOS/Xamarin | Build time selection;
+Can use either <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Xamarin     | Build time selection;
+Can use either <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Mono        | `HttpWebRequest`                                                                        |
+| macOS/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                       |
+| Linux/Mono        | <xref:System.Net.HttpWebRequest>                                                        |
+| Linux/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                       |
+
+Users can also configure a specific transport for <xref:System.Net.Http.HttpClient> by invoking the constructor that takes a 
+<xref:System.Net.Http.HttpMessageHandler>.
   
 ## Examples  
  [!code-csharp[System.Net.Http.HttpClient#1](~/samples/snippets/csharp/VS_Snippets_Misc/system.net.http.httpclient/cs/source.cs#1)]  

--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -71,24 +71,21 @@ The <xref:System.Net.Http.HttpClient> is a high-level API that wraps the lower-l
 
 On each platform, <xref:System.Net.Http.HttpClient> tries to use the best available transport:
 
-| **Host/Runtime**  | **Backend**                                                                             |
-| ----------------- | --------------------------------------------------------------------------------------- |
-| Windows/.NET      | <xref:System.Net.HttpWebRequest>                                                        |
-| Windows/Mono      | <xref:System.Net.HttpWebRequest>                                                        |
-| Windows/UWP       | Windows native <xref:Syste.Net.Http.WinHttpHandler (HTTP 2.0 capable)                   |
-| Windows/.NET Core | Windows native <xref:Syste.Net.Http.WinHttpHandler (HTTP 2.0 capable)                   |
-| Android/Xamarin   | Build time selection;
-Can use either <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
-| iOS, tvOS/Xamarin | Build time selection;
-Can use either <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
-| macOS/Xamarin     | Build time selection;
-Can use either <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
-| macOS/Mono        | `HttpWebRequest`                                                                        |
-| macOS/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                       |
-| Linux/Mono        | <xref:System.Net.HttpWebRequest>                                                        |
-| Linux/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                       |
+| **Host/Runtime**  | **Backend**                                                                               |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| Windows/.NET      | <xref:System.Net.HttpWebRequest>                                                          |
+| Windows/Mono      | <xref:System.Net.HttpWebRequest>                                                          |
+| Windows/UWP       | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
+| Windows/.NET Core | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
+| Android/Xamarin   | Build time selection. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
+| iOS, tvOS/Xamarin | Build time selection. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Xamarin     | Build time selection. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Mono        | <xref:System.Net.HttpWebRequest>                                                                          |
+| macOS/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
+| Linux/Mono        | <xref:System.Net.HttpWebRequest>                                                          |
+| Linux/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
 
-Users can also configure a specific transport for <xref:System.Net.Http.HttpClient> by invoking the constructor that takes a 
+Users can also configure a specific transport for <xref:System.Net.Http.HttpClient> by invoking the constructor that takes an 
 <xref:System.Net.Http.HttpMessageHandler>.
   
 ## Examples  

--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -77,9 +77,9 @@ On each platform, <xref:System.Net.Http.HttpClient> tries to use the best availa
 | Windows/Mono      | <xref:System.Net.HttpWebRequest>                                                          |
 | Windows/UWP       | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
 | Windows/.NET Core | Windows native <xref:System.Net.Http.WinHttpHandler> (HTTP 2.0 capable)                   |
-| Android/Xamarin   | Build time selection. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
-| iOS, tvOS/Xamarin | Build time selection. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
-| macOS/Xamarin     | Build time selection. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| Android/Xamarin   | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Android's native [`HttpURLConnection`](https://developer.xamarin.com/api/type/Java.Net.HttpURLConnection/) |
+| iOS, tvOS/Xamarin | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
+| macOS/Xamarin     | Selected at build-time. Can either use <xref:System.Net.HttpWebRequest> or be configured to use Apple's [`NSUrlSession`](https://developer.xamarin.com/api/type/MonoTouch.Foundation.NSUrlSession/) (HTTP 2.0 capable) |
 | macOS/Mono        | <xref:System.Net.HttpWebRequest>                                                                          |
 | macOS/.NET Core   | `libcurl`-based HTTP transport (HTTP 2.0 capable)                                         |
 | Linux/Mono        | <xref:System.Net.HttpWebRequest>                                                          |


### PR DESCRIPTION
# Add docs on the various HttpClient providers and their default handlers

## Summary

This adds a table showing the provider that HttpClient uses across different .NET implementations.
