### PR TITLE
289210 Description says "gets or sets" but this property only has a get

### DIFF
--- a/xml/System.Net.Mail/MailMessage.xml
+++ b/xml/System.Net.Mail/MailMessage.xml
@@ -1022,7 +1022,7 @@
         <ReturnType>System.Net.Mail.MailAddressCollection</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets or sets the list of addresses to reply to for the mail message.</summary>
+        <summary>Gets the list of addresses to reply to for the mail message.</summary>
         <value>The list of the addresses to reply to for the mail message.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  


### PR DESCRIPTION
289210 Description says "gets or sets" but this property only has a get
Developers can add to the list, but can't set the list itself.  The underlying property is just has a getter.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
