### PR TITLE
2827 Incorrect information for System.Net.Dns

### DIFF
--- a/xml/System.Net/Dns.xml
+++ b/xml/System.Net/Dns.xml
@@ -84,7 +84,7 @@
 > [!NOTE]
 >  This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](~/docs/framework/network-programming/network-tracing.md).  
   
- When an empty string is passed as the host name, this method returns the IPv4 addresses of the local host for all operating systems except Windows Server 2003; for Windows Server 2003, both IPv4 and IPv6 addresses for the local host are returned.  
+ If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
   
  The asynchronous <xref:System.Net.Dns.BeginGetHostAddresses%2A> operation must be completed by calling the <xref:System.Net.Dns.EndGetHostAddresses%2A> method. Typically, the method is invoked by the `requestCallback` delegate.  
   
@@ -393,7 +393,7 @@
 ## Remarks  
  The <xref:System.Net.Dns.BeginGetHostAddresses%2A> method queries a DNS server for the IP addresses associated with a host name. If `hostNameOrAddress` is an IP address, this address is returned without querying the DNS server.  
   
- When an empty string is passed as the host name, this method returns the IPv4 addresses of the local host for all operating systems except Windows Server 2003; for Windows Server 2003, both IPv4 and IPv6 addresses for the local host are returned.  
+ If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
   
 > [!NOTE]
 >  This member emits trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](~/docs/framework/network-programming/network-tracing.md).  
@@ -596,7 +596,7 @@
 ## Remarks  
  The <xref:System.Net.Dns.GetHostAddresses%2A> method queries a DNS server for the IP addresses associated with a host name. If `hostNameOrAddress` is an IP address, this address is returned without querying the DNS server.  
   
- When an empty string is passed as the host name, this method returns the IPv4 addresses of the local host for all operating systems except Windows Server 2003; for Windows Server 2003, both IPv4 and IPv6 addresses for the local host are returned.  
+ If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
   
  IPv6 addresses are filtered from the results of the <xref:System.Net.Dns.GetHostAddresses%2A> method if the local computer does not have IPv6 installed. As a result, it is possible to get back an empty <xref:System.Net.IPAddress> instance if only IPv6 results where available for the `hostNameOrAddress`.parameter.  
   
@@ -939,7 +939,7 @@
 ## Remarks  
  The <xref:System.Net.Dns.GetHostEntry%2A> method queries a DNS server for the IP address that is associated with a host name or IP address.  
   
- When an empty string is passed as the host name, this method returns the IPv4 addresses of the local host.  
+ If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
   
  If the host name could not be found, the <xref:System.Net.Sockets.SocketException> exception is returned with a value of 11001 (Windows Sockets error WSAHOST_NOT_FOUND). This exception can be returned if the DNS server does not respond. This exception can also be returned if the name is not an official host name or alias, or it cannot be found in the database(s) being queried.  
   
@@ -1078,7 +1078,7 @@
   
  This method queries a DNS server for the IP address that is associated with a host name or IP address.  
   
- When an empty string is passed as the host name, this method returns the IPv4 addresses of the local host.  
+ If an empty string is passed as the `hostNameOrAddress` argument, then this method returns the IPv4 and IPv6 addresses of the local host.
   
  If the host name could not be found, the <xref:System.Net.Sockets.SocketException> exception is returned with a value of 11001 (Windows Sockets error WSAHOST_NOT_FOUND). This exception can be returned if the DNS server does not respond. This exception can also be returned if the name is not an official host name or alias, or it cannot be found in the database(s) being queried.  
   


### PR DESCRIPTION
# Updating info about local host IP addresses returned by the Dns class

## Summary

The Dns class can be used to return the IP addresses of the local host, by passing an empty string. The addresses returned are IPv4 and IPv6, so updating the topic to make this clear, and removing obsolete reference to WS2003 being an exception (which it is not).

Fixes #2827