### PR TITLE
Replace mention of MSDN

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/index.md
+++ b/docs/csharp/language-reference/compiler-messages/index.md
@@ -34,7 +34,7 @@ translation.priority.ht:
 # C# Compiler Errors
 Some C# compiler errors have corresponding topics that explain why the error is generated, and, in some cases, how to fix the error. Use one of the following steps to see whether help is available for a particular error message.  
   
--   Find the error number (for example, CS0029) in the [Output Window](/visualstudio/ide/reference/output-window), and then search for it on MSDN.  
+-   Find the error number (for example, CS0029) in the [Output Window](/visualstudio/ide/reference/output-window), and then search for it on Microsoft Docs.  
   
 -   Choose the error number (for example, CS0029) in the [Output Window](/visualstudio/ide/reference/output-window), and then choose the F1 key.  
   


### PR DESCRIPTION
The text was suggesting searching on MSDN. I think the right suggestion now is to search the error code on Microsoft Docs.