### PR TITLE
Removed duplicated "must be" phrase

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-model-layer-validations.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-model-layer-validations.md
@@ -13,7 +13,7 @@ ms.topic: article
 
 In DDD, validation rules can be thought as invariants. The main responsibility of an aggregate is to enforce invariants across state changes for all the entities within that aggregate.
 
-Domain entities should always be valid entities. There are a certain number of invariants for an object that should always be true. For example, an order item object always has to have a quantity that must be must be a positive integer, plus an article name and price. Therefore, invariants enforcement is the responsibility of the domain entities (especially of the aggregate root) and an entity object should not be able to exist without being valid. Invariant rules are simply expressed as contracts, and exceptions or notifications are raised when they are violated.
+Domain entities should always be valid entities. There are a certain number of invariants for an object that should always be true. For example, an order item object always has to have a quantity that must be a positive integer, plus an article name and price. Therefore, invariants enforcement is the responsibility of the domain entities (especially of the aggregate root) and an entity object should not be able to exist without being valid. Invariant rules are simply expressed as contracts, and exceptions or notifications are raised when they are violated.
 
 The reasoning behind this is that many bugs occur because objects are in a state they should never have been in. The following is a good explanation from Greg Young in an [online discussion](http://jeffreypalermo.com/blog/the-fallacy-of-the-always-valid-entity/):
 


### PR DESCRIPTION
# Removed duplicated "must be" phrase

## Just a small fix for the typo.
