### PR TITLE
Rename of communication-between-microservices.md

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1014,6 +1014,11 @@
         {
             "source_path": "docs/csharp/getting-started/getting-started-with-csharp.md",
             "redirect_url": "/dotnet/csharp/getting-started"
+        },
+        {
+            "source_path": "/dotnet/standard/microservices-architecture/architect-microservice-container-applications/communication-between-microservices.md",
+            "redirect_url": "/dotnet/standard/microservices-architecture/architect-microservice-container-applications/communication-in-microservice-architecture.md",
+            "redirect_document_id": true
         }
     ]
 }


### PR DESCRIPTION
Rename from communication-between-microservices.md to communication-in-microservice-architecture.md

No sure what's the "redirect_document_id": true for, though...

