### PR TITLE
286557 Bug in sample code

### DIFF
--- a/xml/System.Net.Sockets/ProtocolType.xml
+++ b/xml/System.Net.Sockets/ProtocolType.xml
@@ -27,14 +27,7 @@
 ## Remarks  
  The <xref:System.Net.Sockets.Socket> class uses the <xref:System.Net.Sockets.ProtocolType> enumeration to inform the Windows Sockets API of the requested protocol. Low-level driver software for the requested protocol must be present on the computer for the <xref:System.Net.Sockets.Socket> to be created successfully.  
   
-   
-  
-## Examples  
- The following example demonstrates how to use <xref:System.Net.Sockets.ProtocolType> to instantiate a <xref:System.Net.Sockets.Socket>.  
-  
- [!code-cpp[Socket_Send_Recieve#1](~/samples/snippets/cpp/VS_Snippets_Remoting/Socket_Send_Recieve/CPP/source.cpp#1)]
- [!code-csharp[Socket_Send_Recieve#1](~/samples/snippets/csharp/VS_Snippets_Remoting/Socket_Send_Recieve/CS/source.cs#1)]
- [!code-vb[Socket_Send_Recieve#1](~/samples/snippets/visualbasic/VS_Snippets_Remoting/Socket_Send_Recieve/VB/source.vb#1)]  
+
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
The sample code here is totally unneeded.  The protocol is a pretty trivial enum; it's not the place for creating an entire sample.
In addition, the sample has multiple problems:
- the code hardly uses the Protocol enum at all
- the code incorrectly doesn't actually read from most connections
- the code incorrectly requires IPv4

# Title

Removed an entire unneeded sample

## Summary

No sample is needed for this simple enum

Fixes #286557



## Details



## Suggested Reviewers

If you know who should review this, use '@' to request a review.
