### PR TITLE
C# Tuple Deconstruction With Existing Variables

### DIFF
--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -353,7 +353,7 @@ public class Point
 ```
 
 > [!WARNING]
->  You cannot mix existing declarations with declarations inside the parantheses. For instance, the following is not allowed: `(var x, y) = MyMethod();`. This produces error CS8184 because *x* is declared inside the parantheses and *y* is previously declared elsewhere.
+>  You cannot mix existing declarations with declarations inside the parantheses. For instance, the following is not allowed: `(var x, y) = MyMethod();`. This produces error CS8184 because *x* is declared inside the parentheses and *y* is previously declared elsewhere.
 
 ### Deconstructing user defined types
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -353,7 +353,7 @@ public class Point
 ```
 
 > [!WARNING]
->  You cannot mix existing declarations with declarations inside the parantheses. For instance, the following is not allowed: `(var x, y) = MyMethod();`. This produces error CS8184 because *x* is declared inside the parentheses and *y* is previously declared elsewhere.
+>  You cannot mix existing declarations with declarations inside the parentheses. For instance, the following is not allowed: `(var x, y) = MyMethod();`. This produces error CS8184 because *x* is declared inside the parentheses and *y* is previously declared elsewhere.
 
 ### Deconstructing user defined types
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -318,7 +318,7 @@ work with the results.
 ## Deconstruction
 
 You can unpackage all the items in a tuple by *deconstructing* the tuple
-returned by a method. There are two different approaches to deconstructing
+returned by a method. There are three different approaches to deconstructing
 tuples.  First, you can explicitly declare the type of each field inside
 parentheses to create discrete variables for each of the elements in the tuple:
 
@@ -339,6 +339,21 @@ declarations inside the parentheses.
 Note that you cannot use a specific
 type outside the parentheses, even if every field in the tuple has the
 same type.
+
+You can deconstruct tuples with existing declarations as well:
+
+```csharp
+public class Point
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+
+    public Point(int x, int y) => (X, Y) = (x, y);
+}
+```
+
+> [!WARNING]
+>  You cannot mix existing declarations with declarations inside the parantheses. For instance, the following is not allowed: `(var x, y) = MyMethod();`. This produces error CS8184 because *x* is declared inside the parantheses and *y* is previously declared elsewhere.
 
 ### Deconstructing user defined types
 


### PR DESCRIPTION
# C# Tuple Deconstruction With Existing Variables

## Summary

Added third option in guide on tuples for deconstruction with an example.

## Details

1. Noted that existing variables can be used for deconstruction.
2. Provided an example.
3. Provided a warning about mixing existing and new declarations for CS8184.

## Suggested Reviewers

Current authors: @BillWagner, @mariaw, @guardrex, @tompratt-AQ, @rpetrusha, @Pothulapati, @selony, @stefanforsberg, and @aarondandy
