### PR TITLE
removed FSharp.Core info from APIs

### DIFF
--- a/xml/System.Collections/IStructuralComparable.xml
+++ b/xml/System.Collections/IStructuralComparable.xml
@@ -19,11 +19,6 @@
     <AssemblyName>netstandard</AssemblyName>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
-  <AssemblyInfo>
-    <AssemblyName>FSharp.Core</AssemblyName>
-    <AssemblyVersion>2.3.98.1</AssemblyVersion>
-    <AssemblyVersion>3.98.4.0</AssemblyVersion>
-  </AssemblyInfo>
   <Interfaces />
   <Docs>
     <summary>Supports the structural comparison of collection objects.</summary>
@@ -79,11 +74,6 @@
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>

--- a/xml/System.Collections/IStructuralEquatable.xml
+++ b/xml/System.Collections/IStructuralEquatable.xml
@@ -19,11 +19,6 @@
     <AssemblyName>netstandard</AssemblyName>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
-  <AssemblyInfo>
-    <AssemblyName>FSharp.Core</AssemblyName>
-    <AssemblyVersion>2.3.98.1</AssemblyVersion>
-    <AssemblyVersion>3.98.4.0</AssemblyVersion>
-  </AssemblyInfo>
   <Interfaces />
   <Docs>
     <summary>Defines methods to support the comparison of objects for structural equality.</summary>
@@ -78,11 +73,6 @@
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
@@ -141,11 +131,6 @@
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>

--- a/xml/System.Numerics/BigInteger.xml
+++ b/xml/System.Numerics/BigInteger.xml
@@ -16,11 +16,6 @@
     <AssemblyName>netstandard</AssemblyName>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </AssemblyInfo>
-  <AssemblyInfo>
-    <AssemblyName>FSharp.Core</AssemblyName>
-    <AssemblyVersion>2.3.98.1</AssemblyVersion>
-    <AssemblyVersion>3.98.4.0</AssemblyVersion>
-  </AssemblyInfo>
   <Base>
     <BaseTypeName>System.ValueType</BaseTypeName>
   </Base>
@@ -359,11 +354,6 @@
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <Parameters>
         <Parameter Name="value" Type="System.Int32" />
       </Parameters>
@@ -410,11 +400,6 @@
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <Parameters>
         <Parameter Name="value" Type="System.Int64" />
@@ -618,11 +603,6 @@
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
@@ -1101,11 +1081,6 @@
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -1265,11 +1240,6 @@
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -1374,11 +1344,6 @@
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -1407,11 +1372,6 @@
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
@@ -1515,11 +1475,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -1591,11 +1546,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
@@ -2102,11 +2052,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -2141,11 +2086,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
@@ -2351,11 +2291,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -2509,11 +2444,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
@@ -2934,11 +2864,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Double</ReturnType>
       </ReturnValue>
@@ -3045,11 +2970,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
       </ReturnValue>
@@ -3101,11 +3021,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int64</ReturnType>
@@ -3610,11 +3525,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -3873,11 +3783,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
@@ -4571,11 +4476,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -4893,11 +4793,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -5157,11 +5052,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Boolean</ReturnType>
       </ReturnValue>
@@ -5319,11 +5209,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -5373,11 +5258,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
@@ -5520,11 +5400,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -5570,11 +5445,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
@@ -5623,11 +5493,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -5666,11 +5531,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
@@ -6075,11 +5935,6 @@ value Mod 2 = 0
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
       </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
-      </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>
       </ReturnValue>
@@ -6186,11 +6041,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Int32</ReturnType>
@@ -6370,11 +6220,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.String</ReturnType>
@@ -6833,11 +6678,6 @@ value Mod 2 = 0
       <AssemblyInfo>
         <AssemblyName>netstandard</AssemblyName>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <AssemblyInfo>
-        <AssemblyName>FSharp.Core</AssemblyName>
-        <AssemblyVersion>2.3.98.1</AssemblyVersion>
-        <AssemblyVersion>3.98.4.0</AssemblyVersion>
       </AssemblyInfo>
       <ReturnValue>
         <ReturnType>System.Numerics.BigInteger</ReturnType>


### PR DESCRIPTION
Noticed in the build reports that we still had some warnings related to F# assemblies we removed recently. 
Apparently, mdoc doesn't know how to handle removal well. 