### PR TITLE
fix api links

### DIFF
--- a/docs/csharp/language-reference/keywords/interpolated-strings.md
+++ b/docs/csharp/language-reference/keywords/interpolated-strings.md
@@ -1,6 +1,6 @@
 ---
 title: "Interpolated Strings (C#)"
-ms.date: "2017-02-03"
+ms.date: "09/25/2017"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -59,13 +59,13 @@ There are three implicit type conversions from an interpolated string:
 
 2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the <xref:System.Object.ToString> method.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
 
-   The following example uses reflection to display the members as well as the field and property values of an <xref:System.IFormattable> variable that is created from an interpolated string. It also passes the <xref:System.IFormattable> variable to the <xref:System.Console(System.String)> method.
+   The following example uses reflection to display the members as well as the field and property values of an <xref:System.IFormattable> variable that is created from an interpolated string. It also passes the <xref:System.IFormattable> variable to the <xref:System.Console.WriteLine(System.String)?displayProperty=nameWithType> method.
 
    [!code-cs[interpolated-strings2](../../../../samples/snippets/csharp/language-reference/keywords/interpolated-strings2.cs#1)]  
 
    Note that the interpolated string can be inspected only by using reflection. If it is passed to a string formatting method, such as <xref:System.Console.WriteLine(System.String)>, its format items are resolved and the result string returned. 
 
-3. Conversion of an interpolated string to an <xref:System.FormattableString> variable that represents a composite format string. Inspecting the composite format string and how it renders as a result string might, for example, help you protect against an injection attack if you were building a query.  <xref:System.FormattableString> also includes <xref:System.FormattableString.ToString> overloads that let you produce result strings for the <xref:System.Globalization.InvariantCulture> and <xref:System.Globalization.CurrentCulture>.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces, until you format.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
+3. Conversion of an interpolated string to an <xref:System.FormattableString> variable that represents a composite format string. Inspecting the composite format string and how it renders as a result string might, for example, help you protect against an injection attack if you were building a query. <xref:System.FormattableString> also includes <xref:System.FormattableString.ToString> overloads that let you produce result strings for the <xref:System.Globalization.CultureInfo.InvariantCulture> and <xref:System.Globalization.CultureInfo.CurrentCulture>.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces, until you format.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
 
    [!code-cs[interpolated-strings3](../../../../samples/snippets/csharp/language-reference/keywords/interpolated-strings3.cs#1)]  
 

--- a/docs/csharp/language-reference/keywords/interpolated-strings.md
+++ b/docs/csharp/language-reference/keywords/interpolated-strings.md
@@ -11,21 +11,6 @@ ms.assetid: 324f267e-1c61-431a-97ed-852c1530742d
 caps.latest.revision: 9
 author: "BillWagner"
 ms.author: "wiwagn"
-translation.priority.ht: 
-  - "de-de"
-  - "es-es"
-  - "fr-fr"
-  - "it-it"
-  - "ja-jp"
-  - "ko-kr"
-  - "ru-ru"
-  - "zh-cn"
-  - "zh-tw"
-translation.priority.mt: 
-  - "cs-cz"
-  - "pl-pl"
-  - "pt-br"
-  - "tr-tr"
 ---
 # Interpolated Strings (C# Reference)
 
@@ -52,7 +37,7 @@ where:
 
 - *field-width* is a signed integer that indicates the number of characters in the field. If it is positive, the field is right-aligned; if negative, left-aligned. 
 
-- *format-string* is a format string appropriate for the type of object being formatted. For example, for a @System.DateTime value, it could be a standard date and time format string such as "D" or "d".
+- *format-string* is a format string appropriate for the type of object being formatted. For example, for a <xref:System.DateTime> value, it could be a standard date and time format string such as "D" or "d".
 
  You can use an interpolated string anywhere you can use a string literal.  The interpolated string is evaluated each time the code with the interpolated string executes. This allows you to separate the definition and evaluation of an interpolated string.  
   
@@ -66,21 +51,21 @@ If the interpolated string contains other characters with special meaning in an 
 
 There are three implicit type conversions from an interpolated string:  
 
-1. Conversion of an interpolated string to a @System.String. The following example returns a string whose interpolated string expressions have been replaced with their string representations. For example:
+1. Conversion of an interpolated string to a <xref:System.String>. The following example returns a string whose interpolated string expressions have been replaced with their string representations. For example:
 
    [!code-cs[interpolated-strings1](../../../../samples/snippets/csharp/language-reference/keywords/interpolated-strings1.cs#1)]  
 
    This is the final result of a string interpretation. All occurrences of double curly braces ("{{" and "}}") are converted to a single curly brace. 
 
-2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the @System.Object.ToString method.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
+2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the <xref:System.Object.ToString> method.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
 
-   The following example uses reflection to display the members as well as the field and property values of an <xref:System.IFormattable> variable that is created from an interpolated string. It also passes the <xref:System.IFormattable> variable to the @System.Console(System.String) method.
+   The following example uses reflection to display the members as well as the field and property values of an <xref:System.IFormattable> variable that is created from an interpolated string. It also passes the <xref:System.IFormattable> variable to the <xref:System.Console(System.String)> method.
 
    [!code-cs[interpolated-strings2](../../../../samples/snippets/csharp/language-reference/keywords/interpolated-strings2.cs#1)]  
 
-   Note that the interpolated string can be inspected only by using reflection. If it is passed to a string formatting method, such as @System.Console.WriteLine(System.String), its format items are resolved and the result string returned. 
+   Note that the interpolated string can be inspected only by using reflection. If it is passed to a string formatting method, such as <xref:System.Console.WriteLine(System.String)>, its format items are resolved and the result string returned. 
 
-3. Conversion of an interpolated string to an <xref:System.FormattableString> variable that represents a composite format string. Inspecting the composite format string and how it renders as a result string might, for example, help you protect against an injection attack if you were building a query.  <xref:System.FormattableString> also includes <xref:System.FormattableString.ToString> overloads that let you produce result strings for the @System.Globalization.InvariantCulture and @System.Globalization.CurrentCulture.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces, until you format.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
+3. Conversion of an interpolated string to an <xref:System.FormattableString> variable that represents a composite format string. Inspecting the composite format string and how it renders as a result string might, for example, help you protect against an injection attack if you were building a query.  <xref:System.FormattableString> also includes <xref:System.FormattableString.ToString> overloads that let you produce result strings for the <xref:System.Globalization.InvariantCulture> and <xref:System.Globalization.CurrentCulture>.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces, until you format.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
 
    [!code-cs[interpolated-strings3](../../../../samples/snippets/csharp/language-reference/keywords/interpolated-strings3.cs#1)]  
 


### PR DESCRIPTION
For some reason, api links using the old `@` notation on this topic are broken:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/interpolated-strings

![image](https://user-images.githubusercontent.com/12971179/30768612-f88c2fc2-9fbe-11e7-9ecf-19d2ccfd8354.png)

Need to see if this is a global issue. We have an issue tracking this change globally anyway: #787 

Related to issue #3094