### PR TITLE
Minor fix

### DIFF
--- a/xml/System.Data.SqlClient/SqlConnection.xml
+++ b/xml/System.Data.SqlClient/SqlConnection.xml
@@ -33,7 +33,7 @@
     </Attribute>
   </Attributes>
   <Docs>
-    <summary>Represents an open connection to a SQL Server database. This class cannot be inherited.</summary>
+    <summary>Represents a connection to a SQL Server database. This class cannot be inherited.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
"Represents an open connection to a SQL Server database" is true most of the time with default configurations of ADO.NET.
But if connection pooling is turned off, the connection won't be retrieved from the pool and will only be open after Open() gets called.
