### PR TITLE
Update expression-trees-explained.md

### DIFF
--- a/docs/csharp/expression-trees-explained.md
+++ b/docs/csharp/expression-trees-explained.md
@@ -59,7 +59,7 @@ each node in the tree to see the code that makes up the statement:
 This may look complicated, but it is very powerful. Following the same process, you can decompose
 much more complicated expressions. Consider this expression:
 ```csharp
-var finalAnswer = this.SecretSauceFuncion(
+var finalAnswer = this.SecretSauceFunction(
     currentState.createInterimResult(), currentState.createSecondValue(1, 2),
     decisionServer.considerFinalOptions("hello")) +
     MoreSecretSauce('A', DateTime.Now, true);


### PR DESCRIPTION
# Title

Small typo expression-trees-explained.md

## Summary

Changed from var finalAnswer = this.SecretSauceFuncion to var finalAnswer = this.SecretSauceFunction

