### PR TITLE
Updates comment reference to non-deprecated class

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlConnection.SqlConnection Example/CS/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlConnection.SqlConnection Example/CS/source.cs
@@ -26,7 +26,7 @@ class Program
     {
         // To avoid storing the connection string in your code, 
         // you can retrieve it from a configuration file, using the 
-        // System.Configuration.ConfigurationSettings.AppSettings property 
+        // System.Configuration.ConfigurationManager.AppSettings property 
         return "Data Source=(local);Initial Catalog=AdventureWorks;"
             + "Integrated Security=SSPI;";
     }

--- a/samples/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlConnection.SqlConnection Example/CS/source.cs
+++ b/samples/snippets/csharp/VS_Snippets_ADO.NET/Classic WebData SqlConnection.SqlConnection Example/CS/source.cs
@@ -26,7 +26,7 @@ class Program
     {
         // To avoid storing the connection string in your code, 
         // you can retrieve it from a configuration file, using the 
-        // System.Configuration.ConfigurationManager.AppSettings property 
+        // System.Configuration.ConfigurationManager.ConnectionStrings property 
         return "Data Source=(local);Initial Catalog=AdventureWorks;"
             + "Integrated Security=SSPI;";
     }

--- a/samples/snippets/visualbasic/VS_Snippets_ADO.NET/Classic WebData SqlConnection.SqlConnection Example/VB/source.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_ADO.NET/Classic WebData SqlConnection.SqlConnection Example/VB/source.vb
@@ -25,7 +25,7 @@ Module Module1
     Private Function GetConnectionString() As String
         ' To avoid storing the connection string in your code,  
         ' you can retrieve it from a configuration file, using the
-        ' System.Configuration.ConfigurationSettings.AppSettings property
+        ' System.Configuration.ConfigurationManager.ConnectionStrings property
         Return "Data Source=(local);Database=AdventureWorks;" _
           & "Integrated Security=SSPI;"
     End Function


### PR DESCRIPTION
System.Configuration.ConfigurationSettings.AppSettings was deprecated in 2.0.

# Fixes comment referencing deprecated class.

## Summary
This is a tiny documentation change.

`System.Configuration.ConfigurationSettings.AppSettings` was deprecated in .NET 2.0.  I modified the comment to suggest using `System.Configuration.ConfigurationManager.AppSettings`