### PR TITLE
Adding Upper/Lowercase Command Explanations

### DIFF
--- a/docs/framework/wpf/graphics-multimedia/path-markup-syntax.md
+++ b/docs/framework/wpf/graphics-multimedia/path-markup-syntax.md
@@ -101,9 +101,12 @@ Paths are discussed in              [Shapes and Basic Drawing in WPF Overview](.
 |Term|Description|  
 |----------|-----------------|  
 |*endPoint*|<xref:System.Windows.Point?displayProperty=fullName><br /><br /> The end point of the line.|  
-  
+
+An uppercase                  `L` indicates that                  `endPoint` is an absolute value; a lowercase                  `l` indicates that                  `endPoint` is an offset to the previous point, or (0,0) if none exists.
+
 ### Horizontal Line Command  
- Creates a horizontal line between the current point and the specified x-coordinate.                          `H 90` is an example of a valid horizontal line command.  
+ Creates a horizontal line between the current point and the specified x-coordinate.                          `H 90` is an example of a valid horizontal line command.
+
   
 |Syntax|  
 |------------|  
@@ -113,8 +116,11 @@ Paths are discussed in              [Shapes and Basic Drawing in WPF Overview](.
 |----------|-----------------|  
 |*x*|<xref:System.Double?displayProperty=fullName><br /><br /> The x-coordinate of the end point of the line.|  
   
+An uppercase                  `H` indicates that                  `x` is an absolute value; a lowercase                  `h` indicates that                  `x` is an offset to the previous point, or (0,0) if none exists.
+  
 ### Vertical Line Command  
- Creates a vertical line between the current point and the specified y-coordinate.                          `v 90` is an example of a valid vertical line command.  
+ Creates a vertical line between the current point and the specified y-coordinate.                          `v 90` is an example of a valid vertical line command.
+
   
 |Syntax|  
 |------------|  
@@ -123,7 +129,9 @@ Paths are discussed in              [Shapes and Basic Drawing in WPF Overview](.
 |Term|Description|  
 |----------|-----------------|  
 |*y*|<xref:System.Double?displayProperty=fullName><br /><br /> The y-coordinate of the end point of the line.|  
-  
+
+An uppercase                  `V` indicates that                  `y` is an absolute value; a lowercase                  `v` indicates that                  `y` is an offset to the previous point, or (0,0) if none exists.  
+    
 ### Cubic Bezier Curve Command  
  Creates a cubic Bezier curve between the current point and the specified end point by using the two specified control points (                         `controlPoint`1 and                          `controlPoint`2).                          `C 100,200 200,400 300,200` is an example of a valid curve command.  
   
@@ -195,7 +203,7 @@ Paths are discussed in              [Shapes and Basic Drawing in WPF Overview](.
 |Syntax|  
 |------------|  
 |`Z`<br /><br /> - or -<br /><br /> `z`|  
-  
+
 <a name="pointsyntax"></a>   
 ## Point Syntax  
  Describes the x- and y-coordinates of a point.  


### PR DESCRIPTION
Adding Upper/Lowercase Command Explanations to some of the simpler commands.

Took me a little while and googling around to find out the difference.

Decided not to change the more complex commands(>1 arg) as they have multiple arguments.

Just out of curiosity, is there a difference between 'Z' or 'z'? Might be worth stating that they are equivalent if there isn't, as all other 'or's on the page have a difference (absolute vs relative).

Was wondering whether it's worth adding it as some sort of note column in the Syntax tables, rather than a note in the sub section.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
