### PR TITLE
Clarification OpenWrite does not support reading.

### DIFF
--- a/xml/System.IO/File.xml
+++ b/xml/System.IO/File.xml
@@ -2392,7 +2392,7 @@
   
  The `path` parameter may specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory. To obtain the current working directory, use the <xref:System.IO.Directory.GetCurrentDirectory%2A> method.  
   
- The returned <xref:System.IO.File.FileStream> does not support reading. To open a file for both reading and writing, use <xref:System.IO.File.Open>.
+ The returned <xref:System.IO.FileStream> does not support reading. To open a file for both reading and writing, use <xref:System.IO.File.Open>.
 
  For a list of common I/O tasks, see [Common I/O Tasks](~/docs/standard/io/common-i-o-tasks.md).  
   

--- a/xml/System.IO/File.xml
+++ b/xml/System.IO/File.xml
@@ -2392,7 +2392,7 @@
   
  The `path` parameter may specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory. To obtain the current working directory, use the <xref:System.IO.Directory.GetCurrentDirectory%2A> method.  
   
- The returned <xref:System.IO.FileStream> does not support reading. To open a file for both reading and writing, use <xref:System.IO.File.Open>.
+ The returned <xref:System.IO.FileStream> does not support reading. To open a file for both reading and writing, use <xref:System.IO.File.Open%2A>.
 
  For a list of common I/O tasks, see [Common I/O Tasks](~/docs/standard/io/common-i-o-tasks.md).  
   

--- a/xml/System.IO/File.xml
+++ b/xml/System.IO/File.xml
@@ -2392,6 +2392,8 @@
   
  The `path` parameter may specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory. To obtain the current working directory, use the <xref:System.IO.Directory.GetCurrentDirectory%2A> method.  
   
+ The returned <xref:System.IO.File.FileStream> does not support reading. To open a file for both reading and writing, use <xref:System.IO.File.Open>.
+
  For a list of common I/O tasks, see [Common I/O Tasks](~/docs/standard/io/common-i-o-tasks.md).  
   
    


### PR DESCRIPTION
It was not perfectly clear that OpenWrite does not support reading and writing, but strictly only writing.

# Added clarification to not use OpenWrite for both reading and writing.

## Summary

"System.NotSupportedException: Stream does not support reading. " is thrown when you attempt to read the stream after using this overload.