### PR TITLE
Fixing small typo in expression tree docs

### DIFF
--- a/docs/csharp/expression-trees-summary.md
+++ b/docs/csharp/expression-trees-summary.md
@@ -41,7 +41,7 @@ still work the same when new language features are introduced.
 
 Even with these limitations, expression trees do enable you to
 create dynamic algorithms that rely on interpreting and modifying
-code that is represetned as a data structure. It's a powerful
+code that is represented as a data structure. It's a powerful
 tool, and it's one of the features of the .NET ecosystem that
 enables rich libraries such as Entity Framework to accomplish
 what they do.


### PR DESCRIPTION
Fixing a small typo.