### PR TITLE
Make the last section header look like a header

### DIFF
--- a/docs/csharp/whats-new/csharp-7-2.md
+++ b/docs/csharp/whats-new/csharp-7-2.md
@@ -64,7 +64,7 @@ For example:
 int binaryValue = 0b_0101_0101;
 ```
 
-## `private protected`
+## _private protected_ access modifier
 
 Finally, a new compound access modifier: `private protected` indicates that a member may be
 accessed by containing class or derived classes that are declared in the same assembly. While `protected internal`


### PR DESCRIPTION
# Make the last section header ('private protected') look like a header in this document: https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-2


## Summary

Make the last section header ('private protected') look like a header in this document: https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-2