### PR TITLE
Add a note about ulimit on macOS

### DIFF
--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -78,7 +78,7 @@ You can increase this limit by following these steps:
 
 2. In a terminal window, run the following command:
 
-```
+```console
 echo 'ulimit -n 2048' | sudo tee -a /etc/profile
 ```
 

--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -50,9 +50,9 @@ The default open file limit on macOS may not be sufficient for some .NET Core wo
 
 You can increase this limit by following these steps:
 
-Using a text editor, create a new file `/Library/LaunchDaemons/limit.maxfiles.plist`, and save the file with this content:
+1. Using a text editor, create a new file _/Library/LaunchDaemons/limit.maxfiles.plist_, and save the file with this content:
 
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
         "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -76,13 +76,13 @@ Using a text editor, create a new file `/Library/LaunchDaemons/limit.maxfiles.pl
 </plist>
 ```
 
-In a terminal window, run the following command:
+2. In a terminal window, run the following command:
 
 ```
 echo 'ulimit -n 2048' | sudo tee -a /etc/profile
 ```
 
-Finally, reboot your Mac to apply these settings.
+3. Reboot your Mac to apply these settings.
 
 ## Visual Studio for Mac
 

--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -44,6 +44,46 @@ Download and install the .NET Core SDK from [.NET Downloads](https://www.microso
 
 Download and install the .NET Core SDK from [.NET Downloads](https://www.microsoft.com/net/download/core). If you have problems with the installation on macOS, consult the [Known issues](https://github.com/dotnet/core/tree/master/release-notes/2.0) topic for the version you have installed.
 
+## Increase the maximum open file limit
+
+The default open file limit on macOS may not be sufficient for some .NET Core workloads, such as restoring projects or running unit tests.
+
+You can increase this limit by following these steps:
+
+Using a text editor, create a new file `/Library/LaunchDaemons/limit.maxfiles.plist`, and save the file with this content:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>limit.maxfiles</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>maxfiles</string>
+      <string>2048</string>
+      <string>4096</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ServiceIPC</key>
+    <false/>
+  </dict>
+</plist>
+```
+
+In a terminal window, run the following command:
+
+```
+echo 'ulimit -n 2048' | sudo tee -a /etc/profile
+```
+
+Finally, reboot your Mac to apply these settings.
+
 ## Visual Studio for Mac
 
 You can use any editor to develop .NET Core applications using the .NET Core SDK. However, if you want to develop .NET Core applications on a Mac in an integrated development environment, you can use [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/). 


### PR DESCRIPTION
# Add a note about ulimit on macOS

## Summary

Various workloads, such as restoring NuGet packages or running unit tests, fail on vanilla macOS installations because the maximum number of open files that macOS allows by default is too low.

This PR adds a note to the macOS prerequisites about this limitation, and provides instructions on how to increase this limit.

## Details

For more details, see some if the GitHub issues that cover this problem:
* Microsoft/vstest#578
* xunit/xunit#1199
* dotnet/cli#809

I created this PR because I hit the issue myself, and although information on how to resolve the issue was scattered around in multiple GitHub issues, there appeared to be no consolidated information on how to properly fix this.

Hope this helps.
