### PR TITLE
Example of active pattern usage in let-binding

### DIFF
--- a/docs/fsharp/language-reference/active-patterns.md
+++ b/docs/fsharp/language-reference/active-patterns.md
@@ -121,7 +121,7 @@ The output of the previous code is as follows:
 
 Active patterns are not restricted only to pattern matching expressions, you can also use them on let-bindings.
 
-[!code-fsharp[Main](../../../samples/snippets/fsharp/lang-ref-2/snippet5006.fs)]
+[!code-fsharp[Main](../../../samples/snippets/fsharp/lang-ref-2/snippet5007.fs)]
 
 The output of the previous code is as follows:
 

--- a/docs/fsharp/language-reference/active-patterns.md
+++ b/docs/fsharp/language-reference/active-patterns.md
@@ -119,6 +119,17 @@ The output of the previous code is as follows:
 12/22/2008 12:00:00 AM 1/1/2009 12:00:00 AM 1/15/2008 12:00:00 AM 12/28/1995 12:00:00 AM
 ```
 
+Active patterns are not restricted only to pattern matching expressions, you can also use them on let-bindings.
+
+[!code-fsharp[Main](../../../samples/snippets/fsharp/lang-ref-2/snippet5006.fs)]
+
+The output of the previous code is as follows:
+
+```
+Hello, random citizen!
+Hello, George!
+```
+
 ## See Also
 [F# Language Reference](index.md)
 

--- a/samples/snippets/fsharp/lang-ref-2/snippet5007.fs
+++ b/samples/snippets/fsharp/lang-ref-2/snippet5007.fs
@@ -1,0 +1,10 @@
+let (|Default|) onNone value =
+    match value with
+    | None -> onNone
+    | Some e -> e
+
+let greet (Default "random citizen" name) =
+    printfn "Hello, %s!" name
+
+greet None
+greet (Some "George")


### PR DESCRIPTION
# Example of active pattern usage in let-binding

Added an example of an active pattern to add a default parameter to a function.

## Summary

The original document used the created active patterns only inside explicit pattern matching expressions. This example shows that the feature can be used in any binding as well.

## Suggested Reviewers

@cartermp 
