### PR TITLE
Fix for C# Discards Guide Code Sample Producing CS8184

### DIFF
--- a/docs/csharp/discards.md
+++ b/docs/csharp/discards.md
@@ -14,10 +14,10 @@ ms.devlang: csharp
 
 Starting with C# 7, C# supports discards, which are temporary, dummy variables that are intentionally unused in application code. Discards are equivalent to unassigned variables; they do not have a value. Because there is only a single discard variable, and that variable may not even be allocated storage, discards can reduce memory allocations. Because they make the intent of your code clear, they enhance its readability and maintainability.
 
-You indicate that a variable is a discard by assigning it the underscore (`_`) as its name. For example, the following method call returns a 3-tuple in which the first and second values are discards:
+You indicate that a variable is a discard by assigning it the underscore (`_`) as its name. For example, the following method call returns a 3-tuple in which the first and second values are discards and *area* is a previously declared variable to be set to the corresponding third component returned by *GetCityInformation*:
 
 ```csharp
-(var _, _, area) = city.GetCityInformation(cityName);
+(_, _, area) = city.GetCityInformation(cityName);
 ```
 
 In C# 7, discards are supported in assignments in the following contexts:


### PR DESCRIPTION
# Fix for C# Discards Guide Code Sample Producing CS8184

## Summary

The code

```csharp
(var _, _, area) = city.GetCityInformation(cityName);
```

produces error CS8184 regarding mixing declarations and existing variables in tuple deconstruction.

This PR is to fix that error and add a comment that *area* is an existing variable.

## Details

1. Code sample changed to:

```csharp
(_, _, area) = city.GetCityInformation(cityName);
```

2. Remark added that *area* is an existing variable.

## Suggested Reviewers

Current authors: @rpetrusha, @mairaw, and @jellypotato-de