### PR TITLE
updating tls/ssl pattern to best practice

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_Remoting/NclSslServerSync/CPP/NclSslServerSync.cpp
+++ b/samples/snippets/cpp/VS_Snippets_Remoting/NclSslServerSync/CPP/NclSslServerSync.cpp
@@ -53,8 +53,8 @@ public:
       // Authenticate the server but don't require the client to authenticate.
       try
       {
-         sslStream->AuthenticateAsServer( serverCertificate, false, 
-             SslProtocols::Tls, true );
+         sslStream->AuthenticateAsServer( serverCertificate, false, true );
+         // false == no client cert required; true == check cert revocation.
          
          // Display the properties and settings for the authenticated stream.
          DisplaySecurityLevel( sslStream );

--- a/samples/snippets/csharp/VS_Snippets_Remoting/NclSslServerSync/CS/serversync.cs
+++ b/samples/snippets/csharp/VS_Snippets_Remoting/NclSslServerSync/CS/serversync.cs
@@ -43,8 +43,9 @@ namespace Examples.System.Net
             // Authenticate the server but don't require the client to authenticate.
             try 
             {
-                sslStream.AuthenticateAsServer(serverCertificate, 
-                    false, SslProtocols.Tls, true);
+                sslStream.AuthenticateAsServer(serverCertificate, false, true);
+                // false == no client cert required; true == check cert revocation.
+                
                 // Display the properties and settings for the authenticated stream.
                 DisplaySecurityLevel(sslStream);
                 DisplaySecurityServices(sslStream);

--- a/samples/snippets/csharp/VS_Snippets_Remoting/NclSslServerSync/CS/serversync.cs
+++ b/samples/snippets/csharp/VS_Snippets_Remoting/NclSslServerSync/CS/serversync.cs
@@ -43,8 +43,7 @@ namespace Examples.System.Net
             // Authenticate the server but don't require the client to authenticate.
             try 
             {
-                sslStream.AuthenticateAsServer(serverCertificate, false, true);
-                // false == no client cert required; true == check cert revocation.
+                sslStream.AuthenticateAsServer(serverCertificate, clientCertificateRequired: false, checkCertificateRevocation: true);
                 
                 // Display the properties and settings for the authenticated stream.
                 DisplaySecurityLevel(sslStream);


### PR DESCRIPTION
# updating tls/ssl pattern to best practice

## Summary

Code example uses SslProtocols.Tls instead of SslProtocols.None
 
Specifically, this line:
                sslStream.AuthenticateAsServer(serverCertificate, 
                    false, SslProtocols.Tls, true);
should be
                sslStream.AuthenticateAsServer(serverCertificate, 
                    false, true); // false=no client cert required; true=check cert revocation
