### PR TITLE
Fix XML Syntax and other minor changes

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/add-element-for-authenticationmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-authenticationmodules-network-settings.md
@@ -35,7 +35,7 @@ Adds an authentication module to the application.
   
 ```xml  
 <add
-  type="client type, System, Version=version number, Culture=culture, PublicKeyToken=token"   
+  type="type_fullname, assembly_fullname"   
 />  
 ```  
   
@@ -46,7 +46,7 @@ Adds an authentication module to the application.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`type`|The class name and specifics of the module that implements the authentication.|  
+|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property, separated by a comma.|  
   
 ### Child Elements  
  None.  
@@ -60,7 +60,7 @@ Adds an authentication module to the application.
 ## Remarks  
  The `add` element adds an authentication module to the end of the list of registered authentication modules. Authentication modules are called in the order in which they were added to the list.  
   
- The value for the `type` attribute should be a valid DLL name and corresponding class name, separated by a comma.  
+ The value for the `type` attribute should be a valid type name and corresponding assembly name, separated by a comma.  
   
 ## Configuration Files  
  This element can be used in the application configuration file or the machine configuration file (Machine.config).  

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-authenticationmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-authenticationmodules-network-settings.md
@@ -33,9 +33,9 @@ Adds an authentication module to the application.
   
 ## Syntax  
   
-```  
-      <add   
-   type = "client type", System, Version="version number", Culture="culture", PublicKeyToken="token"   
+```xml  
+<add
+  type="client type, System, Version=version number, Culture=culture, PublicKeyToken=token"   
 />  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-authenticationmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-authenticationmodules-network-settings.md
@@ -46,7 +46,7 @@ Adds an authentication module to the application.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property, separated by a comma.|  
+|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property), separated by a comma.|  
   
 ### Child Elements  
  None.  

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-bypasslist-network-settings.md
@@ -35,8 +35,8 @@ Adds an IP address or DNS name to the proxy bypass list.
 ## Syntax  
   
 ```xml  
-      <add   
-   address = "regular expression"   
+<add   
+  address="regular expression"   
 />  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-connectionmanagement-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-connectionmanagement-network-settings.md
@@ -34,9 +34,9 @@ Adds an IP address or DNS name to the connection management list.
 ## Syntax  
   
 ```xml  
-      <add   
-   address = "address expression"   
-   maxconnection = integer   
+<add   
+  address="address expression"   
+  maxconnection="integer"   
 />  
 ```  
   
@@ -74,8 +74,8 @@ Adds an IP address or DNS name to the connection management list.
 <configuration>  
   <system.net>  
     <connectionManagement>  
-      <add address = "http://www.contoso.com" maxconnection = "4" />  
-      <add address = "*" maxconnection = "2" />  
+      <add address="http://www.contoso.com" maxconnection="4" />  
+      <add address="*" maxconnection="2" />  
     </connectionManagement>  
   </system.net>  
 </configuration>  

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-schemesettings-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-schemesettings-uri-settings.md
@@ -26,8 +26,9 @@ Adds a scheme setting for a scheme name.
 ## Syntax  
   
 ```xml  
-      <add   
-   name = "http|https" genericUriParserOptions="DontUnescapePathDotsAndSlashes"  
+<add
+  name="http|https"
+  genericUriParserOptions="DontUnescapePathDotsAndSlashes"
 />  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-webrequestmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-webrequestmodules-network-settings.md
@@ -34,9 +34,9 @@ Adds a custom Web request module to the application.
 ## Syntax  
   
 ```xml  
-      <add   
-  prefix = "URI prefix"   
-  type = "module name, Version, Culture, PublicKeyToken"   
+<add   
+  prefix="URI prefix"   
+  type="module name, Version, Culture, PublicKeyToken"   
 />  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/add-element-for-webrequestmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/add-element-for-webrequestmodules-network-settings.md
@@ -36,7 +36,7 @@ Adds a custom Web request module to the application.
 ```xml  
 <add   
   prefix="URI prefix"   
-  type="module name, Version, Culture, PublicKeyToken"   
+  type="type_fullname, assembly_fullname"   
 />  
 ```  
   
@@ -48,7 +48,7 @@ Adds a custom Web request module to the application.
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
 |`prefix`|The URI prefix for requests handled by this Web request module.|  
-|`type`|The assembly and class name of the module that implements this Web request module.|  
+|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property), separated by a comma, that implements this Web request module.|  
   
 ### Child Elements  
  None.  
@@ -64,9 +64,9 @@ Adds a custom Web request module to the application.
   
  The Web request module is created when a URI matching prefix is passed to the <xref:System.Net.WebRequest.Create%2A?displayProperty=nameWithType> method.  
   
- The value for the `prefix` attribute should be the leading characters of a valid UR --for example, "http", or "http://www.contoso.com".  
+ The value for the `prefix` attribute should be the leading characters of a valid URI --for example, "http", or "http://www.contoso.com".  
   
- The value for the `type` attribute should be a valid DLL name and corresponding class name, separated by a comma .  
+ The value for the `type` attribute should be a valid type name and corresponding assembly name, separated by a comma .  
   
 ## Configuration Files  
  This element can be used in the application configuration file or the machine configuration file (Machine.config).  

--- a/docs/framework/configure-apps/file-schema/network/authenticationmodules-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/authenticationmodules-element-network-settings.md
@@ -31,7 +31,7 @@ Specifies modules used to authenticate network requests.
 ## Syntax  
   
 ```xml  
-      <authenticationModules>   
+<authenticationModules>   
 </authenticationModules>  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/bypasslist-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/bypasslist-element-network-settings.md
@@ -32,7 +32,7 @@ Provides a set of regular expressions that describe addresses that do not use a 
 ## Syntax  
   
 ```xml  
-      <bypasslist>   
+<bypasslist>   
 </bypasslist>  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/connectionmanagement-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/connectionmanagement-element-network-settings.md
@@ -31,7 +31,7 @@ Specifies the maximum number of connections to a network host.
 ## Syntax  
   
 ```xml  
-      <connectionManagement>   
+<connectionManagement>   
 </connectionManagement>  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/defaultftpcachepolicy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/defaultftpcachepolicy-element-network-settings.md
@@ -32,7 +32,7 @@ Describes whether FTP caching is active and describes the default caching policy
 ## Syntax  
   
 ```xml  
-< defaultFtpCachePolicy  
+<defaultFtpCachePolicy  
   policyLevel="BypassCache|Default|CacheOnly|CacheIfAvailable|Revalidate|Reload|NoCacheNoStore|Revalidate"  
 />  
 ```  
@@ -78,7 +78,7 @@ Describes whether FTP caching is active and describes the default caching policy
   <system.net>  
     <requestCaching>  
       <defaultFtpCachePolicy  
-        Level="NoCacheNoStore">  
+        policyLevel="NoCacheNoStore">  
       </defaultFtpCachePolicy>  
     </requestCaching>  
   </system.net>  

--- a/docs/framework/configure-apps/file-schema/network/defaulthttpcachepolicy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/defaulthttpcachepolicy-element-network-settings.md
@@ -32,11 +32,11 @@ Describes whether HTTP caching is active and describes the default caching polic
 ## Syntax  
   
 ```xml  
-< defaultHttpCachePolicy  
+<defaultHttpCachePolicy  
   policyLevel="BypassCache|Default"  
-  minimumFresh="d.hh:mm:ss"|"minValue"  
-  maximumAge  ="d.hh:mm:ss"|"maxValue"  
-  maximumStale="d.hh:mm:ss"|"maxValue"  
+  minimumFresh="d.hh:mm:ss|minValue|maxValue"  
+  maximumAge="d.hh:mm:ss|minValue|maxValue"  
+  maximumStale="d.hh:mm:ss|minValue|maxValue"  
 />  
 ```  
   
@@ -76,11 +76,11 @@ Describes whether HTTP caching is active and describes the default caching polic
 <configuration>  
   <system.net>  
     <requestCaching>  
-      <defaultHttpCachePolicy>  
-        <set minimumFresh="0.06:00:00" />  
-        <set maximumAge  ="2.00:00:00" />  
-        <set maximumStale="0.04:00:00" />  
-      </defaultHttpCachePolicy>  
+      <defaultHttpCachePolicy  
+        minimumFresh="0.06:00:00"  
+        maximumAge="2.00:00:00"  
+        maximumStale="0.04:00:00"
+      />  
     </requestCaching>  
   </system.net>  
 </configuration>  

--- a/docs/framework/configure-apps/file-schema/network/httplistener-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/httplistener-element-network-settings.md
@@ -26,8 +26,8 @@ Customizes parameters used by the <xref:System.Net.HttpListener> class.
 ## Syntax  
   
 ```xml  
-      <httpListener  
-  unescapeRequestUrl ="true|false"  
+<httpListener  
+  unescapeRequestUrl="true|false"  
 />  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/httpwebrequest-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/httpwebrequest-element-network-settings.md
@@ -32,7 +32,7 @@ Customizes Web request parameters.
 ## Syntax  
   
 ```xml  
-      <httpWebRequest  
+<httpWebRequest  
   maximumResponseHeadersLength="size"  
   maximumErrorResponseLength="size"  
   maximumUnauthorizedUploadLength="size"  

--- a/docs/framework/configure-apps/file-schema/network/idn-element-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/idn-element-uri-settings.md
@@ -30,7 +30,7 @@ Specifies if Internationalized Domain Name (IDN) parsing is applied to a domain 
 ```xml  
 <idn  
   enabled="All|AllExceptIntranet|None"  
-/idn>  
+/>  
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/network/iriparsing-element-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/iriparsing-element-uri-settings.md
@@ -30,7 +30,7 @@ Specifies if International Resource Identifier (IRI) parsing is applied to a <xr
 ```xml  
 <idn  
   enabled="true|false"  
-/idn>  
+/>  
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/network/iriparsing-element-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/iriparsing-element-uri-settings.md
@@ -28,7 +28,7 @@ Specifies if International Resource Identifier (IRI) parsing is applied to a <xr
 ## Syntax  
   
 ```xml  
-<idn  
+<iriParsing  
   enabled="true|false"  
 />  
 ```  

--- a/docs/framework/configure-apps/file-schema/network/module-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/module-element-network-settings.md
@@ -33,7 +33,7 @@ Adds a new proxy module to the application.
   
 ```xml  
 <module   
-  type="name, System, Version=version number, Culture=culture, PublicKeyToken=token"   
+  type="type_fullname, assembly_fullname"   
 />  
 ```  
   
@@ -44,7 +44,7 @@ Adds a new proxy module to the application.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`type`|The name and specifics of the module that implements the proxy.|  
+|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property, separated by a comma, that implements the proxy.|  
   
 ### Child Elements  
  None.  
@@ -58,7 +58,7 @@ Adds a new proxy module to the application.
 ## Remarks  
  The `module` element registers proxy classes that implement the <xref:System.Net.IWebProxy> interface. After registering the proxy class, `module` can be used to request information through the supported proxy.  
   
- The value for the `type` attribute should be the name of a valid Dynamic Link Library (DLL) and the class name of the module.  
+ The value for the `type` attribute should be the class name of the module and the name of its corresponding Dynamic Link Library (DLL).  
   
 ## Configuration Files  
  This element can be used in the application configuration file or the machine configuration file (Machine.config).  
@@ -71,7 +71,7 @@ Adds a new proxy module to the application.
   <system.net>  
     <defaultProxy>  
       <module  
-        type="Test.CustomWebProxy, System, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"  
+        type="Test.CustomWebProxy, TestProxy, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b23a5c561934e385"  
       />  
     </defaultProxy>  
   </system.net>  

--- a/docs/framework/configure-apps/file-schema/network/module-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/module-element-network-settings.md
@@ -44,7 +44,7 @@ Adds a new proxy module to the application.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property, separated by a comma, that implements the proxy.|  
+|`type`|The fully qualified type name (indicated by the <xref:System.Type.FullName%2A> property) and the assembly name (indicated by the <xref:System.Reflection.Assembly.FullName%2A> property), separated by a comma, that implements the proxy.|  
   
 ### Child Elements  
  None.  

--- a/docs/framework/configure-apps/file-schema/network/module-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/module-element-network-settings.md
@@ -32,8 +32,8 @@ Adds a new proxy module to the application.
 ## Syntax  
   
 ```xml  
-      <module   
-   type = "name", System, Version="version number", Culture="culture", PublicKeyToken="token" "   
+<module   
+  type="name, System, Version=version number, Culture=culture, PublicKeyToken=token"   
 />  
 ```  
   
@@ -71,7 +71,7 @@ Adds a new proxy module to the application.
   <system.net>  
     <defaultProxy>  
       <module  
-        type = "Test.CustomWebProxy, System, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"  
+        type="Test.CustomWebProxy, System, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"  
       />  
     </defaultProxy>  
   </system.net>  

--- a/docs/framework/configure-apps/file-schema/network/network-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/network-element-network-settings.md
@@ -33,15 +33,15 @@ Configures the network options for an external Simple Mail Transport Protocol (S
 ## Syntax  
   
 ```xml  
-      <network  
+<network  
   clientDomain="string"   
   defaultCredentials="true|false"  
   enableSsl="true|false"  
   host="string"   
-password="string"  
+  password="string"  
   port="integer"   
-targetName="string"  
-userName="string"  
+  targetName="string"  
+  userName="string"  
 />  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
@@ -32,13 +32,13 @@ Defines a proxy server.
 ## Syntax  
   
 ```xml  
-      <proxy   
-  autoDetect="true|false|unspecified"    
-  bypassonlocal="true|false|unspecified"   
-proxyaddress="uriString"  
-  scriptLocation="uriString"   
-  usesystemdefault="true|false|unspecified "   
-/>  
+<proxy
+  autoDetect="true|false|unspecified" 
+  bypassonlocal="true|false|unspecified"
+  proxyaddress="uriString"
+  scriptLocation="uriString"
+  usesystemdefault="true|false|unspecified"
+/>
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-authenticationmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-authenticationmodules-network-settings.md
@@ -35,7 +35,7 @@ Removes an authentication module from the application.
   
 ```xml  
 <remove   
-   name="authentication module name"   
+   type="authentication module name"   
 />  
 ```  
   
@@ -46,7 +46,7 @@ Removes an authentication module from the application.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|**name**|The name of the authentication module to remove.|  
+|**type**|The name of the authentication module to remove.|  
   
 ### Child Elements  
  None.  
@@ -60,7 +60,7 @@ Removes an authentication module from the application.
 ## Remarks  
  The `remove` element removes authentication modules that were defined earlier in the configuration file or at a higher level in the configuration hierarchy.  
   
- The value for the `name` attribute should be a valid class name.  
+ The value for the `type` attribute should be a valid class name.  
   
 ## Configuration Files  
  This element can be used in the application configuration file or the machine configuration file (Machine.config).  
@@ -72,7 +72,7 @@ Removes an authentication module from the application.
 <configuration>  
   <system.net>  
     <authenticationModules>  
-      <remove name="System.Net.NtlmClient" />  
+      <remove type="System.Net.NtlmClient" />  
     </authenticationModules>  
   </system.net>  
 </configuration>  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-authenticationmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-authenticationmodules-network-settings.md
@@ -34,8 +34,8 @@ Removes an authentication module from the application.
 ## Syntax  
   
 ```xml  
-      <remove   
-   name = "authentication module name"   
+<remove   
+   name="authentication module name"   
 />  
 ```  
   
@@ -72,7 +72,7 @@ Removes an authentication module from the application.
 <configuration>  
   <system.net>  
     <authenticationModules>  
-      <remove name = "System.Net.NtlmClient" />  
+      <remove name="System.Net.NtlmClient" />  
     </authenticationModules>  
   </system.net>  
 </configuration>  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-bypasslist-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-bypasslist-network-settings.md
@@ -36,7 +36,7 @@ Removes an IP address or DNS name from the proxy bypass list.
   
 ```xml  
 <remove   
-  name="regular expression"   
+  address="regular expression"   
 />
 ```  
   
@@ -47,7 +47,7 @@ Removes an IP address or DNS name from the proxy bypass list.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`name`|A regular expression describing an IP address or DNS name.|  
+|`address`|A regular expression describing an IP address or DNS name.|  
   
 ### Child Elements  
  None.  
@@ -61,7 +61,7 @@ Removes an IP address or DNS name from the proxy bypass list.
 ## Remarks  
  The `remove` element removes regular expressions describing IP addresses or DNS server names from the list of addresses that bypass a proxy server. The addresses were defined earlier in the configuration file or at a higher level in the configuration hierarchy.  
   
- The value for the `name` attribute should be a regular expression that describes a set of IP addresses or host names.  
+ The value for the `address` attribute should be a regular expression that describes a set of IP addresses or host names.  
   
  For more information about regular expressions, see .[.NET Framework Regular Expressions](../../../../../docs/standard/base-types/regular-expressions.md).  
   
@@ -76,7 +76,7 @@ Removes an IP address or DNS name from the proxy bypass list.
   <system.net>  
     <defaultProxy>  
       <bypasslist>  
-        <remove name="[a-z]+\.adventure-works\.com$" />  
+        <remove address="[a-z]+\.adventure-works\.com$" />  
         <add address="[a-z]+\.contoso\.com$" />  
       </bypasslist>  
     </defaultProxy>  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-bypasslist-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-bypasslist-network-settings.md
@@ -35,9 +35,9 @@ Removes an IP address or DNS name from the proxy bypass list.
 ## Syntax  
   
 ```xml  
-      <remove   
-   name = "regular expression"   
-/>  
+<remove   
+  name="regular expression"   
+/>
 ```  
   
 ## Attributes and Elements  
@@ -76,7 +76,7 @@ Removes an IP address or DNS name from the proxy bypass list.
   <system.net>  
     <defaultProxy>  
       <bypasslist>  
-        <remove name = "[a-z]+\.adventure-works\.com$" />  
+        <remove name="[a-z]+\.adventure-works\.com$" />  
         <add address="[a-z]+\.contoso\.com$" />  
       </bypasslist>  
     </defaultProxy>  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-connectionmanagement-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-connectionmanagement-network-settings.md
@@ -34,8 +34,8 @@ Removes an IP address or DNS name from the connection management list.
 ## Syntax  
   
 ```xml  
-      <remove   
-   name = "server name or IP address"   
+<remove   
+  address="server name or IP address"   
 />  
 ```  
   
@@ -72,9 +72,9 @@ Removes an IP address or DNS name from the connection management list.
 <configuration>  
   <system.net>  
     <connectionManagement>  
-      <remove address = "http://www.adventure-works.com"/>  
-      <add address = "http://www.contoso.com" maxconnection = "4" />  
-      <add address = "*" maxconnection = "2" />  
+      <remove address="http://www.adventure-works.com" />  
+      <add address="http://www.contoso.com" maxconnection="4" />  
+      <add address="*" maxconnection="2" />  
     </connectionManagement>  
   </system.net>  
 </configuration>  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-schemesettings-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-schemesettings-uri-settings.md
@@ -26,9 +26,9 @@ Removes a scheme setting for a scheme name.
 ## Syntax  
   
 ```xml  
-      <remove   
-   <name = "http|https"/>  
-/>  
+<remove
+  name="http|https"
+/>
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-webrequestmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-webrequestmodules-network-settings.md
@@ -34,8 +34,8 @@ Removes a custom Web request module from the application.
 ## Syntax  
   
 ```xml  
-      <remove   
-  name = "URI prefix"   
+<remove   
+  name="URI prefix"   
 />  
 ```  
   
@@ -72,7 +72,7 @@ Removes a custom Web request module from the application.
 <configuration>  
   <system.net>  
     <webRequestModules>  
-      <remove prefix = "http">  
+      <remove prefix="http">  
       <add prefix="http"  
            type="System.Net.HttpRequestCreator, System, Version=2.0.3600.0,  
            Culture=neutral, PublicKeyToken=b77a5c561934e089"  

--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-webrequestmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-webrequestmodules-network-settings.md
@@ -35,7 +35,7 @@ Removes a custom Web request module from the application.
   
 ```xml  
 <remove   
-  name="URI prefix"   
+  prefix="URI prefix"   
 />  
 ```  
   
@@ -46,7 +46,7 @@ Removes a custom Web request module from the application.
   
 |**Attribute**|**Description**|  
 |-------------------|---------------------|  
-|`name`|The URI prefix for requests handled by this Web request module.|  
+|`prefix`|The URI prefix for requests handled by this Web request module.|  
   
 ### Child Elements  
  None.  

--- a/docs/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings.md
@@ -25,7 +25,7 @@ Specifies how a <xref:System.Uri> will be parsed for specific schemes.
 ## Syntax  
   
 ```xml  
-      <schemeSettings>   
+<schemeSettings>   
 </schemeSettings>  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/servicepointmanager-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/servicepointmanager-element-network-settings.md
@@ -32,7 +32,7 @@ Configures connections to network resources.
 ## Syntax  
   
 ```xml  
-      <servicePointManager  
+<servicePointManager  
   checkCertificateName="true|false"  
   checkCertificateRevocationList="true|false"  
   encryptionPolicy="AllowNoEncryption|NoEncryption|RequireEncryption"  

--- a/docs/framework/configure-apps/file-schema/network/settings-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/settings-element-network-settings.md
@@ -31,14 +31,14 @@ Configures basic network options for the <xref:System.Net?displayProperty=nameWi
 ## Syntax  
   
 ```xml  
-      <settings>  
-..<httpListener> … </httpListener>  
-..<httpWebRequest> … </httpWebRequest>  
-..<ipv6> … </ipv6>  
-..<performanceCounters> … </performanceCounters>  
+<settings>  
+  <httpListener> … </httpListener>  
+  <httpWebRequest> … </httpWebRequest>  
+  <ipv6> … </ipv6>  
+  <performanceCounters> … </performanceCounters>  
   <servicePointManager> … </servicePointManager>  
-..<socket> … </socket>  
-..<webProxyScript> … </webProxyScript>  
+  <socket> … </socket>  
+  <webProxyScript> … </webProxyScript>  
 </settings>  
 ```  
   

--- a/docs/framework/configure-apps/file-schema/network/socket-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/socket-element-network-settings.md
@@ -32,11 +32,11 @@ Specifies whether socket operations use completion ports.
 ## Syntax  
   
 ```xml  
-      <socket  
+<socket  
   alwaysUseCompletionPortsForConnect="true|false"  
   alwaysUseCompletionPortsForAccept="true|false"  
-  ipProtectionLevel ="EdgeRestricted|Restricted|Unrestricted|Unspecified"  
-/socket>  
+  ipProtectionLevel="EdgeRestricted|Restricted|Unrestricted|Unspecified"  
+/>  
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/network/specifiedpickupdirectory-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/specifiedpickupdirectory-element-network-settings.md
@@ -33,7 +33,7 @@ Configures the local directory for a Simple Mail Transport Protocol (SMTP) serve
 ## Syntax  
   
 ```xml  
-      <specifiedPickupDirectory  
+<specifiedPickupDirectory  
   pickupDirectoryLocation="directory"   
 />  
 ```  

--- a/docs/framework/configure-apps/file-schema/network/system-net-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/system-net-element-network-settings.md
@@ -30,7 +30,7 @@ Contains settings that specify how the .NET Framework connects to the network.
 ## Syntax  
   
 ```xml  
-      <system.net>   
+<system.net>   
 </system.net>  
 ```  
   
@@ -50,7 +50,7 @@ Contains settings that specify how the .NET Framework connects to the network.
 |[mailSettings](../../../../../docs/framework/configure-apps/file-schema/network/mailsettings-element-network-settings.md)|Configures Simple Mail Transport Protocol (SMTP) mail sending options.|  
 |[requestCaching](../../../../../docs/framework/configure-apps/file-schema/network/requestcaching-element-network-settings.md)|Controls the caching mechanism for network requests.|  
 |[settings](../../../../../docs/framework/configure-apps/file-schema/network/settings-element-network-settings.md)|Configures basic network options for classes in the <xref:System.Net> and related child namespaces.|  
-|[\<webRequestModules> Element (Network Settings)](../../../../../docs/framework/configure-apps/file-schema/network/webrequestmodules-element-network-settings.md)|Specifies modules to use to request information from Internet hosts.|  
+|[webRequestModules](../../../../../docs/framework/configure-apps/file-schema/network/webrequestmodules-element-network-settings.md)|Specifies modules to use to request information from Internet hosts.|  
   
 ### Parent Elements  
   
@@ -68,30 +68,30 @@ Contains settings that specify how the .NET Framework connects to the network.
 <configuration>  
   <system.net>  
     <authenticationModules>  
-      <add type = "System.Net.DigestClient" />  
-      <add type = "System.Net.NegotiateClient" />  
-      <add type = "System.Net.KerberosClient" />  
-      <add type = "System.Net.NtlmClient" />  
-      <add type = "System.Net.BasicClient" />  
+      <add type="System.Net.DigestClient" />  
+      <add type="System.Net.NegotiateClient" />  
+      <add type="System.Net.KerberosClient" />  
+      <add type="System.Net.NtlmClient" />  
+      <add type="System.Net.BasicClient" />  
     </authenticationModules>  
     <connectionManagement>  
-      <add address = "*" maxconnection = "2" />  
+      <add address="*" maxconnection="2" />  
     </connectionManagement>  
     <defaultProxy>  
       <proxy  
-        usesystemdefault = "true"  
-        bypassonlocal = "true"  
+        usesystemdefault="true"  
+        bypassonlocal="true"  
       />  
     </defaultProxy>  
     <webRequestModules>  
-      <add prefix = "http"  
-        type = "System.Net.HttpRequestCreator"  
+      <add prefix="http"  
+           type="System.Net.HttpRequestCreator"  
       />  
-      <add prefix = "https"  
-        type = "System.Net.HttpRequestCreator"  
+      <add prefix="https"  
+           type="System.Net.HttpRequestCreator"  
       />  
-      <add prefix = "file"  
-        type = "System.Net.FileWebRequestCreator"  
+      <add prefix="file"  
+           type="System.Net.FileWebRequestCreator"  
       />  
     </webRequestModules>  
   </system.net>  

--- a/docs/framework/configure-apps/file-schema/network/webproxyscript-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/webproxyscript-element-network-settings.md
@@ -32,7 +32,7 @@ Configures the characteristics of the script used to discover Web proxies.
 ## Syntax  
   
 ```xml  
-      <webProxyScript  
+<webProxyScript  
   downloadTimeout="hh:mm:ss"  
 />  
 ```  

--- a/docs/framework/configure-apps/file-schema/network/webrequestmodules-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/webrequestmodules-element-network-settings.md
@@ -31,7 +31,7 @@ Specifies modules to use to request information from network hosts.
 ## Syntax  
   
 ```xml  
-      <webRequestModules>   
+<webRequestModules>   
 </webRequestModules>  
 ```  
   


### PR DESCRIPTION
# Title

Fix XML Syntax and other minor changes

## Summary

Most of the changes are to fix XML formatting issues or to make the XML more readable. There are a few changes to attribute names which I note below.

## Details
[Fix attribute name in Example](https://github.com/dotnet/docs/commit/0fcad6fc02b54b5c7bf9a28ed68d0ba270263219)
[Fix attribute name in Syntax section](https://github.com/dotnet/docs/commit/86e478bfbc02da167ba8598d99aca298b0e77951)
[Change the "name" attribute to "address". According to VS Intellisense](https://github.com/dotnet/docs/commit/f42a2a5fb59827a80e47e211ef75d35ae03f6778)
[Change attribute from "name" to "type", per VS Intellisense.](https://github.com/dotnet/docs/commit/47a35bd722ebf60b953438bf18f3383616131921)
[Change attribute from "name" to "prefix", per VS intellisense](https://github.com/dotnet/docs/commit/e80904ae8d57f7d1fabd418a3ca190683dfe3686)
[Fix element name in Syntax section](https://github.com/dotnet/docs/commit/9de83243a241dde4c22ef1ded6971da6958a038f)