### PR TITLE
Update type-naming guidelines

### DIFF
--- a/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
+++ b/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
@@ -78,10 +78,10 @@ public interface ISessionChannel<TSession> where TSession : ISession{
   
 |Base Type|Derived/Implementing Type Guideline|  
 |---------------|------------------------------------------|  
-|`System.Attribute`|**✓ DO** add the suffix "Attribute" to names of custom attribute classes. add the suffix "Attribute" to names of custom attribute classes.|  
+|`System.Attribute`|**✓ DO** add the suffix "Attribute" to names of custom attribute classes.|  
 |`System.Delegate`|**✓ DO** add the suffix "EventHandler" to names of delegates that are used in events.<br /><br /> **✓ DO** add the suffix "Callback" to names of delegates other than those used as event handlers.<br /><br /> **X DO NOT** add the suffix "Delegate" to a delegate.|  
 |`System.EventArgs`|**✓ DO** add the suffix "EventArgs."|  
-|`System.Enum`|**X DO NOT** derive from this class; use the keyword supported by your language instead; for example, in C#, use the enum keyword.<br /><br /> **X DO NOT** add the suffix "Enum" or "Flag."|  
+|`System.Enum`|**X DO NOT** derive from this class; use the keyword supported by your language instead; for example, in C#, use the `enum` keyword.<br /><br /> **X DO NOT** add the suffix "Enum" or "Flag."|  
 |`System.Exception`|**✓ DO** add the suffix "Exception."|  
 |`IDictionary` <br /> `IDictionary<TKey,TValue>`|**✓ DO** add the suffix "Dictionary." Note that `IDictionary` is a specific type of collection, but this guideline takes precedence over the more general collections guideline that follows.|  
 |`IEnumerable` <br /> `ICollection` <br /> `IList` <br /> `IEnumerable<T>` <br /> `ICollection<T>` <br /> `IList<T>`|**✓ DO** add the suffix "Collection."|  


### PR DESCRIPTION
Changes the following bits:
* Remove duplicate phrase
* Highlight 'enum' as a keyword