### PR TITLE
Revised documentation for CancellationToken.Equals

### DIFF
--- a/xml/System.Threading/CancellationToken.xml
+++ b/xml/System.Threading/CancellationToken.xml
@@ -170,11 +170,24 @@
         <Parameter Name="other" Type="System.Object" />
       </Parameters>
       <Docs>
-        <param name="other">The other object to which to compare this instance.</param>
+        <param name="other">The other object to compare with this instance.</param>
         <summary>Determines whether the current <see cref="T:System.Threading.CancellationToken" /> instance is equal to the specified <see cref="T:System.Object" />.</summary>
         <returns>
-          <see langword="true" /> if <paramref name="other" /> is a <see cref="T:System.Threading.CancellationToken" /> and if the two instances are equal; otherwise, <see langword="false" />. Two tokens are equal if they are associated with the same <see cref="T:System.Threading.CancellationTokenSource" /> or if they were both constructed from public <see cref="T:System.Threading.CancellationToken" /> constructors and their <see cref="P:System.Threading.CancellationToken.IsCancellationRequested" /> values are equal.</returns>
-        <remarks>To be added.</remarks>
+          <see langword="true" /> if <paramref name="other" /> is a <see cref="T:System.Threading.CancellationToken" /> and if the two instances are equal; otherwise, <see langword="false" />. See the Remarks section for more information. </returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+## Remarks  
+
+Two cancellation tokens are equal if any one of the following conditions is true: 
+
+- They are associated with the same <xref:System.Threading.CancellationTokenSource>.
+
+- They were both constructed from public <xref:System.Threading.CancellationToken> constructors, and their <xref:System.Threading.CancellationToken.IsCancellationRequested?displayProperty=nameWithType> values are equal.
+
+- The value of both cancellation tokens is <xref:System.Threading.CancellationToken.None?displayProperty=nameWithType>.
+
+       ]]></format>
+        </remarks>
         <exception cref="T:System.ObjectDisposedException">An associated <see cref="T:System.Threading.CancellationTokenSource" /> has been disposed.</exception>
       </Docs>
     </Member>
@@ -208,11 +221,24 @@
         <Parameter Name="other" Type="System.Threading.CancellationToken" />
       </Parameters>
       <Docs>
-        <param name="other">The other <see cref="T:System.Threading.CancellationToken" /> to which to compare this instance.</param>
+        <param name="other">The other <see cref="T:System.Threading.CancellationToken" /> to compare with this instance.</param>
         <summary>Determines whether the current <see cref="T:System.Threading.CancellationToken" /> instance is equal to the specified token.</summary>
         <returns>
-          <see langword="true" /> if the instances are equal; otherwise, <see langword="false" />. Two tokens are equal if they are associated with the same <see cref="T:System.Threading.CancellationTokenSource" /> or if they were both constructed from public <see cref="T:System.Threading.CancellationToken" /> constructors and their <see cref="P:System.Threading.CancellationToken.IsCancellationRequested" /> values are equal.</returns>
-        <remarks>To be added.</remarks>
+          <see langword="true" /> if the instances are equal; otherwise, <see langword="false" />. See the Remarks section for more information. </returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+## Remarks  
+
+Two cancellation tokens are equal if any one of the following conditions is true: 
+
+- They are associated with the same <xref:System.Threading.CancellationTokenSource>.
+
+- They were both constructed from public <xref:System.Threading.CancellationToken> constructors, and their <xref:System.Threading.CancellationToken.IsCancellationRequested?displayProperty=nameWithType> values are equal.
+
+- The value of both cancellation tokens is <xref:System.Threading.CancellationToken.None?displayProperty=nameWithType>.
+
+       ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -380,8 +406,20 @@
         <param name="right">The second instance.</param>
         <summary>Determines whether two <see cref="T:System.Threading.CancellationToken" /> instances are equal.</summary>
         <returns>
-          <see langword="true" /> if the instances are equal; otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
+          <see langword="true" /> if the instances are equal; otherwise, <see langword="false" /> See the Remarks section for more information.</returns>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+## Remarks  
+
+Two cancellation tokens are equal if any one of the following conditions is true: 
+
+- They are associated with the same <xref:System.Threading.CancellationTokenSource>.
+
+- They were both constructed from public <xref:System.Threading.CancellationToken> constructors, and their <xref:System.Threading.CancellationToken.IsCancellationRequested?displayProperty=nameWithType> values are equal.
+
+- The value of both cancellation tokens is <xref:System.Threading.CancellationToken.None?displayProperty=nameWithType>.
+       ]]></format>
+        </remarks>
         <exception cref="T:System.ObjectDisposedException">An associated <see cref="T:System.Threading.CancellationTokenSource" /> has been disposed.</exception>
       </Docs>
     </Member>
@@ -421,7 +459,15 @@
         <summary>Determines whether two <see cref="T:System.Threading.CancellationToken" /> instances are not equal.</summary>
         <returns>
           <see langword="true" /> if the instances are not equal; otherwise, <see langword="false" />.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+## Remarks  
+
+For the definition of equality, see the <xref:System.Threading.CancellationToken.Equals%2A> method. 
+       ]]></format>
+        
+
+        </remarks>
         <exception cref="T:System.ObjectDisposedException">An associated <see cref="T:System.Threading.CancellationTokenSource" /> has been disposed.</exception>
       </Docs>
     </Member>


### PR DESCRIPTION
# Revised documentation for CancellationToken.Equals

## Summary

Modified the Equals overloads and the Equals operator:
- Noted that two tokens whose value is CancellationToken.None are equal.
- Moved information on comparison from the Return Value section to a bulleted list in the Remarks section.

Fixes #3789 

[Internal Review URL](https://review.docs.microsoft.com/en-us/dotnet/api/system.threading.cancellationtoken?view=netframework-4.7.1&branch=pr-en-us-3801)

## Suggested Reviewers

@mairaw 

