### PR TITLE
put h1 in markdown

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -4,4 +4,6 @@ hide_bc: true
 title: .NET API Browser
 ---
 
+# .NET API Browser
+
 Welcome to the .NET API Browser – your one-stop shop for all .NET-based APIs from Microsoft. Simply start searching for any managed APIs by typing in the box below. You can learn more about the API Browser [in our blog post](https://aka.ms/apibrowser). If you have any feedback, please use [our UserVoice site](https://aka.ms/apibrowserfeedback).


### PR DESCRIPTION
The API browser page template on docs.microsoft.com expects an H1. Right now we are in a transitional period where the H1 will be dynamically rendered if one is not present in the content.

[related issue](https://mseng.visualstudio.com/CSI/_workitems/edit/1054251)

cc @adkinn 