### PR TITLE
Add information which Mono & Xamarin versions support .NET Standard 2.0

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -3,10 +3,10 @@
 | .NET Core                                 | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0    | 1.0    | 2.0   |
 | .NET Framework (with tooling 1.0)         | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2  |        |       |
 | .NET Framework (with tooling 2.0 preview) | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1  | 4.6.1  | 4.6.1 |
-| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | vNext |
-| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | vNext |
-| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0    | 3.0    | vNext |
-| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | vNext |
+| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | 5.4   |
+| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | 10.14 |
+| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0    | 3.0    | 3.8   |
+| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | 7.5   |
 | Universal Windows Platform                | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | vNext  | vNext  | vNext |
 | Windows                                   | 8.0   | 8.0    | 8.1   |       |       |        |        |       |
 | Windows Phone                             | 8.1   | 8.1    | 8.1   |       |       |        |        |       |


### PR DESCRIPTION
This aligns the version table with what we just accepted here: https://github.com/dotnet/standard/pull/438

@mairaw @akoeplinger 