### PR TITLE
Fix dotnet => msbuild command translation example

### DIFF
--- a/docs/core/tools/cli-msbuild-architecture.md
+++ b/docs/core/tools/cli-msbuild-architecture.md
@@ -64,6 +64,6 @@ From an execution perspective, the CLI commands will take their parameters and c
     
 This command is publishing an application into a `pub` folder using the "Release" configuration. Internally, this command gets translated into the following MSBuild invocation: 
 
-   `dotnet msbuild /t:Publish /p:OutputPath=pub /p:Configuration=Release`
+   `msbuild /t:Publish /p:OutputPath=pub /p:Configuration=Release`
 
 The notable exception to this rule are `new` and `run` commands, as they have not been implemented as MSBuild targets.


### PR DESCRIPTION
Fix an incorrect msbuild invocation example
```
dotnet msbuild /t:Publish /p:OutputPath=pub /p:Configuration=Release
```