### PR TITLE
Corrected minor typo Http -> HTTP

### DIFF
--- a/xml/System.Net.Http/HttpMessageInvoker.xml
+++ b/xml/System.Net.Http/HttpMessageInvoker.xml
@@ -22,7 +22,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>A specialty class that allows applications to call the <see cref="M:System.Net.Http.HttpMessageInvoker.SendAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)" /> method on an Http handler chain.</summary>
+    <summary>A specialty class that allows applications to call the <see cref="M:System.Net.Http.HttpMessageInvoker.SendAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)" /> method on an HTTP handler chain.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
Unless they're call outs for types or members, acronyms should not follow the naming rules from the Class Library Design Guidelines.
