### PR TITLE
Correct fwlinks in csharp/language-reference

### DIFF
--- a/docs/csharp/language-reference/compiler-options/baseaddress-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/baseaddress-compiler-option.md
@@ -17,7 +17,7 @@ author: "BillWagner"
 ms.author: "wiwagn"
 ---
 # /baseaddress (C# Compiler Options)
-The **/baseaddress** option lets you specify the preferred base address at which to load a DLL. For more information about when and why to use this option, see [Larry Osterman's WebLog](http://go.microsoft.com/fwlink/?LinkId=107044).  
+The **/baseaddress** option lets you specify the preferred base address at which to load a DLL. For more information about when and why to use this option, see [Larry Osterman's WebLog](https://blogs.msdn.microsoft.com/larryosterman/2004/07/06/why-should-i-even-bother-to-use-dlls-in-my-system/).  
   
 ## Syntax  
   

--- a/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
@@ -34,7 +34,7 @@ This option specifies which codepage to use during compilation if the required p
   
  If the source code files were created with the same codepage that is in effect on your computer or if the source code files were created with UNICODE or UTF-8, you need not use **/codepage**.  
   
- See [GetCPInfo](http://go.microsoft.com/fwlink/?LinkId=148371) for information on how to find which code pages are supported on your system.  
+ See [GetCPInfo](https://msdn.microsoft.com/en-us/library/dd318078(VS.85).aspx) for information on how to find which code pages are supported on your system.  
   
  This compiler option is unavailable in Visual Studio and cannot be changed programmatically.  
   

--- a/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
@@ -34,7 +34,7 @@ This option specifies which codepage to use during compilation if the required p
   
  If the source code files were created with the same codepage that is in effect on your computer or if the source code files were created with UNICODE or UTF-8, you need not use **/codepage**.  
   
- See [GetCPInfo](https://msdn.microsoft.com/en-us/library/dd318078(VS.85).aspx) for information on how to find which code pages are supported on your system.  
+ See [GetCPInfo](https://msdn.microsoft.com/library/dd318078(VS.85).aspx) for information on how to find which code pages are supported on your system.  
   
  This compiler option is unavailable in Visual Studio and cannot be changed programmatically.  
   

--- a/docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md
@@ -48,7 +48,7 @@ This option provides a convenient way to report a C# internal compiler error to 
   
  A user's ability to send reports depends on computer and user policy permissions.  
   
- For more information about error debugger, see [Description of the Dr. Watson for Windows (Drwtsn32.exe) Tool](https://support.microsoft.com/en-us/help/308538/description-of-the-dr--watson-for-windows-drwtsn32-exe-tool).  
+ For more information about error debugger, see [Description of the Dr. Watson for Windows (Drwtsn32.exe) Tool](https://support.microsoft.com/help/308538/description-of-the-dr--watson-for-windows-drwtsn32-exe-tool).  
   
 ### To set this compiler option in the Visual Studio development environment  
   

--- a/docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/errorreport-compiler-option.md
@@ -48,7 +48,7 @@ This option provides a convenient way to report a C# internal compiler error to 
   
  A user's ability to send reports depends on computer and user policy permissions.  
   
- For more information about error debugger, see [Description of the Dr. Watson for Windows (Drwtsn32.exe) Tool](http://go.microsoft.com/fwlink/?LinkId=147286).  
+ For more information about error debugger, see [Description of the Dr. Watson for Windows (Drwtsn32.exe) Tool](https://support.microsoft.com/en-us/help/308538/description-of-the-dr--watson-for-windows-drwtsn32-exe-tool).  
   
 ### To set this compiler option in the Visual Studio development environment  
   

--- a/docs/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
+++ b/docs/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
@@ -25,7 +25,7 @@ ms.author: "wiwagn"
 ---
 # How to: Set Environment Variables for the Visual Studio Command Line
 
-The VsDevCmd.bat file sets the appropriate environment variables to enable command-line builds. For more information about VsDevCmd.bat, see [Knowledge Base article Q248802](http://go.microsoft.com/fwlink/?LinkId=225042).  
+The VsDevCmd.bat file sets the appropriate environment variables to enable command-line builds. For more information about VsDevCmd.bat, see [Knowledge Base article Q248802](https://support.microsoft.com/en-us/help/248802/you-receive-the-out-of-environment-space-error-message-when-you-execut).  
 
 > [!NOTE]
 > The VsDevCmd.bat file is a new file delivered with Visual Studio 2017. Visual Studio 2015 and earlier versions used VSVARS32.bat for the same purpose. This file was stored in \Program Files\Microsoft Visual Studio\\*Version*\Common7\Tools or Program Files (x86)\Microsoft Visual Studio\\*Version*\Common7\Tools.

--- a/docs/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
+++ b/docs/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
@@ -25,7 +25,7 @@ ms.author: "wiwagn"
 ---
 # How to: Set Environment Variables for the Visual Studio Command Line
 
-The VsDevCmd.bat file sets the appropriate environment variables to enable command-line builds. For more information about VsDevCmd.bat, see [Knowledge Base article Q248802](https://support.microsoft.com/en-us/help/248802/you-receive-the-out-of-environment-space-error-message-when-you-execut).  
+The VsDevCmd.bat file sets the appropriate environment variables to enable command-line builds. For more information about VsDevCmd.bat, see [Knowledge Base article Q248802](https://support.microsoft.com/help/248802/you-receive-the-out-of-environment-space-error-message-when-you-execut).  
 
 > [!NOTE]
 > The VsDevCmd.bat file is a new file delivered with Visual Studio 2017. Visual Studio 2015 and earlier versions used VSVARS32.bat for the same purpose. This file was stored in \Program Files\Microsoft Visual Studio\\*Version*\Common7\Tools or Program Files (x86)\Microsoft Visual Studio\\*Version*\Common7\Tools.

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -77,7 +77,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
  [C# Language Specification Reference](../../../csharp/language-reference/language-specification/index.md) : .NET Foundation  
  C# 1.0/1.1 [ISO/IEC 23270:2003](https://www.iso.org/standard/36768.html) Information technology -- C# Language Specification : ISO Catalogue  
  C# 2.0 [ISO/IEC 23270:2006](https://www.iso.org/standard/42926.html) Information technology -- C# Language Specification : ISO Catalogue  
- C# 2.0 [c042926_ISO_IEC_23270_2006(E).zip](http://go.microsoft.com/fwlink/?LinkId=144406) ISO/IEC 23270:2006 in PDF format : ISO Freely Available Standards  
+ C# 2.0 [c042926_ISO_IEC_23270_2006(E).zip](http://standards.iso.org/ittf/PubliclyAvailableStandards/c042926_ISO_IEC_23270_2006(E).zip) ISO/IEC 23270:2006 in PDF format : ISO Freely Available Standards  
  C# 3.0 [CSharp Language Specification.doc](http://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc) C# Language Specification Version 3.0 : Microsoft Corporation  
  C# 4.0 [Ecma-334.pdf](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf) Standard ECMA-334 4th Edition    
  C# 5.0 [CSharp Language Specification.docx](https://www.microsoft.com/download/details.aspx?id=7029) C# Language Specification Version 5.0 : Microsoft Corporation  

--- a/docs/csharp/language-reference/compiler-options/preferreduilang-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/preferreduilang-compiler-option.md
@@ -27,7 +27,7 @@ By using the `/preferreduilang` compiler option, you can specify the language in
   
 ## Arguments  
  `language`  
- The [language name](http://go.microsoft.com/fwlink/p/?LinkId=236992) of the language to use for compiler output.  
+ The [language name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318696(v=vs.85).aspx) of the language to use for compiler output.  
   
 ## Remarks  
  You can use the `/preferreduilang` compiler option to specify the language that you want the C# compiler to use for error messages and other command-line output. If the language pack for the language is not installed, the language setting of the operating system is used instead, and no error is reported.  

--- a/docs/csharp/language-reference/compiler-options/preferreduilang-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/preferreduilang-compiler-option.md
@@ -27,7 +27,7 @@ By using the `/preferreduilang` compiler option, you can specify the language in
   
 ## Arguments  
  `language`  
- The [language name](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318696(v=vs.85).aspx) of the language to use for compiler output.  
+ The [language name](https://msdn.microsoft.com/library/windows/desktop/dd318696(v=vs.85).aspx) of the language to use for compiler output.  
   
 ## Remarks  
  You can use the `/preferreduilang` compiler option to specify the language that you want the C# compiler to use for error messages and other command-line output. If the language pack for the language is not installed, the language setting of the operating system is used instead, and no error is reported.  

--- a/docs/csharp/language-reference/compiler-options/win32icon-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/win32icon-compiler-option.md
@@ -30,7 +30,7 @@ The **/win32icon** option inserts an .ico file in the output file, which gives t
  The .ico file that you want to add to your output file.  
   
 ## Remarks  
- An .ico file can be created with the [Resource Compiler](https://msdn.microsoft.com/en-us/library/aa381042.aspx). The Resource Compiler is invoked when you compile a Visual C++ program; an .ico file is created from the .rc file.  
+ An .ico file can be created with the [Resource Compiler](https://msdn.microsoft.com/library/aa381042.aspx). The Resource Compiler is invoked when you compile a Visual C++ program; an .ico file is created from the .rc file.  
   
  See [/linkresource](../../../csharp/language-reference/compiler-options/linkresource-compiler-option.md) (to reference) or [/resource](../../../csharp/language-reference/compiler-options/resource-compiler-option.md) (to attach) a .NET Framework resource file. See [/win32res](../../../csharp/language-reference/compiler-options/win32res-compiler-option.md) to import a .res file.  
   

--- a/docs/csharp/language-reference/compiler-options/win32icon-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/win32icon-compiler-option.md
@@ -30,7 +30,7 @@ The **/win32icon** option inserts an .ico file in the output file, which gives t
  The .ico file that you want to add to your output file.  
   
 ## Remarks  
- An .ico file can be created with the [Resource Compiler](http://go.microsoft.com/fwlink/?LinkId=148370). The Resource Compiler is invoked when you compile a Visual C++ program; an .ico file is created from the .rc file.  
+ An .ico file can be created with the [Resource Compiler](https://msdn.microsoft.com/en-us/library/aa381042.aspx). The Resource Compiler is invoked when you compile a Visual C++ program; an .ico file is created from the .rc file.  
   
  See [/linkresource](../../../csharp/language-reference/compiler-options/linkresource-compiler-option.md) (to reference) or [/resource](../../../csharp/language-reference/compiler-options/resource-compiler-option.md) (to attach) a .NET Framework resource file. See [/win32res](../../../csharp/language-reference/compiler-options/win32res-compiler-option.md) to import a .res file.  
   

--- a/docs/csharp/language-reference/keywords/await.md
+++ b/docs/csharp/language-reference/keywords/await.md
@@ -31,7 +31,7 @@ The task to which the `await` operator is applied typically is returned by a cal
 [!code-csharp[await-example](../../../../samples/snippets/csharp/language-reference/keywords/await/await1.cs)]  
 
 > [!IMPORTANT]
->  For the complete example, see [Walkthrough: Accessing the Web by Using Async and Await](../../../csharp/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can download the sample from [Developer Code Samples](http://go.microsoft.com/fwlink/?LinkID=255191) on the Microsoft website. The example is in the AsyncWalkthrough_HttpClient project.  
+>  For the complete example, see [Walkthrough: Accessing the Web by Using Async and Await](../../../csharp/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can download the sample from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f) on the Microsoft website. The example is in the AsyncWalkthrough_HttpClient project.  
   
 As shown in the previous example, if `await` is applied to the result of a method call that returns a `Task<TResult>`, then the type of the `await` expression is `TResult`. If `await` is applied to the result of a method call that returns a `Task`, then the type of the `await` expression is `void`. The following example illustrates the difference.  
   

--- a/docs/csharp/language-reference/keywords/explicit.md
+++ b/docs/csharp/language-reference/keywords/explicit.md
@@ -50,4 +50,4 @@ The `explicit` keyword declares a user-defined type conversion operator that mus
  [implicit](../../../csharp/language-reference/keywords/implicit.md)  
  [operator (C# Reference)](../../../csharp/language-reference/keywords/operator.md)  
  [How to: Implement User-Defined Conversions Between Structs](../../../csharp/programming-guide/statements-expressions-operators/how-to-implement-user-defined-conversions-between-structs.md)  
- [Chained user-defined explicit conversions in C#](http://go.microsoft.com/fwlink/?LinkId=112384)
+ [Chained user-defined explicit conversions in C#](https://blogs.msdn.microsoft.com/ericlippert/2007/04/16/chained-user-defined-explicit-conversions-in-c/)

--- a/docs/csharp/language-reference/operators/null-conditional-operator.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operator.md
@@ -34,4 +34,4 @@ The `??` operator is called the null-coalescing operator.  It returns the left-h
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [C# Operators](../../../csharp/language-reference/operators/index.md)  
  [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md)  
- [What Exactly Does 'Lifted' mean?](http://go.microsoft.com/fwlink/?LinkID=112382)
+ [What Exactly Does 'Lifted' mean?](https://blogs.msdn.microsoft.com/ericlippert/2007/06/27/what-exactly-does-lifted-mean/)


### PR DESCRIPTION
All references have been changed except in:
* csharp\language-reference\compiler-options\target-appcontainerexe-compiler-option.md
  (the link is not working)
* csharp\language-reference\keywords\new-modifier.md
  (links to http://www.microsoft.com/en-us/download/details.aspx?id=7029)

Relates to #3424