### PR TITLE
286553 Return value description is incorrect

### DIFF
--- a/xml/System.Net.Sockets/UdpClient.xml
+++ b/xml/System.Net.Sockets/UdpClient.xml
@@ -1334,7 +1334,7 @@
         <param name="asyncResult">An <see cref="T:System.IAsyncResult" /> object returned by a call to <see cref="M:System.Net.Sockets.UdpClient.BeginReceive(System.AsyncCallback,System.Object)" />.</param>
         <param name="remoteEP">The specified remote endpoint.</param>
         <summary>Ends a pending asynchronous receive.</summary>
-        <returns>If successful, the number of bytes received. If unsuccessful, this method returns 0.</returns>
+        <returns>If successful, an array of bytes that contains datagram data.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
The EndReceive will either return an array or throw.

# Title

Updated the return value. The old text had boilerplate about returning an integer

## Summary

The actual value is like the Receive call

Fixes #286553

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

@davidsh 
