### PR TITLE
update the hub page link

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ description: Learn how to use .NET to create a variety of applications on any pl
     <div class="container">
         <ul class="cardsY panelContent featuredContent">
             <li>
-                <a href="https://www.microsoft.com/net/tutorials/csharp/getting-started">
+                <a href="/dotnet/csharp/quick-starts">
                     <div class="cardSize">
                         <div class="cardPadding">
                             <div class="card">


### PR DESCRIPTION
The "Learn C#" link pointed to the marketing site tutorials. It should
point to the docs site quick starts.

/cc @JRAlexander 