### PR TITLE
topic improvements

### DIFF
--- a/docs/framework/install/index.md
+++ b/docs/framework/install/index.md
@@ -1,5 +1,5 @@
 ---
-title: Installation guide
+title: .NET Framework installation guide
 description: Learn how to install the .NET Framework on Windows.
 author: rlander
 ms.author: mairaw
@@ -9,7 +9,6 @@ ms.topic: article
 ms.prod: .net-framework
 ms.devlang: dotnet
 ---
-
 # Installation guide
 
 You can install .NET Framework on various Windows versions.
@@ -28,7 +27,6 @@ You can install .NET Framework on various Windows versions.
 
 ## See also
 
-[Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)   
-[Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)   
+[Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)  
+[Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)  
 [Install the .NET Framework for developers](guide-for-developers.md)
-

--- a/docs/framework/migration-guide/how-to-determine-which-net-framework-updates-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-net-framework-updates-are-installed.md
@@ -1,13 +1,10 @@
 ---
-title: "How to: Determine Which .NET Framework Updates Are Installed"
-ms.custom: ""
-ms.date: "03/30/2017"
+title: "How to: Determine which .NET Framework security updates and hotfixes are installed"
+description: "Learn how to determine which .NET Framework security updates and hotfixes are installed in your machine."
+ms.date: "11/21/2017"
 ms.prod: ".net-framework"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "dotnet-clr"
-ms.tgt_pltfrm: ""
 ms.topic: "article"
 dev_langs:
  - "csharp"
@@ -16,64 +13,101 @@ helpviewer_keywords:
   - "updates, determining for .NET Framework"
   - ".NET Framework, determining updates"
 ms.assetid: 53c7b5f7-d47a-402a-b194-7244a696a88b
-caps.latest.revision: 6
 author: "mairaw"
 ms.author: "mairaw"
 manager: "wpickett"
 ---
-# How to: Determine Which .NET Framework Updates Are Installed
-The installed updates for each version of the .NET Framework installed on a computer are listed in the Windows registry. You can use the Registry Editor (regedit.exe) to view this information.  
-  
- In the Registry Editor, the .NET Framework versions and installed updates for each version are stored in different subkeys. For information about detecting the installed version numbers, see [How to: Determine Which .NET Framework Versions Are Installed](../../../docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md). For information about installing the .NET Framework, see [Install the .NET Framework for developers](../../../docs/framework/install/guide-for-developers.md).  
-  
-### To find installed updates  
-  
-1.  Open the program **regedit.exe**. In Windows 8 and higher open the Start screen and type the name. In earlier versions of Windows, on the **Start** menu, choose **Run** and then, in the **Open** box, enter **regedit.exe**.  
-  
-     You must have administrative credentials to run regedit.exe.  
-  
-2.  In the Registry Editor, open the following subkey:  
-  
-     HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Updates  
-  
-     The installed updates are listed under subkeys that identify the .NET Framework version they apply to. Each update is identified by a Knowledge Base (KB) number.  
-  
-## Example  
- The following code programmatically determines the .NET Framework updates that are installed on a computer. You must have administrative credentials to run this example.  
-  
- [!code-csharp[ListUpdates#1](../../../samples/snippets/csharp/VS_Snippets_CLR/listupdates/cs/program.cs#1)]
- [!code-vb[ListUpdates#1](../../../samples/snippets/visualbasic/VS_Snippets_CLR/listupdates/vb/program.vb#1)]  
-  
- The example produces output that's similar to the following:  
-  
-```  
-Microsoft .NET Framework 3.5 SP1  
-  KB953595  Hotfix for Microsoft .NET Framework 3.5 SP1 (KB953595)  
-  SP1  
-    KB2657424  Security Update for Microsoft .NET Framework 3.5 SP1 (KB2657424)  
-    KB958484  Hotfix for Microsoft .NET Framework 3.5 SP1 (KB958484)  
-    KB963707  Update for Microsoft .NET Framework 3.5 SP1 (KB963707)  
-Microsoft .NET Framework 4 Client Profile  
-  KB2160841  Security Update for Microsoft .NET Framework 4 Client Profile (KB2160841)  
-  KB2446708  Security Update for Microsoft .NET Framework 4 Client Profile (KB2446708)  
-  KB2468871  Update for Microsoft .NET Framework 4 Client Profile (KB2468871)  
-  KB2478663  Security Update for Microsoft .NET Framework 4 Client Profile (KB2478663)  
-  KB2518870  Security Update for Microsoft .NET Framework 4 Client Profile (KB2518870)  
-  KB2533523  Update for Microsoft .NET Framework 4 Client Profile (KB2533523)  
-  KB2539636  Security Update for Microsoft .NET Framework 4 Client Profile (KB2539636)  
-  KB2572078  Security Update for Microsoft .NET Framework 4 Client Profile (KB2572078)  
-  KB2633870  Security Update for Microsoft .NET Framework 4 Client Profile (KB2633870)  
-  KB2656351  Security Update for Microsoft .NET Framework 4 Client Profile (KB2656351)  
-Microsoft .NET Framework 4 Extended  
-  KB2416472  Security Update for Microsoft .NET Framework 4 Extended (KB2416472)  
-  KB2468871  Update for Microsoft .NET Framework 4 Extended (KB2468871)  
-  KB2487367  Security Update for Microsoft .NET Framework 4 Extended (KB2487367)  
-  KB2533523  Update for Microsoft .NET Framework 4 Extended (KB2533523)  
-  KB2656351  Security Update for Microsoft .NET Framework 4 Extended (KB2656351)  
-```  
-  
+# How to: Determine which .NET Framework security updates and hotfixes are installed
+
+This article shows you how to find out which .NET Framework security updates and hotfixes are installed on a computer.
+
+> [!NOTE]
+> All the techniques shown in this article require an account with administrative privileges.
+
+## To find installed updates using the registry
+
+The installed security updates and hotfixes for each version of the .NET Framework installed on a computer are listed in the Windows registry. You can use the Registry Editor (*regedit.exe*) program to view this information.
+
+1. Open the program **regedit.exe**. In Windows 8 and later versions, right-click **Start** ![Windows logo](../get-started/media/windowskeyboardlogo.png "Windowskeyboardlogo"), then select **Run**. In the **Open** box, enter **regedit** and select **OK**.
+
+2. In the Registry Editor, open the following subkey:
+
+     `HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Updates`
+
+     The installed updates are listed under subkeys that identify the .NET Framework version they apply to. Each update is identified by a Knowledge Base (KB) number.
+
+In the Registry Editor, the .NET Framework versions and installed updates for each version are stored in different subkeys. For information about detecting the installed version numbers, see [How to: Determine which .NET Framework versions are installed](../../../docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md).
+
+## To find installed updates by querying the registry in code
+
+The following example programmatically determines the .NET Framework security updates and hotfixes that are installed on a computer:
+
+[!code-csharp[ListUpdates](../../../samples/snippets/csharp/VS_Snippets_CLR/listupdates/cs/program.cs)]
+[!code-vb[ListUpdates](../../../samples/snippets/visualbasic/VS_Snippets_CLR/listupdates/vb/program.vb)]
+
+The example produces an output that's similar to the following one:
+
+```console
+Microsoft .NET Framework 4 Client Profile
+  KB2468871
+  KB2468871v2
+  KB2478063
+  KB2533523
+  KB2544514
+  KB2600211
+  KB2600217
+Microsoft .NET Framework 4 Extended
+  KB2468871
+  KB2468871v2
+  KB2478063
+  KB2533523
+  KB2544514
+  KB2600211
+  KB2600217
+```
+
+## To find installed updates by querying the registry in PowerShell
+
+The following example shows how to determine the .NET Framework security updates and hotfixes that are installed on a computer using PowerShell:
+
+```powershell
+ Get-ChildItem "HKLM:SOFTWARE\Wow6432Node\Microsoft\Updates\*" -Recurse | Where-Object {$_.name -like
+ "*.NET Framework*"}
+```
+
+The example produces an output that's similar to the following one:
+
+```console
+    Hive: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Updates\Microsoft .NET Framework 4 Client Profile
+
+
+Name                           Property
+----                           --------
+KB2468871                      ThisVersionInstalled : Y
+KB2468871v2                    ThisVersionInstalled : Y
+KB2478063                      ThisVersionInstalled : Y
+KB2533523                      ThisVersionInstalled : Y
+KB2544514                      ThisVersionInstalled : Y
+KB2600211                      ThisVersionInstalled : Y
+KB2600217                      ThisVersionInstalled : Y
+
+
+    Hive: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Updates\Microsoft .NET Framework 4 Extended
+
+
+Name                           Property
+----                           --------
+KB2468871                      ThisVersionInstalled : Y
+KB2468871v2                    ThisVersionInstalled : Y
+KB2478063                      ThisVersionInstalled : Y
+KB2533523                      ThisVersionInstalled : Y
+KB2544514                      ThisVersionInstalled : Y
+KB2600211                      ThisVersionInstalled : Y
+KB2600217                      ThisVersionInstalled : Y
+```
+
 ## See also
 
-[How to: Determine Which .NET Framework Versions Are Installed](../../../docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md)   
-[Installing the .NET Framework](../../../docs/framework/install/guide-for-developers.md)   
-[Versions and Dependencies](../../../docs/framework/migration-guide/versions-and-dependencies.md)
+[How to: Determine which .NET Framework versions are installed](../../../docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md)  
+[Install the .NET Framework for developers](../../../docs/framework/install/guide-for-developers.md)  
+[Versions and dependencies](../../../docs/framework/migration-guide/versions-and-dependencies.md)

--- a/docs/framework/migration-guide/how-to-determine-which-net-framework-updates-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-net-framework-updates-are-installed.md
@@ -1,6 +1,6 @@
 ---
 title: "How to: Determine which .NET Framework security updates and hotfixes are installed"
-description: "Learn how to determine which .NET Framework security updates and hotfixes are installed in your machine."
+description: "Learn how to determine which .NET Framework security updates and hotfixes are installed on a computer."
 ms.date: "11/21/2017"
 ms.prod: ".net-framework"
 ms.technology: 

--- a/samples/snippets/csharp/VS_Snippets_CLR/listupdates/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/listupdates/cs/program.cs
@@ -1,5 +1,4 @@
-﻿//<Snippet1>
-using System;
+﻿using System;
 using Microsoft.Win32;
 
 public class GetUpdateHistory
@@ -10,41 +9,21 @@ public class GetUpdateHistory
         {
             foreach (string baseKeyName in baseKey.GetSubKeyNames())
             {
-                if (baseKeyName.Contains(".NET Framework") || baseKeyName.StartsWith("KB") || baseKeyName.Contains(".NETFramework"))
+                if (baseKeyName.Contains(".NET Framework"))
                 {
-
                     using (RegistryKey updateKey = baseKey.OpenSubKey(baseKeyName))
                     {
-                        string name = (string)updateKey.GetValue("PackageName", "");
-                        Console.WriteLine(baseKeyName + "  " + name);
+                        Console.WriteLine(baseKeyName);
                         foreach (string kbKeyName in updateKey.GetSubKeyNames())
                         {
                             using (RegistryKey kbKey = updateKey.OpenSubKey(kbKeyName))
                             {
-                                name = (string)kbKey.GetValue("PackageName", "");
-                                Console.WriteLine("  " + kbKeyName + "  " + name);
-
-                                if (kbKey.SubKeyCount > 0)
-                                {
-                                    foreach (string sbKeyName in kbKey.GetSubKeyNames())
-                                    {
-                                        using (RegistryKey sbSubKey = kbKey.OpenSubKey(sbKeyName))
-                                        {
-                                            name = (string)sbSubKey.GetValue("PackageName", "");
-                                            if (name == "")
-                                                name = (string)sbSubKey.GetValue("Description", "");
-                                            Console.WriteLine("    " + sbKeyName + "  " + name);
-
-                                        }
-                                    }
-                                }
+                                Console.WriteLine("  " + kbKeyName);
                             }
                         }
                     }
-
                 }
             }
         }
     }
 }
-//</Snippet1>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/listupdates/vb/program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/listupdates/vb/program.vb
@@ -1,40 +1,21 @@
 
-'<Snippet1>
 Imports Microsoft.Win32
 
 Public Class GetUpdateHistory
     Public Shared Sub Main()
         Using baseKey As RegistryKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey("SOFTWARE\Microsoft\Updates")
             For Each baseKeyName As String In baseKey.GetSubKeyNames()
-                If baseKeyName.Contains(".NET Framework") OrElse baseKeyName.StartsWith("KB") OrElse baseKeyName.Contains(".NETFramework") Then
-
+                If baseKeyName.Contains(".NET Framework") Then
                     Using updateKey As RegistryKey = baseKey.OpenSubKey(baseKeyName)
-                        Dim name As String = CStr(updateKey.GetValue("PackageName", ""))
-                        Console.WriteLine(baseKeyName & "  " & name)
+                        Console.WriteLine(baseKeyName)
                         For Each kbKeyName As String In updateKey.GetSubKeyNames()
                             Using kbKey As RegistryKey = updateKey.OpenSubKey(kbKeyName)
-                                name = CStr(kbKey.GetValue("PackageName", ""))
-                                Console.WriteLine("  " & kbKeyName & "  " & name)
-
-                                If kbKey.SubKeyCount > 0 Then
-                                    For Each sbKeyName As String In kbKey.GetSubKeyNames()
-                                        Using sbSubKey As RegistryKey = kbKey.OpenSubKey(sbKeyName)
-                                            name = CStr(sbSubKey.GetValue("PackageName", ""))
-                                            If name = "" Then
-                                                name = CStr(sbSubKey.GetValue("Description", ""))
-                                            End If
-                                            Console.WriteLine("    " & sbKeyName & "  " & name)
-
-                                        End Using
-                                    Next sbKeyName
-                                End If
+                                Console.WriteLine("  " & kbKeyName)
                             End Using
                         Next kbKeyName
                     End Using
-
                 End If
             Next baseKeyName
         End Using
     End Sub
 End Class
-'</Snippet1>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/listupdates/vb/program.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/listupdates/vb/program.vb
@@ -12,10 +12,10 @@ Public Class GetUpdateHistory
                             Using kbKey As RegistryKey = updateKey.OpenSubKey(kbKeyName)
                                 Console.WriteLine("  " & kbKeyName)
                             End Using
-                        Next kbKeyName
+                        Next
                     End Using
                 End If
-            Next baseKeyName
+            Next
         End Using
     End Sub
 End Class


### PR DESCRIPTION
The topic https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-net-framework-updates-are-installed has a very low CSAT. Trying to see if some changes can improve the CSAT here.

- Included PowerShell version (@doctordns, @zjalexander do you have any suggestions for me in this PS example?) Ideally I'd just list the KB name like the C#/VB code version.
- Simplified the code. Updates don't have descriptions on my machine or different names. Am I cutting/simplifying too much?
- A lot of traffic arrives here thinking this is a topic to show to update .NET Framework. Changed title to be more explicit about the content

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-net-framework-updates-are-installed?branch=pr-en-us-3763)