### PR TITLE
Adding a detail about VbStrConv.Wide

### DIFF
--- a/xml/Microsoft.VisualBasic/Strings.xml
+++ b/xml/Microsoft.VisualBasic/Strings.xml
@@ -2934,7 +2934,7 @@ Dim aString As String = Replace(TestString, "o", "i")
 |`VbStrConv.UpperCase`|Converts the string to uppercase characters.|  
 |`VbStrConv.LowerCase`|Converts the string to lowercase characters.|  
 |`VbStrConv.ProperCase`|Converts the first letter of every word in string to uppercase.|  
-|`VbStrConv.Wide` <sup>*</sup>|Converts narrow (half-width) characters in the string to wide (full-width) characters.|  
+|`VbStrConv.Wide` <sup>*</sup>|Converts narrow (half-width) characters in the string to wide (full-width) characters. With a Conversion setting of VbStrConv.Wide, the conversion may use Normalization Form C even if an input character is already full-width. For example, the string "は゛" (which is already full-width) is normalized to "ば". See [Unicode normalization forms](http://unicode.org/reports/tr15).|  
 |`VbStrConv.Narrow` <sup>*</sup>|Converts wide (full-width) characters in the string to narrow (half-width) characters.|  
 |`VbStrConv.Katakana` <sup>**</sup>|Converts Hiragana characters in the string to Katakana characters.|  
 |`VbStrConv.Hiragana` <sup>**</sup>|Converts Katakana characters in the string to Hiragana characters.|  


### PR DESCRIPTION
As per email thread with support engineer and product group.

# Adding a detail about VbStrConv.Wide

## the conversion may use Normalization Form C even if an input character is already full-width

