### PR TITLE
Fixed Incorrect Link for F# Windows/.NET Core CLI Getting Started Page

### DIFF
--- a/docs/fsharp/get-started/index.md
+++ b/docs/fsharp/get-started/index.md
@@ -18,7 +18,7 @@ There are multiple ways to get started with F#.  We have multiple articles writt
 
 | OS | Prefer Visual Studio | Prefer Visual Studio Code | Prefer a command line |
 | -- |------------------------|--------------------------|-----------------------------|-------------------------|
-| Windows | [Get started with Visual Studio](get-started-visual-studio.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-vscode.md) |
+| Windows | [Get started with Visual Studio](get-started-visual-studio.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-command-line.md) |
 | macOS | [Get started with VS for Mac](get-started-with-visual-studio-for-mac.md) | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-command-line.md) |
 | Linux | N/A | [Get started with VSCode and Ionide](get-started-vscode.md) | [Get started with the .NET Core CLI](get-started-command-line.md) |
 


### PR DESCRIPTION
# Title

Fixed Incorrect Link for Windows/.NET Core CLI

## Summary

The Windows .Net Core CLI Getting Started link was pointing to the VSCode/Ionide markdown file. Updated it to the point the correct .NET Core CLI Getting Started markdown file.

## Details

No further details.

