### PR TITLE
Fixed exception list for GetFunctionPointerForDelegate<TDelegate>

### DIFF
--- a/xml/System.Runtime.InteropServices/Marshal.xml
+++ b/xml/System.Runtime.InteropServices/Marshal.xml
@@ -2795,7 +2795,7 @@
   
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentException">The <paramref name="d" /> parameter is a generic type.</exception>
+        <exception cref="T:System.ArgumentException">The <paramref name="d" /> parameter is a generic type definition.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="d" /> parameter is <see langword="null" />.</exception>
         <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
       </Docs>
@@ -2848,7 +2848,7 @@
   
  ]]></format>
         </remarks>
-        <exception cref="T:System.ArgumentException">The <paramref name="d" /> parameter is a generic type.</exception>
+        <exception cref="T:System.ArgumentException">The <paramref name="d" /> parameter is a generic type definition.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="d" /> parameter is <see langword="null" />.</exception>
         <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
       </Docs>

--- a/xml/System.Runtime.InteropServices/Marshal.xml
+++ b/xml/System.Runtime.InteropServices/Marshal.xml
@@ -2848,6 +2848,7 @@
   
  ]]></format>
         </remarks>
+        <exception cref="T:System.ArgumentException">The <paramref name="d" /> parameter is a generic type.</exception>
         <exception cref="T:System.ArgumentNullException">The <paramref name="d" /> parameter is <see langword="null" />.</exception>
         <permission cref="T:System.Security.SecurityCriticalAttribute">requires full trust for the immediate caller. This member cannot be used by partially trusted or transparent code.</permission>
       </Docs>


### PR DESCRIPTION
The generic form of GetFunctionPointerForDelegate<TDelegate> previously did not list System.ArgumentException as being thrown, even though it can be, just like its non-generic form.

# Title

Fixed exception list for GetFunctionPointerForDelegate<TDelegate>

## Summary

The generic form of GetFunctionPointerForDelegate<TDelegate> previously did not list System.ArgumentException as being thrown, even though it can be, just like its non-generic form.

## Details

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
