### PR TITLE
Two minor typo errors when referencing 'TryParse' method.

### DIFF
--- a/docs/csharp/language-reference/keywords/out-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/out-parameter-modifier.md
@@ -71,7 +71,7 @@ Overloading is legal, however, if one method takes a `ref` or `out` argument and
   
  [!code-cs[csrefKeywordsMethodParams#4](../../../../samples/snippets/csharp/language-reference/keywords/out/out-4.cs)]  
 
- The [Try pattern](/visualstudio/code-quality/ca1021-avoid-out-parameters#try-pattern-methods.md) involves returning a `bool` to indicate whether an operation succeeded and failed, and returning the value produced by the operation in an `out` argument. A number of parsing methods, such as the @System.DateTime.TryParse(System.String,@System.DateTime) method, use this pattern.
+ The [Try pattern](/visualstudio/code-quality/ca1021-avoid-out-parameters#try-pattern-methods.md) involves returning a `bool` to indicate whether an operation succeeded and failed, and returning the value produced by the operation in an `out` argument. A number of parsing methods, such as the [DateTime.TryParse](xref:System.DateTime.TryParse(System.String,System.DateTime@)) method, use this pattern.
    
 ## Calling a method with an `out` argument
 

--- a/docs/csharp/language-reference/keywords/out-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/out-parameter-modifier.md
@@ -75,11 +75,11 @@ Overloading is legal, however, if one method takes a `ref` or `out` argument and
    
 ## Calling a method with an `out` argument
 
-In C# 6 and earlier, you must declare a variable in a separate statement before you pass it as an `out` argument. The following example declares a variable named `number` before it is passed to the [Int32.TryParse](xref:System.Int32.TryParse)(System.String,@System.Int32) method, which attempts to convert a string to a number.
+In C# 6 and earlier, you must declare a variable in a separate statement before you pass it as an `out` argument. The following example declares a variable named `number` before it is passed to the [Int32.TryParse](xref:System.Int32.TryParse(System.String,System.Int32@)) method, which attempts to convert a string to a number.
 
  [!code-cs[csrefKeywordsMethodParams#5](../../../../samples/snippets/csharp/language-reference/keywords/out/out-5.cs)]  
 
-Starting with C# 7, you can declare the `out` variable in the argument list of the method call, rather than in a separate variable declaration. This produces more compact, readable code, and also prevents you from inadvertently assigning a value to the variable before the method call. The following example is like the previous example, except that it defines the `number` variable in the call to the [Int32.TryParse](xref:System.Int32.TryParse)(System.String,@System.Int32) method.
+Starting with C# 7, you can declare the `out` variable in the argument list of the method call, rather than in a separate variable declaration. This produces more compact, readable code, and also prevents you from inadvertently assigning a value to the variable before the method call. The following example is like the previous example, except that it defines the `number` variable in the call to the [Int32.TryParse](xref:System.Int32.TryParse(System.String,System.Int32@)) method.
 
  [!code-cs[csrefKeywordsMethodParams#6](../../../../samples/snippets/csharp/language-reference/keywords/out/out-6.cs)]  
    

--- a/docs/csharp/language-reference/keywords/out-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/out-parameter-modifier.md
@@ -75,11 +75,11 @@ Overloading is legal, however, if one method takes a `ref` or `out` argument and
    
 ## Calling a method with an `out` argument
 
-In C# 6 and earlier, you must declare a variable in a separate statement before you pass it as an `out` argument. The following example declares a variable named `number` before it is passed to the [Int32.TryParse](xref:System.Int32.TryParse(System.String,@System.Int32) method, which attempts to convert a string to a number.
+In C# 6 and earlier, you must declare a variable in a separate statement before you pass it as an `out` argument. The following example declares a variable named `number` before it is passed to the [Int32.TryParse](xref:System.Int32.TryParse)(System.String,@System.Int32) method, which attempts to convert a string to a number.
 
  [!code-cs[csrefKeywordsMethodParams#5](../../../../samples/snippets/csharp/language-reference/keywords/out/out-5.cs)]  
 
-Starting with C# 7, you can declare the `out` variable in the argument list of the method call, rather than in a separate variable declaration. This produces more compact, readable code, and also prevents you from inadvertently assigning a value to the variable before the method call. The following example is like the previous example, except that it defines the `number` variable in the call to the [Int32.TryParse](xref:System.Int32.TryParse(System.String,@System.Int32) method.
+Starting with C# 7, you can declare the `out` variable in the argument list of the method call, rather than in a separate variable declaration. This produces more compact, readable code, and also prevents you from inadvertently assigning a value to the variable before the method call. The following example is like the previous example, except that it defines the `number` variable in the call to the [Int32.TryParse](xref:System.Int32.TryParse)(System.String,@System.Int32) method.
 
  [!code-cs[csrefKeywordsMethodParams#6](../../../../samples/snippets/csharp/language-reference/keywords/out/out-6.cs)]  
    


### PR DESCRIPTION
Fixed two minor typo errors when referencing TryParse method in 'Calling a method with an out argument' chapter.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
