### PR TITLE
Fix .Net "dotnet/standard repository" link on .Net Standard

### DIFF
--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -75,7 +75,7 @@ The .NET Standard specification is a standardized set of APIs. The specification
 
 ### Official artifacts
 
-The official specification is a set of .cs files that define the APIs that are part of the standard. The [ref directory](https://github.com/dotnet/standard/tree/master/netstandard/ref) in the [dotnet/standard repository](https://github.com/dotnet/corefx/tree/master/src) defines the .NET Standard APIs.
+The official specification is a set of .cs files that define the APIs that are part of the standard. The [ref directory](https://github.com/dotnet/standard/tree/master/netstandard/ref) in the [dotnet/standard repository](https://github.com/dotnet/standard) defines the .NET Standard APIs.
 
 The [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library) metapackage ([source](https://github.com/dotnet/standard/blob/master/netstandard/pkg/NETStandard.Library.dependencies.props)) describes the set of libraries that define (in part) one or more .NET Standard versions.
 


### PR DESCRIPTION
Fix link on page "https://github.com/dotnet/docs/blob/master/docs/standard/net-standard.md".
"dotnet/standard repository" refers to  "https://github.com/dotnet/standard" instead of "https://github.com/dotnet/corefx/tree/master/src".
Fixes #3841
