### PR TITLE
fixed typo

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -122,7 +122,7 @@ The following examples demonstrate various ways you can write async code in C#. 
 This snippet downloads the HTML from www.dotnetfoundation.org and counts the number of times the string ".NET" occurs in the HTML.  It uses ASP.NET MVC to define a web controller method which performs this task, returning the number.
 
 > [!NOTE]
-> You shouldn't ever use regular expressions if you plan on doing actual HTML parsing.  Please using a parsing library if this is your aim in production code.
+> If you plan on doing HTML parsing in production code, don't use regular expressions. Use a parsing library instead.
 
 ```csharp
 private readonly HttpClient _httpClient = new HttpClient();


### PR DESCRIPTION
From LiveFyre comment on https://docs.microsoft.com/en-us/dotnet/csharp/async:
"Please use"

I actually changed the note a bit to have a stronger message.

/cc @BillWagner @cartermp 