### PR TITLE
readonly struct allows writable static members

### DIFF
--- a/docs/csharp/reference-semantics-with-value-types.md
+++ b/docs/csharp/reference-semantics-with-value-types.md
@@ -149,7 +149,7 @@ removes the defensive copies
 that take place when you access methods of a struct used as an `in` parameter.
 
 You can do that by creating a `readonly struct` type. You can add the `readonly`
-modifier to a struct declaration. The compiler enforces that all members of
+modifier to a struct declaration. The compiler enforces that all instance members of
 the struct are `readonly`; the `struct` must be immutable.
 
 There are other optimizations for a `readonly struct`. You can

--- a/samples/csharp/reference-semantics/Point3D.cs
+++ b/samples/csharp/reference-semantics/Point3D.cs
@@ -28,7 +28,7 @@ namespace reference_semantics
         public double Y { get; }
         public double Z { get; }
 
-        private static ReadonlyPoint3D origin = new ReadonlyPoint3D();
+        private static readonly ReadonlyPoint3D origin = new ReadonlyPoint3D();
         public static ref readonly ReadonlyPoint3D Origin => ref origin;
     }
 #endregion    


### PR DESCRIPTION
For a readonly struct, only instance members must be readonly (static members can be writable). This change adds "instance" as a qualifier to correct an otherwise overly-broad statement.

This PR also makes a related change to the related code sample. The field `origin` is immutable both in the sense of not having any of its fields changed and in the sense of not being assigned to a new value. The `readonly` keyword is added indicate that immutable intent.