### PR TITLE
Clarify that the entire instance is constructed before assignment

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -18,7 +18,9 @@ Object initializers let you assign values to any accessible fields or properties
   
  [!code-csharp[csProgGuideLINQ#39](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_1.cs)]  
   
- [!code-csharp[csProgGuideLINQ#45](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_2.cs)]  
+ [!code-csharp[csProgGuideLINQ#45](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_2.cs)] 
+ 
+The object initializers syntax allows you to create an instance, and after that it assigns the newly created object, with its assigned properties, to the variable in the assignment.
   
 ## Object Initializers with anonymous types  
  Although object initializers can be used in any context, they are especially useful in [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query expressions. Query expressions make frequent use of [anonymous types](../../../csharp/programming-guide/classes-and-structs/anonymous-types.md), which can only be initialized by using an object initializer, as shown in the following declaration.  


### PR DESCRIPTION
## Summary
Clarify that the entire instance is constructed before assignment

## Details
It seems some users (for example: https://stackoverflow.com/q/47366192/993547) of the object initializers syntax don't get the order of execution, and often it seems that even experienced users don't know this.

Basic outline of faulting program some users expect to work since they believe the instance is assigned after the constructor is ran (and before the other properties are set):

    class X
    {
        public string Foo { get; set; }
        public int Bar { get; set; }
    }

    class Program
    {
        private static X x;

        static void Main(string[] args)
        {
            x = new X { Foo = "a", Bar = x.Foo.Length };
        }
    }