### PR TITLE
Clarify that that two empty cancellation tokens are always equal

### DIFF
--- a/xml/System.Threading/CancellationToken.xml
+++ b/xml/System.Threading/CancellationToken.xml
@@ -337,7 +337,7 @@
 ## Remarks  
  The cancellation token returned by this property cannot be canceled; that is, its <xref:System.Threading.CancellationToken.CanBeCanceled%2A> property is `false`.  
   
- You can also use the C#  [default(CancellationToken)](~/docs/csharp/language-reference/keywords/default.md) statement to create an empty cancellation token.  
+ You can also use the C#  [default(CancellationToken)](~/docs/csharp/language-reference/keywords/default.md) statement to create an empty (and equivalent) cancellation token. Two empty cancellation tokens are always equal.
   
  ]]></format>
         </remarks>

--- a/xml/System.Threading/CancellationToken.xml
+++ b/xml/System.Threading/CancellationToken.xml
@@ -337,7 +337,9 @@
 ## Remarks  
  The cancellation token returned by this property cannot be canceled; that is, its <xref:System.Threading.CancellationToken.CanBeCanceled%2A> property is `false`.  
   
- You can also use the C#  [default(CancellationToken)](~/docs/csharp/language-reference/keywords/default.md) statement to create an empty (and equivalent) cancellation token. Two empty cancellation tokens are always equal.
+ You can also use the C#  [default(CancellationToken)](~/docs/csharp/language-reference/keywords/default.md) statement to create an empty cancellation token. 
+
+ Two empty cancellation tokens are always equal.
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
Addresses https://github.com/dotnet/corefx/issues/495#issuecomment-323999818
