### PR TITLE
.NET Standard serialization topic

### DIFF
--- a/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
+++ b/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
@@ -1,0 +1,37 @@
+---
+title: "How to: Determine if a .NET Standard object is serializable"
+ms.custom: ""
+ms.date: "10/20/2017"
+ms.prod: ".net"
+ms.topic: "article"
+dev_langs:
+- "csharp"
+- "vb"
+helpviewer_keywords: 
+  - "serializing objects"
+  - "objects, serializing steps"
+author: "rpetrusha"
+ms.author: "ronpet"
+manager: "wpickett"
+---
+# How to: Determine if a .NET Standard object is serializable
+
+The .NET Standard is a specification that defines the types and members that must be present on specific .NET implementations that conform to that version of the standard. However, the .NET Standard does not define whether a type is serializable. The types defined in the .NET Standard Library are not marked with the <xref:System.Serializable> attribute. Instead, specific .NET implementations, such as the .NET Framework and .NET Core, are free determine whether a particular type is serializable. 
+
+If you've developed a library that targets the .NET Standard, your library can be consumed by any .NET implementation that supports the .NET Standard. This means that you cannot know in advance whether a particular type is serializable; you can only determine whether it is serializable at run time.
+
+You can determine whether an object is serializable at runtime by retrieving the value of the <xref:System.Type.IsSerializable> property of a <xref:System.Type> object that represents that object's type. The following example provides one implementation. It defines an `IsSerializable(Object)` method that indicates whether an instance of a type can be serialized.
+
+[!code-csharp[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#2)]
+[!code-vb[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/program.vb#2)]
+
+You can then pass any object to the method to determine whether it can be serialized and deserialized on the current .NET implementation, as the following example shows.
+
+[!code-csharp[test-is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#1)]
+[!code-vb[test-is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/program.vb#1)]
+
+# See also
+
+[Binary serialization](binary-serialization.md)   
+<xref:System.SerializableAttribute?displayProperty=fullName>    
+<xref:System.Type.IsSerializable?displayProperty=nameWithType>   

--- a/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
+++ b/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
@@ -16,7 +16,7 @@ manager: "wpickett"
 ---
 # How to: Determine if a .NET Standard object is serializable
 
-The .NET Standard is a specification that defines the types and members that must be present on specific .NET implementations that conform to that version of the standard. However, the .NET Standard does not define whether a type is serializable. The types defined in the .NET Standard Library are not marked with the <xref:System.Serializable> attribute. Instead, specific .NET implementations, such as the .NET Framework and .NET Core, are free determine whether a particular type is serializable. 
+The .NET Standard is a specification that defines the types and members that must be present on specific .NET implementations that conform to that version of the standard. However, the .NET Standard does not define whether a type is serializable. The types defined in the .NET Standard Library are not marked with the <xref:System.SerializableAttribute> attribute. Instead, specific .NET implementations, such as the .NET Framework and .NET Core, are free determine whether a particular type is serializable. 
 
 If you've developed a library that targets the .NET Standard, your library can be consumed by any .NET implementation that supports the .NET Standard. This means that you cannot know in advance whether a particular type is serializable; you can only determine whether it is serializable at run time.
 

--- a/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
+++ b/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
@@ -16,11 +16,11 @@ manager: "wpickett"
 ---
 # How to: Determine if a .NET Standard object is serializable
 
-The .NET Standard is a specification that defines the types and members that must be present on specific .NET implementations that conform to that version of the standard. However, the .NET Standard does not define whether a type is serializable. The types defined in the .NET Standard Library are not marked with the <xref:System.SerializableAttribute> attribute. Instead, specific .NET implementations, such as the .NET Framework and .NET Core, are free determine whether a particular type is serializable. 
+The .NET Standard is a specification that defines the types and members that must be present on specific .NET implementations that conform to that version of the standard. However, the .NET Standard does not define whether a type is serializable. The types defined in the .NET Standard Library are not marked with the <xref:System.SerializableAttribute> attribute. Instead, specific .NET implementations, such as the .NET Framework and .NET Core, are free to determine whether a particular type is serializable. 
 
 If you've developed a library that targets the .NET Standard, your library can be consumed by any .NET implementation that supports the .NET Standard. This means that you cannot know in advance whether a particular type is serializable; you can only determine whether it is serializable at run time.
 
-You can determine whether an object is serializable at runtime by retrieving the value of the <xref:System.Type.IsSerializable> property of a <xref:System.Type> object that represents that object's type. The following example provides one implementation. It defines an `IsSerializable(Object)` method that indicates whether an instance of a type can be serialized.
+You can determine whether an object is serializable at runtime by retrieving the value of the <xref:System.Type.IsSerializable> property of a <xref:System.Type> object that represents that object's type. The following example provides one implementation. It defines an `IsSerializable(Object)` extension method that indicates whether any <xref:System.Object> instance can be serialized.
 
 [!code-csharp[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#2)]
 [!code-vb[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/program.vb#2)]

--- a/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
+++ b/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Determine if a .NET Standard object is serializable"
+description: "Shows how to determine whether a .NET Standard type can be serialized at run time."
 ms.custom: ""
 ms.date: "10/20/2017"
 ms.prod: ".net"
@@ -25,7 +26,7 @@ You can determine whether an object is serializable at runtime by retrieving the
 [!code-csharp[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#2)]
 [!code-vb[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/library.vb#2)]
 
-You can then pass any object to the method to determine whether it can be serialized and deserialized on the current .NET implementation, as the following example shows.
+You can then pass any object to the method to determine whether it can be serialized and deserialized on the current .NET implementation, as the following example shows:
 
 [!code-csharp[test-is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#1)]
 [!code-vb[test-is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/program.vb#1)]

--- a/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
+++ b/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md
@@ -23,7 +23,7 @@ If you've developed a library that targets the .NET Standard, your library can b
 You can determine whether an object is serializable at runtime by retrieving the value of the <xref:System.Type.IsSerializable> property of a <xref:System.Type> object that represents that object's type. The following example provides one implementation. It defines an `IsSerializable(Object)` extension method that indicates whether any <xref:System.Object> instance can be serialized.
 
 [!code-csharp[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/csharp/program.cs#2)]
-[!code-vb[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/program.vb#2)]
+[!code-vb[is-a-type-serializable](~/samples/snippets/standard/serialization/is-serializable/vb/library.vb#2)]
 
 You can then pass any object to the method to determine whether it can be serialized and deserialized on the current .NET implementation, as the following example shows.
 

--- a/docs/standard/serialization/toc.md
+++ b/docs/standard/serialization/toc.md
@@ -9,6 +9,7 @@
 ### [Version Tolerant Serialization](version-tolerant-serialization.md)
 ### [Serialization Guidelines](serialization-guidelines.md)
 ### [How to: Chunk Serialized Data](how-to-chunk-serialized-data.md)
+### [How to: Determine if a .NET Standard object is serializable](how-to-determine-if-netstandard-object-is-serializable.md)
 ## [XML and SOAP Serialization](xml-and-soap-serialization.md)
 ### [How to: Control Serialization of Derived Classes](how-to-control-serialization-of-derived-classes.md)
 ### [Introducing XML Serialization](introducing-xml-serialization.md)

--- a/samples/snippets/standard/serialization/is-serializable/csharp/Program.cs
+++ b/samples/snippets/standard/serialization/is-serializable/csharp/Program.cs
@@ -1,0 +1,55 @@
+﻿// <Snippet1>
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Libraries;
+
+namespace test_serialization
+{
+    class Program
+    {
+        static void Main()
+        {
+            var value = ValueTuple.Create("03244562", DateTime.Now, 13452.50m);
+		    if (UtilityLibrary.IsSerializable(value))
+			{
+				// Serialize the value tuple.
+            var formatter = new BinaryFormatter();
+				var stream = new FileStream("data.bin", FileMode.Create, 
+				                            FileAccess.Write, FileShare.None);
+				formatter.Serialize(stream, value);
+				stream.Close();
+            // Deserialize the value tuple.
+            var readStream = new FileStream("data.bin", FileMode.Open);
+            var restoredValue = formatter.Deserialize(readStream);
+            Console.WriteLine($"{restoredValue.GetType().Name}: {restoredValue}");
+			}
+			else
+			{
+				Console.WriteLine($"{nameof(value)} is not serializable");
+			}
+        }
+    }
+}
+// The example displays output like the following:
+//    ValueTuple`3: (03244562, 10/18/2017 5:25:22 PM, 13452.50)
+// </Snippet1>
+
+// <Snippet2>
+namespace Libraries
+{
+    using System;
+    
+    public class UtilityLibrary
+    {
+        public static bool IsSerializable(object obj)
+        {
+            if (obj == null) 
+                return false;
+
+            Type t = obj.GetType();
+            return t.IsSerializable;
+        }
+    }
+}
+// </Snippet2>

--- a/samples/snippets/standard/serialization/is-serializable/csharp/Program.cs
+++ b/samples/snippets/standard/serialization/is-serializable/csharp/Program.cs
@@ -6,30 +6,33 @@ using Libraries;
 
 namespace test_serialization
 {
-    class Program
-    {
-        static void Main()
-        {
-            var value = ValueTuple.Create("03244562", DateTime.Now, 13452.50m);
-		    if (UtilityLibrary.IsSerializable(value))
-			{
-				// Serialize the value tuple.
+   class Program
+   {
+      static void Main()
+      {
+         var value = ValueTuple.Create("03244562", DateTime.Now, 13452.50m);
+         if (value.IsSerializable())
+         {
+            // Serialize the value tuple.
             var formatter = new BinaryFormatter();
-				var stream = new FileStream("data.bin", FileMode.Create, 
-				                            FileAccess.Write, FileShare.None);
-				formatter.Serialize(stream, value);
-				stream.Close();
+            using (var stream = new FileStream("data.bin", FileMode.Create, 
+                                        FileAccess.Write, FileShare.None))
+            {                            
+               formatter.Serialize(stream, value);
+            }
             // Deserialize the value tuple.
-            var readStream = new FileStream("data.bin", FileMode.Open);
-            var restoredValue = formatter.Deserialize(readStream);
-            Console.WriteLine($"{restoredValue.GetType().Name}: {restoredValue}");
-			}
-			else
-			{
-				Console.WriteLine($"{nameof(value)} is not serializable");
-			}
-        }
-    }
+            using (var readStream = new FileStream("data.bin", FileMode.Open))
+            {
+               object restoredValue = formatter.Deserialize(readStream);
+               Console.WriteLine($"{restoredValue.GetType().Name}: {restoredValue}");
+            }   
+         }
+         else
+         {
+            Console.WriteLine($"{nameof(value)} is not serializable");
+         }
+      }
+   }
 }
 // The example displays output like the following:
 //    ValueTuple`3: (03244562, 10/18/2017 5:25:22 PM, 13452.50)
@@ -40,9 +43,9 @@ namespace Libraries
 {
     using System;
     
-    public class UtilityLibrary
+    public static class UtilityLibrary
     {
-        public static bool IsSerializable(object obj)
+        public static bool IsSerializable(this object obj)
         {
             if (obj == null) 
                 return false;

--- a/samples/snippets/standard/serialization/is-serializable/csharp/test-serialization.csproj
+++ b/samples/snippets/standard/serialization/is-serializable/csharp/test-serialization.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/standard/serialization/is-serializable/csharp/test-serialization.csproj
+++ b/samples/snippets/standard/serialization/is-serializable/csharp/test-serialization.csproj
@@ -1,11 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-  </ItemGroup>
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
 </Project>

--- a/samples/snippets/standard/serialization/is-serializable/vb/library.vb
+++ b/samples/snippets/standard/serialization/is-serializable/vb/library.vb
@@ -1,0 +1,16 @@
+' <Snippet2>
+Imports System.Runtime.CompilerServices
+
+Namespace Global.Libraries
+   
+	Public Module UtilityLibrary
+    	<Extension>
+      Public Function IsSerializable(ByVal obj As Object) As Boolean
+    		If obj Is Nothing Then Return False 
+
+			Dim t As Type = obj.GetType()
+			Return t.IsSerializable
+		End Function
+	End Module
+End Namespace
+' </Snippet2>

--- a/samples/snippets/standard/serialization/is-serializable/vb/program.vb
+++ b/samples/snippets/standard/serialization/is-serializable/vb/program.vb
@@ -1,23 +1,24 @@
 ' <Snippet1>
 Imports System.IO
 Imports System.Runtime.Serialization.Formatters.Binary
-'Imports Libraries
+Imports Libraries
 
 Module Program
    Sub Main()
       Dim value = ValueTuple.Create("03244562", DateTime.Now, 13452.50d)
-      If Libraries.UtilityLibrary.IsSerializable(value) Then
-   		Dim formatter As New BinaryFormatter()
+   	If value.IsSerializable() Then
+         Dim formatter As New BinaryFormatter()
 	   	' Serialize the value tuple.
-         Dim stream As New FileStream("data.bin", FileMode.Create, 
-			                             FileAccess.Write, FileShare.None)
-			formatter.Serialize(stream, value)
-			stream.Close()
+         Using stream As New FileStream("data.bin", FileMode.Create, 
+			                               FileAccess.Write, FileShare.None)
+            formatter.Serialize(stream, value)
+			End Using
          ' Deserialize the value tuple.
-         Dim readStream As New FileStream("data.bin", FileMode.Open)
-         Dim restoredValue = formatter.Deserialize(readStream)
-         Console.WriteLine($"{restoredValue.GetType().Name}: {restoredValue}")
-		Else
+         Using readStream As New FileStream("data.bin", FileMode.Open)
+            Dim restoredValue = formatter.Deserialize(readStream)
+            Console.WriteLine($"{restoredValue.GetType().Name}: {restoredValue}")
+		   End Using
+      Else
 			Console.WriteLine($"{nameof(value)} is not serializable")
 		End If
     End Sub
@@ -26,15 +27,3 @@ End Module
 '    ValueTuple`3: (03244562, 10/18/2017 5:25:22 PM, 13452.50)
 ' </Snippet1>
 
-' <Snippet2>
-Namespace Libraries
-	Public Class UtilityLibrary
-    	Public Shared Function IsSerializable(obj As Object) As Boolean
-    		If obj Is Nothing Then Return False 
-
-			Dim t As Type = obj.GetType()
-			Return t.IsSerializable
-		End Function
-	End Class
-End Namespace
-' </Snippet2>

--- a/samples/snippets/standard/serialization/is-serializable/vb/program.vb
+++ b/samples/snippets/standard/serialization/is-serializable/vb/program.vb
@@ -1,0 +1,40 @@
+' <Snippet1>
+Imports System.IO
+Imports System.Runtime.Serialization.Formatters.Binary
+'Imports Libraries
+
+Module Program
+   Sub Main()
+      Dim value = ValueTuple.Create("03244562", DateTime.Now, 13452.50d)
+      If Libraries.UtilityLibrary.IsSerializable(value) Then
+   		Dim formatter As New BinaryFormatter()
+	   	' Serialize the value tuple.
+         Dim stream As New FileStream("data.bin", FileMode.Create, 
+			                             FileAccess.Write, FileShare.None)
+			formatter.Serialize(stream, value)
+			stream.Close()
+         ' Deserialize the value tuple.
+         Dim readStream As New FileStream("data.bin", FileMode.Open)
+         Dim restoredValue = formatter.Deserialize(readStream)
+         Console.WriteLine($"{restoredValue.GetType().Name}: {restoredValue}")
+		Else
+			Console.WriteLine($"{nameof(value)} is not serializable")
+		End If
+    End Sub
+End Module
+' The example displays output like the following:
+'    ValueTuple`3: (03244562, 10/18/2017 5:25:22 PM, 13452.50)
+' </Snippet1>
+
+' <Snippet2>
+Namespace Libraries
+	Public Class UtilityLibrary
+    	Public Shared Function IsSerializable(obj As Object) As Boolean
+    		If obj Is Nothing Then Return False 
+
+			Dim t As Type = obj.GetType()
+			Return t.IsSerializable
+		End Function
+	End Class
+End Namespace
+' </Snippet2>

--- a/samples/snippets/standard/serialization/is-serializable/vb/test.serialization.vb.vbproj
+++ b/samples/snippets/standard/serialization/is-serializable/vb/test.serialization.vb.vbproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/samples/snippets/standard/serialization/is-serializable/vb/test.serialization.vb.vbproj
+++ b/samples/snippets/standard/serialization/is-serializable/vb/test.serialization.vb.vbproj
@@ -1,11 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-  </ItemGroup>
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
 </Project>

--- a/xml/System/Type.xml
+++ b/xml/System/Type.xml
@@ -10489,6 +10489,9 @@ GetType(Array).IsAssignableFrom(type)
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+ 
+Types that are defined in the .NET Standard are not marked with <xref:System.SerializableAttribute>. Instead, each .NET implementation determines whether a type is serializable. At run time, you can use the <xref:System.Type.IsSerializable%2A> property to determine whether that implementation supports serialization of an instance of the type. For more information and an example, see [How to determine if a .NET Standard object is serializable](~/docs/standard/serialization/how-to-determine-if-netstandard-object-is-serializable.md).
+  
  If the current <xref:System.Type> represents a constructed generic type, this property applies to the generic type definition from which the type was constructed. For example, if the current <xref:System.Type> represents `MyGenericType<int>` (`MyGenericType(Of Integer)` in Visual Basic), the value of this property is determined by `MyGenericType<T>`.  
   
  If the current <xref:System.Type> represents a type parameter in the definition of a generic type or generic method, this property always returns `false`.  


### PR DESCRIPTION
# .NET Standard serialization topic

Shows how to check whether a type in a .NET Standard library is serializable, since the .NET Standard does not define serialization.

## Summary

Includes project files and source code files for VB and C#, and updates the TOC.

Fixes #3249 

## Details

For convenience, I combined the library method in the same file as the console application, which means that it's no longer a library method that targets the .NET Standard. 

The topic is staged at https://review.docs.microsoft.com/en-us/dotnet/standard/serialization/how-to-determine-if-netstandard-object-is-serializable?branch=pr-en-us-3462. Make sure that all checks have passed below, though, to make sure that you're looking at a build that reflects the current content.

## Suggested Reviewers
@mairaw, @BillWagner, @ViktorHofer 

