### PR TITLE
Adding detail about VbStrConv.Wide behavior

### DIFF
--- a/includes/vbstrconv-wide-md.md
+++ b/includes/vbstrconv-wide-md.md
@@ -1,0 +1,1 @@
+﻿The conversion may use Normalization Form C even if an input character is already full-width. For example, the string "は゛" (which is already full-width) is normalized to "ば". See [Unicode normalization forms](http://unicode.org/reports/tr15).

--- a/xml/Microsoft.VisualBasic/Strings.xml
+++ b/xml/Microsoft.VisualBasic/Strings.xml
@@ -2934,7 +2934,7 @@ Dim aString As String = Replace(TestString, "o", "i")
 |`VbStrConv.UpperCase`|Converts the string to uppercase characters.|  
 |`VbStrConv.LowerCase`|Converts the string to lowercase characters.|  
 |`VbStrConv.ProperCase`|Converts the first letter of every word in string to uppercase.|  
-|`VbStrConv.Wide` <sup>*</sup>|Converts narrow (half-width) characters in the string to wide (full-width) characters.|  
+|`VbStrConv.Wide` <sup>*</sup>|Converts narrow (half-width) characters in the string to wide (full-width) characters. [!INCLUDE[vbstrconv-wide](~/includes/vbstrconv-wide-md.md)]|  
 |`VbStrConv.Narrow` <sup>*</sup>|Converts wide (full-width) characters in the string to narrow (half-width) characters.|  
 |`VbStrConv.Katakana` <sup>**</sup>|Converts Hiragana characters in the string to Katakana characters.|  
 |`VbStrConv.Hiragana` <sup>**</sup>|Converts Katakana characters in the string to Hiragana characters.|  

--- a/xml/Microsoft.VisualBasic/VbStrConv.xml
+++ b/xml/Microsoft.VisualBasic/VbStrConv.xml
@@ -200,7 +200,7 @@
         <ReturnType>Microsoft.VisualBasic.VbStrConv</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Converts narrow (single-byte) characters in the string to wide (double-byte) characters. Applies to Asian locales. This member is equivalent to the Visual Basic constant <see langword="vbWide" />.</summary>
+        <summary>Converts narrow (single-byte) characters in the string to wide (double-byte) characters. Applies to Asian locales. This member is equivalent to the Visual Basic constant <see langword="vbWide" />. [!INCLUDE[vbstrconv-wide](~/includes/vbstrconv-wide-md.md)]</summary>
       </Docs>
     </Member>
   </Members>


### PR DESCRIPTION
# The conversion may use Normalization Form C even if an input character is already full-width

## Summary

As per support engineer and PG findings, adding details about potentially unexpected behavior.