### PR TITLE
Fix Missing more docs for some migrated .NET APIs

### DIFF
--- a/add/metadata/System.Net/HttpWebResponse.meta.md
+++ b/add/metadata/System.Net/HttpWebResponse.meta.md
@@ -65,7 +65,7 @@ manager: "markl"
 ---
 
 ---
-uid: System.Net.HttpWebResponse.Dispose
+uid: System.Net.HttpWebResponse.Dispose*
 ---
 
 ---
@@ -87,7 +87,7 @@ manager: "markl"
 ---
 
 ---
-uid: System.Net.HttpWebResponse.#ctor
+uid: System.Net.HttpWebResponse.#ctor*
 ms.author: "bobdel"
 manager: "markl"
 ---
@@ -100,6 +100,12 @@ manager: "markl"
 
 ---
 uid: System.Net.HttpWebResponse.LastModified
+ms.author: "bobdel"
+manager: "markl"
+---
+
+---
+uid: System.Net.HttpWebResponse.#ctor
 ms.author: "bobdel"
 manager: "markl"
 ---

--- a/xml/System.Net.Http/CookieUsePolicy.xml
+++ b/xml/System.Net.Http/CookieUsePolicy.xml
@@ -13,7 +13,7 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
+    <summary>This enumeration allows control of HTTP cookies when communicating with the server.</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
@@ -33,7 +33,7 @@
         <ReturnType>System.Net.Http.CookieUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that no cookies are sent to the server by the client.</summary>
       </Docs>
     </Member>
     <Member MemberName="UseInternalCookieStoreOnly">
@@ -52,7 +52,7 @@
         <ReturnType>System.Net.Http.CookieUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that cookies are handled internally which optimizes performance. Accessing, adding and deleting cookies is not allowed when this value is used.</summary>
       </Docs>
     </Member>
     <Member MemberName="UseSpecifiedCookieContainer">
@@ -71,7 +71,7 @@
         <ReturnType>System.Net.Http.CookieUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that cookies are managed manually using a <see cref="T:System.Net.CookieContainer" /> type.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net.Http/WinHttpHandler.xml
+++ b/xml/System.Net.Http/WinHttpHandler.xml
@@ -14,8 +14,22 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>
+      <see cref="T:System.Net.Http.WinHttpHandler" /> is a specialty message handler based on the WinHTTP interface of Windows and is intended for use in server environments. This class is also available for use in Desktop apps by installing it as a NuGet package. For more information about installing this class for use in Desktop apps, see [System.Net.Http.WinHttpHandler](http://go.microsoft.com/fwlink/?LinkId=620067).</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ <xref:System.Net.Http.WinHttpHandler> is similar to other existing classes such as <xref:System.Net.Http.HttpClientHandler>. <xref:System.Net.Http.WinHttpHandler> provides a handler underneath an <xref:System.Net.Http.HttpClient> instance and is used to send HTTP requests out to a server and receive server responses.  
+  
+ <xref:System.Net.Http.WinHttpHandler> is designed to be used primarily in server environments by ASP.NET 5 and other .NET applications that communicate with HTTP servers. <xref:System.Net.Http.WinHttpHandler> also provides developers with more granular control over the application's HTTP communication than the <xref:System.Net.Http.HttpClientHandler> class. This allows developers to implement more advanced HTTP scenarios or modify system defaults (for example, proxy settings, timeouts and server SSL certificate validation).  
+  
+ <xref:System.Net.Http.WinHttpHandler> is not intended to be a replacement for <xref:System.Net.Http.HttpClientHandler>, it is a more advanced version provided for scenarios where <xref:System.Net.Http.HttpClientHandler> is insufficient for developers. <xref:System.Net.Http.WinHttpHandler> is implemented as a thin wrapper on the WinHTTP interface of Windows and is only supported on Windows systems.  
+  
+ When using a chain of multiple handlers, <xref:System.Net.Http.WinHttpHandler> should be at the bottom of the chain.  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -32,7 +46,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Net.Http.WinHttpHandler" /> class.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -52,9 +66,16 @@
         <ReturnType>System.Net.DecompressionMethods</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the type of decompression method used by the handler for automatic decompression of the HTTP content response.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is GZip &#124; Deflate.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="AutomaticRedirection">
@@ -73,9 +94,16 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets a value that indicates whether the handler should follow HTTP redirection responses.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is true. In this configuration, all HTTP redirect responses from the server will be followed automatically except if they are redirecting from an HTTPS endpoint to an HTTP endpoint.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="CheckCertificateRevocationList">
@@ -94,9 +122,16 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets a value that indicates whether to check the revocation list of certificates during SSL certificate validation.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is false.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ClientCertificateOption">
@@ -115,9 +150,16 @@
         <ReturnType>System.Net.Http.ClientCertificateOption</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets a value that indicates if the certificate is automatically picked from the certificate store or if the caller is allowed to pass in a specific client certificate.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is ClientCertificateOption.Manual.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ClientCertificates">
@@ -136,9 +178,16 @@
         <ReturnType>System.Security.Cryptography.X509Certificates.X509Certificate2Collection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets a collection of client authentication SSL certificates that are used for client authentication by the Handler if the <see cref="P:System.Net.Http.WinHttpHandler.ClientCertificateOption" /> property is set to Manual.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is an empty collection.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="CookieContainer">
@@ -157,9 +206,16 @@
         <ReturnType>System.Net.CookieContainer</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the managed cookie container object. This property is only used when the <see cref="P:System.Net.Http.WinHttpHandler.CookieUsePolicy" /> property is set to UseSpecifiedCookieContainer. Otherwise, the <see cref="M:System.Net.Http.WinHttpHandler.SendAsync(System.Net.Http.HttpRequestMessage,System.Threading.CancellationToken)" /> method will throw an exception.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is null.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="CookieUsePolicy">
@@ -178,9 +234,16 @@
         <ReturnType>System.Net.Http.CookieUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets a value that indicates how cookies should be managed and used. Developers can choose to ignore cookies, allow the handler to automatically manage them or manually handle them using a <see cref="T:System.Net.CookieContainer" /> object.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default for this property is CookieUsePolicy.UseInternalCookieStoreOnly. If this value is set to CookieUsePolicy.UseSpecifiedCookieContainer, then a container object must be initialized and assigned to the <xref:System.Net.Http.WinHttpHandler.CookieContainer%2A> property. Otherwise, an exception will be thrown when trying to send a request.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="DefaultProxyCredentials">
@@ -199,9 +262,16 @@
         <ReturnType>System.Net.ICredentials</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the credentials used to authenticate the user to an authenticating proxy.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is CredentialCache.DefaultCredentials.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -244,9 +314,16 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the maximum number of allowed HTTP redirects.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is 50. This value only applies if <xref:System.Net.Http.WinHttpHandler.AutomaticRedirection%2A> is set to true.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxConnectionsPerServer">
@@ -265,9 +342,16 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the maximum number of TCP connections allowed to a single server.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is int.MaxValue.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxResponseDrainSize">
@@ -286,9 +370,16 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the maximum amount of data that can be drained from responses in bytes.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is 65536.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="MaxResponseHeadersLength">
@@ -307,9 +398,16 @@
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the maximum size of the header portion from the server response in bytes.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This property protects the client from an unauthorized server attempting to stall the client by sending a response with an infinite amount of header data. The default value for this property is 65536.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="PreAuthenticate">
@@ -328,9 +426,16 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets a value that indicates whether the handler sends an Authorization header with the request.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is false.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="Properties">
@@ -370,9 +475,16 @@
         <ReturnType>System.Net.IWebProxy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the custom proxy when the <see cref="P:System.Net.Http.WinHttpHandler.WindowsProxyUsePolicy" /> property is set to use a custom proxy.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is null.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ReceiveDataTimeout">
@@ -391,9 +503,16 @@
         <ReturnType>System.TimeSpan</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the timeout for receiving the data portion of a response from the server.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is 30 seconds.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ReceiveHeadersTimeout">
@@ -412,9 +531,16 @@
         <ReturnType>System.TimeSpan</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the timeout for receiving the headers of a response from the server.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is 30 seconds.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="SendAsync">
@@ -437,10 +563,10 @@
         <Parameter Name="cancellationToken" Type="System.Threading.CancellationToken" />
       </Parameters>
       <Docs>
-        <param name="request">To be added.</param>
-        <param name="cancellationToken">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
+        <param name="request">The HTTP request message to send</param>
+        <param name="cancellationToken">The cancellation token.</param>
+        <summary>Sends an HTTP request as an asynchronous operation.</summary>
+        <returns>The task object representing the asynchronous operation.</returns>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -460,9 +586,16 @@
         <ReturnType>System.TimeSpan</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the timeout for sending a request.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is 30 seconds.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ServerCertificateValidationCallback">
@@ -481,9 +614,16 @@
         <ReturnType>System.Func&lt;System.Net.Http.HttpRequestMessage,System.Security.Cryptography.X509Certificates.X509Certificate2,System.Security.Cryptography.X509Certificates.X509Chain,System.Net.Security.SslPolicyErrors,System.Boolean&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets or sets a callback method to validate the server certificate. This callback is part of the SSL handshake.</summary>
+        <value>The callback should return true if the server certificate is considered valid and the request should be sent. Otherwise, return false.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value is null. If this property is null, the server certificate will be validated using standard well-known certificate authorities.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ServerCredentials">
@@ -502,9 +642,16 @@
         <ReturnType>System.Net.ICredentials</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the credentials to be used by the client to authenticate to the server.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value for this property is null.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="SslProtocols">
@@ -523,9 +670,16 @@
         <ReturnType>System.Security.Authentication.SslProtocols</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the collection of TLS/SSL protocols supported by the client.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value is SslProtocols.Tls &#124; SslProtocols.Tls11 &#124; SslProtocols.Tls12.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="WindowsProxyUsePolicy">
@@ -544,10 +698,29 @@
         <ReturnType>System.Net.Http.WindowsProxyUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Gets or sets the proxy setting. This property can be set to disable the proxy, use a custom proxy, or use the proxy settings of WinHTTP or WinInet on the machine.</summary>
         <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The default value of this property is the WinHTTP stack proxy settings.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
+    <MemberGroup MemberName="Dispose">
+      <AssemblyInfo>
+        <AssemblyName>System.Net.Http.WinHttpHandler</AssemblyName>
+        <AssemblyVersion>2.0.5.0</AssemblyVersion>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+        <AssemblyVersion>4.0.1.0</AssemblyVersion>
+        <AssemblyVersion>4.0.2.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>Releases the unmanaged resources and disposes of the managed resources used by the invoker.</summary>
+      </Docs>
+    </MemberGroup>
   </Members>
 </Type>

--- a/xml/System.Net.Http/WinHttpHandler.xml
+++ b/xml/System.Net.Http/WinHttpHandler.xml
@@ -22,7 +22,7 @@
 ## Remarks  
  <xref:System.Net.Http.WinHttpHandler> is similar to other existing classes such as <xref:System.Net.Http.HttpClientHandler>. <xref:System.Net.Http.WinHttpHandler> provides a handler underneath an <xref:System.Net.Http.HttpClient> instance and is used to send HTTP requests out to a server and receive server responses.  
   
- <xref:System.Net.Http.WinHttpHandler> is designed to be used primarily in server environments by ASP.NET 5 and other .NET applications that communicate with HTTP servers. <xref:System.Net.Http.WinHttpHandler> also provides developers with more granular control over the application's HTTP communication than the <xref:System.Net.Http.HttpClientHandler> class. This allows developers to implement more advanced HTTP scenarios or modify system defaults (for example, proxy settings, timeouts and server SSL certificate validation).  
+ <xref:System.Net.Http.WinHttpHandler> is designed to be used primarily in server environments by ASP.NET Core and other .NET applications that communicate with HTTP servers. <xref:System.Net.Http.WinHttpHandler> also provides developers with more granular control over the application's HTTP communication than the <xref:System.Net.Http.HttpClientHandler> class. This allows developers to implement more advanced HTTP scenarios or modify system defaults (for example, proxy settings, timeouts and server SSL certificate validation).  
   
  <xref:System.Net.Http.WinHttpHandler> is not intended to be a replacement for <xref:System.Net.Http.HttpClientHandler>, it is a more advanced version provided for scenarios where <xref:System.Net.Http.HttpClientHandler> is insufficient for developers. <xref:System.Net.Http.WinHttpHandler> is implemented as a thin wrapper on the WinHTTP interface of Windows and is only supported on Windows systems.  
   
@@ -156,7 +156,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The default value for this property is ClientCertificateOption.Manual.  
+ The default value for this property is <xref:System.Net.Http.ClientCertificateOption.Manual?displayProperty=fullName>.  
   
  ]]></format>
         </remarks>
@@ -212,7 +212,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The default value for this property is null.  
+ The default value for this property is `null`.  
   
  ]]></format>
         </remarks>
@@ -240,7 +240,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The default for this property is CookieUsePolicy.UseInternalCookieStoreOnly. If this value is set to CookieUsePolicy.UseSpecifiedCookieContainer, then a container object must be initialized and assigned to the <xref:System.Net.Http.WinHttpHandler.CookieContainer%2A> property. Otherwise, an exception will be thrown when trying to send a request.  
+ The default for this property is <xref:System.Net.Http.CookieUsePolicy.UseInternalCookieStoreOnly?displayProperty=fullName>. If this value is set to <xref:System.Net.Http.CookieUsePolicy.UseSpecifiedCookieContainer?displayProperty=fullName>, then a container object must be initialized and assigned to the <xref:System.Net.Http.WinHttpHandler.CookieContainer%2A> property. Otherwise, an exception will be thrown when trying to send a request.  
   
  ]]></format>
         </remarks>
@@ -268,7 +268,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The default value for this property is CredentialCache.DefaultCredentials.  
+ The default value for this property is <xref:System.Net.CredentialCache.DefaultCredentials?displayProperty=fullName>.  
   
  ]]></format>
         </remarks>
@@ -315,12 +315,12 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the maximum number of allowed HTTP redirects.</summary>
-        <value>To be added.</value>
+        <value>The maximum number of allowed HTTP redirects.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The default value for this property is 50. This value only applies if <xref:System.Net.Http.WinHttpHandler.AutomaticRedirection%2A> is set to true.  
+ The default value for this property is 50. This value only applies if <xref:System.Net.Http.WinHttpHandler.AutomaticRedirection%2A> is set to `true`.  
   
  ]]></format>
         </remarks>
@@ -343,7 +343,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the maximum number of TCP connections allowed to a single server.</summary>
-        <value>To be added.</value>
+        <value>The maximum number of TCP connections allowed to a single server.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -371,7 +371,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the maximum amount of data that can be drained from responses in bytes.</summary>
-        <value>To be added.</value>
+        <value>The maximum amount of data that can be drained from responses in bytes.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -399,7 +399,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the maximum size of the header portion from the server response in bytes.</summary>
-        <value>To be added.</value>
+        <value>The maximum size of the header portion from the server response in bytes.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -504,7 +504,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the timeout for receiving the data portion of a response from the server.</summary>
-        <value>To be added.</value>
+        <value>The timeout for receiving the data portion of a response from the server.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -532,7 +532,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the timeout for receiving the headers of a response from the server.</summary>
-        <value>To be added.</value>
+        <value>The timeout for receiving the headers of a response from the server.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -587,7 +587,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the timeout for sending a request.</summary>
-        <value>To be added.</value>
+        <value>The timeout for sending a request.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -643,7 +643,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the credentials to be used by the client to authenticate to the server.</summary>
-        <value>To be added.</value>
+        <value>The credentials to be used by the client to authenticate to the server.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -671,7 +671,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets the collection of TLS/SSL protocols supported by the client.</summary>
-        <value>To be added.</value>
+        <value>The collection of TLS/SSL protocols supported by the client.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Net.Http/WindowsProxyUsePolicy.xml
+++ b/xml/System.Net.Http/WindowsProxyUsePolicy.xml
@@ -13,7 +13,7 @@
     <BaseTypeName>System.Enum</BaseTypeName>
   </Base>
   <Docs>
-    <summary>To be added.</summary>
+    <summary>This enumeration provides available options for the proxy settings used by an <see cref="T:System.Net.Http.HttpClient" /> when running on Windows.</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>
@@ -33,7 +33,7 @@
         <ReturnType>System.Net.Http.WindowsProxyUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that a proxy will not be used.</summary>
       </Docs>
     </Member>
     <Member MemberName="UseCustomProxy">
@@ -52,7 +52,7 @@
         <ReturnType>System.Net.Http.WindowsProxyUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that a custom proxy is used by specifying an object that implements the <see cref="T:System.Net.IWebProxy" /> interface.</summary>
       </Docs>
     </Member>
     <Member MemberName="UseWinHttpProxy">
@@ -71,7 +71,7 @@
         <ReturnType>System.Net.Http.WindowsProxyUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that the current proxy configuration of the WinHTTP API on the machine is used.</summary>
       </Docs>
     </Member>
     <Member MemberName="UseWinInetProxy">
@@ -90,7 +90,7 @@
         <ReturnType>System.Net.Http.WindowsProxyUsePolicy</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
+        <summary>This value indicates that the current proxy configuration of the WinINet API on the machine is used. The proxy settings can be configured using the Internet Explorer Options and supports WPAD and PAC files.</summary>
       </Docs>
     </Member>
   </Members>

--- a/xml/System.Net/HttpWebResponse.xml
+++ b/xml/System.Net/HttpWebResponse.xml
@@ -214,7 +214,7 @@
  You must call either the <xref:System.IO.Stream.Close%2A?displayProperty=fullName> or the <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName> method to close the stream and release the connection for reuse. It is not necessary to call both <xref:System.IO.Stream.Close%2A?displayProperty=fullName> and <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName>, but doing so does not cause an error. Failure to close the stream can cause your application to run out of connections.  
   
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](../Topic/Network%20Tracing%20in%20the%20.NET%20Framework.md).  
+>  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](~/docs/framework/network-programming/network-tracing.md).  
   
    
   
@@ -449,15 +449,15 @@
  When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.WebResponse> references. This method invokes the `Dispose()` method of each referenced object.  
   
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](../Topic/Network%20Tracing%20in%20the%20.NET%20Framework.md).  
+>  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](~/docs/framework/network-programming/network-tracing.md).  
   
  ]]></format>
         </remarks>
         <block subset="none" type="overrides">
           <para>
-            <see langword="Dispose" /> can be called multiple times by other objects. When overriding <see cref="M:System.Net.HttpWebResponse.Dispose(System.Boolean)" />, be careful not to reference objects that have been previously disposed of in an earlier call to <see langword="Dispose" />. For more information about how to implement <see cref="M:System.Net.HttpWebResponse.Dispose(System.Boolean)" />, see [Implementing a Dispose Method](../Topic/Implementing%20a%20Dispose%20Method.md).  
+            <see langword="Dispose" /> can be called multiple times by other objects. When overriding <see cref="M:System.Net.HttpWebResponse.Dispose(System.Boolean)" />, be careful not to reference objects that have been previously disposed of in an earlier call to <see langword="Dispose" />. For more information about how to implement <see cref="M:System.Net.HttpWebResponse.Dispose(System.Boolean)" />, see [Implementing a Dispose Method](~/docs/standard/garbage-collection/implementing-dispose.md).  
   
- For more information about <see langword="Dispose" /> and <see cref="M:System.Object.Finalize" />, see [Cleaning Up Unmanaged Resources](../Topic/Cleaning%20Up%20Unmanaged%20Resources.md) and [Overriding the Finalize Method](http://msdn.microsoft.com/en-us/8026cb68-fe93-43fc-96c1-c09ad7d64cd3).</para>
+ For more information about <see langword="Dispose" /> and <see cref="M:System.Object.Finalize" />, see [Cleaning Up Unmanaged Resources](~/docs/standard/garbage-collection/unmanaged.md) and [Overriding the Finalize Method](http://msdn.microsoft.com/en-us/8026cb68-fe93-43fc-96c1-c09ad7d64cd3).</para>
         </block>
       </Docs>
     </Member>
@@ -584,7 +584,7 @@
 >  You must call either the <xref:System.IO.Stream.Close%2A?displayProperty=fullName> or the  <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName> method to close the stream and release the connection for reuse. It is not necessary to call both <xref:System.IO.Stream.Close%2A?displayProperty=fullName> and <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName>, but doing so does not cause an error. Failure to close the stream will cause your application to run out of connections.  
   
 > [!NOTE]
->  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](../Topic/Network%20Tracing%20in%20the%20.NET%20Framework.md).  
+>  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](~/docs/framework/network-programming/network-tracing.md).  
   
    
   

--- a/xml/System.Net/HttpWebResponse.xml
+++ b/xml/System.Net/HttpWebResponse.xml
@@ -690,10 +690,9 @@
 ## Remarks  
  You can specify mutual authentication using the <xref:System.Net.WebRequest.AuthenticationLevel%2A> property.  
   
- Accessing this property can throw <xref:System.ObjectDisposedException>.  
-  
  ]]></format>
         </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="LastModified">
@@ -853,7 +852,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets the URI of the Internet resource that responded to the request.</summary>
-        <value>A <see cref="T:System.Uri" /> that contains the URI of the Internet resource that responded to the request.</value>
+        <value>The URI of the Internet resource that responded to the request.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -1035,17 +1034,9 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a value that indicates if headers are supported.</summary>
-        <value>Returns <see cref="T:System.Boolean" />.  
-  
- <see langword="true" /> if headers are supported; otherwise, <see langword="false" />.</value>
+        <summary>Gets a value that indicates whether headers are supported.</summary>
+        <value><see langword="true" /> if headers are supported; otherwise, <see langword="false" />. Always returns <see langword="true" />.</value>
         <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
- This property is always true for [!INCLUDE[net_v45](~/includes/net-v45-md.md)].  
-  
- ]]></format>
         </remarks>
       </Docs>
     </Member>

--- a/xml/System.Net/HttpWebResponse.xml
+++ b/xml/System.Net/HttpWebResponse.xml
@@ -28,8 +28,44 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>To be added.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Provides an HTTP-specific implementation of the <see cref="T:System.Net.WebResponse" /> class.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This class contains support for HTTP-specific uses of the properties and methods of the <xref:System.Net.WebResponse> class. The <xref:System.Net.HttpWebResponse> class is used to build HTTP stand-alone client applications that send HTTP requests and receive HTTP responses.  
+  
+> [!NOTE]
+>  Do not confuse <xref:System.Net.HttpWebResponse> with the <xref:System.Web.HttpResponse> class that is used in ASP.NET applications and whose methods and properties are exposed through ASP.NET's intrinsic `Response` object.  
+  
+ You should never directly create an instance of the <xref:System.Net.HttpWebResponse> class. Instead, use the instance returned by a call to <xref:System.Net.HttpWebRequest.GetResponse%2A?displayProperty=fullName>. You must call either the <xref:System.IO.Stream.Close%2A?displayProperty=fullName> or the <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName> method to close the response and release the connection for reuse. It is not necessary to call both <xref:System.IO.Stream.Close%2A?displayProperty=fullName> and <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName>, but doing so does not cause an error.  
+  
+ Common header information returned from the Internet resource is exposed as properties of the class. See the following table for a complete list. Other headers can be read from the <xref:System.Net.HttpWebResponse.Headers%2A> property as name/value pairs.  
+  
+ The following table shows the common HTTP headers that are available through properties of the <xref:System.Net.HttpWebResponse> class.  
+  
+|Header|Property|  
+|------------|--------------|  
+|Content-Encoding|<xref:System.Net.HttpWebResponse.ContentEncoding%2A>|  
+|Content-Length|<xref:System.Net.HttpWebResponse.ContentLength%2A>|  
+|Content-Type|<xref:System.Net.HttpWebResponse.ContentType%2A>|  
+|Last-Modified|<xref:System.Net.HttpWebResponse.LastModified%2A>|  
+|Server|<xref:System.Net.HttpWebResponse.Server%2A>|  
+  
+ The contents of the response from the Internet resource are returned as a <xref:System.IO.Stream> by calling the <xref:System.Net.HttpWebResponse.GetResponseStream%2A> method.  
+  
+   
+  
+## Examples  
+ The following example returns an <xref:System.Net.HttpWebResponse> from an <xref:System.Net.HttpWebRequest>.  
+  
+ [!code-cpp[Classic HttpWebResponse Example#1](~/samples/snippets/cpp/VS_Snippets_Remoting/Classic HttpWebResponse Example/CPP/source.cpp#1)]
+ [!code-csharp[Classic HttpWebResponse Example#1](~/samples/snippets/csharp/VS_Snippets_Remoting/Classic HttpWebResponse Example/CS/source.cs#1)]
+ [!code-vb[Classic HttpWebResponse Example#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/Classic HttpWebResponse Example/VB/source.vb#1)]  
+  
+ ]]></format>
+    </remarks>
+    <altmember cref="T:System.Net.WebResponse" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -55,7 +91,7 @@
       </Attributes>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebResponse" /> class.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
@@ -87,10 +123,18 @@
         <Parameter Name="streamingContext" Type="System.Runtime.Serialization.StreamingContext" />
       </Parameters>
       <Docs>
-        <param name="serializationInfo">To be added.</param>
-        <param name="streamingContext">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="serializationInfo">A <see cref="T:System.Runtime.Serialization.SerializationInfo" /> that contains the information required to serialize the new <see cref="T:System.Net.HttpWebRequest" />.</param>
+        <param name="streamingContext">A <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains the source of the serialized stream that is associated with the new <see cref="T:System.Net.HttpWebRequest" />.</param>
+        <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebResponse" /> class from the specified <see cref="T:System.Runtime.Serialization.SerializationInfo" /> and <see cref="T:System.Runtime.Serialization.StreamingContext" /> instances.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This constructor implements the <xref:System.Runtime.Serialization.ISerializable> interface for the <xref:System.Net.HttpWebRequest> class.  
+  
+ ]]></format>
+        </remarks>
+        <altmember cref="T:System.Runtime.Serialization.ISerializable" />
       </Docs>
     </Member>
     <Member MemberName="CharacterSet">
@@ -115,9 +159,26 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the character set of the response.</summary>
+        <value>A string that contains the character set of the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.CharacterSet%2A> property contains a value that describes the character set of the response. This character set information is taken from the header returned with the response.  
+  
+   
+  
+## Examples  
+ The following example obtains the character set of the response.  
+  
+ [!code-cpp[HttpWebResponse_ContentEncoding_CharacterSet#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_ContentEncoding_CharacterSet/CPP/source.cpp#1)]
+ [!code-csharp[HttpWebResponse_ContentEncoding_CharacterSet#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_ContentEncoding_CharacterSet/CS/source.cs#1)]
+ [!code-vb[HttpWebResponse_ContentEncoding_CharacterSet#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_ContentEncoding_CharacterSet/VB/source.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Close">
@@ -143,8 +204,29 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Closes the response stream.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.Close%2A> method closes the response stream and releases the connection to the resource for reuse by other requests.  
+  
+ You must call either the <xref:System.IO.Stream.Close%2A?displayProperty=fullName> or the <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName> method to close the stream and release the connection for reuse. It is not necessary to call both <xref:System.IO.Stream.Close%2A?displayProperty=fullName> and <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName>, but doing so does not cause an error. Failure to close the stream can cause your application to run out of connections.  
+  
+> [!NOTE]
+>  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](../Topic/Network%20Tracing%20in%20the%20.NET%20Framework.md).  
+  
+   
+  
+## Examples  
+ The following example demonstrates how to close a <xref:System.Net.HttpWebResponse>.  
+  
+ [!code-cpp[HttpWebResponse_Close#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_Close/CPP/httpwebresponse_close.cpp#1)]
+ [!code-csharp[HttpWebResponse_Close#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_Close/CS/httpwebresponse_close.cs#1)]
+ [!code-vb[HttpWebResponse_Close#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_Close/VB/httpwebresponse_close.vb#1)]  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="ContentEncoding">
@@ -169,9 +251,26 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the method that is used to encode the body of the response.</summary>
+        <value>A string that describes the method that is used to encode the body of the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.ContentEncoding%2A> property contains the value of the Content-Encoding header returned with the response.  
+  
+   
+  
+## Examples  
+ The following example uses the <xref:System.Net.HttpWebResponse.ContentEncoding%2A> property to obtain the value of the Content-Encoding header returned with the response.  
+  
+ [!code-cpp[HttpWebResponse_ContentEncoding_CharacterSet#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_ContentEncoding_CharacterSet/CPP/source.cpp#1)]
+ [!code-csharp[HttpWebResponse_ContentEncoding_CharacterSet#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_ContentEncoding_CharacterSet/CS/source.cs#1)]
+ [!code-vb[HttpWebResponse_ContentEncoding_CharacterSet#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_ContentEncoding_CharacterSet/VB/source.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ContentLength">
@@ -197,9 +296,26 @@
         <ReturnType>System.Int64</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the length of the content returned by the request.</summary>
+        <value>The number of bytes returned by the request. Content length does not include header information.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.ContentLength%2A> property contains the value of the Content-Length header returned with the response. If the Content-Length header is not set in the response, <xref:System.Net.HttpWebResponse.ContentLength%2A> is set to the value -1.  
+  
+   
+  
+## Examples  
+ The following example displays the value of this property.  
+  
+ [!code-cpp[NCLResponse1#1](~/samples/snippets/cpp/VS_Snippets_Remoting/NCLResponse1/CPP/httpwebrequest1.cpp#1)]
+ [!code-csharp[NCLResponse1#1](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLResponse1/CS/httpwebrequest1.cs#1)]
+ [!code-vb[NCLResponse1#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLResponse1/VB/httpwebrequest1.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ContentType">
@@ -225,9 +341,26 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the content type of the response.</summary>
+        <value>A string that contains the content type of the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.ContentType%2A> property contains the value of the Content-Type header returned with the response.  
+  
+   
+  
+## Examples  
+ The following example displays the value of this property.  
+  
+ [!code-cpp[NCLResponse1#1](~/samples/snippets/cpp/VS_Snippets_Remoting/NCLResponse1/CPP/httpwebrequest1.cpp#1)]
+ [!code-csharp[NCLResponse1#1](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLResponse1/CS/httpwebrequest1.cs#1)]
+ [!code-vb[NCLResponse1#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLResponse1/VB/httpwebrequest1.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Cookies">
@@ -253,9 +386,29 @@
         <ReturnType>System.Net.CookieCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets or sets the cookies that are associated with this response.</summary>
+        <value>A <see cref="T:System.Net.CookieCollection" /> that contains the cookies that are associated with this response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.Cookies%2A> property provides an instance of the <xref:System.Net.CookieCollection> class that holds the cookies associated with this response.  
+  
+ If the <xref:System.Net.HttpWebRequest.CookieContainer%2A> property of the associated <xref:System.Net.HttpWebRequest> is `null`, the <xref:System.Net.HttpWebResponse.Cookies%2A> property will also be `null`. Any cookie information sent by the server will be available in the <xref:System.Net.HttpWebResponse.Headers%2A> property, however.  
+  
+   
+  
+## Examples  
+ The following example sends a request to a URL and displays the cookies returned in the response.  
+  
+ [!code-cpp[NCLCookies#1](~/samples/snippets/cpp/VS_Snippets_Remoting/NCLCookies/CPP/cookiessnippets.cpp#1)]
+ [!code-csharp[NCLCookies#1](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLCookies/CS/cookiessnippets.cs#1)]
+ [!code-vb[NCLCookies#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLCookies/VB/cookiessnippets.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
+        <altmember cref="T:System.Net.CookieContainer" />
       </Docs>
     </Member>
     <Member MemberName="Dispose">
@@ -284,9 +437,28 @@
         <Parameter Name="disposing" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="disposing">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="disposing">
+          <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to releases only unmanaged resources.</param>
+        <summary>Releases the unmanaged resources used by the <see cref="T:System.Net.HttpWebResponse" />, and optionally disposes of the managed resources.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This method is called by the public `Dispose()` method and the <xref:System.Object.Finalize%2A> method. `Dispose()` invokes the protected `Dispose(Boolean)` method with the `disposing` parameter set to `true`. <xref:System.Object.Finalize%2A> invokes `Dispose` with `disposing` set to `false`.  
+  
+ When the `disposing` parameter is `true`, this method releases all resources held by any managed objects that this <xref:System.Net.WebResponse> references. This method invokes the `Dispose()` method of each referenced object.  
+  
+> [!NOTE]
+>  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](../Topic/Network%20Tracing%20in%20the%20.NET%20Framework.md).  
+  
+ ]]></format>
+        </remarks>
+        <block subset="none" type="overrides">
+          <para>
+            <see langword="Dispose" /> can be called multiple times by other objects. When overriding <see cref="M:System.Net.HttpWebResponse.Dispose(System.Boolean)" />, be careful not to reference objects that have been previously disposed of in an earlier call to <see langword="Dispose" />. For more information about how to implement <see cref="M:System.Net.HttpWebResponse.Dispose(System.Boolean)" />, see [Implementing a Dispose Method](../Topic/Implementing%20a%20Dispose%20Method.md).  
+  
+ For more information about <see langword="Dispose" /> and <see cref="M:System.Object.Finalize" />, see [Cleaning Up Unmanaged Resources](../Topic/Cleaning%20Up%20Unmanaged%20Resources.md) and [Overriding the Finalize Method](http://msdn.microsoft.com/en-us/8026cb68-fe93-43fc-96c1-c09ad7d64cd3).</para>
+        </block>
       </Docs>
     </Member>
     <Member MemberName="GetObjectData">
@@ -315,10 +487,17 @@
         <Parameter Name="streamingContext" Type="System.Runtime.Serialization.StreamingContext" />
       </Parameters>
       <Docs>
-        <param name="serializationInfo">To be added.</param>
-        <param name="streamingContext">To be added.</param>
-        <summary>To be added.</summary>
-        <remarks>To be added.</remarks>
+        <param name="serializationInfo">The <see cref="T:System.Runtime.Serialization.SerializationInfo" /> to populate with data.</param>
+        <param name="streamingContext">A <see cref="T:System.Runtime.Serialization.StreamingContext" /> that specifies the destination for this serialization.</param>
+        <summary>Populates a <see cref="T:System.Runtime.Serialization.SerializationInfo" /> with the data needed to serialize the target object.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Any objects that are included in the <xref:System.Runtime.Serialization.SerializationInfo> are automatically tracked and serialized by the formatter.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetResponseHeader">
@@ -346,10 +525,27 @@
         <Parameter Name="headerName" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="headerName">To be added.</param>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <param name="headerName">The header value to return.</param>
+        <summary>Gets the contents of a header that was returned with the response.</summary>
+        <returns>The contents of the specified header.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Use <xref:System.Net.HttpWebResponse.GetResponseHeader%2A> to retrieve the contents of particular headers. You must specify which header you want to return.  
+  
+   
+  
+## Examples  
+ This example creates a Web request and queries for a response. If the site requires authentication, this example will respond with a challenge string. This string is extracted using <xref:System.Net.HttpWebResponse.GetResponseHeader%2A>.  
+  
+ [!code-cpp[HttpWebResponse_GetResponseHeader#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_GetResponseHeader/CPP/httpwebresponse_getresponseheader.cpp#1)]
+ [!code-csharp[HttpWebResponse_GetResponseHeader#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_GetResponseHeader/CS/httpwebresponse_getresponseheader.cs#1)]
+ [!code-vb[HttpWebResponse_GetResponseHeader#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_GetResponseHeader/VB/httpwebresponse_getresponseheader.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetResponseStream">
@@ -376,9 +572,33 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>To be added.</summary>
-        <returns>To be added.</returns>
-        <remarks>To be added.</remarks>
+        <summary>Gets the stream that is used to read the body of the response from the server.</summary>
+        <returns>A <see cref="T:System.IO.Stream" /> containing the body of the response.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.GetResponseStream%2A> method returns the data stream from the requested Internet resource.  
+  
+> [!NOTE]
+>  You must call either the <xref:System.IO.Stream.Close%2A?displayProperty=fullName> or the  <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName> method to close the stream and release the connection for reuse. It is not necessary to call both <xref:System.IO.Stream.Close%2A?displayProperty=fullName> and <xref:System.Net.HttpWebResponse.Close%2A?displayProperty=fullName>, but doing so does not cause an error. Failure to close the stream will cause your application to run out of connections.  
+  
+> [!NOTE]
+>  This member outputs trace information when you enable network tracing in your application. For more information, see [Network Tracing in the .NET Framework](../Topic/Network%20Tracing%20in%20the%20.NET%20Framework.md).  
+  
+   
+  
+## Examples  
+ The following example demonstrates how to use <xref:System.Net.HttpWebResponse.GetResponseStream%2A> to return the <xref:System.IO.Stream> instance used to read the response from the server.  
+  
+ [!code-cpp[HttpWebResponse_GetResponseStream#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_GetResponseStream/CPP/httpwebresponse_getresponsestream.cpp#1)]
+ [!code-csharp[HttpWebResponse_GetResponseStream#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_GetResponseStream/CS/httpwebresponse_getresponsestream.cs#1)]
+ [!code-vb[HttpWebResponse_GetResponseStream#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_GetResponseStream/VB/httpwebresponse_getresponsestream.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.Net.ProtocolViolationException">There is no response stream.</exception>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Headers">
@@ -404,9 +624,34 @@
         <ReturnType>System.Net.WebHeaderCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the headers that are associated with this response from the server.</summary>
+        <value>A <see cref="T:System.Net.WebHeaderCollection" /> that contains the header information returned with the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.Headers%2A> property is a collection of name/value pairs that contain the HTTP header values returned with the response. Common header information returned from the Internet resource is exposed as properties of the <xref:System.Net.HttpWebResponse> class. The following table lists common headers that the API exposes as properties.  
+  
+|Header|Property|  
+|------------|--------------|  
+|Content-Encoding|<xref:System.Net.HttpWebResponse.ContentEncoding%2A>|  
+|Content-Length|<xref:System.Net.HttpWebResponse.ContentLength%2A>|  
+|Content-Type|<xref:System.Net.HttpWebResponse.ContentType%2A>|  
+|Last-Modified|<xref:System.Net.HttpWebResponse.LastModified%2A>|  
+|Server|<xref:System.Net.HttpWebResponse.Server%2A>|  
+  
+   
+  
+## Examples  
+ The following example writes the contents of all of the response headers to the console.  
+  
+ [!code-cpp[HttpWebResponse_Headers#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_Headers/CPP/httpwebresponse_headers.cpp#1)]
+ [!code-csharp[HttpWebResponse_Headers#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_Headers/CS/httpwebresponse_headers.cs#1)]
+ [!code-vb[HttpWebResponse_Headers#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_Headers/VB/httpwebresponse_headers.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="IsMutuallyAuthenticated">
@@ -436,9 +681,19 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a <see cref="T:System.Boolean" /> value that indicates whether both client and server were authenticated.</summary>
+        <value>
+          <see langword="true" /> if mutual authentication occurred; otherwise, <see langword="false" />.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ You can specify mutual authentication using the <xref:System.Net.WebRequest.AuthenticationLevel%2A> property.  
+  
+ Accessing this property can throw <xref:System.ObjectDisposedException>.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="LastModified">
@@ -463,9 +718,26 @@
         <ReturnType>System.DateTime</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the last date and time that the contents of the response were modified.</summary>
+        <value>A <see cref="T:System.DateTime" /> that contains the date and time that the contents of the response were modified.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.LastModified%2A> property contains the value of the Last-Modified header received with the response. The date and time are assumed to be local time.  
+  
+   
+  
+## Examples  
+ This example creates an <xref:System.Net.HttpWebRequest> and queries for a response. This example then checks whether the entity requested had been modified any time today.  
+  
+ [!code-cpp[HttpWebResponse_LastModified#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_LastModified/CPP/httpwebresponse_lastmodified.cpp#1)]
+ [!code-csharp[HttpWebResponse_LastModified#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_LastModified/CS/httpwebresponse_lastmodified.cs#1)]
+ [!code-vb[HttpWebResponse_LastModified#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_LastModified/VB/httpwebresponse_lastmodified.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Method">
@@ -491,9 +763,26 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the method that is used to return the response.</summary>
+        <value>A string that contains the HTTP method that is used to return the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ <xref:System.Net.HttpWebResponse.Method%2A> returns the method that is used to return the response. Common HTTP methods are GET, HEAD, POST, PUT, and DELETE.  
+  
+   
+  
+## Examples  
+ The following example checks the string contained in <xref:System.Net.HttpWebResponse.Method%2A>, to determine the Http method invoked by the Web server.  
+  
+ [!code-cpp[HttpWebResponse_Method_Server#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_Method_Server/CPP/httpwebresponse_method_server.cpp#1)]
+ [!code-csharp[HttpWebResponse_Method_Server#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_Method_Server/CS/httpwebresponse_method_server.cs#1)]
+ [!code-vb[HttpWebResponse_Method_Server#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_Method_Server/VB/httpwebresponse_method_server.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ProtocolVersion">
@@ -518,9 +807,26 @@
         <ReturnType>System.Version</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the version of the HTTP protocol that is used in the response.</summary>
+        <value>A <see cref="T:System.Version" /> that contains the HTTP protocol version of the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.ProtocolVersion%2A> property contains the HTTP protocol version number of the response sent by the Internet resource.  
+  
+   
+  
+## Examples  
+ This example creates an <xref:System.Net.HttpWebRequest> and queries for an <xref:System.Net.HttpWebResponse>. The example then checks to see if the server is responding with the same version.  
+  
+ [!code-cpp[HttpWebResponse_ProtocolVersion#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_ProtocolVersion/CPP/httpwebresponse_protocolversion.cpp#1)]
+ [!code-csharp[HttpWebResponse_ProtocolVersion#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_ProtocolVersion/CS/httpwebresponse_protocolversion.cs#1)]
+ [!code-vb[HttpWebResponse_ProtocolVersion#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_ProtocolVersion/VB/httpwebresponse_protocolversion.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="ResponseUri">
@@ -546,9 +852,30 @@
         <ReturnType>System.Uri</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the URI of the Internet resource that responded to the request.</summary>
+        <value>A <see cref="T:System.Uri" /> that contains the URI of the Internet resource that responded to the request.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.ResponseUri%2A> property contains the URI of the Internet resource that actually responded to the request. This URI might not be the same as the originally requested URI, if the original server redirected the request.  
+  
+ The <xref:System.Net.HttpWebResponse.ResponseUri%2A> property will use the Content-Location header if present.  
+  
+ Applications that need to access the last redirected <xref:System.Net.HttpWebResponse.ResponseUri%2A> should use the <xref:System.Net.HttpWebRequest.Address%2A?displayProperty=fullName> property rather than <xref:System.Net.HttpWebResponse.ResponseUri%2A>, since the use of <xref:System.Net.HttpWebResponse.ResponseUri%2A> property may open security vulnerabilities.  
+  
+   
+  
+## Examples  
+ This example creates a <xref:System.Net.HttpWebRequest> and queries for an <xref:System.Net.HttpWebResponse> and then checks to see whether the original URI was redirected by the server.  
+  
+ [!code-cpp[HttpWebResponse_ResponseUri#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_ResponseUri/CPP/httpwebresponse_responseuri.cpp#1)]
+ [!code-csharp[HttpWebResponse_ResponseUri#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_ResponseUri/CS/httpwebresponse_responseuri.cs#1)]
+ [!code-vb[HttpWebResponse_ResponseUri#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_ResponseUri/VB/httpwebresponse_responseuri.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="Server">
@@ -573,9 +900,26 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the name of the server that sent the response.</summary>
+        <value>A string that contains the name of the server that sent the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.Server%2A> property contains the value of the Server header returned with the response.  
+  
+   
+  
+## Examples  
+ The following example uses the <xref:System.Net.HttpWebResponse.Server%2A> property to display the Web server's name to the console.  
+  
+ [!code-cpp[HttpWebResponse_Method_Server#2](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_Method_Server/CPP/httpwebresponse_method_server.cpp#2)]
+ [!code-csharp[HttpWebResponse_Method_Server#2](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_Method_Server/CS/httpwebresponse_method_server.cs#2)]
+ [!code-vb[HttpWebResponse_Method_Server#2](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_Method_Server/VB/httpwebresponse_method_server.vb#2)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="StatusCode">
@@ -601,9 +945,26 @@
         <ReturnType>System.Net.HttpStatusCode</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the status of the response.</summary>
+        <value>One of the <see cref="T:System.Net.HttpStatusCode" /> values.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ The <xref:System.Net.HttpWebResponse.StatusCode%2A> parameter is a number that indicates the status of the HTTP response. The expected values for status are defined in the <xref:System.Net.HttpStatusCode> class.  
+  
+   
+  
+## Examples  
+ The following example uses <xref:System.Net.HttpWebResponse.StatusCode%2A> to verify that the status of the <xref:System.Net.HttpWebResponse> is OK.  
+  
+ [!code-cpp[HttpWebResponse_StatusCode_StatusDescription#1](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_StatusCode_StatusDescription/CPP/httpwebresponse_statuscode_statusdescription.cpp#1)]
+ [!code-csharp[HttpWebResponse_StatusCode_StatusDescription#1](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_StatusCode_StatusDescription/CS/httpwebresponse_statuscode_statusdescription.cs#1)]
+ [!code-vb[HttpWebResponse_StatusCode_StatusDescription#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_StatusCode_StatusDescription/VB/httpwebresponse_statuscode_statusdescription.vb#1)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="StatusDescription">
@@ -629,9 +990,26 @@
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets the status description returned with the response.</summary>
+        <value>A string that describes the status of the response.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ A common status message is OK.  
+  
+   
+  
+## Examples  
+ The following example uses <xref:System.Net.HttpWebResponse.StatusDescription%2A> to verify that the status of the <xref:System.Net.HttpWebResponse> is OK.  
+  
+ [!code-cpp[HttpWebResponse_StatusCode_StatusDescription#2](~/samples/snippets/cpp/VS_Snippets_Remoting/HttpWebResponse_StatusCode_StatusDescription/CPP/httpwebresponse_statuscode_statusdescription.cpp#2)]
+ [!code-csharp[HttpWebResponse_StatusCode_StatusDescription#2](~/samples/snippets/csharp/VS_Snippets_Remoting/HttpWebResponse_StatusCode_StatusDescription/CS/httpwebresponse_statuscode_statusdescription.cs#2)]
+ [!code-vb[HttpWebResponse_StatusCode_StatusDescription#2](~/samples/snippets/visualbasic/VS_Snippets_Remoting/HttpWebResponse_StatusCode_StatusDescription/VB/httpwebresponse_statuscode_statusdescription.vb#2)]  
+  
+ ]]></format>
+        </remarks>
+        <exception cref="T:System.ObjectDisposedException">The current instance has been disposed.</exception>
       </Docs>
     </Member>
     <Member MemberName="SupportsHeaders">
@@ -657,9 +1035,18 @@
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>To be added.</summary>
-        <value>To be added.</value>
-        <remarks>To be added.</remarks>
+        <summary>Gets a value that indicates if headers are supported.</summary>
+        <value>Returns <see cref="T:System.Boolean" />.  
+  
+ <see langword="true" /> if headers are supported; otherwise, <see langword="false" />.</value>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ This property is always true for [!INCLUDE[net_v45](~/includes/net-v45-md.md)].  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="System.IDisposable.Dispose">
@@ -707,11 +1094,20 @@
         <Parameter Name="streamingContext" Type="System.Runtime.Serialization.StreamingContext" />
       </Parameters>
       <Docs>
-        <param name="serializationInfo">To be added.</param>
-        <param name="streamingContext">To be added.</param>
-        <summary>To be added.</summary>
+        <param name="serializationInfo">The object into which this <see cref="T:System.Net.HttpWebResponse" /> will be serialized.</param>
+        <param name="streamingContext">The destination of the serialization.</param>
+        <summary>Serializes this instance into the specified <see cref="T:System.Runtime.Serialization.SerializationInfo" /> object.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>
+    <MemberGroup MemberName=".ctor">
+      <AssemblyInfo>
+        <AssemblyName>System</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>Initializes a new instance of the <see cref="T:System.Net.HttpWebResponse" /> class.</summary>
+      </Docs>
+    </MemberGroup>
   </Members>
 </Type>


### PR DESCRIPTION
Fix [Missing more docs for some migrated .NET APIs](https://mseng.visualstudio.com/CSI/_workitems?id=1076648&fullScreen=false&_a=edit)