### PR TITLE
Added Try/Finally pattern when locking the back buffer

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Wpf/WriteableBitmap2/CS/Program.cs
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/WriteableBitmap2/CS/Program.cs
@@ -59,32 +59,35 @@ namespace WriteableBitmapDemo
             int column = (int)e.GetPosition(i).X;
             int row = (int)e.GetPosition(i).Y;
 
-            // Reserve the back buffer for updates.
-            writeableBitmap.Lock();
+            try{
+                // Reserve the back buffer for updates.
+                writeableBitmap.Lock();
 
-            unsafe
-            {
-                // Get a pointer to the back buffer.
-                int pBackBuffer = (int)writeableBitmap.BackBuffer;
+                unsafe
+                {
+                    // Get a pointer to the back buffer.
+                    int pBackBuffer = (int)writeableBitmap.BackBuffer;
 
-                // Find the address of the pixel to draw.
-                pBackBuffer += row * writeableBitmap.BackBufferStride;
-                pBackBuffer += column * 4;
+                    // Find the address of the pixel to draw.
+                    pBackBuffer += row * writeableBitmap.BackBufferStride;
+                    pBackBuffer += column * 4;
 
-                // Compute the pixel's color.
-                int color_data = 255 << 16; // R
-                color_data |= 128 << 8;   // G
-                color_data |= 255 << 0;   // B
+                    // Compute the pixel's color.
+                    int color_data = 255 << 16; // R
+                    color_data |= 128 << 8;   // G
+                    color_data |= 255 << 0;   // B
 
-                // Assign the color data to the pixel.
-                *((int*) pBackBuffer) = color_data;
+                    // Assign the color data to the pixel.
+                    *((int*) pBackBuffer) = color_data;
+                }
+    
+                // Specify the area of the bitmap that changed.
+                writeableBitmap.AddDirtyRect(new Int32Rect(column, row, 1, 1));
             }
-
-            // Specify the area of the bitmap that changed.
-            writeableBitmap.AddDirtyRect(new Int32Rect(column, row, 1, 1));
-
-            // Release the back buffer and make it available for display.
-            writeableBitmap.Unlock();
+            finally{
+                // Release the back buffer and make it available for display.
+                writeableBitmap.Unlock();
+            }
         }
         // </snippet2>
 


### PR DESCRIPTION
# Added Try/Finally pattern when locking the back buffer

## Summary

i noted that the lock and unlock has no safety associated with it and you could fall into having a locked backbuffer without ever releasing it. Simply added try/finally to the sample to make it more compl


## Details

Just encouraging try/finally pattern when locks are involved.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
