### PR TITLE
update MIME types for tutorials

### DIFF
--- a/docs/csharp/quick-starts/branches-and-loops.yml
+++ b/docs/csharp/quick-starts/branches-and-loops.yml
@@ -1,5 +1,4 @@
-### YamlMime:YamlDocument
-documentType: Tutorial
+### YamlMime:Tutorial
 title: Branches and loops
 metadata:
   title:  Branches and loops

--- a/docs/csharp/quick-starts/hello-world.yml
+++ b/docs/csharp/quick-starts/hello-world.yml
@@ -1,5 +1,4 @@
-### YamlMime:YamlDocument
-documentType: Tutorial
+### YamlMime:Tutorial
 title: Hello C#
 metadata:
   title:  Hello C#. Your first introduction to the C# language.

--- a/docs/csharp/quick-starts/list-collection.yml
+++ b/docs/csharp/quick-starts/list-collection.yml
@@ -1,5 +1,4 @@
-### YamlMime:YamlDocument
-documentType: Tutorial
+### YamlMime:Tutorial
 title: Collections in C#
 metadata:
   title:  Collections in C#. Learn to use sequences and collections in C#.

--- a/docs/csharp/quick-starts/numbers-in-csharp.yml
+++ b/docs/csharp/quick-starts/numbers-in-csharp.yml
@@ -1,5 +1,4 @@
-### YamlMime:YamlDocument
-documentType: Tutorial
+### YamlMime:Tutorial
 title: Numbers in C#
 metadata:
   title:  Numbers in C#


### PR DESCRIPTION
An infrastructure change requires this

A recent infrastructure change mandates an update to the headers on all interactive tutorials.

/cc @EisenbergEffect


