### PR TITLE
Update how-to-parse-strings-using-string-split.md

### DIFF
--- a/docs/csharp/programming-guide/strings/how-to-parse-strings-using-string-split.md
+++ b/docs/csharp/programming-guide/strings/how-to-parse-strings-using-string-split.md
@@ -55,7 +55,7 @@ class TestStringSplit
 {  
     static void Main()  
     {  
-        char[] separatingChars = { "<<", "..." };  
+        string[] separatingChars = { "<<", "..." };  
   
         string text = "one<<two......three<four";  
         System.Console.WriteLine("Original text: '{0}'", text);  


### PR DESCRIPTION
There is a bug, char[] should be string[] on line 58 
# tiny bug in example code

There was a bug in the character split example. char[] should be string[] on line 58

## Summary

I was reading for an example on line on a related topic and noticed this bug which is a simple easy to make mistake but still could be discouraging for a user who puts a lot of faith into these very well maintained docs.

## Details

I changed the consructor of seperatingChars to string[] to match the inline array definition and intended use.

