### PR TITLE
Fix misc typos and formatting

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CFX/s_ueenvelopeversion/cs/program.cs
+++ b/samples/snippets/csharp/VS_Snippets_CFX/s_ueenvelopeversion/cs/program.cs
@@ -12,76 +12,71 @@ namespace CS
     {
         static void Main(string[] args)
         {
+            // MessageVersion
+            // <Snippet1>
+            EnvelopeVersion envS11 = EnvelopeVersion.Soap11;
+            // </Snippet1>
+            string nextDestS11 = envS11.NextDestinationActorValue;
+            string[] ultDestsS11 = envS11.GetUltimateDestinationActorValues();
+            string ultS11 = ultDestsS11[0];
+            string toStrS11 = envS11.ToString();
 
-     // MessageVersion
-     // <Snippet1>
-     EnvelopeVersion envS11 = EnvelopeVersion.Soap11;
-     // </Snippet1>
-     string nextDestS11 = envS11.NextDestinationActorValue;
-     string[] ultDestsS11 = envS11.GetUltimateDestinationActorValues();
-     string ultS11 = ultDestsS11[0];
-     string toStrS11 = envS11.ToString();
+            // <Snippet2>
+            EnvelopeVersion envS12 = EnvelopeVersion.Soap12;
+            // </Snippet2>
 
-     // <Snippet2>
-     EnvelopeVersion envS12 = EnvelopeVersion.Soap12;
-     // </Snippet2>
+            // <Snippet3>
+            EnvelopeVersion envNotSOAP =  EnvelopeVersion.None;
+            // </Snippet3>
 
-     // <Snippet3>
-     EnvelopeVersion envNotSOAP =  EnvelopeVersion.None;
-     // </Snippet3>
+            // <Snippet4>
+            string nextDestS12 = envS12.NextDestinationActorValue;
+            // </Snippet4>
 
-     // <Snippet4>
-     string nextDestS12 = envS12.NextDestinationActorValue;
-     // </Snippet4>
+            // <Snippet5>
+            string[] ultDestsS12 = envS12.GetUltimateDestinationActorValues();
+            // </Snippet5>
+             
+            string ultS12 = ultDestsS12[1];
 
-     // <Snippet5>
-     string[] ultDestsS12 = envS12.GetUltimateDestinationActorValues();
-     // </Snippet5>
-     
-     string ultS12 = ultDestsS12[1];
+            // <Snippet6>
+            string toStrS12 = envS12.ToString();
+            // </Snippet6>
+             
+            EnvelopeVersion envNone = EnvelopeVersion.None;
+            string nextDestNone = envNone.NextDestinationActorValue;
+            //The following code throws a System.ArgumentReferenceException.
+            //The object reference is not set to an instance of an object
+            // string[] ultDestsNone = envNone.GetUltimateDestinationActorValues();
+            string toStrNone = envNone.ToString();
 
-     // <Snippet6>
-     string toStrS12 = envS12.ToString();
-     // </Snippet6>
-     
-     EnvelopeVersion envNone = EnvelopeVersion.None;
-     string nextDestNone = envNone.NextDestinationActorValue;
-     //The following code throws a System.ArgumentReferenceExeption.
-     //The object reference is not set to an instance of an object
-     // string[] ultDestsNone = envNone.GetUltimateDestinationActorValues();
-     string toStrNone = envNone.ToString();
+             //EnvelopeVersions
+            Console.WriteLine("EnvelopeVersion.Soap11: {0}", envS11);
+            Console.WriteLine("EnvelopeVersion.Soap12: {0}", envS12);
+            Console.WriteLine("EnvelopeVersion.None: {0}", envNone);
+            Console.WriteLine();
 
-     //EnvelopeVersions
-     Console.WriteLine("EnvelopeVersion.Soap11: {0}", envS11);
-     Console.WriteLine("EnvelopeVersion.Soap12: {0}", envS12);
-     Console.WriteLine("EnvelopeVersion.None: {0}", envNone);
-     Console.WriteLine();
+            //NextDestination
+            Console.WriteLine("NextDest EnvelopeVersion.Soap11: {0}", nextDestS11);
+            Console.WriteLine("NextDest EnvelopeVersion.Soap12: {0}", nextDestS12);
+            Console.WriteLine("NextDest EnvelopeVersion.None: {0}", nextDestNone);
+            Console.WriteLine();
 
-     //NextDestination
-     Console.WriteLine("NextDest EnvelopeVersion.Soap11: {0}", nextDestS11);
-     Console.WriteLine("NextDest EnvelopeVersion.Soap12: {0}", nextDestS12);
-     Console.WriteLine("NextDest EnvelopeVersion.None: {0}", nextDestNone);
-     Console.WriteLine();
+            //UltimateDestinations
+            Console.WriteLine("UltDest EnvelopeVersion.Soap11: {0}", ultS11);
+            Console.WriteLine("UltDest EnvelopeVersion.Soap12: {0}", ultS12);
+            //Console.WriteLine("UltDest EnvelopeVersion.None: {0}", ultDestsNone);
+            Console.WriteLine();
 
-     //UltimateDestinations
-     Console.WriteLine("UltDest EnvelopeVersion.Soap11: {0}", ultS11);
-     Console.WriteLine("UltDest EnvelopeVersion.Soap12: {0}", ultS12);
-     //Console.WriteLine("UltDest EnvelopeVersion.None: {0}", ultDestsNone);
-     Console.WriteLine();
-
-     //ToString
-     Console.WriteLine("EnvelopeVersion.Soap11.ToString(): {0}", toStrS11);
-     Console.WriteLine("EnvelopeVersion.Soap11.ToString(): {0}", toStrS12);
-      Console.WriteLine("EnvelopeVersion.Soap11.ToString(): {0}", toStrNone);
-      Console.WriteLine();
-
+            //ToString
+            Console.WriteLine("EnvelopeVersion.Soap11.ToString(): {0}", toStrS11);
+            Console.WriteLine("EnvelopeVersion.Soap11.ToString(): {0}", toStrS12);
+            Console.WriteLine("EnvelopeVersion.Soap11.ToString(): {0}", toStrNone);
+            Console.WriteLine();
         }
     }
 }
 /*
- * 
- * 
- * 
 Output:
 EnvelopeVersion.Soap11: Soap11 (http://schemas.xmlsoap.org/soap/envelope/)
 EnvelopeVersion.Soap12: Soap12 (http://www.w3.org/2003/05/soap-envelope)

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions2.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_exceptions/cs/taskexceptions2.cs
@@ -7,14 +7,14 @@ public class Example
 {
    public static void Main()
    {
-       try {
-          ExecuteTasks();
-       }
-       catch (AggregateException ae) {
-          foreach (var e in ae.InnerExceptions)
-             Console.WriteLine("{0}:\n   {1}", e.GetType().Name, e.Message);
-
-       }
+	    try {
+	        ExecuteTasks();
+	    }
+	    catch (AggregateException ae) {
+	        foreach (var e in ae.InnerExceptions) {
+	            Console.WriteLine("{0}:\n   {1}", e.GetType().Name, e.Message);
+	        }
+	    }
    }
 
    static void ExecuteTasks()
@@ -24,20 +24,20 @@ public class Example
         List<Task> tasks = new List<Task>();
 
         tasks.Add(Task.Run(() => {
-                             // This should throw an UnauthorizedAccessEXception.
+                             // This should throw an UnauthorizedAccessException.
                               return Directory.GetFiles(path, "*.txt",
                                                         SearchOption.AllDirectories);
-                           } ));
+                           }));
 
         tasks.Add(Task.Run(() => {
                               if (path == @"C:\")
                                  throw new ArgumentException("The system root is not a valid path.");
                               return new String[] { ".txt", ".dll", ".exe", ".bin", ".dat" };
-                           } ));
+                           }));
 
-        tasks.Add(Task.Run( () => {
+        tasks.Add(Task.Run(() => {
                                throw new NotImplementedException("This operation has not been implemented.");
-                           } ));
+                           }));
 
         try {
             Task.WaitAll(tasks.ToArray());

--- a/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/parallel_file.cs
+++ b/samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/parallel_file.cs
@@ -127,7 +127,7 @@ class Program
       }
 
       // For diagnostic purposes.
-      Console.WriteLine("Processed {0} files in {1} milleseconds", fileCount, sw.ElapsedMilliseconds);
+      Console.WriteLine("Processed {0} files in {1} milliseconds", fileCount, sw.ElapsedMilliseconds);
    }
 }
 // </Snippet08>

--- a/samples/snippets/visualbasic/VS_Snippets_CFX/s_ueenvelopeversion/vb/module1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CFX/s_ueenvelopeversion/vb/module1.vb
@@ -45,7 +45,7 @@ Namespace CS
 
             Dim envNone As EnvelopeVersion = EnvelopeVersion.None
             Dim nextDestNone As String = envNone.NextDestinationActorValue
-            'The following code throws a System.ArgumentReferenceExeption.
+            'The following code throws a System.ArgumentReferenceException.
             'The object reference is not set to an instance of an object
             ' string[] ultDestsNone = envNone.GetUltimateDestinationActorValues();
             Dim toStrNone As String = envNone.ToString()

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_exceptions/vb/taskexceptions2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_exceptions/vb/taskexceptions2.vb
@@ -21,7 +21,7 @@ Module Example
         Dim tasks As New List(Of Task)
         
         tasks.Add(Task.Run(Function()
-                             ' This should throw an UnauthorizedAccessEXception.
+                             ' This should throw an UnauthorizedAccessException.
                               Return Directory.GetFiles(path, "*.txt",
                                                         SearchOption.AllDirectories)
                            End Function))

--- a/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/fileiteration08.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/fileiteration08.vb
@@ -125,7 +125,7 @@ Module Example
          Next
 
          ' For diagnostic purposes.
-         Console.WriteLine("Processed {0}  files in {1}  milleseconds", fileCount, sw.ElapsedMilliseconds)
+         Console.WriteLine("Processed {0} files in {1} milliseconds", fileCount, sw.ElapsedMilliseconds)
       End While
    End Sub
 End Module

--- a/xml/System.Data.EntityClient/EntityDataReader.xml
+++ b/xml/System.Data.EntityClient/EntityDataReader.xml
@@ -28,7 +28,7 @@
   
  <xref:System.Data.EntityClient.EntityDataReader> does not implicitly consume result sets to make output parameters available. Therefore, note the following:  
   
--   <xref:System.Data.EntityClient.EntityDataReader> calls the <xref:System.Data.Common.DbDataReader.NextResult%2A?displayProperty=nameWithType> only when <xref:System.Data.EntityClient.EntityDataReader.NextResult%2A?displayProperty=nameWithType> is explicitly called. If <xref:System.Data.Common.DbDataReader.NextResult%2A?displayProperty=nameWithType> throws an exeption, the <xref:System.Data.EntityClient.EntityDataReader> will wrap it in an <xref:System.Data.EntityException> (or a derived exception).  
+-   <xref:System.Data.EntityClient.EntityDataReader> calls the <xref:System.Data.Common.DbDataReader.NextResult%2A?displayProperty=nameWithType> only when <xref:System.Data.EntityClient.EntityDataReader.NextResult%2A?displayProperty=nameWithType> is explicitly called. If <xref:System.Data.Common.DbDataReader.NextResult%2A?displayProperty=nameWithType> throws an exception, the <xref:System.Data.EntityClient.EntityDataReader> will wrap it in an <xref:System.Data.EntityException> (or a derived exception).  
   
 -   <xref:System.Data.EntityClient.EntityDataReader.Close%2A> only closes the <xref:System.Data.Common.DbDataReader>, without consuming any pending records or result sets.  
   


### PR DESCRIPTION
A few more typos. 

In the c# snippets I edited, I also corrected some of the whitespace inconsistencies based on [the style guide](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) - but didn't start changing much beyond that. For future - is mixing unrelated code formatting changes useful, or should I just leave things as is?