### PR TITLE
removed public modifier

### DIFF
--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -4,7 +4,7 @@ description: Learn how to build a simple .NET Core console application with C# u
 keywords: .NET Core, .NET Core console application, Visual Studio 2017
 author: BillWagner
 ms.author: wiwagn
-ms.date: 08/07/2017
+ms.date: 09/13/2017
 ms.topic: article
 ms.prod: .net-core
 ms.technology: devlang-csharp
@@ -56,7 +56,7 @@ Begin by creating a simple "Hello World" console application. Follow these steps
 
 Enhance your application to prompt the user for their name and display it along with the date and time. To modify and test the program, do the following:
 
-1. Enter the following C# code in the code window immediately after the opening bracket that follows the `public static void Main(string[] args)` line and before the first closing bracket:
+1. Enter the following C# code in the code window immediately after the opening bracket that follows the `static void Main(string[] args)` line and before the first closing bracket:
 
    [!code-csharp[GettingStarted#1](../../../samples/snippets/csharp/getting_started/with_visual_studio/helloworld.cs#1)]
 


### PR DESCRIPTION
anonymous feedback from a Korean customer for topic https://docs.microsoft.com/en-us/dotnet/core/tutorials/with-visual-studio#enhancing-the-hello-world-application:
OriginalText: 코드 창에서 public static void Main(string[] args) 줄을 입력하고 에서 public이 다른사진에 입력된것이 안보입니다. 잘못입력된거라생각합니다. 입문이라 정확한건 모르겠습니다.

Google Translation: In the Code window, type public static void Main (string [] args), and I do not see public in the other photo. I think it was entered incorrectly. I do not know precisely because it is an introduction.

It took me a while to understand what he/she was trying to say until I found that line that doesn't match the .NET Core template or the picture.