### PR TITLE
287159 Code sample makes no sense

### DIFF
--- a/docs/framework/network-programming/listening-with-sockets.md
+++ b/docs/framework/network-programming/listening-with-sockets.md
@@ -48,11 +48,15 @@ IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 11000);
  After the local endpoint is determined, the <xref:System.Net.Sockets.Socket> must be associated with that endpoint using the <xref:System.Net.Sockets.Socket.Bind%2A> method and set to listen on the endpoint using the <xref:System.Net.Sockets.Socket.Listen%2A> method. **Bind** throws an exception if the specific address and port combination is already in use. The following example demonstrates associating a **Socket** with an **IPEndPoint**.  
   
 ```vb  
+Dim listener As New Socket(ipAddress.AddressFamily, _  
+    SocketType.Stream, ProtocolType.Tcp) 
 listener.Bind(localEndPoint)  
 listener.Listen(100)  
 ```  
   
 ```csharp  
+Socket listener = new Socket(ipAddress.AddressFamily,
+    SocketType.Stream, ProtocolType.Tcp);
 listener.Bind(localEndPoint);  
 listener.Listen(100);  
 ```  


### PR DESCRIPTION
Fixed the specific issue, which is that the listener wasn't declared.  Used code from the full sample.

# Title
Updated C# and VB sample code to declare the listener

## Summary

User complained that the code didn't make sense because the listener was not declared.  Fixed by declaring the listener.

Fixes #287159



## Details



## Suggested Reviewers

If you know who should review this, use '@' to request a review.
