### PR TITLE
added debug|release back to config option

### DIFF
--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -11,7 +11,6 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 5e1a2bc4-a919-4a86-8f33-a9b218b1fcb3
 ---
-
 # dotnet-build
 
 ## Name
@@ -64,9 +63,9 @@ Directory in which to place the built binaries. You also need to define `--frame
 
 Compiles for a specific [framework](../../standard/frameworks.md). The framework must be defined in the [project file](csproj.md).
 
-`-c|--configuration <CONFIGURATION>`
+`-c|--configuration {Debug|Release}`
 
-Defines the build configuration. If omitted, the build configuration defaults to `Debug`. Use `Release` build a Release configuration.
+Defines the build configuration. The default value is `Debug`.
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -11,7 +11,6 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: eff65fa1-bab4-4421-8260-d0a284b690b2
 ---
-
 # dotnet-clean
 
 ## Name
@@ -46,9 +45,9 @@ Directory in which the build outputs are placed. Specify the `-f|--framework <FR
 
 The [framework](../../standard/frameworks.md) that was specified at build time. The framework must be defined in the [project file](csproj.md). If you specified the framework at build time, you must specify the framework when cleaning.
 
-`-c|--configuration <CONFIGURATION>`
+`-c|--configuration {Debug|Release}`
 
-Defines the configuration. If omitted, it defaults to `Debug`. This property is only required when cleaning if you specified it during build time.
+Defines the build configuration. The default value is `Debug`. This option is only required when cleaning if you specified it during build time.
 
 `-v|--verbosity <LEVEL>`
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -61,7 +61,7 @@ Includes the source files in the NuGet package. The sources files are included i
 
 `-c|--configuration {Debug|Release}`
 
-Configuration to use when building the project. If not specified, configuration defaults to `Debug`.
+Defines the build configuration. The default value is `Debug`.
 
 `--version-suffix <VERSION_SUFFIX>`
 

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -11,7 +11,6 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 8dbbb3f7-b817-4161-a6c8-a3489d05e051
 ---
-
 # dotnet-pack
 
 ## Name
@@ -60,7 +59,7 @@ Generates the symbols `nupkg`.
 
 Includes the source files in the NuGet package. The sources files are included in the `src` folder within the `nupkg`. 
 
-`-c|--configuration <CONFIGURATION>`
+`-c|--configuration {Debug|Release}`
 
 Configuration to use when building the project. If not specified, configuration defaults to `Debug`.
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -11,7 +11,6 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: f2ef275a-7c5e-430a-8c30-65f52af62771
 ---
-
 # dotnet-publish
 
 ## Name
@@ -57,9 +56,9 @@ Publishes the application for a given runtime. This is used when creating a [sel
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
 
-`-c|--configuration <CONFIGURATION>`
+`-c|--configuration {Debug|Release}`
 
-Configuration to use when building the project. The default value is `Debug`.
+Defines the build configuration. The default value is `Debug`.
 
 `--version-suffix <VERSION_SUFFIX>`
 

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -11,7 +11,6 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 40d4e60f-9900-4a48-b03c-0bae06792d91
 ---
-
 # dotnet-run
 
 ## Name 
@@ -50,9 +49,9 @@ Delimits arguments to `dotnet run` from arguments for the application being run.
 
 Prints out a short help for the command.
 
-`-c|--configuration <CONFIGURATION>`
+`-c|--configuration {Debug|Release}`
 
-Configuration to use for building the project. The default value is `Debug`.
+Defines the build configuration. The default value is `Debug`.
 
 `-f|--framework <FRAMEWORK>`
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -11,8 +11,7 @@ ms.technology: dotnet-cli
 ms.devlang: dotnet
 ms.assetid: 4bf0aef4-148a-41c6-bb95-0a9e1af8762e
 ---
-
-#dotnet-test
+# dotnet-test
 
 ## Name
 
@@ -60,9 +59,9 @@ Use the custom test adapters from the specified path in the test run.
 
 Specifies a logger for test results. 
 
-`-c|--configuration <CONFIGURATION>`
+`-c|--configuration {Debug|Release}`
 
-Configuration under which to build. The default value is `Debug`, but your project's configuration could override this default SDK setting.
+Defines the build configuration. The default value is `Debug`, but your project's configuration could override this default SDK setting.
 
 `-f|--framework <FRAMEWORK>`
 


### PR DESCRIPTION
We used to show the possible values for the -c option in the CLI commands but this got lost over time. Responding to this LiveFyre comment: "would be useful to add more information about the -c flag. i had to google around to find the existence of -c Release" at https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#comments-container