### PR TITLE
&#124; didn't render to `|` properly

### DIFF
--- a/docs/standard/design-guidelines/operator-overloads.md
+++ b/docs/standard/design-guidelines/operator-overloads.md
@@ -64,9 +64,9 @@ Operator overloads allow framework types to appear as if they were built-in lang
 |`%`|`op_Modulus`|`Mod or Remainder`|  
 |`^`|`op_ExclusiveOr`|`Xor`|  
 |`& (binary)`|`op_BitwiseAnd`|`BitwiseAnd`|  
-|`&#124;`|`op_BitwiseOr`|`BitwiseOr`|  
+|<code>&#124;</code>|`op_BitwiseOr`|`BitwiseOr`|  
 |`&&`|`op_LogicalAnd`|`And`|  
-|`&#124;&#124;`|`op_LogicalOr`|`Or`|  
+|<code>&#124;&#124;</code>|`op_LogicalOr`|`Or`|  
 |`=`|`op_Assign`|`Assign`|  
 |`<<`|`op_LeftShift`|`LeftShift`|  
 |`>>`|`op_RightShift`|`RightShift`|  
@@ -85,7 +85,7 @@ Operator overloads allow framework types to appear as if they were built-in lang
 |`%=`|`op_ModulusAssignment`|`Mod`|  
 |`+=`|`op_AdditionAssignment`|`Add`|  
 |`&=`|`op_BitwiseAndAssignment`|`BitwiseAnd`|  
-|`&#124;=`|`op_BitwiseOrAssignment`|`BitwiseOr`|  
+|<code>&#124;=</code>|`op_BitwiseOrAssignment`|`BitwiseOr`|  
 |`,`|`op_Comma`|`Comma`|  
 |`/=`|`op_DivisionAssignment`|`Divide`|  
 |`--`|`op_Decrement`|`Decrement`|  


### PR DESCRIPTION
# Pipe character not rendered correctly

## Summary

Because the pipe character is used to create tables, it has to be escaped. `&#124;` is not rendered as a pipe when placed between ticks. Instead, it's better to use `<code> </code>` markup.

### More information
https://stackoverflow.com/questions/17319940/how-to-escape-a-pipe-char-in-a-code-statement-in-a-markdown-table/17320389#17320389