### PR TITLE
removed invisible characters

### DIFF
--- a/docs/csharp/misc/cs0625.md
+++ b/docs/csharp/misc/cs0625.md
@@ -1,13 +1,9 @@
 ---
 title: "Compiler Error CS0625"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-
 ms.technology: 
   - "devlang-csharp"
-
 ms.topic: "article"
 f1_keywords: 
   - "CS0625"
@@ -19,27 +15,11 @@ ms.assetid: 44091813-9988-436c-b35e-e24094793782
 caps.latest.revision: 7
 author: "BillWagner"
 ms.author: "wiwagn"
-
-translation.priority.ht: 
-  - "de-de"
-  - "es-es"
-  - "fr-fr"
-  - "it-it"
-  - "ja-jp"
-  - "ko-kr"
-  - "ru-ru"
-  - "zh-cn"
-  - "zh-tw"
-translation.priority.mt: 
-  - "cs-cz"
-  - "pl-pl"
-  - "pt-br"
-  - "tr-tr"
 ---
 # Compiler Error CS0625
-'field': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute  
+'field': instance field types marked with StructLayout(LayoutKind.Explicit) must have a FieldOffset attribute.
   
-When a struct is marked with an explicit **StructLayout** attribute, all fields in the struct must have the [FieldOffset](xref:System​.Runtime​.InteropServices.FieldOffsetAttribute) attribute. For more information, see [StructLayoutAttribute Class](xref:System​.Runtime​.InteropServices.StructLayoutAttribute). 
+When a struct is marked with an explicit **StructLayout** attribute, all fields in the struct must have the [FieldOffset](xref:System.Runtime.InteropServices.FieldOffsetAttribute) attribute. For more information, see [StructLayoutAttribute Class](xref:System.Runtime.InteropServices.StructLayoutAttribute). 
 
 The following sample generates CS0625:  
   

--- a/docs/csharp/misc/cs0626.md
+++ b/docs/csharp/misc/cs0626.md
@@ -1,13 +1,9 @@
 ---
 title: "Compiler Warning (level 1) CS0626"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-
 ms.technology: 
   - "devlang-csharp"
-
 ms.topic: "article"
 f1_keywords: 
   - "CS0626"
@@ -19,27 +15,12 @@ ms.assetid: 2cd5061c-80e7-48d3-8d14-be7fc642af94
 caps.latest.revision: 8
 author: "BillWagner"
 ms.author: "wiwagn"
-
-translation.priority.ht: 
-  - "de-de"
-  - "es-es"
-  - "fr-fr"
-  - "it-it"
-  - "ja-jp"
-  - "ko-kr"
-  - "ru-ru"
-  - "zh-cn"
-  - "zh-tw"
-translation.priority.mt: 
-  - "cs-cz"
-  - "pl-pl"
-  - "pt-br"
-  - "tr-tr"
 ---
 # Compiler Warning (level 1) CS0626
-Method, operator, or accessor 'method' is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation  
+
+Method, operator, or accessor 'method' is marked external and has no attributes on it. Consider adding a DllImport attribute to specify the external implementation.
   
- A method marked `extern` should also be marked with an attribute, for example, the [DllImport](xref:System​.Runtime​.InteropServices.DllImportAttribute) attribute.
+ A method marked `extern` should also be marked with an attribute, for example, the [DllImport](xref:System.Runtime.InteropServices.DllImportAttribute) attribute.
   
  The attribute specifies where the method is implemented. At run time, the program will need this information.  
   

--- a/docs/csharp/misc/cs0637.md
+++ b/docs/csharp/misc/cs0637.md
@@ -1,13 +1,9 @@
 ---
 title: "Compiler Error CS0637"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-
 ms.technology: 
   - "devlang-csharp"
-
 ms.topic: "article"
 f1_keywords: 
   - "CS0637"
@@ -19,27 +15,12 @@ ms.assetid: 02f6964c-0fcc-4f81-8ebb-0330aecdde19
 caps.latest.revision: 8
 author: "BillWagner"
 ms.author: "wiwagn"
-
-translation.priority.ht: 
-  - "de-de"
-  - "es-es"
-  - "fr-fr"
-  - "it-it"
-  - "ja-jp"
-  - "ko-kr"
-  - "ru-ru"
-  - "zh-cn"
-  - "zh-tw"
-translation.priority.mt: 
-  - "cs-cz"
-  - "pl-pl"
-  - "pt-br"
-  - "tr-tr"
 ---
 # Compiler Error CS0637
-The FieldOffset attribute is not allowed on static or const fields  
+
+The FieldOffset attribute is not allowed on static or const fields.
   
- The [FieldOffset](xref:System​.Runtime​.InteropServices.FieldOffsetAttribute) attribute cannot be used on fields marked with [static](../../csharp/language-reference/keywords/static.md) or [const](../../csharp/language-reference/keywords/const.md).  
+ The [FieldOffset](xref:System.Runtime.InteropServices.FieldOffsetAttribute) attribute cannot be used on fields marked with [static](../../csharp/language-reference/keywords/static.md) or [const](../../csharp/language-reference/keywords/const.md).  
   
  The following sample generates CS0637:  
   

--- a/docs/csharp/misc/cs0662.md
+++ b/docs/csharp/misc/cs0662.md
@@ -1,13 +1,9 @@
 ---
 title: "Compiler Error CS0662"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-
 ms.technology: 
   - "devlang-csharp"
-
 ms.topic: "article"
 f1_keywords: 
   - "CS0662"
@@ -19,27 +15,12 @@ ms.assetid: 836fa15e-3bf3-4af5-8acf-072d7d731dcd
 caps.latest.revision: 7
 author: "BillWagner"
 ms.author: "wiwagn"
-
-translation.priority.ht: 
-  - "de-de"
-  - "es-es"
-  - "fr-fr"
-  - "it-it"
-  - "ja-jp"
-  - "ko-kr"
-  - "ru-ru"
-  - "zh-cn"
-  - "zh-tw"
-translation.priority.mt: 
-  - "cs-cz"
-  - "pl-pl"
-  - "pt-br"
-  - "tr-tr"
 ---
 # Compiler Error CS0662
+
 'method' cannot specify only Out attribute on a ref parameter. Use both In and Out attributes, or neither.  
   
- An interface method has a parameter that uses [ref](../../csharp/language-reference/keywords/ref.md) with just the [Out](xref:System​.Runtime​.InteropServices.OutAttribute) attribute. A `ref` parameter that uses the **Out** attribute must also use the [In](xref:System​.Runtime​.InteropServices.InAttribute) attribute.  
+ An interface method has a parameter that uses [ref](../../csharp/language-reference/keywords/ref.md) with just the [Out](xref:System.Runtime.InteropServices.OutAttribute) attribute. A `ref` parameter that uses the **Out** attribute must also use the [In](xref:System.Runtime.InteropServices.InAttribute) attribute.  
   
  The following sample generates CS0662:  
   

--- a/docs/csharp/misc/cs0669.md
+++ b/docs/csharp/misc/cs0669.md
@@ -1,13 +1,9 @@
 ---
 title: "Compiler Error CS0669"
-
 ms.date: "2015-07-20"
 ms.prod: .net
-
-
 ms.technology: 
   - "devlang-csharp"
-
 ms.topic: "article"
 f1_keywords: 
   - "CS0669"
@@ -19,42 +15,27 @@ ms.assetid: c7f81869-79d7-481f-a026-2cef0e87df4c
 caps.latest.revision: 6
 author: "BillWagner"
 ms.author: "wiwagn"
-
-translation.priority.ht: 
-  - "de-de"
-  - "es-es"
-  - "fr-fr"
-  - "it-it"
-  - "ja-jp"
-  - "ko-kr"
-  - "ru-ru"
-  - "zh-cn"
-  - "zh-tw"
-translation.priority.mt: 
-  - "cs-cz"
-  - "pl-pl"
-  - "pt-br"
-  - "tr-tr"
 ---
 # Compiler Error CS0669
-A class with the ComImport attribute cannot have a user-defined constructor. 
-  
- The COM interop layer in the common language runtime supplies the constructor for [ComImport](xref:System​.Runtime​.InteropServices.ComImportAttribute) classes. Consequently, a COM object can be used as a managed object in the runtime.  
-  
- The following sample generates CS0669:  
-  
+
+A class with the ComImport attribute cannot have a user-defined constructor.
+
+The COM interop layer in the common language runtime supplies the constructor for [ComImport](xref:System.Runtime.InteropServices.ComImportAttribute) classes. Consequently, a COM object can be used as a managed object in the runtime.
+
+The following sample generates CS0669:
+
 ```csharp
-// CS0669.cs  
-using System.Runtime.InteropServices;  
-[ComImport, Guid("00000000-0000-0000-0000-000000000001")]  
-class TestClass  
-{  
-   TestClass()   // CS0669, delete constructor to resolve  
-   {  
-   }  
-  
-   public static void Main()  
-   {  
-   }  
-}  
+// CS0669.cs
+using System.Runtime.InteropServices;
+[ComImport, Guid("00000000-0000-0000-0000-000000000001")]
+class TestClass
+{
+   TestClass()   // CS0669, delete constructor to resolve
+   {
+   }
+
+   public static void Main()
+   {
+   }
+}
 ```


### PR DESCRIPTION
The API links in these topics seemed to have some hidden characters which would cause OPS to fail to build these links.

e.g. 
![image](https://user-images.githubusercontent.com/12971179/30672534-e07478fc-9e21-11e7-94a4-f042f0edfc1c.png)
