### PR TITLE
Update shape.cs

### DIFF
--- a/samples/snippets/csharp/tutorials/inheritance/shape.cs
+++ b/samples/snippets/csharp/tutorials/inheritance/shape.cs
@@ -112,6 +112,6 @@ public class Example
 //            Is Square: False, Diagonal: 15.62
 //         Square: area, 25; perimeter, 20
 //            Diagonal: 7.07
-//         Circle: area, 88.83; perimeter, 18.85
+//         Circle: area, 28.27; perimeter, 18.85
 // </Snippet3>
 } // Namespace definition.

--- a/samples/snippets/csharp/tutorials/inheritance/shape.cs
+++ b/samples/snippets/csharp/tutorials/inheritance/shape.cs
@@ -64,7 +64,7 @@ public class Circle : Shape
       Radius = radius;
    } 
 
-   public override double Area => Math.Round(Math.Pi * Radius * Radius, 2); 
+   public override double Area => Math.Round(Math.PI * Radius * Radius, 2); 
 
    public override double Perimeter => Math.Round(Math.PI * 2 * Radius, 2); 
 

--- a/samples/snippets/csharp/tutorials/inheritance/shape.cs
+++ b/samples/snippets/csharp/tutorials/inheritance/shape.cs
@@ -64,7 +64,7 @@ public class Circle : Shape
       Radius = radius;
    } 
 
-   public override double Area => Math.Round(Math.Pow(Math.PI * Radius, 2), 2); 
+   public override double Area => Math.Round(Math.Pi * Radius * Radius, 2); 
 
    public override double Perimeter => Math.Round(Math.PI * 2 * Radius, 2); 
 

--- a/samples/snippets/csharp/tutorials/inheritance/shape.cs
+++ b/samples/snippets/csharp/tutorials/inheritance/shape.cs
@@ -64,7 +64,7 @@ public class Circle : Shape
       Radius = radius;
    } 
 
-   public override double Area => Math.Round(Math.PI Math.Pow(Radius, 2), 2); 
+   public override double Area => Math.Round(Math.PI * Math.Pow(Radius, 2), 2); 
 
    public override double Perimeter => Math.Round(Math.PI * 2 * Radius, 2); 
 

--- a/samples/snippets/csharp/tutorials/inheritance/shape.cs
+++ b/samples/snippets/csharp/tutorials/inheritance/shape.cs
@@ -64,7 +64,7 @@ public class Circle : Shape
       Radius = radius;
    } 
 
-   public override double Area => Math.Round(Math.PI * Radius * Radius, 2); 
+   public override double Area => Math.Round(Math.PI Math.Pow(Radius, 2), 2); 
 
    public override double Perimeter => Math.Round(Math.PI * 2 * Radius, 2); 
 


### PR DESCRIPTION
Math.Pow(Math.PI * Radius, 2) should be Math.Pi * Radius * Radius since Area = pi * Radius^2 = pi * Radius * Radius

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
