### PR TITLE
quick link fix to the hub page

### DIFF
--- a/index.md
+++ b/index.md
@@ -163,7 +163,7 @@ description: Learn how to use .NET to create a variety of applications on any pl
                                             </div>
                                             <div class="cardText">
                                                 <h3><a href="/dotnet/csharp">C# Guide</a></h3>
-                                                <p><a href="/dotnet/csharp/quick-starts">Tour of C#</a></p>
+                                                <p><a href="/dotnet/csharp/quick-starts">Quick Starts</a></p>
                                                 <p><a href="/dotnet/csharp/getting-started">Get Started</a></p>
                                                 <p><a href="/dotnet/csharp/tour-of-csharp">Tour of C#</a></p>
                                                 <p><a href="/dotnet/csharp/language-reference">C# Language Reference</a></p>


### PR DESCRIPTION
The link target was updated for the Quick Starts, but the displayed
text was not.