### PR TITLE
improved formatting

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives/index.md
+++ b/docs/csharp/language-reference/preprocessor-directives/index.md
@@ -1,5 +1,5 @@
 ---
-title: "C# Preprocessor Directives"
+title: "C# preprocessor directives"
 ms.date: "2015-07-20"
 ms.prod: .net
 ms.technology: 
@@ -31,43 +31,30 @@ translation.priority.ht:
   - "zh-cn"
   - "zh-tw"
 ---
-# C# Preprocessor Directives
-This section contains information about the following C# preprocessor directives.  
-  
- [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md)  
-  
- [#else](../../../csharp/language-reference/preprocessor-directives/preprocessor-else.md)  
-  
- [#elif](../../../csharp/language-reference/preprocessor-directives/preprocessor-elif.md)  
-  
- [#endif](../../../csharp/language-reference/preprocessor-directives/preprocessor-endif.md)  
-  
- [#define](../../../csharp/language-reference/preprocessor-directives/preprocessor-define.md)  
-  
- [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md)  
-  
- [#warning](../../../csharp/language-reference/preprocessor-directives/preprocessor-warning.md)  
-  
- [#error](../../../csharp/language-reference/preprocessor-directives/preprocessor-error.md)  
-  
- [#line](../../../csharp/language-reference/preprocessor-directives/preprocessor-line.md)  
-  
- [#region](../../../csharp/language-reference/preprocessor-directives/preprocessor-region.md)  
-  
- [#endregion](../../../csharp/language-reference/preprocessor-directives/preprocessor-endregion.md)  
-  
- [#pragma](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma.md)  
-  
- [#pragma warning](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md)  
-  
- [#pragma checksum](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md)  
-  
- See the individual topics for more information and examples.  
-  
- Although the compiler does not have a separate preprocessor, the directives described in this section are processed as if there were one. They are used to help in conditional compilation. Unlike C and C++ directives, you cannot use these directives to create macros.  
-  
- A preprocessor directive must be the only instruction on a line.  
-  
-## See Also  
+# C# preprocessor directives
+This section contains information about the following C# preprocessor directives:
+
+- [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md)
+- [#else](../../../csharp/language-reference/preprocessor-directives/preprocessor-else.md)
+- [#elif](../../../csharp/language-reference/preprocessor-directives/preprocessor-elif.md)
+- [#endif](../../../csharp/language-reference/preprocessor-directives/preprocessor-endif.md)
+- [#define](../../../csharp/language-reference/preprocessor-directives/preprocessor-define.md)
+- [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md)
+- [#warning](../../../csharp/language-reference/preprocessor-directives/preprocessor-warning.md)
+- [#error](../../../csharp/language-reference/preprocessor-directives/preprocessor-error.md)
+- [#line](../../../csharp/language-reference/preprocessor-directives/preprocessor-line.md)
+- [#region](../../../csharp/language-reference/preprocessor-directives/preprocessor-region.md)
+- [#endregion](../../../csharp/language-reference/preprocessor-directives/preprocessor-endregion.md)
+- [#pragma](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma.md)
+- [#pragma warning](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md)
+- [#pragma checksum](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md)
+
+See the individual topics for more information and examples.
+
+Although the compiler doesn't have a separate preprocessor, the directives described in this section are processed as if there were one. They are used to help in conditional compilation. Unlike C and C++ directives, you cannot use these directives to create macros.
+
+A preprocessor directive must be the only instruction on a line.
+
+## See also
  [C# Reference](../../../csharp/language-reference/index.md)   
  [C# Programming Guide](../../../csharp/programming-guide/index.md)


### PR DESCRIPTION
Trying to compress [the page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives/) a bit. Seems like a lot of dead space:

![image](https://user-images.githubusercontent.com/12971179/29551872-b9c04c82-86c9-11e7-8f62-cafad9573b14.png)

/cc @BillWagner 