### PR TITLE
Initial stab at documentation for the Windows Compatibility Pack

### DIFF
--- a/docs/core/porting/windows-compat-pack.md
+++ b/docs/core/porting/windows-compat-pack.md
@@ -48,7 +48,6 @@ APIs:
 * DirectoryServices
 * Drawing
 * EventLog
-* MEF
 * Odbc
 * Perf Counters
 * Permissions

--- a/docs/core/porting/windows-compat-pack.md
+++ b/docs/core/porting/windows-compat-pack.md
@@ -1,0 +1,99 @@
+---
+title: Porting to .NET Core - Using the Windows Compatibility Pack
+description: Porting to .NET Core - Using the Windows Compatibility Pack
+keywords: .NET, .NET Core, Windows, Compatibility
+author: immol
+ms.author: mairaw
+ms.date: 11/13/2017
+ms.topic: article
+ms.prod: .net-core
+ms.devlang: dotnet
+ms.assetid: ffa28aed-45dd-4b02-965f-768c467829c3
+---
+
+# Using the Windows Compatibility Pack
+
+Many customers have reported that the primary reason why they have trouble
+porting to .NET Core is that they depend on APIs and technologies that only
+exist in .NET Framework. The *Windows Compatibility Pack* is about providing a
+good chunk of these technologies so that building .NET Core applications as well
+as .NET Standard libraries becomes much more viable for existing code.
+
+This is a logical [extension of .NET Standard 2.0][API Expansion] which
+significantly increased the API set to ensure code largely already compiles
+as-is. But in order to keep .NET Standard understandable, this didn't include
+technologies that can't work across all platforms, such as registry, WMI, or
+reflection emit APIs.
+
+The *Windows Compatibility Pack* sits above .NET Standard and is thus free to
+provide access to technologies that are Windows only. It is especially useful
+for customers that want to move to .NET Core but plan to stay on Windows as a
+first step. In that scenario, not being able to use Windows-only technologies is
+only a migration hurdle with zero architectural benefits.
+
+## Contents
+
+The *Windows Compatibility Pack* is provided via the NuGet Package
+[Microsoft.Windows.Compatibility] and can be referenced from .NET Core as well
+as .NET Standard.
+
+It provides about 20,000 APIs, including Windows-only as well as cross-platform
+APIs:
+
+* ACLs
+* Code Pages
+* CodeDom
+* Configuration
+* Crypto
+* DirectoryServices
+* Drawing
+* EventLog
+* MEF
+* Odbc
+* Perf Counters
+* Permissions
+* Ports
+* Registry
+* Runtime Caching
+* WCF
+* Windows Services
+
+For more details, take a look at the [spec of the compatibility pack][proposal].
+
+## Getting Started
+
+1. When porting existing code to .NET Core or .NET Standard, install the NuGet
+   package [Microsoft.Windows.Compatibility].
+2. If you want to stay on Windows, you're all set.
+3. If you want to run the .NET Core application or .NET Standard library on
+   Linux or macOS, use the [API Analyzer] to find usage of APIs that won't
+   work cross-platform.
+4. Either remove the usages of those APIs, replace them with cross-platform
+   alternatives, or guard them using a platform check, like:
+    ```CSharp
+    private static string GetLoggingPath()
+    {
+        // If we're on Windows and the desktop app has configured a logging path, we'll use that.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            using (var key = Registry.CurrentUser.OpenSubKey(@"Software\Fabrikam\AssetManagement"))
+            {
+                if (key?.GetValue("LoggingDirectoryPath") is string configuredPath)
+                    return configuredPath;
+            }
+        }
+
+        // We're either not on Windows or no logging path was configured, so we'll use the location
+        // for non-roaming user-specific data files.
+        var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(appDataPath, "Fabrikam", "AssetManagement", "Logging");
+    }
+    ```
+
+For a demo, check out the [Channel 9 video of the Windows Compatibility Pack][Video].
+
+[Proposal]: https://github.com/dotnet/designs/blob/master/accepted/compat-pack/compat-pack.md
+[Microsoft.Windows.Compatibility]: https://www.nuget.org/packages/Microsoft.Windows.Compatibility
+[API Expansion]: ../whats-new/index.md#api-changes-and-library-support
+[API Analyzer]: https://blogs.msdn.microsoft.com/dotnet/2017/10/31/introducing-api-analyzer/
+[Video]: https://channel9.msdn.com

--- a/docs/core/porting/windows-compat-pack.md
+++ b/docs/core/porting/windows-compat-pack.md
@@ -1,78 +1,84 @@
 ---
 title: Porting to .NET Core - Using the Windows Compatibility Pack
-description: Porting to .NET Core - Using the Windows Compatibility Pack
+description: Learn about the Windows Compatibility Pack and how can you use it to port existing .NET Framework code to .NET Core
 keywords: .NET, .NET Core, Windows, Compatibility
-author: immol
+author: terrajobst
 ms.author: mairaw
 ms.date: 11/13/2017
 ms.topic: article
 ms.prod: .net-core
-ms.devlang: dotnet
-ms.assetid: ffa28aed-45dd-4b02-965f-768c467829c3
 ---
 
 # Using the Windows Compatibility Pack
 
-Many customers have reported that the primary reason why they have trouble
-porting to .NET Core is that they depend on APIs and technologies that only
-exist in .NET Framework. The *Windows Compatibility Pack* is about providing a
-good chunk of these technologies so that building .NET Core applications as well
-as .NET Standard libraries becomes much more viable for existing code.
+One of the most common issues that developers face when porting their existing
+code to .NET Core is that they depend on APIs and technologies that only exist
+in the .NET Framework. The *Windows Compatibility Pack* is about providing many
+of these technologies so that building .NET Core applications as well as .NET
+Standard libraries becomes much more viable for existing code.
 
-This is a logical [extension of .NET Standard 2.0][API Expansion] which
-significantly increased the API set to ensure code largely already compiles
-as-is. But in order to keep .NET Standard understandable, this didn't include
-technologies that can't work across all platforms, such as registry, WMI, or
-reflection emit APIs.
+This package is a logical [extension of .NET Standard 2.0](../whats-new/index.md#api-changes-and-library-support)
+that significantly increases API set and existing code compiles with almost no
+modifications. But in order to keep the promise of .NET Standard ("it is the set
+of APIs that all .NET implementations provide"), this didn't include
+technologies that can't work across all platforms, such as registry, Windows
+Management Instrumentation (WMI), or reflection emit APIs.
 
-The *Windows Compatibility Pack* sits above .NET Standard and is thus free to
-provide access to technologies that are Windows only. It is especially useful
-for customers that want to move to .NET Core but plan to stay on Windows as a
-first step. In that scenario, not being able to use Windows-only technologies is
-only a migration hurdle with zero architectural benefits.
+The *Windows Compatibility Pack* sits on top of .NET Standard and provides
+access to technologies that are Windows only. It's especially useful for
+customers that want to move to .NET Core but plan to stay on Windows as a first
+step. In that scenario, not being able to use Windows-only technologies is only
+a migration hurdle with zero architectural benefits.
 
-## Contents
+## Package contents
 
 The *Windows Compatibility Pack* is provided via the NuGet Package
-[Microsoft.Windows.Compatibility] and can be referenced from .NET Core as well
-as .NET Standard.
+[Microsoft.Windows.Compatibility](https://www.nuget.org/packages/Microsoft.Windows.Compatibility)
+and can be referenced from projects targeting .NET Core or .NET Standard.
 
 It provides about 20,000 APIs, including Windows-only as well as cross-platform
-APIs:
+APIs from the following technology areas:
 
-* ACLs
 * Code Pages
 * CodeDom
 * Configuration
-* Crypto
-* DirectoryServices
+* Directory Services
 * Drawing
-* EventLog
-* Odbc
-* Perf Counters
+* ODBC
 * Permissions
 * Ports
-* Registry
-* Runtime Caching
-* WCF
+* Windows Access Control Lists (ACL)
+* Windows Communication Foundation (WCF)
+* Windows Cryptography
+* Windows EventLog
+* Windows Management Instrumentation (WMI)
+* Windows Performance Counters
+* Windows Registry
+* Windows Runtime Caching
 * Windows Services
 
-For more details, take a look at the [spec of the compatibility pack][proposal].
+For more information, see the [spec of the compatibility pack](https://github.com/dotnet/designs/blob/master/accepted/compat-pack/compat-pack.md).
 
-## Getting Started
+## Get started
 
-1. When porting existing code to .NET Core or .NET Standard, install the NuGet
-   package [Microsoft.Windows.Compatibility].
-2. If you want to stay on Windows, you're all set.
-3. If you want to run the .NET Core application or .NET Standard library on
-   Linux or macOS, use the [API Analyzer] to find usage of APIs that won't
-   work cross-platform.
-4. Either remove the usages of those APIs, replace them with cross-platform
+1. Before porting, make sure to take a look at the [Porting Process](index.md).
+
+2. When porting existing code to .NET Core or .NET Standard, install the NuGet
+   package [Microsoft.Windows.Compatibility](https://www.nuget.org/packages/Microsoft.Windows.Compatibility).
+
+3. If you want to stay on Windows, you're all set.
+
+4. If you want to run the .NET Core application or .NET Standard library on
+   Linux or macOS, use the [API Analyzer](https://blogs.msdn.microsoft.com/dotnet/2017/10/31/introducing-api-analyzer/)
+   to find usage of APIs that won't work cross-platform.
+
+5. Either remove the usages of those APIs, replace them with cross-platform
    alternatives, or guard them using a platform check, like:
-    ```CSharp
+
+    ```csharp
     private static string GetLoggingPath()
     {
-        // If we're on Windows and the desktop app has configured a logging path, we'll use that.
+        // Verify the code is running on Windows.
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             using (var key = Registry.CurrentUser.OpenSubKey(@"Software\Fabrikam\AssetManagement"))
@@ -82,17 +88,12 @@ For more details, take a look at the [spec of the compatibility pack][proposal].
             }
         }
 
-        // We're either not on Windows or no logging path was configured, so we'll use the location
-        // for non-roaming user-specific data files.
+        // This is either not running on Windows or no logging path was configured,
+        // so just use the path for non-roaming user-specific data files.
         var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         return Path.Combine(appDataPath, "Fabrikam", "AssetManagement", "Logging");
     }
     ```
 
-For a demo, check out the [Channel 9 video of the Windows Compatibility Pack][Video].
+For a demo, check out the [Channel 9 video of the Windows Compatibility Pack](https://channel9.msdn.com).
 
-[Proposal]: https://github.com/dotnet/designs/blob/master/accepted/compat-pack/compat-pack.md
-[Microsoft.Windows.Compatibility]: https://www.nuget.org/packages/Microsoft.Windows.Compatibility
-[API Expansion]: ../whats-new/index.md#api-changes-and-library-support
-[API Analyzer]: https://blogs.msdn.microsoft.com/dotnet/2017/10/31/introducing-api-analyzer/
-[Video]: https://channel9.msdn.com

--- a/docs/core/whats-new/index.md
+++ b/docs/core/whats-new/index.md
@@ -17,7 +17,7 @@ ms.prod: .net-core
 - [Platform improvements](#platform-improvements)
 - [API changes](#api-changes-and-library-support)
 - [Visual Studio integration](#visual-studio-integration)
-- [Documentation improvements](#documentation-improvements) 
+- [Documentation improvements](#documentation-improvements)
 
 ## Tooling
 
@@ -25,13 +25,13 @@ ms.prod: .net-core
 
 In previous versions of .NET Core, you had to run the [dotnet restore](../tools/dotnet-restore.md) command to download dependencies immediately after you created a new project with the [dotnet new](../tools/dotnet-new.md) command, as well as whenever you added a new dependency to your project.
 
-You can also disable the automatic invocation of `dotnet restore` by passing the `--no-restore` switch to the `new`, `run`, `build`, `publish`, `pack`, and `test` commands. 
+You can also disable the automatic invocation of `dotnet restore` by passing the `--no-restore` switch to the `new`, `run`, `build`, `publish`, `pack`, and `test` commands.
 
 [!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
 
 ### Retargeting to .NET Core 2.0
 
-If the .NET Core 2.0 SDK is installed, projects that target .NET Core 1.x can be retargeted to .NET Core 2.0. 
+If the .NET Core 2.0 SDK is installed, projects that target .NET Core 1.x can be retargeted to .NET Core 2.0.
 
 To retarget to .NET Core 2.0, edit your project file by changing the value of the `<TargetFramework>` element (or the `<TargetFrameworks>` element if you have more than one target in your project file) from 1.x to 2.0:
 
@@ -63,7 +63,7 @@ With version 2.0, .NET Core now supports Visual Basic 2017. You can use Visual B
 - .NET Core class libraries
 - .NET Standard class libraries
 - .NET Core unit test projects
-- .NET Core xUnit test projects 
+- .NET Core xUnit test projects
 
 For example, to create a Visual Basic "Hello World" application, do the following steps from the command line:
 
@@ -72,7 +72,7 @@ For example, to create a Visual Basic "Hello World" application, do the followin
 1. Enter the command `dotnet new console -lang vb`.
 
    The command creates a project file with a `.vbproj` file extension, along with a Visual Basic source code file named *Program.vb*. This file contains the source code to write the string "Hello World!" to the console window.
-  
+
 1.  Enter the command `dotnet run`. The [.NET Core CLI tools](../tools/index.md) automatically compile and execute the application, which displays the message "Hello World!" in the console window.
 
 ### Support for C# 7.1
@@ -93,11 +93,11 @@ For example, to create a Visual Basic "Hello World" application, do the followin
 
 .NET Core 2.0 offers a single Linux implementation that works on multiple Linux distributions. .NET Core 1.x required that you download a distribution-specific Linux implementation.
 
-You can also develop apps that target Linux as a single operating system. .NET Core 1.x required that you target each Linux distribution separately. 
+You can also develop apps that target Linux as a single operating system. .NET Core 1.x required that you target each Linux distribution separately.
 
 ### Support for the Apple cryptographic libraries
 
-.NET Core 1.x on macOS required the OpenSSL toolkit's cryptographic library. .NET Core 2.0 uses the Apple cryptographic libraries and doesn't require OpenSSL, so you no longer need to install it. 
+.NET Core 1.x on macOS required the OpenSSL toolkit's cryptographic library. .NET Core 2.0 uses the Apple cryptographic libraries and doesn't require OpenSSL, so you no longer need to install it.
 
 ## API changes and library support
 
@@ -113,9 +113,9 @@ For a list of the APIs that have been added to the .NET Standard since its last 
 
 ### Expanded surface area
 
-The total number of APIs available on .NET Core 2.0 has more than doubled in comparison with .NET Core 1.1. 
+The total number of APIs available on .NET Core 2.0 has more than doubled in comparison with .NET Core 1.1.
 
-And with the [Windows Compatibility Pack](core/porting/windows-compat-pack.md) porting from .NET Framework has also become much simpler.
+And with the [Windows Compatibility Pack](../porting/windows-compat-pack.md) porting from .NET Framework has also become much simpler.
 
 ### Support for .NET Framework libraries
 
@@ -127,13 +127,13 @@ Visual Studio 2017 version 15.3 and in some cases Visual Studio for Mac offer a 
 
 ### Retargeting .NET Core apps and .NET Standard libraries
 
-If the .NET Core 2.0 SDK is installed, you can retarget .NET Core 1.x projects to .NET Core 2.0 and .NET Standard 1.x libraries to .NET Standard 2.0. 
+If the .NET Core 2.0 SDK is installed, you can retarget .NET Core 1.x projects to .NET Core 2.0 and .NET Standard 1.x libraries to .NET Standard 2.0.
 
 To retarget your project in Visual Studio, you open the **Application** tab of the project's properties dialog and change the **Target framework** value to **.NET Core 2.0** or **.NET Standard 2.0**. You can also change it by right-clicking on the project and selecting the **Edit \*.csproj file** option. For more information, see the [Tooling](#tooling) section earlier in this topic.
 
 ### Live Unit Testing support for .NET Core
 
-Whenever you modify your code, Live Unit Testing automatically runs any affected unit tests in the background and displays the results and code coverage live in the Visual Studio environment. .NET Core 2.0 now supports Live Unit Testing. Previously, Live Unit Testing was available only for .NET Framework applications. 
+Whenever you modify your code, Live Unit Testing automatically runs any affected unit tests in the background and displays the results and code coverage live in the Visual Studio environment. .NET Core 2.0 now supports Live Unit Testing. Previously, Live Unit Testing was available only for .NET Framework applications.
 
 For more information, see [Live Unit Testing with Visual Studio 2017](/visualstudio/test/live-unit-testing) and the [Live Unit Testing FAQ](/visualstudio/test/live-unit-testing-faq).
 
@@ -141,7 +141,7 @@ For more information, see [Live Unit Testing with Visual Studio 2017](/visualstu
 
 If you're building a project for multiple target frameworks, you can now select the target platform from the top-level menu. In the following figure, a project named SCD1 targets 64-bit Mac OS X 10.11 (`osx.10.11-x64`) and 64-bit Windows 10/Windows Server 2016 (`win10-x64`). You can select the target framework before selecting the project button, in this case to run a debug build.
 
-![Selecting the target framework when building a project](media/multitarget.png) 
+![Selecting the target framework when building a project](media/multitarget.png)
 
 ### Side-by-side support for .NET Core SDKs
 

--- a/docs/core/whats-new/index.md
+++ b/docs/core/whats-new/index.md
@@ -115,6 +115,8 @@ For a list of the APIs that have been added to the .NET Standard since its last 
 
 The total number of APIs available on .NET Core 2.0 has more than doubled in comparison with .NET Core 1.1. 
 
+And with the [Windows Compatibility Pack](core/porting/windows-compat-pack.md) porting from .NET Framework has also become much simpler.
+
 ### Support for .NET Framework libraries
 
 .NET Core code can reference existing .NET Framework libraries, including existing NuGet packages. Note that the libraries must use APIs that are found in .NET Standard.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -150,6 +150,7 @@
 ### [Organizing projects for .NET Core](core/porting/project-structure.md)
 ### [Analyzing third-party dependencies](core/porting/third-party-deps.md)
 ### [Porting libraries](core/porting/libraries.md)
+### [Using the Windows Compatibility Pack](core/porting/windows-compat-pack.md)
 <!--### [🔧 NuGet packages](core/porting/nuget-packages.md)-->
 ## [Build .NET Core from source](core/build/index.md)
 ### [.NET Core distribution packaging](core/build/distribution-packaging.md)


### PR DESCRIPTION
This adds some getting started documentation for the Windows Compatibility Pack.

@mairaw, I've removed the use of we but I'm sure could use some of your wordsmithing magic :-)

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/core/porting/windows-compat-pack?branch=pr-en-us-3674)