### PR TITLE
Added a missing variable in creating a windows service walkthrough

### DIFF
--- a/docs/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer.md
+++ b/docs/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer.md
@@ -109,7 +109,16 @@ This article demonstrates how to create a simple Windows Service application in 
     AddHandler timer.Elapsed, AddressOf Me.OnTimer  
     timer.Start()  
     ```  
-  
+     Add a member variable to the class. It will contain the identifier of the next event to write into the event log.
+
+    ```csharp
+    private int eventId = 1;
+    ```
+
+    ```vb
+    Private eventId As Integer = 1
+    ```
+
      Add code to handle the timer event:  
   
     ```csharp  


### PR DESCRIPTION
Fixes #2850

I added the variable a class member since the sample code increments it. Its defaut value is set to 1 since the increment is done after writing the log entry => the first event log entry has an id equal to 1.
