### PR TITLE
Code doesn't show difference in using "lock" 

### DIFF
--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/lock-statement_2.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/lock-statement_2.cs
@@ -65,5 +65,9 @@
             {
                 threads[i].Start();
             }
+            
+            //block main thread until all other threads have ran to completion.
+            foreach (var t in threads)
+                t.Join();
         }
     }


### PR DESCRIPTION
Originally, did not wait for all threads to complete. As a result, not able to see the expected output when using the lock statement and not using the lock statement (in this scenario).