### PR TITLE
Replace UWP vNext with 10.0.16299

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -1,16 +1,16 @@
-| .NET Standard                             | [1.0] | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]  | [1.6]  | [2.0] |
-|-------------------------------------------|-------|--------|-------|-------|-------|--------|--------|-------|
-| .NET Core                                 | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0    | 1.0    | 2.0   |
-| .NET Framework (with .NET Core 1.x SDK)   | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2  |        |       |
-| .NET Framework (with .NET Core 2.0 SDK)   | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1  | 4.6.1  | 4.6.1 |
-| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6    | 4.6    | 5.4   |
-| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0   | 10.0   | 10.14 |
-| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0    | 3.0    | 3.8   |
-| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0    | 7.0    | 8.0   |
-| Universal Windows Platform                | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | vNext  | vNext  | vNext |
-| Windows                                   | 8.0   | 8.0    | 8.1   |       |       |        |        |       |
-| Windows Phone                             | 8.1   | 8.1    | 8.1   |       |       |        |        |       |
-| Windows Phone Silverlight                 | 8.0   |        |       |       |       |        |        |       |
+| .NET Standard                             | [1.0] | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]      | [1.6]      | [2.0]      |
+|-------------------------------------------|-------|--------|-------|-------|-------|------------|------------|------------|
+| .NET Core                                 | 1.0   | 1.0    | 1.0   | 1.0   | 1.0   | 1.0        | 1.0        | 2.0        |
+| .NET Framework (with .NET Core 1.x SDK)   | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.2      |            |            |
+| .NET Framework (with .NET Core 2.0 SDK)   | 4.5   | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1      | 4.6.1      | 4.6.1      |
+| Mono                                      | 4.6   | 4.6    | 4.6   | 4.6   | 4.6   | 4.6        | 4.6        | 5.4        |
+| Xamarin.iOS                               | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0       | 10.0       | 10.14      |
+| Xamarin.Mac                               | 3.0   | 3.0    | 3.0   | 3.0   | 3.0   | 3.0        | 3.0        | 3.8        |
+| Xamarin.Android                           | 7.0   | 7.0    | 7.0   | 7.0   | 7.0   | 7.0        | 7.0        | 8.0        |
+| Universal Windows Platform                | 10.0  | 10.0   | 10.0  | 10.0  | 10.0  | 10.0.16299 | 10.0.16299 | 10.0.16299 |
+| Windows                                   | 8.0   | 8.0    | 8.1   |       |       |            |            |            |
+| Windows Phone                             | 8.1   | 8.1    | 8.1   |       |       |            |            |            |
+| Windows Phone Silverlight                 | 8.0   |        |       |       |       |            |            |            |
 
 - The columns represent .NET Standard versions. Each header cell is a link to a document that shows which APIs got added in that version of .NET Standard.
 - The rows represent the different .NET implementations.


### PR DESCRIPTION
Update .NET Standard support table to include the actual version number of UWP that supports .NET Standard 2.0