### PR TITLE
Fix incorrect reference to .NET Core 2.0 twice in docs

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -101,7 +101,7 @@ Specifies a NuGet package source to use during the restore operation. This overr
 
 Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 1.x](#tab/netcore1x)
 
 `--configfile <FILE>`
 


### PR DESCRIPTION
Nothing special, just fix typo