### PR TITLE
Use x86_64 and amd64 instead of x64 for Linux distributions

### DIFF
--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -4,7 +4,7 @@ description: Supported Linux versions and .NET Core dependencies to develop, dep
 keywords: .NET, .NET Core, Linux, debian, ubuntu, RHEL, centOS,
 author: jralexander
 ms.author: johalex
-ms.date: 09/06/2017
+ms.date: 09/07/2017
 ms.topic: article
 ms.prod: .net-core
 ms.devlang: dotnet

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -24,7 +24,7 @@ This article shows the dependencies needed to develop .NET Core applications on 
 
 .NET Core 2.0 treats Linux as a single operating system. There is a single Linux build (per chip architecture) for supported Linux distros.
 
-NET Core 2.x is supported on the following Linux x64 distributions/versions:
+NET Core 2.x is supported on the following Linux 64-bit (`x86_64` or `amd64`) distributions/versions:
 
  * Red Hat Enterprise Linux 7
  * CentOS 7
@@ -40,7 +40,7 @@ See [.NET Core 2.x Supported OS Versions](https://github.com/dotnet/core/blob/ma
 
 # [.NET Core 1.x](#tab/netcore1x)
 
-.NET Core 1.x is supported on the following Linux x64 distributions/versions:
+.NET Core 1.x is supported on the following Linux 64-bit (`x86_64` or `amd64`) distributions/versions:
 
 * Red Hat Enterprise Linux 7
 * CentOS 7


### PR DESCRIPTION
Most Linux distributions for Intel 64-bit architectures are called 64-bit, `x86_64` or `amd64`. `x64` is largely a Windows-ism, and probably not very useful when looking for the architectures on Linux distributions. Update the linux-prerequisites doc to reflect this.

This is an update for https://github.com/dotnet/docs/pull/2955

## Suggested Reviewers
@JRAlexander 
