### PR TITLE
SHA256.Create Documentation is incorrect: there are multiple implementations

### DIFF
--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -37,7 +37,7 @@
   
  The hash size for the <xref:System.Security.Cryptography.SHA256> algorithm is 256 bits.  
   
- This is an abstract class. The only implementation of this class is <xref:System.Security.Cryptography.SHA256Managed>.  
+ This is an abstract class. The only implementation of this class is <xref:System.Security.Cryptography.SHA256Managed>.  <<-- This is not true.  There are 3 implementations in the .NET Framework.  Can you specify which one is returned in various cases?
   
    
   


### PR DESCRIPTION
The statement is wrong.  There are 3 implementations.  It would be nice to know which one is picked in various scenarios.
e.g. In my basic testing normally Create returned a SHA256Managed implementation.  When I turned on Enable FIPS compliance instead Create returned a SHA256Cng.