### PR TITLE
Fix a sample code: C# guide > Statements > do statement

### DIFF
--- a/samples/snippets/csharp/tour/statements/Program.cs
+++ b/samples/snippets/csharp/tour/statements/Program.cs
@@ -75,10 +75,10 @@ namespace Statements
             do 
             {
                 s = Console.ReadLine();
-                if (string.IsNullOrEmpty(s)) 
-                    Console.WriteLine(s);
+                Console.WriteLine(s);
             } while (!string.IsNullOrEmpty(s));
         }
+        
 
         static void ForStatement(string[] args)
         {


### PR DESCRIPTION
The original sample reads a line and print it if it **is** null or empty - I don't think it is supposed to be this way.

Added a blank line so I don't have to edit those references in [statements.md
](https://github.com/dotnet/docs/blob/master/docs/csharp/tour-of-csharp/statements.md)