### PR TITLE
Update how-to-determine-which-versions-are-installed.md

### DIFF
--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -158,7 +158,7 @@ Users can install and run multiple versions of the .NET Framework on their compu
 - The following example checks the value of the `Release` keyword to determine whether .NET Framework 4.6.2 or higher is installed, regardless of Windows OS version (returning `True` if it is and `False` otherwise).
 
     ```PowerShell
-    Get-ChildItem "hklm:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\" | Get-ItemPropertyValue -Name Release | % { $_ -ge 394802 } 
+    Get-ChildItem "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\" | Get-ItemPropertyValue -Name Release | ForEach-Object { $_ -ge 394802 } 
     ```
 
     You can replace `394802` in the previous example with another value from the following table to check for a different minimum-required .NET Framework version.


### PR DESCRIPTION
# Title Update: How to determine which versions are installed
## Summary

I made two changes:
1. Changed hklm: to HKLM:  - the latter is how Get-PsDrive displays the drive name.
2. Replaced aliases to full cmdlet names - aliases are great but can confuse. A best practice is to spell out cmdlet names in full.

## Details

The registry drive names are all upper case by default. The documentation should reflect that.

Also, while using aliases is convenient at the console, we should not be using them here unless really necessary - and in this case, it isn't. In general, we should be showing whatever PowerShell shows (eg using Get-PSDrives or using tab completion and the inbox help.
