### PR TITLE
removed namespace files for F#

### DIFF
--- a/xml/ns-Microsoft.FSharp.Collections.xml
+++ b/xml/ns-Microsoft.FSharp.Collections.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Collections">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Control.xml
+++ b/xml/ns-Microsoft.FSharp.Control.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Control">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Core.CompilerServices.xml
+++ b/xml/ns-Microsoft.FSharp.Core.CompilerServices.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Core.CompilerServices">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Core.xml
+++ b/xml/ns-Microsoft.FSharp.Core.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Core">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Data.UnitSystems.SI.UnitNames.xml
+++ b/xml/ns-Microsoft.FSharp.Data.UnitSystems.SI.UnitNames.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Data.UnitSystems.SI.UnitNames">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Linq.QueryRunExtensions.xml
+++ b/xml/ns-Microsoft.FSharp.Linq.QueryRunExtensions.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Linq.QueryRunExtensions">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Linq.RuntimeHelpers.xml
+++ b/xml/ns-Microsoft.FSharp.Linq.RuntimeHelpers.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Linq.RuntimeHelpers">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Linq.xml
+++ b/xml/ns-Microsoft.FSharp.Linq.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Linq">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.NativeInterop.xml
+++ b/xml/ns-Microsoft.FSharp.NativeInterop.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.NativeInterop">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Quotations.xml
+++ b/xml/ns-Microsoft.FSharp.Quotations.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Quotations">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>

--- a/xml/ns-Microsoft.FSharp.Reflection.xml
+++ b/xml/ns-Microsoft.FSharp.Reflection.xml
@@ -1,6 +1,0 @@
-<Namespace Name="Microsoft.FSharp.Reflection">
-  <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
-  </Docs>
-</Namespace>


### PR DESCRIPTION
F# assemblies and APIs were removed with PR #2893, however namespace files somehow were not deleted as part of the process.