### PR TITLE
Remove useless ` char on WebUtility.xml docs

### DIFF
--- a/xml/System.Net/WebUtility.xml
+++ b/xml/System.Net/WebUtility.xml
@@ -351,13 +351,13 @@
   
  URL encoding replaces all character codes except for letters, numbers, and the following punctuation characters:  
   
--   `-` (minus sign`)`  
+-   `-` (minus sign)  
   
--   `_` (underscore`)`  
+-   `_` (underscore)  
   
--   `.` (period`)`  
+-   `.` (period)  
   
--   `!` (exclamation point`)`  
+-   `!` (exclamation point)  
   
 -   \* (asterisk)  
   


### PR DESCRIPTION
# Remove useless ` char on WebUtility.xml docs

## Summary

` char is used for close parenthesis and is interpreted as <code> balise in html mode 
