### PR TITLE
enable edit source for languages

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -3,8 +3,6 @@
   "need_preview_pull_request": true,
   "need_pr_comments": false,
   "need_generate_pdf_url_template": true,
-  "git_repository_branch_open_to_public_contributors": "master",
-  "git_repository_url_open_to_public_contributors": "https://github.com/dotnet/docs",
   "branch_target_mapping": {
     "live": [
       "Publish",

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -3,6 +3,7 @@
   "need_preview_pull_request": true,
   "need_pr_comments": false,
   "need_generate_pdf_url_template": true,
+  "git_repository_branch_open_to_public_contributors": "master",
   "branch_target_mapping": {
     "live": [
       "Publish",

--- a/docfx.json
+++ b/docfx.json
@@ -149,10 +149,6 @@
       "ms.date": {
         "_csharplang/spec/*.md": "07/01/2017",
         "_vblang/spec/*.md": "07/21/2017"
-      },
-      "open_to_public_contributors": {
-        "_csharplang/spec/*.md": false,
-        "_vblang/spec/*.md": false
       }
     },
     "dest": "_site",


### PR DESCRIPTION
The edit button should not redirect readers to the source csharplang and vblang repositories.

So, let's enable editing the specs from docs.

/cc @dend @mairaw 