### PR TITLE
Correct error in dimensioning C# array

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.Random/cs/Random2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.Random/cs/Random2.cs
@@ -8,7 +8,7 @@ public class Class1
       // Instantiate random number generator using system-supplied value as seed.
       Random rand = new Random();
       // Generate and display 5 random byte (integer) values.
-      byte[] bytes = new byte[4];
+      byte[] bytes = new byte[5];
       rand.NextBytes(bytes);
       Console.WriteLine("Five random byte values:");
       foreach (byte byteValue in bytes)


### PR DESCRIPTION
# Correct error in dimensioning C# array

## Summary

In converting a VB example to C#, I forgot about a basic language difference in array declarations.

Fixes #3454

## Suggested Reviewers

//cc @mairaw @BillWagner 

