### PR TITLE
remove empty xaml section

### DIFF
--- a/xml/Microsoft.Windows.Themes/ProgressBarBrushConverter.xml
+++ b/xml/Microsoft.Windows.Themes/ProgressBarBrushConverter.xml
@@ -28,15 +28,7 @@
   </Interfaces>
   <Docs>
     <summary>Creates the <see cref="T:System.Windows.Media.Brush" /> used to draw the <see cref="T:System.Windows.Controls.ProgressBar" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_ProgressBarBrushConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/Microsoft.Windows.Themes/ProgressBarHighlightConverter.xml
+++ b/xml/Microsoft.Windows.Themes/ProgressBarHighlightConverter.xml
@@ -25,9 +25,7 @@
   
 ## Remarks  
  The <xref:System.Windows.Media.DrawingBrush> is twice as long as progress bar track and will animate to the right.  
-  
-<a name="xamlTextUsage_ProgressBarHighlightConverter"></a>   
-## XAML Text Usage  
+ 
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Collections.ObjectModel/ObservableCollection`1.xml
+++ b/xml/System.Collections.ObjectModel/ObservableCollection`1.xml
@@ -69,11 +69,6 @@
 -   <xref:System.Collections.ObjectModel.ObservableCollection%601> is in a namespace and assembly that are not initially mapped to the default XML namespace. You must map a prefix for the namespace and assembly, and then use that prefix on the object element tag for <xref:System.Collections.ObjectModel.ObservableCollection%601>.  
   
  A more straightforward way to use <xref:System.Collections.ObjectModel.ObservableCollection%601> capabilities from XAML in an application is to declare your own non-generic custom collection class that derives from <xref:System.Collections.ObjectModel.ObservableCollection%601>, and constrains it to a specific type. Then map the assembly that contains this class, and reference it as an object element in your XAML.  
-  
-<a name="xamlTextUsage_ObservableCollection"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Collections.ObjectModel.ReadOnlyObservableCollection`1" />

--- a/xml/System.Windows.Controls/GridView.xml
+++ b/xml/System.Windows.Controls/GridView.xml
@@ -880,17 +880,7 @@
       <Docs>
         <summary>Gets the key that references the style that is defined for each <see cref="T:System.Windows.Controls.ListViewItem" /> in a <see cref="T:System.Windows.Controls.GridView" />.</summary>
         <value>A <see cref="T:System.Windows.ResourceKey" /> that references the style for each <see cref="T:System.Windows.Controls.ListViewItem" />. The default value references the default style for a <see cref="T:System.Windows.Controls.ListViewItem" /> control in the current theme.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_GridViewItemContainerStyleKey"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GridViewScrollViewerStyleKey">
@@ -913,10 +903,6 @@
   
 ## Remarks  
  You can use this read-only static property in [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)] by assigning its static value to another property value. Specifically, this property's static value defines the resource key that is used to look up the default <xref:System.Windows.Controls.ScrollViewer> style of a <xref:System.Windows.Controls.GridView>. To redefine this style, reference the <xref:System.Windows.Controls.GridView.GridViewScrollViewerStyleKey%2A> by using the [x:Static Markup Extension](~/docs/framework/xaml-services/x-static-markup-extension.md) and assign that value as the [x:Key Directive](~/docs/framework/xaml-services/x-key-directive.md) of the new <xref:System.Windows.Style>.  
-  
-<a name="xamlTextUsage_GridViewScrollViewerStyleKey"></a>   
-## XAML Text Usage  
- See Remarks.  
   
  ]]></format>
         </remarks>
@@ -943,12 +929,8 @@
 ## Remarks  
  You can use this read-only static property in [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)] by assigning its static value to another property value. Specifically, this property's static value defines the resource key that is used to look up the default <xref:System.Windows.Controls.ListView> style. To redefine this style, reference the <xref:System.Windows.Controls.GridView.GridViewStyleKey%2A> by using the [x:Static Markup Extension](~/docs/framework/xaml-services/x-static-markup-extension.md) and assign that value as the [x:Key Directive](~/docs/framework/xaml-services/x-key-directive.md) of the new <xref:System.Windows.Style>.  
   
- You can use this read-only property in [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)] as an [x:Key Directive](~/docs/framework/xaml-services/x-key-directive.md) of a <xref:System.Windows.Style> that redefines the <xref:System.Windows.Style> for the <xref:System.Windows.Controls.ListView>.  
-  
-<a name="xamlTextUsage_GridViewStyleKey"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
+ You can use this read-only property in [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)] as an [x:Key Directive](~/docs/framework/xaml-services/x-key-directive.md) of a <xref:System.Windows.Style> that redefines the <xref:System.Windows.Style> for the <xref:System.Windows.Controls.ListView>.    
+ 
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows.Controls/GridViewRowPresenter.xml
+++ b/xml/System.Windows.Controls/GridViewRowPresenter.xml
@@ -93,10 +93,6 @@
   
  [!code-xaml[ListViewItemStyleSnippet#ControlTemplate](~/samples/snippets/csharp/VS_Snippets_Wpf/ListViewItemStyleSnippet/CS/Window1.xaml#controltemplate)]   
   
-<a name="xamlTextUsage_Content"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
 <a name="dependencyPropertyInfo_Content"></a>   
 ## Dependency Property Information  
   

--- a/xml/System.Windows.Controls/SpellCheck.xml
+++ b/xml/System.Windows.Controls/SpellCheck.xml
@@ -193,10 +193,6 @@ ListBox
 ## Remarks  
  This dependency property also has a specialized write-only attached property usage. The [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] syntax for setting the property is `<`*textBoxBaseClass* **SpellCheck.IsEnabled**`="`*boolValue*`" .../>`, where *textBoxBaseClass* is an object element for a class that derives from <xref:System.Windows.Controls.Primitives.TextBoxBase>, and *boolValue* is either `true` or `false` (case insensitive). To set the property as an attached property in code, see the <xref:System.Windows.Controls.SpellCheck.SetIsEnabled%2A> method. There is no matching `GetIsEnabled` accessor. To get the value, get the current <xref:System.Windows.Controls.SpellCheck> object from the <xref:System.Windows.Controls.Primitives.TextBoxBase.SpellCheck%2A?displayProperty=nameWithType> property, and then get the value of the <xref:System.Windows.Controls.SpellCheck.IsEnabled%2A> property from that <xref:System.Windows.Controls.SpellCheck>.  
   
-<a name="xamlTextUsage_IsEnabled"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
 <a name="dependencyPropertyInfo_IsEnabled"></a>   
 ## Dependency Property Information  
   
@@ -310,10 +306,6 @@ ListBox
  The spelling reform rules that are determined by this property refer to the French and German spelling reforms. This property has no effect when it is used with any other language.  
   
  This dependency property also has a specialized write-only attached property usage. The [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] syntax for setting the property is `<`*textBoxBaseClass* **SpellCheck.SpellingReform**`="`*enumValue*`" .../>`, where *textBoxBaseClass* is an object element for a class that derives from <xref:System.Windows.Controls.Primitives.TextBoxBase>, and *enumValue* is a string name for a value of the <xref:System.Windows.Controls.SpellingReform> enumeration. To set the property as an attached property in code, see the <xref:System.Windows.Controls.SpellCheck.SetSpellingReform%2A> method. There is no matching `GetSpellingReform` accessor. To get the value, get the current <xref:System.Windows.Controls.SpellCheck> object from the <xref:System.Windows.Controls.Primitives.TextBoxBase.SpellCheck%2A?displayProperty=nameWithType> property, and then get the value of the <xref:System.Windows.Controls.SpellCheck.SpellingReform%2A> property from that <xref:System.Windows.Controls.SpellCheck>.  
-  
-<a name="xamlTextUsage_SpellingReform"></a>   
-## XAML Text Usage  
- See Remarks.  
   
 <a name="dependencyPropertyInfo_SpellingReform"></a>   
 ## Dependency Property Information  

--- a/xml/System.Windows.Converters/Int32RectValueSerializer.xml
+++ b/xml/System.Windows.Converters/Int32RectValueSerializer.xml
@@ -17,9 +17,7 @@
   
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
-  
-<a name="xamlTextUsage_Int32RectValueSerializer"></a>   
-## XAML Text Usage  
+ 
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Converters/PointValueSerializer.xml
+++ b/xml/System.Windows.Converters/PointValueSerializer.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of <see cref="T:System.String" /> to and from instances of <see cref="T:System.Windows.Point" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Int32RectValueSerializer"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows.Converters/RectValueSerializer.xml
+++ b/xml/System.Windows.Converters/RectValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_Int32RectValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Converters/SizeValueSerializer.xml
+++ b/xml/System.Windows.Converters/SizeValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_Int32RectValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Converters/VectorValueSerializer.xml
+++ b/xml/System.Windows.Converters/VectorValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_Int32RectValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Data/Binding.xml
+++ b/xml/System.Windows.Data/Binding.xml
@@ -672,11 +672,7 @@
  The <xref:System.Windows.Data.Binding.ElementName%2A?displayProperty=nameWithType> and <xref:System.Windows.Data.Binding.Source%2A?displayProperty=nameWithType> properties also enable you to set the source of the binding explicitly. However, only one of the three properties, <xref:System.Windows.Data.Binding.ElementName%2A>, <xref:System.Windows.Data.Binding.Source%2A>, and <xref:System.Windows.Data.Binding.RelativeSource%2A>, should be set for each binding, or a conflict can occur. This property throws an exception if there is a binding source conflict.  
   
  For [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] information, see [RelativeSource MarkupExtension](~/docs/framework/wpf/advanced/relativesource-markupextension.md).  
-  
-<a name="xamlTextUsage_RelativeSource"></a>   
-## XAML Text Usage  
-   
-  
+    
 ## Examples  
  The following example shows a style trigger that creates a <xref:System.Windows.Controls.ToolTip> that reports a validation error message. The value of the setter binds to the error content of the current <xref:System.Windows.Controls.TextBox> (the <xref:System.Windows.Controls.TextBox> using the style) using the <xref:System.Windows.Data.Binding.RelativeSource%2A> property. For more information on this example, see [How to: Implement Binding Validation](~/docs/framework/wpf/data/how-to-implement-binding-validation.md).  
   

--- a/xml/System.Windows.Data/CollectionView.xml
+++ b/xml/System.Windows.Data/CollectionView.xml
@@ -43,10 +43,6 @@
   
  To set a view in [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)], use the <xref:System.Windows.Data.CollectionViewSource> class. <xref:System.Windows.Data.CollectionViewSource> is the [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] representation of the <xref:System.Windows.Data.CollectionView> class, and it exposes the most commonly used members of the <xref:System.Windows.Data.CollectionView> class.  
   
-<a name="xamlTextUsage_CollectionView"></a>   
-## XAML Text Usage  
- See Remarks  
-  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Data/RelativeSource.xml
+++ b/xml/System.Windows.Data/RelativeSource.xml
@@ -29,10 +29,6 @@
   
  For [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] information, see [RelativeSource MarkupExtension](~/docs/framework/wpf/advanced/relativesource-markupextension.md).  
   
-<a name="xamlTextUsage_RelativeSource"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example shows a style trigger that creates a <xref:System.Windows.Controls.ToolTip> that reports a validation error message. Using the <xref:System.Windows.Data.Binding.RelativeSource%2A> property, the value of the setter binds to the error content of the current <xref:System.Windows.Controls.TextBox> (the <xref:System.Windows.Controls.TextBox> using the style). For more information on this example, see [How to: Implement Binding Validation](~/docs/framework/wpf/data/how-to-implement-binding-validation.md).  
   

--- a/xml/System.Windows.Input/CommandConverter.xml
+++ b/xml/System.Windows.Input/CommandConverter.xml
@@ -17,9 +17,7 @@
   
 ## Remarks  
  The <xref:System.Windows.Input.CommandConverter> class only converts an instance of <xref:System.Windows.Input.ICommand> to and from a <xref:System.String>.  
-  
-<a name="xamlTextUsage_CommandConverter"></a>   
-## XAML Text Usage  
+ 
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/CursorConverter.xml
+++ b/xml/System.Windows.Input/CursorConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  <xref:System.Windows.Input.CursorConverter> works for two modes: specifying a standard cursor (one of the static constant names of <xref:System.Windows.Input.Cursors>) or specifying a file name. The named file must be a `.cur` or `.ani` file identified by extension. See [How to: Change the Cursor Type](~/docs/framework/wpf/advanced/how-to-change-the-cursor-type.md).  
   
-<a name="xamlTextUsage_CursorConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/InputScopeConverter.xml
+++ b/xml/System.Windows.Input/InputScopeConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts a <see cref="T:System.Windows.Input.InputScope" /> to and from other types.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_InputScopeConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows.Input/InputScopeNameConverter.xml
+++ b/xml/System.Windows.Input/InputScopeNameConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of <see cref="T:System.Windows.Input.InputScopeName" /> to and from other data types.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_InputScopeNameConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows.Input/KeyConverter.xml
+++ b/xml/System.Windows.Input/KeyConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.Input.KeyConverter> class only converts an instance <xref:System.Windows.Input.Key> to and from a <xref:System.String>.  
   
-<a name="xamlTextUsage_KeyConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/KeyGestureConverter.xml
+++ b/xml/System.Windows.Input/KeyGestureConverter.xml
@@ -20,8 +20,6 @@
   
  The <xref:System.Windows.Input.KeyGestureConverter> converts to and from a <xref:System.String> using the "+" character as the delimiter between the modifier keys and the key.  For example, the string `Control+A` would be converted into a <xref:System.Windows.Input.KeyGesture> with a <xref:System.Windows.Input.KeyGesture.Modifiers%2A> property equal to <xref:System.Windows.Input.ModifierKeys.Control> and <xref:System.Windows.Input.KeyGesture.Key%2A> property equal to <xref:System.Windows.Input.Key.A>.  
   
-<a name="xamlTextUsage_KeyGestureConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/KeyGestureValueSerializer.xml
+++ b/xml/System.Windows.Input/KeyGestureValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_KeyGestureValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Primitives.MarkupWriter" />

--- a/xml/System.Windows.Input/KeyValueSerializer.xml
+++ b/xml/System.Windows.Input/KeyValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_KeyValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Primitives.MarkupWriter" />

--- a/xml/System.Windows.Input/ModifierKeysConverter.xml
+++ b/xml/System.Windows.Input/ModifierKeysConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.Input.ModifierKeysConverter> converts to and from a <xref:System.String> using the "+" character as the delimiter.  For example, the string `Control+ALT` would be converted into a <xref:System.Windows.Input.ModifierKeys> object consisting of the <xref:System.Windows.Input.ModifierKeys.Control> and <xref:System.Windows.Input.ModifierKeys.Alt> keys. This behavior differs from the default XAML parser-level enumeration combine character of ",".  
   
-<a name="xamlTextUsage_ModifierKeysConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/ModifierKeysValueSerializer.xml
+++ b/xml/System.Windows.Input/ModifierKeysValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_ModifierKeysValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Primitives.MarkupWriter" />

--- a/xml/System.Windows.Input/MouseActionConverter.xml
+++ b/xml/System.Windows.Input/MouseActionConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.Input.MouseActionConverter> class only converts an instance of <xref:System.Windows.Input.MouseAction> to and from a <xref:System.String>.  
   
-<a name="xamlTextUsage_MouseActionConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/MouseActionValueSerializer.xml
+++ b/xml/System.Windows.Input/MouseActionValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_MouseActionValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Primitives.MarkupWriter" />

--- a/xml/System.Windows.Input/MouseGestureConverter.xml
+++ b/xml/System.Windows.Input/MouseGestureConverter.xml
@@ -20,8 +20,6 @@
   
  The <xref:System.Windows.Input.MouseGestureConverter> converts to and from a <xref:System.String> using the "+" character as the delimiter between the modifier keys and the mouse action.  For example, the string `Control+RightClick` would be converted into a <xref:System.Windows.Input.MouseGesture> with a <xref:System.Windows.Input.MouseGesture.Modifiers%2A> property equal to <xref:System.Windows.Input.ModifierKeys.Control> and <xref:System.Windows.Input.MouseGesture.MouseAction%2A> property equal to <xref:System.Windows.Input.MouseAction.RightClick>.  
   
-<a name="xamlTextUsage_MouseGestureConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Input/MouseGestureValueSerializer.xml
+++ b/xml/System.Windows.Input/MouseGestureValueSerializer.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This class is typically only utilized by the <xref:System.Windows.Markup.Primitives.MarkupWriter> for serialization purposes.  
   
-<a name="xamlTextUsage_MouseGestureValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Primitives.MarkupWriter" />

--- a/xml/System.Windows.Markup.Localizer/BamlLocalizabilityResolver.xml
+++ b/xml/System.Windows.Markup.Localizer/BamlLocalizabilityResolver.xml
@@ -32,8 +32,6 @@
   
 -   <xref:System.Windows.Markup.Localizer.BamlLocalizabilityResolver> is subclassed by an internal class that performs the practical aspects of the class functions for <xref:System.Windows.Markup.Localizer.BamlLocalizer>.  
   
-<a name="xamlTextUsage_BamlLocalizabilityResolver"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Localizer.BamlLocalizer" />

--- a/xml/System.Windows.Markup.Localizer/BamlLocalizableResource.xml
+++ b/xml/System.Windows.Markup.Localizer/BamlLocalizableResource.xml
@@ -17,11 +17,7 @@
   
 ## Remarks  
  The <xref:System.Windows.Markup.Localizer.BamlLocalizableResource> class is the value component of the key-value pairs found in a <xref:System.Windows.Markup.Localizer.BamlLocalizationDictionary>.  
-  
-<a name="xamlTextUsage_BamlLocalizableResource"></a>   
-## XAML Text Usage  
-   
-  
+    
 ## Examples  
  The following example demonstrates how to use a <xref:System.Windows.Markup.Localizer.BamlLocalizableResource>.  
   
@@ -91,15 +87,7 @@
       <Docs>
         <summary>Gets or sets the localization category of a resource.</summary>
         <value>The localization category, as a value of the enumeration.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Category"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Comments">
@@ -123,8 +111,6 @@
 ## Remarks  
  Localization comments are authored by the developer to provide rules or hints for localizers. The comments are free-form strings that are extracted from [!INCLUDE[TLA2#tla_baml](~/includes/tla2sharptla-baml-md.md)] or from localization comments files. To attach comments to an element in [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)], use the <xref:System.Windows.Localization.Comments%2A?displayProperty=nameWithType> attached property For more information on this attached property, see [Localization Attributes and Comments](~/docs/framework/wpf/advanced/localization-attributes-and-comments.md).  
   
-<a name="xamlTextUsage_Comments"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -152,8 +138,6 @@
   
  Child elements in the content can also be formatted as XML markup to improve readability. To do so, when <xref:System.Windows.Markup.Localizer.BamlLocalizer> queries the <xref:System.Windows.Markup.Localizer.ElementLocalizability> of a desired element, set the <xref:System.Windows.Markup.Localizer.ElementLocalizability.FormattingTag%2A> property to the desired tag name.  
   
-<a name="xamlTextUsage_Content"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -216,15 +200,7 @@
         <summary>Gets or sets a value that indicates whether the localizable resource is modifiable.</summary>
         <value>
           <see langword="true" /> if the resource is modifiable; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Modifiable"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Readable">
@@ -253,8 +229,6 @@
   
  When the string "Red" is used as a predefined color value of a <xref:System.Windows.Media.Brush>, it cannot be translated. Therefore the <xref:System.Windows.Markup.Localizer.BamlLocalizableResource.Readable%2A> property should be set to `false`.  
   
-<a name="xamlTextUsage_Readable"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows.Markup.Localizer/BamlLocalizableResourceKey.xml
+++ b/xml/System.Windows.Markup.Localizer/BamlLocalizableResourceKey.xml
@@ -21,11 +21,7 @@
  The <xref:System.Windows.Markup.Localizer.BamlLocalizableResourceKey.Uid%2A> value must be added to the source [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)] file either by using the `updateuid` [!INCLUDE[TLA#tla_msbuild](~/includes/tlasharptla-msbuild-md.md)] target (for example, `msbuild /t:updateuid myproj.proj`), or manually in the markup. [!INCLUDE[TLA2#tla_baml](~/includes/tla2sharptla-baml-md.md)] without a <xref:System.Windows.Markup.Localizer.BamlLocalizableResourceKey.Uid%2A> cannot be localized. The class name is the type name of the element that contains the localizable property. The property name refers to the property that has the localizable value. A special property called "`$Content`" is used to represent values that are the initialization text or content property of an element. For example the `$Content` property name would apply to the initialization text `Click` in the following XAML:  
   
  `<TextBlock x:Uid="myBlock">Click </TextBlock>`  
-  
-<a name="xamlTextUsage_BamlLocalizableResourceKey"></a>   
-## XAML Text Usage  
-   
-  
+    
 ## Examples  
  The following example demonstrates how to use a <xref:System.Windows.Markup.Localizer.BamlLocalizableResourceKey>.  
   

--- a/xml/System.Windows.Markup.Localizer/BamlLocalizationDictionary.xml
+++ b/xml/System.Windows.Markup.Localizer/BamlLocalizationDictionary.xml
@@ -21,11 +21,7 @@
   
 ## Remarks  
  The dictionary contains a mapping from resource keys (specified as <xref:System.Windows.Markup.Localizer.BamlLocalizableResourceKey> objects) to resource values (specified as <xref:System.Windows.Markup.Localizer.BamlLocalizableResource> objects).  
-  
-<a name="xamlTextUsage_BamlLocalizationDictionary"></a>   
-## XAML Text Usage  
-   
-  
+    
 ## Examples  
  The following example demonstrates how to use a <xref:System.Windows.Markup.Localizer.BamlLocalizationDictionary>.  
   

--- a/xml/System.Windows.Markup.Localizer/BamlLocalizationDictionaryEnumerator.xml
+++ b/xml/System.Windows.Markup.Localizer/BamlLocalizationDictionaryEnumerator.xml
@@ -16,15 +16,7 @@
   </Interfaces>
   <Docs>
     <summary>Defines a specialized enumerator that can enumerate over the content of a <see cref="T:System.Windows.Markup.Localizer.BamlLocalizationDictionary" /> object.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_BamlLocalizationDictionaryEnumerator"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Windows.Markup.Localizer.BamlLocalizationDictionary" />
     <altmember cref="M:System.Windows.Markup.Localizer.BamlLocalizationDictionary.GetEnumerator" />
   </Docs>

--- a/xml/System.Windows.Markup/AmbientAttribute.xml
+++ b/xml/System.Windows.Markup/AmbientAttribute.xml
@@ -52,8 +52,6 @@
   
  See <xref:System.Windows.ResourceDictionary> for an example of a scenario for setting <xref:System.Windows.Markup.AmbientAttribute> at type level.  
   
-<a name="xamlTextUsage_AmbientAttribute"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="P:System.Xaml.XamlMember.IsAmbient" />

--- a/xml/System.Windows.Markup/ArrayExtension.xml
+++ b/xml/System.Windows.Markup/ArrayExtension.xml
@@ -35,8 +35,6 @@
   
  The System.Xaml assembly uses <xref:System.Windows.Markup.XmlnsDefinitionAttribute> to map types from the <xref:System.Windows.Markup> CLR namespace in the assembly to the XAML namespace for the XAML language ([!INCLUDE[TLA#tla_xamlxmlnsv1](~/includes/tlasharptla-xamlxmlnsv1-md.md)]). In typical XAML markup, you declare a prefix for [!INCLUDE[TLA#tla_xamlxmlnsv1](~/includes/tlasharptla-xamlxmlnsv1-md.md)] in a root element mapping and use the prefix `x`.  
   
-<a name="xamlTextUsage_ArrayExtension"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>
@@ -196,8 +194,6 @@
   
  For XAML usage information, see [x:Array Markup Extension](~/docs/framework/xaml-services/x-array-markup-extension.md).  
   
-<a name="xamlTextUsage_Items"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -268,8 +264,6 @@
 ## Remarks  
  For XAML usage information, see [x:Array Markup Extension](~/docs/framework/xaml-services/x-array-markup-extension.md).  
   
-<a name="xamlTextUsage_Type"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows.Markup/ComponentResourceKeyConverter.xml
+++ b/xml/System.Windows.Markup/ComponentResourceKeyConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.ComponentResourceKey> type should not use a type converter pathway to convert values. You should use markup extensions instead. For this reason, the <xref:System.Windows.Markup.ComponentResourceKeyConverter.CanConvertFrom%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Type%29> and <xref:System.Windows.Markup.ComponentResourceKeyConverter.CanConvertTo%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Type%29> methods always return `false`. The <xref:System.Windows.Markup.ComponentResourceKeyConverter.ConvertFrom%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Globalization.CultureInfo%2CSystem.Object%29> and <xref:System.Windows.Markup.ComponentResourceKeyConverter.ConvertTo%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Globalization.CultureInfo%2CSystem.Object%2CSystem.Type%29> methods always throw an exception. The exceptions might possibly report invalid input, but even input that is considered valid will result in <xref:System.NotSupportedException>.  
   
-<a name="xamlTextUsage_ComponentResourceKeyConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <forInternalUseOnly />

--- a/xml/System.Windows.Markup/ContentPropertyAttribute.xml
+++ b/xml/System.Windows.Markup/ContentPropertyAttribute.xml
@@ -34,11 +34,7 @@
   
 ## WPF Usage Notes  
  An example of a class in [!INCLUDE[TLA#tla_winclient](~/includes/tlasharptla-winclient-md.md)] that uses the <xref:System.Windows.Markup.ContentPropertyAttribute> is <xref:System.Windows.Controls.ContentControl>, which the <xref:System.Windows.Controls.Button> class inherits from.  The property <xref:System.Windows.Controls.ContentControl.Content%2A> on the <xref:System.Windows.Controls.ContentControl> is the content property set by the <xref:System.Windows.Markup.ContentPropertyAttribute>.  If a <xref:System.Windows.Controls.Button> is instantiate in XAML <xref:System.Windows.Controls.ContentControl.Content%2A> of the <xref:System.Windows.Controls.Button> will be set to the element that is between the start and end button tags.  
-  
-<a name="xamlTextUsage_ContentPropertyAttribute"></a>   
-## XAML Text Usage  
-   
-  
+    
 ## Examples  
  The following example creates a class named `Film` that has a <xref:System.Windows.Markup.ContentPropertyAttribute> applied.  The property named `Title` is indicated as the content property.  
   

--- a/xml/System.Windows.Markup/DateTimeValueSerializer.xml
+++ b/xml/System.Windows.Markup/DateTimeValueSerializer.xml
@@ -25,8 +25,6 @@
   
  In previous versions of the .NET Framework, this class existed in the WPF-specific assembly WindowsBase. In [!INCLUDE[net_v40_long](~/includes/net-v40-long-md.md)], <xref:System.Windows.Markup.DateTimeValueSerializer> is in the System.Xaml assembly. See [Types Migrated from WPF to System.Xaml](~/docs/framework/xaml-services/types-migrated-from-wpf-to-system-xaml.md).  
   
-<a name="xamlTextUsage_DateTimeValueSerializer"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.Primitives.MarkupWriter" />

--- a/xml/System.Windows.Markup/DependencyPropertyConverter.xml
+++ b/xml/System.Windows.Markup/DependencyPropertyConverter.xml
@@ -24,8 +24,6 @@
   
  The behavior of this converter is specifically oriented around a single WPF scenario for XAML processing: reading the attribute value of <xref:System.Windows.Setter.Property%2A> and generating a <xref:System.Windows.DependencyProperty> value.  
   
-<a name="xamlTextUsage_DependencyPropertyConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/DependsOnAttribute.xml
+++ b/xml/System.Windows.Markup/DependsOnAttribute.xml
@@ -37,8 +37,6 @@
 ## WPF Usage Notes  
  The <xref:System.Windows.Setter.Value%2A> property on the <xref:System.Windows.Setter> class is an example of a property in WPF where the <xref:System.Windows.Markup.DependsOnAttribute> attribute is applied.  <xref:System.Windows.Setter.Value%2A> depends on <xref:System.Windows.Setter.Property%2A> and <xref:System.Windows.Setter.TargetName%2A> being processed first, otherwise there is no way to know what type is supposed to be created for value converter cases.  
   
-<a name="xamlTextUsage_DependsOnAttribute"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="P:System.Xaml.XamlMember.DependsOn" />

--- a/xml/System.Windows.Markup/EventSetterHandlerConverter.xml
+++ b/xml/System.Windows.Markup/EventSetterHandlerConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  For more information about how XAML for WPF processes event handler names, see [XAML Overview (WPF)](~/docs/framework/wpf/advanced/xaml-overview-wpf.md).  
   
-<a name="xamlTextUsage_EventSetterHandlerConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/InternalTypeHelper.xml
+++ b/xml/System.Windows.Markup/InternalTypeHelper.xml
@@ -25,8 +25,6 @@
   
  When compiling a XAML file, you can use public types, but you can also use internal types subject to the same limitations that exist on code access to internal types. <xref:System.Windows.Markup.InternalTypeHelper> enables support of internal access level types for markup. This involves the compiler creating a generated class that derives from <xref:System.Windows.Markup.InternalTypeHelper> and implements its members. The generated class exists in a security and access context such that only the same assembly or other assemblies specifically attributed for shared internal access can reference the generated class and thus the internal types.  
   
-<a name="xamlTextUsage_InternalTypeHelper"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/NamespaceMapEntry.xml
+++ b/xml/System.Windows.Markup/NamespaceMapEntry.xml
@@ -25,8 +25,6 @@
   
  Alternative techniques that do not require including WPF assemblies include referencing the XAML schema context (available in a service provider context from <xref:System.Xaml.IXamlSchemaContextProvider>, or from <xref:System.Xaml.XamlObjectWriter.SchemaContext%2A?displayProperty=nameWithType> from a XAML node loop or general XAML writer frame of reference.) The XAML schema context includes API for returning its assemblies, preferred prefix mappings, and XAML namespace information.  
   
-<a name="xamlTextUsage_NamespaceMapEntry"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.XamlTypeMapper" />
@@ -110,8 +108,6 @@
 ## Remarks  
  Use the "simple name" form for <xref:System.Windows.Markup.NamespaceMapEntry.AssemblyName%2A>. In particular, do not specify the full path, and do not include the file extension. This is analogous to the form that might be reported by <xref:System.Reflection.AssemblyName.Name%2A?displayProperty=nameWithType>.  
   
-<a name="xamlTextUsage_AssemblyName"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">The value <see cref="P:System.Windows.Markup.NamespaceMapEntry.AssemblyName" /> is being set to is <see langword="null" />.</exception>
@@ -133,15 +129,7 @@
       <Docs>
         <summary>Gets or sets the CLR namespace that contains the types being mapped.</summary>
         <value>The CLR namespace.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_ClrNamespace"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The value <see cref="P:System.Windows.Markup.NamespaceMapEntry.ClrNamespace" /> is being set to is <see langword="null" />.</exception>
         <altmember cref="T:System.Windows.Markup.XamlTypeMapper" />
       </Docs>
@@ -161,15 +149,7 @@
       <Docs>
         <summary>Gets or sets the mapping prefix for the XML namespace being mapped to.</summary>
         <value>The mapping prefix for the XML namespace.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_XmlNamespace"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">The value <see cref="P:System.Windows.Markup.NamespaceMapEntry.XmlNamespace" /> is being set to is <see langword="null" />.</exception>
         <altmember cref="T:System.Windows.Markup.XamlTypeMapper" />
       </Docs>

--- a/xml/System.Windows.Markup/NullExtension.xml
+++ b/xml/System.Windows.Markup/NullExtension.xml
@@ -35,8 +35,6 @@
 ## WPF Usage Notes  
  For WPF dependency properties, when you set a dependency property value to `null`, you are not necessarily setting the property to its default value, even if it is a reference property. The default value of a dependency property depends on its dependency property registration. An unset value is not necessarily `null` either; see <xref:System.Windows.DependencyProperty.UnsetValue>. For more information, see <xref:System.Windows.DependencyObject.ClearValue%2A> or [Dependency Properties Overview](~/docs/framework/wpf/advanced/dependency-properties-overview.md).  
   
-<a name="xamlTextUsage_NullExtension"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/ParserContext.xml
+++ b/xml/System.Windows.Markup/ParserContext.xml
@@ -28,8 +28,6 @@
   
  `xml:lang` and `xml:space` behavior is one of the aspects of a context you can override. By default, the parser context uses `en-us` based values. For more information on why the language-level context for XAML uses `en-us` rather than a culture-invariant value, see [WPF Globalization and Localization Overview](~/docs/framework/wpf/advanced/wpf-globalization-and-localization-overview.md).  
   
-<a name="xamlTextUsage_ParserContext"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.XamlReader" />
@@ -91,8 +89,6 @@
 ## Remarks  
  The <xref:System.Windows.Markup.ParserContext.BaseUri%2A> is used to resolve external resources that are referenced in XAML.  
   
-<a name="xamlTextUsage_BaseUri"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <altmember cref="P:System.Xml.XmlParserContext.BaseURI" />
@@ -186,8 +182,6 @@
 ## Remarks  
  This property is analogous to <xref:System.Xml.XmlReader.XmlLang%2A?displayProperty=nameWithType>.  
   
-<a name="xamlTextUsage_XmlLang"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <altmember cref="T:System.Windows.Markup.XmlLanguage" />
@@ -217,8 +211,6 @@
   
  The <xref:System.Windows.Markup.XmlnsDictionary> uses XAML namespace prefixes as keys and the complete XAML namespace identifier (typically a URI in string form) as values.  
   
-<a name="xamlTextUsage_XmlnsDictionary"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <altmember cref="T:System.Windows.Markup.XmlnsDictionary" />
@@ -245,8 +237,6 @@
 ## Remarks  
  This property is analogous to <xref:System.Xml.XmlReader.XmlSpace%2A?displayProperty=nameWithType>.  
   
-<a name="xamlTextUsage_XmlSpace"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows.Markup/Reference.xml
+++ b/xml/System.Windows.Markup/Reference.xml
@@ -29,8 +29,6 @@
   
  The System.Xaml assembly uses <xref:System.Windows.Markup.XmlnsDefinitionAttribute> to map all types in the assembly to the XAML namespace for the XAML language ([!INCLUDE[TLA#tla_xamlxmlnsv1](~/includes/tlasharptla-xamlxmlnsv1-md.md)]). Typically you declare a prefix for [!INCLUDE[TLA#tla_xamlxmlnsv1](~/includes/tlasharptla-xamlxmlnsv1-md.md)] in a root element mapping and use the prefix `x`.  
   
-<a name="xamlTextUsage_Reference"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>
@@ -88,15 +86,7 @@
       <Docs>
         <summary>Gets or sets the XAML name to obtain the reference for.</summary>
         <value>The XAML name of the element to obtain the reference for.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Name"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ProvideValue">

--- a/xml/System.Windows.Markup/ResourceReferenceExpressionConverter.xml
+++ b/xml/System.Windows.Markup/ResourceReferenceExpressionConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  `ResourceReferenceExpression` is an internal class, so your code cannot obtain instances of the class to convert.  
   
-<a name="xamlTextUsage_ResourceReferenceExpressionConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <forInternalUseOnly />

--- a/xml/System.Windows.Markup/RoutedEventConverter.xml
+++ b/xml/System.Windows.Markup/RoutedEventConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.Markup.RoutedEventConverter> class only converts an instance of <xref:System.Windows.RoutedEvent> from a <xref:System.String>.  
   
-<a name="xamlTextUsage_RoutedEventConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/ServiceProviders.xml
+++ b/xml/System.Windows.Markup/ServiceProviders.xml
@@ -32,8 +32,6 @@
   
  Using this class requires referencing WPF assemblies, it is not intended for general .NET Framework XAML Services scenarios. The scenario here is for WPF internal implementation of service-intensive features during serialization, such as when processing the `ShouldSerialize` implementations of certain types. The practical class involved in this scenario is the derived class <xref:System.Windows.Markup.XamlDesignerSerializationManager>.  
   
-<a name="xamlTextUsage_ServiceProviders"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/StaticExtension.xml
+++ b/xml/System.Windows.Markup/StaticExtension.xml
@@ -31,8 +31,6 @@
   
  You typically use static references to obtain static values from types, including from types that cannot be instantiated in XAML because the type is static. Common examples of cases where `{x:Static}` is useful include values that can be thought of as constants, such as fixed math values or unique keys for states. The static members being referenced do not have to come from specific framework assemblies associated with XAML schema context. You can map other assemblies and CLR namespaces for XAML usage and then can refer to static members of types in XAML using the prefix you mapped.  
   
-<a name="xamlTextUsage_StaticExtension"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>
@@ -111,8 +109,6 @@
   
  Under the normal scenario of use by the [!INCLUDE[TLA2#tla_winclient](~/includes/tla2sharptla-winclient-md.md)] XAML processor, the XAML processor passes a type resolver for CLR types as part of its service contract, and this resolver is used on the <xref:System.Windows.Markup.StaticExtension.ProvideValue%2A> call.  
   
-<a name="xamlTextUsage_Member"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">Attempted to set <see cref="P:System.Windows.Markup.StaticExtension.Member" /> to <see langword="null" />.</exception>
@@ -148,8 +144,6 @@
   
  For XAML usage information, see [x:Static Markup Extension](~/docs/framework/xaml-services/x-static-markup-extension.md).  
   
-<a name="xamlTextUsage_MemberType"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">Attempted to set <see cref="P:System.Windows.Markup.StaticExtension.MemberType" /> to <see langword="null" />.</exception>

--- a/xml/System.Windows.Markup/TemplateKeyConverter.xml
+++ b/xml/System.Windows.Markup/TemplateKeyConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.TemplateKey> type should not use a type converter pathway to convert values (should use markup extensions instead). For this reason, the <xref:System.Windows.Markup.TemplateKeyConverter.CanConvertFrom%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Type%29> and <xref:System.Windows.Markup.TemplateKeyConverter.CanConvertTo%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Type%29> methods always return `false`. The <xref:System.Windows.Markup.TemplateKeyConverter.ConvertFrom%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Globalization.CultureInfo%2CSystem.Object%29> and <xref:System.Windows.Markup.TemplateKeyConverter.ConvertTo%28System.ComponentModel.ITypeDescriptorContext%2CSystem.Globalization.CultureInfo%2CSystem.Object%2CSystem.Type%29> methods always throw an exception.  
   
-<a name="xamlTextUsage_TemplateKeyConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/TrimSurroundingWhitespaceAttribute.xml
+++ b/xml/System.Windows.Markup/TrimSurroundingWhitespaceAttribute.xml
@@ -28,8 +28,6 @@
   
  In previous versions of the .NET Framework, this class existed in the WPF-specific assembly WindowsBase. In [!INCLUDE[net_v40_long](~/includes/net-v40-long-md.md)], <xref:System.Windows.Markup.TrimSurroundingWhitespaceAttribute> is in the System.Xaml assembly. For more information, see [Types Migrated from WPF to System.Xaml](~/docs/framework/xaml-services/types-migrated-from-wpf-to-system-xaml.md).  
   
-<a name="xamlTextUsage_TrimSurroundingWhitespaceAttribute"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/TypeExtension.xml
+++ b/xml/System.Windows.Markup/TypeExtension.xml
@@ -35,8 +35,6 @@
 ## WPF Usage Notes  
  Type references are commonly used for style, template, and databinding feature areas in [!INCLUDE[TLA2#tla_winclient](~/includes/tla2sharptla-winclient-md.md)], when these features are referenced by XAML.  
   
-<a name="xamlTextUsage_TypeExtension"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>
@@ -182,8 +180,6 @@
   
  This property is settable per usual rules regarding markup extension usage. However, if you are setting with a <xref:System.Type>, then the purpose of this markup extension is irrelevant, because the same <xref:System.Type> is returned from a <xref:System.Windows.Markup.TypeExtension.ProvideValue%2A> call.  
   
-<a name="xamlTextUsage_Type"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">Attempted to set to <see langword="null" />.</exception>
@@ -209,15 +205,7 @@
       <Docs>
         <summary>Gets or sets the type name represented by this markup extension.</summary>
         <value>A string that identifies the type. This string uses the format *prefix*<c>:</c>*className*. (*prefix* is the mapping prefix for an XML namespace, and is only required to reference types that are not mapped to the default XML namespace for WPF ([!INCLUDE[TLA#tla_wpfxmlnsv1](~/includes/tlasharptla-wpfxmlnsv1-md.md)]).</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_TypeName"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentNullException">Attempted to set to <see langword="null" />.</exception>
       </Docs>
     </Member>

--- a/xml/System.Windows.Markup/WhitespaceSignificantCollectionAttribute.xml
+++ b/xml/System.Windows.Markup/WhitespaceSignificantCollectionAttribute.xml
@@ -31,8 +31,6 @@
 ## WPF Usage Notes  
  <xref:System.Windows.Documents.InlineCollection> is an example [!INCLUDE[TLA2#tla_winclient](~/includes/tla2sharptla-winclient-md.md)] class where this attribute is applied.  
   
-<a name="xamlTextUsage_WhitespaceSignificantCollectionAttribute"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/XamlInstanceCreator.xml
+++ b/xml/System.Windows.Markup/XamlInstanceCreator.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.Markup.XamlInstanceCreator> class is only intended for use by the WPF XAML markup compiler.  
   
-<a name="xamlTextUsage_XamlInstanceCreator"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <forInternalUseOnly />

--- a/xml/System.Windows.Markup/XamlReader.xml
+++ b/xml/System.Windows.Markup/XamlReader.xml
@@ -56,10 +56,6 @@
   
  If you are targeting [!INCLUDE[net_v40_short](~/includes/net-v40-short-md.md)], the external API is the same, but parts of the implementation are built on the [!INCLUDE[net_v40_short](~/includes/net-v40-short-md.md)] general XAML implementation in the System.Xaml assembly, which improves many of the technical and reporting aspects of parsing XAML. Targeting [!INCLUDE[net_v40_short](~/includes/net-v40-short-md.md)] necessarily entails including System.Xaml as a reference, and details of implementation such as the exceptions reported may come from System.Xaml defined types.  
   
-<a name="xamlTextUsage_XamlReader"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example converts a <xref:System.Windows.Controls.Button> into a string using the <xref:System.Windows.Markup.XamlWriter> class.  The string is then loaded back into a <xref:System.Windows.Controls.Button> using the static <xref:System.Windows.Markup.XamlReader.Load%2A> method on the <xref:System.Windows.Markup.XamlReader> class.  
   

--- a/xml/System.Windows.Markup/XamlTypeMapper.xml
+++ b/xml/System.Windows.Markup/XamlTypeMapper.xml
@@ -25,8 +25,6 @@
 ## Default Mapper  
  You can obtain a default mapper using the <xref:System.Windows.Markup.XamlTypeMapper.DefaultMapper%2A> static property. The default mapper only works on a default assembly list. No specific information about assemblies (as is specified in <xref:System.Windows.Markup.XamlTypeMapper> constructors) is used.  
   
-<a name="xamlTextUsage_XamlTypeMapper"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.NamespaceMapEntry" />

--- a/xml/System.Windows.Markup/XmlLanguageConverter.xml
+++ b/xml/System.Windows.Markup/XmlLanguageConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  This converter exists primarily so that the existing `xml:lang` settings in an XML file do not interfere with the parsing of attributes that use <xref:System.Windows.Markup.XmlLanguage> as their underlying type.  
   
-<a name="xamlTextUsage_XmlLanguageConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.XmlLanguage" />

--- a/xml/System.Windows.Markup/XmlnsDefinitionAttribute.xml
+++ b/xml/System.Windows.Markup/XmlnsDefinitionAttribute.xml
@@ -32,8 +32,6 @@
   
  In previous versions of the .NET Framework, this class existed in the WPF-specific assembly WindowsBase. In [!INCLUDE[net_v40_long](~/includes/net-v40-long-md.md)], <xref:System.Windows.Markup.XmlnsDefinitionAttribute> is in the System.Xaml assembly. For more information, see [Types Migrated from WPF to System.Xaml](~/docs/framework/xaml-services/types-migrated-from-wpf-to-system-xaml.md).  
   
-<a name="xamlTextUsage_XmlnsDefinitionAttribute"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Markup/XmlnsDictionary.xml
+++ b/xml/System.Windows.Markup/XmlnsDictionary.xml
@@ -27,8 +27,6 @@
   
  The <xref:System.Windows.Markup.XmlnsDictionary> adds the concept of scope for a XAML namespace. A default <xref:System.Collections.IDictionary> might contain prefix keys and XML namespace URI values. The scope concept in <xref:System.Windows.Markup.XmlnsDictionary> parallels the XML concept that a prefix might be redefined. If so, the redefinition only applies at that level or below in a DOM view of the XML (the previous definition applies at higher level in the DOM). The scope concept is mostly abstracted away in the <xref:System.Windows.Markup.XmlnsDictionary> API, such that you can call APIs such as <xref:System.Windows.Markup.XmlnsDictionary.LookupNamespace%2A> without being concerned about scope. However, <xref:System.Windows.Markup.XmlnsDictionary> does expose <xref:System.Windows.Markup.XmlnsDictionary.PushScope%2A> and <xref:System.Windows.Markup.XmlnsDictionary.PopScope%2A> so that a custom <xref:System.Windows.Markup.ParserContext> implementation that changes scope can synchronize with the scope for the <xref:System.Windows.Markup.XmlnsDictionary>.  
   
-<a name="xamlTextUsage_XmlnsDictionary"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.ResourceDictionary" />
@@ -457,15 +455,7 @@
         <param name="prefix">The prefix from which to get or set the associated XML namespace URI.</param>
         <summary>Gets or sets the XAML namespace URI associated with the specified prefix.</summary>
         <value>The corresponding XAML namespace URI.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Object"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentException">
           <paramref name="prefix" /> is not a string  
   
@@ -523,15 +513,7 @@
       <Docs>
         <summary>Gets a collection of all the keys in the <see cref="T:System.Windows.Markup.XmlnsDictionary" />.</summary>
         <value>The collection of all the keys in the dictionary.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Keys"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="LookupNamespace">

--- a/xml/System.Windows.Media.Animation/Int32KeyFrame.xml
+++ b/xml/System.Windows.Media.Animation/Int32KeyFrame.xml
@@ -24,10 +24,6 @@
   
  For XAML syntaxes that take a <xref:System.Windows.Media.Animation.Int32KeyFrame>, you need to specify a non-abstract derived type of <xref:System.Windows.Media.Animation.Int32KeyFrame> as an object element. For details, see the XAML syntax on the reference pages for <xref:System.Windows.Media.Animation.DiscreteInt32KeyFrame>, <xref:System.Windows.Media.Animation.EasingInt32KeyFrame>, <xref:System.Windows.Media.Animation.LinearInt32KeyFrame>, <xref:System.Windows.Media.Animation.SplineInt32KeyFrame>.  
   
-<a name="xamlTextUsage_Int32KeyFrame"></a>   
-## XAML Text Usage  
- See Remarks  
-  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Animation.Int32KeyFrameCollection" />

--- a/xml/System.Windows.Media.Imaging/BmpBitmapEncoder.xml
+++ b/xml/System.Windows.Media.Imaging/BmpBitmapEncoder.xml
@@ -20,8 +20,6 @@
   
  Encoding does not work in partial trust. See [WPF Partial Trust Security](~/docs/framework/wpf/wpf-partial-trust-security.md) for information on partial trust.  
   
-<a name="xamlTextUsage_No"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Imaging.BitmapEncoder" />

--- a/xml/System.Windows.Media.Imaging/ColorConvertedBitmap.xml
+++ b/xml/System.Windows.Media.Imaging/ColorConvertedBitmap.xml
@@ -28,12 +28,6 @@
   
  A <xref:System.Windows.Media.Imaging.ColorConvertedBitmap> is never cached.  
   
-<a name="xamlTextUsage_ColorConvertedBitmap"></a>   
-## XAML Text Usage  
- See Remarks  
-  
-   
-  
 ## Examples  
  The following example shows how to create an instance of <xref:System.Windows.Media.Imaging.ColorConvertedBitmap> and use it to convert color.  
   
@@ -289,9 +283,6 @@
 ## Remarks  
  When you make property changes to a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap>, the changes must be done within a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.BeginInit%2A> and <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.EndInit%2A> block.  
   
-<a name="xamlTextUsage_Property"></a>   
-## XAML Text Usage  
-  
 <a name="dependencyPropertyInfo_DestinationColorContext"></a>   
 ## Dependency Property Information  
   
@@ -350,9 +341,6 @@
   
 ## Remarks  
  When you make property changes to a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap>, the changes must be done within a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.BeginInit%2A> and <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.EndInit%2A> block.  
-  
-<a name="xamlTextUsage_Property2"></a>   
-## XAML Text Usage  
   
 <a name="dependencyPropertyInfo_DestinationFormat"></a>   
 ## Dependency Property Information  
@@ -501,9 +489,6 @@
 ## Remarks  
  When you make property changes to a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap>, the changes must be done within a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.BeginInit%2A> and <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.EndInit%2A> block.  
   
-<a name="xamlTextUsage_Property3"></a>   
-## XAML Text Usage  
-  
 <a name="dependencyPropertyInfo_Source"></a>   
 ## Dependency Property Information  
   
@@ -545,9 +530,6 @@
   
 ## Remarks  
  When you make property changes to a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap>, the changes must be done within a <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.BeginInit%2A> and <xref:System.Windows.Media.Imaging.ColorConvertedBitmap.EndInit%2A> block.  
-  
-<a name="xamlTextUsage_Property4"></a>   
-## XAML Text Usage  
   
 <a name="dependencyPropertyInfo_SourceColorContext"></a>   
 ## Dependency Property Information  

--- a/xml/System.Windows.Media.Imaging/GifBitmapEncoder.xml
+++ b/xml/System.Windows.Media.Imaging/GifBitmapEncoder.xml
@@ -20,8 +20,6 @@
   
  Encoding does not work in partial trust. See [WPF Partial Trust Security](~/docs/framework/wpf/wpf-partial-trust-security.md) for information on partial trust.  
   
-<a name="xamlTextUsage_No"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Imaging.BitmapEncoder" />

--- a/xml/System.Windows.Media.Imaging/JpegBitmapEncoder.xml
+++ b/xml/System.Windows.Media.Imaging/JpegBitmapEncoder.xml
@@ -20,8 +20,6 @@
   
  Encoding does not work in partial trust. See [WPF Partial Trust Security](~/docs/framework/wpf/wpf-partial-trust-security.md) for information on partial trust.  
   
-<a name="xamlTextUsage_No"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Imaging.BitmapEncoder" />
@@ -125,10 +123,6 @@
 ## Remarks  
  The vertical flip represents a lossless transformation of the source image and replaces any previous lossless transformation.  
   
-<a name="XAMLTextUsage_FlipVertical"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example demonstrates how to set the value of the <xref:System.Windows.Media.Imaging.JpegBitmapEncoder.FlipVertical%2A> property.  
   
@@ -160,12 +154,6 @@
         <value>The quality level of the [!INCLUDE[TLA2#tla_jpegorg](~/includes/tla2sharptla-jpegorg-md.md)] image. The value range is 1 (lowest quality) to 100 (highest quality) inclusive.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_QualityLevel"></a>   
-## XAML Text Usage  
-   
   
 ## Examples  
  The following example demonstrates how to set the value of the <xref:System.Windows.Media.Imaging.JpegBitmapEncoder.QualityLevel%2A> property.  
@@ -203,10 +191,6 @@
  Rotation is supported only in 90-degree increments.  
   
  The rotation represents a lossless transformation of the source image and replaces any previous lossless transformation.  
-  
-<a name="XAMLTextUsage_Rotation"></a>   
-## XAML Text Usage  
-   
   
 ## Examples  
  The following example demonstrates how to set the value of the <xref:System.Windows.Media.Imaging.JpegBitmapEncoder.Rotation%2A> property.  

--- a/xml/System.Windows.Media.Imaging/PngBitmapEncoder.xml
+++ b/xml/System.Windows.Media.Imaging/PngBitmapEncoder.xml
@@ -20,8 +20,6 @@
   
  Encoding does not work in partial trust. See [WPF Partial Trust Security](~/docs/framework/wpf/wpf-partial-trust-security.md) for information on partial trust.  
   
-<a name="xamlTextUsage_No"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Imaging.BitmapEncoder" />
@@ -79,10 +77,6 @@
   
 ## Remarks  
  Interlacing refers to the process of displaying a [!INCLUDE[TLA2#tla_png](~/includes/tla2sharptla-png-md.md)] frame in two fields. One field contains the even lines of the frame, and the other field contains the odd lines of the frame. When the [!INCLUDE[TLA2#tla_png](~/includes/tla2sharptla-png-md.md)] is viewed, the lines in one field are displayed first, and then the lines in the second field are displayed.  
-  
-<a name="XAMLTextUsage_Interlace"></a>   
-## XAML Text Usage  
-   
   
 ## Examples  
  The following example demonstrates how to use the <xref:System.Windows.Media.Imaging.PngBitmapEncoder.Interlace%2A> property.  

--- a/xml/System.Windows.Media.Imaging/TiffBitmapEncoder.xml
+++ b/xml/System.Windows.Media.Imaging/TiffBitmapEncoder.xml
@@ -20,8 +20,6 @@
   
  Encoding does not work in partial trust. See [WPF Partial Trust Security](~/docs/framework/wpf/wpf-partial-trust-security.md) for information on partial trust.  
   
-<a name="xamlTextUsage_No"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Imaging.BitmapEncoder" />
@@ -79,10 +77,6 @@
   
 ## Remarks  
  The <xref:System.Windows.Media.Imaging.TiffCompressOption.Ccitt3>, <xref:System.Windows.Media.Imaging.TiffCompressOption.Ccitt4>, and <xref:System.Windows.Media.Imaging.TiffCompressOption.Rle> values require that the <xref:System.Windows.Media.PixelFormat> value be set to <xref:System.Windows.Media.PixelFormats.BlackWhite%2A?displayProperty=nameWithType>.  
-  
-<a name="XAMLTextUsage_Compression"></a>   
-## XAML Text Usage  
-   
   
 ## Examples  
  The following example demonstrates how to use the <xref:System.Windows.Media.Imaging.TiffBitmapEncoder.Compression%2A> property.  

--- a/xml/System.Windows.Media.Imaging/WmpBitmapEncoder.xml
+++ b/xml/System.Windows.Media.Imaging/WmpBitmapEncoder.xml
@@ -22,8 +22,6 @@
   
  Encoding does not work in partial trust. See [WPF Partial Trust Security](~/docs/framework/wpf/wpf-partial-trust-security.md) for information on partial trust.  
   
-<a name="xamlTextUsage_No"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Media.Imaging.BitmapEncoder" />
@@ -108,8 +106,6 @@
 ## Remarks  
  This property has an effect only if <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.CompressedDomainTranscode%2A> is set to `true` and the image contains either a planar or interleaved alpha channel; otherwise, it is ignored.  
   
-<a name="XAMLTextUsage_1"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value given is not between 0 and 4.</exception>
@@ -136,8 +132,6 @@
 ## Remarks  
  This property has an effect only if <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.InterleavedAlpha%2A> is `false`.  
   
-<a name="XAMLTextUsage_2"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -158,15 +152,7 @@
         <summary>Gets or sets a value that indicates whether compressed domain operations can be used. Compressed domain operations are transformation operations that are done without decoding the image data.</summary>
         <value>
           <see langword="true" /> if compressed domain operations can be used; otherwise, <see langword="false" />. The default is <see langword="true" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_3"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlipHorizontal">
@@ -185,15 +171,7 @@
         <summary>Gets or sets a value indicating whether to flip the image horizontally.</summary>
         <value>
           <see langword="true" /> if the image is to be flipped horizontally; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_4"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FlipVertical">
@@ -212,15 +190,7 @@
         <summary>Gets or sets a value that indicates whether to flip the image vertically.</summary>
         <value>
           <see langword="true" /> if the image is to be flipped vertically; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_5"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="FrequencyOrder">
@@ -239,15 +209,7 @@
         <summary>Gets or sets a value that indicates whether to encoding in frequency order.</summary>
         <value>
           <see langword="true" /> to encode the image in frequency order; <see langword="false" /> to encode the image by its spatial orientation. The default is <see langword="true" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_6"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="HorizontalTileSlices">
@@ -275,8 +237,6 @@
   
  When used in combination with <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.VerticalTileSlices%2A>, a grid of tiles is formed. For example, if both properties are set to 1, the image is divided into 4 tiles.  
   
-<a name="XAMLTextUsage_7"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -303,8 +263,6 @@
 ## Remarks  
  This value is valid only when <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.CompressedDomainTranscode%2A> is `true` and a subregion encode is requested.  
   
-<a name="XAMLTextUsage_8"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -352,8 +310,6 @@
 ## Remarks  
  This property has an effect only if <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.CompressedDomainTranscode%2A> is set to `true`; otherwise, it is ignored.  
   
-<a name="XAMLTextUsage_9"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value given is not between 0 and 3.</exception>
@@ -374,15 +330,7 @@
       <Docs>
         <summary>Gets or sets the image quality level.</summary>
         <value>The image quality level. The range is 0 to 1.0 (lossless image quality). The default is 0.9.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_10"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="InterleavedAlpha">
@@ -407,8 +355,6 @@
 ## Remarks  
  Interleaved alpha channels are only supported by certain pixel formats.  
   
-<a name="XAMLTextUsage_11"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -429,15 +375,7 @@
         <summary>Gets or sets a value that indicates whether to encode using lossless compression.</summary>
         <value>
           <see langword="true" /> to use lossless compression; otherwise, <see langword="false" />. The default is <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_12"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="OverlapLevel">
@@ -473,15 +411,7 @@
  </term><description> Two levels of overlap processing are enabled. In addition to the first level of processing, encoded values of 16x16 macro blocks are modified based on the values of neighboring macro blocks.  
   
  </description></item></list></value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_13"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="QualityLevel">
@@ -499,15 +429,7 @@
       <Docs>
         <summary>Gets or sets the compression quality for the main image.</summary>
         <value>The compression quality for the main image. A value of 1 is considered lossless, and higher values indicate a high compression ratio and lower image quality. The range is 1 to 255. The default is 1.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_14"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Rotation">
@@ -525,15 +447,7 @@
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Windows.Media.Imaging.Rotation" /> of the image.</summary>
         <value>The rotation of the image.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_15"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="SubsamplingLevel">
@@ -573,15 +487,7 @@
  </term><description> 4:4:4 encoding. Chroma resolution is preserved.  
   
  </description></item></list></value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_16"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">The value given is not between 0 and 3.</exception>
       </Docs>
     </Member>
@@ -609,8 +515,6 @@
   
  When <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.UseCodecOptions%2A> is `false`, <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.QualityLevel%2A>, <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.OverlapLevel%2A>, and <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.SubsamplingLevel%2A> are set based on <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.ImageQualityLevel%2A>.  
   
-<a name="XAMLTextUsage_17"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -640,8 +544,6 @@
   
  When used in combination with <xref:System.Windows.Media.Imaging.WmpBitmapEncoder.HorizontalTileSlices%2A>, a grid of tiles is formed. For example, if both properties are set to 1, the image is divided into 4 tiles.  
   
-<a name="XAMLTextUsage_18"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows.Media.Media3D/Rect3D.xml
+++ b/xml/System.Windows.Media.Media3D/Rect3D.xml
@@ -34,9 +34,6 @@
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
   
-<a name="xamlTextUsage_Rect3D"></a>   
-## XAML Text Usage  
-  
  ]]></format>
     </remarks>
   </Docs>
@@ -505,10 +502,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_Location"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -763,10 +757,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_SizeX"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -793,10 +784,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_SizeY"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -823,10 +811,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_SizeZ"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -853,10 +838,7 @@
  Rect3D is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_Size3D"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -1074,10 +1056,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_X"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -1104,10 +1083,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_Y"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>
@@ -1134,10 +1110,7 @@
  <xref:System.Windows.Media.Media3D.Rect3D> is typically used to represent the bounds of a <xref:System.Windows.Media.Media3D.MeshGeometry3D> or <xref:System.Windows.Media.Media3D.Model3D>.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_Z"></a>   
-## XAML Text Usage  
-  
+    
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows.Media.Media3D/Size3D.xml
+++ b/xml/System.Windows.Media.Media3D/Size3D.xml
@@ -29,12 +29,7 @@
   
 ## Remarks  
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_ResourceReferenceExpressionConverter"></a>   
-## XAML Text Usage  
-  
-   
-  
+    
 ## Examples  
  This example shows how to determine if two  <xref:System.Windows.Media.Media3D.Size3D> structures are equal using the <xref:System.Windows.Media.Media3D.Size3D> static <xref:System.Windows.Media.Media3D.Size3D.Equals%2A> method.  
   
@@ -580,12 +575,7 @@
  The <xref:System.Windows.Media.Media3D.Size3D.X%2A>, <xref:System.Windows.Media.Media3D.Size3D.Y%2A>, and <xref:System.Windows.Media.Media3D.Size3D.Z%2A> values must be non-negative.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_X"></a>   
-## XAML Text Usage  
-  
-   
-  
+    
 ## Examples  
  The following example shows how to check if two <xref:System.Windows.Media.Media3D.Size3D> structures are equal. It also shows how to assign values to a <xref:System.Windows.Media.Media3D.Size3D> structure when the structure is being declared and after the structure has been declared.  
   
@@ -618,12 +608,7 @@
  The <xref:System.Windows.Media.Media3D.Size3D.X%2A>, <xref:System.Windows.Media.Media3D.Size3D.Y%2A>, and <xref:System.Windows.Media.Media3D.Size3D.Z%2A> values must be non-negative.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_Y"></a>   
-## XAML Text Usage  
-  
-   
-  
+    
 ## Examples  
  The following example shows how to check if two <xref:System.Windows.Media.Media3D.Size3D> structures are equal. It also shows how to assign values to a <xref:System.Windows.Media.Media3D.Size3D> structure when the structure is being declared and after the structure has been declared.  
   
@@ -655,12 +640,7 @@
  The <xref:System.Windows.Media.Media3D.Size3D.X%2A>, <xref:System.Windows.Media.Media3D.Size3D.Y%2A>, and <xref:System.Windows.Media.Media3D.Size3D.Z%2A> values must be non-negative.  
   
  <xref:System.Windows.Media.Media3D.Size3D> and <xref:System.Windows.Media.Media3D.Rect3D> are not typically used in XAML, because no settable properties exist in the WPF 3D object model that use those types.  
-  
-<a name="xamlTextUsage_Z"></a>   
-## XAML Text Usage  
-  
-   
-  
+    
 ## Examples  
  The following example shows how to check if two <xref:System.Windows.Media.Media3D.Size3D> structures are equal. It also shows how to assign values to a <xref:System.Windows.Media.Media3D.Size3D> structure when the structure is being declared and after the structure has been declared.  
   

--- a/xml/System.Windows.Media/GlyphRun.xml
+++ b/xml/System.Windows.Media/GlyphRun.xml
@@ -31,8 +31,6 @@
  ![Diagraph of glyph measurements](~/add/media/glyph-example.png "Diagraph of glyph measurements")  
 Various typographic qualities of two different glyph characters  
   
-<a name="xamlTextUsage_GlyphRun"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>
@@ -203,8 +201,6 @@ Various typographic qualities of two different glyph characters
 ## Remarks  
  Each item in the list of advance widths corresponds to the glyph values returned by the <xref:System.Windows.Media.GlyphRun.GlyphIndices%2A> property. The nominal origin of the n<sup>th</sup> glyph in the run (n>0) is the nominal origin of the n-1<sup>th</sup> glyph plus the n-1<sup>th</sup> advance width added along the runs advance vector. Base glyphs generally have a non-zero advance width, whereas combining glyphs generally have a zero advance width.  
   
-<a name="xamlTextUsage_AdvanceWidths"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -224,15 +220,7 @@ Various typographic qualities of two different glyph characters
       <Docs>
         <summary>Gets or sets the baseline origin of the <see cref="T:System.Windows.Media.GlyphRun" />.</summary>
         <value>A <see cref="T:System.Windows.Point" /> value representing the baseline origin.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_BaselineOrigin"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BidiLevel">
@@ -250,15 +238,7 @@ Various typographic qualities of two different glyph characters
       <Docs>
         <summary>Gets or sets the bidirectional nesting level of the <see cref="T:System.Windows.Media.GlyphRun" />.</summary>
         <value>An <see cref="T:System.Int32" /> value that represents the bidirectional nesting level.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_BidiLevel"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="BuildGeometry">
@@ -316,8 +296,6 @@ Various typographic qualities of two different glyph characters
 ## Remarks  
  The return value is `null` if there is a caret stop for every UTF16 code point in the Unicode representing the <xref:System.Windows.Media.GlyphRun>.  
   
-<a name="xamlTextUsage_CaretStops"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -345,15 +323,7 @@ Various typographic qualities of two different glyph characters
       <Docs>
         <summary>Gets or sets the list of UTF16 code points that represent the Unicode content of the <see cref="T:System.Windows.Media.GlyphRun" />.</summary>
         <value>A list of <see cref="T:System.Char" /> values that represent Unicode content.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Characters"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="ClusterMap">
@@ -389,8 +359,6 @@ Various typographic qualities of two different glyph characters
   
  If the list is `null` or equal to <xref:System.String.Empty>, sequential 1 to 1 mapping is assumed.  
   
-<a name="xamlTextUsage_ClusterMap"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -468,8 +436,6 @@ Various typographic qualities of two different glyph characters
 ## Remarks  
  When a <xref:System.Windows.Media.GlyphRun> is rendered on a device that has built-in support for the named device font, the <xref:System.Windows.Media.GlyphRun> should be rendered using a device specific mechanism for selecting that font, and by sending Unicode code points rather than glyph indices. When rendering onto a device that does not include built-in support for the named device font, <xref:System.Windows.Media.GlyphRun.DeviceFontName%2A> should be ignored.  
   
-<a name="xamlTextUsage_DeviceFontName"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -489,15 +455,7 @@ Various typographic qualities of two different glyph characters
       <Docs>
         <summary>Gets or sets the em size used for rendering the <see cref="T:System.Windows.Media.GlyphRun" />.</summary>
         <value>A <see cref="T:System.Double" /> value that represents the em size used for rendering.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_FontRenderingEmSize"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="GetCaretCharacterHitFromDistance">
@@ -652,8 +610,6 @@ Various typographic qualities of two different glyph characters
 ## Remarks  
  The default value of the glyph indices are defined by the font's character map table for the corresponding Unicode code points in the inner text.  
   
-<a name="xamlTextUsage_GlyphIndices"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -689,8 +645,6 @@ Various typographic qualities of two different glyph characters
   
  Base glyphs generally have a glyph offset of (0, 0), combining glyphs generally have an offset that places them correctly on top of the nearest preceding base glyph.  
   
-<a name="xamlTextUsage_GlyphOffsets"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -710,15 +664,7 @@ Various typographic qualities of two different glyph characters
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Windows.Media.GlyphTypeface" /> for the <see cref="T:System.Windows.Media.GlyphRun" />.</summary>
         <value>The <see cref="T:System.Windows.Media.GlyphTypeface" /> for the <see cref="T:System.Windows.Media.GlyphRun" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_GlyphTypeface"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsHitTestable">
@@ -762,8 +708,6 @@ Various typographic qualities of two different glyph characters
 ## Remarks  
  If <xref:System.Windows.Media.GlyphRun.IsSideways%2A> is `true`, the glyphs that make up text characters are rotated 90° counter-clockwise, using vertical baseline positioning metrics.  
   
-<a name="xamlTextUsage_IsSideways"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
       </Docs>
@@ -783,15 +727,7 @@ Various typographic qualities of two different glyph characters
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Windows.Markup.XmlLanguage" /> for the <see cref="T:System.Windows.Media.GlyphRun" />.</summary>
         <value>The <see cref="T:System.Windows.Markup.XmlLanguage" /> for the <see cref="T:System.Windows.Media.GlyphRun" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Language"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="PixelsPerDip">

--- a/xml/System.Windows.Media/GlyphTypeface.xml
+++ b/xml/System.Windows.Media/GlyphTypeface.xml
@@ -43,8 +43,6 @@
  ![Diagraph of glyph measurements](~/add/media/glyph-example.png "Diagraph of glyph measurements")  
 Metric values of glyph characters  
   
-<a name="xamlTextUsage_GlyphTypeface"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Documents.Glyphs" />
@@ -608,15 +606,7 @@ Metric values of glyph characters
       <Docs>
         <summary>Gets or sets the [!INCLUDE[TLA2#tla_uri](~/includes/tla2sharptla-uri-md.md)] for the <see cref="T:System.Windows.Media.GlyphTypeface" /> object.</summary>
         <value>The [!INCLUDE[TLA2#tla_uri](~/includes/tla2sharptla-uri-md.md)] for the <see cref="T:System.Windows.Media.GlyphTypeface" /> object.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_FontUri"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
         <permission cref="T:System.Security.Permissions.FileIOPermission">for getting the original [!INCLUDE[TLA2#tla_uri](~/includes/tla2sharptla-uri-md.md)] of the <see cref="T:System.Windows.Media.GlyphTypeface" />. The original [!INCLUDE[TLA2#tla_uri](~/includes/tla2sharptla-uri-md.md)] may reveal local file system information. Associated enumeration: <see cref="F:System.Security.Permissions.FileIOPermissionAccess.PathDiscovery" /></permission>
       </Docs>
     </Member>
@@ -1016,15 +1006,7 @@ Metric values of glyph characters
       <Docs>
         <summary>Gets or sets the <see cref="T:System.Windows.Media.StyleSimulations" /> for the <see cref="T:System.Windows.Media.GlyphTypeface" /> object.</summary>
         <value>One of the <see cref="T:System.Windows.Media.StyleSimulations" /> values that represents the style simulation for the font.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_StyleSimulations"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Symbol">

--- a/xml/System.Windows.Media/TransformConverter.xml
+++ b/xml/System.Windows.Media/TransformConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts a <see cref="T:System.Windows.Media.Transform" /> object to or from another object type.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_TransformConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows.Threading/DispatcherOperationStatus.xml
+++ b/xml/System.Windows.Threading/DispatcherOperationStatus.xml
@@ -19,8 +19,6 @@
   
  The stages of a <xref:System.Windows.Threading.DispatcherOperation> are Pending, Executing, and Completed.  At any point before the operation completes, the status can be set to Aborted.  
   
-<a name="xamlTextUsage_DispatcherOperationStatus"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Threading/DispatcherPriority.xml
+++ b/xml/System.Windows.Threading/DispatcherPriority.xml
@@ -21,10 +21,6 @@
   
  If an operation is posted using <xref:System.Windows.Threading.Dispatcher.Invoke%2A> on its own <xref:System.Windows.Threading.DispatcherPriority.ContextIdle> at a priority of Send, the operation bypasses the queue and is immediately executed.  
   
-<a name="xamlTextUsage_DispatcherPriority"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example is a call to <xref:System.Windows.Threading.Dispatcher.BeginInvoke%2A> that passes a delegate which accepts an argument.  The priority is set to Normal.  
   

--- a/xml/System.Windows.Threading/DispatcherSynchronizationContext.xml
+++ b/xml/System.Windows.Threading/DispatcherSynchronizationContext.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  If a <xref:System.Windows.Threading.Dispatcher> is not specified at the creation of the <xref:System.Windows.Threading.DispatcherSynchronizationContext> instance, the current <xref:System.Windows.Threading.Dispatcher> is associated with the <xref:System.Windows.Threading.DispatcherSynchronizationContext>.  
   
-<a name="xamlTextUsage_DispatcherSynchronizationContext"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows.Threading/DispatcherTimer.xml
+++ b/xml/System.Windows.Threading/DispatcherTimer.xml
@@ -24,10 +24,6 @@
   
  A <xref:System.Windows.Threading.DispatcherTimer> will keep an object alive whenever the object's methods are bound to the timer.  
   
-<a name="xamlTextUsage_DispatcherTimer"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example creates a <xref:System.Windows.Threading.DispatcherTimer> that updates the contents of a <xref:System.Windows.Controls.Label> and calls the <xref:System.Windows.Input.CommandManager.InvalidateRequerySuggested%2A> method on the <xref:System.Windows.Input.CommandManager>.  
   
@@ -188,10 +184,6 @@
 ## Remarks  
  Timers are not guaranteed to execute exactly when the time interval occurs, but they are guaranteed to not execute before the time interval occurs.  This is because <xref:System.Windows.Threading.DispatcherTimer> operations are placed on the <xref:System.Windows.Threading.Dispatcher> queue like other operations.  When the <xref:System.Windows.Threading.DispatcherTimer> operation executes is dependent on the other jobs in the queue and their priorities.  
   
-<a name="XAMLTextUsage_Interval"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example creates a <xref:System.Windows.Threading.DispatcherTimer>.  A new <xref:System.Windows.Threading.DispatcherTimer> object named `dispatcherTimer` is created.  The event handler `dispatcherTimer_Tick` is added to the <xref:System.Windows.Threading.DispatcherTimer.Tick> event.  The <xref:System.Windows.Threading.DispatcherTimer.Interval%2A> is set to 1 second using a <xref:System.TimeSpan> object.  
   
@@ -229,10 +221,6 @@
  Calling <xref:System.Windows.Threading.DispatcherTimer.Start%2A> sets <xref:System.Windows.Threading.DispatcherTimer.IsEnabled%2A> to `true`.  
   
  Calling <xref:System.Windows.Threading.DispatcherTimer.Stop%2A> sets <xref:System.Windows.Threading.DispatcherTimer.IsEnabled%2A> to `false`.  
-  
-<a name="XAMLTextUsage_IsEnabled"></a>   
-## XAML Text Usage  
-   
   
 ## Examples  
  The following example creates a <xref:System.Windows.Threading.DispatcherTimer>.  A new <xref:System.Windows.Threading.DispatcherTimer> object named `dispatcherTimer` is created.  The event handler `dispatcherTimer_Tick` is added to the <xref:System.Windows.Threading.DispatcherTimer.Tick> event.  The <xref:System.Windows.Threading.DispatcherTimer.Interval%2A> is set to 1 second using a <xref:System.TimeSpan> object.  
@@ -327,15 +315,7 @@
       <Docs>
         <summary>Gets or sets a user-defined data object.</summary>
         <value>The user-defined data.  The default is <see langword="null" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_Tag"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Tick">
@@ -354,12 +334,6 @@
         <summary>Occurs when the timer interval has elapsed.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Tick"></a>   
-## XAML Text Usage  
-   
   
 ## Examples  
  The following example creates a <xref:System.Windows.Threading.DispatcherTimer.Tick> event handler.  The event handler updates a <xref:System.Windows.Controls.Label> that displays the current second, and it calls <xref:System.Windows.Input.CommandManager.InvalidateRequerySuggested%2A> on the <xref:System.Windows.Input.CommandManager>.  

--- a/xml/System.Windows/ComponentResourceKey.xml
+++ b/xml/System.Windows/ComponentResourceKey.xml
@@ -31,10 +31,6 @@
   
  You can also use the [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] [ComponentResourceKey Markup Extension](~/docs/framework/wpf/advanced/componentresourcekey-markup-extension.md) in verbose syntax directly to create a loose instance of the key. This is useful if you want to declare private resources from other assemblies that are less discoverable to customize.  
   
-<a name="xamlTextUsage_ComponentResourceKey"></a>   
-## XAML Text Usage  
- See Remarks  
-  
  ]]></format>
     </remarks>
   </Docs>
@@ -190,12 +186,6 @@
   
  Typically, the string used for a <xref:System.Windows.ComponentResourceKey.ResourceId%2A> value conforms to the [XamlName Grammar](~/docs/framework/xaml-services/xamlname-grammar.md).  
   
-<a name="xamlTextUsage_2"></a>   
-## XAML Text Usage  
- See Remarks  
-  
-   
-  
 ## Examples  
  The following example shows how to use the <xref:System.Windows.ComponentResourceKey.ResourceId%2A> to differentiate this key from others associated with this type.  
   
@@ -246,12 +236,6 @@
  For [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] information, see [ComponentResourceKey Markup Extension](~/docs/framework/wpf/advanced/componentresourcekey-markup-extension.md).  
   
  The <xref:System.Windows.ComponentResourceKey> element is used by custom components to define keys for resources that are accessed from external assemblies, based on targeting an assembly that contains the type. Custom components often define new types which must be in the assembly where the resource is located. Generally these types have no other implementation, the types only exist in order to satisfy the lookup requirements of a <xref:System.Windows.ComponentResourceKey>.  
-  
-<a name="xamlTextUsage_3"></a>   
-## XAML Text Usage  
- See Remarks  
-  
-   
   
 ## Examples  
  The following example shows how to define a <xref:System.Windows.ComponentResourceKey> including <xref:System.Windows.ComponentResourceKey.TypeInTargetAssembly%2A> and <xref:System.Windows.ComponentResourceKey.ResourceId%2A> using the [ComponentResourceKey Markup Extension](~/docs/framework/wpf/advanced/componentresourcekey-markup-extension.md). This resource can then be placed in an external assembly and accessed by a key usage that requests the resource using an analogous <xref:System.Windows.ComponentResourceKey> in the request.  

--- a/xml/System.Windows/CornerRadiusConverter.xml
+++ b/xml/System.Windows/CornerRadiusConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of other types to and from a <see cref="T:System.Windows.CornerRadius" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_CornerRadiusConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Windows.CornerRadius" />
   </Docs>
   <Members>

--- a/xml/System.Windows/DataObject.xml
+++ b/xml/System.Windows/DataObject.xml
@@ -22,12 +22,6 @@
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
-## Remarks  
-  
-<a name="xamlTextUsage_DataObject"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example shows how to use this class.  
   

--- a/xml/System.Windows/DeferrableContentConverter.xml
+++ b/xml/System.Windows/DeferrableContentConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts a stream to a <see cref="T:System.Windows.DeferrableContent" /> instance.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_DeferrableContentConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/DialogResultConverter.xml
+++ b/xml/System.Windows/DialogResultConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts the <see cref="P:System.Windows.Window.DialogResult" /> property, which is a <see cref="T:System.Nullable`1" /> value of type <see cref="T:System.Boolean" />, to and from other types.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_DialogResultConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.ComponentModel.TypeConverter" />
   </Docs>
   <Members>

--- a/xml/System.Windows/DynamicResourceExtensionConverter.xml
+++ b/xml/System.Windows/DynamicResourceExtensionConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  Referencing the type converter is not typically necessary for typical scenarios that involve making resource references either from XAML or code. For more information about the markup extension that this type converter supports, see [DynamicResource Markup Extension](~/docs/framework/wpf/advanced/dynamicresource-markup-extension.md).  
   
-<a name="XAMLTextUsage_DynamicResourceExtensionConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.DynamicResourceExtension" />

--- a/xml/System.Windows/ExpressionConverter.xml
+++ b/xml/System.Windows/ExpressionConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.Expression> type should not use a type converter pathway to convert values (should use markup extensions instead). For this reason, <xref:System.Windows.ExpressionConverter.CanConvertFrom%2A?displayProperty=nameWithType> and <xref:System.Windows.ExpressionConverter.CanConvertTo%2A?displayProperty=nameWithType> always return `false`. <xref:System.Windows.ExpressionConverter.ConvertFrom%2A?displayProperty=nameWithType> and <xref:System.Windows.ExpressionConverter.ConvertTo%2A?displayProperty=nameWithType> always throw an exception.  
   
-<a name="XAMLTextUsage_ExpressionConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <forInternalUseOnly />

--- a/xml/System.Windows/FigureLengthConverter.xml
+++ b/xml/System.Windows/FigureLengthConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of other types to and from a <see cref="T:System.Windows.FigureLength" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_FigureLengthConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Windows.FigureLength" />
   </Docs>
   <Members>

--- a/xml/System.Windows/FontSizeConverter.xml
+++ b/xml/System.Windows/FontSizeConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.FontSizeConverter> object supports conversion to and from the following types: include <xref:System.String>, <xref:System.Int32>, <xref:System.Single>, and <xref:System.Double>. There is no actual `FontSize` type, but values for font sizes are generally typed as <xref:System.Double>, so the converter's destination type is <xref:System.Double>.  
   
-<a name="XAMLTextUsage_FontSizeConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows/FontStretchConverter.xml
+++ b/xml/System.Windows/FontStretchConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of <see cref="T:System.Windows.FontStretch" /> to and from other type representations.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_FontStretchConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/FontStyleConverter.xml
+++ b/xml/System.Windows/FontStyleConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.FontStyleConverter> object supports conversion to and from the <xref:System.String> type.  
   
-<a name="XAMLTextUsage_FontStyleConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows/FontWeightConverter.xml
+++ b/xml/System.Windows/FontWeightConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.FontWeightConverter> object supports conversion to and from the <xref:System.String> type.  
   
-<a name="XAMLTextUsage_FontWeightConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows/FrameworkElementFactory.xml
+++ b/xml/System.Windows/FrameworkElementFactory.xml
@@ -23,8 +23,6 @@
 ## Remarks  
  This class is a deprecated way to programmatically create templates, which are subclasses of <xref:System.Windows.FrameworkTemplate> such as <xref:System.Windows.Controls.ControlTemplate> or <xref:System.Windows.DataTemplate>; not all of the template functionality is available when you create a template using this class. The recommended way to programmatically create a template is to load [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] from a string or a memory stream using the <xref:System.Windows.Markup.XamlReader.Load%2A> method of the <xref:System.Windows.Markup.XamlReader> class.  
   
-<a name="xamlTextUsage_FrameworkElementFactory"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>
@@ -184,15 +182,7 @@
       <Docs>
         <summary>Gets the first child factory.</summary>
         <value>A <see cref="T:System.Windows.FrameworkElementFactory" /> the first child factory.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_FirstChild"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="IsSealed">
@@ -211,15 +201,7 @@
         <summary>Gets a value that indicates whether this object is in an immutable state.</summary>
         <value>
           <see langword="true" /> if this object is in an immutable state; otherwise, <see langword="false" />.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_IsSealed"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Name">
@@ -237,15 +219,7 @@
       <Docs>
         <summary>Gets or sets the name of a template item.</summary>
         <value>A string that is the template identifier.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Name"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="NextSibling">
@@ -263,15 +237,7 @@
       <Docs>
         <summary>Gets the next sibling factory.</summary>
         <value>A <see cref="T:System.Windows.FrameworkElementFactory" /> that is the next sibling factory.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_NextSibling"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Parent">
@@ -289,15 +255,7 @@
       <Docs>
         <summary>Gets the parent <see cref="T:System.Windows.FrameworkElementFactory" />.</summary>
         <value>A <see cref="T:System.Windows.FrameworkElementFactory" /> that is the parent factory.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Parent"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="RemoveHandler">
@@ -407,15 +365,7 @@
       <Docs>
         <summary>Gets or sets the text string to produce.</summary>
         <value>The text string to produce.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Text"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <Member MemberName="Type">
@@ -433,15 +383,7 @@
       <Docs>
         <summary>Gets or sets the type of the objects this factory produces.</summary>
         <value>The type of the objects this factory produces.</value>
-        <remarks>
-          <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_Type"></a>   
-## XAML Text Usage  
- ]]></format>
-        </remarks>
+        <remarks>To be added.</remarks>
       </Docs>
     </Member>
     <MemberGroup MemberName="AddHandler">

--- a/xml/System.Windows/FreezableCollection`1.xml
+++ b/xml/System.Windows/FreezableCollection`1.xml
@@ -66,10 +66,6 @@
   
 -   Any child elements of the collection in either of the above scenarios must be of the type of either the implemented constraint, or as specified by .  
   
-<a name="xamlTextUsage_FreezableCollection_g"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows/GridLengthConverter.xml
+++ b/xml/System.Windows/GridLengthConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  <xref:System.Windows.GridLengthConverter> supports conversion to and from the following types: <xref:System.String>, <xref:System.Decimal>, <xref:System.Single>, <xref:System.Double>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>.  
   
-<a name="XAMLTextUsage_GridLengthConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.GridLength" />

--- a/xml/System.Windows/Int32RectConverter.xml
+++ b/xml/System.Windows/Int32RectConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of other types to and from an <see cref="T:System.Windows.Int32Rect" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_Int32RectConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/KeySplineConverter.xml
+++ b/xml/System.Windows/KeySplineConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of other types to and from a <see cref="T:System.Windows.Media.Animation.KeySpline" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_KeySplineConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Windows.Media.Animation.KeySpline" />
   </Docs>
   <Members>

--- a/xml/System.Windows/KeyTimeConverter.xml
+++ b/xml/System.Windows/KeyTimeConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of <see cref="T:System.Windows.Media.Animation.KeyTime" /> to and from other types.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_KeyTimeConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Windows.Media.Animation.KeyTime" />
   </Docs>
   <Members>

--- a/xml/System.Windows/LengthConverter.xml
+++ b/xml/System.Windows/LengthConverter.xml
@@ -18,10 +18,6 @@
 ## Remarks  
  <xref:System.Windows.LengthConverter> supports conversion to and from the following types: <xref:System.String>, <xref:System.Decimal>, <xref:System.Single>, <xref:System.Double>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, and <xref:System.UInt64>.  
   
-<a name="XAMLTextUsage_LengthConverter"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example shows how to create and use an instance of the <xref:System.Windows.LengthConverter> object. A custom method called `ChangeLeft` is defined, which converts the content of a <xref:System.Windows.Controls.ListBoxItem> (defined in a separate [!INCLUDE[TLA#tla_xaml](~/includes/tlasharptla-xaml-md.md)] file) to an instance of <xref:System.Double>, and later into a <xref:System.String>. This method passes the <xref:System.Windows.Controls.ListBoxItem> to a <xref:System.Windows.LengthConverter> object, which converts the <xref:System.Windows.Controls.ListBoxItem> <xref:System.Windows.Controls.ContentControl.Content%2A> to an instance of <xref:System.Double>. Notice that this value has already been converted to a <xref:System.String> by using the <xref:System.Windows.Controls.Control.ToString%2A> method. This value is then passed back to the <xref:System.Windows.Controls.Canvas.SetLeft%2A> method and the <xref:System.Windows.Controls.Canvas.GetLeft%2A> method of the <xref:System.Windows.Controls.Canvas> in order to change the position of the `text1` object.  
   

--- a/xml/System.Windows/NameScope.xml
+++ b/xml/System.Windows/NameScope.xml
@@ -46,8 +46,6 @@
   
  Names in a XAML namescope must use a particular grammar that restricts the strings you might use for inputs of <xref:System.Windows.NameScope> API. See [XamlName Grammar](~/docs/framework/xaml-services/xamlname-grammar.md).  
   
-<a name="xamlTextUsage_NameScope"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Markup.INameScope" />

--- a/xml/System.Windows/NullableBoolConverter.xml
+++ b/xml/System.Windows/NullableBoolConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The Nullable\<bool> type is used for selection state in certain controls. This converter enables that non-set attribute values do not mean either `true` or `false` but instead mean an unset state.  
   
-<a name="XAMLTextUsage_NullableBoolConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="P:System.Windows.Window.DialogResult" />

--- a/xml/System.Windows/PointConverter.xml
+++ b/xml/System.Windows/PointConverter.xml
@@ -15,12 +15,6 @@
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
-## Remarks  
-  
-<a name="XAMLTextUsage_PointConverter"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following code example uses a <xref:System.Windows.PointConverter> to convert a string into a <xref:System.Windows.Point>.  
   

--- a/xml/System.Windows/PropertyPathConverter.xml
+++ b/xml/System.Windows/PropertyPathConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  A <xref:System.Windows.PropertyPath> is used to specify type and property paths to objects involved in a binding, or for storyboard target property paths.  
   
-<a name="XAMLTextUsage_PropertyPathConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
   </Docs>

--- a/xml/System.Windows/ResourceDictionary.xml
+++ b/xml/System.Windows/ResourceDictionary.xml
@@ -467,10 +467,6 @@ The invalidations happen when an implicit data template resource changes.</summa
   
  You do not use indexers to define collection members in [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)]. Instead, you create child elements in markup. The child elements are either child elements of <xref:System.Windows.ResourceDictionary>, or of a property element where the property type is `ResourceDictionary`. For details, see the [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] usage sections in <xref:System.Windows.ResourceDictionary>.  
   
-<a name="xamlTextUsage_Item"></a>   
-## XAML Text Usage  
- See Remarks.  
-  
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/System.Windows/SizeConverter.xml
+++ b/xml/System.Windows/SizeConverter.xml
@@ -18,8 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.SizeConverter> class supports conversion of <xref:System.String> values and base values that the <xref:System.ComponentModel.TypeConverter> class supports.  
   
-<a name="XAMLTextUsage_SizeConverter"></a>   
-## XAML Text Usage  
  ]]></format>
     </remarks>
     <altmember cref="T:System.Windows.Size" />

--- a/xml/System.Windows/StaticResourceExtension.xml
+++ b/xml/System.Windows/StaticResourceExtension.xml
@@ -29,11 +29,7 @@
  `{StaticResource}` is a markup extension that is specific to the WPF implementation of XAML. You can use `{StaticResource}` when referencing the default XAML namespace for WPF, without using a prefix. In contrast, markup extensions that are defined for XAML language support (such as `{x:Type}`) require the prefix for the XAML language XAML namespace in the usage. For more information, see [Markup Extensions and WPF XAML](~/docs/framework/wpf/advanced/markup-extensions-and-wpf-xaml.md).  
   
  Static resource references are generally used in XAML whenever a [DynamicResource Markup Extension](~/docs/framework/wpf/advanced/dynamicresource-markup-extension.md) is not explicitly necessary.  
-  
-<a name="xamlTextUsage_StaticResourceExtension"></a>   
-## XAML Text Usage  
- See Remarks  
-  
+    
  ]]></format>
     </remarks>
   </Docs>
@@ -142,8 +138,6 @@
 ## Remarks  
  For [!INCLUDE[TLA2#tla_xaml](~/includes/tla2sharptla-xaml-md.md)] usage information, see [StaticResource Markup Extension](~/docs/framework/wpf/advanced/staticresource-markup-extension.md).  
   
-<a name="xamlTextUsage_ResourceKey"></a>   
-## XAML Text Usage  
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentNullException">Specified value as <see langword="null" />, either through markup extension usage or explicit construction.</exception>

--- a/xml/System.Windows/StrokeCollectionConverter.xml
+++ b/xml/System.Windows/StrokeCollectionConverter.xml
@@ -18,10 +18,6 @@
 ## Remarks  
  The <xref:System.Windows.StrokeCollectionConverter> converts a <xref:System.Windows.Ink.StrokeCollection> to a string that represents the <xref:System.Windows.Ink.StrokeCollection> in base-64, encoded Ink Serialized Format (ISF). It is useful to store ink data as base-64, encoded ISF when it is not possible to store raw byte data, such as in Web pages.  
   
-<a name="XAMLTextUsage_StrokeCollectionConverter"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example demonstrates how to convert a base-64, encoded ISF string to a <xref:System.Windows.Ink.StrokeCollection>. This assumes that there is an <xref:System.Windows.Controls.InkPresenter> called `presenter`.  
   

--- a/xml/System.Windows/TemplateBindingExpressionConverter.xml
+++ b/xml/System.Windows/TemplateBindingExpressionConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>A type converter that is used to construct a markup extension from a <see cref="T:System.Windows.TemplateBindingExpression" /> instance during serialization.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_TemplateBindingExpressionConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/TemplateBindingExtensionConverter.xml
+++ b/xml/System.Windows/TemplateBindingExtensionConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>A type converter that is used to construct a <see cref="T:System.Windows.TemplateBindingExtension" /> from an instance during serialization.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_TemplateBindingExtensionConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/TemplateContentLoader.xml
+++ b/xml/System.Windows/TemplateContentLoader.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Implements <see cref="T:System.Xaml.XamlDeferringLoader" /> in order to defer loading of the XAML content that is defined for a template in WPF XAML.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="xamlTextUsage_TemplateContentLoader"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/TextDecorationCollectionConverter.xml
+++ b/xml/System.Windows/TextDecorationCollectionConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of <see cref="T:System.Windows.TextDecorationCollection" /> from other data types.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_TextDecorationCollectionConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Windows/ThicknessConverter.xml
+++ b/xml/System.Windows/ThicknessConverter.xml
@@ -12,15 +12,7 @@
   <Interfaces />
   <Docs>
     <summary>Converts instances of other types to and from instances of <see cref="T:System.Windows.Thickness" />.</summary>
-    <remarks>
-      <format type="text/markdown"><![CDATA[  
-  
-## Remarks  
-  
-<a name="XAMLTextUsage_ThicknessConverter"></a>   
-## XAML Text Usage  
- ]]></format>
-    </remarks>
+    <remarks>To be added.</remarks>
     <altmember cref="T:System.Windows.Thickness" />
   </Docs>
   <Members>

--- a/xml/System.Windows/UIElement.xml
+++ b/xml/System.Windows/UIElement.xml
@@ -10919,10 +10919,6 @@ Image with an Elliptical Clip Region
   
  A more common scenario is handling the <xref:System.Windows.FrameworkElement.SizeChanged> event with the class handler override or the <xref:System.Windows.UIElement.OnRenderSizeChanged%2A> event.  
   
-<a name="xamlTextUsage_RenderSize"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example shows how a custom adorner uses the <xref:System.Windows.UIElement.RenderSize%2A> value in order to create and size the rectangle graphic that defines the adorner, as part of its <xref:System.Windows.UIElement.OnRender%2A> implementation.  
   

--- a/xml/System.Windows/VectorConverter.xml
+++ b/xml/System.Windows/VectorConverter.xml
@@ -15,12 +15,6 @@
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
-## Remarks  
-  
-<a name="XAMLTextUsage_VectorConverter"></a>   
-## XAML Text Usage  
-   
-  
 ## Examples  
  The following example uses a <xref:System.Windows.VectorConverter> to convert a string into a <xref:System.Windows.Vector>.  
   


### PR DESCRIPTION
Fixes #3957

I'm either removing the completely empty sections or the ones that just say See remarks, since that was already inside remarks anyway. Before I totally resolve that issue, I wanna see if I can get access to our old CMS to double check we didn't have any data loss between the multiple migrations.