### PR TITLE
adding PowerShell filter

### DIFF
--- a/add/metadata/System/TimeZoneInfo.meta.md
+++ b/add/metadata/System/TimeZoneInfo.meta.md
@@ -437,7 +437,7 @@ ms.technology:
 author: "rpetrusha"
 ms.author: "ronpet"
 manager: "wpickett"
-langs: ["csharp", "vb", "cpp", "powershell"]
+langs: ["csharp", "vb", "powershell"]
 ---
 
 ---

--- a/add/metadata/System/TimeZoneInfo.meta.md
+++ b/add/metadata/System/TimeZoneInfo.meta.md
@@ -437,6 +437,7 @@ ms.technology:
 author: "rpetrusha"
 ms.author: "ronpet"
 manager: "wpickett"
+langs: ["csharp", "vb", "cpp", "powershell"]
 ---
 
 ---

--- a/xml/System/TimeZoneInfo.xml
+++ b/xml/System/TimeZoneInfo.xml
@@ -2398,7 +2398,7 @@
   
  [!code-csharp[System.TimeZone2.Class#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Class/CS/TimeZone2_Examples.cs#4)]
  [!code-vb[System.TimeZone2.Class#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.Class/VB/TimeZone2_Examples.vb#4)]
- [!code-ps[System.TimeZone2.Class#4](~/samples/snippets/powershell/VS_Snippets_CLR_System/System.TimeZone2.Class/PS/Timezone2_Examples.ps1)] 
+ [!code-powershell[System.TimeZone2.Class#4](~/samples/snippets/powershell/VS_Snippets_CLR_System/System.TimeZone2.Class/PS/Timezone2_Examples.ps1)] 
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
The page https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.supportsdaylightsavingtime?view=netframework-4.7.1 now has a PowerShell example that is always displayed. Trying to see if adding this to the metadata file would enable the filter on that API only.