### PR TITLE
fix implementation of percentile die

### DIFF
--- a/docs/csharp/whats-new/csharp-7.md
+++ b/docs/csharp/whats-new/csharp-7.md
@@ -248,7 +248,7 @@ of a number of die rolls:
 [!code-csharp[SumDieRolls](../../../samples/snippets/csharp/new-in-7/patternmatch.cs#14_SumDieRolls "Sum die rolls")]
 
 You might quickly find that you need to find the sum of die rolls where
-some of the rolls are made with more than one die. Part of the input
+some of the rolls are made with multiple dice (dice is the plural of die). Part of the input
 sequence may be multiple results instead of a single number:
 
 [!code-csharp[SumDieRollsWithGroups](../../../samples/snippets/csharp/new-in-7/patternmatch.cs#15_SumDieRollsWithGroups "Sum die rolls with groups")]
@@ -304,9 +304,9 @@ use percentile dice to represent larger ranges of numbers.
 > together and you can get every number from 0 through 99.
 
 To add this kind of die to your collection, first define a type to represent
-the percentile die:
+the percentile dice. The `TensDigit` property stores values `0`, `10`, `20`, up to `90`:
 
-[!code-csharp[18_PercentileDie](../../../samples/snippets/csharp/new-in-7/patternmatch.cs#18_PercentileDie "Percentile Die type")]
+[!code-csharp[18_PercentileDice](../../../samples/snippets/csharp/new-in-7/patternmatch.cs#18_PercentileDice "Percentile Die type")]
 
 Then, add a `case` match expression for the new type:
 

--- a/samples/snippets/csharp/new-in-7/patternmatch.cs
+++ b/samples/snippets/csharp/new-in-7/patternmatch.cs
@@ -9,13 +9,13 @@ namespace new_in_7
     #region 18_PercentileDie
     public struct PercentileDie
     {
-        public int Value { get; }
-        public int Multiplier { get; }
+        public int OnesDigit { get; }
+        public int TensDigit { get; }
 
-        public PercentileDie(int multiplier, int value)
+        public PercentileDie(int tensDigit, int onesDigit)
         {
-            this.Value = value;
-            this.Multiplier = multiplier;
+            this.OnesDigit = onesDigit;
+            this.TensDigit = tensDigit;
         }
     }
     #endregion
@@ -110,7 +110,7 @@ namespace new_in_7
                         sum += val;
                         break;
                     case PercentileDie die:
-                        sum += die.Multiplier * die.Value;
+                        sum += die.TensDigit * 10 + die.OnesDigit;
                         break;
                     case IEnumerable<object> subList when subList.Any():
                         sum += DiceSum5(subList);

--- a/samples/snippets/csharp/new-in-7/patternmatch.cs
+++ b/samples/snippets/csharp/new-in-7/patternmatch.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace new_in_7
 {
-    #region 18_PercentileDie
-    public struct PercentileDie
+    #region 18_PercentileDice
+    public struct PercentileDice
     {
         public int OnesDigit { get; }
         public int TensDigit { get; }
@@ -109,8 +109,8 @@ namespace new_in_7
                     case int val:
                         sum += val;
                         break;
-                    case PercentileDie die:
-                        sum += die.TensDigit * 10 + die.OnesDigit;
+                    case PercentileDice dice:
+                        sum += dice.TensDigit + dice.OnesDigit;
                         break;
                     case IEnumerable<object> subList when subList.Any():
                         sum += DiceSum5(subList);

--- a/samples/snippets/csharp/new-in-7/patternmatch.cs
+++ b/samples/snippets/csharp/new-in-7/patternmatch.cs
@@ -12,7 +12,7 @@ namespace new_in_7
         public int OnesDigit { get; }
         public int TensDigit { get; }
 
-        public PercentileDie(int tensDigit, int onesDigit)
+        public PercentileDice(int tensDigit, int onesDigit)
         {
             this.OnesDigit = onesDigit;
             this.TensDigit = tensDigit;


### PR DESCRIPTION
From a LiveFyre comment. (See the comment on "What's new in C# 7")

The implementation of the percentile die died not match the description in the text. This PR fixes that.

