### PR TITLE
Fixing obsolete message.

### DIFF
--- a/xml/System.Net.Mail/SmtpClient.xml
+++ b/xml/System.Net.Mail/SmtpClient.xml
@@ -23,11 +23,6 @@
       <InterfaceName>System.IDisposable</InterfaceName>
     </Interface>
   </Interfaces>
-  <Attributes>
-    <Attribute>
-      <AttributeName>System.Obsolete("SmtpClient and its network of types are poorly designed, we strongly recommend you use https://github.com/jstedfast/MailKit and https://github.com/jstedfast/MimeKit instead")</AttributeName>
-    </Attribute>
-  </Attributes>
   <Docs>
     <summary>Allows applications to send e-mail by using the Simple Mail Transfer Protocol (SMTP).</summary>
     <remarks>


### PR DESCRIPTION
This API is not obsolete. Removing the "obsolete" attribute.

The docs were not correct, at least in terms of .NET Framework. We believe that the comment went into the docs w.r.t .NET Core.