### PR TITLE
is-type-pattern6.cs - Use correct variable in null check

### DIFF
--- a/samples/snippets/csharp/language-reference/keywords/is/is-type-pattern6.cs
+++ b/samples/snippets/csharp/language-reference/keywords/is/is-type-pattern6.cs
@@ -9,7 +9,7 @@ public class Employee : IComparable
     public int CompareTo(Object o)
     {
         var e = o as Employee;
-        if (o == null)
+        if (e == null)
         {
            throw new ArgumentException("o is not an Employee object.");
         }


### PR DESCRIPTION
## Summary

The wrong variable `o` was used in a null-check. Should be `e`.
