### PR TITLE
Fixes a SHA256 documentation error and adds details

### DIFF
--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -157,7 +157,7 @@ The .NET Framework includes the implementations and their associated hashName va
 
  ]]></format>
         </remarks>
-        <exception cref="T:System.Reflection.TargetInvocationException">On the .NET Framework 4.6.1 and earlier versions only: The algorithm was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
+        <exception cref="T:System.Reflection.TargetInvocationException">On the .NET Framework 4.6.1 and earlier versions only: The algorithm described by the <paramref name="hashName" /> parameter was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
       </Docs>
     </Member>
     <MemberGroup MemberName="Create">

--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -110,10 +110,10 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Creates an instance of the default implementation of <see cref="T:System.Security.Cryptography.SHA256" />. When this behavior is not overriden, the default implementation is <see cref="T:System.Security.Cryptography.SHA256Managed" />.</summary>
-        <returns>A new instance of <see cref="T:System.Security.Cryptography.SHA256" />.</returns>
+        <summary>Creates an instance of the default implementation of <see cref="T:System.Security.Cryptography.SHA256" />.</summary>
+        <returns>A new instance of <see cref="T:System.Security.Cryptography.SHA256"/>. On the .NET Framework, this method creates an instance of the <see cref="T:System.Security.Cryptography.SHA256Managed" /> class if FIPS mode is not active; if FIPS mode is active, it creates an instance of the <see cref="T:System.Security.Cryptography.SHA256Cng"/> class. On .NET Core, it returns an instance of a private class derived from <see cref="T:System.Security.Cryptography.SHA256"/>.</returns>
         <remarks>To be added.</remarks>
-        <exception cref="T:System.Reflection.TargetInvocationException">The algorithm was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
+        <exception cref="T:System.Reflection.TargetInvocationException">On the .NET Framework 4.6.1 and earlier versions only: The algorithm was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
       </Docs>
     </Member>
     <Member MemberName="Create">

--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -37,7 +37,7 @@
   
  The hash size for the <xref:System.Security.Cryptography.SHA256> algorithm is 256 bits.  
   
- This is an abstract class. The .NET Framework provides 3 implementations derived from this class. 
+ This is an abstract class. 
   
 ## Examples  
  The following example calculates the SHA-256 hash for all files in a directory.  
@@ -162,11 +162,13 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Out of the box, the valid implementations names, and their associated implementations, are the following : 
- * SHA256, SHA-256 or System.Security.Cryptography.SHA256 : implementation is <see cref="T:System.Security.Cryptography.SHA256Managed" />   
- * System.Security.Cryptography.SHA256Cng : implementation is <see cref="T:System.Security.Cryptography.SHA256Cng" />   
- * System.Security.Cryptography.SHA256CryptoServiceProvider - implementation is <see cref="T:System.Security.Cryptography.SHA256CryptoServiceProvider" />   
-  
+The .NET Framework includes the implementations and their associated hashName values:
+| Implementation | hashName |
+|----------|---------|
+| <xref:System.Security.Cryptography.SHA256Managed> | SHA256 </br> SHA-256 <br /> System.Security.Cryptography.SHA256 |
+| <xref:System.Security.Cryptography.SHA256Cng> | System.Security.Cryptography.SHA256Cng |
+| <xref:System.Security.Cryptography.SHA256CryptoServiceProvider> | System.Security.Cryptography.SHA256CryptoServiceProvider |
+
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -110,7 +110,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Creates an instance of the default implementation of <see cref="T:System.Security.Cryptography.SHA256" />. When this behavior is not overriden, the default implementation is <see cref="T:System.Security.Cryptography.SHA256Managed" /></summary>
+        <summary>Creates an instance of the default implementation of <see cref="T:System.Security.Cryptography.SHA256" />. When this behavior is not overriden, the default implementation is <see cref="T:System.Security.Cryptography.SHA256Managed" />.</summary>
         <returns>A new instance of <see cref="T:System.Security.Cryptography.SHA256" />.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.Reflection.TargetInvocationException">The algorithm was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
@@ -158,6 +158,17 @@
       </AssemblyInfo>
       <Docs>
         <summary>Allows specific implementations of this abstract class to be instantiated.</summary>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ Out of the box, the valid implementations names, and their associated implementations, are the following : 
+ * SHA256, SHA-256 or System.Security.Cryptography.SHA256 : implementation is <see cref="T:System.Security.Cryptography.SHA256Managed" />   
+ * System.Security.Cryptography.SHA256Cng : implementation is <see cref="T:System.Security.Cryptography.SHA256Cng" />   
+ * System.Security.Cryptography.SHA256CryptoServiceProvider - implementation is <see cref="T:System.Security.Cryptography.SHA256CryptoServiceProvider" />   
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </MemberGroup>
   </Members>

--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -110,7 +110,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Creates an instance of the default implementation of <see cref="T:System.Security.Cryptography.SHA256" />.</summary>
+        <summary>Creates an instance of the default implementation of <see cref="T:System.Security.Cryptography.SHA256" />. When this behavior is not overriden, the default implementation is <see cref="T:System.Security.Cryptography.SHA256Managed" /></summary>
         <returns>A new instance of <see cref="T:System.Security.Cryptography.SHA256" />.</returns>
         <remarks>To be added.</remarks>
         <exception cref="T:System.Reflection.TargetInvocationException">The algorithm was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>

--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -144,20 +144,6 @@
         <param name="hashName">The name of the specific implementation of <see cref="T:System.Security.Cryptography.SHA256" /> to be used.</param>
         <summary>Creates an instance of a specified implementation of <see cref="T:System.Security.Cryptography.SHA256" />.</summary>
         <returns>A new instance of <see cref="T:System.Security.Cryptography.SHA256" /> using the specified implementation.</returns>
-        <remarks>To be added.</remarks>
-        <exception cref="T:System.Reflection.TargetInvocationException">The algorithm described by the <paramref name="hashName" /> parameter was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
-      </Docs>
-    </Member>
-    <MemberGroup MemberName="Create">
-      <AssemblyInfo>
-        <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
-        <AssemblyVersion>4.0.0.0</AssemblyVersion>
-        <AssemblyVersion>4.1.0.0</AssemblyVersion>
-        <AssemblyVersion>4.2.0.0</AssemblyVersion>
-        <AssemblyVersion>4.3.0.0</AssemblyVersion>
-      </AssemblyInfo>
-      <Docs>
-        <summary>Allows specific implementations of this abstract class to be instantiated.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -171,6 +157,20 @@ The .NET Framework includes the implementations and their associated hashName va
 
  ]]></format>
         </remarks>
+        <exception cref="T:System.Reflection.TargetInvocationException">On the .NET Framework 4.6.1 and earlier versions only: The algorithm was used with Federal Information Processing Standards (FIPS) mode enabled, but is not FIPS compatible.</exception>
+      </Docs>
+    </Member>
+    <MemberGroup MemberName="Create">
+      <AssemblyInfo>
+        <AssemblyName>System.Security.Cryptography.Algorithms</AssemblyName>
+        <AssemblyVersion>4.0.0.0</AssemblyVersion>
+        <AssemblyVersion>4.1.0.0</AssemblyVersion>
+        <AssemblyVersion>4.2.0.0</AssemblyVersion>
+        <AssemblyVersion>4.3.0.0</AssemblyVersion>
+      </AssemblyInfo>
+      <Docs>
+        <summary>Allows specific implementations of this abstract class to be instantiated.</summary>
+        <remarks></remarks>
       </Docs>
     </MemberGroup>
   </Members>

--- a/xml/System.Security.Cryptography/SHA256.xml
+++ b/xml/System.Security.Cryptography/SHA256.xml
@@ -37,9 +37,7 @@
   
  The hash size for the <xref:System.Security.Cryptography.SHA256> algorithm is 256 bits.  
   
- This is an abstract class. The only implementation of this class is <xref:System.Security.Cryptography.SHA256Managed>.  
-  
-   
+ This is an abstract class. The .NET Framework provides 3 implementations derived from this class. 
   
 ## Examples  
  The following example calculates the SHA-256 hash for all files in a directory.  


### PR DESCRIPTION
Fixes #3495

Here is a first "draft" to fix this issue. The informations related to the SHA256 implementations have been taken from [referencesource.microsoft.com](http://referencesource.microsoft.com/#mscorlib/system/security/cryptography/sha256.cs) and [MSDN](https://msdn.microsoft.com/en-us/library/system.security.cryptography.cryptoconfig(v=vs.110).aspx)

Let me know if anything needs rework.