### PR TITLE
Escaping the Entity symbols

### DIFF
--- a/docs/framework/xaml-services/xml-character-entities-and-xaml.md
+++ b/docs/framework/xaml-services/xml-character-entities-and-xaml.md
@@ -52,11 +52,11 @@ XAML uses character entities defined in XML for special characters. This topic d
   
 |Character|Entity|Notes|  
 |---------------|------------|-----------|  
-|& (ampersand)|&amp;|Must be used both for attribute values and for content of an element.|  
-|> (greater-than character)|&gt;|Must be used for an attribute value, but > is acceptable as the content of an element as long as < does not precede it.|  
-|< (less-than character)|&lt;|Must be used for an attribute value, but \< is acceptable as the content of an element as long as > does not follow it.|  
-|" (straight quotation mark)|&quot;|Must be used for an attribute value, but a straight quotation mark (") is acceptable as the content of an element. Note that attribute values may be enclosed either by a single straight quotation mark (') or by a straight quotation mark ("); whichever character appears first defines the attribute value enclosure, and the alternative quote can then be used as a literal within the value.|  
-|' (single straight quotation mark)|&apos;|Must be used for an attribute value, but a single straight quotation mark (') is acceptable as the content of an element. Note that attribute values may be enclosed either by a single straight quotation mark (') or by a straight quotation mark ("); whichever character appears first defines the attribute value enclosure, and the alternative quote can then be used as a literal within the value.|  
+|& (ampersand)|\&amp;|Must be used both for attribute values and for content of an element.|  
+|> (greater-than character)|\&gt;|Must be used for an attribute value, but > is acceptable as the content of an element as long as < does not precede it.|  
+|< (less-than character)|\&lt;|Must be used for an attribute value, but \< is acceptable as the content of an element as long as > does not follow it.|  
+|" (straight quotation mark)|\&quot;|Must be used for an attribute value, but a straight quotation mark (") is acceptable as the content of an element. Note that attribute values may be enclosed either by a single straight quotation mark (') or by a straight quotation mark ("); whichever character appears first defines the attribute value enclosure, and the alternative quote can then be used as a literal within the value.|  
+|' (single straight quotation mark)|\&apos;|Must be used for an attribute value, but a single straight quotation mark (') is acceptable as the content of an element. Note that attribute values may be enclosed either by a single straight quotation mark (') or by a straight quotation mark ("); whichever character appears first defines the attribute value enclosure, and the alternative quote can then be used as a literal within the value.|  
 |(numeric character mappings)|&#*[integer]*; or &#x*[hex]*;|XAML supports numeric character mappings into the encoding that is active.|  
 |(nonbreaking space)|&\#160; (assuming UTF-8 encoding)|For flow document elements, or elements that take text such as the WPF <xref:System.Windows.Controls.TextBox>, nonbreaking spaces are not normalized out of the markup, even for `xml:space="default"`. (For more information, see [Whitespace Processing in XAML](../../../docs/framework/xaml-services/whitespace-processing-in-xaml.md).)|  
   


### PR DESCRIPTION
# Escaping the Entity symbols

## Summary

The Entity symbols were not escaped and hence were showing as the "rendered" version (">" instead of "& gt ;", etc.), which is what the whole article is about. The rendered symbols were of no use for the people coming to this article looking for ways to use those symbols in their XAML files.

