### PR TITLE
remove microsoft docs from H1 or title

### DIFF
--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -1,5 +1,5 @@
 ---
-title: Get started with C# and Visual Studio Code - C# Guide | Microsoft Docs
+title: Get started with C# and Visual Studio Code - C# Guide
 description: Learn how to create and debug your first .NET Core application in C# using Visual Studio Code. 
 keywords: C#, Get Started, Acquisition, Install, Visual Studio Code, Cross Platform
 author: kendrahavens

--- a/docs/csharp/discards.md
+++ b/docs/csharp/discards.md
@@ -1,5 +1,5 @@
 ---
-title: Discards - C# Guide| Microsoft Docs
+title: Discards - C# Guide
 description: Describes C#'s support for discards, which are unassigned, discardable variables, and the ways in which discards can be used.
 keywords: .NET,.NET Core
 author: rpetrusha

--- a/docs/csharp/quick-starts/index.md
+++ b/docs/csharp/quick-starts/index.md
@@ -1,5 +1,5 @@
 ---
-title: Quick Starts - C# Guide | Microsoft Docs
+title: Quick Starts - C# Guide
 description: Learn C# in your browser
 keywords: C#, Get Started, Lessons, Interactive
 author: billwagner

--- a/docs/framework/migration-guide/retargeting/index.md
+++ b/docs/framework/migration-guide/retargeting/index.md
@@ -13,7 +13,7 @@ ms.author: "ronpet"
 manager: "wpickett"
 ---
 
-# "Retargeting Changes in the .NET Framework | Microsoft Docs"
+# Retargeting Changes in the .NET Framework
 
 [!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 

--- a/docs/framework/migration-guide/runtime/index.md
+++ b/docs/framework/migration-guide/runtime/index.md
@@ -13,7 +13,7 @@ ms.author: "ronpet"
 manager: "wpickett"
 ---
 
-# "Runtime Changes in the .NET Framework | Microsoft Docs"
+# Runtime Changes in the .NET Framework
 
 [!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 

--- a/docs/framework/windows-workflow-foundation/wf-migration-guidance.md
+++ b/docs/framework/windows-workflow-foundation/wf-migration-guidance.md
@@ -1,5 +1,5 @@
 ---
-title: "Windows Workflow Foundation (WF) Migration Guidance | Microsoft Docs"
+title: "Windows Workflow Foundation (WF) Migration Guidance"
 ms.date: "06/19/2017"
 ms.prod: ".net-framework"
 ms.topic: "article"

--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Standard | Microsoft Docs
+title: .NET Standard
 description: Learn about .NET Standard, its versions and the .NET implementations that support it.   
 keywords: .NET Standard, PCL, .NET
 author: mairaw

--- a/docs/standard/portability-analyzer.md
+++ b/docs/standard/portability-analyzer.md
@@ -1,5 +1,5 @@
 ---
-title: The .NET Portability Analyzer - .NET | Microsoft Docs
+title: The .NET Portability Analyzer - .NET
 description: Learn how to use the .NET Portability Analyzer tool to evaluate how portable your code is among the various .NET implementations.
 keywords: .NET, .NET Core
 author: blackdwarf

--- a/docs/standard/tour.md
+++ b/docs/standard/tour.md
@@ -1,5 +1,5 @@
 ---
-title: Tour of .NET | Microsoft Docs
+title: Tour of .NET
 description: A guided tour through some of the prominent features of .NET.   
 keywords: .NET, .NET Core, Tour, Programming Languages, Unsafe, Memory Management, Type Safety, Async
 author: cartermp


### PR DESCRIPTION
While testing a PR, I've stumbled across this odd H1 on docs:
![image](https://user-images.githubusercontent.com/12971179/31039604-bc9a4cc2-a533-11e7-9c95-0706c5e41001.png)

So decided to scan the repo and see what else we had left.