### PR TITLE
use asp.net 4.x to mean non-core asp.net

### DIFF
--- a/docs/standard/glossary.md
+++ b/docs/standard/glossary.md
@@ -27,13 +27,13 @@ The original ASP.NET implementation that ships with the .NET Framework.
 
 Sometimes ASP.NET is an umbrella term that refers to both ASP.NET implementations including ASP.NET Core. The meaning that the term carries in any given instance is determined by context. Refer to ASP.NET 4.x when you want to make it clear that you’re not using ASP.NET to mean both implementations. 
 
-See [ASP.NET](/aspnet/#pivot=aspnet).
+See [ASP.NET documentation](/aspnet/#pivot=aspnet).
 
 ## ASP.NET Core
 
 A cross-platform, high-performance, open source implementation of ASP.NET built on .NET Core.
 
-See [ASP.NET Core](/aspnet/#pivot=core).
+See [ASP.NET Core documentation](/aspnet/#pivot=core).
 
 ## assembly
 

--- a/docs/standard/glossary.md
+++ b/docs/standard/glossary.md
@@ -25,7 +25,7 @@ Similar to [JIT](#jit), this compiler also translates [IL](#il) to machine code.
 
 The original ASP.NET implementation that ships with the .NET Framework.
 
-Sometimes ASP.NET is an umbrella term that refers to both ASP.NET implementations including ASP.NET Core. The meaning that the term carries in any given instance is determined by context. 
+Sometimes ASP.NET is an umbrella term that refers to both ASP.NET implementations including ASP.NET Core. The meaning that the term carries in any given instance is determined by context. Refer to ASP.NET 4.x when you want to make it clear that you’re not using ASP.NET to mean both implementations. 
 
 See [ASP.NET](/aspnet/#pivot=aspnet).
 


### PR DESCRIPTION
Add a note to the glossary suggesting use of "ASP.NET 4.x" to mean non-Core ASP.NET.  Purpose is to help avoid usages such as "ASP.NET proper," "legacy ASP.NET," "ASP.NET classic", etc. 