### PR TITLE
Argument name (id -> userId) corrected

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -188,7 +188,7 @@ public static Task<IEnumerable<User>> GetUsers(IEnumerable<int> userIds)
     
     foreach (int userId in userIds)
     {
-        getUserTasks.Add(GetUser(id));
+        getUserTasks.Add(GetUser(userId));
     }
     
     return await Task.WhenAll(getUserTasks);


### PR DESCRIPTION
inside the foreach loop ("foreach (int userId in userIds)") of GetUsers(IEnumerable<int> userIds):
changed
getUserTasks.Add(GetUser(id));
to
getUserTasks.Add(GetUser(userId));