### PR TITLE
[F#] Correcting light syntax for the code block

### DIFF
--- a/docs/fsharp/language-reference/verbose-syntax.md
+++ b/docs/fsharp/language-reference/verbose-syntax.md
@@ -75,9 +75,10 @@ code block
 </td><td>
 
 ```
-<expression1>
-<expression2>
-...
+(
+    <expression1>
+    <expression2>
+)
 ```
 
 </td><td>


### PR DESCRIPTION
I'm not sure whether this fits here but I couldn't find a better place for this. Actually I even think we should outline the usage of `(...)` more. It wasn't obvious to me before.

## Summary

I've changed the description of a code block for the light syntax.

## Suggested Reviewers
What do you think @cartermp ?
