### PR TITLE
[Templates] Add special requirements on local file uninstall.

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -132,6 +132,10 @@ Filters templates based on available types. Predefined values are "project", "it
 
 Uninstalls a source or template pack at the `PATH` or `NUGET_ID` provided.
 
+> [!NOTE]
+> To uninstall a template using a `PATH`, you need to fully qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.
+> Additionally, do not include a final terminating directory slash on your template path.
+
 # [.NET Core 1.x](#tab/netcore1x)
 
 `-all|--show-all`

--- a/docs/core/tutorials/create-custom-template.md
+++ b/docs/core/tutorials/create-custom-template.md
@@ -203,6 +203,10 @@ If you created the template on your local file system at *C:/Users/\<USER>/Docum
 dotnet new -u C:/Users/<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp
 ```
 
+> [!NOTE]
+> To uninstall the template from your local file system, you will need to fully-qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.
+> Additionally, do not include a final terminating directory slash on your template path.
+
 ## See also
 
 [dotnet/templating GitHub repo Wiki](https://github.com/dotnet/templating/wiki)  

--- a/docs/core/tutorials/create-custom-template.md
+++ b/docs/core/tutorials/create-custom-template.md
@@ -204,7 +204,7 @@ dotnet new -u C:/Users/<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate
 ```
 
 > [!NOTE]
-> To uninstall the template from your local file system, you will need to fully-qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.
+> To uninstall the template from your local file system, you need to fully qualify the path. For example, *C:/Users/\<USER>/Documents/Templates/GarciaSoftware.ConsoleTemplate.CSharp* will work, but *./GarciaSoftware.ConsoleTemplate.CSharp* from the containing folder will not.
 > Additionally, do not include a final terminating directory slash on your template path.
 
 ## See also


### PR DESCRIPTION
## Summary

This adds a `NOTE` clarification block for local directory template uninstalls.

After an issue being unable to uninstall a template from a local directory, it was found that there were other requirements on the local path that weren't documented.

Addresses requirements discovered in dotnet/templating#1226.