### PR TITLE
Update misspelled option name

### DIFF
--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -40,7 +40,7 @@ Prints out a short help for the command.
 
 Specifies the server URL. This option is required unless `DefaultPushSource` config value is set in the NuGet config file.
 
-`--symbols-source <SOURCE>`
+`--symbol-source <SOURCE>`
 
 Specifies the symbol server URL.
 


### PR DESCRIPTION
# Documentation mismatch

## Summary

`--symbols-source` does not exist as an option, instead `--symbol-source` exist. Basically `s` is missing.

