### PR TITLE
Fix syntax highlightings for events

### DIFF
--- a/docs/csharp/programming-guide/events/how-to-implement-custom-event-accessors.md
+++ b/docs/csharp/programming-guide/events/how-to-implement-custom-event-accessors.md
@@ -22,24 +22,24 @@ An event is a special kind of multicast delegate that can only be invoked from w
 ## Example  
  The following example shows how to implement custom add and remove event accessors. Although you can substitute any code inside the accessors, we recommend that you lock the event before you add or remove a new event handler method.  
   
-```  
+```csharp
 event EventHandler IDrawingObject.OnDraw  
+{  
+    add  
+    {  
+        lock (PreDrawEvent)  
         {  
-            add  
-            {  
-                lock (PreDrawEvent)  
-                {  
-                    PreDrawEvent += value;  
-                }  
-            }  
-            remove  
-            {  
-                lock (PreDrawEvent)  
-                {  
-                    PreDrawEvent -= value;  
-                }  
-            }  
+            PreDrawEvent += value;  
         }  
+    }  
+    remove  
+    {  
+        lock (PreDrawEvent)  
+        {  
+            PreDrawEvent -= value;  
+        }  
+    }  
+}  
 ```  
   
 ## See Also  

--- a/docs/csharp/programming-guide/events/how-to-implement-interface-events.md
+++ b/docs/csharp/programming-guide/events/how-to-implement-interface-events.md
@@ -20,7 +20,7 @@ An [interface](../../../csharp/language-reference/keywords/interface.md) can dec
   
 -   Declare the event in your class and then invoke it in the appropriate areas.  
   
-    ```  
+    ```csharp
     namespace ImplementInterfaceEvents  
     {  
         public interface IDrawingObject  

--- a/docs/csharp/programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md
+++ b/docs/csharp/programming-guide/events/how-to-subscribe-to-and-unsubscribe-from-events.md
@@ -31,7 +31,7 @@ You subscribe to an event that is published by another class when you want to wr
   
      The line of code that is required to subscribe to the event is also automatically generated in the `InitializeComponent` method in the Form1.Designer.cs file in your project. It resembles this:  
   
-    ```  
+    ```csharp
     this.Load += new System.EventHandler(this.Form1_Load);  
     ```  
   
@@ -39,7 +39,7 @@ You subscribe to an event that is published by another class when you want to wr
   
 1.  Define an event handler method whose signature matches the delegate signature for the event. For example, if the event is based on the <xref:System.EventHandler> delegate type, the following code represents the method stub:  
   
-    ```  
+    ```csharp
     void HandleCustomEvent(object sender, CustomEventArgs a)  
     {  
        // Do something useful here.  
@@ -48,19 +48,19 @@ You subscribe to an event that is published by another class when you want to wr
   
 2.  Use the addition assignment operator (`+=`) to attach your event handler to the event. In the following example, assume that an object named `publisher` has an event named `RaiseCustomEvent`. Note that the subscriber class needs a reference to the publisher class in order to subscribe to its events.  
   
-    ```  
+    ```csharp
     publisher.RaiseCustomEvent += HandleCustomEvent;  
     ```  
   
      Note that the previous syntax is new in C# 2.0. It is exactly equivalent to the C# 1.0 syntax in which the encapsulating delegate must be explicitly created by using the `new` keyword:  
   
-    ```  
+    ```csharp
     publisher.RaiseCustomEvent += new CustomEventHandler(HandleCustomEvent);  
     ```  
   
      An event handler can also be added by using a lambda expression:  
   
-    ```  
+    ```csharp
     public Form1()  
     {  
         InitializeComponent();  
@@ -76,7 +76,7 @@ You subscribe to an event that is published by another class when you want to wr
   
 -   If you will not have to unsubscribe to an event later, you can use the addition assignment operator (`+=`) to attach an anonymous method to the event. In the following example, assume that an object named `publisher` has an event named `RaiseCustomEvent` and that a `CustomEventArgs` class has also been defined to carry some kind of specialized event information. Note that the subscriber class needs a reference to `publisher` in order to subscribe to its events.  
   
-    ```  
+    ```csharp
     publisher.RaiseCustomEvent += delegate(object o, CustomEventArgs e)  
     {  
       string s = o.ToString() + " " + e.ToString();  
@@ -93,7 +93,7 @@ You subscribe to an event that is published by another class when you want to wr
   
 -   Use the subtraction assignment operator (`-=`) to unsubscribe from an event:  
   
-    ```  
+    ```csharp
     publisher.RaiseCustomEvent -= HandleCustomEvent;  
     ```  
   


### PR DESCRIPTION
Just added C# syntax highlighting to snippets

Same as #4018 (I deleted my repo before checks were done)
(is there an easier way to reopen a pr?)