### PR TITLE
reorder samples

### DIFF
--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -100,8 +100,8 @@
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.  
   
  [!code-csharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/cs/program.cs#1)]
- [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
  [!code-vb[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/vb/module1.vb#1)]  
+ [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
   
  The following example demonstrates several properties and methods of the <xref:System.Collections.Generic.List%601> generic class of type string. (For an example of a <xref:System.Collections.Generic.List%601> of complex types, see the <xref:System.Collections.Generic.List%601.Contains%2A> method.)  
   
@@ -117,8 +117,8 @@
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
     </remarks>
@@ -173,8 +173,8 @@
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -330,8 +330,8 @@
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.  
   
  [!code-csharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/cs/program.cs#1)]
- [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
  [!code-vb[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/vb/module1.vb#1)]  
+ [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
   
  The following example demonstrates several properties and methods of the <xref:System.Collections.Generic.List%601> generic class, including the <xref:System.Collections.Generic.List%601.Add%2A> method. The default constructor is used to create a list of strings with a capacity of 0. The <xref:System.Collections.Generic.List%601.Capacity%2A> property is displayed, and then the <xref:System.Collections.Generic.List%601.Add%2A> method is used to add several items. The items are listed, and the <xref:System.Collections.Generic.List%601.Capacity%2A> property is displayed again, along with the <xref:System.Collections.Generic.List%601.Count%2A> property, to show that the capacity has been increased as needed.  
   
@@ -339,8 +339,8 @@
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -738,8 +738,8 @@
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -792,8 +792,8 @@
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -1156,8 +1156,8 @@
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -2368,15 +2368,15 @@ Public Function StartsWith(e As Employee) As Boolean
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.  
   
  [!code-csharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/cs/program.cs#1)]
- [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
  [!code-vb[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/vb/module1.vb#1)]  
+ [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
   
  The following example demonstrates the <xref:System.Collections.Generic.List%601.Insert%2A> method, along with various other properties and methods of the <xref:System.Collections.Generic.List%601> generic class. After the list is created, elements are added. The <xref:System.Collections.Generic.List%601.Insert%2A> method is used to insert an item into the middle of the list. The item inserted is a duplicate, which is later removed using the <xref:System.Collections.Generic.List%601.Remove%2A> method.  
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -2755,15 +2755,15 @@ Public Function StartsWith(e As Employee) As Boolean
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.  
   
  [!code-csharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/cs/program.cs#1)]
- [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
  [!code-vb[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/vb/module1.vb#1)]  
+ [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
   
  The following example demonstrates <xref:System.Collections.Generic.List%601.Remove%2A> method. Several properties and methods of the <xref:System.Collections.Generic.List%601> generic class are used to add, insert, and search the list. After these operations, the list contains a duplicate. The <xref:System.Collections.Generic.List%601.Remove%2A> method is used to remove the first instance of the duplicate item, and the contents are displayed. The <xref:System.Collections.Generic.List%601.Remove%2A> method always removes the first instance it encounters.  
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>
@@ -2885,8 +2885,8 @@ Public Function StartsWith(e As Employee) As Boolean
  The following example demonstrates how to add, remove, and insert a simple business object in a <xref:System.Collections.Generic.List%601>.  
   
  [!code-csharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/cs/program.cs#1)]
- [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
  [!code-vb[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/vb/module1.vb#1)]  
+ [!code-fsharp[System.Collections.Generic.List.AddRemoveInsert#1](~/samples/snippets/fsharp/VS_Snippets_CLR_System/system.collections.generic.list.addremoveinsert/fs/addremoveinsert.fs#1)]
   
  ]]></format>
         </remarks>
@@ -4200,8 +4200,8 @@ finally
   
  [!code-cpp[List\`1_Class#1](~/samples/snippets/cpp/VS_Snippets_CLR/List`1_Class/cpp/source.cpp#1)]
  [!code-csharp[List\`1_Class#1](~/samples/snippets/csharp/VS_Snippets_CLR/List`1_Class/cs/source.cs#1)]
- [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
  [!code-vb[List\`1_Class#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/List`1_Class/vb/source.vb#1)]  
+ [!code-fsharp[List\`1_Class#1](~/samples/snippets/fsharp/VS_Snippets_CLR/List`1_Class/fs/listclass.fs#1)]
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
VB samples are always being displayed no matter which language is selected in the language picker.
https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1?view=netframework-4.7.1

Testing to see if moving the VB samples to after the fsharp reference will help.

@adkinn we also need to check how we can override the language selection for individual APIs. I'd like to customize the language filter for the APIs in this set individually.
My previous PR (#3632) to override the language filter for https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.supportsdaylightsavingtime?view=netframework-4.7.1, didn't really work, even after a full build. 

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1?view=netframework-4.7.1&branch=pr-en-us-3687)