### PR TITLE
Corrected typos  in ValueTuple generic types

### DIFF
--- a/xml/System/ValueTuple`1.xml
+++ b/xml/System/ValueTuple`1.xml
@@ -127,9 +127,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`1" /> instance to a specified <see cref="T:System.ValueTuple`1" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -340,7 +340,7 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`1" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
  <list type="table"><listheader><term> Vaue  
   

--- a/xml/System/ValueTuple`2.xml
+++ b/xml/System/ValueTuple`2.xml
@@ -131,9 +131,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`2" /> instance to a specified <see cref="T:System.ValueTuple`2" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -374,9 +374,9 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`2" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   

--- a/xml/System/ValueTuple`3.xml
+++ b/xml/System/ValueTuple`3.xml
@@ -135,9 +135,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`3" /> instance to a specified <see cref="T:System.ValueTuple`3" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -408,9 +408,9 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`3" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   

--- a/xml/System/ValueTuple`4.xml
+++ b/xml/System/ValueTuple`4.xml
@@ -139,7 +139,7 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`4" /> instance to a specified <see cref="T:System.ValueTuple`4" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
  <list type="table"><listheader><term> Vaue  
   
@@ -442,7 +442,7 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`4" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
  <list type="table"><listheader><term> Vaue  
   

--- a/xml/System/ValueTuple`5.xml
+++ b/xml/System/ValueTuple`5.xml
@@ -143,9 +143,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`5" /> instance to a specified <see cref="T:System.ValueTuple`5" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -476,9 +476,9 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`5" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   

--- a/xml/System/ValueTuple`6.xml
+++ b/xml/System/ValueTuple`6.xml
@@ -147,9 +147,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`6" /> instance to a specified <see cref="T:System.ValueTuple`6" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -510,9 +510,9 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`6" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   

--- a/xml/System/ValueTuple`7.xml
+++ b/xml/System/ValueTuple`7.xml
@@ -151,9 +151,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`7" /> instance to a specified <see cref="T:System.ValueTuple`7" /> instance.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and                      <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -544,9 +544,9 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`7" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   

--- a/xml/System/ValueTuple`8.xml
+++ b/xml/System/ValueTuple`8.xml
@@ -170,9 +170,9 @@
       <Docs>
         <param name="other">The tuple to compare with this instance.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`8" /> instance to a specified <see cref="T:System.ValueTuple`8" /> instance</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   
@@ -600,9 +600,9 @@
         <param name="other">The object to compare with the current instance.</param>
         <param name="comparer">An object that provides custom rules for comparison.</param>
         <summary>Compares the current <see cref="T:System.ValueTuple`8" /> instance to a specified object by using a specified comparer and returns an integer that indicates whether the current object is before, after, or in the same position as the specified object in the sort order.</summary>
-        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following able.  
+        <returns>A signed integer that indicates the relative position of this instance and <paramref name="other" /> in the sort order, as shown in the following table.  
   
- <list type="table"><listheader><term> Vaue  
+ <list type="table"><listheader><term> Value  
   
  </term><description> Description  
   


### PR DESCRIPTION
# Corrected typos  in ValueTuple generic types

1. Changed all instances of "following able" to "following table"
2. Changed "Vaue" to "Value"
3. Accidentally included a typo in my branch name (valuetyple instead of valuetuple)

## Suggested Reviewers
@mairaw 

