### PR TITLE
fix architecture landing page

### DIFF
--- a/docs/standard/guidance-architecture.md
+++ b/docs/standard/guidance-architecture.md
@@ -14,6 +14,10 @@ ms.technology: dotnet
 
 This guide is an introduction to the recommended end to end lifecycle processes you'll use to develop, validate, and deploy containerized Docker applications using Visual Studio and Microsoft Azure.
 
+## [Architect modern web applications with ASP.NET Core and Azure](modern-web-apps-azure-architecture/index.md)
+
+This guide is an introduction to the recommended architecture, design, and deployment processes you'll use to build ASP.NET and ASP.NET Core applications and host those applications in Azure.
+
 ## [Architecting Container and Microservice Based Applications](microservices-architecture/index.md)
 
 This guide is an introduction to developing microservices-based applications and managing them using containers. It discusses architectural design and implementation approaches using .NET Core and Docker containers. 


### PR DESCRIPTION
The landing page for the architectural guides did not include the latest eBook, with guidance for ASP.NET and ASP.NET Core application hosted in azure. This PR fixes that.

