### PR TITLE
Fix typos in String.Split Method (Char[], StringSplitOptions)

### DIFF
--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -9409,7 +9409,7 @@ String 'This is a string.' in domain 'NewDomain': 75CC8236
   
  If the `options` parameter is <xref:System.StringSplitOptions.RemoveEmptyEntries> and the length of this instance is zero, the method returns an empty array.  
   
- Each element of `separator` defines a separate delimiter that consists of a single character. If the `options` argument is <xref:System.StringSplitOptions.None>, and two delimiters are adjacent or a delimiter is found at the beginning or end of this instance, the corresponding array element contains <xref:System.String.Empty?displayProperty=nameWithType>. For example, if `separator` includes  two elements, "-" and "_", the value of the string instance is "-_aa-\_", and the value of   the `options` argument is <xref:System.StringSplitOptions.None>, the method returns a string array with the following five elements:  
+ Each element of `separator` defines a separate delimiter that consists of a single character. If the `options` argument is <xref:System.StringSplitOptions.None>, and two delimiters are adjacent or a delimiter is found at the beginning or end of this instance, the corresponding array element contains <xref:System.String.Empty?displayProperty=nameWithType>. For example, if `separator` includes  two elements, "-" and "\_", the value of the string instance is "-\_aa-\_", and the value of   the `options` argument is <xref:System.StringSplitOptions.None>, the method returns a string array with the following five elements:  
   
 1.  <xref:System.String.Empty?displayProperty=nameWithType>, which represents the empty string that precedes the "-" character at index 0.  
   


### PR DESCRIPTION
Added in the missing backslash escape for the underscores in the example under Remarks for String.Split Method (Char[], StringSplitOptions).

