### PR TITLE
Update intro-net-docker.md

### DIFF
--- a/docs/core/docker/intro-net-docker.md
+++ b/docs/core/docker/intro-net-docker.md
@@ -166,7 +166,7 @@ The [dotnet-framework:4.6.2 sample](https://github.com/Microsoft/dotnet-framewor
 
 #### Microsoft Azure Command Line Interface (CLI)
 
-* [Microsoft Azure Command Line Interface (CLI) images on DockerHub](Docker image for Microsoft Azure Command Line Interface) 
+* [Microsoft Azure Command Line Interface (CLI) images on DockerHub](https://hub.docker.com/r/microsoft/azure-cli/) 
 
 * [Microsoft Azure Command Line Interface (CLI) images on GitHub](https://github.com/Microsoft/OMS-docker)
 


### PR DESCRIPTION
# Fixed a broken link to point to: https://hub.docker.com/r/microsoft/azure-cli/

## Summary
The document had an invalid link to the CLI docker container on Docker Hub. The URL was updated to point to the container image on Dockerhub.

## Details

Looking at the underlying page on the web, the link was broken. This P/R fixes that error.
## Suggested Reviewers

If you know who should review this, use '@' to request a review.
