### PR TITLE
fix OS name

### DIFF
--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -22,7 +22,7 @@ You may have arrived on this page after trying to run an application and seeing 
 The .NET Framework 4.7.1 is included with:
 
 * [Windows 10 Fall Creators Update (version 1709)](https://www.microsoft.com/software-download/windows10)
-* [Windows Server (version 1709)](https://docs.microsoft.com/windows-server/get-started/get-started-with-1709)
+* [Windows Server, version 1709](https://docs.microsoft.com/windows-server/get-started/get-started-with-1709)
 
 > [!div class="button"]
 [Download .NET Framework 4.7.1](https://www.microsoft.com/net/download/thank-you/net471?utm_source=ms-docs&utm_medium=referral)

--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -4,7 +4,7 @@ description: Learn how to install the .NET Framework on Windows 10 or Windows Se
 author: rlander
 ms.author: mairaw
 keywords: .NET Framework, Install
-ms.date: 11/17/2017
+ms.date: 12/20/2017
 ms.topic: article
 ms.custom: "updateeachrelease"
 ms.prod: .net-framework
@@ -22,7 +22,7 @@ You may have arrived on this page after trying to run an application and seeing 
 The .NET Framework 4.7.1 is included with:
 
 * [Windows 10 Fall Creators Update (version 1709)](https://www.microsoft.com/software-download/windows10)
-* [Windows Server 2016 (version 1709)](https://docs.microsoft.com/windows-server/get-started/get-started-with-1709)
+* [Windows Server (version 1709)](https://docs.microsoft.com/windows-server/get-started/get-started-with-1709)
 
 > [!div class="button"]
 [Download .NET Framework 4.7.1](https://www.microsoft.com/net/download/thank-you/net471?utm_source=ms-docs&utm_medium=referral)


### PR DESCRIPTION
Anonymous feedback: "There is no such thing as Windows Server 2016 (version 1709); it should be Windows Server, version 1709"

https://docs.microsoft.com/en-us/dotnet/framework/install/on-windows-10

/cc @rpetrusha @vivmishra
