### PR TITLE
Correct typos in AggregateException doco

### DIFF
--- a/xml/System/AggregateException.xml
+++ b/xml/System/AggregateException.xml
@@ -80,9 +80,9 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This constructor initializes the <xref:System.Exception.Message%2A> property of the new instance to a system-supplied message that describes the error, such as "DefaultMessageDisplayedByParameterlessCtorWriterMustSupply" This message takes into account the current system culture.  
+ This constructor initializes the <xref:System.Exception.Message%2A> property of the new instance to a system-supplied message that describes the error, such as "System.AggregateException: One or more errors occurred." This message takes into account the current system culture.  
   
- The following table shows the initial property values for an instance of <xref:System.InsufficientMemoryException>.  
+ The following table shows the initial property values for an instance of <xref:System.AggregateException>.  
   
 |Property|Value|  
 |--------------|-----------|  


### PR DESCRIPTION
## Summary

* Refer to `AggregateException` rather than `InsufficientMemoryException`, in the `AggregateException` doco
* Replace placeholder text with typical en-US message for `AggregateException`
