### PR TITLE
Remove hyperlink markup code mixed into code examples

### DIFF
--- a/docs/framework/tools/signtool-exe.md
+++ b/docs/framework/tools/signtool-exe.md
@@ -176,7 +176,7 @@ signtool sign /f MyCert.pfx /p MyPassword MyFile.exe
  The following command digitally signs and time-stamps a file. The certificate used to sign the file is stored in a PFX file.  
   
 ```  
-signtool sign /f MyCert.pfx /t  HYPERLINK "http://timestamp.verisign.com/scripts/timstamp.dll" http://timestamp.verisign.com/scripts/timstamp.dll MyFile.exe  
+signtool sign /f MyCert.pfx /t http://timestamp.verisign.com/scripts/timstamp.dll MyFile.exe  
 ```  
   
  The following command signs a file by using a certificate located in the `My` store that has a subject name of `My Company Certificate`.  
@@ -194,7 +194,7 @@ Signtool sign /f MyCert.pfx /d: "MyControl" /du http://www.example.com/MyControl
  The following command time-stamps a file that has already been digitally signed.  
   
 ```  
-signtool timestamp /t  HYPERLINK "http://timestamp.verisign.com/scripts/timstamp.dll" http://timestamp.verisign.com/scripts/timstamp.dll MyFile.exe  
+signtool timestamp /t http://timestamp.verisign.com/scripts/timstamp.dll MyFile.exe  
 ```  
   
  The following command verifies that a file has been signed.  


### PR DESCRIPTION
# Title

Remove hyperlink markup code mixed into code examples

## Summary

It looks like some formatting markup got into the code examples.  This makes the example code not valid.

## Details

Removing them.
