### PR TITLE
Finxing a small missing space

### DIFF
--- a/docs/framework/wpf/getting-started/whats-new.md
+++ b/docs/framework/wpf/getting-started/whats-new.md
@@ -19,7 +19,7 @@ ms.author: dotnetcontent
 manager: "wpickett"
 ---
 # What&#39;s New in WPF Version 4.5
-<a name="introduction"></a> Thistopic contains information about new and enhanced features in [!INCLUDE[TLA#tla_winclient](../../../../includes/tlasharptla-winclient-md.md)] version 4.5.  
+<a name="introduction"></a> This topic contains information about new and enhanced features in [!INCLUDE[TLA#tla_winclient](../../../../includes/tlasharptla-winclient-md.md)] version 4.5.  
   
  This topic contains the following sections:  
   


### PR DESCRIPTION
At the start of the article it read "Thistopic" instead of "This topic"

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

There was a small typo at the start of the article, a missing space..

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

The article started "Thistopic" instead of "This topic" a common typo when typing fast.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
