### PR TITLE
Making the examples a bit more consistent

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_CFX/c_datacontract/vb/source.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/c_datacontract/vb/source.vb
@@ -64,16 +64,16 @@ Namespace GenericTypes
     
     '<snippet3>
     <DataContract()>  _
-    Public Class MyGenericType1 (Of T)
+    Public Class MyGenericType1(Of T)
         ' Code not shown.
     End Class
     '</snippet3>
 
    '<snippet4>
-    <DataContract()> Public Class MyGenericType2(Of T)
-
-        <DataMember()> Dim theData As T
-
+    <DataContract()>  _
+    Public Class MyGenericType2(Of T)
+        <DataMember()>  _
+        Dim theData As T
     End Class 
     '</snippet4>
 End Namespace 


### PR DESCRIPTION
These were the only places - in this file - where an attribute was on the same line as the class/field.