### PR TITLE
fix minor typo on "What's new in C# 7.2"

### DIFF
--- a/docs/csharp/whats-new/csharp-7-2.md
+++ b/docs/csharp/whats-new/csharp-7-2.md
@@ -56,7 +56,7 @@ named arguments are in the correct positions. For more information see
 
 The implementation of support for digit separators in C# 7.0
 didn't allow the `_` to be the first character of the literal value. Hex
-and binary numeric literals for may now begin with an `_`. 
+and binary numeric literals may now begin with an `_`. 
 
 For example:
 


### PR DESCRIPTION
# Title

Fixing a small typo in the "What's new in C# 7.2" article.

## Summary

There's a sentence "Hex and binary numeric literals for may now begin with an _." on that page. The "for" in that sentence is probably a typo and should be removed.
