### PR TITLE
switch archive version

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1054,11 +1054,11 @@
         },
         {
             "source_path": "docs/csharp/programming-guide/strings/how-to-convert-between-legacy-encondings-and-unicode.md",
-            "redirect_url": "https://msdn.microsoft.com/en-us/library/cc165448(v=vs.140).aspx"
+            "redirect_url": "https://msdn.microsoft.com/en-us/library/cc165448(v=vs.120).aspx"
         },
         {
             "source_path": "docs/csharp/programming-guide/strings/how-to-convert-rtf-to-plain-text.md",
-            "redirect_url": "https://msdn.microsoft.com/en-us/library/cc488002(v=vs.140).aspx"
+            "redirect_url": "https://msdn.microsoft.com/en-us/library/cc488002(v=vs.120).aspx"
         },
         {
             "source_path": "docs/csharp/parallel.md",


### PR DESCRIPTION
Redirecting to the current version on MSDN caused an infinite redirect loop. Instead, redirect to version N-1, so that the redirects continue for the current and future site updates.

/cc @ghogen 