### PR TITLE
SocketType enumeration: Revisions based on PR #2518

### DIFF
--- a/xml/System.Net.Sockets/SocketType.xml
+++ b/xml/System.Net.Sockets/SocketType.xml
@@ -28,12 +28,12 @@
  Before a <xref:System.Net.Sockets.Socket> can send and receive data, it must first be created using an <xref:System.Net.Sockets.AddressFamily>, a <xref:System.Net.Sockets.SocketType>, and a <xref:System.Net.Sockets.ProtocolType>. The <xref:System.Net.Sockets.SocketType> enumeration provides several options for defining the type of <xref:System.Net.Sockets.Socket> that you intend to open.  
   
 > [!NOTE]
->  <xref:System.Net.Sockets.SocketType> will sometimes implicitly indicate which <xref:System.Net.Sockets.ProtocolType> will be used within an <xref:System.Net.Sockets.AddressFamily>. For example when the <xref:System.Net.Sockets.SocketType> is Dgram, the <xref:System.Net.Sockets.ProtocolType> is always <xref:System.Net.Sockets.ProtocolType>.When the <xref:System.Net.Sockets.SocketType> is Stream, the <xref:System.Net.Sockets.ProtocolType> is always <xref:System.Net.Sockets.ProtocolType>. If you try to create a <xref:System.Net.Sockets.Socket> with an incompatible combination, <xref:System.Net.Sockets.Socket> will throw a <xref:System.Net.Sockets.SocketException>.  
+>  <xref:System.Net.Sockets.SocketType> sometimes implicitly indicates which <xref:System.Net.Sockets.ProtocolType> is used within an <xref:System.Net.Sockets.AddressFamily>. For example, when the <xref:System.Net.Sockets.SocketType?displayProperty=fullName> is <xref:System.Net.Sockets.SocketType.Dgram?displayProperty=fullName>, the <xref:System.Net.Sockets.ProtocolType?displayProperty=fullName> is always <xref:System.Net.Sockets.ProtocolType.Udp?displayProperty=fullName>. When the <xref:System.Net.Sockets.SocketType?displayProperty=fullName> is <xref:System.Net.Sockets.SocketType.Stream?displayProperty=fullName>, the <xref:System.Net.Sockets.ProtocolType?displayProperty=fullName> is always <xref:System.Net.Sockets.ProtocolType.Tcp?displayProperty=fullName>. If you try to create a <xref:System.Net.Sockets.Socket> with an incompatible combination, <xref:System.Net.Sockets.Socket> throws a <xref:System.Net.Sockets.SocketException>.  
   
    
   
 ## Examples  
- The following example uses the Stream enumerated member as a parameter to the <xref:System.Net.Sockets.Socket> constructor.  
+ The following example uses <xref:System.Net.Sockets.SocketType.Stream?displayProperty=fullName> as a parameter to the <xref:System.Net.Sockets.Socket> constructor.  
   
  [!code-cpp[SelectModeExample#1](~/samples/snippets/cpp/VS_Snippets_Remoting/SelectModeExample/CPP/source.cpp#1)]
  [!code-csharp[SelectModeExample#1](~/samples/snippets/csharp/VS_Snippets_Remoting/SelectModeExample/CS/source.cs#1)]
@@ -66,7 +66,7 @@
         <ReturnType>System.Net.Sockets.SocketType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Supports datagrams, which are connectionless, unreliable messages of a fixed (typically small) maximum length. Messages might be lost or duplicated and might arrive out of order. A <see cref="T:System.Net.Sockets.Socket" /> of type <see cref="F:System.Net.Sockets.SocketType.Dgram" /> requires no connection prior to sending and receiving data, and can communicate with multiple peers. <see cref="F:System.Net.Sockets.SocketType.Dgram" /> uses the Datagram Protocol (<see cref="F:System.Net.Sockets.ProtocolType.Udp" />) and the <see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /><see cref="T:System.Net.Sockets.AddressFamily" />.</summary>
+        <summary>Supports datagrams, which are connectionless, unreliable messages of a fixed (typically small) maximum length. Messages might be lost or duplicated and might arrive out of order. A <see cref="T:System.Net.Sockets.Socket" /> of type <see cref="F:System.Net.Sockets.SocketType.Dgram" /> requires no connection prior to sending and receiving data, and can communicate with multiple peers. <see cref="F:System.Net.Sockets.SocketType.Dgram" /> uses the Datagram Protocol (<see langword="ProtocolType" />.<see cref="F:System.Net.Sockets.ProtocolType.Udp" />) and the <see langword="AddressFamily" />.<see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> address family.</summary>
       </Docs>
     </Member>
     <Member MemberName="Raw">
@@ -92,7 +92,7 @@
         <ReturnType>System.Net.Sockets.SocketType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Supports access to the underlying transport protocol. Using the <see cref="T:System.Net.Sockets.SocketType" /><see cref="F:System.Net.Sockets.SocketType.Raw" />, you can communicate using protocols like Internet Control Message Protocol (<see cref="F:System.Net.Sockets.ProtocolType.Icmp" />) and Internet Group Management Protocol (<see cref="F:System.Net.Sockets.ProtocolType.Igmp" />). Your application must provide a complete IP header when sending. Received datagrams return with the IP header and options intact.</summary>
+        <summary>Supports access to the underlying transport protocol. Using <see cref="F:System.Net.Sockets.SocketType.Raw" />, you can communicate using protocols like Internet Control Message Protocol (<see langword="ProtocolType" />.<see cref="F:System.Net.Sockets.ProtocolType.Icmp" />) and Internet Group Management Protocol (<see langword="ProtocolType" />.<see cref="F:System.Net.Sockets.ProtocolType.Igmp" />). Your application must provide a complete IP header when sending. Received datagrams return with the IP header and options intact.</summary>
       </Docs>
     </Member>
     <Member MemberName="Rdm">
@@ -118,7 +118,7 @@
         <ReturnType>System.Net.Sockets.SocketType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Supports connectionless, message-oriented, reliably delivered messages, and preserves message boundaries in data. Rdm (Reliably Delivered Messages) messages arrive unduplicated and in order. Furthermore, the sender is notified if messages are lost. If you initialize a <see langword="Socket" /> using <see cref="F:System.Net.Sockets.SocketType.Rdm" />, you do not require a remote host connection before sending and receiving data. With <see cref="F:System.Net.Sockets.SocketType.Rdm" />, you can communicate with multiple peers.</summary>
+        <summary>Supports connectionless, message-oriented, reliably delivered messages, and preserves message boundaries in data. Rdm (Reliably Delivered Messages) messages arrive unduplicated and in order. Furthermore, the sender is notified if messages are lost. If you initialize a <see cref="T:System.Net.Sockets.Socket" /> using <see cref="F:System.Net.Sockets.SocketType.Rdm" />, you do not require a remote host connection before sending and receiving data. With <see cref="F:System.Net.Sockets.SocketType.Rdm" />, you can communicate with multiple peers.</summary>
       </Docs>
     </Member>
     <Member MemberName="Seqpacket">
@@ -144,7 +144,7 @@
         <ReturnType>System.Net.Sockets.SocketType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Provides connection-oriented and reliable two-way transfer of ordered byte streams across a network. <see cref="F:System.Net.Sockets.SocketType.Seqpacket" /> does not duplicate data, and it preserves boundaries within the data stream. A <see langword="Socket" /> of type <see cref="F:System.Net.Sockets.SocketType.Seqpacket" /> communicates with a single peer and requires a remote host connection before communication can begin.</summary>
+        <summary>Provides connection-oriented and reliable two-way transfer of ordered byte streams across a network. <see cref="F:System.Net.Sockets.SocketType.Seqpacket" /> does not duplicate data, and it preserves boundaries within the data stream. A <see cref="T:System.Net.Sockets.Socket" /> of type <see cref="F:System.Net.Sockets.SocketType.Seqpacket" /> communicates with a single peer and requires a remote host connection before communication can begin.</summary>
       </Docs>
     </Member>
     <Member MemberName="Stream">
@@ -170,7 +170,7 @@
         <ReturnType>System.Net.Sockets.SocketType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Supports reliable, two-way, connection-based byte streams without the duplication of data and without preservation of boundaries. A <see langword="Socket" /> of this type communicates with a single peer and requires a remote host connection before communication can begin. <see cref="F:System.Net.Sockets.SocketType.Stream" /> uses the Transmission Control Protocol (<see cref="F:System.Net.Sockets.ProtocolType.Tcp" />) <see cref="T:System.Net.Sockets.ProtocolType" /> and the <see langword="InterNetwork" /><see cref="T:System.Net.Sockets.AddressFamily" />.</summary>
+        <summary>Supports reliable, two-way, connection-based byte streams without the duplication of data and without preservation of boundaries. A <see cref="T:System.Net.Sockets.Socket" /> of this type communicates with a single peer and requires a remote host connection before communication can begin. <see cref="F:System.Net.Sockets.SocketType.Stream" /> uses the Transmission Control Protocol (<see langword="ProtocolType" />.<see cref="F:System.Net.Sockets.ProtocolType.Tcp" />) and the <see langword="AddressFamily" />.<see cref="F:System.Net.Sockets.AddressFamily.InterNetwork" /> address family.</summary> 
       </Docs>
     </Member>
     <Member MemberName="Unknown">
@@ -196,7 +196,7 @@
         <ReturnType>System.Net.Sockets.SocketType</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Specifies an unknown <see langword="Socket" /> type.</summary>
+        <summary>Specifies an unknown <see cref="Socket" /> type.</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
# SocketType enumeration: Revisions based on PR #2518

## Summary

Adds a number of fully qualified member names, corrects content drop-out from migration, changes `InterNetwork AddressFamily` to `AddressFamily.InterNetwork`

## Suggested Reviewers

@tmpreston, @svick, @mairaw 


