### PR TITLE
Fixed Server Core support in .NET system requirements

### DIFF
--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -82,7 +82,9 @@ The .NET Framework requires administrator privileges for installation. If you do
 
 - [!INCLUDE[winserver8](../../../includes/winserver8-md.md)] includes the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)], so you don't have to install it separately. Similarly, [!INCLUDE[winblue_server_2](../../../includes/winblue-server-2-md.md)] includes the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)].
 
-- The .NET Framework is supported in the Server Core Role with Windows Server 2008 R2 SP1 or later but isn't supported on Windows Server 2008 R2 for Itanium-Based Systems.
+- The .NET Framework has limited for the Server Core Role with Windows Server 2008 R2 SP1 or later. Here is a list of unsupported APIs: https://msdn.microsoft.com/en-us/library/ee391632.aspx
+
+- The .NET Framework isn't supported on Windows Server 2008 R2 for Itanium-Based Systems.
 
 - On Windows Server 2008 SP2, the .NET Framework is not supported in the Server Core Role.
 

--- a/docs/framework/get-started/system-requirements.md
+++ b/docs/framework/get-started/system-requirements.md
@@ -82,7 +82,7 @@ The .NET Framework requires administrator privileges for installation. If you do
 
 - [!INCLUDE[winserver8](../../../includes/winserver8-md.md)] includes the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)], so you don't have to install it separately. Similarly, [!INCLUDE[winblue_server_2](../../../includes/winblue-server-2-md.md)] includes the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)].
 
-- The .NET Framework has limited for the Server Core Role with Windows Server 2008 R2 SP1 or later. Here is a list of unsupported APIs: https://msdn.microsoft.com/en-us/library/ee391632.aspx
+- The .NET Framework has limited support for the Server Core Role with Windows Server 2008 R2 SP1 or later. See [Server Core .NET Functionality](https://msdn.microsoft.com/library/ee391632.aspx) for a list of unsupported APIs.
 
 - The .NET Framework isn't supported on Windows Server 2008 R2 for Itanium-Based Systems.
 


### PR DESCRIPTION
Added a link to the unsupported APIs in ServerCore and more specifically explained .NET server core support. Does the linked page need to be somewhere other than MSDN?

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
