### PR TITLE
Update starting1.cs

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting1.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 public class Example
 {

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting1.cs
@@ -41,10 +41,10 @@ public class Example
        // <Snippet33>
        int[] years = { 2013, 2014, 2015 };
        int[] population = { 1025632, 1105967, 1148203 };
-       String s = String.Format("{0,6} {1,15}\n\n", "Year", "Population");
-       for(int index = 0; index < years.Length; index++)
-          s += String.Format("{0,6} {1,15:N0}\n",
-                             years[index], population[index]);
+       StringBuilder myStringBuilder = new StringBuilder();
+       myStringBuilder.Append(String.Format("{0,6} {1,15}\n\n", "Year", "Population"));
+       for (int index = 0; index < years.Length; index++)
+          myStringBuilder.Append(String.Format("{0,6} {1,15:N0}\n", years[index], population[index]));
        // Result:
        //      Year      Population
        //
@@ -52,7 +52,7 @@ public class Example
        //      2014       1,105,967
        //      2015       1,148,203
        // </Snippet33>
-       Console.WriteLine(s);
+       Console.WriteLine(myStringBuilder);
    }
 
    private static void Snippet34()


### PR DESCRIPTION
# Controlling spacing example

The current inplementation of the "Controlling spacing"-example is bad practice.
 
Have a look at this video, it explains why it is bad practice:
https://www.youtube.com/watch?v=4lFAs6FYTXg

## Conclusion: 

In for-loops always use StringBuilder instead of string-concatenation. Strings are immutable and as a result you would create many unnecessary objects on the heap by using string-concatenation instead of StringBuilder.