### PR TITLE
fix UTF code formatting

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture1.cs
@@ -78,7 +78,7 @@ public class Example
 //
 //          Executing the delegate synchronously:
 //          Formatting using the fr-FR culture on thread 1.
-//          163�025�412,32 €   18�905�365,59 €
+//          163 025 412,32 €   18 905 365,59 €
 //
 //          Executing a task asynchronously:
 //          Formatting using the en-US culture on thread 3.

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture1.cs
@@ -60,15 +60,15 @@ public class Example
 //
 //         Executing the delegate synchronously:
 //         Formatting using the fr-FR culture on thread 1.
-//         163 025 412,32 €   18 905 365,59 €
+//         163 025 412,32 â‚¬   18 905 365,59 â‚¬
 //
 //         Executing a task asynchronously:
 //         Formatting using the fr-FR culture on thread 3.
-//         163 025 412,32 €   18 905 365,59 €
+//         163 025 412,32 â‚¬   18 905 365,59 â‚¬
 //
 //         Executing a task synchronously:
 //         Formatting using the fr-FR culture on thread 1.
-//         163 025 412,32 €   18 905 365,59 €
+//         163 025 412,32 â‚¬   18 905 365,59 â‚¬
 // </Snippet1>
 // If the TargetFrameworkAttribute statement is removed, the example
 // displays the following output:
@@ -78,7 +78,7 @@ public class Example
 //
 //          Executing the delegate synchronously:
 //          Formatting using the fr-FR culture on thread 1.
-//          163 025 412,32 ?   18 905 365,59 ?
+//          163ï¿½025ï¿½412,32 â‚¬   18ï¿½905ï¿½365,59 â‚¬
 //
 //          Executing a task asynchronously:
 //          Formatting using the en-US culture on thread 3.
@@ -86,6 +86,6 @@ public class Example
 //
 //          Executing a task synchronously:
 //          Formatting using the fr-FR culture on thread 1.
-//          163 025 412,32 ?   18 905 365,59 ?
+//          163 025 412,32 â‚¬   18 905 365,59 â‚¬
 // </Snippet5>
 

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture2.cs
@@ -56,7 +56,7 @@ public class Example
 //     
 //     Executing the delegate synchronously:
 //     Formatting using the fr-FR culture on thread 1.
-//     163 025 412,32 €   18 905 365,59 €
+//     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 //     
 //     Executing a task asynchronously:
 //     Formatting using the en-US culture on thread 3.
@@ -64,7 +64,7 @@ public class Example
 //     
 //     Executing a task synchronously:
 //     Formatting using the fr-FR culture on thread 1.
-//     163 025 412,32 €   18 905 365,59 €
+//     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 // </Snippet2>
 
 

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture3.cs
@@ -57,15 +57,15 @@ public class Example
 //     
 //     Executing the delegate synchronously:
 //     Formatting using the fr-FR culture on thread 1.
-//     163 025 412,32 €   18 905 365,59 €
+//     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 //     
 //     Executing a task asynchronously:
 //     Formatting using the fr-FR culture on thread 3.
-//     163 025 412,32 €   18 905 365,59 €
+//     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 //     
 //     Executing a task synchronously:
 //     Formatting using the fr-FR culture on thread 1.
-//     163 025 412,32 €   18 905 365,59 €
+//     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 // </Snippet3>
 
 

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture4.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/cs/asyncculture4.cs
@@ -68,13 +68,13 @@ public class DataRetriever : MarshalByRefObject
 //     Executing a task asynchronously in a single appdomain:
 //     Current culture is fr-FR
 //     Thread 3 is running in app domain 'AsyncCulture4.exe'
-//     93,48 €
+//     93,48 â‚¬
 //     
 //     Executing a task synchronously in two appdomains:
 //     Thread 4 is running in app domain 'AsyncCulture4.exe'
 //     Current culture is fr-FR
 //     Thread 4 is running in app domain 'Domain2'
-//     288,66 €
+//     288,66 â‚¬
 // </Snippet4>
 
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture1.vb
@@ -63,15 +63,15 @@ End Module
 '
 '          Executing the delegate synchronously:
 '          Formatting Imports the fr-FR culture on thread 1.
-'          163 025 412,32 €   18 905 365,59 €
+'          163 025 412,32 â‚¬   18 905 365,59 â‚¬
 '
 '          Executing a task asynchronously:
 '          Formatting Imports the fr-FR culture on thread 3.
-'          163 025 412,32 €   18 905 365,59 €
+'          163 025 412,32 â‚¬   18 905 365,59 â‚¬
 '
 '          Executing a task synchronously:
 '          Formatting Imports the fr-FR culture on thread 1.
-'          163 025 412,32 €   18 905 365,59 €
+'          163 025 412,32 â‚¬   18 905 365,59 â‚¬
 ' </Snippet1>
 ' If the TargetFrameworkAttribute statement is removed, the example
 ' displays the following output:
@@ -81,7 +81,7 @@ End Module
 '
 '          Executing the delegate synchronously:
 '          Formatting using the fr-FR culture on thread 1.
-'          163 025 412,32 ?   18 905 365,59 ?
+'          163 025 412,32 â‚¬   18 905 365,59 â‚¬
 '
 '          Executing a task asynchronously:
 '          Formatting using the en-US culture on thread 3.
@@ -89,5 +89,5 @@ End Module
 '
 '          Executing a task synchronously:
 '          Formatting using the fr-FR culture on thread 1.
-'          163 025 412,32 ?   18 905 365,59 ?
+'          163 025 412,32 â‚¬   18 905 365,59 â‚¬
 ' </Snippet5>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture2.vb
@@ -60,7 +60,7 @@ End Module
 '     
 '     Executing the delegate synchronously:
 '     Formatting using the fr-FR culture on thread 1.
-'     163 025 412,32 €   18 905 365,59 €
+'     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 '     
 '     Executing a task asynchronously:
 '     Formatting using the en-US culture on thread 3.
@@ -68,5 +68,5 @@ End Module
 '     
 '     Executing a task synchronously:
 '     Formatting using the fr-FR culture on thread 1.
-'     163 025 412,32 €   18 905 365,59 €
+'     163 025 412,32 â‚¬   18 905 365,59 â‚¬
 ' </Snippet2>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture3.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture3.vb
@@ -61,13 +61,13 @@ End Module
 '       
 '       Executing the delegate synchronously:
 '       Formatting using the fr-FR culture on thread 1.
-'       163 025 412,32 €   18 905 365,59 €
+'       163 025 412,32 â‚¬   18 905 365,59 â‚¬
 '       
 '       Executing a task asynchronously:
 '       Formatting using the fr-FR culture on thread 3.
-'       163 025 412,32 €   18 905 365,59 €
+'       163 025 412,32 â‚¬   18 905 365,59 â‚¬
 '       
 '       Executing a task synchronously:
 '       Formatting using the fr-FR culture on thread 1.
-'       163 025 412,32 €   18 905 365,59 €
+'       163 025 412,32 â‚¬   18 905 365,59 â‚¬
 ' </Snippet3>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture4.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.globalization.cultureinfo.class.async/vb/asyncculture4.vb
@@ -70,12 +70,12 @@ End Class
 '     Executing a task asynchronously in a single appdomain:
 '     Current culture is fr-FR
 '     Thread 3 is running in app domain 'AsyncCulture4.exe'
-'     93,48 €
+'     93,48 â‚¬
 '     
 '     Executing a task synchronously in two appdomains:
 '     Thread 4 is running in app domain 'AsyncCulture4.exe'
 '     Current culture is fr-FR
 '     Thread 4 is running in app domain 'Domain2'
-'     288,66 €
+'     288,66 â‚¬
 ' </Snippet4>
 


### PR DESCRIPTION
The Euro characters were not formatted correctly.

This PR fixes it.

[Internal review link](https://review.docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-based-asynchronous-programming?branch=pr-en-us-3821)


cc @richlander 