### PR TITLE
287073 Fix typo in code sample

### DIFF
--- a/docs/framework/network-programming/asynchronous-server-socket-example.md
+++ b/docs/framework/network-programming/asynchronous-server-socket-example.md
@@ -57,12 +57,12 @@ Public Class AsynchronousSocketListener
         Dim bytes() As Byte = New [Byte](1023) {}  
   
         ' Establish the local endpoint for the socket.  
-        Dim ipHostInfo As IPHostEntry = Dns.Resolve(Dns.GetHostName())  
+        Dim ipHostInfo As IPHostEntry = Dns.GetHostEntry(Dns.GetHostName())  
         Dim ipAddress As IPAddress = ipHostInfo.AddressList(0)  
         Dim localEndPoint As New IPEndPoint(ipAddress, 11000)  
   
         ' Create a TCP/IP socket.  
-        Dim listener As New Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)  
+        Dim listener As New Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp)  
   
         ' Bind the socket to the local endpoint and listen for incoming connections.  
         listener.Bind(localEndPoint)  
@@ -181,12 +181,12 @@ public class AsynchronousSocketListener {
         // Establish the local endpoint for the socket.  
         // The DNS name of the computer  
         // running the listener is "host.contoso.com".  
-        IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName());  
+        IPHostEntry ipHostInfo = Dns.GetHostEntry(Dns.GetHostName());  
         IPAddress ipAddress = ipHostInfo.AddressList[0];  
         IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 11000);  
   
         // Create a TCP/IP socket.  
-        Socket listener = new Socket(AddressFamily.InterNetwork,  
+        Socket listener = new Socket(ipAddress.AddressFamily,  
             SocketType.Stream, ProtocolType.Tcp );  
   
         // Bind the socket to the local endpoint and listen for incoming connections.  


### PR DESCRIPTION
The code sample uses obsolete Dns.Resolve() which I switched to 
IPHostEntry ipHostInfo = Dns.GetHostEntry(Dns.GetHostName()); and updated 
Socket sender = new Socket(ipAddress.AddressFamily, to not specify IPv4 (!)

see also:
https://github.com/dotnet/docs/pull/3511
https://github.com/dotnet/docs/pull/3512 
https://github.com/dotnet/docs/pull/3513

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
