### PR TITLE
There's no such a thing as match expression

### DIFF
--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -21,7 +21,7 @@ author: "BillWagner"
 ms.author: "wiwagn"
 ---
 # switch (C# Reference)
-`switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *match expression*. 
+`switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *switch expression*. 
   
  [!code-cs[switch#1](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch1.cs#1)]  
 
@@ -33,15 +33,15 @@ It is equivalent to the following example that uses an `if`-`else` construct.
 
 [!code-cs[switch#3a](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch3a.cs#1)] 
 
-## The match expression
+## The switch expression
 
-The match expression provides the value to match against the patterns in `case` labels. Its syntax is:
+The switch expression provides the value to match against the patterns in `case` labels. Its syntax is:
 
 ```csharp
    switch (expr)
 ```
 
-In C# 6, the match expression must be an expression that returns a value of the following types:
+In C# 6, the switch expression must be an expression that returns a value of the following types:
 
 - a [char](char.md).
 - a [string](string.md).
@@ -49,7 +49,7 @@ In C# 6, the match expression must be an expression that returns a value of the 
 - an integral value, such as an [int](int.md) or a [long](long.md).
 - an [enum](enum.md) value.
 
-Starting with C# 7, the match expression can be any non-null expression.
+Starting with C# 7, the switch expression can be any non-null expression.
  
 ## The switch section
  
@@ -77,17 +77,17 @@ This requirement is usually met by explicitly exiting the switch section by usin
   
  [!code-cs[switch#4](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch4.cs#1)]    
   
- Execution of the statement list in the switch section with a case label that matches the match expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `goto label`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label. A `goto` statement, if it is used, must transfer control to a constant label. This restriction is necessary, since attempting to transfer control to a non-constant label can have undesirable side-effects, such transferring control to an unintended location in code or creating an endless loop.
+ Execution of the statement list in the switch section with a case label that matches the switch expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `goto label`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label. A `goto` statement, if it is used, must transfer control to a constant label. This restriction is necessary, since attempting to transfer control to a non-constant label can have undesirable side-effects, such transferring control to an unintended location in code or creating an endless loop.
 
 ## Case labels
 
- Each case label specifies a pattern to compare to the match expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the match expression, control is transfered to the section with the `default` case label, if there is one. If there is no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
+ Each case label specifies a pattern to compare to the switch expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the switch expression, control is transfered to the section with the `default` case label, if there is one. If there is no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
 
  For information on the `switch` statement and pattern matching, see the [Pattern matching with the `switch` statement](#pattern) section.
 
- Because C# 6 supports only the constant pattern and does not allow the repetition of constant values, case labels define mutually exclusive values, and only one pattern can match the match expression. As a result, the order in which `case` statements appear is unimportant.
+ Because C# 6 supports only the constant pattern and does not allow the repetition of constant values, case labels define mutually exclusive values, and only one pattern can match the switch expression. As a result, the order in which `case` statements appear is unimportant.
 
- In C# 7, however, because other patterns are supported, case labels need not define mutually exclusive values, and multiple patterns can match the match expression. Because only the statements in the switch section that contains the first matching pattern are executed, the order in which `case` statements appear is now important. If C# detects a switch section whose case statement or statements are equivalent to or are subsets of previous statements, it generates a compiler error, CS8120, "The switch case has already been handled by a previous case." 
+ In C# 7, however, because other patterns are supported, case labels need not define mutually exclusive values, and multiple patterns can match the switch expression. Because only the statements in the switch section that contains the first matching pattern are executed, the order in which `case` statements appear is now important. If C# detects a switch section whose case statement or statements are equivalent to or are subsets of previous statements, it generates a compiler error, CS8120, "The switch case has already been handled by a previous case." 
 
  The following example illustrates a `switch` statement that uses a variety of non-mutually exclusive patterns. If you move the `case 0:` switch section so that it is no longer the first section in the `switch` statement, C# generates a compiler error because an integer whose value is zero is a subset of all integers, which is the pattern defined by the `case int val` statement.
 
@@ -101,17 +101,17 @@ You can correct this issue and eliminate the compiler warning in one of two ways
  
 ## The `default` case
 
-The `default` case specifies the switch section to execute if the match expression does not match any other `case` label. If a `default` case is not present and the match expression does not match any other `case` label, program flow falls through the `switch` statement.
+The `default` case specifies the switch section to execute if the match expression does not match any other `case` label. If a `default` case is not present and the switch expression does not match any other `case` label, program flow falls through the `switch` statement.
 
 The `default` case can appear in any order in the `switch` statement. Regardless of its order in the source code, it is always evaluated last, after all `case` labels have been evaluated.
 
 ## <a name="pattern" /> Pattern matching with the `switch` statement
   
-Each `case` statement defines a pattern that, if it matches the match expression, causes its  containing switch section to be executed. All versions of C# support the constant pattern. The remaining patterns are supported beginning with C# 7. 
+Each `case` statement defines a pattern that, if it matches the switch expression, causes its  containing switch section to be executed. All versions of C# support the constant pattern. The remaining patterns are supported beginning with C# 7. 
   
 ### Constant pattern 
 
-The constant pattern tests whether the match expression equals a specified constant. Its syntax is:
+The constant pattern tests whether the switch expression equals a specified constant. Its syntax is:
 
 ```csharp
    case constant:
@@ -177,7 +177,7 @@ Without pattern matching, this code might be written as follows. The use of type
 
 ## The `case` statement and the `when` clause
 
-Starting with C# 7, because case statements need not be mutually exclusive, you can use add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value. One of the more common uses for the `when` clause is used to prevent a switch section from executing when the value of a match expression is `null`. 
+Starting with C# 7, because case statements need not be mutually exclusive, you can use add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value. One of the more common uses for the `when` clause is used to prevent a switch section from executing when the value of a switch expression is `null`. 
 
  The following example defines a base `Shape` class, a `Rectangle` class that derives from `Shape`, and a `Square` class that derives from `Rectangle`. It uses the `when` clause to ensure that the `ShowShapeInfo` treats a `Rectangle` object that has been assigned equal lengths and widths as a `Square` even if is has not been instantiated as a `Square` object. The method does not attempt to display information either about an object that is `null` or a shape whose area is zero. 
 
@@ -194,7 +194,4 @@ Note that the `when` clause in the example that attempts to test whether a `Shap
  [C# Programming Guide](../../programming-guide/index.md)   
  [C# Keywords](index.md)   
  [if-else](if-else.md)   
- [Pattern Matching](../../pattern-matching.md)   
- 
-
- 
+ [Pattern Matching](../../pattern-matching.md)


### PR DESCRIPTION
From the C# spec available on GitHub:

1. The switch statement selects for execution a statement list having an associated switch label that corresponds to the value of the switch expression.

2. A switch_statement consists of the keyword switch, followed by a parenthesized expression (called the switch expression)

Source: https://github.com/dotnet/csharplang/blob/master/spec/statements.md#the-switch-statement