### PR TITLE
M10669: Possible typo mistake: 'SC1721'

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1721.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1721.md
@@ -36,7 +36,7 @@ Class 'class' cannot have multiple base classes: 'class_1' and 'class_2'
  The most common cause of this error message is attempting to use multiple inheritance. A class in C# may only inherit directly from one class. However, a class can implement any number of interfaces.  
   
 ## Example  
- The following example shows one way in which SC1721 is generated, and then shows two possible ways to avoid the error.  
+ The following example shows one way in which CS1721 is generated, and then shows two possible ways to avoid the error.  
   
 ```csharp  
 // CS1721.cs  


### PR DESCRIPTION
@BillWagner,
It seems that 'SC1721' is a typo of 'CS1721'. Could you help to review this and reply, please?
Many thanks in advance!

