### PR TITLE
replaced msdn links + renamed topic

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -834,6 +834,11 @@
         {
             "source_path": "docs/tutorials/index.md",
             "redirect_url": "/dotnet/samples-and-tutorials/"
+        },        
+        {
+            "source_path": "docs/visual-basic/programming-guide/concepts/covariance-contravariance/covariance-and-contravariance.md",
+            "redirect_url": "/dotnet/visual-basic/programming-guide/concepts/covariance-contravariance/index",
+            "redirect_document_id": true
         },
         {
             "source_path": "docs/visual-basic/developing-apps/debugging.md",

--- a/docs/csharp/language-reference/keywords/in-generic-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-generic-modifier.md
@@ -40,7 +40,7 @@ For generic type parameters, the `in` keyword specifies that the type parameter 
   
  A contravariant delegate can be assigned another delegate of the same type, but with a less derived generic type parameter.  
   
- For more information, see [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8).  
+ For more information, see [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md).  
   
 ## Example  
  The following example shows how to declare, extend, and implement a contravariant generic interface. It also shows how you can use implicit conversion for classes that implement this interface.  
@@ -57,5 +57,5 @@ For generic type parameters, the `in` keyword specifies that the type parameter 
   
 ## See Also  
  [out](../../../csharp/language-reference/keywords/out-generic-modifier.md)   
- [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8)   
+ [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md)   
  [Modifiers](../../../csharp/language-reference/keywords/modifiers.md)

--- a/docs/csharp/language-reference/keywords/out-generic-modifier.md
+++ b/docs/csharp/language-reference/keywords/out-generic-modifier.md
@@ -65,6 +65,6 @@ For generic type parameters, the `out` keyword specifies that the type parameter
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
 ## See Also  
- [Variance in Generic Interfaces](http://msdn.microsoft.com/library/e14322da-1db3-42f2-9a67-397daddd6b6a)   
+ [Variance in Generic Interfaces](../../programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md)   
  [in](../../../csharp/language-reference/keywords/in-generic-modifier.md)   
  [Modifiers](../../../csharp/language-reference/keywords/modifiers.md)

--- a/docs/standard/generics/covariance-and-contravariance.md
+++ b/docs/standard/generics/covariance-and-contravariance.md
@@ -188,5 +188,6 @@ manager: "wpickett"
 |<xref:System.Linq.IQueryable%601>|Yes||  
   
 ## See Also  
- [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8)   
+ [Covariance and Contravariance (C#)](../../csharp/programming-guide/concepts/covariance-contravariance/index.md)   
+ [Covariance and Contravariance (Visual Basic)](../../visual-basic/programming-guide/concepts/covariance-contravariance/index.md)    
  [Variance in Delegates](http://msdn.microsoft.com/library/e3b98197-6c5b-4e55-9c6e-9739b60645ca)

--- a/docs/visual-basic/language-reference/modifiers/in-generic-modifier.md
+++ b/docs/visual-basic/language-reference/modifiers/in-generic-modifier.md
@@ -1,13 +1,9 @@
 ---
 title: "In (Generic Modifier) (Visual Basic)"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 f1_keywords: 
   - "vb.VarianceIn"
@@ -20,7 +16,6 @@ ms.assetid: 59bb13c5-fe96-42b8-8286-86293d1661c5
 caps.latest.revision: 19
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -42,7 +37,7 @@ For generic type parameters, the `In` keyword specifies that the type parameter 
 ## Remarks  
  Contravariance enables you to use a less derived type than that specified by the generic parameter. This allows for implicit conversion of classes that implement variant interfaces and implicit conversion of delegate types.  
   
- For more information, see [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8).  
+ For more information, see [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md).  
   
 ## Rules  
  You can use the `In` keyword in generic interfaces and delegates.  
@@ -69,5 +64,5 @@ For generic type parameters, the `In` keyword specifies that the type parameter 
  [!code-vb[vbVarianceKeywords#2](../../../visual-basic/language-reference/modifiers/codesnippet/VisualBasic/in-generic-modifier_2.vb)]  
   
 ## See Also  
- [Variance in Generic Interfaces](http://msdn.microsoft.com/library/e14322da-1db3-42f2-9a67-397daddd6b6a)   
+ [Variance in Generic Interfaces](../../programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md)   
  [Out](../../../visual-basic/language-reference/modifiers/out-generic-modifier.md)

--- a/docs/visual-basic/language-reference/modifiers/out-generic-modifier.md
+++ b/docs/visual-basic/language-reference/modifiers/out-generic-modifier.md
@@ -1,13 +1,9 @@
 ---
 title: "Out (Generic Modifier) (Visual Basic)"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 f1_keywords: 
   - "vb.VarianceOut"
@@ -20,7 +16,6 @@ ms.assetid: c4418369-1518-4a46-9a1e-054c61038eca
 caps.latest.revision: 14
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -42,7 +37,7 @@ For generic type parameters, the `Out` keyword specifies that the type is covari
 ## Remarks  
  Covariance enables you to use a more derived type than that specified by the generic parameter. This allows for implicit conversion of classes that implement variant interfaces and implicit conversion of delegate types.  
   
- For more information, see [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8).  
+ For more information, see [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md).  
   
 ## Rules  
  You can use the `Out` keyword in generic interfaces and delegates.  
@@ -78,5 +73,5 @@ For generic type parameters, the `Out` keyword specifies that the type is covari
  [!code-vb[vbVarianceKeywords#4](../../../visual-basic/language-reference/modifiers/codesnippet/VisualBasic/out-generic-modifier_2.vb)]  
   
 ## See Also  
- [Variance in Generic Interfaces](http://msdn.microsoft.com/library/e14322da-1db3-42f2-9a67-397daddd6b6a)   
+ [Variance in Generic Interfaces](../../programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md)   
  [In](../../../visual-basic/language-reference/modifiers/in-generic-modifier.md)

--- a/docs/visual-basic/language-reference/statements/delegate-statement.md
+++ b/docs/visual-basic/language-reference/statements/delegate-statement.md
@@ -1,13 +1,9 @@
 ---
 title: "Delegate Statement"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 f1_keywords: 
   - "vb.Delegate"
@@ -20,7 +16,6 @@ ms.assetid: f799c518-0817-40cc-ad0b-4da846fdba57
 caps.latest.revision: 27
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -92,6 +87,6 @@ Used to declare a delegate. A delegate is a reference type that refers to a `Sha
  [Delegates](../../../visual-basic/programming-guide/language-features/delegates/index.md)   
  [How to: Use a Generic Class](../../../visual-basic/programming-guide/language-features/data-types/how-to-use-a-generic-class.md)   
  [Generic Types in Visual Basic](../../../visual-basic/programming-guide/language-features/data-types/generic-types.md)   
- [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8)   
+ [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md)   
  [In](../../../visual-basic/language-reference/modifiers/in-generic-modifier.md)   
  [Out](../../../visual-basic/language-reference/modifiers/out-generic-modifier.md)

--- a/docs/visual-basic/language-reference/statements/interface-statement.md
+++ b/docs/visual-basic/language-reference/statements/interface-statement.md
@@ -1,13 +1,9 @@
 ---
 title: "Interface Statement (Visual Basic)"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 f1_keywords: 
   - "vb.Interface"
@@ -20,7 +16,6 @@ ms.assetid: 8997af73-bda3-4f79-bd41-ca396b610260
 caps.latest.revision: 26
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -143,6 +138,6 @@ End Interface
  [Function Statement](../../../visual-basic/language-reference/statements/function-statement.md)   
  [Sub Statement](../../../visual-basic/language-reference/statements/sub-statement.md)   
  [Generic Types in Visual Basic](../../../visual-basic/programming-guide/language-features/data-types/generic-types.md)   
- [Variance in Generic Interfaces](http://msdn.microsoft.com/library/e14322da-1db3-42f2-9a67-397daddd6b6a)   
+ [Variance in Generic Interfaces](../../programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md)   
  [In](../../../visual-basic/language-reference/modifiers/in-generic-modifier.md)   
  [Out](../../../visual-basic/language-reference/modifiers/out-generic-modifier.md)

--- a/docs/visual-basic/language-reference/statements/type-list.md
+++ b/docs/visual-basic/language-reference/statements/type-list.md
@@ -1,13 +1,9 @@
 ---
 title: "Type List (Visual Basic)"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 f1_keywords: 
   - "StructureConstraint"
@@ -37,7 +33,6 @@ ms.assetid: 56db947a-2ae8-40f2-a70a-960764e9d0db
 caps.latest.revision: 33
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -66,7 +61,7 @@ Specifies the *type parameters* for a *generic* programming element. Multiple pa
   
 |Term|Definition|  
 |---|---|  
-|`genericmodifier`|Optional. Can be used only in generic interfaces and delegates. You can declare a type covariant by using the [Out](../../../visual-basic/language-reference/modifiers/out-generic-modifier.md) keyword or contravariant by using the [In](../../../visual-basic/language-reference/modifiers/in-generic-modifier.md) keyword. See [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8).|  
+|`genericmodifier`|Optional. Can be used only in generic interfaces and delegates. You can declare a type covariant by using the [Out](../../../visual-basic/language-reference/modifiers/out-generic-modifier.md) keyword or contravariant by using the [In](../../../visual-basic/language-reference/modifiers/in-generic-modifier.md) keyword. See [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md).|  
 |`typename`|Required. Name of the type parameter. This is a placeholder, to be replaced by a defined type supplied by the corresponding type argument.|  
 |`constraintlist`|Optional. List of requirements that constrain the data type that can be supplied for `typename`. If you have multiple constraints, enclose them in curly braces (`{ }`) and separate them with commas. You must introduce the constraint list with the [As](../../../visual-basic/language-reference/statements/as-clause.md) keyword. You use `As` only once, at the beginning of the list.|  
   
@@ -123,6 +118,6 @@ Specifies the *type parameters* for a *generic* programming element. Multiple pa
  [Structure Statement](../../../visual-basic/language-reference/statements/structure-statement.md)   
  [Sub Statement](../../../visual-basic/language-reference/statements/sub-statement.md)   
  [How to: Use a Generic Class](../../../visual-basic/programming-guide/language-features/data-types/how-to-use-a-generic-class.md)   
- [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8)   
+ [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md)   
  [In](../../../visual-basic/language-reference/modifiers/in-generic-modifier.md)   
  [Out](../../../visual-basic/language-reference/modifiers/out-generic-modifier.md)

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
@@ -1,10 +1,7 @@
 ---
 title: "Covariance and Contravariance (Visual Basic)"
-ms.custom: ""
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
 ms.tgt_pltfrm: ""
@@ -15,7 +12,6 @@ ms.assetid: 59224c46-9931-466b-8c6e-3648c3e609c6
 caps.latest.revision: 3
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.mt: 
   - "cs-cz"
   - "pl-pl"

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/toc.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/toc.md
@@ -1,4 +1,4 @@
-# [Covariance and Contravariance](covariance-and-contravariance.md)
+# [Covariance and Contravariance](index.md)
 ## [Variance in Generic Interfaces](variance-in-generic-interfaces.md)
 ### [Creating Variant Generic Interfaces](creating-variant-generic-interfaces.md)
 ### [Using Variance in Interfaces for Generic Collections](using-variance-in-interfaces-for-generic-collections.md)

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
@@ -1,10 +1,7 @@
 ---
 title: "Using Variance for Func and Action Generic Delegates (Visual Basic)"
-ms.custom: ""
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
 ms.tgt_pltfrm: ""
@@ -15,7 +12,6 @@ ms.assetid: 36c3012f-b39c-493b-b90f-079b5912ac1b
 caps.latest.revision: 3
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.mt: 
   - "cs-cz"
   - "pl-pl"
@@ -103,5 +99,5 @@ End Class
 ```  
   
 ## See Also  
- [Covariance and Contravariance (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/covariance-and-contravariance.md)   
+ [Covariance and Contravariance (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/index.md)   
  [Generics](~/docs/standard/generics/index.md)

--- a/docs/visual-basic/programming-guide/concepts/index.md
+++ b/docs/visual-basic/programming-guide/concepts/index.md
@@ -1,13 +1,9 @@
 ---
 title: "Programming Concepts (Visual Basic)"
-ms.custom: ""
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 dev_langs: 
   - "VB"
@@ -15,7 +11,6 @@ ms.assetid: cc9cac84-61f6-476e-b8c7-9bae7749bd90
 caps.latest.revision: 4
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.mt: 
   - "cs-cz"
   - "pl-pl"
@@ -34,12 +29,12 @@ This section explains programming concepts in the Visual Basic language.
 |[Attributes overview (Visual Basic)](../../../visual-basic/programming-guide/concepts/attributes/index.md)|Discusses how to provide additional information about programming elements such as types, fields, methods, and properties by using attributes.|  
 |[Caller Information (Visual Basic)](../../../visual-basic/programming-guide/concepts/caller-information.md)|Describes how to obtain information about the caller of a method. This information includes the file path and the line number of the source code and the member name of the caller.|  
 |[Collections (Visual Basic)](../../../visual-basic/programming-guide/concepts/collections.md)|Describes some of the types of collections provided by the .NET Framework. Demonstrates how to use simple collections and collections of key/value pairs.|  
-|[Covariance and Contravariance (Visual Basic)](../../../visual-basic/programming-guide/concepts/covariance-contravariance/covariance-and-contravariance.md)|Shows how to enable implicit conversion of generic type parameters in interfaces and delegates.|  
+|[Covariance and Contravariance (Visual Basic)](../../../visual-basic/programming-guide/concepts/covariance-contravariance/index.md)|Shows how to enable implicit conversion of generic type parameters in interfaces and delegates.|  
 |[Expression Trees (Visual Basic)](../../../visual-basic/programming-guide/concepts/expression-trees/index.md)|Explains how you can use expression trees to enable dynamic modification of executable code.|  
 |[Iterators (Visual Basic)](../../../visual-basic/programming-guide/concepts/iterators.md)|Describes iterators, which are used to step through collections and return elements one at a time.|  
 |[Language-Integrated Query (LINQ) (Visual Basic)](../../../visual-basic/programming-guide/concepts/linq/index.md)|Discusses the powerful query capabilities in the language syntax of Visual Basic, and themodel for querying relational databases, XML documents, datasets, and in-memory collections.|  
 |[Object-Oriented Programming (Visual Basic)](../../../visual-basic/programming-guide/concepts/object-oriented-programming.md)|Describes common object-oriented concepts, including encapsulation, inheritance, and polymorphism.|  
-|[Reflection (Visual Basic)](../../../visual-basic/programming-guide/concepts/reflection.md)|Explains how to use reflection to dynamically create an instance of a type, bind the type to an existing object, or get the type from an existing object and invoke its methods or access its fields and properties.|  
+|[Reflection (Visual Basic)](../../../visual-basic/programming-guide/concepts/reflection.md)|Explains how to use reflection to dynamically create an instance of a type, bind the type to an existing object, or get the type from an existing object and invoke its methods or access its fields and properties.|
 |[Serialization (Visual Basic)](../../../visual-basic/programming-guide/concepts/serialization/index.md)|Describes key concepts in binary, XML, and SOAP serialization.|  
 |[Threading (Visual Basic)](../../../visual-basic/programming-guide/concepts/threading/index.md)|Provides an overview of the .NET threading model and shows how to write code that performs multiple tasks at the same time to improve the performance and responsiveness of your applications.|  
   
@@ -47,4 +42,4 @@ This section explains programming concepts in the Visual Basic language.
   
 |||  
 |---|---|  
-|[Performance Tips](https://msdn.microsoft.com/library/ms173196(VS.110).aspx) | Discusses several basic rules that may help you increase the performance of your application.|
+|[Performance Tips](../../../framework/performance/performance-tips.md) | Discusses several basic rules that may help you increase the performance of your application.|

--- a/docs/visual-basic/programming-guide/language-features/data-types/generic-types.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/generic-types.md
@@ -1,13 +1,9 @@
 ---
 title: "Generic Types in Visual Basic (Visual Basic)"
-ms.custom: ""
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 dev_langs: 
   - "VB"
@@ -49,7 +45,6 @@ ms.assetid: 89f771d9-ecbb-4737-88b8-116b63c6cf4d
 caps.latest.revision: 45
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "de-de"
   - "es-es"
@@ -180,5 +175,5 @@ Screwdriver set as a generic tool
  [Of](../../../../visual-basic/language-reference/statements/of-clause.md)   
  [As](../../../../visual-basic/language-reference/statements/as-clause.md)   
  [Object Data Type](../../../../visual-basic/language-reference/data-types/object-data-type.md)   
- [Covariance and Contravariance](http://msdn.microsoft.com/library/a58cc086-276f-4f91-a366-85b7f95f38b8)   
+ [Covariance and Contravariance](../../programming-guide/concepts/covariance-contravariance/index.md)   
  [Iterators](http://msdn.microsoft.com/library/f45331db-d595-46ec-9142-551d3d1eb1a7)

--- a/docs/visual-basic/programming-guide/language-features/interfaces/index.md
+++ b/docs/visual-basic/programming-guide/language-features/interfaces/index.md
@@ -1,13 +1,9 @@
 ---
 title: "Interfaces (Visual Basic)"
-ms.custom: ""
 ms.date: "2015-07-20"
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
-
 ms.topic: "article"
 dev_langs: 
   - "VB"
@@ -20,7 +16,6 @@ ms.assetid: 61b06674-12c9-430b-be68-cc67ecee1f5b
 caps.latest.revision: 11
 author: dotnet-bot
 ms.author: dotnetcontent
-
 translation.priority.ht: 
   - "cs-cz"
   - "de-de"
@@ -106,4 +101,4 @@ translation.priority.ht:
 |Title|Description|  
 |-----------|-----------------|  
 |[Walkthrough: Creating and Implementing Interfaces](../../../../visual-basic/programming-guide/language-features/interfaces/walkthrough-creating-and-implementing-interfaces.md)|Provides a detailed procedure that takes you through the process of defining and implementing your own interface.|  
-|[Variance in Generic Interfaces](http://msdn.microsoft.com/library/e14322da-1db3-42f2-9a67-397daddd6b6a)|Discusses covariance and contravariance in generic interfaces and provides a list of variant generic interfaces in the .NET Framework.|
+|[Variance in Generic Interfaces](../../concepts/covariance-contravariance/variance-in-generic-interfaces.md)|Discusses covariance and contravariance in generic interfaces and provides a list of variant generic interfaces in the .NET Framework.|


### PR DESCRIPTION
PR #2828 has updated this link on just one topic. By searching for the same URL across the docs, I found a few more instances.
While fixing that link, I also noticed that the VB version of the new target link was not named index,.md as it should be, so fixed that too.

I think these set of topics are some of the ones that don't make sense to be split. They're exactly the same except for the samples.