### PR TITLE
fixed formulas

### DIFF
--- a/samples/snippets/csharp/language-reference/keywords/using/using-static1.cs
+++ b/samples/snippets/csharp/language-reference/keywords/using/using-static1.cs
@@ -15,12 +15,12 @@ public class Circle
       get { return 2 * Radius; }
    }
 
-   public double Area
+   public double Circumference
    {
       get { return 2 * Radius * Math.PI; }      
    }
 
-   public double Circumference
+   public double Area
    {
       get { return Math.PI * Math.Pow(Radius, 2); }
    }

--- a/samples/snippets/csharp/language-reference/keywords/using/using-static2.cs
+++ b/samples/snippets/csharp/language-reference/keywords/using/using-static2.cs
@@ -16,12 +16,12 @@ public class Circle
       get { return 2 * Radius; }
    }
 
-   public double Area
+   public double Circumference
    {
       get { return 2 * Radius * PI; }      
    }
 
-   public double Circumference
+   public double Area
    {
       get { return PI * Pow(Radius, 2); }
    }

--- a/samples/snippets/csharp/language-reference/keywords/using/using-static3.cs
+++ b/samples/snippets/csharp/language-reference/keywords/using/using-static3.cs
@@ -39,12 +39,12 @@ public class Circle
       get { return 2 * Radius; }
    }
 
-   public double Area
+   public double Circumference
    {
       get { return 2 * Radius * PI; }      
    }
 
-   public double Circumference
+   public double Area
    {
       get { return PI * Pow(Radius, 2); }
    }
@@ -55,6 +55,5 @@ public class Circle
 //       Information about the circle:
 //          Radius: 12.45
 //          Diameter: 24.90
-//          Circumference: 486.95
-//          Area: 78.23
-   
+//          Circumference: 78.23
+//          Area: 486.95


### PR DESCRIPTION
LiveFyre comment:
Nice doc, but demo is wrong, as learned in my junior school. 
> s = s + Format(" Area: {0:N2}\n", c.Radius);         << NONO, should be c.Area
AND Calculations of Area and Circumfence is swapped
Wrong output:
// Circumference: 486.95   => 78.23
// Area: 12.45  => 486.95
Back to school :-)