### PR TITLE
Fix some typos in dotnet CLI documentation

### DIFF
--- a/docs/core/tools/dotnet-migrate.md
+++ b/docs/core/tools/dotnet-migrate.md
@@ -33,7 +33,7 @@ Migration is performed on the following:
 * A *solution.sln* file, where it migrates the projects referenced in the solution.
 * On all sub-directories of the given directory recursively.
 
-The `dotnet migrate` command keeps the migrated *project.json* file inside a `backup` directory, which it creates if the directory doesn't exist. This behavior is overriden using the `--skip-backup` option.
+The `dotnet migrate` command keeps the migrated *project.json* file inside a `backup` directory, which it creates if the directory doesn't exist. This behavior is overridden using the `--skip-backup` option.
 
 By default, the migration operation outputs the state of the migration process to standard output (STDOUT). If you use the `--report-file <REPORT_FILE>` option, the output is saved to the file specify. 
 

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -90,7 +90,7 @@ If a relative path is provided, the output directory generated is relative to th
 
 `--self-contained`
 
-Publishes the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine. If a runtime identifier is specified, its default value is `true`. For more infomation about the different deployment types, see [.NET Core application deployment](../deploying/index.md).
+Publishes the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine. If a runtime identifier is specified, its default value is `true`. For more information about the different deployment types, see [.NET Core application deployment](../deploying/index.md).
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -206,7 +206,7 @@ Expressions can be joined with conditional operators:
 | <code>&#124;</code>      | OR       |
 | `&`      | AND      |
 
-You can enclose expressions in paranthesis when using conditional operators (for example, `(Name~TestMethod1) | (Name~TestMethod2)`).
+You can enclose expressions in parenthesis when using conditional operators (for example, `(Name~TestMethod1) | (Name~TestMethod2)`).
 
 For additional information and examples on how to use selective unit test filtering, see [Running selective unit tests](../testing/selective-unit-tests.md).
 

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -42,7 +42,7 @@ The only time `dotnet` is used as a command on its own is to run [framework-depe
 
 `--additionaldeps <PATH>`
 
-Path to additonal *deps.json* file.
+Path to additional *deps.json* file.
 
 `--additionalprobingpath <PATH>`
 


### PR DESCRIPTION
Fix some typos in dotnet CLI documentation

PS: Should be squashed when merged