### PR TITLE
Update retrieving-binary-data.md

### DIFF
--- a/docs/framework/data/adonet/retrieving-binary-data.md
+++ b/docs/framework/data/adonet/retrieving-binary-data.md
@@ -146,7 +146,7 @@ while (reader.Read())
   }  
   
   // Write the remaining buffer.  
-  writer.Write(outByte, 0, (int)retval - 1);  
+  writer.Write(outByte, 0, (int)retval);  
   writer.Flush();  
   
   // Close the output file.  


### PR DESCRIPTION


# Title

Small bug fix

## Summary

the retval-1 in the final write is a bug.

## Details

the retval-1 in the final write is a bug.  Simple demonstration is if there is 1 byte remaining that was read, 0 bytes are then written, truncating the data.

