### PR TITLE
Fixed links

### DIFF
--- a/xml/ns-System.Diagnostics.Eventing.Reader.xml
+++ b/xml/ns-System.Diagnostics.Eventing.Reader.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Diagnostics.Eventing.Reader">
   <Docs>
-    <summary>Using the <see cref="N:System.Diagnostics.Eventing.Reader" /> namespace, you can develop applications that read and manage event logs. An event in an event log contains information, a warning, or an error that has been published by a specific application, service, or operating system component.  These events are read by applications that monitor a computer's health and applications that take action when specific events occur.  For more information, see [Technology Summary for Reading and Managing Event Logs](https://msdn.microsoft.com/en-us/library/bb671205.aspx) and [Event Log Scenarios](https://msdn.microsoft.com/en-us/library/bb671204.aspx).</summary>
+    <summary>Using the <see cref="N:System.Diagnostics.Eventing.Reader" /> namespace, you can develop applications that read and manage event logs. An event in an event log contains information, a warning, or an error that has been published by a specific application, service, or operating system component.  These events are read by applications that monitor a computer's health and applications that take action when specific events occur.  For more information, see [Technology Summary for Reading and Managing Event Logs](https://msdn.microsoft.com/library/bb671205.aspx) and [Event Log Scenarios](https://msdn.microsoft.com/library/bb671204.aspx).</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>

--- a/xml/ns-System.Diagnostics.Eventing.Reader.xml
+++ b/xml/ns-System.Diagnostics.Eventing.Reader.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Diagnostics.Eventing.Reader">
   <Docs>
-    <summary>Using the <see cref="N:System.Diagnostics.Eventing.Reader" /> namespace, you can develop applications that read and manage event logs. An event in an event log contains information, a warning, or an error that has been published by a specific application, service, or operating system component.  These events are read by applications that monitor a computer's health and applications that take action when specific events occur.  For more information, see [Technology Summary for Reading and Managing Event Logs](https://msdn.microsoft.com/en-us/library/bb671205(v=vs.100).aspx) and [Event Log Scenarios](https://msdn.microsoft.com/en-us/library/bb671204(v=vs.100).aspx).</summary>
+    <summary>Using the <see cref="N:System.Diagnostics.Eventing.Reader" /> namespace, you can develop applications that read and manage event logs. An event in an event log contains information, a warning, or an error that has been published by a specific application, service, or operating system component.  These events are read by applications that monitor a computer's health and applications that take action when specific events occur.  For more information, see [Technology Summary for Reading and Managing Event Logs](https://msdn.microsoft.com/en-us/library/bb671205.aspx) and [Event Log Scenarios](https://msdn.microsoft.com/en-us/library/bb671204.aspx).</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>

--- a/xml/ns-System.Diagnostics.Eventing.Reader.xml
+++ b/xml/ns-System.Diagnostics.Eventing.Reader.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Diagnostics.Eventing.Reader">
   <Docs>
-    <summary>Using the <see cref="N:System.Diagnostics.Eventing.Reader" /> namespace, you can develop applications that read and manage event logs. An event in an event log contains information, a warning, or an error that has been published by a specific application, service, or operating system component.  These events are read by applications that monitor a computer's health and applications that take action when specific events occur.  For more information, see  and .</summary>
+    <summary>Using the <see cref="N:System.Diagnostics.Eventing.Reader" /> namespace, you can develop applications that read and manage event logs. An event in an event log contains information, a warning, or an error that has been published by a specific application, service, or operating system component.  These events are read by applications that monitor a computer's health and applications that take action when specific events occur.  For more information, see [Technology Summary for Reading and Managing Event Logs](https://msdn.microsoft.com/en-us/library/bb671205(v=vs.100).aspx) and [Event Log Scenarios](https://msdn.microsoft.com/en-us/library/bb671204(v=vs.100).aspx).</summary>
     <remarks>To be added.</remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
Up to version [10](https://msdn.microsoft.com/en-us/library/system.diagnostics.eventing.reader(v=vs.100).aspx), the docs used to point to these two other pages, but in version [11](https://msdn.microsoft.com/en-us/library/system.diagnostics.eventing.reader(v=vs.110).aspx) the links where removed leaving some text behind.

>  For more information, see and .

I wasn't able to find the current version of the two referenced docs.

Should the links be added back even if pointing to a previous version of the docs or should the sentence be removed altogether?