### PR TITLE
Update list of Exceptions for Directory.GetParent

### DIFF
--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -2694,14 +2694,14 @@ Directory::CreateDirectory("Public\\Html");
   
  ]]></format>
         </remarks>
-        <exception cref="T:System.IO.IOException">The directory specified by <paramref name="path" /> is read-only.</exception>
-        <exception cref="T:System.UnauthorizedAccessException">The caller does not have the required permission.</exception>
         <exception cref="T:System.ArgumentException">
           <paramref name="path" /> is a zero-length string, contains only white space, or contains one or more invalid characters. You can query for invalid characters with the  <see cref="M:System.IO.Path.GetInvalidPathChars" /> method.</exception>
+        <exception cref="T:System.Security.SecurityException">The caller does not have the required permissions.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="path" /> is <see langword="null" />.</exception>
+        <exception cref="T:System.NotSupportedException">
+          <paramref name="path" /> contains a colon (":") that is not part of a volume identifier (for example, "c:\\").</exception>
         <exception cref="T:System.IO.PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. For example, on Windows-based platforms, paths must be less than 248 characters and file names must be less than 260 characters.</exception>
-        <exception cref="T:System.IO.DirectoryNotFoundException">The specified path was not found.</exception>
         <permission cref="T:System.Security.Permissions.FileIOPermission">for reading from files or directories. Associated enumeration: <see cref="F:System.Security.Permissions.FileIOPermissionAccess.Read" /></permission>
         <altmember cref="T:System.IO.DirectoryInfo" />
       </Docs>


### PR DESCRIPTION
# Update list of Exceptions for Directory.GetParent

## Summary

Removed IOException, UnauthorizedAccessException, and DirectoryNotFoundException from the list of Exceptions for Directory.GetParent(), since they cannot actually get thrown by Directory.GetParent().

Also, added SecurityException and NotSupportedException since they can get thrown by Directory.GetParent(), but were not listed  in the documentation before.

## Details

Listing those Exceptions that I am now removing was confusing because they implied that Directory.GetParent() performs IO operations, which has performance and reliability implications, but Directory.GetParent() does not actually perform IO operations.

I confirmed that these Exceptions are not thrown by testing the function, and also by examining the referencesource code. According to the source, Directory.GetParent() is exactly equal to calling Path.GetFullPath(), followed by Path.GetDirectoryName(), followed by new DirectoryInfo(), none of which list in their documentation the three Exceptions that I am removing.
Conversely, SecurityException and NotSupportedException are listed in the documentation for Path.GetFullPath(), but were not listed for Directory.GetParent, so I am now adding them to Directory.GetParent.

## Suggested Reviewers
