### PR TITLE
Update sample code for documentation VB.NET "what's new : language features : Tuples"

### DIFF
--- a/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
@@ -29,9 +29,9 @@ Module Module1
 
     Private Sub MethodCallWithTuple()
         ' <Snippet3>
-        Dim number As String = "123,456"
-        Dim result = ParseInteger(number)
-        Console.WriteLine($"{IIf(result.Success, $"Success: {number:N0}", "Failure")}")
+        Dim numericString As String = "123,456"
+        Dim result = ParseInteger(numericString)
+        Console.WriteLine($"{IIf(result.Success, $"Success: {result.Number:N0}", "Failure")}")
         Console.ReadLine()
         '      Output: Success: 123,456
         ' </Snippet3>

--- a/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
@@ -4,7 +4,7 @@ Imports System.Globalization
 Public Module NumericLibrary
     Public Function ParseInteger(value As String) As (Success As Boolean, Number As Int32)
         Dim number As Integer
-        Return (Int32.TryParse(value, NumberStyles.Any, Nothing, number), number)
+        Return (Int32.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, number), number)
     End Function
 End Module
 ' </Snippet2>


### PR DESCRIPTION
# Title

In the code snippers of the documentation for VB.NET about Tuples, I found a small error.

Snippet 3 outputs the original string that is being parsed, rather than the output. It should output the result, as it is also being outputted in snippet 1 (the "original" version, before using the new language features). Another minor thing : the variable name of the "to be parsed string" maybe should match the original version?

## Summary

* Changed the culture info used
* Fixed sample snippet 3

Fixes #3165 
