### PR TITLE
Fixing a detail about add@type

### DIFF
--- a/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-source.md
+++ b/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-source.md
@@ -46,7 +46,7 @@ Adds a listener to the `Listeners` collection for a trace source.
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|`type`|Required attribute.<br /><br /> Specifies the type of the listener. You must use a string that meets the requirements specified in [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md).|  
+|`type`|Required attribute, unless you're referencing a listener in the `sharedListeners` collection, in which case you only need to refer to it by name (see the Example).<br /><br /> Specifies the type of the listener. You must use a string that meets the requirements specified in [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md).|  
 |`initializeData`|Optional attribute.<br /><br /> The string passed to the constructor for the specified class. A <xref:System.Configuration.ConfigurationException> is thrown if the class does not have a constructor that takes a string.|  
 |`name`|Optional attribute.<br /><br /> Specifies the name of the listener.|  
 |`traceOutputOptions`|Optional attribute.<br /><br /> Specifies the <xref:System.Diagnostics.TraceListener.TraceOutputOptions%2A> property value for the trace listener.|  

--- a/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-source.md
+++ b/docs/framework/configure-apps/file-schema/trace-debug/add-element-for-listeners-for-source.md
@@ -46,7 +46,7 @@ Adds a listener to the `Listeners` collection for a trace source.
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|`type`|Required attribute, unless you're referencing a listener in the `sharedListeners` collection, in which case you only need to refer to it by name (see the Example).<br /><br /> Specifies the type of the listener. You must use a string that meets the requirements specified in [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md).|  
+|`type`|Required attribute, unless you're referencing a listener in the `sharedListeners` collection, in which case you only need to refer to it by name (see the [Example](#example)).<br /><br /> Specifies the type of the listener. You must use a string that meets the requirements specified in [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md).|  
 |`initializeData`|Optional attribute.<br /><br /> The string passed to the constructor for the specified class. A <xref:System.Configuration.ConfigurationException> is thrown if the class does not have a constructor that takes a string.|  
 |`name`|Optional attribute.<br /><br /> Specifies the name of the listener.|  
 |`traceOutputOptions`|Optional attribute.<br /><br /> Specifies the <xref:System.Diagnostics.TraceListener.TraceOutputOptions%2A> property value for the trace listener.|  


### PR DESCRIPTION
add@type is actually only required if the listener being added is NOT in the sharedListeners collection. Adding that detail.

# Fixing a detail about add@type

## Summary

add@type is actually only required if the listener being added is NOT in the sharedListeners collection. Adding that detail.

## Details

## Suggested Reviewers
