### PR TITLE
Error on line 29

### DIFF
--- a/docs/framework/wcf/feature-details/caching-support-for-wcf-web-http-services.md
+++ b/docs/framework/wcf/feature-details/caching-support-for-wcf-web-http-services.md
@@ -26,7 +26,8 @@ ms.workload:
  [!INCLUDE[netfx40_short](../../../../includes/netfx40-short-md.md)] introduces a new attribute called <xref:System.ServiceModel.Web.AspNetCacheProfileAttribute> that allows you to specify a cache profile name. This attribute is applied to a service operation. The following example applies the <xref:System.ServiceModel.Activation.AspNetCompatibilityRequirementsAttribute> to a service to enable ASP.NET compatibility and configures the `GetCustomer` operation for caching. The <!--zz<xref:System.ServiceModel.Activation.AspNetCacheProfileAttribute>--> `System.ServiceModel.Activation.AspNetCacheProfileAttribute` attribute specifies a cache profile that contains the cache settings to be used.  
   
 ```csharp
-[ServiceContract] AspNetCompatibilityRequirements(RequirementsMode=AspNetCompatibilityRequirementsMode.Allowed)]
+[ServiceContract] 
+[AspNetCompatibilityRequirements(RequirementsMode=AspNetCompatibilityRequirementsMode.Allowed)]
 public class Service
 {
     [WebGet(UriTemplate = "{id}")]


### PR DESCRIPTION
AspNetCompatibilityRequirements without [ and in the same line of ServiceContract. Added new line with correct code.

# AspNetCompatibilityRequirements without [

Added new line with correct code: [AspNetCompatibilityRequirements(RequirementsMode=AspNetCompatibilityRequirementsMode.Allowed)]

