### PR TITLE
Example doesn't explain the use of "set accessor "

### DIFF
--- a/samples/snippets/csharp/programming-guide/classes-and-structs/properties-3.cs
+++ b/samples/snippets/csharp/programming-guide/classes-and-structs/properties-3.cs
@@ -7,8 +7,8 @@ public class SaleItem
    
    public SaleItem(string name, decimal cost)
    {
-      this.name = name;
-      this.cost = cost;
+      Name = name;
+      Price = cost;
    }
 
    public string Name 


### PR DESCRIPTION
This example is a part of explanation on Expression body definitions at https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties. This example explains the use of "get accessor" but ignore the use of "set accessor". Modified code to show the use of "set accessor" also.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
