### PR TITLE
Revised String.Format method and its overloads 

### DIFF
--- a/includes/interpolated-strings.md
+++ b/includes/interpolated-strings.md
@@ -1,0 +1,3 @@
+
+> [!IMPORTANT]
+> Instead of calling the **String.Format** method or using [composite format strings](~/docs/standard/base-types/composite-formatting.md), you can use interpolated strings if your language supports them. An interpolated string is a string that contains *interpolated expressions*. Each interpolated expression is resolved with the expression's value and included in the result string when the string is assigned. For more information, see [Interpolated Strings (C# Reference)](~/docs/csharp/language-reference/keywords/interpolated-strings.md) and [Interpolated Strings (Visual Basic Reference)](~/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md).

--- a/includes/provider-string-format.md
+++ b/includes/provider-string-format.md
@@ -1,0 +1,5 @@
+
+However, when calling the **String.Format** method, it is not necessary to focus on the particular overload that you want to call. Instead, you can call the method with an object that provides culture-sensitive or custom formatting and a [composite format string](~/docs/standard/base-types/composite-formatting.md) that includes one or more format items. You assign each format item a numeric index; the first index starts at 0. In addition to the initial string, your method call should have as many additional arguments as it has index values. For example, a string whose format items have indexes of 0 and 1 should have 2 arguments; one with indexes 0 through 5 should have 6 arguments. Your language compiler will then resolve your method call to a particular overload of the **String.Format** method.  
+
+For more detailed documentation on using the **String.Format** method, see [Getting started with the String.Format method](#Starting) and [Which method do I call?](#FTaskList).   
+

--- a/includes/simple-string-format.md
+++ b/includes/simple-string-format.md
@@ -1,0 +1,5 @@
+
+However, when calling the **String.Format** method, it is not necessary to focus on the particular overload that you want to call. Instead, you can call the method with a [composite format string](~/docs/standard/base-types/composite-formatting.md) that includes one or more format items. You assign each format item a numeric index; the first index starts at 0. In addition to the initial string, your method call should have as many additional arguments as it has index values. For example, a string whose format items have indexes of 0 and 1 should have 2 arguments; one with indexes 0 through 5 should have 6 arguments. Your language compiler will then resolve your method call to a particular overload of the **String.Format** method.  
+
+For more detailed documentation on using the **String.Format** method, see [Getting started with the String.Format method](#Starting) and [Which method do I call?](#FTaskList).   
+

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -4306,7 +4306,7 @@
       <Docs>
         <summary>Converts the value of objects to strings based on the formats specified and inserts them into another string.  
   
- If you are new to the String.Format method, see the [Getting started with the String.Format method](#Starting) section for a quick overview.  
+ If you are new to the `String.Format` method, see the [Getting started with the String.Format method](#Starting) section for a quick overview.  
   
  See the [Remarks](#remarks-top) section for general documentation for the String.Format method.</summary>
         <remarks>

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -108,7 +108,7 @@
  Each character in a string is defined by a Unicode scalar value, also called a Unicode code point or the ordinal (numeric) value of the Unicode character. Each code point is encoded by using UTF-16 encoding, and the numeric value of each element of the encoding is represented by a <xref:System.Char> object.  
   
 > [!NOTE]
->  Note that, because a <xref:System.String> instance consists of a sequential collection of UTF-16 code units, it is possible to create a <xref:System.String> object that is not a well-formed Unicode string. For example, it is possible to create a string that has a low surrogate without a corresponding high surrogate. Although some methods, such as the methods of encoding and decoding objects in the <xref:System.Text> namespace, may performs checks to ensure that strings are well-formed, <xref:System.String> class members do not ensure that a string is well-formed.  
+>  Note that, because a <xref:System.String> instance consists of a sequential collection of UTF-16 code units, it is possible to create a <xref:System.String> object that is not a well-formed Unicode string. For example, it is possible to create a string that has a low surrogate without a corresponding high surrogate. Although some methods, such as the methods of encoding and decoding objects in the <xref:System.Text> namespace, may performs checks to ensure that strings are well-formed, <xref:System.String> class members don't ensure that a string is well-formed.  
   
  A single <xref:System.Char> object usually represents a single code point; that is, the numeric value of the <xref:System.Char> equals the code point. For example, the code point for the character "a" is U+0061. However, a code point might require more than one encoded element (more than one <xref:System.Char> object). The Unicode standard defines two types of characters that correspond to multiple <xref:System.Char> objects: graphemes, and Unicode supplementary code points that correspond to characters in the Unicode supplementary planes.  
   
@@ -164,7 +164,7 @@
   
 -   The string created by the `strcpy_s` or `wcscpy_s` functions is not necessarily identical to the string created by the <xref:System.String.Copy%2A?displayProperty=nameWithType> method.  
   
- You should ensure that native C and C++ code that instantiates <xref:System.String> objects, and code that is passed <xref:System.String> objects through platform invoke, do not assume that an embedded null character marks the end of the string.  
+ You should ensure that native C and C++ code that instantiates <xref:System.String> objects, and code that is passed <xref:System.String> objects through platform invoke, don't assume that an embedded null character marks the end of the string.  
   
  Embedded null characters in a string are also treated differently when a string is sorted (or compared) and when a string is searched. Null characters are ignored when performing culture-sensitive comparisons between two strings, including comparisons using the invariant culture. They are considered only for ordinal or case-insensitive ordinal comparisons. On the other hand, embedded null characters are always considered when searching a string with methods such as <xref:System.String.Contains%2A>, <xref:System.String.StartsWith%2A>, and <xref:System.String.IndexOf%2A>.  
   
@@ -351,7 +351,7 @@
   
  For more information about word, string, and ordinal sort rules, see the <xref:System.Globalization.CompareOptions?displayProperty=nameWithType> topic. For additional recommendations on when to use each rule, see [Best Practices for Using Strings](~/docs/standard/base-types/best-practices-strings.md).  
   
- Ordinarily, you do not call string comparison methods such as <xref:System.String.Compare%2A> directly to determine the sort order of strings. Instead, comparison methods are called by sorting methods such as <xref:System.Array.Sort%2A?displayProperty=nameWithType> or <xref:System.Collections.Generic.List%601.Sort%2A?displayProperty=nameWithType>. The following example performs four different sorting operations (word sort using the current culture, word sort using the invariant culture, ordinal sort, and string sort using the invariant culture) without explicitly calling a string comparison method, although they do specify the type of comparison to use. Note that each type of sort produces a unique ordering of strings in its array.  
+ Ordinarily, you don't call string comparison methods such as <xref:System.String.Compare%2A> directly to determine the sort order of strings. Instead, comparison methods are called by sorting methods such as <xref:System.Array.Sort%2A?displayProperty=nameWithType> or <xref:System.Collections.Generic.List%601.Sort%2A?displayProperty=nameWithType>. The following example performs four different sorting operations (word sort using the current culture, word sort using the invariant culture, ordinal sort, and string sort using the invariant culture) without explicitly calling a string comparison method, although they do specify the type of comparison to use. Note that each type of sort produces a unique ordering of strings in its array.  
   
  [!code-cpp[System.String.Class#12](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Class/cpp/string.compare2.cpp#12)]
  [!code-csharp[System.String.Class#12](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Class/cs/compare2.cs#12)]
@@ -481,7 +481,7 @@
 -   <xref:System.String.TrimStart%2A> removes all occurrences of a character from the beginning of a string.  
   
 > [!IMPORTANT]
->  All string modification methods return a new <xref:System.String> object. They do not modify the value of the current instance.  
+>  All string modification methods return a new <xref:System.String> object. They don't modify the value of the current instance.  
   
 ### Extracting substrings from a string  
  The <xref:System.String.Split%2A?displayProperty=nameWithType> method separates a single string into multiple strings. Overloads of the method allow you to specify multiple delimiters, to determine the maximum number of substrings that the method extracts, and to determine whether empty strings (which occur when delimiters are adjacent) are included among the returned strings.  
@@ -606,7 +606,7 @@
   
 <a name="Params"></a>   
 ## Parameters  
- Here is a complete list of parameters used by <xref:System.String> constructors that do not include a pointer parameter. For the parameters used by each overload, see the overload syntax above.  
+ Here is a complete list of parameters used by <xref:System.String> constructors that don't include a pointer parameter. For the parameters used by each overload, see the overload syntax above.  
   
 |Parameter|Type|Description|  
 |---------------|----------|-----------------|  
@@ -627,7 +627,7 @@
   
 <a name="Exceptions"></a>   
 ## Exceptions  
- Here's a list of exceptions thrown by constructors that do not include pointer parameters.  
+ Here's a list of exceptions thrown by constructors that don't include pointer parameters.  
   
 |Exception|Condition|Thrown by|  
 |---------------|---------------|---------------|  
@@ -693,7 +693,7 @@
   
 <a name="Repetitive"></a>   
 ## Handling repetitive strings  
- Apps that parse or decode streams of text often use the <xref:System.String.%23ctor%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29> constructor or the <xref:System.Text.StringBuilder.Append%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29?displayProperty=nameWithType> method to convert sequences of characters into a string. Repeatedly creating new strings with the same value instead of creating and reusing one string wastes memory. If you are likely to create the same string value repeatedly by calling the <xref:System.String.%23ctor%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29> constructor, even if you do not know in advance what those identical string values may be, you can use a lookup table instead.  
+ Apps that parse or decode streams of text often use the <xref:System.String.%23ctor%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29> constructor or the <xref:System.Text.StringBuilder.Append%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29?displayProperty=nameWithType> method to convert sequences of characters into a string. Repeatedly creating new strings with the same value instead of creating and reusing one string wastes memory. If you are likely to create the same string value repeatedly by calling the <xref:System.String.%23ctor%28System.Char%5B%5D%2CSystem.Int32%2CSystem.Int32%29> constructor, even if you don't know in advance what those identical string values may be, you can use a lookup table instead.  
   
  For example, suppose you read and parse a stream of characters from a file that contains XML tags and attributes. When you parse the stream, you repeatedly encounter certain tokens (that is, sequences of characters that have a symbolic meaning). Tokens equivalent to the strings "0", "1", "true", and "false" are likely to occur frequently in an XML stream.  
   
@@ -4306,9 +4306,9 @@
       <Docs>
         <summary>Converts the value of objects to strings based on the formats specified and inserts them into another string.  
   
- If you are new to the <see cref="Overload:System.String.Format" /> method, see the [Getting started with the String.Format method](#Starting) section for a quick overview.  
+ If you are new to the String.Format method, see the [Getting started with the String.Format method](#Starting) section for a quick overview.  
   
- See the [Remarks](#Format_Syntax) section for complete documentation for all <see cref="Overload:System.String.Format" /> overloads.</summary>
+ See the [Remarks](#Starting) section for general documentation for the String.Format method.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -4316,10 +4316,6 @@
  In this section:  
   
  [Getting started with the String.Format method](#Starting)   
- [Overloaded method syntax](#Format_Syntax)   
- [Parameters](#Format_Params)   
- [Return value](#Format_Returns)   
- [Exceptions](#Format_Exceptions)   
  [Which method do I call?](#FTaskList)   
  [The Format method in brief](#Format_Brief)   
  [The Format item](#FormatItem)   
@@ -4328,8 +4324,6 @@
  [Formatting and culture](#Format_Culture)   
  [Custom formatting operations](#Format_Custom)   
  Examples:   
- [Formatting a single argument](#Format1_Example)  
- [Formatting two arguments](#Format2_Example)  
  [Formatting three arguments](#Format3_Example)  
  [Formatting more than three arguments](#Format4_Example)  
  [Culture-sensitive formatting](#Format5_Example)  
@@ -4354,7 +4348,8 @@
   
  Besides formatting, you can also control alignment and spacing.  
   
- Inserting a string  
+ ### Inserting a string  
+
  <xref:System.String.Format%2A?displayProperty=nameWithType> starts with a format string, followed by one or more objects or expressions that will be converted to strings and inserted at a specified place in the format string. For example:  
   
  [!code-cpp[System.String.Format#30](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/starting1.cpp#30)]
@@ -4371,7 +4366,7 @@
   
  You can have as many format items and as many objects in the object list as you want, as long as the index of every format item has a matching object in the object list. You also don't have to worry about which overload you call; the compiler will select the appropriate one for you.  
   
- Controlling formatting  
+ ### Controlling formatting  
  You can follow the index in a format item with a format string to control how an object is formatted. For example, `{0:d}` applies the "d" format string to the first object in the object list. Here is an example with a single object and two format items:  
   
  [!code-cpp[System.String.Format#32](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/starting1.cpp#32)]
@@ -4380,7 +4375,7 @@
   
  A number of types support format strings, including all numeric types (both                                          [standard](~/docs/standard/base-types/standard-numeric-format-strings.md) and                                          [custom](~/docs/standard/base-types/custom-numeric-format-strings.md) format strings), all dates and times (both                                          [standard](~/docs/standard/base-types/standard-date-and-time-format-strings.md) and                                          [custom](~/docs/standard/base-types/custom-date-and-time-format-strings.md) format strings) and time intervals (both                                          [standard](~/docs/standard/base-types/standard-timespan-format-strings.md) and                                          [custom](~/docs/standard/base-types/custom-timespan-format-strings.md) format strings), all enumeration types                                          [enumeration types](~/docs/standard/base-types/enumeration-format-strings.md), and                                          [GUIDs](https://msdn.microsoft.com/library/97af8hh4.aspx). You can also add support for format strings to your own types.  
   
- Controlling spacing  
+ ### Controlling spacing  
  You can define the width of the string that is inserted into the result string by using syntax such as `{0,12}`, which inserts a 12-character string. In this case, the string representation of the first object is right-aligned in the 12-character field.  (If the string representation of the first object is more than 12 characters in length, though, the preferred field width is ignored, and the entire string is inserted into the result string.)  
   
  The following example defines a 6-character field to hold the string "Year" and some year strings, as well as an 15-character field to hold the string "Population" and some population data. Note that the characters are right-aligned in the field.  
@@ -4389,7 +4384,7 @@
  [!code-csharp[System.String.Format#33](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/starting1.cs#33)]
  [!code-vb[System.String.Format#33](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/starting1.vb#33)]  
   
- Controlling alignment  
+ ### Controlling alignment  
  By default, strings are right-aligned within their field if you specify a field width. To left-align strings in a field, you preface the field width with a negative sign, such as `{0,-12}` to define a 12-character right-aligned field.  
   
  The following example is similar to the previous one, except that it left-aligns both labels and data.  
@@ -4400,62 +4395,18 @@
   
  <xref:System.String.Format%2A?displayProperty=nameWithType> makes use of the composite formatting feature. For more information, see [Composite Formatting](~/docs/standard/base-types/composite-formatting.md).  
   
-<a name="Format_Syntax"></a>   
-## Overloaded method syntax  
- For additional guidance on choosing an overload, see [Which method do I call?](#FTaskList)  
-  
- `String String.Format(String format, Object arg0)`  
- Replaces the format items with the string representation of a specified object ([example](#Format1_Example)).  
-  
- `String String.Format(String format, Object arg0, Object arg1)`  
- Replaces the format items with the string representation of two specified objects ([example](#Format2_Example)).  
-  
- `String String.Format(String format, Object arg0, Object arg1, Object arg2)`  
- Replaces the format items with the string representation of three specified objects ([example](#Format3_Example)).  
-  
- `String String.Format(String format, params Object[] args)`  
- Replaces the format items with the string representations of corresponding objects in a specified array ([example](#Format4_Example)).  
-  
- `String String.Format(IFormatProvider provider, String format, params Object[] args)`  
- Replaces the format items with the string representation of corresponding objects in a specified array, and uses the specified culture-specific formatting information ([example](#Format5_Example)) or custom formatting information ([example](#Format6_Example)).  
-  
-<a name="Format_Params"></a>   
-## Parameters  
- This is a complete list of parameters for the <xref:System.String.Format%2A> method; see the overload syntax above for the parameters used by each overload. Only the `format` parameter is used by all overloads.  
-  
-|Parameter|Type|Description|  
-|---------------|----------|-----------------|  
-|`format`|<xref:System.String>|A composite format string that includes one or more format items (see [The format item](#FormatItem)).|  
-|`arg0`|<xref:System.String>|The first or only object to format.|  
-|`arg1`|<xref:System.String>|The second object to format.|  
-|`arg2`|<xref:System.String>|The third object to format.|  
-|`args`|<xref:System.String>[]|Zero or more objects to format, supplied either in a comma-delimited list or as an array.|  
-|`provider`|<xref:System.IFormatProvider>|An object that supplies custom or culture-specific formatting information.|  
-  
-<a name="Format_Returns"></a>   
-## Return value  
- Type: <xref:System.String>  
-A copy of `format` in which the format items have been replaced by the string representations of the corresponding arguments.  
-  
-<a name="Format_Exceptions"></a>   
-## Exceptions  
-  
-|Exception|Condition|Thrown by|  
-|---------------|---------------|---------------|  
-|<xref:System.ArgumentNullException>|`format` is `null`.|All overloads.|  
-|<xref:System.FormatException>|`format` is invalid.<br /><br /> -or-<br /><br /> The index of a format item is less than zero, or greater than or equal to the number of arguments in the arguments list.|All overloads.|  
-  
 <a name="FTaskList"></a>   
 ## Which method do I call?  
   
 |To|Call|  
 |--------|----------|  
-|Format one or more objects by using the conventions of the current culture.|Except for the overloads that include a `provider` parameter, the remaining <xref:System.String.Format%2A> overloads include a <xref:System.String> parameter followed by one or more object parameters. Because of this, you do not have to determine which <xref:System.String.Format%2A> overload you intend to call. Your language compiler will select the appropriate overload from among the overloads that don't have a `provider` parameter, based on your argument list. For example, if your argument list has five arguments, the compiler will call the <xref:System.String.Format%28System.String%2CSystem.Object%5B%5D%29> method.|  
-|Format one or more objects by using the conventions of a specific culture.|Each <xref:System.String.Format%2A> overload that begins with a `provider` parameter is followed by a <xref:System.String> parameter and one or more object parameters. Because of this, you do not have to determine which specific <xref:System.String.Format%2A> overload you intend to call. Your language compiler will select the appropriate overload from among the overloads that have a `provider` parameter, based on your argument list. For example, if your argument list has five arguments, the compiler will call the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> method.|  
-|Perform a custom formatting operation either with an <xref:System.ICustomFormatter> implementation or an <xref:System.IFormattable> implementation.|Any of the four overloads with a `provider` parameter. compiler will select the appropriate overload from among the overloads that have a `provider` parameter, based on your argument list.|  
+|Format one or more objects by using the conventions of the current culture.|Except for the overloads that include a `provider` parameter, the remaining <xref:System.String.Format%2A> overloads include a <xref:System.String> parameter followed by one or more object parameters. Because of this, you don't have to determine which <xref:System.String.Format%2A> overload you intend to call. Your language compiler selects the appropriate overload from among the overloads that don't have a `provider` parameter, based on your argument list. For example, if your argument list has five arguments, the compiler calls the <xref:System.String.Format%28System.String%2CSystem.Object%5B%5D%29> method.|  
+|Format one or more objects by using the conventions of a specific culture.|Each <xref:System.String.Format%2A> overload that begins with a `provider` parameter is followed by a <xref:System.String> parameter and one or more object parameters. Because of this, you don't have to determine which specific <xref:System.String.Format%2A> overload you intend to call. Your language compiler selects the appropriate overload from among the overloads that have a `provider` parameter, based on your argument list. For example, if your argument list has five arguments, the compiler calls the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> method.|  
+|Perform a custom formatting operation either with an <xref:System.ICustomFormatter> implementation or an <xref:System.IFormattable> implementation.|Any of the four overloads with a `provider` parameter. The compiler selects the appropriate overload from among the overloads that have a `provider` parameter, based on your argument list.|  
   
 <a name="Format_Brief"></a>   
-## The Format method in brief  
+## The Format method in brief 
+
  Each overload of the <xref:System.String.Format%2A> method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to include zero-based indexed placeholders, called format items, in a composite format string. At run time, each format item is replaced with the string representation of the corresponding argument in a parameter list. If the value of the argument is                  `null`, the format item is replaced with <xref:System.String.Empty?displayProperty=nameWithType>. For example, the following call to the <xref:System.String.Format%28System.String%2CSystem.Object%2CSystem.Object%2CSystem.Object%29> method includes a format string with three format items, {0}, {1}, and {2}, and an argument list with three items.  
   
  [!code-cpp[System.String.Format#8](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/formatoverload1.cpp#8)]
@@ -4467,14 +4418,12 @@ A copy of `format` in which the format items have been replaced by the string re
  A format item has this syntax:  
   
 ```  
-  
-{  
-index[,alignment][ :formatString] }  
+{index[,alignment][ :formatString] }  
 ```  
-  
+ 
  Brackets denote optional elements. The opening and closing braces are required. (To include a literal opening or closing brace in the format string, see the "Escaping Braces" section in the [Composite Formatting](~/docs/standard/base-types/composite-formatting.md) article.)  
   
- For example, a format item to format a currency value might appears like this:  
+ For example, a format item to format a currency value might appear like this:  
   
  [!code-cpp[System.String.Format#12](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/formatsyntax1.cpp#12)]
  [!code-csharp[System.String.Format#12](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatsyntax1.cs#12)]  
@@ -4492,13 +4441,13 @@ index[,alignment][ :formatString] }
  *formatString*  
  Optional. A string that specifies the format of the corresponding argument's result string. If you omit *formatString*, the corresponding argument's parameterless `ToString` method is called to produce its string representation. If you specify *formatString*, the argument referenced by the format item must implement the <xref:System.IFormattable> interface. Types that support format strings include:  
   
--   All integral and floating-point types. (See                                                  [Standard Numeric Format Strings](~/docs/standard/base-types/standard-numeric-format-strings.md) and                                                  [Custom Numeric Format Strings](~/docs/standard/base-types/custom-numeric-format-strings.md).)  
+-   All integral and floating-point types. (See [Standard Numeric Format Strings](~/docs/standard/base-types/standard-numeric-format-strings.md) and [Custom Numeric Format Strings](~/docs/standard/base-types/custom-numeric-format-strings.md).)  
   
--   <xref:System.DateTime> and <xref:System.DateTimeOffset>. (See                                                 [Standard Date and Time Format Strings](~/docs/standard/base-types/standard-date-and-time-format-strings.md) and                                                  [Custom Date and Time Format Strings](~/docs/standard/base-types/custom-date-and-time-format-strings.md).)  
+-   <xref:System.DateTime> and <xref:System.DateTimeOffset>. (See [Standard Date and Time Format Strings](~/docs/standard/base-types/standard-date-and-time-format-strings.md) and [Custom Date and Time Format Strings](~/docs/standard/base-types/custom-date-and-time-format-strings.md).)  
   
 -   All enumeration types. (See [Enumeration Format Strings](~/docs/standard/base-types/enumeration-format-strings.md).)  
   
--   <xref:System.TimeSpan> values. (See                                                  [Standard TimeSpan Format Strings](~/docs/standard/base-types/standard-timespan-format-strings.md) and                                                  [Custom TimeSpan Format Strings](~/docs/standard/base-types/custom-timespan-format-strings.md).)  
+-   <xref:System.TimeSpan> values. (See [Standard TimeSpan Format Strings](~/docs/standard/base-types/standard-timespan-format-strings.md) and [Custom TimeSpan Format Strings](~/docs/standard/base-types/custom-timespan-format-strings.md).)  
   
 -   GUIDs. (See the <xref:System.Guid.ToString%28System.String%29?displayProperty=nameWithType> method.)  
   
@@ -4548,30 +4497,6 @@ index[,alignment][ :formatString] }
  You can also call the any of the overloads of the <xref:System.String.Format%2A> method that have a  `provider` parameter <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> overload to perform custom formatting operations. For example, you could format an integer as an identification number or as a telephone number. To perform custom formatting, your `provider` argument must implement both the <xref:System.IFormatProvider> and <xref:System.ICustomFormatter> interfaces. When the <xref:System.String.Format%2A> method is passed an <xref:System.ICustomFormatter> implementation as the `provider` argument, the <xref:System.String.Format%2A> method calls its   <xref:System.IFormatProvider.GetFormat%2A?displayProperty=nameWithType> implementation and requests an object of type <xref:System.ICustomFormatter>. It then calls the returned <xref:System.ICustomFormatter> object's <xref:System.ICustomFormatter.Format%2A> method to format each format item in the composite string passed to it.  
   
  For more information about providing custom formatting solutions, see [How to: Define and Use Custom Numeric Format Providers](~/docs/standard/base-types/how-to-define-and-use-custom-numeric-format-providers.md) and <xref:System.ICustomFormatter>. For an example that converts integers to formatted custom numbers, see [Example 6: A custom formatting operation](#Format6_Example). For an example that converts unsigned bytes to Roman numerals, see [Example 7: An intercept provider and Roman numeral formatter](#Format7_Example).  
-  
-<a name="Format1_Example"></a>   
-## Example 1: Formatting a single argument  
- The following example uses the <xref:System.String.Format%28System.String%2CSystem.Object%29> method to embed an individual's age in the middle of a string.  
-  
- [!code-cpp[System.String.Format#7](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format7.cpp#7)]
- [!code-csharp[System.String.Format#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format7.cs#7)]
- [!code-vb[System.String.Format#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format7.vb#7)]  
-  
-<a name="Format2_Example"></a>   
-## Example 2: Formatting two arguments  
- This example uses the <xref:System.String.Format%28System.String%2CSystem.Object%2CSystem.Object%29> method to display time and temperature data stored in a generic <xref:System.Collections.Generic.Dictionary%602> object. Note that the format string has three format items, although there are only two objects to format. This is because the first object in the list (a date and time value) is used by two format items: The first format item displays the time, and the second displays the date.  
-  
- [!code-cpp[System.String.Format#6](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/formatexample4.cpp#6)]
- [!code-csharp[System.String.Format#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatexample4.cs#6)]
- [!code-vb[System.String.Format#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/formatexample4.vb#6)]  
-  
-<a name="Format3_Example"></a>   
-## Example 3: Formatting three arguments  
- This example uses the <xref:System.String.Format%28System.String%2CSystem.Object%2CSystem.Object%2CSystem.Object%29> method to create a string that illustrates the result of a Boolean `And` operation with two integer values. Note that the format string includes six format items, but the method has only three items in its parameter list, because each item is formatted in two different ways.  
-  
- [!code-cpp[System.String.Format#4](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format4.cpp#4)]
- [!code-csharp[System.String.Format#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format4.cs#4)]
- [!code-vb[System.String.Format#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format4.vb#4)]  
   
 <a name="Format4_Example"></a>   
 ## Example 4: Formatting more than three arguments  
@@ -4743,7 +4668,7 @@ index[,alignment][ :formatString] }
       <Docs>
         <param name="format">A [composite format string](~/docs/standard/base-types/composite-formatting.md).</param>
         <param name="arg0">The object to format.</param>
-        <summary>Replaces one or more format items in a specified string with the string representation of a specified object.</summary>
+        <summary>Replaces one or more format items in a string with the string representation of a specified object.</summary>
         <returns>A copy of <paramref name="format" /> in which any format items are replaced by the string representation of <paramref name="arg0" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -4752,7 +4677,15 @@ index[,alignment][ :formatString] }
   
 > [!NOTE]
 >  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+
+## Example: Formatting a single argument  
+ 
+ The following example uses the <xref:System.String.Format%28System.String%2CSystem.Object%29> method to embed an individual's age in the middle of a string.  
   
+ [!code-cpp[System.String.Format#7](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format7.cpp#7)]
+ [!code-csharp[System.String.Format#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format7.cs#7)]
+ [!code-vb[System.String.Format#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format7.vb#7)]  
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -4918,7 +4851,7 @@ index[,alignment][ :formatString] }
         <param name="provider">An object that supplies culture-specific formatting information.</param>
         <param name="format">A [composite format string](~/docs/standard/base-types/composite-formatting.md).</param>
         <param name="args">An object array that contains zero or more objects to format.</param>
-        <summary>Replaces the format items in a specified string with the string representations of corresponding objects in a specified array. A parameter supplies culture-specific formatting information.</summary>
+        <summary>Replaces the format items in a string with the string representations of corresponding objects in a specified array. A parameter supplies culture-specific formatting information.</summary>
         <returns>A copy of <paramref name="format" /> in which the format items have been replaced by the string representation of the corresponding objects in <paramref name="args" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -4976,7 +4909,7 @@ index[,alignment][ :formatString] }
         <param name="format">A [composite format string](~/docs/standard/base-types/composite-formatting.md).</param>
         <param name="arg0">The first object to format.</param>
         <param name="arg1">The second object to format.</param>
-        <summary>Replaces the format items in a specified string with the string representation of two specified objects.</summary>
+        <summary>Replaces the format items in a string with the string representation of two specified objects.</summary>
         <returns>A copy of <paramref name="format" /> in which format items are replaced by the string representations of <paramref name="arg0" /> and <paramref name="arg1" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -4985,7 +4918,15 @@ index[,alignment][ :formatString] }
   
 > [!NOTE]
 >  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+
+## Example: Formatting two arguments  
+ 
+ This example uses the <xref:System.String.Format%28System.String%2CSystem.Object%2CSystem.Object%29> method to display time and temperature data stored in a generic <xref:System.Collections.Generic.Dictionary%602> object. Note that the format string has three format items, although there are only two objects to format. This is because the first object in the list (a date and time value) is used by two format items: The first format item displays the time, and the second displays the date.  
   
+ [!code-cpp[System.String.Format#6](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/formatexample4.cpp#6)]
+ [!code-csharp[System.String.Format#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/formatexample4.cs#6)]
+ [!code-vb[System.String.Format#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/formatexample4.vb#6)]  
+    
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5032,7 +4973,7 @@ index[,alignment][ :formatString] }
         <param name="format">A [composite format string](~/docs/standard/base-types/composite-formatting.md).</param>
         <param name="arg0">The first object to format.</param>
         <param name="arg1">The second object to format.</param>
-        <summary>Replaces the format items in a specified string with the string representation of two specified objects. A parameter supplies culture-specific formatting information.</summary>
+        <summary>Replaces the format items in a string with the string representation of two specified objects. A parameter supplies culture-specific formatting information.</summary>
         <returns>A copy of <paramref name="format" /> in which format items are replaced by the string representations of <paramref name="arg0" /> and <paramref name="arg1" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -5088,7 +5029,7 @@ index[,alignment][ :formatString] }
         <param name="arg0">The first object to format.</param>
         <param name="arg1">The second object to format.</param>
         <param name="arg2">The third object to format.</param>
-        <summary>Replaces the format items in a specified string with the string representation of three specified objects.</summary>
+        <summary>Replaces the format items in a string with the string representation of three specified objects.</summary>
         <returns>A copy of <paramref name="format" /> in which the format items have been replaced by the string representations of <paramref name="arg0" />, <paramref name="arg1" />, and <paramref name="arg2" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -5097,7 +5038,17 @@ index[,alignment][ :formatString] }
   
 > [!NOTE]
 >  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+
+<a name="Format3_Example"></a>   
+
+## Example: Formatting three arguments  
+ 
+ This example uses the <xref:System.String.Format%28System.String%2CSystem.Object%2CSystem.Object%2CSystem.Object%29> method to create a string that illustrates the result of a Boolean `And` operation with two integer values. Note that the format string includes six format items, but the method has only three items in its parameter list, because each item is formatted in two different ways.  
   
+ [!code-cpp[System.String.Format#4](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format4.cpp#4)]
+ [!code-csharp[System.String.Format#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format4.cs#4)]
+ [!code-vb[System.String.Format#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format4.vb#4)]  
+    
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5146,7 +5097,7 @@ index[,alignment][ :formatString] }
         <param name="arg0">The first object to format.</param>
         <param name="arg1">The second object to format.</param>
         <param name="arg2">The third object to format.</param>
-        <summary>Replaces the format items in a specified string with the string representation of three specified objects. An parameter supplies culture-specific formatting information.</summary>
+        <summary>Replaces the format items in a string with the string representation of three specified objects. An parameter supplies culture-specific formatting information.</summary>
         <returns>A copy of <paramref name="format" /> in which the format items have been replaced by the string representations of <paramref name="arg0" />, <paramref name="arg1" />, and <paramref name="arg2" />.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
@@ -5269,7 +5220,7 @@ index[,alignment][ :formatString] }
 >   
 >  As a result, hash codes should never be used outside of the application domain in which they were created, they should never be used as key fields in a collection, and they should never be persisted.  
 >   
->  Finally, do not use the hash code instead of a value returned by a cryptographic hashing function if you need a cryptographically strong hash. For cryptographic hashes, use a class derived from the <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> or <xref:System.Security.Cryptography.KeyedHashAlgorithm?displayProperty=nameWithType> class.  
+>  Finally, don't use the hash code instead of a value returned by a cryptographic hashing function if you need a cryptographically strong hash. For cryptographic hashes, use a class derived from the <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> or <xref:System.Security.Cryptography.KeyedHashAlgorithm?displayProperty=nameWithType> class.  
 >   
 >  For more information about hash codes, see <xref:System.Object.GetHashCode%2A?displayProperty=nameWithType>.  
   
@@ -5310,7 +5261,7 @@ String 'This is a string.' in domain 'NewDomain': 75CC8236
 ```  
   
 > [!IMPORTANT]
->  Hash codes are used to insert and retrieve keyed objects from hash tables efficiently. However, hash codes do not uniquely identify strings. Identical strings have  equal hash codes, but the common language runtime can also assign the same hash code to different strings. In addition, hash codes can vary by version of the .NET Framework, by platform within a single version, and by application domain. Because of this, you should not serialize or persist hash code values, nor should you use them as keys in a hash table or dictionary.  
+>  Hash codes are used to insert and retrieve keyed objects from hash tables efficiently. However, hash codes don't uniquely identify strings. Identical strings have  equal hash codes, but the common language runtime can also assign the same hash code to different strings. In addition, hash codes can vary by version of the .NET Framework, by platform within a single version, and by application domain. Because of this, you should not serialize or persist hash code values, nor should you use them as keys in a hash table or dictionary.  
   
  For additional information about the use of hash codes and the `GetHashCode` method, see <xref:System.Object.GetHashCode%2A?displayProperty=nameWithType>.  
   
@@ -8997,7 +8948,7 @@ String 'This is a string.' in domain 'NewDomain': 75CC8236
   
 -   The sequence and number of delimiter characters is variable or unknown.  
   
- For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (in C#) or `vbCrLf` (in Visual Basic) characters is variable, and they do not always serve as delimiters.  
+ For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (in C#) or `vbCrLf` (in Visual Basic) characters is variable, and they don't always serve as delimiters.  
   
 ```  
   
@@ -9155,7 +9106,7 @@ String 'This is a string.' in domain 'NewDomain': 75CC8236
   
 -   The sequence and number of delimiter characters is variable or unknown.  
   
- For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (in C#) or `vbCrLf` (in Visual Basic) characters is variable, and they do not always serve as delimiters.  
+ For example, the <xref:System.String.Split%2A> method cannot be used to split the following string, because the number of `\n` (in C#) or `vbCrLf` (in Visual Basic) characters is variable, and they don't always serve as delimiters.  
   
 ```  
   

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -4308,11 +4308,15 @@
   
  If you are new to the String.Format method, see the [Getting started with the String.Format method](#Starting) section for a quick overview.  
   
- See the [Remarks](#Starting) section for general documentation for the String.Format method.</summary>
+ See the [Remarks](#remarks-top) section for general documentation for the String.Format method.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
+<a name="remarks-top"></a>   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
+ 
  In this section:  
   
  [Getting started with the String.Format method](#Starting)   
@@ -4323,14 +4327,7 @@
  [Format items that have the same index](#SameIndex)   
  [Formatting and culture](#Format_Culture)   
  [Custom formatting operations](#Format_Custom)   
- Examples:   
- [Formatting three arguments](#Format3_Example)  
- [Formatting more than three arguments](#Format4_Example)  
- [Culture-sensitive formatting](#Format5_Example)  
- [A custom formatting operation](#Format6_Example)  
- [An intercept provider and Roman numeral formatter](#Format7_Example)  
-[Version information](#Format_Versions)  
-[String.Format Q & A](#QA)  
+ [String.Format Q & A](#QA)  
   
 <a name="Starting"></a>   
 ## Getting started with the String.Format method  
@@ -4498,37 +4495,14 @@
   
  For more information about providing custom formatting solutions, see [How to: Define and Use Custom Numeric Format Providers](~/docs/standard/base-types/how-to-define-and-use-custom-numeric-format-providers.md) and <xref:System.ICustomFormatter>. For an example that converts integers to formatted custom numbers, see [Example 6: A custom formatting operation](#Format6_Example). For an example that converts unsigned bytes to Roman numerals, see [Example 7: An intercept provider and Roman numeral formatter](#Format7_Example).  
   
-<a name="Format4_Example"></a>   
-## Example 4: Formatting more than three arguments  
- This example creates a string that contains data on the high and low temperature on a particular date. The composite format string has five format items in the C# example and six in the Visual Basic example. Two of the format items define the width of their corresponding value's string representation, and the first format item also includes a standard date and time format string.  
-  
- [!code-cpp[System.String.Format#5](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format5.cpp#5)]
- [!code-csharp[System.String.Format#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format5.cs#5)]
- [!code-vb[System.String.Format#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format5.vb#5)]  
-  
- You can also pass the objects to be formatted as an array rather than a an argument list.  
-  
- [!code-cpp[System.String.Format#10](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format_paramarray1.cpp#10)]
- [!code-csharp[System.String.Format#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format_paramarray1.cs#10)]
- [!code-vb[System.String.Format#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format_paramarray1.vb#10)]  
-  
-<a name="Format5_Example"></a>   
-## Example 5: Culture-sensitive formatting  
- This example uses the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> method to display the string representation of some date and time values and numeric values by using several different cultures.  
-  
- [!code-csharp[System.String.Format2#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format2/cs/Example2.cs#2)]
- [!code-vb[System.String.Format2#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format2/vb/Example2.vb#2)]  
-  
-<a name="Format6_Example"></a>   
-## Example 6: A custom formatting operation  
+### Example: A custom formatting operation  
  This example defines a format provider that formats an integer value as a customer account number in the form x-xxxxx-xx.  
   
  [!code-cpp[System.String.Format#2](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/formatexample2.cpp#2)]
  [!code-csharp[System.String.Format#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/FormatExample2.cs#2)]
  [!code-vb[System.String.Format#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/FormatExample2.vb#2)]  
   
-<a name="Format7_Example"></a>   
-## Example 7: An intercept provider and Roman numeral formatter  
+### Example: An intercept provider and Roman numeral formatter  
  This example defines a custom format provider that implements the <xref:System.ICustomFormatter> and <xref:System.IFormatProvider> interfaces to do two things:  
   
 -   It displays the parameters passed to its <xref:System.ICustomFormatter.Format%2A?displayProperty=nameWithType> implementation. This enables us to see what parameters the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> method is passing to the custom formatting implementation for each object that it tries to format. This can be useful when you're debugging your application.  
@@ -4539,28 +4513,14 @@
  [!code-csharp[System.String.Format#11](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/interceptor2.cs#11)]
  [!code-vb[System.String.Format#11](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/interceptor2.vb#11)]  
   
-<a name="Format_Versions"></a>   
-## Version information  
- .NET Framework  
- All overloads are supported in: 4.5, 4, 3.5, 3.0, 2.0, 1.1, 1.0  
-  
- .NET Framework Client Profile  
- All overloads are supported in: 4, 3.5 SP1  
-  
- Portable Class Library  
- Only <xref:System.String.Format%28System.String%2CSystem.Object%5B%5D%29> and <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> are supported  
-  
- .NET for Windows Store apps  
- Only <xref:System.String.Format%28System.String%2CSystem.Object%5B%5D%29> and <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> are supported in Windows 8  
-  
 <a name="QA"></a>   
 ## String.Format Q & A  
   
 ### Where can I find a list of the predefined format strings that can be used with format items?  
   
--   For all integral and floating-point types, see                                                  [Standard Numeric Format Strings](~/docs/standard/base-types/standard-numeric-format-strings.md) and                                                  [Custom Numeric Format Strings](~/docs/standard/base-types/custom-numeric-format-strings.md).  
+-   For all integral and floating-point types, see [Standard Numeric Format Strings](~/docs/standard/base-types/standard-numeric-format-strings.md) and [Custom Numeric Format Strings](~/docs/standard/base-types/custom-numeric-format-strings.md).  
   
--   For date and time values, see                                                  [Standard Date and Time Format Strings](~/docs/standard/base-types/standard-date-and-time-format-strings.md) and                                                  [Custom Date and Time Format Strings](~/docs/standard/base-types/custom-date-and-time-format-strings.md).  
+-   For date and time values, see [Standard Date and Time Format Strings](~/docs/standard/base-types/standard-date-and-time-format-strings.md) and [Custom Date and Time Format Strings](~/docs/standard/base-types/custom-date-and-time-format-strings.md).  
   
 -   For enumeration values, see [Enumeration Format Strings](~/docs/standard/base-types/enumeration-format-strings.md).  
   
@@ -4674,9 +4634,12 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert the value of an expression to its string representation and to embed that representation in a string. 
+
+[!INCLUDE[simple-string-format](~/includes/simple-string-format.md)]
 
 ## Example: Formatting a single argument  
  
@@ -4741,10 +4704,27 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert the value of four or more expressions to their string representations and to embed those representations in a string. Since the `args` parameter is marked with the <xref:System.ParamArrayAttribute?displayProperty=nameWithType> attribute, you can pass the objects to the method as individual arguments or as an <xref:System.Object> array. 
+
+[!INCLUDE[simple-string-format](~/includes/simple-string-format.md)]
+
+## Example: Formatting more than three arguments  
+ 
+ This example creates a string that contains data on the high and low temperature on a particular date. The composite format string has five format items in the C# example and six in the Visual Basic example. Two of the format items define the width of their corresponding value's string representation, and the first format item also includes a standard date and time format string.  
   
+ [!code-cpp[System.String.Format#5](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format5.cpp#5)]
+ [!code-csharp[System.String.Format#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format5.cs#5)]
+ [!code-vb[System.String.Format#5](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format5.vb#5)]  
+  
+ You can also pass the objects to be formatted as an array rather than a an argument list.  
+  
+ [!code-cpp[System.String.Format#10](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.String.Format/cpp/format_paramarray1.cpp#10)]
+ [!code-csharp[System.String.Format#10](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/format_paramarray1.cs#10)]
+ [!code-vb[System.String.Format#10](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/format_paramarray1.vb#10)]  
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -4795,9 +4775,12 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert the value of an expression to its string representation and to embed that representation in a string. In performing the conversion, the method uses culture-sensitive formatting or a custom formatter. The method converts `arg0` to its string representation by calling its **ToString(IFormatProvider)** method or, if the object's corresponding format item includes a format string, by calling its **ToString(String,IFormatProvider)** method. If these methods don't exist, it calls the object's parameterless **ToString** method.  
+
+[!INCLUDE[provider-string-format](~/includes/provider-string-format.md)]
   
  ]]></format>
         </remarks>
@@ -4857,10 +4840,19 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert four or more expressions to their string representations and to embed those representations in a string. In performing the conversion, the method uses culture-sensitive formatting or a custom formatter. The method converts each <xref:System.Object> argument to its string representation by calling its **ToString(IFormatProvider)** method or, if the object's corresponding format item includes a format string, by calling its **ToString(String,IFormatProvider)** method. If these methods don't exist, it calls the object's parameterless **ToString** method.  
+
+[!INCLUDE[provider-string-format](~/includes/provider-string-format.md)]
   
+## Example: Culture-sensitive formatting  
+ This example uses the <xref:System.String.Format%28System.IFormatProvider%2CSystem.String%2CSystem.Object%5B%5D%29> method to display the string representation of some date and time values and numeric values by using several different cultures.  
+  
+ [!code-csharp[System.String.Format2#2](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format2/cs/Example2.cs#2)]
+ [!code-vb[System.String.Format2#2](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format2/vb/Example2.vb#2)]  
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -4915,9 +4907,12 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert the value of two expressions to their string representations and to embed those representations in a string. 
+
+[!INCLUDE[simple-string-format](~/includes/simple-string-format.md)]
 
 ## Example: Formatting two arguments  
  
@@ -4979,10 +4974,13 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
-  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert two expressions to their string representations and to embed those representations in a string. In performing the conversion, the method uses culture-sensitive formatting or a custom formatter. The method converts each <xref:System.Object> argument to its string representation by calling its **ToString(IFormatProvider)** method or, if the object's corresponding format item includes a format string, by calling its **ToString(String,IFormatProvider)** method. If these methods don't exist, it calls the object's parameterless **ToString** method.  
+
+[!INCLUDE[provider-string-format](~/includes/provider-string-format.md)]
+    
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">
@@ -5035,11 +5033,12 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
 
-<a name="Format3_Example"></a>   
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
+  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert the value of three expressions to their string representations and to embed those representations in a string. 
+
+[!INCLUDE[simple-string-format](~/includes/simple-string-format.md)]
 
 ## Example: Formatting three arguments  
  
@@ -5103,10 +5102,13 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
+
+[!INCLUDE[interpolated-strings](~/includes/interpolated-strings.md)] 
   
-> [!NOTE]
->  For examples and comprehensive usage information about this and other overloads of the `Format` method, see the <xref:System.String.Format%2A> overload summary.  
-  
+This method uses the [composite formatting feature](~/docs/standard/base-types/composite-formatting.md) to convert three expressions to their string representations and to embed those representations in a string. In performing the conversion, the method uses culture-sensitive formatting or a custom formatter. The method converts each <xref:System.Object> argument to its string representation by calling its **ToString(IFormatProvider)** method or, if the object's corresponding format item includes a format string, by calling its **ToString(String,IFormatProvider)** method. If these methods don't exist, it calls the object's parameterless **ToString** method.  
+
+[!INCLUDE[provider-string-format](~/includes/provider-string-format.md)]
+    
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">


### PR DESCRIPTION
# Revised String.Format method and its overloads 

## Summary

Revises **String.Format** so that the documentation is appropriate for the current page design, which includes all overloads on a single page.

Fixes #3702

## Details
In addition to deleting content made inappropriate by the design of docs.microsoft.com, I've done the following:
1. Recommended interpolated strings as an alternative to **String.Format**.
2. Moved examples so that they appear along with the appropriate overload.
3. Added minimal documentation for each overload. (The basic issue here is that you really don't have to pay any attention to which overload you're calling; the compiler resolves the call appropriately and transparently to the developer.)

This is still a work in progress; I'd like to see it built before going any further.

## Suggested Reviewers

@mairaw @BillWagner

