### PR TITLE
Fix the number of access modifiers

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/access-modifiers.md
@@ -49,7 +49,7 @@ All types and type members have an accessibility level, which controls whether t
  You can enable specific other assemblies to access your internal types by using the InternalsVisibleToAttribute. For more information, see [Friend Assemblies](http://msdn.microsoft.com/library/df0c70ea-2c2a-4bdc-9526-df951ad2d055).  
   
 ## Class and Struct Member Accessibility  
- Class members (including nested classes and structs) can be declared with any of the five types of access. Struct members cannot be declared as protected because structs do not support inheritance.  
+ Class members (including nested classes and structs) can be declared with any of the six types of access. Struct members cannot be declared as protected because structs do not support inheritance.  
   
  Normally, the accessibility of a member is not greater than the accessibility of the type that contains it. However, a public member of an internal class might be accessible from outside the assembly if the member implements interface methods or overrides virtual methods that are defined in a public base class.  
   


### PR DESCRIPTION
In C# 7.2 a new access modifier ‘private protected’ has been added, so access modifiers are now 6 and not 5.

# Title

Number of access modifiers

## Summary

In C# 7.2 a new access modifier ‘private protected’ has been added. "Class and Struct Member Accessibility" section is now updated and shows the real number of access modifiers.

## Details

In C# 7.2 a new access modifier ‘private protected’ has been added. "Class and Struct Member Accessibility" section is now updated and shows the real number of access modifiers.
