### PR TITLE
Minor typo fix for 'Optional' parameter documentation

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/procedures/optional-parameters.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/optional-parameters.md
@@ -35,7 +35,7 @@ You can specify that a procedure parameter is optional and no argument has to be
  The following syntax shows a procedure declaration with an optional parameter:  
   
 ```  
-Sub sub name(ByVal parameter1 As datatype1, Optional ByVal parameter2 As datatype2 = defaultvalue)  
+Sub name(ByVal parameter1 As datatype1, Optional ByVal parameter2 As datatype2 = defaultvalue)  
 ```  
   
 ## Calling Procedures with Optional Parameters  
@@ -44,7 +44,7 @@ Sub sub name(ByVal parameter1 As datatype1, Optional ByVal parameter2 As datatyp
  When you omit one or more optional arguments in the argument list, you use successive commas to mark their positions. The following example call supplies the first and fourth arguments but not the second or third:  
   
 ```  
-sub name(argument 1, , , argument 4)  
+Sub name(argument 1, , , argument 4)  
 ```  
   
  The following example makes several calls to the `MsgBox` function. `MsgBox` has one required parameter and two optional parameters.  

--- a/docs/visual-basic/programming-guide/language-features/procedures/optional-parameters.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/optional-parameters.md
@@ -34,7 +34,7 @@ You can specify that a procedure parameter is optional and no argument has to be
   
  The following syntax shows a procedure declaration with an optional parameter:  
   
-```  
+```vb  
 Sub name(ByVal parameter1 As datatype1, Optional ByVal parameter2 As datatype2 = defaultvalue)  
 ```  
   
@@ -43,7 +43,7 @@ Sub name(ByVal parameter1 As datatype1, Optional ByVal parameter2 As datatype2 =
   
  When you omit one or more optional arguments in the argument list, you use successive commas to mark their positions. The following example call supplies the first and fourth arguments but not the second or third:  
   
-```  
+```vb  
 Sub name(argument 1, , , argument 4)  
 ```  
   


### PR DESCRIPTION
# Minor typo fix for 'Optional' parameter documentation

## Summary

Fixes a minor typo in the 'Optional' parameter documentation

## Details

In these changes, I removed an extra "sub" in a code example and capitalized the "sub" in another code example for consistency.