### PR TITLE
BUG 90785 HttpWebRequest.Credentials property is cleared on redirect

### DIFF
--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -1642,7 +1642,7 @@
   
  Supported authentication schemes include Digest, Negotiate, Kerberos, NTLM, and Basic.  
   
- For security reasons, when automatically following redirects (that is, when the <xref:System.Net.HttpWebRequest.AllowAutoRedirect%2A> property is set to `true`), store the credentials that you want to be included in the redirect in a <xref:System.Net.CredentialCache> and assign it to this property. This property will automatically be set to `null` upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to `null` under those conditions prevents credentials from being sent to any unintended destination. 
+ For security reasons, when automatically following redirects, store the credentials that you want to be included in the redirect in a <xref:System.Net.CredentialCache> and assign it to this property. This property will automatically be set to `null` upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to `null` under those conditions prevents credentials from being sent to any unintended destination.
   
 ## Examples  
  The following code example sets the credentials for a request.  

--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -1642,7 +1642,7 @@
   
  Supported authentication schemes include Digest, Negotiate, Kerberos, NTLM, and Basic.  
   
-   
+ For security reasons, credentials that you wish to be included when automatically following redirects (when the <xref:System.Net.HttpWebRequest.AllowAutoRedirect%2A> property is set to <see langword="true"/>) need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache> or <xref:System.Net.WebClient.UseDefaultCredentials%2A>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
   
 ## Examples  
  The following code example sets the credentials for a request.  

--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -1642,7 +1642,7 @@
   
  Supported authentication schemes include Digest, Negotiate, Kerberos, NTLM, and Basic.  
   
- For security reasons, credentials that you wish to be included when automatically following redirects (when the <xref:System.Net.HttpWebRequest.AllowAutoRedirect%2A> property is set to <see langword="true"/>) need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache> or <xref:System.Net.WebClient.UseDefaultCredentials%2A>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
+ For security reasons, credentials that you wish to be included when automatically following redirects (when the <xref:System.Net.HttpWebRequest.AllowAutoRedirect%2A> property is set to <see langword="true"/>) need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
   
 ## Examples  
  The following code example sets the credentials for a request.  

--- a/xml/System.Net/HttpWebRequest.xml
+++ b/xml/System.Net/HttpWebRequest.xml
@@ -1642,7 +1642,7 @@
   
  Supported authentication schemes include Digest, Negotiate, Kerberos, NTLM, and Basic.  
   
- For security reasons, credentials that you wish to be included when automatically following redirects (when the <xref:System.Net.HttpWebRequest.AllowAutoRedirect%2A> property is set to <see langword="true"/>) need to be stored within a <xref:System.Net.CredentialCache> assigned to this property. This property will automatically be set to <see langword="null"/> upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to <see langword="null"/> under those conditions prevents credentials from being sent to any unintended destination.  
+ For security reasons, when automatically following redirects (that is, when the <xref:System.Net.HttpWebRequest.AllowAutoRedirect%2A> property is set to `true`), store the credentials that you want to be included in the redirect in a <xref:System.Net.CredentialCache> and assign it to this property. This property will automatically be set to `null` upon redirection if it contains anything except a <xref:System.Net.CredentialCache>. Having this property value be automatically set to `null` under those conditions prevents credentials from being sent to any unintended destination. 
   
 ## Examples  
  The following code example sets the credentials for a request.  


### PR DESCRIPTION
# Adding info about clearing HttpWebRequest.Credentials on redirect

## Summary

When a redirect takes place, HttpWebRequest.Credentials is cleared on under certain circumstances for security reasons. This change describes those circumstances (tracked in BUG 90785).