### PR TITLE
Fix code formatting in Query Expressions

### DIFF
--- a/docs/fsharp/language-reference/query-expressions.md
+++ b/docs/fsharp/language-reference/query-expressions.md
@@ -803,7 +803,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`LEFT JOIN` with two tables.<br/>
+</td></tr><tr><td><code>LEFT JOIN</code> with two tables.<br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 LEFT JOIN CourseSelection

--- a/docs/fsharp/language-reference/query-expressions.md
+++ b/docs/fsharp/language-reference/query-expressions.md
@@ -89,7 +89,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
     <th>Description</th>
   </tr>
   <tr>
-  <td>`contains`</td>
+  <td><code>contains</code></td>
 <td>Determines whether the selected elements include a specified element.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
@@ -104,7 +104,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 
 
 <tr>
-  <td>`count`</td><td>Returns the number of selected elements.<br/><br/>
+  <td><code>count</code></td><td>Returns the number of selected elements.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -114,7 +114,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`last`</td><td>Selects the last element of those selected so far.<br/><br/>
+<td><code>last</code></td><td>Selects the last element of those selected so far.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for number in data do
@@ -123,7 +123,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`lastOrDefault`</td><td>Selects the last element of those selected so far, or a default value if no element is found.<br/><br/>
+<td><code>lastOrDefault</code></td><td>Selects the last element of those selected so far, or a default value if no element is found.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for number in data do
@@ -133,7 +133,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`exactlyOne`</td><td>Selects the single, specific element selected so far. If multiple elements are present, an exception is thrown.<br/><br/>
+<td><code>exactlyOne</code></td><td>Selects the single, specific element selected so far. If multiple elements are present, an exception is thrown.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -144,7 +144,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`exactlyOneOrDefault`</td><td>Selects the single, specific element of those selected so far, or a default value if that element is not found.<br/><br/>
+<td><code>exactlyOneOrDefault</code></td><td>Selects the single, specific element of those selected so far, or a default value if that element is not found.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -155,7 +155,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`headOrDefault`</td><td>Selects the first element of those selected so far, or a default value if the sequence contains no elements.<br/><br/>
+<td><code>headOrDefault</code></td><td>Selects the first element of those selected so far, or a default value if the sequence contains no elements.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -165,7 +165,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`select`</td><td>Projects each of the elements selected so far.<br/><br/>
+<td><code>select</code></td><td>Projects each of the elements selected so far.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -174,7 +174,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`where`</td><td>Selects elements based on a specified predicate.<br/><br/>
+<td><code>where</code></td><td>Selects elements based on a specified predicate.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -184,7 +184,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`minBy`</td><td>Selects a value for each element selected so far and returns the minimum resulting value.<br/><br/>
+<td><code>minBy</code></td><td>Selects a value for each element selected so far and returns the minimum resulting value.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -193,7 +193,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`maxBy`</td><td>Selects a value for each element selected so far and returns the maximum resulting value.<br/><br/>
+<td><code>maxBy</code></td><td>Selects a value for each element selected so far and returns the maximum resulting value.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -202,7 +202,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`groupBy`</td><td>Groups the elements selected so far according to a specified key selector.<br/><br/>
+<td><code>groupBy</code></td><td>Groups the elements selected so far according to a specified key selector.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -212,7 +212,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`sortBy`</td><td>Sorts the elements selected so far in ascending order by the given sorting key.<br/><br/>
+<td><code>sortBy</code></td><td>Sorts the elements selected so far in ascending order by the given sorting key.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -222,7 +222,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`sortByDescending`</td><td>Sorts the elements selected so far in descending order by the given sorting key.<br/><br/>
+<td><code>sortByDescending</code></td><td>Sorts the elements selected so far in descending order by the given sorting key.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -232,7 +232,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`thenBy`</td><td>Performs a subsequent ordering of the elements selected so far in ascending order by the given sorting key. This operator may only be used after a `sortBy`, `sortByDescending`, `thenBy`, or `thenByDescending`.<br/><br/>
+<td><code>thenBy</code></td><td>Performs a subsequent ordering of the elements selected so far in ascending order by the given sorting key. This operator may only be used after a <code>sortBy</code>, <code>sortByDescending</code>, <code>thenBy</code>, or <code>thenByDescending</code>.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -244,7 +244,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`thenByDescending`</td><td>Performs a subsequent ordering of the elements selected so far in descending order by the given sorting key. This operator may only be used after a `sortBy`, `sortByDescending`, `thenBy`, or `thenByDescending`.<br/><br/>
+<td><code>thenByDescending</code></td><td>Performs a subsequent ordering of the elements selected so far in descending order by the given sorting key. This operator may only be used after a <code>sortBy</code>, <code>sortByDescending</code>, <code>thenBy</code>, or <code>thenByDescending</code>.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -256,7 +256,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`groupValBy`</td><td>Selects a value for each element selected so far and groups the elements by the given key.<br/><br/>
+<td><code>groupValBy</code></td><td>Selects a value for each element selected so far and groups the elements by the given key.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -266,7 +266,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`join`</td><td>Correlates two sets of selected values based on matching keys. Note that the order of the keys around the = sign in a join expression is significant. In all joins, if the line is split after the `-&gt;` symbol, the indentation must be indented at least as far as the keyword `for`.<br/><br/>
+<td><code>join</code></td><td>Correlates two sets of selected values based on matching keys. Note that the order of the keys around the = sign in a join expression is significant. In all joins, if the line is split after the <code>-&gt;</code> symbol, the indentation must be indented at least as far as the keyword <code>for</code>.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -277,7 +277,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`groupJoin`</td><td>Correlates two sets of selected values based on matching keys and groups the results. Note that the order of the keys around the = sign in a join expression is significant.<br/><br/>
+<td><code>groupJoin</code></td><td>Correlates two sets of selected values based on matching keys and groups the results. Note that the order of the keys around the = sign in a join expression is significant.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -291,7 +291,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`leftOuterJoin`</td><td>Correlates two sets of selected values based on matching keys and groups the results. If any group is empty, a group with a single default value is used instead. Note that the order of the keys around the = sign in a join expression is significant.<br/><br/>
+<td><code>leftOuterJoin</code></td><td>Correlates two sets of selected values based on matching keys and groups the results. If any group is empty, a group with a single default value is used instead. Note that the order of the keys around the = sign in a join expression is significant.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -303,7 +303,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`sumByNullable`</td><td>Selects a nullable value for each element selected so far and returns the sum of these values. If any nullable does not have a value, it is ignored.<br/><br/>
+<td><code>sumByNullable</code></td><td>Selects a nullable value for each element selected so far and returns the sum of these values. If any nullable does not have a value, it is ignored.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -312,7 +312,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`minByNullable`</td><td>Selects a nullable value for each element selected so far and returns the minimum of these values. If any nullable does not have a value, it is ignored.<br/><br/>
+<td><code>minByNullable</code></td><td>Selects a nullable value for each element selected so far and returns the minimum of these values. If any nullable does not have a value, it is ignored.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -321,7 +321,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`maxByNullable`</td><td>Selects a nullable value for each element selected so far and returns the maximum of these values. If any nullable does not have a value, it is ignored.<br/><br/>
+<td><code>maxByNullable</code></td><td>Selects a nullable value for each element selected so far and returns the maximum of these values. If any nullable does not have a value, it is ignored.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -330,7 +330,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`averageByNullable`</td><td>Selects a nullable value for each element selected so far and returns the average of these values. If any nullable does not have a value, it is ignored.<br/><br/>
+<td><code>averageByNullable</code></td><td>Selects a nullable value for each element selected so far and returns the average of these values. If any nullable does not have a value, it is ignored.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -339,7 +339,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`averageBy`</td><td>Selects a value for each element selected so far and returns the average of these values.<br/><br/>
+<td><code>averageBy</code></td><td>Selects a value for each element selected so far and returns the average of these values.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -348,7 +348,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`distinct`</td><td>Selects distinct elements from the elements selected so far.<br/><br/>
+<td><code>distinct</code></td><td>Selects distinct elements from the elements selected so far.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -359,7 +359,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`exists`</td><td>Determines whether any element selected so far satisfies a condition.<br/><br/>
+<td><code>exists</code></td><td>Determines whether any element selected so far satisfies a condition.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -372,7 +372,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`find`</td><td>Selects the first element selected so far that satisfies a specified condition.<br/><br/>
+<td><code>find</code></td><td>Selects the first element selected so far that satisfies a specified condition.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -381,7 +381,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`all`</td><td>Determines whether all elements selected so far satisfy a condition.<br/><br/>
+<td><code>all</code></td><td>Determines whether all elements selected so far satisfy a condition.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -390,7 +390,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`head`</td><td>Selects the first element from those selected so far.<br/><br/>
+<td><code>head</code></td><td>Selects the first element from those selected so far.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -399,7 +399,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`nth`</td><td>Selects the element at a specified index amongst those selected so far.<br/><br/>
+<td><code>nth</code></td><td>Selects the element at a specified index amongst those selected so far.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for numbers in data do
@@ -408,7 +408,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`skip`</td><td>Bypasses a specified number of the elements selected so far and then selects the remaining elements.<br/><br/>
+<td><code>skip</code></td><td>Bypasses a specified number of the elements selected so far and then selects the remaining elements.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -417,7 +417,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`skipWhile`</td><td>Bypasses elements in a sequence as long as a specified condition is true and then selects the remaining elements.<br/><br/>
+<td><code>skipWhile</code></td><td>Bypasses elements in a sequence as long as a specified condition is true and then selects the remaining elements.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for number in data do
@@ -427,7 +427,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`sumBy`</td><td>Selects a value for each element selected so far and returns the sum of these values.<br/><br/>
+<td><code>sumBy</code></td><td>Selects a value for each element selected so far and returns the sum of these values.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -436,7 +436,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`take`</td><td>Selects a specified number of contiguous elements from those selected so far.<br/><br/>
+<td><code>take</code></td><td>Selects a specified number of contiguous elements from those selected so far.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -446,7 +446,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`takeWhile`</td><td>Selects elements from a sequence as long as a specified condition is true, and then skips the remaining elements.<br/><br/>
+<td><code>takeWhile</code></td><td>Selects elements from a sequence as long as a specified condition is true, and then skips the remaining elements.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for number in data do
@@ -455,7 +455,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`sortByNullable`</td><td>Sorts the elements selected so far in ascending order by the given nullable sorting key.<br/><br/>
+<td><code>sortByNullable</code></td><td>Sorts the elements selected so far in ascending order by the given nullable sorting key.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -465,7 +465,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`sortByNullableDescending`</td><td>Sorts the elements selected so far in descending order by the given nullable sorting key.<br/><br/>
+<td><code>sortByNullableDescending</code></td><td>Sorts the elements selected so far in descending order by the given nullable sorting key.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -475,7 +475,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`thenByNullable`</td><td>Performs a subsequent ordering of the elements selected so far in ascending order by the given nullable sorting key. This operator may only be used immediately after a `sortBy`, `sortByDescending`, `thenBy`, or `thenByDescending`, or their nullable variants.<br/><br/>
+<td><code>thenByNullable</code></td><td>Performs a subsequent ordering of the elements selected so far in ascending order by the given nullable sorting key. This operator may only be used immediately after a <code>sortBy</code>, <code>sortByDescending</code>, <code>thenBy</code>, or <code>thenByDescending</code>, or their nullable variants.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -486,7 +486,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 </code></pre>
 
 </td></tr><tr>
-<td>`thenByNullableDescending`</td><td>Performs a subsequent ordering of the elements selected so far in descending order by the given nullable sorting key. This operator may only be used immediately after a `sortBy`, `sortByDescending`, `thenBy`, or `thenByDescending`, or their nullable variants.<br/><br/>
+<td><code>thenByNullableDescending</code></td><td>Performs a subsequent ordering of the elements selected so far in descending order by the given nullable sorting key. This operator may only be used immediately after a <code>sortBy</code>, <code>sortByDescending</code>, <code>thenBy</code>, or <code>thenByDescending</code>, or their nullable variants.<br/><br/>
 
 <pre><code class="lang-fsharp">query {
     for student in db.Student do
@@ -542,7 +542,7 @@ query {
 </code></pre>
 
 </td></tr><tr>
-<td>`EXISTS`
+<td><code>EXISTS</code>
 </br>
 
 <pre><code class="lang-sql">SELECT * FROM Student
@@ -676,7 +676,7 @@ query {
 </code></pre>
 
 </td></tr><tr><td>
-`IN` a set of specified values<br/>
+<code>IN</code> a set of specified values<br/>
 
 <pre><code class="lang-sql">SELECT *
 FROM Student
@@ -699,7 +699,7 @@ query {
 </code></pre>
 
 </td></tr><tr><td>
-`LIKE` and `TOP`.<br/>
+<code>LIKE</code> and <code>TOP</code>.<br/>
 
 <pre><code class="lang-sql">-- '_e%' matches strings where the second character is 'e'
 SELECT TOP 2 * FROM Student
@@ -717,7 +717,7 @@ query {
 </code></pre>
 
 </td></tr><tr><td>
-`LIKE` with pattern match set.<br/>
+<code>LIKE</code> with pattern match set.<br/>
 
 <pre><code class="lang-sql">-- '[abc]%' matches strings where the first character is
 -- 'a', 'b', 'c', 'A', 'B', or 'C'
@@ -734,7 +734,7 @@ WHERE Student.Name LIKE '[abc]%'
 </code></pre>
 
 </td></tr><tr><td>
-`LIKE` with set exclusion pattern.<br/>
+<code>LIKE</code> with set exclusion pattern.<br/>
 
 <pre><code class="lang-sql">-- '[^abc]%' matches strings where the first character is
 -- not 'a', 'b', 'c', 'A', 'B', or 'C'
@@ -753,7 +753,7 @@ query {
 </code></pre>
 
 </td></tr><tr><td>
-`LIKE` on one field, but select a different field.<br/>
+<code>LIKE</code> on one field, but select a different field.<br/>
 
 <pre><code class="lang-sql">SELECT StudentID AS ID FROM Student
 WHERE Student.Name LIKE '[^abc]%'
@@ -768,7 +768,7 @@ WHERE Student.Name LIKE '[^abc]%'
 }
 </code></pre>
 
-</td></tr><tr><td>`LIKE`, with substring search.<br/>
+</td></tr><tr><td><code>LIKE</code>, with substring search.<br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 WHERE Student.Name like '%A%'
@@ -785,7 +785,7 @@ query {
 </code></pre>
 
 </td></tr><tr><td>
-Simple `JOIN` with two tables.<br/>
+Simple <code>JOIN</code> with two tables.<br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 JOIN CourseSelection
@@ -822,7 +822,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`JOIN` with `COUNT`<br/>
+</td></tr><tr><td><code>JOIN</code> with <code>COUNT</code><br/>
 
 <pre><code class="lang-sql">SELECT COUNT( * ) FROM Student
 JOIN CourseSelection
@@ -840,7 +840,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`DISTINCT`<br/>
+</td></tr><tr><td><code>DISTINCT</code><br/>
 
 <pre><code class="lang-sql">SELECT DISTINCT StudentID FROM CourseSelection
 </code></pre>
@@ -873,7 +873,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`BETWEEN`<br/>
+</td></tr><tr><td><code>BETWEEN</code><br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 WHERE Student.Age BETWEEN 10 AND 15
@@ -889,7 +889,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`OR`<br/>
+</td></tr><tr><td><code>OR</code><br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 WHERE Student.Age = 11 OR Student.Age = 12
@@ -905,7 +905,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`OR` with ordering<br/>
+</td></tr><tr><td><code>OR</code> with ordering<br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 WHERE Student.Age = 12 OR Student.Age = 13
@@ -923,7 +923,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`TOP`, `OR`, and ordering.<br/>
+</td></tr><tr><td><code>TOP</code>, <code>OR</code>, and ordering.<br/>
 
 <pre><code class="lang-sql">SELECT TOP 2 student.Name FROM Student
 WHERE Student.Age = 11 OR Student.Age = 12
@@ -945,7 +945,7 @@ query {
 }
 </code></pre>
 
-</td></tr><tr><td>`UNION` of two queries.<br/>
+</td></tr><tr><td><code>UNION</code> of two queries.<br/>
 
 <pre><code class="lang-sql">SELECT * FROM Student
 UNION
@@ -994,7 +994,7 @@ let query2 =
 query1.Intersect(query2)
 </code></pre>
 
-</td></tr><tr><td>`CASE` condition.<br/>
+</td></tr><tr><td><code>CASE</code> condition.<br/>
 
 <pre><code class="lang-sql">SELECT student.StudentID,
 CASE Student.Age


### PR DESCRIPTION
It seems backticks don't work for code formatting inside HTML tables:

![](https://user-images.githubusercontent.com/287848/33376988-127a17ce-d510-11e7-90d5-22aceda76e87.png)

This PR replaces them with `<code>`, which should work.