### PR TITLE
Fix some typos in the C# language-related docs

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -169,7 +169,7 @@ private async void SeeTheDotNets_Click(object sender, RoutedEventArgs e)
 
 ### Waiting for Multiple Tasks to Complete
 
-You may find yourself in a situation where you need to retrieve multiple pieces of data concurrently.  The `Task` API contains two methods, `Task.WhenAll` and `Task.WhenAny` which allow you to write asynchronous code which performs a non-blocking wait on mulitple background jobs.
+You may find yourself in a situation where you need to retrieve multiple pieces of data concurrently.  The `Task` API contains two methods, `Task.WhenAll` and `Task.WhenAny` which allow you to write asynchronous code which performs a non-blocking wait on multiple background jobs.
 
 This example shows how you might grab `User` data for a set of `userId`s.
 

--- a/docs/csharp/language-reference/compiler-messages/cs0592.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0592.md
@@ -17,7 +17,7 @@ ms.author: "wiwagn"
 # Compiler Error CS0592
 Attribute 'attribute' is not valid on this declaration type. It is valid on 'type' declarations only.  
   
- When you define an attribute, you define what constructs it can be applied to by specifying an `AttributeTargets` value. In the following example, the `MyAttribute` attribute can be applied to interfaces only, because the `AttributeUsage` attribute specifies `AttributeTargets.Iterface`. The error is generated because the attribute is applied to a class (class `A`).  
+ When you define an attribute, you define what constructs it can be applied to by specifying an `AttributeTargets` value. In the following example, the `MyAttribute` attribute can be applied to interfaces only, because the `AttributeUsage` attribute specifies `AttributeTargets.Interface`. The error is generated because the attribute is applied to a class (class `A`).  
   
 ## Example  
  The following sample generates CS0592:  

--- a/docs/csharp/language-reference/compiler-messages/cs1640.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1640.md
@@ -53,7 +53,7 @@ public class Test
     {  
         foreach (int i in new C()){}    // CS1640  
   
-        // Try specifing the type of IEnumerable<T>  
+        // Try specifying the type of IEnumerable<T>  
         // foreach (int i in (IEnumerable<int>)new C()){}  
         return 1;  
     }  

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -81,7 +81,7 @@ This requirement is usually met by explicitly exiting the switch section by usin
 
 ## Case labels
 
- Each case label specifies a pattern to compare to the match expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the match expression, control is transfered to the section with the `default` case label, if there is one. If there is no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
+ Each case label specifies a pattern to compare to the match expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the match expression, control is transferred to the section with the `default` case label, if there is one. If there is no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
 
  For information on the `switch` statement and pattern matching, see the [Pattern matching with the `switch` statement](#pattern) section.
 

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -86,7 +86,7 @@ In addition to the members that are explicitly defined in a type, a type inherit
 
 [!code-csharp[csSnippets.Methods#104](../../samples/snippets/csharp/concepts/methods/inherited1.cs#104)]
 
-Types can override inherited members by using the `override` keyword and providing an implementation for the overridden method. The method signature must be the same as that of the overriden method. The following example is like the previous one, except that it overrides the <xref:System.Object.Equals(System.Object)> method. (It also overrides the <xref:System.Object.GetHashCode> method, since the two methods are intended to provide consistent results.)
+Types can override inherited members by using the `override` keyword and providing an implementation for the overridden method. The method signature must be the same as that of the overridden method. The following example is like the previous one, except that it overrides the <xref:System.Object.Equals(System.Object)> method. (It also overrides the <xref:System.Object.GetHashCode> method, since the two methods are intended to provide consistent results.)
 
 [!code-csharp[csSnippets.Methods#105](../../samples/snippets/csharp/concepts/methods/overridden1.cs#105)]
 

--- a/docs/csharp/tour-of-csharp/arrays.md
+++ b/docs/csharp/tour-of-csharp/arrays.md
@@ -1,6 +1,6 @@
 ---
 title: C# Arrays - A tour of the C# language
-description: Arrays are the most basic collection type in the C# langauge
+description: Arrays are the most basic collection type in the C# language
 keywords: .NET, csharp, array, collection
 author: BillWagner
 ms.author: wiwagn

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -134,7 +134,7 @@ and `explicitFieldTwo`, not `localVariableOne` and `localVariableTwo`:
 
 For any field where an explicit name is not provided, an applicable implicit
 name will be projected. Note that there is no requirement to provide semantic names,
-either explicitly or implicitly. The folowing initializer will have field
+either explicitly or implicitly. The following initializer will have field
 names `Item1`, whose value is `42` and `StringContent`, whose value is "The answer to everything":
 
 [!code-csharp[MixedTuple](../../samples/snippets/csharp/tuples/tuples/program.cs#MixedTuple "mixed tuple")]

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -25,7 +25,7 @@ major features added in each release.
     - This page describes the latest features in the C# language. This covers C# 7.1, currently available in [Visual Studio 2017 version 15.3](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 
 * [C# 7](csharp-7.md):
-    - This page describes the features added in C# 7. Theses were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
+    - This page describes the features added in C# 7. These were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
      
 * [C# 6](csharp-6.md):
     - This page describes the features that were added in C# 6. These features are available in Visual Studio 2015 for Windows developers, and on .NET Core 1.0 for developers exploring C# on macOS and Linux.


### PR DESCRIPTION
Fix some typos in the C# language-related docs

PS: These could probably be squashed in a single commit on merge