### PR TITLE
Update RHEL to be just RHEL, not RHEL Server

### DIFF
--- a/docs/core/get-started.md
+++ b/docs/core/get-started.md
@@ -34,7 +34,7 @@ See the [Prerequisites for Windows development](windows-prerequisites.md) topic 
 
 Install .NET Core on your distribution/version:
 
-* [Red Hat Enterprise Linux 7 Server](https://www.microsoft.com/net/core#linuxredhat)
+* [Red Hat Enterprise Linux 7](https://www.microsoft.com/net/core#linuxredhat)
 * [Ubuntu 14.04, 16.04, 16.10, 17.04 & Linux Mint 17, 18](https://www.microsoft.com/net/core#linuxubuntu)
 * [Debian 8.2+, 8.7+, 9](https://www.microsoft.com/net/core#linuxdebian)
 * [Fedora 24, 25, 26](https://www.microsoft.com/net/core#linuxfedora)


### PR DESCRIPTION
## Summary

.NET Core is available for all RHEL variants, not just Server.

## Details

.NET Core can be installed on all RHEL variants: Workstation, Server and ComputeNode. No need to single out Server here. It could be confusing for users.

See https://github.com/dotnet/docs/pull/2965 for additional details.

## Suggested Reviewers

@JRAlexander 

Thanks!