### PR TITLE
Update to clarify OSX

### DIFF
--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -11,7 +11,7 @@ ms.devlang: dotnet
 ms.assetid: c33b1241-ab66-4583-9eba-52cf51146f5a
 ---
 
-# Prerequisites for .NET Core on Mac
+# Prerequisites for .NET Core on macOS
 
 This article shows you the supported macOS versions and .NET Core dependencies that you need to develop, deploy, and run .NET Core applications on macOS machines. The supported OS versions and dependencies that follow apply to the three ways of developing .NET Core apps on a Mac: via the [command-line with your favorite editor](tutorials/using-with-xplat-cli.md), [Visual Studio Code](https://code.visualstudio.com/), and [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/).
 

--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -172,7 +172,7 @@ macOS RIDs use the older "OSX" branding.
 - `osx.10.12-x64` (.NET Core 1.1 or later versions)
 - `osx.10.13-x64`
 
-See [Prerequisites for .NET Core on MacOS](macos-prerequisites.md) for more information.
+See [Prerequisites for .NET Core on macOS](macos-prerequisites.md) for more information.
 
 ## Android RIDs (.NET Core 2.0 or later versions)
 

--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -106,6 +106,8 @@ The following list shows the most common RIDs used for each OS. It doesn't cover
   - `win10-arm`
   - `win10-arm64`
 
+See [Prerequisites for .NET Core on Windows](windows-prerequisites.md) for more information.
+
 ## Linux RIDs
 
 - Portable
@@ -158,13 +160,19 @@ The following list shows the most common RIDs used for each OS. It doesn't cover
   - `linuxmint.18-x64`
   - `linuxmint.18.1-x64` (.NET Core 2.0 or later versions)
 
-## OS X RIDs
+See [Prerequisites for .NET Core on Linux](linux-prerequisites.md) for more information.
 
-- `osx-x64` (.NET Core 2.0 or later versions, min version is `osx.10.12-x64`)
+## macOS RIDs
+
+macOS RIDs use the older "OSX" branding.
+
+- `osx-x64` (.NET Core 2.0 or later versions, minimum version is `osx.10.12-x64`)
 - `osx.10.10-x64`
 - `osx.10.11-x64`
 - `osx.10.12-x64` (.NET Core 1.1 or later versions)
 - `osx.10.13-x64`
+
+See [Prerequisites for .NET Core on MacOS](macos-prerequisites.md) for more information.
 
 ## Android RIDs (.NET Core 2.0 or later versions)
 
@@ -172,4 +180,5 @@ The following list shows the most common RIDs used for each OS. It doesn't cover
 - `android.21`
 
 ## See also
- [Runtime IDs](https://github.com/dotnet/corefx/blob/master/pkg/Microsoft.NETCore.Platforms/readme.md)
+
+[Runtime IDs](https://github.com/dotnet/corefx/blob/master/pkg/Microsoft.NETCore.Platforms/readme.md)

--- a/docs/core/rid-catalog.md
+++ b/docs/core/rid-catalog.md
@@ -160,10 +160,11 @@ The following list shows the most common RIDs used for each OS. It doesn't cover
 
 ## OS X RIDs
 
-- `osx-x64` (.NET Core 2.0 or later versions)
+- `osx-x64` (.NET Core 2.0 or later versions, min version is `osx.10.12-x64`)
 - `osx.10.10-x64`
 - `osx.10.11-x64`
 - `osx.10.12-x64` (.NET Core 1.1 or later versions)
+- `osx.10.13-x64`
 
 ## Android RIDs (.NET Core 2.0 or later versions)
 


### PR DESCRIPTION
Adds 10.13 and clarifies that osx-x64 starts at 10.12.