### PR TITLE
Topic improvements

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -158,7 +158,7 @@ Instead of creating new tests, apply these two attributes, `[Theory]` and `[Inli
 
 [!code-csharp[Sample_TestCode](../../../samples/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService_IsPrimeShould.cs?name=Sample_TestCode)]
 
-Run `dotnet test` again, and two of these tests should fail. To make all of the tests pass, change the `if` clause at the beginning of the method:
+Run `dotnet test` again, and two of these tests should fail. To make all of the tests pass, change the `if` clause at the beginning of the `IsPrime` method in the *PrimeService.cs* file:
 
 ```csharp
 if (candidate < 2)

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -3,7 +3,7 @@ title: Unit testing C# code in .NET Core using dotnet test and xUnit
 description: Learn unit test concepts in C# and .NET Core through an interactive experience building a sample solution step-by-step using dotnet test and xUnit.
 author: ardalis
 ms.author: wiwagn
-ms.date: 09/08/2017
+ms.date: 11/29/2017
 ms.topic: article
 ms.prod: .net-core
 ---
@@ -14,9 +14,9 @@ This tutorial takes you through an interactive experience building a sample solu
 ## Creating the source project
 
 Open a shell window. Create a directory called *unit-testing-using-dotnet-test* to hold the solution.
-Inside this new directory, run [`dotnet new sln`](../tools/dotnet-new.md) to create a new solution. This
+Inside this new directory, run [`dotnet new sln`](../tools/dotnet-new.md) to create a new solution. Having a solution 
 makes it easier to manage both the class library and the unit test project.
-Inside the solution directory, create a *PrimeService* directory. The directory and file structure thus far is shown below:
+Inside the solution directory, create a *PrimeService* directory. The directory and file structure thus far should be as follows:
 
 ```
 /unit-testing-using-dotnet-test
@@ -24,7 +24,7 @@ Inside the solution directory, create a *PrimeService* directory. The directory 
     /PrimeService
 ```
 
-Make *PrimeService* the current directory and run [`dotnet new classlib`](../tools/dotnet-new.md) to create the source project. Rename *Class1.cs* to *PrimeService.cs*. To use test-driven development (TDD), you'll create a failing implementation of the `PrimeService` class:
+Make *PrimeService* the current directory and run [`dotnet new classlib`](../tools/dotnet-new.md) to create the source project. Rename *Class1.cs* to *PrimeService.cs*. To use test-driven development (TDD), you first create a failing implementation of the `PrimeService` class:
 
 ```csharp
 using System;
@@ -33,16 +33,21 @@ namespace Prime.Services
 {
     public class PrimeService
     {
-        public bool IsPrime(int candidate) 
+        public bool IsPrime(int candidate)
         {
             throw new NotImplementedException("Please create a test first");
-        } 
+        }
     }
 }
 ```
 
-Change the directory back to the *unit-testing-using-dotnet-test* directory. Run [`dotnet sln add .\PrimeService\PrimeService.csproj`](../tools/dotnet-sln.md)
-to add the class library project to the solution.
+Change the directory back to the *unit-testing-using-dotnet-test* directory.
+
+Run the [dotnet sln](../tools/dotnet-sln.md) command to add the class library project to the solution:
+
+```
+dotnet sln add .\PrimeService\PrimeService.csproj
+```
 
 ## Creating the test project
 
@@ -57,11 +62,11 @@ Next, create the *PrimeService.Tests* directory. The following outline shows the
     /PrimeService.Tests
 ```
 
-Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new xunit`](../tools/dotnet-new.md). This creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *PrimeServiceTests.csproj*:
+Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new xunit`](../tools/dotnet-new.md). This command creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *PrimeServiceTests.csproj* file similar to the following code:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   <PackageReference Include="xunit" Version="2.2.0" />
   <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
 </ItemGroup>
@@ -88,7 +93,11 @@ The following shows the final solution layout:
         PrimeServiceTests.csproj
 ```
 
-Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj`](../tools/dotnet-sln.md) in the *unit-testing-using-dotnet-test* directory. 
+To add the test project to the solution, run the [dotnet sln](../tools/dotnet-sln.md) command in the *unit-testing-using-dotnet-test* directory:
+
+```
+dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj
+```
 
 ## Creating the first test
 
@@ -120,9 +129,9 @@ namespace Prime.UnitTests.Services
 }
 ```
 
-The `[Fact]` attribute indicates a test method that is run by the test runner. From the *unit-testing-using-dotnet-test*, execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The xUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
+The `[Fact]` attribute indicates a test method that is run by the test runner. From the *PrimeService.Tests* folder, execute [`dotnet test`](../tools/dotnet-test.md) to build the tests and the class library and then run the tests. The xUnit test runner contains the program entry point to run your tests. `dotnet test` starts the test runner using the unit test project you've created.
 
-Your test fails. You haven't created the implementation yet. Make this test by writing the simplest code in the `PrimeService` class that works:
+Your test fails. You haven't created the implementation yet. Make this test by writing the simplest code in the `PrimeService` class that works. Replace the existing `IsPrime` method implementation with the following code:
 
 ```csharp
 public bool IsPrime(int candidate)
@@ -135,17 +144,21 @@ public bool IsPrime(int candidate)
 }
 ```
 
-In the *unit-testing-using-dotnet-test* directory, run `dotnet test` again. The `dotnet test` command runs a build for the `PrimeService` project and then for the `PrimeService.Tests` project. After building both projects, it runs this single test. It passes.
+In the *PrimeService.Tests* directory, run `dotnet test` again. The `dotnet test` command runs a build for the `PrimeService` project and then for the `PrimeService.Tests` project. After building both projects, it runs this single test. It passes.
 
 ## Adding more features
 
-Now that you've made one test pass, it's time to write more. There are a few other simple cases for prime numbers: 0, -1. You could add those cases as new tests with the `[Fact]` attribute, but that quickly becomes tedious. There are other xUnit attributes that enable you to write a suite of similar tests.  A `[Theory]` attribute represents a suite of tests that execute the same code but have different input arguments. You can use the `[InlineData]` attribute to specify values for those inputs.
+Now that you've made one test pass, it's time to write more. There are a few other simple cases for prime numbers: 0, -1. You could add those cases as new tests with the `[Fact]` attribute, but that quickly becomes tedious. There are other xUnit attributes that enable you to write a suite of similar tests:
 
-Instead of creating new tests, apply these two attributes to create a single theory. The theory is a method that tests several values less than two, which is the lowest prime number:
+- `[Theory]` represents a suite of tests that execute the same code but have different input arguments.
+
+- `[InlineData]` attribute specifies values for those inputs.
+
+Instead of creating new tests, apply these two attributes, `[Theory]` and `[InlineData]`, to create a single theory in the *PrimeService_IsPrimeShould.cs* file. The theory is a method that tests several values less than two, which is the lowest prime number:
 
 [!code-csharp[Sample_TestCode](../../../samples/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService_IsPrimeShould.cs?name=Sample_TestCode)]
 
-Run `dotnet test`, and two of these tests fail. To make all of the tests pass, change the `if` clause at the beginning of the method:
+Run `dotnet test` again, and two of these tests should fail. To make all of the tests pass, change the `if` clause at the beginning of the method:
 
 ```csharp
 if (candidate < 2)
@@ -155,4 +168,4 @@ Continue to iterate by adding more tests, more theories, and more code in the ma
 
 ### Additional resources
 
-[Testing controller logic in ASP.NET Core](https://docs.microsoft.com/aspnet/core/mvc/controllers/testing)
+[Testing controller logic in ASP.NET Core](/aspnet/core/mvc/controllers/testing)

--- a/samples/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService.Tests.csproj
+++ b/samples/core/getting-started/unit-testing-using-dotnet-test/PrimeService.Tests/PrimeService.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #3762 

What I changed:
- There were certain things that were not explicit where it should be done
- Changed where you run dotnet test (see LiveFyre comment below)
- Updated Microsoft.NET.Test.Sdk
- There were a couple of commands that were not really copy and pasteable. So changed the paragraph so folks can now do that.

Related LiveFyre comment:
"By running dotnet test from the outer folder, it will indeed build both class library project and unit test project, but it will attempt to locate tests in both folders, finding none in the former and producing error message "No test is available in C:\dev\dotnet\unit-testing-using-dotnet-test\PrimeService\bin\Debug\netstandard2.0\PrimeService.dll. Make sure test project has a nuget reference of package "Microsoft.NET.Test.Sdk" and framework version settings are appropriate and try again." The README in this sample's repository suggests running dotnet test within the PrimeService.Tests folder."