### PR TITLE
It's SecurityProtocolType.SystemDefault, not SecurityProtocolType.System.Default.

### DIFF
--- a/docs/framework/migration-guide/retargeting/4.6.2-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.6.2-4.7.md
@@ -29,7 +29,7 @@ If you are migrating from the .NET Framework 4.6.2 to 4.7, review the following 
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.SystemDefault](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
 [!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 


### PR DESCRIPTION
It's SecurityProtocolType.SystemDefault, not SecurityProtocolType.System.Default.