### PR TITLE
Expand Low Memory GC Occurance

### DIFF
--- a/docs/standard/garbage-collection/fundamentals.md
+++ b/docs/standard/garbage-collection/fundamentals.md
@@ -86,7 +86,7 @@ manager: "wpickett"
 ## Conditions for a garbage collection  
  Garbage collection occurs when one of the following conditions is true:  
   
--   The system has low physical memory.  
+-   The system has low physical memory, such as when the system receives a low memory notification from the operating system.  
   
 -   The memory that is used by allocated objects on the managed heap surpasses an acceptable threshold. This threshold is continuously adjusted as the process runs.  
   

--- a/docs/standard/garbage-collection/fundamentals.md
+++ b/docs/standard/garbage-collection/fundamentals.md
@@ -86,7 +86,7 @@ manager: "wpickett"
 ## Conditions for a garbage collection  
  Garbage collection occurs when one of the following conditions is true:  
   
--   The system has low physical memory, such as when the system receives a low memory notification from the operating system.  
+-   The system has low physical memory. This is detected by either the low memory notification from the OS or low memory indicated by the host.
   
 -   The memory that is used by allocated objects on the managed heap surpasses an acceptable threshold. This threshold is continuously adjusted as the process runs.  
   


### PR DESCRIPTION
Expand "The system has low physical memory" description, providing one way that the system figures this out, as per Latency Modes documentation page

https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/latency

This reads as follows:

   During low latency periods, generation 2 collections are suppressed unless the following occurs:
   The system receives a low memory notification from the operating system.

Took me a while to find out whether the OS goes through each .NET app and invoked GC, or some sort of notification happens, or if this is only taken into consideration at the next allocation.

From reading the Latency Modes page, my understanding is that the OS sends a low memory notification too all (potentially only .NET?) processes that the system has low memory.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
