### PR TITLE
Introduction to classes - fix argument's list, code formatting

### DIFF
--- a/docs/csharp/quick-starts/introduction-to-classes.md
+++ b/docs/csharp/quick-starts/introduction-to-classes.md
@@ -64,7 +64,7 @@ namespace classes
         {
         }
 
-        public void MakeWithdrawal(decimal amount, DateTime date, string payee, string note)
+        public void MakeWithdrawal(decimal amount, DateTime date, string note)
         {
         }
     }

--- a/docs/csharp/quick-starts/introduction-to-classes.md
+++ b/docs/csharp/quick-starts/introduction-to-classes.md
@@ -164,9 +164,11 @@ Next, test that you are catching error conditions by trying to create an account
 
 ```csharp
 // Test that the initial balances must be positive:
-try {
+try
+{
     var invalidAccount = new BankAccount("invalid", -55);
-} catch (ArgumentOutOfRangeException e)
+}
+catch (ArgumentOutOfRangeException e)
 {
     Console.WriteLine("Exception caught creating account with negative balance");
     Console.WriteLine(e.ToString());
@@ -177,9 +179,11 @@ You use the [`try` and `catch` statements](../language-reference/keywords/try-ca
 
 ```csharp
 // Test for a negative balance
-try {
+try
+{
     account.MakeWithdrawal(750, DateTime.Now, "Attempt to overdraw");
-} catch (InvalidOperationException e)
+}
+catch (InvalidOperationException e)
 {
     Console.WriteLine("Exception caught trying to overdraw");
     Console.WriteLine(e.ToString());

--- a/samples/csharp/classes-quickstart/BankAccount.cs
+++ b/samples/csharp/classes-quickstart/BankAccount.cs
@@ -13,8 +13,11 @@ namespace classes
             get
             {
                 decimal balance = 0;
-                foreach(var item in allTransactions)
+                foreach (var item in allTransactions)
+                {
                     balance += item.Amount;
+                }
+
                 return balance;
             }
         }
@@ -26,7 +29,7 @@ namespace classes
         {
             this.Number = accountNumberSeed.ToString();
             accountNumberSeed++;
-            
+
             this.Owner = name;
             MakeDeposit(initialBalance, DateTime.Now, "Initial balance");
         }
@@ -40,7 +43,9 @@ namespace classes
         public void MakeDeposit(decimal amount, DateTime date, string note)
         {
             if (amount <= 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(amount), "Amount of deposit must be positive");
+            }
             var deposit = new Transaction(amount, date, note);
             allTransactions.Add(deposit);
         }
@@ -48,9 +53,13 @@ namespace classes
         public void MakeWithdrawal(decimal amount, DateTime date, string note)
         {
             if (amount <= 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(amount), "Amount of withdrawal must be positive");
+            }
             if (Balance - amount < 0)
+            {
                 throw new InvalidOperationException("Not sufficient funds for this withdrawal");
+            }
             var withdrawal = new Transaction(-amount, date, note);
             allTransactions.Add(withdrawal);
         }
@@ -63,7 +72,9 @@ namespace classes
 
             report.AppendLine("Date\t\tAmount\tNote");
             foreach (var item in allTransactions)
+            {
                 report.AppendLine($"{item.Date.ToShortDateString()}\t{item.Amount}\t{item.Notes}");
+            }
 
             return report.ToString();
         }

--- a/samples/csharp/classes-quickstart/Program.cs
+++ b/samples/csharp/classes-quickstart/Program.cs
@@ -17,23 +17,26 @@ namespace classes
             Console.WriteLine(account.GetAccountHistory());
 
             // Test that the initial balances must be positive:
-            try {
+            try
+            {
                 var invalidAccount = new BankAccount("invalid", -55);
-            } catch (ArgumentOutOfRangeException e)
+            }
+            catch (ArgumentOutOfRangeException e)
             {
                 Console.WriteLine("Exception caught creating account with negative balance");
                 Console.WriteLine(e.ToString());
             }
 
             // Test for a negative balance
-            try {
+            try
+            {
                 account.MakeWithdrawal(750, DateTime.Now, "Attempt to overdraw");
-            } catch (InvalidOperationException e)
+            }
+            catch (InvalidOperationException e)
             {
                 Console.WriteLine("Exception caught trying to overdraw");
                 Console.WriteLine(e.ToString());
             }
-
         }
     }
 }

--- a/samples/csharp/classes-quickstart/transaction.cs
+++ b/samples/csharp/classes-quickstart/transaction.cs
@@ -7,6 +7,7 @@ namespace classes
         public decimal Amount { get; }
         public DateTime Date { get; }
         public string Notes { get; }
+
         public Transaction(decimal amount, DateTime date, string note)
         {
             this.Amount = amount;


### PR DESCRIPTION
## Details

Argument's list in the initial definition of `MakeWithdrawal` method was different than later one when implementations of method's body was provided. It could result in unnecessary compilation error if user adds only implementation of the body and try tests provided in tutorial.

  