### PR TITLE
Extend sample with check for 4.7.1 version in cs and vb code snippets.

### DIFF
--- a/samples/snippets/csharp/framework/migration-guide/versions-installed3.cs
+++ b/samples/snippets/csharp/framework/migration-guide/versions-installed3.cs
@@ -26,8 +26,10 @@ public class GetDotNetVersion
    // Checking the version using >= will enable forward compatibility.
    private static string CheckFor45PlusVersion(int releaseKey)
    {
+      if (releaseKey >= 461308)
+         return "4.7.1 or later";
       if (releaseKey >= 460798)
-         return "4.7 or later";
+         return "4.7";
       if (releaseKey >= 394802)
          return "4.6.2";
       if (releaseKey >= 394254) {

--- a/samples/snippets/visualbasic/framework/migration-guide/versions-installed3.vb
+++ b/samples/snippets/visualbasic/framework/migration-guide/versions-installed3.vb
@@ -19,10 +19,12 @@ Public Module GetDotNetVersion
 
    ' Checking the version using >= will enable forward compatibility.
    Private Function CheckFor45PlusVersion(releaseKey As Integer) As String
-      If releaseKey >= 460798 Then
-         Return "4.7 or later"
+      If releaseKey >= 461308 Then
+         Return "4.7.1 or later"
+      Else If releaseKey >= 460798 Then
+         Return "4.7"
       Else If releaseKey >= 394802 Then
-         Return "4.6.2 or later"
+         Return "4.6.2"
       Else If releaseKey >= 394254 Then 
          Return "4.6.1"
       Else If releaseKey >= 393295 Then


### PR DESCRIPTION
# Title
Extend code with check for 4.7.1 version in cs and vb code snippets.

## Summary
Updated code with releaseKey check for framework version 4.7.1 based on table provided in document [How to: Determine Which .NET Framework Versions Are Installed](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#net_d)

## Details

I updated code snippets to reflect Values of the Release DWORD provided in document [How to: Determine Which .NET Framework Versions Are Installed](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#net_d).
