### PR TITLE
Add a documentation page for compiler error CS7003

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs7003.md
+++ b/docs/csharp/language-reference/compiler-messages/cs7003.md
@@ -24,3 +24,6 @@ This error occurs if you use a generic type needing one parameter type without p
 
     public class MyGenericClass<T> { }
 ```
+
+## See Also  
+ [Generics](../../../csharp/programming-guide/generics/generic-type-parameters.md)   

--- a/docs/csharp/language-reference/compiler-messages/cs7003.md
+++ b/docs/csharp/language-reference/compiler-messages/cs7003.md
@@ -1,0 +1,26 @@
+# Compiler Error CS7003
+Unexpected use of an unbound generic name
+
+This error occurs if you use a generic type needing one parameter type without passing any generic parameter type name between the angle brackets. This use may be a variable declaration, or an object instanciation.
+
+## To correct this error  
+  
+1.  Provide one parameter type name in angle brackets when using a generic type.  
+
+ ## Example  
+ The following example generates CS7003:  
+  
+```csharp  
+// CS7003.cs  
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var myVar1 = new MyGenericClass<>();  //CS7003
+
+            MyGenericClass<> var2;                //CS7003
+        }
+    }
+
+    public class MyGenericClass<T> { }
+```

--- a/docs/csharp/language-reference/compiler-messages/cs7003.md
+++ b/docs/csharp/language-reference/compiler-messages/cs7003.md
@@ -5,7 +5,7 @@ This error occurs if you use a generic type needing one parameter type without p
 
 ## To correct this error  
   
-1.  Provide one parameter type name in angle brackets when using a generic type.  
+Provide one parameter type name in angle brackets when using a generic type.  
 
  ## Example  
  The following example generates CS7003:  

--- a/docs/csharp/language-reference/compiler-messages/toc.md
+++ b/docs/csharp/language-reference/compiler-messages/toc.md
@@ -106,6 +106,7 @@
 ## [Compiler Error CS1943](cs1943.md)
 ## [Compiler Error CS1946](cs1946.md)
 ## [Compiler Error CS2032](cs2032.md)
+## [Compiler Error CS7003](cs7003.md)
 ## [Compiler Warning (level 1) CS0420](cs0420.md)
 ## [Compiler Warning (level 1) CS0465](cs0465.md)
 ## [Compiler Warning (level 1) CS1058](cs1058.md)


### PR DESCRIPTION
Fixes #1593

To this day, the compiler error CS7003 remains undocumented. This PR adds a documentation page for this error.
