### PR TITLE
Fix some typos in the F# docs

### DIFF
--- a/docs/fsharp/language-reference/flexible-types.md
+++ b/docs/fsharp/language-reference/flexible-types.md
@@ -1,6 +1,6 @@
 ---
 title: Flexible Types (F#)
-description: Learn how to use F# flexible type annotation, which indicates that a parameter, variable, or value has a type that is compatible with a specifed type.
+description: Learn how to use F# flexible type annotation, which indicates that a parameter, variable, or value has a type that is compatible with a specified type.
 keywords: visual f#, f#, functional programming
 author: cartermp
 ms.author: phcart
@@ -14,7 +14,7 @@ ms.assetid: c8b510f2-3405-4cc9-b55b-e47b35e2b15b
 
 # Flexible Types
 
-A *flexible type annotation* indicates that a parameter, variable, or value has a type that is compatible with a specifed type, where compatibility is determined by position in an object-oriented hierarchy of classes or interfaces. Flexible types are useful specifically when the automatic conversion to types higher in the type hierarchy does not occur but you still want to enable your functionality to work with any type in the hierarchy or any type that implements an interface.
+A *flexible type annotation* indicates that a parameter, variable, or value has a type that is compatible with a specified type, where compatibility is determined by position in an object-oriented hierarchy of classes or interfaces. Flexible types are useful specifically when the automatic conversion to types higher in the type hierarchy does not occur but you still want to enable your functionality to work with any type in the hierarchy or any type that implements an interface.
 
 ## Syntax
 

--- a/docs/fsharp/language-reference/results.md
+++ b/docs/fsharp/language-reference/results.md
@@ -42,7 +42,7 @@ type Request =
 
 // Define some logic for what defines a valid name.
 //
-// Generates a Result which is an Ok if the name valides;
+// Generates a Result which is an Ok if the name validates;
 // otherwise, it generates a Result which is an Error.
 let validateName req =
     match req.Name with

--- a/docs/fsharp/language-reference/results.md
+++ b/docs/fsharp/language-reference/results.md
@@ -42,7 +42,7 @@ type Request =
 
 // Define some logic for what defines a valid name.
 //
-// Generates a Result wich is an Ok if the name valides;
+// Generates a Result which is an Ok if the name valides;
 // otherwise, it generates a Result which is an Error.
 let validateName req =
     match req.Name with
@@ -51,7 +51,7 @@ let validateName req =
     | "bananas" -> Error "Bananas is not a name."
     | _ -> Ok req
 
-// Similarily, define some email validation logic.
+// Similarly, define some email validation logic.
 let validateEmail req =
     match req.Email with
     | null -> Error "No email found."

--- a/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
+++ b/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
@@ -622,7 +622,7 @@ methodName = "Match",
 parameters = [ProvidedParameter("input", typeof<string>)], 
 returnType = matchTy, 
 InvokeCode = fun args -> <@@ ((%%args.[0]:obj) :?> Regex).Match(%%args.[1]) :> obj @@>)
-matchMeth.AddXmlDoc "Searches the specified input string for the first occurrence of this regular expression" 
+matchMeth.AddXmlDoc "Searches the specified input string for the first ocurrence of this regular expression" 
 
 ty.AddMember matchMeth
 ```

--- a/samples/snippets/fsharp/azure/table-storage.fsx
+++ b/samples/snippets/fsharp/azure/table-storage.fsx
@@ -71,7 +71,7 @@ batchOp.Insert(customer2)
 table.ExecuteBatch(batchOp)
 
 //
-// Retreive all entities in a partition.
+// Retrieve all entities in a partition.
 //
 
 let query =

--- a/samples/snippets/fsharp/lang-ref-1/snippet2901.fs
+++ b/samples/snippets/fsharp/lang-ref-1/snippet2901.fs
@@ -17,7 +17,7 @@ type Shape2D(x0 : float, y0 : float) =
     abstract Name : string with get
 
     // This method is not declared abstract. It cannot be
-    // overriden.
+    // overridden.
     member this.Move dx dy =
        x <- x + dx
        y <- y + dy


### PR DESCRIPTION
Fix some typos in the F# docs

PS: These should probably be squashed