### PR TITLE
Correction to uri canonicalization info [Work Item 487269]

### DIFF
--- a/xml/System/Uri.xml
+++ b/xml/System/Uri.xml
@@ -52,49 +52,39 @@
   
 -   If the host name is an IPv6 address, the canonical IPv6 address is used. ScopeId and other optional IPv6 data are removed.  
   
--   Removes default and empty port numbers.  
-  
--   Canonicalizes the path for hierarchical URIs by compacting sequences such as /./, /../, //, including escaped representations. Note that there are some schemes for which escaped representations are not compacted.  
+-   Removes default and empty port numbers.
+
+-   Escaped characters (also known as percent-encoded octets) that do not have a reserved purpose are decoded (also known as being unescaped). These unreserved characters include uppercase and lowercase letters (%41-%5A and %61-%7A), decimal digits (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), and tilde (%7E).
+
+-   Canonicalizes the path for hierarchical URIs by compacting sequences such as /./, /../, and // (whether or not the sequence is escaped). Note that there are some schemes for which these sequences are not compacted.
   
 -   For hierarchical URIs, if the host is not terminated with a forward slash (/), one is added.  
   
--   By default, any reserved characters in the URI are escaped in accordance with RFC 2396. This behavior changes if International Resource Identifiers or International Domain Name parsing is enabled in which case reserved characters in the URI are escaped in accordance with RFC 3986 and RFC 3987.  
-  
- As part of canonicalization in the constructor for some schemes, escaped representations are compacted. The schemes for which URI will compact escaped sequences include the following: file, http, https, net.pipe, and net.tcp. For all other schemes, escaped sequences are not compacted. For example: if you percent encode the two dots ".." as "%2E%2E" then the URI constructor will compact this sequence for some schemes. For example, the following code sample shows a URI constructor for the http scheme.  
+-   By default, any reserved characters in the URI are escaped in accordance with RFC 2396. This behavior changes if International Resource Identifiers or International Domain Name parsing is enabled in which case reserved characters in the URI are escaped in accordance with RFC 3986 and RFC 3987.
+
+ As part of canonicalization in the constructor for some schemes, dot-segments and empty segments (/./, /../, and //) are compacted (in other words, they are removed). The schemes for which URI will compact these sequences include http, https, tcp, net.pipe, and net.tcp. For some other schemes, these sequences are not compacted. Here's how this compacting looks in practice.
   
 ```  
   
-Uri uri = new Uri("http://myUrl/%2E%2E/%2E%2E");  
+var uri = new Uri("http://myUrl/../.."); // http scheme, unescaped
+OR
+var uri = new Uri("http://myUrl/%2E%2E/%2E%2E"); // http scheme, escaped
+OR
+var uri = new Uri("tcp://myUrl/../.."); // ftp scheme, unescaped
+OR
+var uri = new Uri("tcp://myUrl/%2E%2E/%2E%2E"); // ftp scheme, unescaped
+
 Console.WriteLine(uri.AbsoluteUri);  
 Console.WriteLine(uri.PathAndQuery);  
   
 ```  
   
- When this code is executed, it returns the following output with the escaped sequence compacted.  
-  
+ When this code is executed, it returns the following output, with the escaped sequences unescaped if necessary and then compacted.
+
 ```  
   
 http://myUrl/  
 /  
-  
-```  
-  
- The following code example shows a URI constructor for the ftp scheme:  
-  
-```  
-  
-Uri uri = new Uri("ftp://myUrl/%2E%2E/%2E%2E");  
-Console.WriteLine(uri.AbsoluteUri);  
-Console.WriteLine(uri.PathAndQuery);  
-  
-```  
-  
- When this code is executed, it returns the following output with the escaped sequence not compacted.  
-  
-```  
-  
-ftp://myUrl/%2E%2E/%2E%2E  
-/%2E%2E/%2E%2E  
   
 ```  
   

--- a/xml/System/Uri.xml
+++ b/xml/System/Uri.xml
@@ -54,7 +54,7 @@
   
 -   Removes default and empty port numbers.
 
--   Escaped characters (also known as percent-encoded octets) that do not have a reserved purpose are decoded (also known as being unescaped). These unreserved characters include uppercase and lowercase letters (%41-%5A and %61-%7A), decimal digits (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), and tilde (%7E).
+-   Escaped characters (also known as percent-encoded octets) that don't have a reserved purpose are decoded (also known as being unescaped). These unreserved characters include uppercase and lowercase letters (%41-%5A and %61-%7A), decimal digits (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), and tilde (%7E).
 
 -   Canonicalizes the path for hierarchical URIs by compacting sequences such as /./, /../, and // (whether or not the sequence is escaped). Note that there are some schemes for which these sequences are not compacted.
   
@@ -65,7 +65,6 @@
  As part of canonicalization in the constructor for some schemes, dot-segments and empty segments (/./, /../, and //) are compacted (in other words, they are removed). The schemes for which URI will compact these sequences include http, https, tcp, net.pipe, and net.tcp. For some other schemes, these sequences are not compacted. Here's how this compacting looks in practice.
   
 ```  
-  
 var uri = new Uri("http://myUrl/../.."); // http scheme, unescaped
 OR
 var uri = new Uri("http://myUrl/%2E%2E/%2E%2E"); // http scheme, escaped
@@ -76,16 +75,13 @@ var uri = new Uri("tcp://myUrl/%2E%2E/%2E%2E"); // ftp scheme, unescaped
 
 Console.WriteLine(uri.AbsoluteUri);  
 Console.WriteLine(uri.PathAndQuery);  
-  
 ```  
   
  When this code is executed, it returns the following output, with the escaped sequences unescaped if necessary and then compacted.
 
 ```  
-  
 http://myUrl/  
 /  
-  
 ```  
   
  You can transform the contents of the <xref:System.Uri> class from an escape encoded URI reference to a readable URI reference by using the <xref:System.Uri.ToString%2A> method. Note that some reserved characters might still be escaped in the output of the <xref:System.Uri.ToString%2A> method. This is to support unambiguous reconstruction of a URI from the value returned by <xref:System.Uri.ToString%2A>.  


### PR DESCRIPTION
Documentation updated needed regarding Uri canonicalization with FTP scheme [Work Item 487269]

#  Uri canonicalization with FTP scheme [Work Item 487269]

The topic was describing scheme-specific compacting behavior as if it were a function of escaped (versus unescaped) characters. But in fact this compacting behavior is independent of whether or not the characters are escaped.

## Summary

The changes involve changing the Remarks section to correct the info, and changing the code example and what it ouputs. Http and ftp behave the same way, and the code example now shows that.

Fixes #3036 

## Details

See Work Item 487269

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
