### PR TITLE
90785 WebClient.Credentials property is cleared on redirect

### DIFF
--- a/xml/System.Net/WebClient.xml
+++ b/xml/System.Net/WebClient.xml
@@ -352,7 +352,7 @@
   
  If the <xref:System.Net.WebClient> class is being used in a middle tier application, such as an ASP.NET application, the <xref:System.Net.CredentialCache.DefaultCredentials%2A> belong to the account running the ASP page (the server-side credentials). Typically, you would set this property to the credentials of the client on whose behalf the request is made.  
   
- For security reasons, credentials that you wish to be included when automatically following redirects need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache> or <xref:System.Net.WebClient.UseDefaultCredentials%2A>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
+ For security reasons, credentials that you wish to be included when automatically following redirects need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
   
 ## Examples  
  The following code example uses the user's system credentials to authenticate a request.  

--- a/xml/System.Net/WebClient.xml
+++ b/xml/System.Net/WebClient.xml
@@ -352,7 +352,7 @@
   
  If the <xref:System.Net.WebClient> class is being used in a middle tier application, such as an ASP.NET application, the <xref:System.Net.CredentialCache.DefaultCredentials%2A> belong to the account running the ASP page (the server-side credentials). Typically, you would set this property to the credentials of the client on whose behalf the request is made.  
   
-   
+ For security reasons, credentials that you wish to be included when automatically following redirects need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache> or <xref:System.Net.WebClient.UseDefaultCredentials%2A>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
   
 ## Examples  
  The following code example uses the user's system credentials to authenticate a request.  

--- a/xml/System.Net/WebClient.xml
+++ b/xml/System.Net/WebClient.xml
@@ -352,7 +352,7 @@
   
  If the <xref:System.Net.WebClient> class is being used in a middle tier application, such as an ASP.NET application, the <xref:System.Net.CredentialCache.DefaultCredentials%2A> belong to the account running the ASP page (the server-side credentials). Typically, you would set this property to the credentials of the client on whose behalf the request is made.  
   
- For security reasons, credentials that you wish to be included when automatically following redirects need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
+ For security reasons, when automatically following redirects, store the credentials that you want to be included in the redirect in a <xref:System.Net.CredentialCache> and assign it to this property. This property will automatically be set to `null` upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to `null` under those conditions prevents credentials from being sent to any unintended destination.
   
 ## Examples  
  The following code example uses the user's system credentials to authenticate a request.  


### PR DESCRIPTION
# Adding info about auto-clearing of Credentials on redirect

## Summary

When a redirect takes place, WebClient.Credentials is cleared on under certain circumstances for security reasons. This change describes those circumstances (tracked in BUG 90785).