### PR TITLE
fix formatting

### DIFF
--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -31,42 +31,42 @@ references:
   name.vb: IsGenericMethodDefinition
   fullName: MethodInfo.IsGenericMethodDefinition
   fullName.vb: MethodInfo.IsGenericMethodDefinition
-- uid: System​.Runtime​.InteropServices.FieldOffsetAttribute
+- uid: System.Runtime.InteropServices.FieldOffsetAttribute
   href: https://msdn.microsoft.com/library/system.runtime.interopservices.fieldoffsetattribute(v=vs.110).aspx
   name: FieldOffsetAttribute
   name.vb: FieldOffsetAttribute
-  fullName: System​.Runtime​.InteropServices.FieldOffsetAttribute
-  fullName.vb: System​.Runtime​.InteropServices.FieldOffsetAttribute
-- uid: System​.Runtime​.InteropServices.StructLayoutAttribute
+  fullName: System.Runtime.InteropServices.FieldOffsetAttribute
+  fullName.vb: System.Runtime.InteropServices.FieldOffsetAttribute
+- uid: System.Runtime.InteropServices.StructLayoutAttribute
   href: https://msdn.microsoft.com/library/system.runtime.interopservices.structlayoutattribute(v=vs.110).aspx
   name: StructLayoutAttribute
   name.vb: StructLayoutAttribute
-  fullName: System​.Runtime​.InteropServices.StructLayoutAttribute
-  fullName.vb: System​.Runtime​.InteropServices.StructLayoutAttribute
-- uid: System​.Runtime​.InteropServices.DllImportAttribute
+  fullName: System.Runtime.InteropServices.StructLayoutAttribute
+  fullName.vb: System.Runtime.InteropServices.StructLayoutAttribute
+- uid: System.Runtime.InteropServices.DllImportAttribute
   href: https://msdn.microsoft.com/library/system.runtime.interopservices.dllimportattribute(v=vs.110).aspx
   name: DllImportAttribute
   name.vb: DllImportAttribute
-  fullName: System​.Runtime​.InteropServices.DllImportAttribute
-  fullName.vb: System​.Runtime​.InteropServices.DllImportAttribute
-- uid: System​.Runtime​.InteropServices.OutAttribute
+  fullName: System.Runtime.InteropServices.DllImportAttribute
+  fullName.vb: System.Runtime.InteropServices.DllImportAttribute
+- uid: System.Runtime.InteropServices.OutAttribute
   href: https://msdn.microsoft.com/library/system.runtime.interopservices.outattribute(v=vs.110).aspx
   name: OutAttribute
   name.vb: OutAttribute
-  fullName: System​.Runtime​.InteropServices.OutAttribute
-  fullName.vb: System​.Runtime​.InteropServices.OutAttribute
-- uid: System​.Runtime​.InteropServices.InAttribute
+  fullName: System.Runtime.InteropServices.OutAttribute
+  fullName.vb: System.Runtime.InteropServices.OutAttribute
+- uid: System.Runtime.InteropServices.InAttribute
   href: https://msdn.microsoft.com/library/system.runtime.interopservices.inattribute(v=vs.110).aspx
   name: InAttribute
   name.vb: InAttribute
-  fullName: System​.Runtime​.InteropServices.InAttribute
-  fullName.vb: System​.Runtime​.InteropServices.InAttribute
-- uid: System​.Runtime​.InteropServices.ComImportAttribute
+  fullName: System.Runtime.InteropServices.InAttribute
+  fullName.vb: System.Runtime.InteropServices.InAttribute
+- uid: System.Runtime.InteropServices.ComImportAttribute
   href: https://msdn.microsoft.com/library/system.runtime.interopservices.comimportattribute(v=vs.110).aspx
   name: ComImportAttribute
   name.vb: ComImportAttribute
-  fullName: System​.Runtime​.InteropServices.ComImportAttribute
-  fullName.vb: System​.Runtime​.InteropServices.ComImportAttribute
+  fullName: System.Runtime.InteropServices.ComImportAttribute
+  fullName.vb: System.Runtime.InteropServices.ComImportAttribute
 - uid: Microsoft.VisualBasic.PowerPacks.DataRepeater.BeginResetItemTemplate*
   href: https://msdn.microsoft.com/library/microsoft.visualbasic.powerpacks.datarepeater.beginresetitemtemplate.aspx
   name: BeginResetItemTemplate
@@ -97,13 +97,13 @@ references:
   name.vb: DataRepeaterLayoutStyles.Vertical
   fullName: DataRepeaterLayoutStyles.Vertical
   fullName.vb: DataRepeaterLayoutStyles.Vertical
- - uid: Microsoft.VisualBasic.PowerPacks.DataRepeaterLayoutStyles.Horizontal
+- uid: Microsoft.VisualBasic.PowerPacks.DataRepeaterLayoutStyles.Horizontal
   href: https://msdn.microsoft.com/library/microsoft.visualbasic.powerpacks.datarepeaterlayoutstyles.aspx
   name: DataRepeaterLayoutStyles.Horizontal
   name.vb: DataRepeaterLayoutStyles.Horizontal
   fullName: DataRepeaterLayoutStyles.Horizontal
   fullName.vb: DataRepeaterLayoutStyles.Horizontal 
- - uid: Microsoft.VisualBasic.PowerPacks.BackStyle.Opaque
+- uid: Microsoft.VisualBasic.PowerPacks.BackStyle.Opaque
   href: https://msdn.microsoft.com/en-us/library/microsoft.visualbasic.powerpacks.backstyle.aspx
   name: BackStyle.Opaque
   name.vb: BackStyle.Opaque


### PR DESCRIPTION
Noticed warnings on master build report have increased and saw the following warning: 
"Unable to download xref map file from _zip/missingapi.yml, details: (Line: 100, Col: 2, Idx: 5422) - (Line: 100, Col: 2, Idx: 5422): While parsing a block mapping, did not find expected key."

/cc @rpetrusha 