### PR TITLE
Fixed typo in syntax example.

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/certificate-for-identity.md
+++ b/docs/framework/configure-apps/file-schema/wcf/certificate-for-identity.md
@@ -26,7 +26,7 @@ Specifies an X.509 certificate used to validate a server to a client.
 ## Syntax  
   
 ```xml  
-<certificate encodedValue = "Sring" />  
+<certificate encodedValue = "String" />  
 ```  
   
 ## Attributes and Elements  


### PR DESCRIPTION
The example xml had a typo for the attribute encodedValue.