### PR TITLE
Fixed link to ".NET Framework 4.5"

### DIFF
--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -29,7 +29,7 @@ ms.workload:
 [.NET 2015 and .NET Framework 4.6](#v46)   
 [.NET Framework 4.5.2](#v452)   
 [.NET Framework 4.5.1](#v451)   
-[.NET Framework 4.5](#core)   
+[.NET Framework 4.5](#v45)   
 
 This article does not provide comprehensive information about each new feature and is subject to change. For general information about the .NET Framework, see [Getting Started](../../../docs/framework/get-started/index.md). For supported platforms, see [System Requirements](~/docs/framework/get-started/system-requirements.md). For download links and installation instructions, see [Installation Guide](../../../docs/framework/install/guide-for-developers.md).
 
@@ -1292,7 +1292,7 @@ For more information on the <xref:System.TimeZoneInfo> structure and time zone a
 
  [Back to top](#introduction)
 
-<a name="core"></a> 
+<a name="v45"></a> 
 ## What's new in the .NET Framework 4.5
 
 ### Core new features and improvements


### PR DESCRIPTION
# Title
Fixed link to ".NET Framework 4.5"

## Summary
The link to ".NET Framework 4.5" was pointing to "#core" which directed to the "Core" section in "What's new in the .NET Framework 4.7.1". Created new "#v45" in order to be consistent with nomenclature.

## Details

See above.

## Suggested Reviewers

I am not sure who should review, this is my first pull request.
