### PR TITLE
Fix typo from nullible to nullable

### DIFF
--- a/docs/csharp/language-reference/operators/null-conditional-operator.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operator.md
@@ -20,7 +20,7 @@ ms.author: "wiwagn"
 The `??` operator is called the null-coalescing operator.  It returns the left-hand operand if the operand is not null; otherwise it returns the right hand operand.  
   
 ## Remarks  
- A nullable type can represent a value from the type’s domain, or the value can be undefined (in which case the value is null). You can use the `??` operator’s syntactic expressiveness to return an appropriate value (the right hand operand) when the left operand has a nullible type whose value is null. If you try to assign a nullable value type to a non-nullable value type without using the `??` operator, you will generate a compile-time error. If you use a cast, and the nullable value type is currently undefined, an `InvalidOperationException` exception will be thrown.  
+ A nullable type can represent a value from the type’s domain, or the value can be undefined (in which case the value is null). You can use the `??` operator’s syntactic expressiveness to return an appropriate value (the right hand operand) when the left operand has a nullable type whose value is null. If you try to assign a nullable value type to a non-nullable value type without using the `??` operator, you will generate a compile-time error. If you use a cast, and the nullable value type is currently undefined, an `InvalidOperationException` exception will be thrown.  
   
  For more information, see [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md).  
   


### PR DESCRIPTION
# Fix typo from nullible to nullable

## Summary

Simple typo found and fixed.

## Details

Simple typo found and fixed.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
