### PR TITLE
L4295: Incorrect link structure

### DIFF
--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -186,7 +186,7 @@ Starting with C# 7, because case statements need not be mutually exclusive, you 
 Note that the `when` clause in the example that attempts to test whether a `Shape` object is `null` does not execute. The correct type pattern to test for a `null` is `case null:`.
 
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+ [!INCLUDE[CSharplangspec](../../../../includes/csharplangspec-md.md)]  
   
 ## See Also  
 


### PR DESCRIPTION
Hello, @BillWagner, 
Loc engineers have reported source technical issue that cause broken format for target versions. The struture of reported like should be as proposed.
 
Please, check this and help to merge if agreed. 

Many thanks in advance.

