### PR TITLE
Small update for outdated and wrong title in TOC within Microservices online eBook

### DIFF
--- a/docs/standard/microservices-architecture/toc.md
+++ b/docs/standard/microservices-architecture/toc.md
@@ -20,7 +20,7 @@
 ### [Challenges and solutions for distributed data management](architect-microservice-container-applications/distributed-data-management.md)
 ### [Identifying domain-model boundaries for each microservice](architect-microservice-container-applications/identify-microservice-domain-model-boundaries.md)
 ### [Direct client-to-microservice communication versus the API Gateway pattern](architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md)
-### [Communication between microservices](architect-microservice-container-applications/communication-in-microservice-architecture.md)
+### [Communication in a microservice architecture](architect-microservice-container-applications/communication-in-microservice-architecture.md)
 ### [Asynchronous message-based communication](architect-microservice-container-applications/asynchronous-message-based-communication.md)
 ### [Creating, evolving, and versioning microservice APIs and contracts](architect-microservice-container-applications/maintain-microservice-apis.md)
 ### [Microservices addressability and the service registry](architect-microservice-container-applications/microservices-addressability-service-registry.md)


### PR DESCRIPTION
# Title
Small update for outdated and wrong title in TOC within Microservices online eBook

## Summary
The title at the TOC was not changed so it doesn't match the title at the page itself.
Now it matches right.

## Suggested Reviewers

Maira or Bill Wagner
