### PR TITLE
494407 Corrections to DnsSafeHost and IdnHost

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_Remoting/NCLUriEnhancements/CPP/nclurienhancements.cpp
+++ b/samples/snippets/cpp/VS_Snippets_Remoting/NCLUriEnhancements/CPP/nclurienhancements.cpp
@@ -82,13 +82,13 @@ void SampleDNSSafeHost()
 {
    //<snippet4>
    // Create new Uri using a string address.         
-   Uri^ address = gcnew Uri( "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm" );
+   Uri^ address = gcnew Uri( "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm" );
 
    // Make the address DNS safe. 
    // The following outputs "[fe80::200:39ff:fe36:1a2d]".
    Console::WriteLine( address->Host );
 
-   // The following outputs "fe80::200:39ff:fe36:1a2d%4".
+   // The following outputs "fe80::200:39ff:fe36:1a2d%254".
    Console::WriteLine( address->DnsSafeHost );
    //</snippet4>
 }

--- a/samples/snippets/csharp/VS_Snippets_Remoting/NCLUriEnhancements/CS/nclurienhancements.cs
+++ b/samples/snippets/csharp/VS_Snippets_Remoting/NCLUriEnhancements/CS/nclurienhancements.cs
@@ -101,14 +101,14 @@ namespace Example
         {
             //<snippet4>
             // Create new Uri using a string address.         
-            Uri address = new Uri("http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm");
+            Uri address = new Uri("http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm");
 
             // Make the address DNS safe. 
 
             // The following outputs "[fe80::200:39ff:fe36:1a2d]".
             Console.WriteLine(address.Host);
 
-            // The following outputs "fe80::200:39ff:fe36:1a2d%4".
+            // The following outputs "fe80::200:39ff:fe36:1a2d%254".
             Console.WriteLine(address.DnsSafeHost);
             //</snippet4>
         }

--- a/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLUriEnhancements/VB/nclurienhancements.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLUriEnhancements/VB/nclurienhancements.vb
@@ -76,13 +76,13 @@ Public Class Test
     Private Shared Sub SampleDNSSafeHost() 
         '<snippet4>
         ' Create new Uri using a string address.         
-        Dim address As New Uri("http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm")
+        Dim address As New Uri("http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm")
         
         ' Make the address DNS safe. 
         ' The following outputs "[fe80::200:39ff:fe36:1a2d]".
         Console.WriteLine(address.Host)
         
-        ' The following outputs "fe80::200:39ff:fe36:1a2d%4".
+        ' The following outputs "fe80::200:39ff:fe36:1a2d%254".
         Console.WriteLine(address.DnsSafeHost)
     
     End Sub 'SampleDNSSafeHost

--- a/xml/System/Uri.xml
+++ b/xml/System/Uri.xml
@@ -1348,7 +1348,7 @@ http://myUrl/
 ## Remarks  
  For IPv6 addresses, the brackets ([]) are removed and the <xref:System.Net.IPAddress.ScopeId%2A> property is set, if one was specified when this instance was constructed.
 
-If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then DnsSafeHost returns an escaped string. Unescape any escaped string returned from ```DnsSafeHost``` before using that string for DNS resolution (see the Example). If you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then DnsSafeHost returns an unescaped string.
+If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then DnsSafeHost returns an escaped string. Unescape any escaped string returned from `DnsSafeHost` before using that string for DNS resolution (see the Example). If you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then DnsSafeHost returns an unescaped string.
   
  The <xref:System.Uri.DnsSafeHost%2A> property is dependent on configuration settings, as discussed later in this topic. Configuration settings cannot be changed by Windows Store applications, which can lead to inconsistent results when using <xref:System.Uri.DnsSafeHost%2A>. The <xref:System.Uri.IdnHost%2A> property is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current *app.config* settings might be.  
   

--- a/xml/System/Uri.xml
+++ b/xml/System/Uri.xml
@@ -110,7 +110,7 @@ http://myUrl/
   
  To enable support for IRI, the following change is required:  
   
--   Specify whether you want Internationalized Domain Name (IDN) parsing applied to the domain name and whether IRI parsing rules should be applied. This can be done in the machine.config or in the app.config file. For example, add the following:  
+-   Specify whether you want Internationalized Domain Name (IDN) parsing applied to the domain name and whether IRI parsing rules should be applied. This can be done in the *machine.config* or in the *app.config* file. For example, add the following:  
   
     ```  
     <configuration>  
@@ -121,7 +121,7 @@ http://myUrl/
     </configuration>  
     ```  
   
- Users of .NET Framework 4.5 and newer always have IRI enabled. IRI parsing cannot be changed using a .config file.  
+ Users of .NET Framework 4.5 and newer always have IRI enabled. IRI parsing cannot be changed using a *.config* file.  
   
  Enabling IDN will convert all Unicode labels in a domain name to their Punycode equivalents. Punycode names contain only ASCII characters and always start with the xn-- prefix. The reason for this is to support existing DNS servers on the Internet, since most DNS servers only support ASCII characters (see RFC 3940).  
   
@@ -141,7 +141,7 @@ http://myUrl/
   
      This value will not convert any Unicode domain names to use Punycode. This is the default value which is consistent with the .NET Framework 2.0 behaviour.  
   
- When IRI parsing is enabled (iriParsing enabled = `true`) normalization and character checking are done according to the latest IRI rules in RFC 3986 and RFC 3987. When IRI parsing is disabled, normalization and character checking are performed according to RFC 2396 and RFC 2732 (for IPv6 literals).  In versions of the .NET Framework before version 4.5, the default value is `false`. In .NET Framework version 4.5 and newer, the default value is `true`, and the enabled state of IRI parsing cannot be modified by settings in a .config file.  
+ When IRI parsing is enabled (iriParsing enabled = `true`) normalization and character checking are done according to the latest IRI rules in RFC 3986 and RFC 3987. When IRI parsing is disabled, normalization and character checking are performed according to RFC 2396 and RFC 2732 (for IPv6 literals).  In versions of the .NET Framework before version 4.5, the default value is `false`. In .NET Framework version 4.5 and newer, the default value is `true`, and the enabled state of IRI parsing cannot be modified by settings in a *.config* file.  
   
  IRI and IDN processing in the <xref:System.Uri> class can also be controlled using the <xref:System.Configuration.IriParsingElement?displayProperty=fullName>, <xref:System.Configuration.IdnElement?displayProperty=fullName>, and <xref:System.Configuration.UriSection?displayProperty=fullName> configuration setting classes. The <xref:System.Configuration.IriParsingElement?displayProperty=fullName> setting enables or disables IRI processing in the <xref:System.Uri> class. The <xref:System.Configuration.IdnElement?displayProperty=fullName> setting enables or disables IDN processing in the <xref:System.Uri> class. The <xref:System.Configuration.IriParsingElement?displayProperty=fullName> setting also indirectly controls IDN. IRI processing must be enabled for IDN processing to be possible. If IRI processing is disabled, then IDN processing will be set to the default setting where the .NET Framework 2.0 behavior is used for compatibility and IDN names are not used.  
   
@@ -152,7 +152,7 @@ http://myUrl/
  The <xref:System.GenericUriParserOptions?displayProperty=fullName> type indicates the parser supports Internationalized Domain Name (IDN) parsing (IDN) of host names. Whether IDN is used is dictated by the configuration values previously discussed.  
   
 ## Performance Considerations  
- If you use a Web.config file that contains URIs to initialize your application, additional time is required to process the URIs if their scheme identifiers are nonstandard. In such a case, initialize the affected parts of your application when the URIs are needed, not at start time.  
+ If you use a *Web.config *file that contains URIs to initialize your application, additional time is required to process the URIs if their scheme identifiers are nonstandard. In such a case, initialize the affected parts of your application when the URIs are needed, not at start time.  
   
    
   
@@ -1340,7 +1340,7 @@ http://myUrl/
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a host name that, after being unescaped if necessary, is safe to use for DNS resolution (see Remarks).</summary>
+        <summary>Gets a host name that, after being unescaped if necessary, is safe to use for DNS resolution.</summary>
         <value>A <see cref="T:System.String" /> that contains the host part of the URI in a format suitable for DNS resolution; or the original host string, if it is already suitable for resolution.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -1348,19 +1348,19 @@ http://myUrl/
 ## Remarks  
  For IPv6 addresses, the brackets ([]) are removed and the <xref:System.Net.IPAddress.ScopeId%2A> property is set, if one was specified when this instance was constructed.
 
-If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then DnsSafeHost returns an escaped string. You should unescape any escaped string returned from DnsSafeHost before using that string for DNS resolution (see the Example). Be aware that if you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then DnsSafeHost returns an unescaped string.
+If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then DnsSafeHost returns an escaped string. Unescape any escaped string returned from ```DnsSafeHost``` before using that string for DNS resolution (see the Example). If you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then DnsSafeHost returns an unescaped string.
   
- The <xref:System.Uri.DnsSafeHost%2A> property is dependent on configuration settings, as discussed later in this topic. Configuration settings cannot be changed by Windows Store applications, which can lead to inconsistent results when using <xref:System.Uri.DnsSafeHost%2A>. The <xref:System.Uri.IdnHost%2A> property is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current app.config settings might be.  
+ The <xref:System.Uri.DnsSafeHost%2A> property is dependent on configuration settings, as discussed later in this topic. Configuration settings cannot be changed by Windows Store applications, which can lead to inconsistent results when using <xref:System.Uri.DnsSafeHost%2A>. The <xref:System.Uri.IdnHost%2A> property is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current *app.config* settings might be.  
   
  The <xref:System.Uri.DnsSafeHost%2A> property has been extended in .NET Framework v3.5, 3.0 SP1, and 2.0 SP1 to provide International Resource Identifier (IRI) support based on RFC 3987. Current users will not see any change from the .NET Framework 2.0 behavior unless they specifically enable IRI. This ensures application compatibility with prior versions of the .NET Framework.  
   
  To enable support for IRI, the following two changes are required:  
   
-1.  Add the following line to the machine.config file under the .NET Framework 2.0 directory  
+1.  Add the following line to the *machine.config* file under the .NET Framework 2.0 directory  
   
      \<section name="uri" type="System.Configuration.UriSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />  
   
-2.  Specify whether you want Internationalized Domain Name (IDN) parsing applied to the domain name and whether IRI parsing rules should be applied. This can be done in the machine.config or in the app.config file. For example, add the following:  
+2.  Specify whether you want Internationalized Domain Name (IDN) parsing applied to the domain name and whether IRI parsing rules should be applied. This can be done in the *machine.config* or in the *app.config* file. For example, add the following:  
   
     ```  
     <configuration>  
@@ -1402,7 +1402,7 @@ If you used an escaped string to construct this instance (for example, "http://[
  [!code-csharp[NCLUriEnhancements#4](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLUriEnhancements/CS/nclurienhancements.cs#4)]
  [!code-vb[NCLUriEnhancements#4](~/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLUriEnhancements/VB/nclurienhancements.vb#4)]  
 
- Use the <xref:System.Uri.UnescapeDataString%2A> method to unescape the host name before resolving it (for example, you can resolve it by calling the <xref:System.Net.Dns.GetHostEntry%2A> method).
+ As explained in Remarks, unescape the host name before resolving it. You can use the <xref:System.Uri.UnescapeDataString%2A> method to unescape the host name, and you can resolve it by calling the <xref:System.Net.Dns.GetHostEntry%2A> method.
 
  ]]></format>
         </remarks>
@@ -2177,7 +2177,7 @@ If you used an escaped string to construct this instance (for example, "http://[
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The RFC 3490 compliant International Domain Name of the host, using Punycode as appropriate. This string, after being unescaped if necessary, is safe to use for DNS resolution (see Remarks).</summary>
+        <summary>The RFC 3490 compliant International Domain Name of the host, using Punycode as appropriate. This string, after being unescaped if necessary, is safe to use for DNS resolution.</summary>
         <value>Returns the hostname, formatted with Punycode according to the IDN standard.<see cref="T:System.String" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -2185,7 +2185,7 @@ If you used an escaped string to construct this instance (for example, "http://[
 ## Remarks  
  This property is provided for the use of lower-level networking protocols that require the domain name in Punycode form. If your code does not require that specific format, use <xref:System.Uri.Host%2A> for the hostname.  
   
- The deprecated <xref:System.Uri.DnsSafeHost%2A> property is dependent on app.config settings, which cannot be changed by Windows Store applications. IdnHost is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current app.config settings might be.  
+ The deprecated <xref:System.Uri.DnsSafeHost%2A> property is dependent on *app.config* settings, which cannot be changed by Windows Store applications. IdnHost is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current *app.config* settings might be.  
 
  If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then IdnHost returns an escaped string. You should unescape any escaped string returned from IdnHost before using that string for DNS resolution. Be aware that if you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then IdnHost returns an unescaped string.
 

--- a/xml/System/Uri.xml
+++ b/xml/System/Uri.xml
@@ -1340,13 +1340,15 @@ http://myUrl/
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets an unescaped host name that is safe to use for DNS resolution.</summary>
-        <value>A <see cref="T:System.String" /> that contains the unescaped host part of the URI that is suitable for DNS resolution; or the original unescaped host string, if it is already suitable for resolution.</value>
+        <summary>Gets a host name that, after being unescaped if necessary, is safe to use for DNS resolution (see Remarks).</summary>
+        <value>A <see cref="T:System.String" /> that contains the host part of the URI in a format suitable for DNS resolution; or the original host string, if it is already suitable for resolution.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- For IPv6 addresses, the brackets ([]) are removed and the <xref:System.Net.IPAddress.ScopeId%2A> property is set, if one was specified when this instance was constructed.  
+ For IPv6 addresses, the brackets ([]) are removed and the <xref:System.Net.IPAddress.ScopeId%2A> property is set, if one was specified when this instance was constructed.
+
+If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then DnsSafeHost returns an escaped string. You should unescape any escaped string returned from DnsSafeHost before using that string for DNS resolution (see the Example). Be aware that if you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then DnsSafeHost returns an unescaped string.
   
  The <xref:System.Uri.DnsSafeHost%2A> property is dependent on configuration settings, as discussed later in this topic. Configuration settings cannot be changed by Windows Store applications, which can lead to inconsistent results when using <xref:System.Uri.DnsSafeHost%2A>. The <xref:System.Uri.IdnHost%2A> property is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current app.config settings might be.  
   
@@ -1399,7 +1401,9 @@ http://myUrl/
  [!code-cpp[NCLUriEnhancements#4](~/samples/snippets/cpp/VS_Snippets_Remoting/NCLUriEnhancements/CPP/nclurienhancements.cpp#4)]
  [!code-csharp[NCLUriEnhancements#4](~/samples/snippets/csharp/VS_Snippets_Remoting/NCLUriEnhancements/CS/nclurienhancements.cs#4)]
  [!code-vb[NCLUriEnhancements#4](~/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLUriEnhancements/VB/nclurienhancements.vb#4)]  
-  
+
+ Use the <xref:System.Uri.UnescapeDataString%2A> method to unescape the host name before resolving it (for example, you can resolve it by calling the <xref:System.Net.Dns.GetHostEntry%2A> method).
+
  ]]></format>
         </remarks>
         <exception cref="T:System.InvalidOperationException">This instance represents a relative URI, and this property is valid only for absolute URIs.</exception>
@@ -2173,7 +2177,7 @@ http://myUrl/
         <ReturnType>System.String</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The RFC 3490 compliant International Domain Name of the host, using Punycode as appropriate.</summary>
+        <summary>The RFC 3490 compliant International Domain Name of the host, using Punycode as appropriate. This string, after being unescaped if necessary, is safe to use for DNS resolution (see Remarks).</summary>
         <value>Returns the hostname, formatted with Punycode according to the IDN standard.<see cref="T:System.String" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -2181,8 +2185,11 @@ http://myUrl/
 ## Remarks  
  This property is provided for the use of lower-level networking protocols that require the domain name in Punycode form. If your code does not require that specific format, use <xref:System.Uri.Host%2A> for the hostname.  
   
- The deprecated <xref:System.Uri.DnsSafeHost%2A> property is dependent on app.config settings, which cannot be changed by Windows Store applications. This property is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current app.config settings might be.  
-  
+ The deprecated <xref:System.Uri.DnsSafeHost%2A> property is dependent on app.config settings, which cannot be changed by Windows Store applications. IdnHost is provided as the preferred alternative to using <xref:System.Uri.DnsSafeHost%2A>, because <xref:System.Uri.IdnHost%2A> is guaranteed to always be DNS safe, no matter what the current app.config settings might be.  
+
+ If you used an escaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%254]/temp/example.htm"), then IdnHost returns an escaped string. You should unescape any escaped string returned from IdnHost before using that string for DNS resolution. Be aware that if you used an invalid unescaped string to construct this instance (for example, "http://[fe80::200:39ff:fe36:1a2d%4]/temp/example.htm"), then IdnHost returns an unescaped string.
+
+
  ]]></format>
         </remarks>
       </Docs>


### PR DESCRIPTION
# Corrections to DnsSafeHost and IdnHost

## Summary

The example was encouraging devs to pass an invalid uri, so changed that. The topic was wrong about whether or not the values returned from these properties are escaped or not, so fixed that.