### PR TITLE
Improve Suits and Ranks definitions

### DIFF
--- a/samples/csharp/getting-started/console-linq/Program.cs
+++ b/samples/csharp/getting-started/console-linq/Program.cs
@@ -36,32 +36,11 @@ namespace LinqFaroShuffle
     public class Program
     {
         #region snippet4
-        static IEnumerable<Suit> Suits()
-        {
-            yield return Suit.Clubs;
-            yield return Suit.Diamonds;
-            yield return Suit.Hearts;
-            yield return Suit.Spades;
-        }
+        static IEnumerable<Suit> Suits() => Enum.GetValues(typeof(Suit)) as IEnumerable<Suit>;
         #endregion
 
         #region snippet5
-        static IEnumerable<Rank> Ranks()
-        {
-            yield return Rank.Two;
-            yield return Rank.Three;
-            yield return Rank.Four;
-            yield return Rank.Five;
-            yield return Rank.Six;
-            yield return Rank.Seven;
-            yield return Rank.Eight;
-            yield return Rank.Nine;
-            yield return Rank.Ten;
-            yield return Rank.Jack;
-            yield return Rank.Queen;
-            yield return Rank.King;
-            yield return Rank.Ace;
-        }
+        static IEnumerable<Rank> Ranks() => Enum.GetValues(typeof(Rank)) as IEnumerable<Rank>;
         #endregion
 
         #region snippet1

--- a/samples/csharp/getting-started/console-linq/console-linq.csproj
+++ b/samples/csharp/getting-started/console-linq/console-linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/samples/csharp/getting-started/console-linq/console-linq.csproj
+++ b/samples/csharp/getting-started/console-linq/console-linq.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# Improve Suits and Ranks definitions in console-linq example


## Summary

After the Enum based definitions are introduced, it is much easier to implement `Suits()` and `Ranks()` functions as following:

    public static IEnumerable<Suit> Suits() => Enum.GetValues(typeof(Suit)) as IEnumerable<Suit>;

and 

    public static IEnumerable<Rank> Ranks() => Enum.GetValues(typeof(Rank)) as IEnumerable<Rank>;



instead of listing each rank's and suit's item with the yield line explicitly, like



    static IEnumerable<Rank> Ranks()
    {
        yield return Rank.Two;
        yield return Rank.Three;
        yield return Rank.Four;
        yield return Rank.Five;
        yield return Rank.Six;
        yield return Rank.Seven;
        yield return Rank.Eight;
        yield return Rank.Nine;
        yield return Rank.Ten;
        yield return Rank.Jack;
        yield return Rank.Queen;
        yield return Rank.King;
        yield return Rank.Ace;
    }

## Suggested Reviewers

@BillWagner 
