### PR TITLE
Fix spelling of Referer

### DIFF
--- a/xml/System.Net/WebHeaderCollection.xml
+++ b/xml/System.Net/WebHeaderCollection.xml
@@ -58,7 +58,7 @@
   
 -   Range  
   
--   Referrer  
+-   Referer  
   
 -   Transfer-Encoding  
   


### PR DESCRIPTION
in the list of restricted headers 'Referer' is misspelled as 'Referrer' like the old HTTP spec. However, the code correctly detects if you add 'Referer' as a header it will give you an error and specify you to use the specific property and it does not give an error if you add 'Referrer' to the WebHeaderCollection.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
