### PR TITLE
Fix framework in dotnet store command topic

### DIFF
--- a/docs/core/deploying/runtime-store.md
+++ b/docs/core/deploying/runtime-store.md
@@ -76,7 +76,7 @@ dotnet store --manifest <PATH_TO_MANIFEST_FILE> --runtime <RUNTIME_IDENTIFIER> -
 **Example**
 
 ```console
-dotnet store --manifest packages.csproj --runtime win10-x64 --framework netstandard2.0 --framework-version 2.0.0
+dotnet store --manifest packages.csproj --runtime win10-x64 --framework netcoreapp2.0 --framework-version 2.0.0
 ```
 
 You can pass multiple target package store manifest paths to a single [`dotnet store`](../tools/dotnet-store.md) command by repeating the option and path in the command.


### PR DESCRIPTION
@mairaw This is a topic bug fix.

Reported by @PauliusNorkus ... thank u again. Thanks to @dasmulli for reminding me about the framework problem. Using `netstandard2.0` worked during pre-release (when the topic was written) but no more. @dasMulli suspects that it used to work because coreclr had implementions for `netstandard`.