### PR TITLE
Minor fixes : inconsistent wording and some ghost characters

### DIFF
--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -64,7 +64,7 @@ auto-properties. C# 6 improves the auto-properties capabilities so that you can 
 them in more scenarios. You won't need to fall back on the more verbose syntax of
 declaring and manipulating the backing field by hand so often.
 
-The new syntax addresses scenarios for read only properties, and for initializing
+The new syntax addresses scenarios for read-only properties, and for initializing
 the variable storage behind an auto-property.
 
 ### Read-only auto-properties
@@ -131,7 +131,7 @@ is part of the property declaration, making it easier to equate the
 storage allocation with public interface for `Student` objects.
 
 Property Initializers can be used with read/write properties as well
-as read only properties, as shown here.
+as read-only properties, as shown here.
 
 [!code-csharp[ReadWriteInitialization](../../../samples/snippets/csharp/new-in-6/newcode.cs#ReadWriteInitialization)]
 
@@ -145,7 +145,7 @@ a great candidate:
 
 [!code-csharp[ToStringExpressionMember](../../../samples/snippets/csharp/new-in-6/newcode.cs#ToStringExpressionMember)]
 
-You can also use expression-bodied members in read only properties as well:
+You can also use expression-bodied members in read-only properties as well:
 
 [!code-csharp[FullNameExpressionMember](../../../samples/snippets/csharp/new-in-6/newcode.cs#FullNameExpressionMember)]
 

--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -97,7 +97,7 @@ public class Student
 
     public void ChangeName(string newLastName)
     {
-        // Generates CS 0200: Property or indexer cannot be assigned to -- it is read only
+        // Generates CS0200: Property or indexer cannot be assigned to -- it is read only
         LastName = newLastName;
     }
 }
@@ -140,7 +140,7 @@ as read only properties, as shown here.
 The body of a lot of members that we write consist of only one statement
 that can be represented as an expression. You can reduce that syntax by
 writing an expression-bodied member instead. It works for methods and
-read-only properties." For example, an override of `ToString()` is often
+read-only properties. For example, an override of `ToString()` is often
 a great candidate:
 
 [!code-csharp[ToStringExpressionMember](../../../samples/snippets/csharp/new-in-6/newcode.cs#ToStringExpressionMember)]

--- a/samples/snippets/csharp/new-in-6/Newcode.cs
+++ b/samples/snippets/csharp/new-in-6/Newcode.cs
@@ -35,7 +35,7 @@ namespace NewStyle
         public ICollection<double> Grades { get; } = new List<double>();
         // </Initialization>
         // <ReadWriteInitialization>
-        public Standing YearInSchool { get; set;} = Standing.Freshman;
+        public Standing YearInSchool { get; set; } = Standing.Freshman;
         // </ReadWriteInitialization>
 
         // <FullNameExpressionMember>

--- a/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
@@ -29,9 +29,9 @@ Module Module1
 
     Private Sub MethodCallWithTuple()
         ' <Snippet3>
-        Dim number As String = "123,456"
-        Dim result = ParseInteger(number)
-        Console.WriteLine($"{IIf(result.Success, $"Success: {number:N0}", "Failure")}")
+        Dim numericString As String = "123,456"
+        Dim result = ParseInteger(numericString)
+        Console.WriteLine($"{IIf(result.Success, $"Success: {result.Number:N0}", "Failure")}")
         Console.ReadLine()
         '      Output: Success: 123,456
         ' </Snippet3>

--- a/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb
@@ -4,7 +4,7 @@ Imports System.Globalization
 Public Module NumericLibrary
     Public Function ParseInteger(value As String) As (Success As Boolean, Number As Int32)
         Dim number As Integer
-        Return (Int32.TryParse(value, NumberStyles.Any, Nothing, number), number)
+        Return (Int32.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, number), number)
     End Function
 End Module
 ' </Snippet2>


### PR DESCRIPTION
I fixed some some minor inconsistent use of "read-only properties" and "read only properties".
Removed some "ghost" characters.