### PR TITLE
link to Code coverage doc

### DIFF
--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -43,7 +43,7 @@ You can read about those combinations in these walkthroughs:
 
 You can choose different languages for your class libraries and your unit test libraries. You can learn how by mixing and matching the walkthroughs referenced above.
 
-* If you are using Visual Studio, just see [Live Unit Testing in .NET Core](/visualstudio/test/live-unit-testing)
+* Visual Studio Enterprise offers great testing tools for .NET Core. Check out [Live Unit Testing](/visualstudio/test/live-unit-testing) or [code coverage](https://github.com/Microsoft/vstest-docs/blob/master/docs/analyze.md#working-with-code-coverage) to learn more.
 * For additional information and examples on how to use selective unit test filtering, see [Running selective unit tests](selective-unit-tests.md), or [including and excluding tests with Visual Studio](/visualstudio/test/live-unit-testing#including-and-excluding-test-projects-and-test-methods).
 * The XUnit team has written a tutorial that shows
 [how to use xUnit with .NET Core and Visual Studio](http://xunit.github.io/docs/getting-started-dotnet-core.html).


### PR DESCRIPTION
## Details

Adding a cross link to the docs on setting up code coverage with .NET Core. There was a complaint that it was unclear how to enable code coverage with .NET Core and the user was not sure if it was even possible. This will make the doc easier to find.

FYI, part of the confusion was also that code coverage is only available for .NET Core if you are using Visual Studio Enterprise on Windows OS.

## Suggested Reviewers
@rpetrusha 
