### PR TITLE
Noted default decimal value is 0, not 0.0

### DIFF
--- a/docs/csharp/language-reference/keywords/decimal.md
+++ b/docs/csharp/language-reference/keywords/decimal.md
@@ -21,6 +21,8 @@ The `decimal` keyword indicates a 128-bit data type. Compared to other floating-
 |Type|Approximate Range|Precision|.NET Framework type|  
 |----------|-----------------------|---------------|-------------------------|  
 |`decimal`|(-7.9 x 10<sup>28</sup> to 7.9 x 10<sup>28</sup>) / (10<sup>0</sup> to 10<sup>28</sup>)|28-29 significant digits|<xref:System.Decimal?displayProperty=nameWithType>|  
+
+The default value of a `decimal` is 0m.
   
 ## Literals  
  If you want a numeric real literal to be treated as `decimal`, use the suffix m or M, for example:  

--- a/docs/csharp/language-reference/keywords/default-values-table.md
+++ b/docs/csharp/language-reference/keywords/default-values-table.md
@@ -40,7 +40,7 @@ Remember that using uninitialized variables in C# is not allowed.
 |[bool](../../../csharp/language-reference/keywords/bool.md)|`false`|
 |[byte](../../../csharp/language-reference/keywords/byte.md)|0|
 |[char](../../../csharp/language-reference/keywords/char.md)|'\0'|
-|[decimal](../../../csharp/language-reference/keywords/decimal.md)|0.0M|
+|[decimal](../../../csharp/language-reference/keywords/decimal.md)|0M|
 |[double](../../../csharp/language-reference/keywords/double.md)|0.0D|
 |[enum](../../../csharp/language-reference/keywords/enum.md)|The value produced by the expression (E)0, where E is the enum identifier.|
 |[float](../../../csharp/language-reference/keywords/float.md)|0.0F|

--- a/xml/System/Decimal.xml
+++ b/xml/System/Decimal.xml
@@ -53,7 +53,7 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Decimal> value type represents decimal numbers ranging from positive 79,228,162,514,264,337,593,543,950,335 to negative 79,228,162,514,264,337,593,543,950,335. The <xref:System.Decimal> value type is appropriate for financial calculations that require large numbers of significant integral and fractional digits and no round-off errors. The <xref:System.Decimal> type does not eliminate the need for rounding. Rather, it minimizes errors due to rounding. For example, the following code produces a result of 0.9999999999999999999999999999 instead of 1.  
+ The <xref:System.Decimal> value type represents decimal numbers ranging from positive 79,228,162,514,264,337,593,543,950,335 to negative 79,228,162,514,264,337,593,543,950,335. The default value of a `Decimal` is 0. The <xref:System.Decimal> value type is appropriate for financial calculations that require large numbers of significant integral and fractional digits and no round-off errors. The <xref:System.Decimal> type does not eliminate the need for rounding. Rather, it minimizes errors due to rounding. For example, the following code produces a result of 0.9999999999999999999999999999 instead of 1.  
   
  [!code-cpp[System.Decimal.Class#1](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.Decimal.Class/cpp/decimal1.cpp#1)]
  [!code-csharp[System.Decimal.Class#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Decimal.Class/cs/DecimalDivision_46630_1.cs#1)]


### PR DESCRIPTION
# Noted default decimal value is 0, not 0.0

## Summary

The C# documentation incorrectly indicated that the default value of a Decimal is 0.0 rather than 0. (They have different binary representations.) The VB documentation is correct, and the System.Decimal API reference topic didn't note a default value.

Fixes #3740 

## Suggested Reviewers

@BillWagner @PerSetAl
