### PR TITLE
Fix for email address used in example

### DIFF
--- a/docs/fsharp/language-reference/results.md
+++ b/docs/fsharp/language-reference/results.md
@@ -73,7 +73,7 @@ let test() =
     | Error e -> printfn "Error: %s" e
     // Prints " "My request was valid!  Name: Phillip Email: phillip@consoto.biz"
 
-    let req2 = { Name = "Phillip"; Email = "phillip@bananas.biz" }
+    let req2 = { Name = "Phillip"; Email = "phillip@bananas.com" }
     let res2 = validateRequest (OK req2)
     match res2 with
     | Ok req -> printfn "My request was valid! Name: %s Email %s" req1.Name req1.Email


### PR DESCRIPTION
The "bad" email used in the final example was `bananas.biz` and not `bananas.com` as the it should be to trigger the `Error` path.