### PR TITLE
Add tuple deconstructing assignment documentation with code snippet

### DIFF
--- a/docs/csharp/deconstruct.md
+++ b/docs/csharp/deconstruct.md
@@ -54,7 +54,7 @@ same type. This generates compiler error CS8136, "Deconstruction 'var (...)' for
 
 Note that you must also assign each element of the tuple to a variable. If you omit any elements, the compiler generates error CS8132, "Cannot deconstruct a tuple of 'x' elements into 'y' variables."
 
-Note that you cannot mix declarations and assignments to existing variables on the left-hand side of a deconstruction. If you try to deconstruct a tuple into newly declared variables as well as variables that have already been declared, the compiler generates error CS8184, "A deconstruction cannot mix declarations and expressions on the left-hand-side."
+Note that you cannot mix declarations and assignments to existing variables on the left-hand side of a deconstruction. The compiler generates error CS8184, "a deconstruction cannot mix declarations and expressions on the left-hand-side." when the members include newly declared and existing variables.
 
 ## Deconstructing tuple elements with discards
 

--- a/docs/csharp/deconstruct.md
+++ b/docs/csharp/deconstruct.md
@@ -29,7 +29,7 @@ C# features built-in support for deconstructing tuples, which lets you unpackage
 var (name, address, city, zip) = contact.GetAddressInfo();
 ```
 
-There are two ways to deconstruct a tuple:
+There are three ways to deconstruct a tuple:
 
 - You can explicitly declare the type of each field inside parentheses. The following example uses this approach to deconstruct the 3-tuple returned by the `QueryCityData` method.
 
@@ -45,10 +45,16 @@ There are two ways to deconstruct a tuple:
 
     This is cumbersome and is not recommended.
 
+- Lastly, you may deconstruct the typle into variables that have already been declared.
+
+    [!code-csharp[Deconstruction-Declared](../../samples/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-tuple5.cs#1)]
+
 Note that you cannot specify a specific type outside the parentheses even if every field in the tuple has the
 same type. This generates compiler error CS8136, "Deconstruction 'var (...)' form disallows a specific type for 'var'.".
 
 Note that you must also assign each element of the tuple to a variable. If you omit any elements, the compiler generates error CS8132, "Cannot deconstruct a tuple of 'x' elements into 'y' variables."
+
+Note that you cannot mix declarations and assignments to existing variables on the left-hand side of a deconstruction. If you try to deconstruct a tuple into newly declared variables as well as variables that have already been declared, the compiler generates error CS8184, "A deconstruction cannot mix declarations and expressions on the left-hand-side."
 
 ## Deconstructing tuple elements with discards
 

--- a/docs/csharp/deconstruct.md
+++ b/docs/csharp/deconstruct.md
@@ -45,7 +45,7 @@ There are three ways to deconstruct a tuple:
 
     This is cumbersome and is not recommended.
 
-- Lastly, you may deconstruct the typle into variables that have already been declared.
+- Lastly, you may deconstruct the tuple into variables that have already been declared.
 
     [!code-csharp[Deconstruction-Declared](../../samples/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-tuple5.cs#1)]
 

--- a/samples/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-tuple5.cs
+++ b/samples/snippets/csharp/programming-guide/deconstructing-tuples/deconstruct-tuple5.cs
@@ -1,0 +1,25 @@
+using System;
+
+public class Example
+{
+    // <Snippet1>
+    public static void Main()
+    {
+        string city = "Raleigh";
+        int population = 458880;
+        double area = 144.8;
+
+        (city, population, area) = QueryCityData("New York City");
+
+        // Do something with the data.
+    }
+    // </Snippet1>
+
+    private static (string, int, double) QueryCityData(string name)
+    {
+        if (name == "New York City")
+            return (name, 8175133, 468.48);
+
+        return ("", 0, 0);
+    }
+}


### PR DESCRIPTION
# Add tuple deconstructing assignment documentation with code snippet

## Summary

I have added more detail for deconstructing a tuple into variables that have already been declared.

Fixes #3690

## Details

So, up until #3690, I had no idea that you could deconstruct tuples into pre-declared variables. I agree that this feature should be mentioned in the "Deconstructing tuples and other types" page and, well, here's this PR.

The only page I wound up changing was _deconstruct.md_. I mentioned the possibility of deconstructing into declared variables, added a code example, and added a note about mixing declared variables with undeclared variables on the left side of a tuple deconstruction statement.

I did not modify _tuples.md_ because it actually already mentions this possibility (although only briefly) and includes sample code that is similar to that of @BillWagner's in #3690. **Advice for additional changes here is welcome.**

Advice is also welcome as to where it would be a good place to mention the swap one-liner that was also recommended in the open issue.

## Suggested Reviewers

@BillWagner because he commented on the original issue.