### PR TITLE
Fixed: Invalid example code

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex4.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/cancellation/cs/cancellationex4.cs
@@ -2,81 +2,35 @@
 using System;
 using System.Net;
 using System.Threading;
-using System.Threading.Tasks;
 
 class Example
 {
-   EventHandler externalEvent;
+    static void Main()
+    {
+        CancellationTokenSource cts = new CancellationTokenSource();
 
-   void Example1()
-   {
-      CancellationTokenSource cts = new CancellationTokenSource();
-      externalEvent +=
-         (sender, obj) => { cts.Cancel(); }; //wire up an external requester
-      try {
-          int val = LongRunningFunc(cts.Token);
-      }
-      catch (OperationCanceledException) {
-          //cleanup after cancellation if required...
-          Console.WriteLine("Operation was canceled as expected.");
-      }
-      finally {
-         cts.Dispose();
-      }
+        StartWebRequest(cts.Token);
 
-  }
+        // cancellation will cause the web 
+        // request to be cancelled
+        cts.Cancel();
+    }
 
-  private static int LongRunningFunc(CancellationToken token)
-  {
-      Console.WriteLine("Long running method");
-      int total = 0;
-      for (int i = 0; i < 100000; i++)
-      {
-          for (int j = 0; j < 100000; j++)
-          {
-              total++;
-          }
-          if (token.IsCancellationRequested)
-          { // observe cancellation
-              Console.WriteLine("Cancellation observed.");
-              throw new OperationCanceledException(token); // acknowledge cancellation
-          }
-      }
-      Console.WriteLine("Done looping");
-      return total;
-   }
+    static void StartWebRequest(CancellationToken token)
+    {
+        WebClient wc = new WebClient();
+        wc.DownloadStringCompleted += (s, e) => Console.WriteLine("Request completed.");
 
-   static void Main()
-   {
-      Example ex = new Example();
+        // Cancellation on the token will 
+        // call CancelAsync on the WebClient.
+        token.Register(() =>
+        {
+            wc.CancelAsync();
+            Console.WriteLine("Request cancelled!");
+        });
 
-      Thread t = new Thread(new ThreadStart(ex.Example1));
-      t.Start();
-
-      Console.WriteLine("Press 'c' to cancel.");
-      if (Console.ReadKey(true).KeyChar == 'c')
-          ex.externalEvent.Invoke(ex, new EventArgs());
-
-      Console.WriteLine("Press enter to exit.");
-      Console.ReadLine();
-  }
-}
-
-class CancelWaitHandleMiniSnippetsForOverviewTopic
-{
-
-  static void CancelByCallback()
-  {
-      CancellationTokenSource cts = new CancellationTokenSource();
-      CancellationToken token = cts.Token;
-      WebClient wc = new WebClient();
-
-      // To request cancellation on the token
-      // will call CancelAsync on the WebClient.
-      token.Register(() => wc.CancelAsync());
-
-      Console.WriteLine("Starting request");
-      wc.DownloadStringAsync(new Uri("http://www.contoso.com"));
-   }
+        Console.WriteLine("Starting request.");
+        wc.DownloadStringAsync(new Uri("http://www.contoso.com"));
+    }
 }
 //</snippet4>

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex4.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/cancellation/vb/cancellationex4.vb
@@ -2,84 +2,34 @@
 Option Strict On
 
 ' <Snippet4>
-Imports System
 Imports System.Net
 Imports System.Threading
-Imports System.Threading.Tasks
 
 Class Example
-    Public Shared Event externalEvent(ByVal sender As Object, ByVal obj As Object)
+	Private Shared Sub Main()
+		Dim cts As New CancellationTokenSource()
 
-    Public Sub Example1()
-        Dim cts As New CancellationTokenSource()
-        AddHandler externalEvent, Sub(sender, obj) cts.Cancel()
+		StartWebRequest(cts.Token)
 
-        Try
-            Dim val As Integer = LongRunningFunc(cts.Token)
-        Catch oce As OperationCanceledException
-            'cleanup after cancellation if required...
-            Console.WriteLine("Operation was canceled as expected.")
-        Finally
-           cts.Dispose()
-        End Try
-    End Sub
+		' cancellation will cause the web 
+		' request to be cancelled
+		cts.Cancel()
+	End Sub
 
-    Private Shared Function LongRunningFunc(ByVal token As CancellationToken) As Integer
-        Console.WriteLine("Long running method")
-        Dim total As Integer = 0
-        For i As Integer = 0 To 1000000
-            For j As Integer = 0 To 1000000
-                total = total + total
-            Next
-            If token.IsCancellationRequested Then
-                ' observe cancellation
-                Console.WriteLine("Cancellation observed.")
-                Throw New OperationCanceledException(token) ' acknowledge cancellation
-            End If
-        Next
-        Console.WriteLine("Done looping")
-        Return total
-    End Function
+	Private Shared Sub StartWebRequest(token As CancellationToken)
+		Dim wc As New WebClient()
+		wc.DownloadStringCompleted += Function(s, e) Console.WriteLine("Request completed.")
 
-    Shared Sub Main()
-        Dim ex As New Example()
-        Dim t As Thread
-        t = New Thread(AddressOf ex.Example1)
-        t.Start()
+		' Cancellation on the token will 
+		' call CancelAsync on the WebClient.
+		token.Register(Function() 
+		wc.CancelAsync()
+		Console.WriteLine("Request cancelled!")
 
-        Console.WriteLine("Press 'c' to cancel.")
-        If Console.ReadKey(True).KeyChar = "c"c Then
-            RaiseEvent externalEvent(ex, New EventArgs())
+End Function)
 
-            Console.WriteLine("Press enter to exit.")
-            Console.ReadLine()
-        End If
-    End Sub
-End Class
-
-Class MyCancelableObject
-
-    Public Sub Cancel()
-    End Sub
-
-    Shared Sub ObjectCancellationMiniSnippetForOverview()
-
-
-    End Sub
-End Class
-Class CancelWaitHandleMiniSnippetsForOverviewTopic
-
-    Shared Sub CancelByCallback()
-        Dim cts As New CancellationTokenSource()
-        Dim token As CancellationToken = cts.Token
-        Dim wc As New WebClient()
-
-        ' To request cancellation on the token
-        ' will call CancelAsync on the WebClient.
-        token.Register(Sub() wc.CancelAsync())
-
-        Console.WriteLine("Starting request")
-        wc.DownloadStringAsync(New Uri("http://www.contoso.com"))
-    End Sub
+		Console.WriteLine("Starting request.")
+		wc.DownloadStringAsync(New Uri("http://www.contoso.com"))
+	End Sub
 End Class
 ' </Snippet4>


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/standard/threading/cancellation-in-managed-threads
 
Most of the sample code in the **Listening by Registering a Callback** section had nothing to do with this section. I created a small but complete example code. 