### PR TITLE
Fix the regular expression for HTML parsing

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -135,7 +135,7 @@ public async Task<int> GetDotNetCountAsync()
     // to accept another request, rather than blocking on this one.
     var html = await _httpClient.DownloadStringAsync("http://dotnetfoundation.org");
 
-    return Regex.Matches(html, ".NET").Count;
+    return Regex.Matches(html, @"\.NET").Count;
 }
 ```
 
@@ -158,7 +158,7 @@ private async void SeeTheDotNets_Click(object sender, RoutedEventArgs e)
     // The await operator suspends SeeTheDotNets_Click, returning control to its caller.
     // This is what allows the app to be responsive and not hang on the UI thread.
     var html = await getDotNetFoundationHtmlTask;
-    int count = Regex.Matches(html, ".NET").Count;
+    int count = Regex.Matches(html, @"\.NET").Count;
 
     DotNetCountLabel.Text = $"Number of .NETs on dotnetfoundation.org: {count}";
 


### PR DESCRIPTION
# Fix the regular expression used in the examples for HTML parsing

## Summary

The text in the article asserts that a certain regular expression counts the number of a ".NET" string occurrences in a file. It does not.

## Details

The regular expression ".NET" matches not the ".NET" string, but any symbol followed by "NET" ([proof](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference#character_classes)). Therefore, the example is incorrect. It is not easy to succinctly describe what exactly `Regex.Matches(html, ".NET").Count` is. For example:
```csharp
> System.Text.RegularExpressions.Regex.Matches("aNET NETxNET", ".NET").Count
3
> System.Text.RegularExpressions.Regex.Matches("NETNETNET", ".NET").Count
1
```
Thus it would be easier to fix the regular expression and use `@"\.NET"` instead of `".NET"`.
## Suggested Reviewers
