### PR TITLE
Fix spacing typo in .NET container guidance docs

### DIFF
--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/general-guidance.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/general-guidance.md
@@ -20,7 +20,7 @@ You should use .NET Core for your containerized Docker server application when:
 
 -   You need to start containers fast and want a small footprint per container to achieve better density or more containers per hardware unit in order to lower your costs.
 
-In short, when you create new containerized .NET applications, you should consider.NET Core as the default choice. It has many benefits and fits best with the containers philosophy and style of working.
+In short, when you create new containerized .NET applications, you should consider .NET Core as the default choice. It has many benefits and fits best with the containers philosophy and style of working.
 
 An additional benefit of using .NET Core is that you can run side by side .NET versions for applications within the same machine. This benefit is more important for servers or VMs that do not use containers, because containers isolate the versions of .NET that the app needs. (As long as they are compatible with the underlying OS.)
 


### PR DESCRIPTION
The docs were missing a space between "consider" and ".NET".