### PR TITLE
Effect of Control.RightToLeft setting on OpenFileDialog

### DIFF
--- a/docs/framework/winforms/advanced/bi-directional-support-for-windows-forms-applications.md
+++ b/docs/framework/winforms/advanced/bi-directional-support-for-windows-forms-applications.md
@@ -1,26 +1,18 @@
 ---
 title: "Bi-Directional Support for Windows Forms Applications"
-ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "09/30/2017"
 ms.prod: ".net-framework"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "dotnet-winforms"
-ms.tgt_pltfrm: ""
 ms.topic: "article"
-dev_langs: 
-  - "jsharp"
 helpviewer_keywords: 
   - "globalization [Windows Forms], bi-directional support in Windows"
   - "Windows Forms, international"
   - "localization [Windows Forms], bi-directional support in Windows"
   - "bi-directional language support, Windows applications"
   - "Windows Forms, bi-directional support"
-ms.assetid: 7b622fa4-f390-4e4d-b624-83a1917cccf2
-caps.latest.revision: 20
-author: dotnet-bot
-ms.author: dotnetcontent
+author: rpetrusha
+ms.author: ronpet
 manager: "wpickett"
 ---
 # Bi-Directional Support for Windows Forms Applications
@@ -61,7 +53,7 @@ You can use [!INCLUDE[vsprvs](../../../../includes/vsprvs-md.md)] to create Wind
 |<xref:System.Windows.Forms.MonthCalendar>|Not affected; depends on the language of the operating system|Mirrors the control|Yes|  
 |<xref:System.Windows.Forms.NotifyIcon>|Not supported|Not supported|No|  
 |<xref:System.Windows.Forms.NumericUpDown>|Up and down buttons are left-aligned|No effect|No|  
-|<xref:System.Windows.Forms.OpenFileDialog>|Not affected; depends on the language of the operating system|No effect|No|  
+|<xref:System.Windows.Forms.OpenFileDialog>|On right-to-left operating systems, setting the containing form's <xref:System.Windows.Forms.Control.RightToLeft> property to <xref:System.Windows.Forms.RightToLeft.Yes?displayProperty=nameWithType> localizes the dialog |No effect|No|  
 |<xref:System.Windows.Forms.PageSetupDialog>|Not affected; depends on the language of the operating system|No effect|No|  
 |<xref:System.Windows.Forms.Panel>|Child controls may inherit this property|Use <xref:System.Windows.Forms.TableLayoutPanel> within the control for right to left support|Yes|  
 |<xref:System.Windows.Forms.PictureBox>|Not supported|No effect|No|  

--- a/xml/System.Windows.Forms/OpenFileDialog.xml
+++ b/xml/System.Windows.Forms/OpenFileDialog.xml
@@ -22,7 +22,7 @@
 
 On a right-to-left operating system, setting the containing form's <xref:System.Windows.Forms.Control.RightToLeft> property to <xref:System.Windows.Forms.RightToLeft.Yes?displayProperty=nameWithType> localizes the dialog's **File Name**, **Open**, and **Cancel** buttons. If the property is not set to <xref:System.Windows.Forms.RightToLeft.Yes?displayProperty=nameWithType>, English text is used instead.  
 
- If you want to give the user the ability to select a folder instead of a file,use <xref:System.Windows.Forms.FolderBrowserDialog> instead.  
+ If you want to give the user the ability to select a folder instead of a file, use <xref:System.Windows.Forms.FolderBrowserDialog> instead.  
   
    
   

--- a/xml/System.Windows.Forms/OpenFileDialog.xml
+++ b/xml/System.Windows.Forms/OpenFileDialog.xml
@@ -19,8 +19,10 @@
  This class allows you to check whether a file exists and to open it. The <xref:System.Windows.Forms.OpenFileDialog.ShowReadOnly%2A> property determines whether a read-only check box appears in the dialog box. The <xref:System.Windows.Forms.OpenFileDialog.ReadOnlyChecked%2A> property indicates whether the read-only check box is checked.  
   
  Most of the core functionality for this class is found in the <xref:System.Windows.Forms.FileDialog> class.  
-  
- If you want to give the user the ability to select a folder instead of a file, use <xref:System.Windows.Forms.FolderBrowserDialog> instead.  
+
+On a right-to-left operating system, setting the containing form's <xref:System.Windows.Forms.Control.RightToLeft> property to <xref:System.Windows.Forms.RightToLeft.Yes?displayProperty=nameWithType> localizes the dialog's **File Name**, **Open**, and **Cancel** buttons. If the property is not set to <xref:System.Windows.Forms.RightToLeft.Yes?displayProperty=nameWithType>, English text is used instead.  
+
+ If you want to give the user the ability to select a folder instead of a file,use <xref:System.Windows.Forms.FolderBrowserDialog> instead.  
   
    
   


### PR DESCRIPTION
# Effect of Control.RightToLeft setting on OpenFileDialog

## Summary

The documentation doesn't note that, on a right-to-left OS, the containing form's RightToLeft property must be set to RightToLeft.Yes for the dialog to be localized.

## Suggested Reviewers

@Tanya-Solyanik, @mairaw 
 