### PR TITLE
Make restriction more prominent

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/variables/local-type-inference.md
+++ b/docs/visual-basic/programming-guide/language-features/variables/local-type-inference.md
@@ -28,10 +28,13 @@ ms.author: dotnetcontent
 The Visual Basic compiler uses *type inference* to determine the data types of local variables declared without an `As` clause. The compiler infers the type of the variable from the type of the initialization expression. This enables you to declare variables without explicitly stating a type, as shown in the following example. As a result of the declarations, both `num1` and `num2` are strongly typed as integers.  
   
  [!code-vb[VbVbalrTypeInference#1](../../../../visual-basic/language-reference/statements/codesnippet/VisualBasic/local-type-inference_1.vb)]  
-  
+ 
 > [!NOTE]
 >  If you do not want `num2` in the previous example to be typed as an `Integer`, you can specify another type by using a declaration like `Dim num3 As Object = 3` or `Dim num4 As Double = 3`.  
-  
+
+> [!NOTE]
+>  Type inference can be used only for non-static local variables; it cannot be used to determine the type of class fields, properties, or functions.
+ 
  Local type inference applies at procedure level. It cannot be used to declare variables at module level (within a class, structure, module, or interface but not within a procedure or block). If `num2` in the previous example were a field of a class instead of a local variable in a procedure, the declaration would cause an error with `Option Strict` on, and would classify `num2` as an `Object` with `Option Strict` off. Similarly, local type inference does not apply to procedure level variables declared as `Static`.  
   
 ## Type Inference vs. Late Binding  
@@ -72,9 +75,6 @@ The Visual Basic compiler uses *type inference* to determine the data types of l
  If the value set for `Option Infer` in a file conflicts with the value set in the IDE or on the command line, the value in the file has precedence.  
   
  For more information, see [Option Infer Statement](../../../../visual-basic/language-reference/statements/option-infer-statement.md) and [Compile Page, Project Designer (Visual Basic)](/visualstudio/ide/reference/compile-page-project-designer-visual-basic).  
-  
-## Restrictions  
- Type inference can be used only for non-static local variables; it cannot be used to determine the type of class fields, properties, or functions.  
   
 ## See Also  
  [Anonymous Types](../../../../visual-basic/programming-guide/language-features/objects-and-classes/anonymous-types.md)   


### PR DESCRIPTION
# Title

Make restriction note more prominent

## Summary

Propose moving the type inference restriction higher on the page.

## Details

Moved type inference restriction to top and include in a note window. This is something that can slip past compilers and cause run-time errors, thus should be more important than a footnote.

## Suggested Reviewers
