### PR TITLE
Fixed a typo in ServiceThrottlingBehavior

### DIFF
--- a/xml/System.ServiceModel.Description/ServiceThrottlingBehavior.xml
+++ b/xml/System.ServiceModel.Description/ServiceThrottlingBehavior.xml
@@ -119,7 +119,7 @@
       </ReturnValue>
       <Docs>
         <summary>Gets or sets a value that specifies the maximum number of <see cref="T:System.ServiceModel.InstanceContext" /> objects in the service that can execute at one time.</summary>
-        <value>The maximum number of <see cref="T:System.ServiceModel.InstanceContext" /> objects in the service at one time. The default is the sum of the value of <see cref="P:System.ServiceModel.Description.ServiceThrottlingBehavior.MaxConcurrentSessions" /> and the value of <see cref="P:System.ServiceModel.Description.ServiceThrottlingBehavior.MaxConcurrentCalls" />..</value>
+        <value>The maximum number of <see cref="T:System.ServiceModel.InstanceContext" /> objects in the service at one time. The default is the sum of the value of <see cref="P:System.ServiceModel.Description.ServiceThrottlingBehavior.MaxConcurrentSessions" /> and the value of <see cref="P:System.ServiceModel.Description.ServiceThrottlingBehavior.MaxConcurrentCalls" />.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
# Fixed: Reduced a double period to a single.

## Summary

Found a small typo in https://docs.microsoft.com/en-us/dotnet/api/system.servicemodel.description.servicethrottlingbehavior.maxconcurrentinstances?view=netframework-4.7.1 - a double period right before the example. 

I did not create a separate issue for this.
