### PR TITLE
Update typo (from "unescaped" to "escaped")

### DIFF
--- a/xml/System/Uri.xml
+++ b/xml/System/Uri.xml
@@ -71,7 +71,7 @@ var uri = new Uri("http://myUrl/%2E%2E/%2E%2E"); // http scheme, escaped
 OR
 var uri = new Uri("tcp://myUrl/../.."); // ftp scheme, unescaped
 OR
-var uri = new Uri("tcp://myUrl/%2E%2E/%2E%2E"); // ftp scheme, unescaped
+var uri = new Uri("tcp://myUrl/%2E%2E/%2E%2E"); // ftp scheme, escaped
 
 Console.WriteLine(uri.AbsoluteUri);  
 Console.WriteLine(uri.PathAndQuery);  


### PR DESCRIPTION
# Simple typo fix

From:
var uri = new Uri("tcp://myUrl/%2E%2E/%2E%2E"); // ftp scheme, unescaped

To:
var uri = new Uri("tcp://myUrl/%2E%2E/%2E%2E"); // ftp scheme, escaped

## Summary

Simple typo fix.

## Details

Fixed typo.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
