### PR TITLE
Adds FileNotFoundException to exceptions thrown by Assembly.GetExportedTypes()

### DIFF
--- a/xml/System.Reflection/Assembly.xml
+++ b/xml/System.Reflection/Assembly.xml
@@ -1159,6 +1159,7 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">The assembly is a dynamic assembly.</exception>
+        <exception cref="T:System.IO.FileNotFoundException">Unable to load a dependent assembly.</exception>
       </Docs>
     </Member>
     <Member MemberName="GetFile">


### PR DESCRIPTION
# Adds FileNotFoundException to GetExportedTypes()

## Summary

This PR adds `System.IO.FileNotFoundException` to the list of exceptions thrown by `Assembly.GetExportedTypes()`. `System.IO.FileNotFoundException` is thrown when a dependent type cannot be resolved. 

Example:
`System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.AspNetCore.Hosting.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.`

I was unable to figure out how to serve up this specific page via `docfx`, so apologies if there are issues. Wording recommendations welcome.

This seemed small enough to not need an issue but I'm happy to open one on request.
