### PR TITLE
use C# interactive in foreach

### DIFF
--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/foreach-in_1.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/foreach-in_1.cs
@@ -8,7 +8,15 @@ class ForEachTest
             System.Console.WriteLine(element);
         }
         System.Console.WriteLine();
-
+        // Output:
+        // 0
+        // 1
+        // 1
+        // 2
+        // 3
+        // 5
+        // 8
+        // 13
 
         // Compare the previous loop to a similar for loop.
         for (int i = 0; i < fibarray.Length; i++)
@@ -16,7 +24,15 @@ class ForEachTest
             System.Console.WriteLine(fibarray[i]);
         }
         System.Console.WriteLine();
-
+        // Output:
+        // 0
+        // 1
+        // 1
+        // 2
+        // 3
+        // 5
+        // 8
+        // 13
 
         // You can maintain a count of the elements in the collection.
         int count = 0;
@@ -26,33 +42,17 @@ class ForEachTest
             System.Console.WriteLine("Element #{0}: {1}", count, element);
         }
         System.Console.WriteLine("Number of elements in the array: {0}", count);
+        // Output:
+        // Element #1: 0
+        // Element #2: 1
+        // Element #3: 1
+        // Element #4: 2
+        // Element #5: 3
+        // Element #6: 5
+        // Element #7: 8
+        // Element #8: 13
+        // Number of elements in the array: 8
     }
-    // Output:
-    // 0
-    // 1
-    // 1
-    // 2
-    // 3
-    // 5
-    // 8
-    // 13
 
-    // 0
-    // 1
-    // 1
-    // 2
-    // 3
-    // 5
-    // 8
-    // 13
 
-    // Element #1: 0
-    // Element #2: 1
-    // Element #3: 1
-    // Element #4: 2
-    // Element #5: 3
-    // Element #6: 5
-    // Element #7: 8
-    // Element #8: 13
-    // Number of elements in the array: 8
 }

--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/foreach-in_1.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/foreach-in_1.cs
@@ -2,6 +2,13 @@ class ForEachTest
 {
     static void Main(string[] args)
     {
+        ExampleOne();
+        ExampleTwo();
+        ExampleThree();
+    }
+
+    private static void ExampleOne() // 12 - 26
+    {
         int[] fibarray = new int[] { 0, 1, 1, 2, 3, 5, 8, 13 };
         foreach (int element in fibarray)
         {
@@ -17,7 +24,11 @@ class ForEachTest
         // 5
         // 8
         // 13
+    }
 
+    private static void ExampleTwo() // 31-46
+    {
+        int[] fibarray = new int[] { 0, 1, 1, 2, 3, 5, 8, 13 };
         // Compare the previous loop to a similar for loop.
         for (int i = 0; i < fibarray.Length; i++)
         {
@@ -33,7 +44,11 @@ class ForEachTest
         // 5
         // 8
         // 13
+    }
 
+    private static void ExampleThree() // 51 - 69
+    {
+        int[] fibarray = new int[] { 0, 1, 1, 2, 3, 5, 8, 13 };
         // You can maintain a count of the elements in the collection.
         int count = 0;
         foreach (int element in fibarray)

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -47,19 +47,23 @@ The `foreach` statement repeats a group of embedded statements for each element 
  [How to: Access a Collection Class with foreach](../../programming-guide/classes-and-structs/how-to-access-a-collection-class-with-foreach.md)  
 
 ## Example
- The following code shows three examples:
+ The following code shows three examples.
+
+> [!TIP]
+> You can modify the examples to experiment with the syntax and try different
+> usages that are more similar to your use case.
 
 -   a typical `foreach` loop that displays the contents of an array of integers
 
-[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L5-L15)]
+[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L12-L26)]
 
 -   a [for](../../../csharp/language-reference/keywords/for.md) loop that does the same thing
 
-[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L21-L35)]
+[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L31-L46)]
 
 -   a `foreach` loop that maintains a count of the number of elements in the array
 
-[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L37-L54)]
+[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L51-L69)]
  
 ## C# Language Specification
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -51,7 +51,8 @@ The `foreach` statement repeats a group of embedded statements for each element 
 
 > [!TIP]
 > You can modify the examples to experiment with the syntax and try different
-> usages that are more similar to your use case.
+> usages that are more similar to your use case. Press "Run" to run the code,
+> then edit and press "Run" again.
 
 -   a typical `foreach` loop that displays the contents of an array of integers
 
@@ -66,11 +67,16 @@ The `foreach` statement repeats a group of embedded statements for each element 
 [!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L51-L69)]
  
 ## C# Language Specification
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
 
 ## See Also  
- [C# Reference](../index.md)
- [C# Programming Guide](../../programming-guide/index.md)
- [C# Keywords](index.md)
- [Iteration Statements](iteration-statements.md)
- [for](for.md)
+
+[C# Reference](../index.md)
+
+[C# Programming Guide](../../programming-guide/index.md)
+
+[C# Keywords](index.md)
+
+[Iteration Statements](iteration-statements.md)
+
+[for](for.md)

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -1,6 +1,6 @@
 ---
 title: "foreach, in (C# Reference)"
-ms.date: "2015-07-20"
+ms.date: 10/11/2017"
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -32,37 +32,41 @@ translation.priority.ht:
   - "zh-tw"
 ---
 # foreach, in (C# Reference)
-The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The `foreach` statement is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](../../../csharp/language-reference/keywords/for.md) loop.  
+The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The `foreach` statement is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
   
- The embedded statements continue to execute for each element in the array or collection. After the iteration has been completed for all the elements in the collection, control is transferred to the next statement following the `foreach` block.  
+ The embedded statements continue to execute for each element in the array or collection. After the iteration has been completed for all the elements in the collection, control is transferred to the next statement following the `foreach` block.
   
- At any point within the `foreach` block, you can break out of the loop by using the [break](../../../csharp/language-reference/keywords/break.md) keyword, or step to the next iteration in the loop by using the [continue](../../../csharp/language-reference/keywords/continue.md) keyword.  
-  
- A `foreach` loop can also be exited by the [goto](../../../csharp/language-reference/keywords/goto.md), [return](../../../csharp/language-reference/keywords/return.md), or [throw](../../../csharp/language-reference/keywords/throw.md) statements.  
-  
+ At any point within the `foreach` block, you can break out of the loop by using the [break](break.md) keyword, or step to the next iteration in the loop by using the [continue](continue.md) keyword.
+
+ A `foreach` loop can also be exited by the [goto](goto.md), [return](return.md), or [throw](throw.md) statements.
+
  For more information about the `foreach` keyword and code samples, see the following topics:  
-  
- [Using foreach with Arrays](../../../csharp/programming-guide/arrays/using-foreach-with-arrays.md)  
-  
- [How to: Access a Collection Class with foreach](../../../csharp/programming-guide/classes-and-structs/how-to-access-a-collection-class-with-foreach.md)  
-  
-## Example  
- The following code shows three examples:  
-  
--   a typical `foreach` loop that displays the contents of an array of integers  
-  
--   a [for](../../../csharp/language-reference/keywords/for.md) loop that does the same thing  
-  
--   a `foreach` loop that maintains a count of the number of elements in the array  
-  
- [!code-cs[csrefKeywordsIteration#4](../../../csharp/language-reference/keywords/codesnippet/CSharp/foreach-in_1.cs)]  
-  
-## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
+
+ [Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)  
+
+ [How to: Access a Collection Class with foreach](../../programming-guide/classes-and-structs/how-to-access-a-collection-class-with-foreach.md)  
+
+## Example
+ The following code shows three examples:
+
+-   a typical `foreach` loop that displays the contents of an array of integers
+
+[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L5-L15)]
+
+-   a [for](../../../csharp/language-reference/keywords/for.md) loop that does the same thing
+
+[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L21-L35)]
+
+-   a `foreach` loop that maintains a count of the number of elements in the array
+
+[!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L37-L54)]
+ 
+## C# Language Specification
+ [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+
 ## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)   
- [C# Programming Guide](../../../csharp/programming-guide/index.md)   
- [C# Keywords](../../../csharp/language-reference/keywords/index.md)   
- [Iteration Statements](../../../csharp/language-reference/keywords/iteration-statements.md)   
- [for](../../../csharp/language-reference/keywords/for.md)
+ [C# Reference](../index.md)
+ [C# Programming Guide](../../programming-guide/index.md)
+ [C# Keywords](index.md)
+ [Iteration Statements](iteration-statements.md)
+ [for](for.md)


### PR DESCRIPTION
Fixes #3343
The reference page for the `foreach` keyword now has examples you can run online.

[Internal review link](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/foreach-in?branch=pr-en-us-3379)
