### PR TITLE
Fix Badly Broken Links Pt 3

### DIFF
--- a/xml/System.Web.UI.DataVisualization.Charting/ChartGraphics.xml
+++ b/xml/System.Web.UI.DataVisualization.Charting/ChartGraphics.xml
@@ -20,7 +20,7 @@
   
  Note also that, by default, <xref:System.Drawing.Graphics> functions usually take absolute coordinates. Therefore the conversion methods of this class should be useful if you perform drawing operations.  
   
- A <xref:System.Web.UI.DataVisualization.Charting.ChartGraphics> object is exposed in the <xref:System.Web.UI.DataVisualization.Charting.ChartPaintEventArgs.ChartGraphics%2A> property of the <xref:System.Web.UI.DataVisualization.Charting.ChartPaintEventArgs> class?qualifyHint=False&autoUpgrade=True, which makes it easy to perform custom drawing in the <xref:System.Web.UI.DataVisualization.Charting.Chart.PrePaint> and <xref:System.Web.UI.DataVisualization.Charting.Chart.PostPaint> events.  
+ A <xref:System.Web.UI.DataVisualization.Charting.ChartGraphics> object is exposed in the <xref:System.Web.UI.DataVisualization.Charting.ChartPaintEventArgs.ChartGraphics%2A> property of the <xref:System.Web.UI.DataVisualization.Charting.ChartPaintEventArgs> class, which makes it easy to perform custom drawing in the <xref:System.Web.UI.DataVisualization.Charting.Chart.PrePaint> and <xref:System.Web.UI.DataVisualization.Charting.Chart.PostPaint> events.  
   
 > [!IMPORTANT]
 >  If significant changes are made to the default behavior of the <xref:System.Drawing.Graphics> object, the chart image and its associated elements may be drawn erratically. For example, positioning may be altered. It is highly recommended that you become well acquainted with GDI+ before you make any significant changes to the properties of the <xref:System.Drawing.Graphics> object.  

--- a/xml/System.Web.UI.DataVisualization.Charting/SeriesCollection.xml
+++ b/xml/System.Web.UI.DataVisualization.Charting/SeriesCollection.xml
@@ -56,7 +56,7 @@
   
  The `name` argument refers to the `Name` property of the object being added.  
   
- **Note** If you use this method to add <xref:System.Web.UI.DataVisualization.Charting.Series> objects to the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Web.UI.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Web.UI.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point. To add a series that can handle multiple Y-values per data point, use the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection.Add%2A> System.Int32)?qualifyHint=False&autoUpgrade=True definition of this overloaded method.  
+ **Note** If you use this method to add <xref:System.Web.UI.DataVisualization.Charting.Series> objects to the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Web.UI.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Web.UI.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point. To add a series that can handle multiple Y-values per data point, use the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection.Add(System.Int32)> definition of this overloaded method.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Web.UI.DataVisualization.Charting/SeriesCollection.xml
+++ b/xml/System.Web.UI.DataVisualization.Charting/SeriesCollection.xml
@@ -56,7 +56,7 @@
   
  The `name` argument refers to the `Name` property of the object being added.  
   
- **Note** If you use this method to add <xref:System.Web.UI.DataVisualization.Charting.Series> objects to the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Web.UI.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Web.UI.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point. To add a series that can handle multiple Y-values per data point, use the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection.Add(System.Int32)> definition of this overloaded method.  
+ **Note** If you use this method to add <xref:System.Web.UI.DataVisualization.Charting.Series> objects to the <xref:System.Web.UI.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Web.UI.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Web.UI.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Forms.DataVisualization.Charting/ChartGraphics.xml
+++ b/xml/System.Windows.Forms.DataVisualization.Charting/ChartGraphics.xml
@@ -20,7 +20,7 @@
   
  Note also that, by default, <xref:System.Drawing.Graphics> functions usually take absolute coordinates. Therefore the conversion methods of this class should be useful if you perform drawing operations.  
   
- A <xref:System.Windows.Forms.DataVisualization.Charting.ChartGraphics> object is exposed in the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs.ChartGraphics%2A> property of the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs> class?qualifyHint=False&autoUpgrade=True, which makes it easy to perform custom drawing in the <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PrePaint> and <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PostPaint> events.  
+ A <xref:System.Windows.Forms.DataVisualization.Charting.ChartGraphics> object is exposed in the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs.ChartGraphics%2A> property of the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs%2A> class, which makes it easy to perform custom drawing in the <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PrePaint> and <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PostPaint> events.  
   
 > [!IMPORTANT]
 >  If significant changes are made to the default behavior of the <xref:System.Drawing.Graphics> object, the chart image and its associated elements may be drawn erratically. For example, positioning may be altered. It is highly recommended that you become well acquainted with GDI+ before you make any significant changes to the properties of the <xref:System.Drawing.Graphics> object.  

--- a/xml/System.Windows.Forms.DataVisualization.Charting/ChartGraphics.xml
+++ b/xml/System.Windows.Forms.DataVisualization.Charting/ChartGraphics.xml
@@ -20,7 +20,7 @@
   
  Note also that, by default, <xref:System.Drawing.Graphics> functions usually take absolute coordinates. Therefore the conversion methods of this class should be useful if you perform drawing operations.  
   
- A <xref:System.Windows.Forms.DataVisualization.Charting.ChartGraphics> object is exposed in the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs.ChartGraphics%2A> property of the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs%2A> class, which makes it easy to perform custom drawing in the <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PrePaint> and <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PostPaint> events.  
+ A <xref:System.Windows.Forms.DataVisualization.Charting.ChartGraphics> object is exposed in the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs.ChartGraphics%2A> property of the <xref:System.Windows.Forms.DataVisualization.Charting.ChartPaintEventArgs> class, which makes it easy to perform custom drawing in the <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PrePaint> and <xref:System.Windows.Forms.DataVisualization.Charting.Chart.PostPaint> events.  
   
 > [!IMPORTANT]
 >  If significant changes are made to the default behavior of the <xref:System.Drawing.Graphics> object, the chart image and its associated elements may be drawn erratically. For example, positioning may be altered. It is highly recommended that you become well acquainted with GDI+ before you make any significant changes to the properties of the <xref:System.Drawing.Graphics> object.  

--- a/xml/System.Windows.Forms.DataVisualization.Charting/SeriesCollection.xml
+++ b/xml/System.Windows.Forms.DataVisualization.Charting/SeriesCollection.xml
@@ -56,7 +56,7 @@
   
  The `name` argument refers to the `Name` property of the object being added.  
   
- **Note** If you use this method to add <xref:System.Windows.Forms.DataVisualization.Charting.Series> objects to the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Windows.Forms.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Windows.Forms.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point. To add a series that can handle multiple Y-values per data point, use the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection.Add%2A> System.Int32)?qualifyHint=False&autoUpgrade=True definition of this overloaded method.  
+ **Note** If you use this method to add <xref:System.Windows.Forms.DataVisualization.Charting.Series> objects to the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Windows.Forms.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Windows.Forms.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point. To add a series that can handle multiple Y-values per data point, use the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection.Add(System.Int32)> definition of this overloaded method.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Forms.DataVisualization.Charting/SeriesCollection.xml
+++ b/xml/System.Windows.Forms.DataVisualization.Charting/SeriesCollection.xml
@@ -56,7 +56,7 @@
   
  The `name` argument refers to the `Name` property of the object being added.  
   
- **Note** If you use this method to add <xref:System.Windows.Forms.DataVisualization.Charting.Series> objects to the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Windows.Forms.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Windows.Forms.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point. To add a series that can handle multiple Y-values per data point, use the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection.Add(System.Int32)> definition of this overloaded method.  
+ **Note** If you use this method to add <xref:System.Windows.Forms.DataVisualization.Charting.Series> objects to the <xref:System.Windows.Forms.DataVisualization.Charting.SeriesCollection> class, the associated <xref:System.Windows.Forms.DataVisualization.Charting.DataPoint> objects of the newly added <xref:System.Windows.Forms.DataVisualization.Charting.Series> object cannot have more than one Y-value per data point.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Input/StylusPointCollection.xml
+++ b/xml/System.Windows.Input/StylusPointCollection.xml
@@ -439,9 +439,7 @@
         <summary>Converts a <see cref="T:System.Windows.Input.StylusPointCollection" /> into a point array.</summary>
         <returns>A point array that contains points that correspond to each <see cref="T:System.Windows.Input.StylusPoint" /> in the <see cref="T:System.Windows.Input.StylusPointCollection" />.</returns>
         <remarks>
-          <format type="text/markdown"><![CDATA[The equivalent method for this operator is ?qualifyHint=True&autoUpgrade=False  
-  
-## Examples  
+          <format type="text/markdown"><![CDATA[## Examples  
  The following example demonstrates how to erase the strokes that are surrounded by a lasso. The example assumes that there is an <xref:System.Windows.Controls.InkPresenter> called `presenter`.  
   
  [!code-csharp[StrokeCollectionMethods#2](~/samples/snippets/csharp/VS_Snippets_Wpf/StrokeCollectionMethods/CSharp/StrokeCollectionDemo.cs#2)]


### PR DESCRIPTION
Third batch of updated links from conversion

## Summary

Third batch of updated links from conversion (part 3 of badly converted links)

Note: this PR is Part 3 of several to make fixing  #2459 easier to review. Part 1 was #3757, part 2 was #3815.

Migration broken links are identified by searching the repo for *qualifyHint*, which can be found [here](https://github.com/dotnet/docs/search?utf8=%E2%9C%93&q=qualifyhint&type=).

[Internal Review URL (System.Web.UI.DataVisualization.Charting.ChartGraphics)](https://review.docs.microsoft.com/en-us/dotnet/api/system.web.ui.datavisualization.charting.chartgraphics?view=netframework-4.7&branch=pr-en-us-3876)
[Internal Review URL (System.Windows.Forms.DataVisualization.Charting.ChartGraphics)](https://review.docs.microsoft.com/en-us/dotnet/api/system.windows.forms.datavisualization.charting.chartgraphics?view=netframework-4.7&branch=pr-en-us-3876)
[Internal Review URL (System.Web.UI.DataVisualization.Charting.SeriesCollection)](https://review.docs.microsoft.com/en-us/dotnet/api/system.web.ui.datavisualization.charting.seriescollection?view=netframework-4.7&branch=pr-en-us-3876)
[Internal Review URL (System.Windows.Forms.DataVisualization.Charting.SeriesCollection)](https://review.docs.microsoft.com/en-us/dotnet/api/system.windows.forms.datavisualization.charting.seriescollection?view=netframework-4.7&branch=pr-en-us-3876)
[Internal Review URL (System.Windows.Input.StylusPointCollection)](https://review.docs.microsoft.com/en-us/dotnet/api/system.windows.input.styluspointcollection?view=netframework-4.7&branch=pr-en-us-3876)

## Suggested Reviewers

If you know who should review this, use '@' to request a review.