### PR TITLE
Revised information on embedding videos in style guide

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -351,19 +351,29 @@ Currently, OPS can embed both Channel 9 and youtube videos with the following sy
 
 ### Channel 9
 
+```markdown
 > [!VIDEO <channel9_video_link>]
+```
 
-For example:
+To get the video's correct URL, select the **Embed** tab below the video frame, and copy the URL from the `<iframe>` element. For example:
 
+```markdown
 > [!VIDEO https://channel9.msdn.com/Series/A-Nonexistent-Video/03/player]
+```
 
 ### YouTube
 
+To get the video's correct URL, right-click on the video, select **Copy Embed Code**, and copy the URL from the `<iframe>` element.
+
+```markdown
 > [!VIDEO <youtube_video_link>]
+```
 
 For example:
 
+```markdown
 > [!VIDEO https://www.youtube.com/embed/ZZZz9_Zzz9z]
+```
 
 ## docs.microsoft extensions
 

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -347,7 +347,7 @@ function fancyAlert(arg) {
 
 ## Videos
 
-Currently, OPS can embed both Channel 9 and youtube videos with the following syntax:
+Currently, you can embed both Channel 9 and YouTube videos with the following syntax:
 
 ### Channel 9
 
@@ -358,7 +358,7 @@ Currently, OPS can embed both Channel 9 and youtube videos with the following sy
 To get the video's correct URL, select the **Embed** tab below the video frame, and copy the URL from the `<iframe>` element. For example:
 
 ```markdown
-> [!VIDEO https://channel9.msdn.com/Series/A-Nonexistent-Video/03/player]
+> [!VIDEO https://channel9.msdn.com/Blogs/dotnet/NET-Core-20-Released/player]
 ```
 
 ### YouTube
@@ -372,7 +372,7 @@ To get the video's correct URL, right-click on the video, select **Copy Embed Co
 For example:
 
 ```markdown
-> [!VIDEO https://www.youtube.com/embed/ZZZz9_Zzz9z]
+> [!VIDEO https://www.youtube.com/embed/Q2mMbjw6cLA]
 ```
 
 ## docs.microsoft extensions

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -347,13 +347,23 @@ function fancyAlert(arg) {
 
 ## Videos
 
+Currently, OPS can embed both Channel 9 and youtube videos with the following syntax:
+
 ### Channel 9
 
-<iframe src="https://channel9.msdn.com/Shows/On-NET/Shipping-NET-Core-RC2--Tools-Preview-1/player" width="960" height="540" allowFullScreen frameBorder="0"></iframe>
+> [!VIDEO <channel9_video_link>]
+
+For example:
+
+> [!VIDEO https://channel9.msdn.com/Series/A-Nonexistent-Video/03/player]
 
 ### YouTube
 
-<iframe width="420" height="315" src="https://www.youtube.com/embed/g2a4W6Q7aRw" frameborder="0" allowfullscreen></iframe>
+> [!VIDEO <youtube_video_link>]
+
+For example:
+
+> [!VIDEO https://www.youtube.com/embed/ZZZz9_Zzz9z]
 
 ## docs.microsoft extensions
 


### PR DESCRIPTION
# Revised information on embedding videos in style guide

The style guide uses the `<iframe>` HTML element to embed a video, and does not mention the `> [!VIDEO]` markdown extension. This PR documents it.

## Suggested Reviewers

@mairaw 
