### PR TITLE
Fix malformed mailSettings XML snippet

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/mailsettings-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/mailsettings-element-network-settings.md
@@ -31,9 +31,9 @@ Configures mail sending options.
 ## Syntax  
   
 ```xml  
-      <mailSettings  
+<mailSettings>
   <smtp> … </smtp>  
-/mailsettings>  
+</mailSettings>
 ```  
   
 ## Attributes and Elements  


### PR DESCRIPTION
Address a malformed `mailSettings` XML snippet.