### PR TITLE
Fix incorrect VerticalScrollBarVisibilityattribute

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Wpf/TextBox_MiscCode/CSharp/Window1.xaml
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/TextBox_MiscCode/CSharp/Window1.xaml
@@ -25,7 +25,7 @@
       Name="tbMultiLine"
       TextWrapping="Wrap"
       AcceptsReturn="True"
-      VerticalScrollBarVisibility="Visible"
+      ScrollViewer.VerticalScrollBarVisibility="Visible"
     >
       This TextBox will allow the user to enter multiple lines of text.  When the RETURN key is pressed, 
       or when typed text reaches the edge of the text box, a new line is automatically inserted.


### PR DESCRIPTION
# Title

Fix incorrect VerticalScrollBarVisibility attribute.

## Summary

Fixed a code snippet for the "Creating a Multiline TextBox control" article.

## Details

VerticalScrollBarVisibility is an attached property, and must be qualified by it's owner control when used on a TextBox.