### PR TITLE
Fix Monitor.Exit in the correct object.

### DIFF
--- a/docs/standard/threading/managed-threading-best-practices.md
+++ b/docs/standard/threading/managed-threading-best-practices.md
@@ -40,7 +40,7 @@ If Monitor.TryEnter(lockObject, 300) Then
     Try  
         ' Place code protected by the Monitor here.  
     Finally  
-        Monitor.Exit(Me)  
+        Monitor.Exit(lockObject)  
     End Try  
 Else  
     ' Code to execute if the attempt times out.  


### PR DESCRIPTION
# Fix Monitor.Exit in the correct object.

There isn't any issue created for it, but I could create if necessary.

This change fixes the correct object beeing referenced in the line` Monitor.Exit`

## Suggested Reviewers

@mairaw 