### PR TITLE
fix inconsistent modifiers declaration order

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.RSACryptoServiceProvider/CS/sample.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.Security.Cryptography.RSACryptoServiceProvider/CS/sample.cs
@@ -46,7 +46,7 @@ class RSACSPSample
         }
     }
 
-    static public byte[] RSAEncrypt(byte[] DataToEncrypt, RSAParameters RSAKeyInfo, bool DoOAEPPadding)
+    public static byte[] RSAEncrypt(byte[] DataToEncrypt, RSAParameters RSAKeyInfo, bool DoOAEPPadding)
     {
         try
         {
@@ -77,7 +77,7 @@ class RSACSPSample
 
     }
 
-    static public byte[] RSADecrypt(byte[] DataToDecrypt, RSAParameters RSAKeyInfo, bool DoOAEPPadding)
+    public static byte[] RSADecrypt(byte[] DataToDecrypt, RSAParameters RSAKeyInfo, bool DoOAEPPadding)
     {
         try
         {


### PR DESCRIPTION

# Title
fix inconsistent modifiers declaration order for RSACryptServiceProvider sample


## Summary
use “public static” instead of "static public"
