### PR TITLE
added info about relative paths for output

### DIFF
--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -1,15 +1,12 @@
 ---
 title: dotnet publish command - .NET Core CLI
 description: The dotnet publish command publishes your .NET Core project into a directory. 
-keywords: dotnet-publish, CLI, CLI command, .NET Core
-author: blackdwarf
+author: mairaw
 ms.author: mairaw
-ms.date: 08/12/2017
+ms.date: 09/01/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: dotnet-cli
-ms.devlang: dotnet
-ms.assetid: f2ef275a-7c5e-430a-8c30-65f52af62771
 ---
 # dotnet publish
 
@@ -89,6 +86,7 @@ Doesn't perform an implicit restore when running the command.
 `-o|--output <OUTPUT_DIRECTORY>`
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
+If a relative path is provided to this option, the output directory is relative to the project file location, not to the current working directory.
 
 `--self-contained`
 
@@ -127,6 +125,7 @@ Specifies one or several [target manifests](../deploying/runtime-store.md) to us
 `-o|--output <OUTPUT_DIRECTORY>`
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
+If a relative path is provided to this option, the output directory is relative to the project file location, not to the current working directory.
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -86,7 +86,7 @@ Doesn't perform an implicit restore when running the command.
 `-o|--output <OUTPUT_DIRECTORY>`
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
-If a relative path is provided to this option, the output directory is relative to the project file location, not to the current working directory.
+If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory.
 
 `--self-contained`
 
@@ -125,7 +125,7 @@ Specifies one or several [target manifests](../deploying/runtime-store.md) to us
 `-o|--output <OUTPUT_DIRECTORY>`
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
-If a relative path is provided to this option, the output directory is relative to the project file location, not to the current working directory.
+If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory.
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 


### PR DESCRIPTION
Addressing LiveFyre content for [dotnet publish](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-publish):
Just found out the hard way that if OUTPUT_DIRECTORY is relative, it's relative to the project file, not the current working directory. Can we add this detail explicitly? Others seem to be hitting this too (https://github.com/dotnet/cli/issues/3951)