### PR TITLE
'url' parameter is not clear it accepts application-relative virtual …

### DIFF
--- a/xml/System.Web/HttpResponse.xml
+++ b/xml/System.Web/HttpResponse.xml
@@ -1619,7 +1619,7 @@
         <Parameter Name="url" Type="System.String" />
       </Parameters>
       <Docs>
-        <param name="url">The target location.</param>
+        <param name="url">The target location. This may be an application-relative virtual path.</param>
         <summary>Redirects a request to a new URL and specifies the new URL.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  


### PR DESCRIPTION
It's not clear that Response.Redirect accepts application-relative virtual paths, e.g. "~". Not sure if there is a better way to express this information or if there should be a link explaining what a virtual path is: https://docs.microsoft.com/en-us/dotnet/api/system.web.virtualpathutility.toabsolute?view=netframework-4.7.1#System_Web_VirtualPathUtility_ToAbsolute_System_String_ .