### PR TITLE
fix formatting issues

### DIFF
--- a/docs/framework/wpf/advanced/how-to-localize-an-application.md
+++ b/docs/framework/wpf/advanced/how-to-localize-an-application.md
@@ -125,39 +125,39 @@ This tutorial explains how to create a localized application by using the LocBam
     > [!NOTE]
     >  If the input file, HelloApp.resources.dll, is not in the same directory as LocBaml.exe move one of the files so that both files are in the same directory.  
   
-3.  When you run LocBaml to parse files, the output consists of seven fields delimited by commas (.csv files) or tabs (.txt files). The following shows the parsed .csv file for the HelloApp.resources.dll:  
+3.  When you run LocBaml to parse files, the output consists of seven fields delimited by commas (.csv files) or tabs (.txt files). The following shows the parsed .csv file for the HelloApp.resources.dll:
+
+   | |
+   |-|
+   |HelloApp.g.en-US.resources:window1.baml,Stack1:System.Windows.Controls.StackPanel.$Content,Ignore,FALSE, FALSE,,#Text1;#Text2;|
+   |HelloApp.g.en-US.resources:window1.baml,Text1:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Hello World|
+   |HelloApp.g.en-US.resources:window1.baml,Text2:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Goodbye World|
+
+   The seven fields are:  
   
-   ||  
-   |-|  
-   |HelloApp.g.en-US.resources:window1.baml,Stack1:System.Windows.Controls.StackPanel.$Content,Ignore,FALSE, FALSE,,#Text1;#Text2;|  
-   |HelloApp.g.en-US.resources:window1.baml,Text1:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Hello World|  
-   |HelloApp.g.en-US.resources:window1.baml,Text2:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Goodbye World|  
+   1.  **BAML Name**. The name of the BAML resource with respect to the source language satellite assembly.  
   
-     The seven fields are:  
+   2.  **Resource Key**. The localized resource identifier.  
   
-    1.  **BAML Name**. The name of the BAML resource with respect to the source language satellite assembly.  
+   3.  **Category**. The value type. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
   
-    2.  **Resource Key**. The localized resource identifier.  
+   4.  **Readability**. Whether the value can be read by a localizer. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
   
-    3.  **Category**. The value type. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
+   5.  **Modifiability**. Whether the value can be modified by a localizer. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
   
-    4.  **Readability**. Whether the value can be read by a localizer. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
+   6.  **Comments**. Additional description of the value to help determine how a value is localized. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
   
-    5.  **Modifiability**. Whether the value can be modified by a localizer. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
+   7.  **Value**. The text value to translate to the desired culture.  
   
-    6.  **Comments**. Additional description of the value to help determine how a value is localized. See [Localization Attributes and Comments](../../../../docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
+   The following table shows how these fields map to the delimited values of the .csv file:  
   
-    7.  **Value**. The text value to translate to the desired culture.  
+   |BAML name|Resource key|Category|Readability|Modifiability|Comments|Value|  
+   |---------------|------------------|--------------|-----------------|-------------------|--------------|-----------|
+   |HelloApp.g.en-US.resources:window1.baml|Stack1:System.Windows.Controls.StackPanel.$Content|Ignore|FALSE|FALSE||#Text1;#Text2|
+   |HelloApp.g.en-US.resources:window1.baml|Text1:System.Windows.Controls.TextBlock.$Content|None|TRUE|TRUE||Hello World|
+   |HelloApp.g.en-US.resources:window1.baml|Text2:System.Windows.Controls.TextBlock.$Content|None|TRUE|TRUE||Goodbye World|
   
-     The following table shows how these fields map to the delimited values of the .csv file:  
-  
-    |BAML name|Resource key|Category|Readability|Modifiability|Comments|Value|  
-    |---------------|------------------|--------------|-----------------|-------------------|--------------|-----------|  
-    |HelloApp.g.en-US.resources:window1.baml|Stack1:System.Windows.Controls.StackPanel.$Content|Ignore|FALSE|FALSE||#Text1;#Text2|  
-    |HelloApp.g.en-US.resources:window1.baml|Text1:System.Windows.Controls.TextBlock.$Content|None|TRUE|TRUE||Hello World|  
-    |HelloApp.g.en-US.resources:window1.baml|Text2:System.Windows.Controls.TextBlock.$Content|None|TRUE|TRUE||Goodbye World|  
-  
-     Notice that all the values for the **Comments** field contain no values; if a field doesn't have a value, it is empty. Also notice that the item in the first row is neither readable nor modifiable, and has "Ignore" as its **Category** value, all of which indicates that the value is not localizable.  
+   Notice that all the values for the **Comments** field contain no values; if a field doesn't have a value, it is empty. Also notice that the item in the first row is neither readable nor modifiable, and has "Ignore" as its **Category** value, all of which indicates that the value is not localizable.  
   
 4.  To facilitate discovery of localizable items in parsed files, particularly in large files, you can sort or filter the items by **Category**, **Readability**, and **Modifiability**. For example, you can filter out unreadable and unmodifiable values.  
   

--- a/docs/framework/wpf/advanced/how-to-localize-an-application.md
+++ b/docs/framework/wpf/advanced/how-to-localize-an-application.md
@@ -1,10 +1,7 @@
 ---
 title: "How to: Localize an Application"
-ms.custom: ""
 ms.date: "03/30/2017"
 ms.prod: ".net-framework"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "dotnet-wpf"
 ms.tgt_pltfrm: ""
@@ -17,7 +14,6 @@ helpviewer_keywords:
   - "LocBaml tool [WPF]"
   - "applications [WPF], localizing"
 ms.assetid: 5001227e-9326-48a4-9dcd-ba1b89ee6653
-caps.latest.revision: 37
 author: dotnet-bot
 ms.author: dotnetcontent
 manager: "wpickett"
@@ -27,8 +23,6 @@ This tutorial explains how to create a localized application by using the LocBam
   
 > [!NOTE]
 >  The LocBaml tool is not a production-ready application. It is presented as a sample that uses some of the localization APIs and illustrates how you might write a localization tool.  
->   
-  
   
 <a name="Introduction"></a>   
 ## Overview  
@@ -133,11 +127,11 @@ This tutorial explains how to create a localized application by using the LocBam
   
 3.  When you run LocBaml to parse files, the output consists of seven fields delimited by commas (.csv files) or tabs (.txt files). The following shows the parsed .csv file for the HelloApp.resources.dll:  
   
-    ||  
-    |-|  
-    |HelloApp.g.en-US.resources:window1.baml,Stack1:System.Windows.Controls.StackPanel.$Content,Ignore,FALSE, FALSE,,#Text1;#Text2;|  
-    |HelloApp.g.en-US.resources:window1.baml,Text1:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Hello World|  
-    |HelloApp.g.en-US.resources:window1.baml,Text2:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Goodbye World|  
+   ||  
+   |-|  
+   |HelloApp.g.en-US.resources:window1.baml,Stack1:System.Windows.Controls.StackPanel.$Content,Ignore,FALSE, FALSE,,#Text1;#Text2;|  
+   |HelloApp.g.en-US.resources:window1.baml,Text1:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Hello World|  
+   |HelloApp.g.en-US.resources:window1.baml,Text2:System.Windows.Controls.TextBlock.$Content,None,TRUE, TRUE,,Goodbye World|  
   
      The seven fields are:  
   
@@ -200,10 +194,9 @@ This tutorial explains how to create a localized application by using the LocBam
   
     -   In your application, add the following code to App.xaml.cs:  
   
-   [!code-xaml[LocBamlChangeCultureSnippets#LocBamlChangeCultureMARKUP](../../../../samples/snippets/csharp/VS_Snippets_Wpf/LocBamlChangeCultureSnippets/CSharp/App.xaml#locbamlchangeculturemarkup)]  
-  
-         [!code-csharp[LocBamlChangeCultureSnippets#LocBamlChangeCultureCODEBEHIND](../../../../samples/snippets/csharp/VS_Snippets_Wpf/LocBamlChangeCultureSnippets/CSharp/App.xaml.cs#locbamlchangeculturecodebehind)]
-         [!code-vb[LocBamlChangeCultureSnippets#LocBamlChangeCultureCODEBEHIND](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/LocBamlChangeCultureSnippets/VisualBasic/Application.xaml.vb#locbamlchangeculturecodebehind)]  
+   [!code-xaml[LocBamlChangeCultureSnippets#LocBamlChangeCultureMARKUP](../../../../samples/snippets/csharp/VS_Snippets_Wpf/LocBamlChangeCultureSnippets/CSharp/App.xaml#locbamlchangeculturemarkup)]
+   [!code-csharp[LocBamlChangeCultureSnippets#LocBamlChangeCultureCODEBEHIND](../../../../samples/snippets/csharp/VS_Snippets_Wpf/LocBamlChangeCultureSnippets/CSharp/App.xaml.cs#locbamlchangeculturecodebehind)]
+   [!code-vb[LocBamlChangeCultureSnippets#LocBamlChangeCultureCODEBEHIND](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/LocBamlChangeCultureSnippets/VisualBasic/Application.xaml.vb#locbamlchangeculturecodebehind)]  
   
 <a name="Some_Tips_for_Using_LocBaml"></a>   
 ## Some Tips for Using LocBaml  


### PR DESCRIPTION
While reviewing the issue #3623, I've noticed that the topic (https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-localize-an-application) has some other issues:

- A broken table:
![image](https://user-images.githubusercontent.com/12971179/32470573-9a6abefa-c30d-11e7-9045-4313bc36caa0.png)

- Broken snippet references
![image](https://user-images.githubusercontent.com/12971179/32470588-ae267b96-c30d-11e7-9b98-2f949ad4b1db.png)

While we wait for the team to confirm the new location of the samples, I thought I'd fix these other issues.

[Internal Review URL](https://review.docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/how-to-localize-an-application?branch=pr-en-us-3625)
