### PR TITLE
Update Mutex.xml

### DIFF
--- a/includes/backslash-mutex.md
+++ b/includes/backslash-mutex.md
@@ -1,2 +1,1 @@
-> [!NOTE]
-> The backslash (\\) is a reserved character in a mutex name. Don't use a backslash (\\) in a mutex name except as specified in the note on using mutexes in terminal server sessions. Otherwise, a <xref:System.IO.DirectoryNotFoundException> may be thrown, even though the name of the mutex represents an existing file.
+The backslash (\\) is a reserved character in a mutex name. Don't use a backslash (\\) in a mutex name except as specified in the note on using mutexes in terminal server sessions. Otherwise, a <xref:System.IO.DirectoryNotFoundException> may be thrown, even though the name of the mutex represents an existing file.

--- a/includes/backslash-mutex.md
+++ b/includes/backslash-mutex.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The backslash (\\) is a reserved character in a mutex name. Don't use a backslash (\\) in a mutex name except as specified in the note on using mutexes in terminal server sessions. Otherwise, a <xref:System.IO.DirectoryNotFoundException> may be thrown, even though the name of the mutex represents existing file.
+> The backslash (\\) is a reserved character in a mutex name. Don't use a backslash (\\) in a mutex name except as specified in the note on using mutexes in terminal server sessions. Otherwise, a <xref:System.IO.DirectoryNotFoundException> may be thrown, even though the name of the mutex represents an existing file.

--- a/includes/backslash-mutex.md
+++ b/includes/backslash-mutex.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> The backslash (\\) is a reserved character in a mutex name. Don't use a backslash (\\) in a mutex name except as specified in the note on using mutexes in terminal server sessions. Otherwise, a <xref:System.IO.DirectoryNotFoundException> may be thrown, even though the name of the mutex represents existing file.

--- a/xml/System.Threading/Mutex.xml
+++ b/xml/System.Threading/Mutex.xml
@@ -67,9 +67,7 @@
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
   
-> [!NOTE]
-> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).
-
+[!INCLUDE[backslash-mutex-note](~/includes/backslash-mutex.md)]
 
   
 ## Examples  
@@ -232,9 +230,8 @@
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
   
-> [!NOTE]
-> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).   
-  
+[!INCLUDE[backslash-mutex-note](~/includes/backslash-mutex.md)]
+
 ## Examples  
  The following example shows how a named mutex is used to signal between threads running in two separate processes.  
   
@@ -309,9 +306,7 @@
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
 
-> [!NOTE]
-> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).  
-   
+[!INCLUDE[backslash-mutex-note](~/includes/backslash-mutex.md)]   
   
 ## Examples  
  The following code example shows how a named mutex is used to signal between processes or threads. Run this program from two or more command windows. Each process creates a <xref:System.Threading.Mutex> object that represents the named mutex "MyMutex". The named mutex is a system object. In this example, its lifetime is bounded by the lifetimes of the <xref:System.Threading.Mutex> objects that represent it. The named mutex is created when the first process creates its local <xref:System.Threading.Mutex> object, and destroyed when all the <xref:System.Threading.Mutex> objects that represent it have been released. The named mutex is initially owned by the first process. The second process and any subsequent processes wait for earlier processes to release the named mutex.  
@@ -382,9 +377,7 @@
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
 
-> [!NOTE]
-> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).
-  
+[!INCLUDE[backslash-mutex-note](~/includes/backslash-mutex.md)]  
    
   
 ## Examples  

--- a/xml/System.Threading/Mutex.xml
+++ b/xml/System.Threading/Mutex.xml
@@ -67,7 +67,10 @@
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
   
-   
+> [!NOTE]
+> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).
+
+
   
 ## Examples  
  This example shows how a local <xref:System.Threading.Mutex> object is used to synchronize access to a protected resource. Because each calling thread is blocked until it acquires ownership of the mutex, it must call the <xref:System.Threading.Mutex.ReleaseMutex%2A> method to release ownership of the thread.  
@@ -229,7 +232,8 @@
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
   
-   
+> [!NOTE]
+> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).   
   
 ## Examples  
  The following example shows how a named mutex is used to signal between threads running in two separate processes.  
@@ -304,7 +308,9 @@
   
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
-  
+
+> [!NOTE]
+> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).  
    
   
 ## Examples  
@@ -375,6 +381,9 @@
   
 > [!NOTE]
 >  On a server that is running Terminal Services, a named system mutex can have two levels of visibility. If its name begins with the prefix "Global\\", the mutex is visible in all terminal server sessions. If its name begins with the prefix "Local\\", the mutex is visible only in the terminal server session where it was created. In that case, a separate mutex with the same name can exist in each of the other terminal server sessions on the server. If you do not specify a prefix when you create a named mutex, it takes the prefix "Local\\". Within a terminal server session, two mutexes whose names differ only by their prefixes are separate mutexes, and both are visible to all processes in the terminal server session. That is, the prefix names "Global\\" and "Local\\" describe the scope of the mutex name relative to terminal server sessions, not relative to processes.  
+
+> [!NOTE]
+> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).
   
    
   


### PR DESCRIPTION
Information that backslash (\\) is a reserved character in mutex name in general is missing. Following text should be added below the note about terminal services:

> [!NOTE]
> Backslash (\\) is a reserved character in Mutex name. Do not use backslash (\\) in mutext name except as specified above otherwise <xref:System.IO.DirectoryNotFoundException> may be thrown (even though the name of the mutext represents existing file).

# Title

Improved documentation of Mutext name regarding use of backslash (\\).

## Summary

Backslash (\\) is reserved character in Mutex name. However this information was missing in the documentation. Let's say I was just hoping that I can give the Mutex the same name as is the path of file I want to lock and it took me lot of time to figure out where is the problem - that I should not use backslash (\\) in Mutex name (expect special use for terminal services). This pull request is adding the information.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Added note about restriction of usage of backslash (\\).

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
