### PR TITLE
Update language reference for non-trailing named arguments

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
@@ -6,12 +6,12 @@
             PrintOrderDetails("Foo", 31, true);
 
             // Named arguments can be supplied for the parameters in any order.
-            PrintOrderDetails(orderNum: 31, isShipped: true, sellerName: "Foo");
-            PrintOrderDetails(isShipped: true, sellerName: "Foo", orderNum: 31);
+            PrintOrderDetails(orderNum: 31, hasShipped: true, sellerName: "Foo");
+            PrintOrderDetails(hasShipped: true, sellerName: "Foo", orderNum: 31);
 
             // Named arguments mixed with positional arguments are valid
             // as long as they are used in their correct position.
-            PrintOrderDetails("Foo", 31, isShipped: true);
+            PrintOrderDetails("Foo", 31, hasShipped: true);
             PrintOrderDetails("Foo", orderNum: 31, true);
             PrintOrderDetails(sellerName: "Foo", orderNum: 31, true);
 
@@ -22,8 +22,8 @@
             // PrintOrderDetails(31, true, sellerName: "Foo");
         }
 
-        static void PrintOrderDetails(string sellerName, int orderNum, bool isShipped)
+        static void PrintOrderDetails(string sellerName, int orderNum, bool hasShipped)
         {
-            Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Shipped: {isShipped}");
+            Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Shipped: {hasShipped}");
         }
     }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
@@ -26,7 +26,7 @@
         {
             if (string.IsNullOrWhiteSpace(sellerName))
             {
-                throw new ArgumentException("Seller name cannot be null or empty.", nameof(sellerName));
+                throw new ArgumentException(message: "Seller name cannot be null or empty.", paramName: nameof(sellerName));
             }
 
             Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Product: {productName}");

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
@@ -3,27 +3,27 @@
         static void Main(string[] args)
         {
             // The method can be called in the normal way, by using positional arguments.
-            PrintOrderDetails("Foo", 31, true);
+            PrintOrderDetails("Gift Shop", 31, "Red Mug");
 
             // Named arguments can be supplied for the parameters in any order.
-            PrintOrderDetails(orderNum: 31, hasShipped: true, sellerName: "Foo");
-            PrintOrderDetails(hasShipped: true, sellerName: "Foo", orderNum: 31);
+            PrintOrderDetails(orderNum: 31, productName: "Red Mug", sellerName: "Gift Shop");
+            PrintOrderDetails(productName: "Red Mug", sellerName: "Gift Shop", orderNum: 31);
 
             // Named arguments mixed with positional arguments are valid
             // as long as they are used in their correct position.
-            PrintOrderDetails("Foo", 31, hasShipped: true);
-            PrintOrderDetails("Foo", orderNum: 31, true);
-            PrintOrderDetails(sellerName: "Foo", orderNum: 31, true);
+            PrintOrderDetails("Gift Shop", 31, productName: "Red Mug");
+            PrintOrderDetails(sellerName: "Gift Shop", 31, productName: "Red Mug");    // C# 7.2 onwards
+            PrintOrderDetails("Gift Shop", orderNum: 31, "Red Mug");                   // C# 7.2 onwards
 
             // However, mixed arguments are invalid if used out-of-order.
             // The following statements will cause a compiler error.
-            // PrintOrderDetails(sellerName: "Foo", true, 31);
-            // PrintOrderDetails(31, sellerName: "Foo", true);
-            // PrintOrderDetails(31, true, sellerName: "Foo");
+            // PrintOrderDetails(productName: "Red Mug", 31, "Gift Shop");
+            // PrintOrderDetails(31, sellerName: "Gift Shop", "Red Mug");
+            // PrintOrderDetails(31, "Red Mug", sellerName: "Gift Shop");
         }
 
-        static void PrintOrderDetails(string sellerName, int orderNum, bool hasShipped)
+        static void PrintOrderDetails(string sellerName, int orderNum, string productName)
         {
-            Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Shipped: {hasShipped}");
+            Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Product: {productName}");
         }
     }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
@@ -24,6 +24,11 @@
 
         static void PrintOrderDetails(string sellerName, int orderNum, string productName)
         {
+            if (string.IsNullOrWhiteSpace(sellerName))
+            {
+                throw new ArgumentException("Seller name cannot be null or empty.", nameof(sellerName));
+            }
+
             Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Product: {productName}");
         }
     }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs
@@ -3,22 +3,27 @@
         static void Main(string[] args)
         {
             // The method can be called in the normal way, by using positional arguments.
-            Console.WriteLine(CalculateBMI(123, 64));
+            PrintOrderDetails("Foo", 31, true);
 
-            // Named arguments can be supplied for the parameters in either order.
-            Console.WriteLine(CalculateBMI(weight: 123, height: 64));
-            Console.WriteLine(CalculateBMI(height: 64, weight: 123));
+            // Named arguments can be supplied for the parameters in any order.
+            PrintOrderDetails(orderNum: 31, isShipped: true, sellerName: "Foo");
+            PrintOrderDetails(isShipped: true, sellerName: "Foo", orderNum: 31);
 
-            // Positional arguments cannot follow named arguments.
-            // The following statement causes a compiler error.
-            //Console.WriteLine(CalculateBMI(weight: 123, 64));
+            // Named arguments mixed with positional arguments are valid
+            // as long as they are used in their correct position.
+            PrintOrderDetails("Foo", 31, isShipped: true);
+            PrintOrderDetails("Foo", orderNum: 31, true);
+            PrintOrderDetails(sellerName: "Foo", orderNum: 31, true);
 
-            // Named arguments can follow positional arguments.
-            Console.WriteLine(CalculateBMI(123, height: 64));
+            // However, mixed arguments are invalid if used out-of-order.
+            // The following statements will cause a compiler error.
+            // PrintOrderDetails(sellerName: "Foo", true, 31);
+            // PrintOrderDetails(31, sellerName: "Foo", true);
+            // PrintOrderDetails(31, true, sellerName: "Foo");
         }
 
-        static int CalculateBMI(int weight, int height)
+        static void PrintOrderDetails(string sellerName, int orderNum, bool isShipped)
         {
-            return (weight * 703) / (height * height);
+            Console.WriteLine($"Seller: {sellerName}, Order #: {orderNum}, Shipped: {isShipped}");
         }
     }

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -50,28 +50,32 @@ translation.priority.ht:
  Named and optional parameters, when used together, enable you to supply arguments for only a few parameters from a list of optional parameters. This capability greatly facilitates calls to COM interfaces such as the Microsoft Office Automation APIs.  
   
 ## Named Arguments  
- Named arguments free you from the need to remember or to look up the order of parameters in the parameter lists of called methods. The parameter for each argument can be specified by parameter name. For example, a function that calculates body mass index (BMI) can be called in the standard way by sending arguments for weight and height by position, in the order defined by the function.  
+ Named arguments free you from the need to remember or to look up the order of parameters in the parameter lists of called methods. The parameter for each argument can be specified by parameter name. For example, a function that prints order details (such as, seller name, order number & shipping status) can be called in the standard way by sending arguments by position, in the order defined by the function.
   
- `CalculateBMI(123, 64);`  
+ `PrintOrderDetails("Foo", 31, true);`
   
- If you do not remember the order of the parameters but you do know their names, you can send the arguments in either order, weight first or height first.  
+ If you do not remember the order of the parameters but know their names, you can send the arguments in any order.  
   
- `CalculateBMI(weight: 123, height: 64);`  
+ `PrintOrderDetails(orderNum: 31, hasShipped: true, sellerName: "Foo");`
   
- `CalculateBMI(height: 64, weight: 123);`  
+ `PrintOrderDetails(hasShipped: true, sellerName: "Foo", orderNum: 31);`
   
  Named arguments also improve the readability of your code by identifying what each argument represents.  
   
- A named argument can follow positional arguments, as shown here.  
+ Named arguments are valid as long as they're used in the correct position, as shown here.
   
- `CalculateBMI(123, height: 64);`  
+ `PrintOrderDetails("Foo", 31, hasShipped: true);`
   
- However, a positional argument cannot follow a named argument. The following statement causes a compiler error.  
+ `PrintOrderDetails(sellerName: "Foo", orderNum: 31, true);`
   
- `//CalculateBMI(weight: 123, 64);`  
+ However, out-of-order named arguments are invalid. The following statements cause a compiler error.
+
+ `// PrintOrderDetails(31, sellerName: "Foo", true);`
+
+ `// PrintOrderDetails(31, true, sellerName: "Foo");`
   
 ## Example  
- The following code implements the examples from this section.  
+ The following code implements the examples from this section along with some additional ones.  
   
  [!code-cs[csProgGuideNamedAndOptional#1](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/named-and-optional-arguments_1.cs)]  
   

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -50,29 +50,33 @@ translation.priority.ht:
  Named and optional parameters, when used together, enable you to supply arguments for only a few parameters from a list of optional parameters. This capability greatly facilitates calls to COM interfaces such as the Microsoft Office Automation APIs.  
   
 ## Named Arguments  
- Named arguments free you from the need to remember or to look up the order of parameters in the parameter lists of called methods. The parameter for each argument can be specified by parameter name. For example, a function that prints order details (such as, seller name, order number & shipping status) can be called in the standard way by sending arguments by position, in the order defined by the function.
+ Named arguments free you from the need to remember or to look up the order of parameters in the parameter lists of called methods. The parameter for each argument can be specified by parameter name. For example, a function that prints order details (such as, seller name, order number & product name) can be called in the standard way by sending arguments by position, in the order defined by the function.
   
- `PrintOrderDetails("Foo", 31, true);`
+ `PrintOrderDetails("Gift Shop", 31, "Red Mug");`
   
  If you do not remember the order of the parameters but know their names, you can send the arguments in any order.  
   
- `PrintOrderDetails(orderNum: 31, hasShipped: true, sellerName: "Foo");`
+ `PrintOrderDetails(orderNum: 31, productName: "Red Mug", sellerName: "Gift Shop");`
   
- `PrintOrderDetails(hasShipped: true, sellerName: "Foo", orderNum: 31);`
+ `PrintOrderDetails(productName: "Red Mug", sellerName: "Gift Shop", orderNum: 31);`
   
  Named arguments also improve the readability of your code by identifying what each argument represents.  
   
- Named arguments are valid as long as they're used in the correct position, as shown here.
-  
- `PrintOrderDetails("Foo", 31, hasShipped: true);`
-  
- `PrintOrderDetails(sellerName: "Foo", orderNum: 31, true);`
-  
- However, out-of-order named arguments are invalid. The following statements cause a compiler error.
+ Named arguments, when used with positional arguments, are valid as long as 
 
- `// PrintOrderDetails(31, sellerName: "Foo", true);`
+- they're not followed by any positional arguments, or
 
- `// PrintOrderDetails(31, true, sellerName: "Foo");`
+ `PrintOrderDetails("Gift Shop", 31, productName: "Red Mug");`
+
+- _starting with C# 7.2_, they're used in the correct position.
+
+ `PrintOrderDetails(sellerName: "Gift Shop", 31, productName: "Red Mug");`
+  
+ However, out-of-order named arguments are invalid if they're followed by positional arguments. The following statements cause a compiler error.
+
+ `// PrintOrderDetails(productName: "Red Mug", 31, "Gift Shop");`
+
+ `// PrintOrderDetails(31, sellerName: "Gift Shop", "Red Mug");`
   
 ## Example  
  The following code implements the examples from this section along with some additional ones.  

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -74,9 +74,10 @@ translation.priority.ht:
   
  However, out-of-order named arguments are invalid if they're followed by positional arguments. The following statements cause a compiler error.
 
- `// PrintOrderDetails(productName: "Red Mug", 31, "Gift Shop");`
-
- `// PrintOrderDetails(31, sellerName: "Gift Shop", "Red Mug");`
+ ```csharp
+ // This generates CS1738: Named argument specifications must appear after all fixed arguments have been specified.
+ PrintOrderDetails(productName: "Red Mug", 31, "Gift Shop");
+ ```
   
 ## Example  
  The following code implements the examples from this section along with some additional ones.  

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -68,7 +68,7 @@ translation.priority.ht:
 
  `PrintOrderDetails("Gift Shop", 31, productName: "Red Mug");`
 
-- _starting with C# 7.2_, they're used in the correct position.
+- _starting with C# 7.2_, they're used in the correct position. In the example below, the parameter `orderNum` is in the correct position but isn't explicitly named.
 
  `PrintOrderDetails(sellerName: "Gift Shop", 31, productName: "Red Mug");`
   

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -60,7 +60,7 @@ translation.priority.ht:
   
  `PrintOrderDetails(productName: "Red Mug", sellerName: "Gift Shop", orderNum: 31);`
   
- Named arguments also improve the readability of your code by identifying what each argument represents.  
+ Named arguments also improve the readability of your code by identifying what each argument represents. In the example method below, the `sellerName` cannot be null or whitespace. As both `sellerName` and `productName` are string types, instead of sending arguments by position, it makes sense to use named arguments to disambiguate the two and reduce confusion for anyone reading the code.
   
  Named arguments, when used with positional arguments, are valid as long as 
 
@@ -72,7 +72,7 @@ translation.priority.ht:
 
  `PrintOrderDetails(sellerName: "Gift Shop", 31, productName: "Red Mug");`
   
- However, out-of-order named arguments are invalid if they're followed by positional arguments. The following statements cause a compiler error.
+ However, out-of-order named arguments are invalid if they're followed by positional arguments.
 
  ```csharp
  // This generates CS1738: Named argument specifications must appear after all fixed arguments have been specified.


### PR DESCRIPTION
# Title

Update language reference for non-trailing named arguments

## Summary

Support has been added for non-trailing named arguments used in the correct order in C# 7.2. This PR updates the public C# language reference to explain the new contract.

Fixes #3240 

## Details

Since we're expanding use-cases for named arguments with C# 7.2, the public language reference will be update to explain the usages.

Moreover, a more sophisticated example replaces the current code snippet to cover all the variants that are now allowed along with ones that are still illegal. So instead of having a 2-parameter method, we'll have a 3-parameter method.