### PR TITLE
Fixed bad link from previous PR

### DIFF
--- a/xml/System.Diagnostics.Contracts/Contract.xml
+++ b/xml/System.Diagnostics.Contracts/Contract.xml
@@ -1220,7 +1220,7 @@
    
   
 ## Examples  
- The following example shows how to use the <xref:System.Diagnostics.Contracts.Contract.Result``1*> method to specify an expected return value. This code example is part of a larger example provided for the <xref:System.Diagnostics.Contracts.ContractClassAttribute> class.  
+ The following example shows how to use the <xref:System.Diagnostics.Contracts.Contract.Result``1%2A> method to specify an expected return value. This code example is part of a larger example provided for the <xref:System.Diagnostics.Contracts.ContractClassAttribute> class.  
   
  [!code-csharp[ContractExample#3](~/samples/snippets/csharp/VS_Snippets_CLR/contractexample/cs/program.cs#3)]
  [!code-vb[ContractExample#3](~/samples/snippets/visualbasic/VS_Snippets_CLR/contractexample/vb/program.vb#3)]  

--- a/xml/System.Diagnostics.Contracts/Contract.xml
+++ b/xml/System.Diagnostics.Contracts/Contract.xml
@@ -1220,7 +1220,7 @@
    
   
 ## Examples  
- The following example shows how to use the <xref:System.Diagnostics.Contracts.Contract.Result``1%2A> method to specify an expected return value. This code example is part of a larger example provided for the <xref:System.Diagnostics.Contracts.ContractClassAttribute> class.  
+ The following example shows how to use the <xref:System.Diagnostics.Contracts.Contract.Result%2A> method to specify an expected return value. This code example is part of a larger example provided for the <xref:System.Diagnostics.Contracts.ContractClassAttribute> class.  
   
  [!code-csharp[ContractExample#3](~/samples/snippets/csharp/VS_Snippets_CLR/contractexample/cs/program.cs#3)]
  [!code-vb[ContractExample#3](~/samples/snippets/visualbasic/VS_Snippets_CLR/contractexample/vb/program.vb#3)]  

--- a/xml/System.Diagnostics/Process.xml
+++ b/xml/System.Diagnostics/Process.xml
@@ -862,7 +862,7 @@ The following code example creates a process that prints a file. It sets the <xr
  The event only occurs during asynchronous read operations on <xref:System.Diagnostics.Process.StandardError%2A>. To start asynchronous read operations, you must redirect the <xref:System.Diagnostics.Process.StandardError%2A> stream of a <xref:System.Diagnostics.Process>, add your event handler to the <xref:System.Diagnostics.Process.ErrorDataReceived> event, and call <xref:System.Diagnostics.Process.BeginErrorReadLine%2A>. Thereafter, the <xref:System.Diagnostics.Process.ErrorDataReceived> event signals each time the process writes a line to the redirected <xref:System.Diagnostics.Process.StandardError%2A> stream, until the process exits or calls <xref:System.Diagnostics.Process.CancelErrorRead%2A>.  
   
 > [!NOTE]
->  The application that is processing the asynchronous output should call the <xref:System.Diagnostics.Process.WaitForExit> method to ensure that the output buffer has been flushed. Note that specifying a timeout by using the <xref:System.Diagnostics.Process.WaitForExit(Int32)> overload does *not* ensure the output buffer has been flushed.
+>  The application that is processing the asynchronous output should call the <xref:System.Diagnostics.Process.WaitForExit> method to ensure that the output buffer has been flushed. Note that specifying a timeout by using the <xref:System.Diagnostics.Process.WaitForExit(System.Int32)> overload does *not* ensure the output buffer has been flushed.
   
    
   


### PR DESCRIPTION
# Fixed bad link from previous PR

## Summary

A previous PR included a bad link to a specific overload. This PR fixes the link. 
I've also fixed (hopefully) a second broken link in the System.Diagnostics.Contracts namespace.

## Suggested Reviewers

/cc @BillWagner 
