### PR TITLE
"MultiSubnetfailover" is no longer required

### DIFF
--- a/docs/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery.md
+++ b/docs/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery.md
@@ -36,6 +36,9 @@ This topic discusses SqlClient support (added in [!INCLUDE[net_v45](../../../../
 1.  <xref:System.Data.SqlClient.SqlConnectionStringBuilder.ApplicationIntent%2A>  
   
 2.  <xref:System.Data.SqlClient.SqlConnectionStringBuilder.MultiSubnetFailover%2A>  
+
+> [!NOTE]
+>  Specifying `MultiSubnetFailover` is not required with [!INCLUDE[net_v461](../../../../../includes/net-v461-md.md)]) or later.
   
 ## Connecting With MultiSubnetFailover  
  Always specify `MultiSubnetFailover=True` when connecting to a [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] 2012 availability group listener or [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] 2012 Failover Cluster Instance. `MultiSubnetFailover` enables faster failover for all Availability Groups and or Failover Cluster Instance in [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] 2012 and will significantly reduce failover time for single and multi-subnet AlwaysOn topologies. During a multi-subnet failover, the client will attempt connections in parallel. During a subnet failover, will aggressively retry the TCP connection.  

--- a/docs/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery.md
+++ b/docs/framework/data/adonet/sql/sqlclient-support-for-high-availability-disaster-recovery.md
@@ -38,7 +38,7 @@ This topic discusses SqlClient support (added in [!INCLUDE[net_v45](../../../../
 2.  <xref:System.Data.SqlClient.SqlConnectionStringBuilder.MultiSubnetFailover%2A>  
 
 > [!NOTE]
->  Specifying `MultiSubnetFailover` is not required with [!INCLUDE[net_v461](../../../../../includes/net-v461-md.md)]) or later.
+>  Setting `MultiSubnetFailover` to `true` isn't required with [!INCLUDE[net_v461](../../../../../includes/net-v461-md.md)]) or later versions.
   
 ## Connecting With MultiSubnetFailover  
  Always specify `MultiSubnetFailover=True` when connecting to a [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] 2012 availability group listener or [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] 2012 Failover Cluster Instance. `MultiSubnetFailover` enables faster failover for all Availability Groups and or Failover Cluster Instance in [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] 2012 and will significantly reduce failover time for single and multi-subnet AlwaysOn topologies. During a multi-subnet failover, the client will attempt connections in parallel. During a subnet failover, will aggressively retry the TCP connection.  


### PR DESCRIPTION
See this blog post https://blogs.msdn.microsoft.com/dotnet/2015/11/30/net-framework-4-6-1-is-now-available/ - this key is not required with .NET 4.6.1 or later
