### PR TITLE
Fixed broken link in .NET Native docs

### DIFF
--- a/docs/framework/net-native/index.md
+++ b/docs/framework/net-native/index.md
@@ -45,7 +45,7 @@ ms.workload:
 -   Optimized app memory usage.  
 
 > [!IMPORTANT]
-> For the vast majority of apps and scenarios, .NET Native offers significantly faster startup times and superior performance when compared to an app compiled to IL or to an NGEN image. However, your results may vary. To ensure that your app has benefited from the performance enhancements of .NET Native, you should compare its performance with that of the non-.NET Native version of your app. For more information, see [Performance Session Overview](https:/docs.microsoft.com/visualstudio/profiling/performance-session-overview).
+> For the vast majority of apps and scenarios, .NET Native offers significantly faster startup times and superior performance when compared to an app compiled to IL or to an NGEN image. However, your results may vary. To ensure that your app has benefited from the performance enhancements of .NET Native, you should compare its performance with that of the non-.NET Native version of your app. For more information, see [Performance Session Overview](https://docs.microsoft.com/visualstudio/profiling/performance-session-overview).
  
 But [!INCLUDE[net_native](../../../includes/net-native-md.md)] involves more than a compilation to native code. It transforms the way that .NET Framework apps are built and executed. In particular:  
   


### PR DESCRIPTION
# Fixed broken link in .NET Native docs

The URL in the link to [Performance Session Overview](https://docs.microsoft.com/en-us/visualstudio/profiling/performance-session-overview) was badly formed.


## Suggested Reviewers

@BillWagner 
