### PR TITLE
Update dated .NET Framework/VS references

### DIFF
--- a/docs/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md
+++ b/docs/standard/parallel-programming/how-to-write-messages-to-and-read-messages-from-a-dataflow-block.md
@@ -24,8 +24,8 @@ manager: "wpickett"
 This document describes how to use the TPL Dataflow Library to write messages to and read messages from a dataflow block. The TPL Dataflow Library provides both synchronous and asynchronous methods for writing messages to and reading messages from a dataflow block. This document uses the <xref:System.Threading.Tasks.Dataflow.BufferBlock%601?displayProperty=nameWithType> class. The <xref:System.Threading.Tasks.Dataflow.BufferBlock%601> class buffers messages and behaves as both a message source and as a message target.  
   
 > [!TIP]
->  The TPL Dataflow Library (<xref:System.Threading.Tasks.Dataflow?displayProperty=nameWithType> namespace) is not distributed with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)]. To install the <xref:System.Threading.Tasks.Dataflow> namespace, open your project in [!INCLUDE[vs_dev11_long](../../../includes/vs-dev11-long-md.md)], choose **Manage NuGet Packages** from the Project menu, and search online for the `Microsoft.Tpl.Dataflow` package.  
-  
+>  The TPL Dataflow Library (the <xref:System.Threading.Tasks.Dataflow> namespace) is not distributed with the .NET Framework. To install the <xref:System.Threading.Tasks.Dataflow> namespace, open your project in Visual Studio, choose **Manage NuGet Packages** from the **Project** menu, and search online for the `System.Threading.Tasks.Dataflow` package.  
+
 ## Writing to and Reading from a Dataflow Block Synchronously  
  The following example uses the <xref:System.Threading.Tasks.Dataflow.DataflowBlock.Post%2A> method to write to a <xref:System.Threading.Tasks.Dataflow.BufferBlock%601> dataflow block and the <xref:System.Threading.Tasks.Dataflow.DataflowBlock.Receive%2A> method to read from the same object.  
   


### PR DESCRIPTION
This 'tip' block still referred to .NET Framework 4.5 and VS 2012.

I took the new text directly from the API page below - is there a better way to share that text block, or is copying and pasting ok?

https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.dataflow?view=netcore-2.0#remarks
