### PR TITLE
fix typo

### DIFF
--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/identify-microservice-domain-model-boundaries.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/identify-microservice-domain-model-boundaries.md
@@ -107,7 +107,7 @@ Sometimes a granular API Gateway can also be a microservice by itself, and even 
 
 Granularity in the API Gateway tier can be especially useful for more advanced composite UI applications based on microservices, because the concept of a fine-grained API Gateway is similar to an UI composition service. We discuss this later in the [Creating composite UI based on microservices](#creating-composite-ui-based-on-microservices-including-visual-ui-shape-and-layout-generated-by-multiple-microservices).
 
-Therefore, for many medium- and large-size applications, using a custom-built API Gateway is usually a good approach, but not as a single monolithic aggregator or unique central ASPI Gateway.
+Therefore, for many medium- and large-size applications, using a custom-built API Gateway is usually a good approach, but not as a single monolithic aggregator or unique central API Gateway.
 
 Another approach is to use a product like [Azure API Management](https://azure.microsoft.com/services/api-management/) as shown in Figure 4-14. This approach not only solves your API Gateway needs, but provides features like gathering insights from your APIs. If you are using an API management solution, an API Gateway is only a component within that full API management solution.
 


### PR DESCRIPTION
Livefyre comment for https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/architect-microservice-container-applications/identify-microservice-domain-model-boundaries

Probably a typo. Shouldn't it be API Gateway?

There's a second comment there that I'm not addressing.