### PR TITLE
Made variable naming consistent with other examples

### DIFF
--- a/docs/visual-basic/programming-guide/program-structure/codesnippet/VisualBasic/coding-conventions_21.vb
+++ b/docs/visual-basic/programming-guide/program-structure/codesnippet/VisualBasic/coding-conventions_21.vb
@@ -1,4 +1,4 @@
     Dim customerOrders = From customer In customers 
-                         Join order In orders 
-                           On customer.CustomerID Equals order.CustomerID 
-                         Select Customer = customer, Order = order
+                         Join ord In orders 
+                           On customer.CustomerID Equals ord.CustomerID 
+                         Select Customer = customer, Order = ord


### PR DESCRIPTION
# Made variable naming consistent with other examples

## Summary

Variations of the same code fragment used different naming conventions. PR #3887 corrected one of these. This PR corrects the remaining one.

## Suggested Reviewers

@BillWagner 
