### PR TITLE
fixed file encoding

### DIFF
--- a/samples/snippets/csharp/language-reference/keywords/interpolated-strings2.cs
+++ b/samples/snippets/csharp/language-reference/keywords/interpolated-strings2.cs
@@ -1,4 +1,4 @@
-// <Snippet1>
+ï»¿// <Snippet1>
 using System;
 using System.Globalization;
 using System.Reflection;
@@ -62,6 +62,6 @@ public class Example
 //       -------
 //       
 //       The cost of this item is $1,000.00.
-//       The cost of this item is 1 000,00 €.
+//       The cost of this item is 1Â 000,00 â‚¬.
 // </Snippet1>
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/interpolated-strings has character encoding issues. Saving file as UTF-8 to see if it fixes the issue.

Related to #3094 