### PR TITLE
Update lambda vs local func

### DIFF
--- a/docs/csharp/local-functions-vs-lambdas.md
+++ b/docs/csharp/local-functions-vs-lambdas.md
@@ -29,13 +29,12 @@ Contrast that implementation with a version that uses lambda expressions:
 
 The local functions have names. The lambda expressions are anonymous methods
 that are assigned to variables that are `Func` or `Action` types. When you
-declare a local function the argument types and return type are part of the 
-function declaration. The argument types and return type are part of the
-variable type declaration when you declare a lambda expression instead of
-being part of the body of the lambda expression. Those two difference may
-result in more clear code.
+declare a local function, the argument types and return type are part of the 
+function declaration. Instead of being part of the body of the lambda expression, the argument types and return type are part of the lambda
+expression's variable type declaration. Those two differences may
+result in clearer code.
 
-Second, local functions have different rules for definite assignment
+Local functions have different rules for definite assignment
 than lambda expressions. A local function declaration can be referenced
 from any code location where it is in scope. A lambda expression must be
 assigned before it can be accessed (or called through a delgate
@@ -43,7 +42,11 @@ referencing the lambda expression.) Notice that the version using the
 lambda expression must declare and initialize the lambda expression,
 `nthFactorial` before defining it. Not doing so results in a compile
 time error for referencing `nthFactorial` before assigning it.
-Recursive algorithms are easier to create using local functions.
+These differences mean that recursive algorithms are easier to create
+using local functions. You can declare and define a local function that
+calls itself. Lambda expressions must be declared, and assigned a default
+value before they can be re-assigned to a body that references the same
+lambda expression.
 
 Definite assignment rules also affect any variables that are captured
 by the local function or lamdba epression. Both local functions and
@@ -51,7 +54,7 @@ lambda expression rules demand that any captured variables are definitely
 assigned at the point when the local function or lambda expression is
 converted to a delegate. The difference is that lambda expressions are converted
 to delegates when they are declared. Local functions are converted to delegates
-only when used as a delegate. If you declare a local function, and only
+only when used as a delegate. If you declare a local function and only
 reference it by calling it like a method, it will not be converted to
 a delegate. That rule enables you to declare
 a local function at any convenient location in its enclosing scope. It's common
@@ -59,9 +62,7 @@ to declare local functions at the end of the parent method, after any return
 statements.
 
 Third, the compiler can perform static analysis that enables local functions to
-definitely assign captured variables in the enclosing scope.
-
-Consider this example:
+definitely assign captured variables in the enclosing scope. Consider this example:
 
 ```csharp
 bool M()

--- a/docs/csharp/local-functions-vs-lambdas.md
+++ b/docs/csharp/local-functions-vs-lambdas.md
@@ -45,15 +45,53 @@ lambda expression must declare and initialize the lambda expression,
 time error for referencing `nthFactorial` before assigning it.
 Recursive algorithms are easier to create using local functions.
 
-Third, for lambda expressions, the compiler must always create an anonymous class
-and an instance of that class to store any variables captured by the
-closure. Consider this async example:
+Definite assignment rules also affect any variables that are captured
+by the local function or lamdba epression. Both local functions and
+lambda expression rules demand that any captured variables are definitely
+assigned at the point when the local function or lambda expression is
+converted to a delegate. The difference is that lambda expressions are converted
+to delegates when they are declared. Local functions are converted to delegates
+only when used as a delegate. If you declare a local function, and only
+reference it by calling it like a method, it will not be converted to
+a delegate. That rule enables you to declare
+a local function at any convenient location in its enclosing scope. It's common
+to declare local functions at the end of the parent method, after any return
+statements.
+
+Third, the compiler can perform static analysis that enables local functions to
+definitely assign captured variables in the enclosing scope.
+
+Consider this example:
+
+```csharp
+bool M()
+{
+    int y;
+    Local();
+    return y;
+
+    void Local() => y = 0;
+}
+```
+
+The compiler can determine that `Local` definitely assigns `y` when called. Because `Local` is called before the `return` statement, `y` is definitiely
+assigned at the `return` statement.
+
+The analysis that enables that analysis enables the fourth difference.
+Depending on their use, local functions can avoid heap allocations that
+are always necessary for lambda expressions. If a local function is never
+converted to a delegate and none of the variables captured by a locatl function
+are converted to delegates, the compiler can avoid heap allocations. 
+
+Consider this async example:
 
 [!code-csharp[TaskLambdaExample](../../samples/snippets/csharp/new-in-7/AsyncWork.cs#36_TaskLambdaExample "Task returning method with lambda expression")]
 
 The closure for this lambda expression contains the `address`,
 `index` and `name` variables. In the case of local functions, the object
-that implements the closure may be a `struct` type. That would save on
+that implements the closure may be a `struct` type. That struct type would
+be passed by reference to the local functionn. This difference in
+implementation would save on
 an allocation.
 
 The instantiation necessary for lambda expressions means extra memory

--- a/docs/csharp/local-functions-vs-lambdas.md
+++ b/docs/csharp/local-functions-vs-lambdas.md
@@ -42,6 +42,7 @@ This recursive method is simple enough that the local function is implemented
 as a private method with a compiler generated name. Its only difference from
 other private methods is that it is semantically scoped inside the outer function.
 
+<< Phillip commented that this is unrelated to hte first item (at least as written-)>>
 Second, local functions can be called before they are defined. Lambda
 expressions must be declared before they are defined. This
 means local functions are easier to use in recursive algorithms, as shown

--- a/docs/csharp/local-functions-vs-lambdas.md
+++ b/docs/csharp/local-functions-vs-lambdas.md
@@ -13,9 +13,10 @@ ms.assetid: 368d1752-3659-489a-97b4-f15d87e49ae3
 ---
 # Local functions compared to lambda expressions
 
-At first glance, [local functions](programming-guide/classes-and-structs/local-functions.md) and [lambda expressions](lambda-expressions.md) are very similar.
-Depending on your needs, local functions may be a much better and simpler
-solution.
+At first glance, [local functions](programming-guide/classes-and-structs/local-functions.md) and [lambda expressions](lambda-expressions.md) are very similar. In many cases, the choice between using
+lambda expressions and local functions is a matter of style and personal
+preference. However, there are real differences in where you can use one or
+the other that you should be aware of.
 
 Let's examine the differences between the local function and lambda expression
 implementations of the factorial algorithm. First the version using a local function:
@@ -26,8 +27,12 @@ Contrast that implementation with a version that uses lambda expressions:
 
 [!code-csharp[26_LambdaFactorial](../../samples/snippets/csharp/new-in-7/MathUtilities.cs#38_LambdaFactorial "Recursive factorial using lambda expressions")]
 
-First, lambda expressions are implemented by instantiating a delegate
-and invoking that delegate. Local functions are implemented as method calls.
+The local functions have names. The lambda expressions are anonymous methods
+that are assigned to variables that are `Func` or `Action` types. This may
+result in more readable code. Note that the argument types and return type
+are part of the function declaration, not part of the variable declaration.
+Those two difference may result in more clear code.
+
 The instantiation necessary for lambda expressions means extra memory
 allocations, which may be a performance factor in time critical code paths.
 Local functions do not incur this overhead. In the example above, the local

--- a/docs/csharp/local-functions-vs-lambdas.md
+++ b/docs/csharp/local-functions-vs-lambdas.md
@@ -28,29 +28,21 @@ Contrast that implementation with a version that uses lambda expressions:
 [!code-csharp[26_LambdaFactorial](../../samples/snippets/csharp/new-in-7/MathUtilities.cs#38_LambdaFactorial "Recursive factorial using lambda expressions")]
 
 The local functions have names. The lambda expressions are anonymous methods
-that are assigned to variables that are `Func` or `Action` types. This may
-result in more readable code. Note that the argument types and return type
-are part of the function declaration, not part of the variable declaration.
-Those two difference may result in more clear code.
+that are assigned to variables that are `Func` or `Action` types. When you
+declare a local function the argument types and return type are part of the 
+function declaration. The argument types and return type are part of the
+variable type declaration when you declare a lambda expression instead of
+being part of the body of the lambda expression. Those two difference may
+result in more clear code.
 
-The instantiation necessary for lambda expressions means extra memory
-allocations, which may be a performance factor in time critical code paths.
-Local functions do not incur this overhead. In the example above, the local
-functions version has 2 fewer allocations than the lambda expression version.
-
-This recursive method is simple enough that the local function is implemented
-as a private method with a compiler generated name. Its only difference from
-other private methods is that it is semantically scoped inside the outer function.
-
-<< Phillip commented that this is unrelated to hte first item (at least as written-)>>
-Second, local functions can be called before they are defined. Lambda
-expressions must be declared before they are defined. This
-means local functions are easier to use in recursive algorithms, as shown
-above.
-
-Notice that the version using the lambda expression must declare and initialize
-the lambda expression, `nthFactorial` before defining it. Not doing so results
-in a compile time error for referencing `nthFactorial` before assigning it.
+Second, local functions have different rules for definite assignment
+than lambda expressions. A local function declaration can be referenced
+from any code location where it is in scope. A lambda expression must be
+assigned before it can be accessed (or called through a delgate
+referencing the lambda expression.) Notice that the version using the
+lambda expression must declare and initialize the lambda expression,
+`nthFactorial` before defining it. Not doing so results in a compile
+time error for referencing `nthFactorial` before assigning it.
 Recursive algorithms are easier to create using local functions.
 
 Third, for lambda expressions, the compiler must always create an anonymous class
@@ -64,6 +56,11 @@ The closure for this lambda expression contains the `address`,
 that implements the closure may be a `struct` type. That would save on
 an allocation.
 
+The instantiation necessary for lambda expressions means extra memory
+allocations, which may be a performance factor in time critical code paths.
+Local functions do not incur this overhead. In the example above, the local
+functions version has 2 fewer allocations than the lambda expression version.
+
 > [!NOTE]
 > The local function equivalent of this method also uses a class for the closure. Whether the closure for a local function is implemented as a `class` or a `struct` is an implementation detail. A local function may use a `struct` whereas a lambda will always use a `class`.
 
@@ -71,7 +68,8 @@ an allocation.
 
 One final advantage not demonstrated in this sample is that local
 functions can be implemented as iterators, using the `yield return`
-syntax to produce a sequence of values.
+syntax to produce a sequence of values. The `yield return` statement
+is not allowed in lambda expressions.
 
 While local functions may seem redundant to lambda expressions,
 they actually serve different purposes and have different uses.


### PR DESCRIPTION
Fixes #3501

@agocke wrote [this blog post](http://commentout.net/localfunc.html) on the distinctions between local functions and lambda expressions. The current topic that describes those differences was missing some of those items.

This PR fixes that.