### PR TITLE
Fixed multiple typos in f# signatures chapter

### DIFF
--- a/samples/snippets/fsharp/fssignatures/snippet9001.fs
+++ b/samples/snippets/fsharp/fssignatures/snippet9001.fs
@@ -7,17 +7,17 @@ module Module1 =
 
     type Type1() =
         member type1.method1() =
-            printfn "test1.method1"
+            printfn "type1.method1"
         member type1.method2() =
-            printfn "test1.method2"
+            printfn "type1.method2"
 
 
     [<Sealed>]
     type Type2() =
         member type2.method1() =
-            printfn "test1.method1"
-        member type1.method2() =
-            printfn "test1.method2"
+            printfn "type2.method1"
+        member type2.method2() =
+            printfn "type2.method2"
 
     [<Interface>]
     type InterfaceType1 =


### PR DESCRIPTION
There were a few typos in f# signatures chapter. E.g. the type alias while declaring member functions within Type2 was different within the same type. A few other minor typos were also corrected.