### PR TITLE
fix typo

### DIFF
--- a/docs/framework/mef/attributed-programming-model-overview-mef.md
+++ b/docs/framework/mef/attributed-programming-model-overview-mef.md
@@ -1,13 +1,9 @@
 ---
 title: "Attributed Programming Model Overview (MEF)"
-ms.custom: ""
 ms.date: "03/30/2017"
 ms.prod: ".net-framework"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "dotnet-clr"
-ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords: 
   - "MEF, attributed programming model"
@@ -959,4 +955,4 @@ public class PartSeven
   
 ## See Also  
  [Channel 9 Video: Open Up Your Applications with the Managed Extensibility Framework](http://channel9.msdn.com/events/TechEd/NorthAmerica/2009/DTL328)   
- [Channel 9 Video: Mnaaged Extensibility Framework (MEF) 2.0](http://channel9.msdn.com/posts/NET-45-Oleg-Lvovitch-and-Kevin-Ransom-Managed-Extensibility-Framework-MEF-20)
+ [Channel 9 Video: Managed Extensibility Framework (MEF) 2.0](http://channel9.msdn.com/posts/NET-45-Oleg-Lvovitch-and-Kevin-Ransom-Managed-Extensibility-Framework-MEF-20)


### PR DESCRIPTION
LiveFyre comment for https://docs.microsoft.com/en-us/dotnet/framework/mef/attributed-programming-model-overview-mef#see-also:
"Wrong spell in the 2nd link."