### PR TITLE
Fix library type

### DIFF
--- a/docs/standard/class-libraries.md
+++ b/docs/standard/class-libraries.md
@@ -20,7 +20,7 @@ There are three types of class libraries that you can use:
 
 *   **Platform-specific** class libraries have access to all the APIs in a given platform (for example, .NET Framework, Xamarin iOS), but can only be used by apps and libraries that target that platform.
 *   **Portable** class libraries have access to a subset of APIs, and can be used by apps and libraries that target multiple platforms.
-*   **.NET Core** class libraries are a merger of the platform-specific and portable library concept into a single model that provides the best of both.
+*   **.NET Standard** class libraries are a merger of the platform-specific and portable library concept into a single model that provides the best of both.
 
 ## Platform-specific Class Libraries
 


### PR DESCRIPTION
1. The third element of the list should match the third level 2 header in the article, which is about .NET Standard and not .NET Core
2. While you can create .NET Core libraries, I think Microsoft encourages everyone to prefer to create .NET Standard libraries