### PR TITLE
replaced long with int in ServiceStatus struct

### DIFF
--- a/docs/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer.md
+++ b/docs/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer.md
@@ -183,13 +183,13 @@ This article demonstrates how to create a simple Windows Service application in 
       [StructLayout(LayoutKind.Sequential)]  
       public struct ServiceStatus  
       {  
-          public long dwServiceType;  
+          public int dwServiceType;  
           public ServiceState dwCurrentState;  
-          public long dwControlsAccepted;  
-          public long dwWin32ExitCode;  
-          public long dwServiceSpecificExitCode;  
-          public long dwCheckPoint;  
-          public long dwWaitHint;  
+          public int dwControlsAccepted;  
+          public int dwWin32ExitCode;  
+          public int dwServiceSpecificExitCode;  
+          public int dwCheckPoint;  
+          public int dwWaitHint;  
       };  
     ```  
   


### PR DESCRIPTION
Using long produces an error message, in the event log viewer, about an "invalid state 0", as reported here: https://stackoverflow.com/questions/30299600/service-causes-scm-error-reported-an-invalid-current-state-0