### PR TITLE
Update pattern matching switch for var

### DIFF
--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -246,11 +246,11 @@ searching for known command values. You might write something like:
 
 [!code-csharp[VarCaseExpression](../../samples/csharp/PatternMatching/Program.cs#VarCaseExpression "use a var case expression to filter white space")]]
 
-The `var` case matches `null`, the empty string, or any sring that contains
-only whitespace. Notice that the preceding code using the `?.` operator to
+The `var` case matches `null`, the empty string, or any string that contains
+only whitespace. Notice that the preceding code uses the `?.` operator to
 ensure that it does not accidentally throw a <xref:System.NullReferenceException>. The `default` case handles any other string values that are not understood by this command parser.
 
-This simple example shows one example where you may want to consider
+This is one example shows one example where you may want to consider
 a `var` case expression that is distinct from a `default` expression.
 
 ## Conclusions

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -231,13 +231,27 @@ that other type pattern expressions include. That means the variable
 may be null, and a null check is necessary in that case.
 
 Those two rules mean that in many instances, a `var` declaration
-in a `case` expression is the same as a `default` expression. 
+in a `case` expression matches the same conditions as a `default` expression.
+Because any non-default case is preferred to the `default` case, the `default`
+case will never execute.
 
-. The type is the static type of the switch variable.
-. It matches all values, including the null value
-. If and only if there is a when clause does it differ from the default case.
+> [!NOTE]
+> The compiler does not emit a warning in those cases where a `default` case
+> has been written but will never execute. This is consistent with current
+> `switch` statement behavior where all possible cases have been listed.
 
+The third rule introduces uses where a `var` case may be useful. Imagine
+that you are doing a pattern match where the input is a string and you are
+searching for known command values. You might write something like:
 
+[!code-csharp[VarCaseExpression](../../samples/csharp/PatternMatching/Program.cs#VarCaseExpression "use a var case expression to filter white space")]]
+
+The `var` case matches `null`, the empty string, or any sring that contains
+only whitespace. Notice that the preceding code using the `?.` operator to
+ensure that it does not accidentally throw a <xref:System.NullReferenceException>. The `default` case handles any other string values that are not understood by this command parser.
+
+This simple example shows one example where you may want to consider
+a `var` case expression that is distinct from a `default` expression.
 
 ## Conclusions
 

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -244,8 +244,6 @@ The third rule introduces uses where a `var` case may be useful. Imagine
 that you are doing a pattern match where the input is a string and you are
 searching for known command values. You might write something like:
 
-[!code-csharp[VarCaseExpression](../../samples/csharp/PatternMatching/Program.cs#VarCaseExpression "use a var case expression to filter white space")]
-
 The `var` case matches `null`, the empty string, or any string that contains
 only whitespace. Notice that the preceding code uses the `?.` operator to
 ensure that it does not accidentally throw a <xref:System.NullReferenceException>. The `default` case handles any other string values that are not understood by this command parser.

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -244,7 +244,7 @@ The third rule introduces uses where a `var` case may be useful. Imagine
 that you are doing a pattern match where the input is a string and you are
 searching for known command values. You might write something like:
 
-[!code-csharp[VarCaseExpression](../../samples/csharp/PatternMatching/Program.cs#VarCaseExpression "use a var case expression to filter white space")]]
+[!code-csharp[VarCaseExpression](../../samples/csharp/PatternMatching/Program.cs#VarCaseExpression "use a var case expression to filter white space")]
 
 The `var` case matches `null`, the empty string, or any string that contains
 only whitespace. Notice that the preceding code uses the `?.` operator to

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -216,6 +216,29 @@ checked the type, you don't need an additional null check. You can see that from
 the fact that there are no null checks in any of the case blocks of the samples above:
 they are not necessary, since matching the type pattern guarantees a non-null value.
 
+## `var` declarations in `case` expressions
+
+The introduction of `var` as one of the match expressions introduces new
+rules to the pattern match.
+
+The first rule is that the `var` declaration
+follows the normal type inference rules: The type is inferred to be the
+static type of the switch expression. From that rule, the type always
+matches.
+
+The second rule is that a `var` declaration does not have the null check
+that other type pattern expressions include. That means the variable
+may be null, and a null check is necessary in that case.
+
+Those two rules mean that in many instances, a `var` declaration
+in a `case` expression is the same as a `default` expression. 
+
+. The type is the static type of the switch variable.
+. It matches all values, including the null value
+. If and only if there is a when clause does it differ from the default case.
+
+
+
 ## Conclusions
 
 *Pattern Matching constructs* enable you to easily manage control flow

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -244,6 +244,8 @@ The third rule introduces uses where a `var` case may be useful. Imagine
 that you are doing a pattern match where the input is a string and you are
 searching for known command values. You might write something like:
 
+[!code-csharp[VarCaseExpression](../../samples/csharp/PatternMatching/Program.cs#VarCaseExpression "use a var case expression to filter white space")]
+
 The `var` case matches `null`, the empty string, or any string that contains
 only whitespace. Notice that the preceding code uses the `?.` operator to
 ensure that it does not accidentally throw a <xref:System.NullReferenceException>. The `default` case handles any other string values that are not understood by this command parser.

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -250,7 +250,7 @@ The `var` case matches `null`, the empty string, or any string that contains
 only whitespace. Notice that the preceding code uses the `?.` operator to
 ensure that it does not accidentally throw a <xref:System.NullReferenceException>. The `default` case handles any other string values that are not understood by this command parser.
 
-This is one example shows one example where you may want to consider
+This is one example where you may want to consider
 a `var` case expression that is distinct from a `default` expression.
 
 ## Conclusions

--- a/samples/csharp/PatternMatching/Program.cs
+++ b/samples/csharp/PatternMatching/Program.cs
@@ -11,8 +11,8 @@ namespace PatternMatching
     {
         static void Main(string[] args)
         {
-            var s = new Square(4);
-            var c = new Circle(2);
+            var s = CreateShape("square");
+            var c = CreateShape("circle");
 
             WriteLine(GeometricUtilities.ComputeArea(s));
             WriteLine(GeometricUtilities.ComputeArea(c));
@@ -23,6 +23,34 @@ namespace PatternMatching
             WriteLine(GeometricUtilities.ComputeArea_Version3(s));
             WriteLine(GeometricUtilities.ComputeArea_Version3(c));
             
+            var what = CreateShape("       ");
+            WriteLine(what);
+
+            var wrong = CreateShape("trapezoid");
+            WriteLine(wrong);
         }
+
+#region VarCaseExpression
+        static object CreateShape(string shapeDescription)
+        {
+            switch (shapeDescription)
+            {
+                case "circle":
+                    return new Circle(2);
+
+                case "square":
+                    return new Square(4);
+                
+                case "large-circle":
+                    return new Circle(12);
+
+                case var o when (o?.Trim()?.Length ?? 0) == 0:
+                    // whitespace
+                    return null;
+                default:
+                    return "invalid shape description";
+            }            
+        }
+#endregion
     }
 }


### PR DESCRIPTION
The first version of this topic did not explain the subtle behavior of `var` in a pattern matching case expression.

The additional sections discuss those.

/cc @samuelenglard @jaredpar @mgravell