### PR TITLE
Corrected spelling error: APIto -> API to

### DIFF
--- a/xml/System.Xml/XmlReader.xml
+++ b/xml/System.Xml/XmlReader.xml
@@ -351,7 +351,7 @@ Six Month Review Date:  7/8/2003 12:00:00 AM
    
   
 ## Examples  
- The following example code shows how to use the asynchronous APIto parse XML.  
+ The following example code shows how to use the asynchronous API to parse XML.  
   
  [!code-csharp[System.Xml.XmlReader.Class#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.xml.xmlreader.class/cs/program.cs#6)]
  [!code-vb[System.Xml.XmlReader.Class#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.xml.xmlreader.class/vb/module1.vb#6)]  


### PR DESCRIPTION
# Correct spelling error: APIto -> API to

## Summary

A space is missing between two words.