### PR TITLE
Changed order to ord to avoid highlighting miss match

### DIFF
--- a/docs/visual-basic/programming-guide/program-structure/codesnippet/VisualBasic/coding-conventions_26.vb
+++ b/docs/visual-basic/programming-guide/program-structure/codesnippet/VisualBasic/coding-conventions_26.vb
@@ -1,4 +1,4 @@
     Dim customerList2 = From cust In customers 
-                        Join order In orders 
-                          On cust.CustomerID Equals order.CustomerID 
-                        Select cust, order
+                        Join ord In orders 
+                          On cust.CustomerID Equals ord.CustomerID 
+                        Select cust, ord


### PR DESCRIPTION
# Typofix

Changed variable name "order" to "ord" to avoid highlighting miss match with the reserved word "order" (order/sorting operator)
