### PR TITLE
Typo fix in Method to Canonical Function Mapping

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/clr-method-to-canonical-function-mapping.md
+++ b/docs/framework/data/adonet/ef/language-reference/clr-method-to-canonical-function-mapping.md
@@ -38,7 +38,7 @@ The Entity Framework provides a set of canonical functions that implement functi
 |Microsoft.VisualBasic.Strings.Trim(String `str`)|Trim(`str`)|  
 |Microsoft.VisualBasic.Strings.LTrim(String `str`)|Ltrim(`str`)|  
 |Microsoft.VisualBasic.Strings.RTrim(String `str`)|Rtrim(`str`)|  
-icrosoft.VisualBasic.Strings.Len(String `expression`)|Length(`expression`)|  
+|Microsoft.VisualBasic.Strings.Len(String `expression`)|Length(`expression`)|  
 |Microsoft.VisualBasic.Strings.Left(String `str`, Int32 `Length`)|Left(`str`, `Length`)|  
 |Microsoft.VisualBasic.Strings.Mid(String `str`, Int32 `Start`, Int32 `Length`)|Substring(`str`, `Start`, `Length`)|  
 |Microsoft.VisualBasic.Strings.Right(String `str`, Int32 `Length`)|Right(`str`, `Length`)|  


### PR DESCRIPTION
## Title
Typo fix in clr-method-to-canonical-function-mapping.md

## Summary

Added 

> "|M"

 in front of 

> icrosoft.VisualBasic.Strings.Len

 string.
