### PR TITLE
Fix ServiceBase xref in migration-docs

### DIFF
--- a/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md
+++ b/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md
@@ -2,7 +2,7 @@
 
 |   |   |
 |---|---|
-|Details|In the .NET Framework 4.7 and earlier versions, exceptions thrown on service startup are not propagated to the caller of <xref:System.ServiceProcess.ServiceBase.Run?displayProperty=nameWithType>.Starting with applications that target the .NET Framework 4.7.1, the runtime propagates exceptions to <xref:System.ServiceProcess.ServiceBase.Run?displayProperty=nameWithType> for services that fail to start.|
+|Details|In the .NET Framework 4.7 and earlier versions, exceptions thrown on service startup are not propagated to the caller of <xref:System.ServiceProcess.ServiceBase.Run%2A?displayProperty=nameWithType>.Starting with applications that target the .NET Framework 4.7.1, the runtime propagates exceptions to <xref:System.ServiceProcess.ServiceBase.Run%2A?displayProperty=nameWithType> for services that fail to start.|
 |Suggestion|On service start, if there is an exception, that exception will be propagated. This should help diagnose cases where services fail to start.If this behavior is undesirable, you can opt out of it by adding the following <AppContextSwitchOverrides> element to the <runtime> section of your application configuration file:<pre><code>&lt;AppContextSwitchOverrides value=&quot;Switch.System.ServiceProcess.DontThrowExceptionsOnStart=true&quot; /&gt;&#13;&#10;</code></pre>If your application targets an earlier version than 4.7.1 but you want to have this behavior, add the following <AppContextSwitchOverrides> element to the <runtime> section of your application configuration file:<pre><code>&lt;AppContextSwitchOverrides value=&quot;Switch.System.ServiceProcess.DontThrowExceptionsOnStart=false&quot; /&gt;&#13;&#10;</code></pre>|
 |Scope|Minor|
 |Version|4.7.1|


### PR DESCRIPTION
# Fixes ServiceBase cross-reference

Integrates the fixes from https://github.com/Microsoft/dotnet/pull/545.

## Suggested Reviewers

@rpetrusha 
