### PR TITLE
Changed link on VB top-level page to Visual Studio downloads page

### DIFF
--- a/docs/visual-basic/index.md
+++ b/docs/visual-basic/index.md
@@ -10,10 +10,8 @@ dev_langs:
 helpviewer_keywords: 
   - "programming, Visual Basic"
   - "Visual Basic"
-ms.assetid: 5cc578fe-d9e5-4015-937d-b34b83207072
-caps.latest.revision: 37
-author: dotnet-bot
-ms.author: dotnetcontent
+author: rpetrusha
+ms.author: ronpet
 translation.priority.ht: 
   - "de-de"
   - "es-es"
@@ -36,7 +34,7 @@ Visual Basic is engineered for productively building type-safe and object-orient
   
  This generation of Visual Basic continues the tradition of giving you a fast and easy way to create .NET Framework-based applications.  
   
- If you don't already have Visual Basic, you can acquire a version of Visual Studio that includes Visual Basic for free from the [Visual Studio](https://www.visualstudio.com/products/free-developer-offers-vs) site.  
+ If you don't already have Visual Basic, you can acquire a version of Visual Studio that includes Visual Basic for free from the [Visual Studio](https://www.visualstudio.com/products/downloads) site.  
   
 ## In This Section  
  [Getting Started](../visual-basic/getting-started/index.md)   


### PR DESCRIPTION
# Changed link on VB top-level page to Visual Studio downloads page

## Summary

The link to a free download of Visual Studio goes to [Visual Studio Free Developer Software and Services](https://www.visualstudio.com/free-developer-offers/). An internal doc bug opened by @cartertmp argues it should go to the [Visual Studio Downloads](https://www.visualstudio.com/downloads/) page. This PR makes that change.

## Suggested Reviewers
@cartertmp

