### PR TITLE
Fixes incorrectly used `\b` in host.cpp

### DIFF
--- a/samples/core/hosting/host.cpp
+++ b/samples/core/hosting/host.cpp
@@ -165,7 +165,7 @@ int wmain(int argc, wchar_t* argv[])
 	}
 	else
 	{
-		printf("Runtime started\b");
+		printf("Runtime started\n");
 	}
 
 


### PR DESCRIPTION
In samples/core/hosting/host.cpp, \b is used instead of \n around line 168. This PR fixes the error.

Fixes #3291

