### PR TITLE
Fix links that lead to a 404 page

### DIFF
--- a/docs/core/docker/intro-net-docker.md
+++ b/docs/core/docker/intro-net-docker.md
@@ -34,7 +34,7 @@ The [relationship between Docker containers, images, and registries](https://doc
 * [Docker overview](https://docs.docker.com/engine/docker-overview/)
 * [Dockerfile on Windows Containers](https://docs.microsoft.com/virtualization/windowscontainers/manage-docker/manage-windows-dockerfile)
 * [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)
-* [Building Docker Images for .NET Core applications](..\building-net-docker-images.md)
+* [Building Docker Images for .NET Core applications](../docker/building-net-docker-images.md)
 
 
 ### Getting .NET Docker Images

--- a/docs/csharp/quick-starts/introduction-to-classes.md
+++ b/docs/csharp/quick-starts/introduction-to-classes.md
@@ -144,7 +144,7 @@ This introduces the concept of ***exceptions***. The standard way of indicating 
 
 [!code-csharp[DepositAndWithdrawal](../../../samples/csharp/classes-quickstart/BankAccount.cs#DepositAndWithdrawal "Make deposits and withdrawals")]
 
-The [`throw`](../language-reference/throw.md) statment **throws** an exception. Execution of the current method ends, and will resume when a matching `catch` block is found. You'll add a `catch` block to test this code a little later on.
+The [`throw`](../language-reference/keywords/throw.md) statment **throws** an exception. Execution of the current method ends, and will resume when a matching `catch` block is found. You'll add a `catch` block to test this code a little later on.
 
 The constructor should get one change so that it adds an initial transaction, rather than updating the balance directly. Since you already wrote the `MakeDeposit` method, call it from your constructor. The finished constructor should look like this:
 


### PR DESCRIPTION
This PR fixes two links that lead to a 404 in the following pages : 

[Introduction to classes](https://github.com/dotnet/docs/blob/master/docs/csharp/quick-starts/introduction-to-classes.md)
[Introduction to .NET and Docker](https://github.com/dotnet/docs/blob/master/docs/core/docker/intro-net-docker.md)

