### PR TITLE
Fix incorrect usage of paramref on type parameters for System.Func and System.Converter

### DIFF
--- a/xml/System/Converter`2.xml
+++ b/xml/System/Converter`2.xml
@@ -41,7 +41,7 @@
     <typeparam name="TOutput">The type the input object is to be converted to.</typeparam>
     <param name="input">The object to convert.</param>
     <summary>Represents a method that converts an object from one type to another type.</summary>
-    <returns>The <paramref name="TOutput" /> that represents the converted <paramref name="TInput" />.</returns>
+    <returns>The <typeparamref name="TOutput" /> that represents the converted <typeparamref name="TInput" />.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   

--- a/xml/System/Func`1.xml
+++ b/xml/System/Func`1.xml
@@ -40,7 +40,7 @@
   </ReturnValue>
   <Docs>
     <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
-    <summary>Encapsulates a method that has no parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has no parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`10.xml
+++ b/xml/System/Func`10.xml
@@ -108,7 +108,7 @@
     <param name="arg7">The seventh parameter of the method that this delegate encapsulates.</param>
     <param name="arg8">The eighth parameter of the method that this delegate encapsulates.</param>
     <param name="arg9">The ninth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has nine parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has nine parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`11.xml
+++ b/xml/System/Func`11.xml
@@ -116,7 +116,7 @@
     <param name="arg8">The eighth parameter of the method that this delegate encapsulates.</param>
     <param name="arg9">The ninth parameter of the method that this delegate encapsulates.</param>
     <param name="arg10">The tenth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 10 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 10 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`12.xml
+++ b/xml/System/Func`12.xml
@@ -124,7 +124,7 @@
     <param name="arg9">The ninth parameter of the method that this delegate encapsulates.</param>
     <param name="arg10">The tenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg11">The eleventh parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 11 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 11 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`13.xml
+++ b/xml/System/Func`13.xml
@@ -132,7 +132,7 @@
     <param name="arg10">The tenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg11">The eleventh parameter of the method that this delegate encapsulates.</param>
     <param name="arg12">The twelfth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 12 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 12 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`14.xml
+++ b/xml/System/Func`14.xml
@@ -140,7 +140,7 @@
     <param name="arg11">The eleventh parameter of the method that this delegate encapsulates.</param>
     <param name="arg12">The twelfth parameter of the method that this delegate encapsulates.</param>
     <param name="arg13">The thirteenth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 13 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 13 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`15.xml
+++ b/xml/System/Func`15.xml
@@ -148,7 +148,7 @@
     <param name="arg12">The twelfth parameter of the method that this delegate encapsulates.</param>
     <param name="arg13">The thirteenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg14">The fourteenth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 14 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 14 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`16.xml
+++ b/xml/System/Func`16.xml
@@ -156,7 +156,7 @@
     <param name="arg13">The thirteenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg14">The fourteenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg15">The fifteenth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 15 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 15 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`17.xml
+++ b/xml/System/Func`17.xml
@@ -164,7 +164,7 @@
     <param name="arg14">The fourteenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg15">The fifteenth parameter of the method that this delegate encapsulates.</param>
     <param name="arg16">The sixteenth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has 16 parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has 16 parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`2.xml
+++ b/xml/System/Func`2.xml
@@ -49,7 +49,7 @@
     <typeparam name="T">The type of the parameter of the method that this delegate encapsulates.</typeparam>
     <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
     <param name="arg">The parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has one parameter and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has one parameter and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`3.xml
+++ b/xml/System/Func`3.xml
@@ -57,7 +57,7 @@
     <typeparam name="TResult">The type of the return value of the method that this delegate encapsulates.</typeparam>
     <param name="arg1">The first parameter of the method that this delegate encapsulates.</param>
     <param name="arg2">The second parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has two parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has two parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`4.xml
+++ b/xml/System/Func`4.xml
@@ -65,7 +65,7 @@
     <param name="arg1">The first parameter of the method that this delegate encapsulates.</param>
     <param name="arg2">The second parameter of the method that this delegate encapsulates.</param>
     <param name="arg3">The third parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has three parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has three parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`5.xml
+++ b/xml/System/Func`5.xml
@@ -73,7 +73,7 @@
     <param name="arg2">The second parameter of the method that this delegate encapsulates.</param>
     <param name="arg3">The third parameter of the method that this delegate encapsulates.</param>
     <param name="arg4">The fourth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has four parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has four parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`6.xml
+++ b/xml/System/Func`6.xml
@@ -76,7 +76,7 @@
     <param name="arg3">The third parameter of the method that this delegate encapsulates.</param>
     <param name="arg4">The fourth parameter of the method that this delegate encapsulates.</param>
     <param name="arg5">The fifth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has five parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has five parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`7.xml
+++ b/xml/System/Func`7.xml
@@ -84,7 +84,7 @@
     <param name="arg4">The fourth parameter of the method that this delegate encapsulates.</param>
     <param name="arg5">The fifth parameter of the method that this delegate encapsulates.</param>
     <param name="arg6">The sixth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has six parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has six parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`8.xml
+++ b/xml/System/Func`8.xml
@@ -92,7 +92,7 @@
     <param name="arg5">The fifth parameter of the method that this delegate encapsulates.</param>
     <param name="arg6">The sixth parameter of the method that this delegate encapsulates.</param>
     <param name="arg7">The seventh parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has seven parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has seven parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  

--- a/xml/System/Func`9.xml
+++ b/xml/System/Func`9.xml
@@ -100,7 +100,7 @@
     <param name="arg6">The sixth parameter of the method that this delegate encapsulates.</param>
     <param name="arg7">The seventh parameter of the method that this delegate encapsulates.</param>
     <param name="arg8">The eighth parameter of the method that this delegate encapsulates.</param>
-    <summary>Encapsulates a method that has eight parameters and returns a value of the type specified by the <paramref name="TResult" /> parameter.</summary>
+    <summary>Encapsulates a method that has eight parameters and returns a value of the type specified by the <typeparamref name="TResult" /> parameter.</summary>
     <returns>The return value of the method that this delegate encapsulates.</returns>
     <remarks>
       <format type="text/markdown"><![CDATA[  


### PR DESCRIPTION
## Summary
Fix incorrect usage of paramref on type parameters for System.Func and System.Converter

## Details
The documentation for `System.Func` and `System.Converter` used `paramref` for type type parameters. This change corrects it to `typeparamref`.

Other types defined in `Action.cs` do not have issues.