### PR TITLE
Fixed link anchor

### DIFF
--- a/includes/immutable-nuget-short-md.md
+++ b/includes/immutable-nuget-short-md.md
@@ -1,1 +1,1 @@
-**NuGet package**: [System.Collections.Immutable](http://go.microsoft.com/fwlink/?LinkId=318047) ([about immutable collections and how to install](/dotnet/api/system.collections.immutable#remarks))
+**NuGet package**: [System.Collections.Immutable](http://go.microsoft.com/fwlink/?LinkId=318047) ([about immutable collections and how to install](/dotnet/api/system.collections.immutable#Remarks))


### PR DESCRIPTION
It seems the part of the link after `#` is case-sensitive and so it has to be `#Remarks`, not `#remarks`.