### PR TITLE
Update Form1.cs

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Winforms/System.Drawing.Icon.ExtractAssociatedIconEx/CS/Form1.cs
+++ b/samples/snippets/csharp/VS_Snippets_Winforms/System.Drawing.Icon.ExtractAssociatedIconEx/CS/Form1.cs
@@ -47,8 +47,7 @@ namespace ExtractAssociatedIcon
                 Icon iconForFile = SystemIcons.WinLogo;
 
                 item = new ListViewItem(file.Name, 1);
-                iconForFile = Icon.ExtractAssociatedIcon(file.FullName);
-                
+                                
                 // Check to see if the image collection contains an image
                 // for this extension, using the extension as a key.
                 if (!imageList1.Images.ContainsKey(file.Extension))


### PR DESCRIPTION
Removed unneeded iconForFile = Icon.ExtractAssociatedIcon(file.FullName); this would cause extraction every time and defeat the purpose of the the imagelist check.

# Removed Extract Icon Extraction call

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

The extract call made the following statements moot, and defeated the purpose of the caching.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
