### PR TITLE
Add Examples of Collection Initializers

### DIFF
--- a/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs
+++ b/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs
@@ -7,6 +7,7 @@ namespace ExampleProject
     class FormattedAddresses : IEnumerable<string>
     {
         private List<string> internalList;
+        
         public IEnumerator<string> GetEnumerator()
         {
             return internalList.GetEnumerator();

--- a/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs
+++ b/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ExampleProject
+{
+    class FormattedAddresses : IEnumerable<string>
+    {
+        private List<string> internalList;
+        public IEnumerator<string> GetEnumerator()
+        {
+            return internalList.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return internalList.GetEnumerator();
+        }
+
+        public FormattedAddresses()
+        {
+            internalList = new List<string>();
+        }
+
+        public void Add(string firstname, string lastname, string street, string city, string state, string zipcode)
+        {
+            internalList.Add(
+                $@"{firstname} {lastname}
+{street}
+{city}, {state} {zipcode}"
+            );
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            FormattedAddresses addresses = new FormattedAddresses()
+            {
+                {"John", "Doe", "123 Street", "Topeka", "KS", "00000" },
+                {"Jane", "Smith", "456 Street", "Topeka", "KS", "00000" }
+            };
+
+            Console.WriteLine("Address Entries:");
+
+            foreach(string addressEntry in addresses)
+            {
+                Console.WriteLine("\r\n" + addressEntry);
+            }
+        }
+
+        /*
+         * Prints:
+         
+            Address Entries:
+
+            John Doe
+            123 Street
+            Topeka, KS 00000
+
+            Jane Smith
+            456 Street
+            Topeka, KS 00000
+         */
+    }
+}

--- a/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs
+++ b/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs
@@ -6,31 +6,16 @@ namespace ExampleProject
 {
     class FormattedAddresses : IEnumerable<string>
     {
-        private List<string> internalList;
-        
-        public IEnumerator<string> GetEnumerator()
-        {
-            return internalList.GetEnumerator();
-        }
+        private List<string> internalList = new List<string>();
+        public IEnumerator<string> GetEnumerator() => internalList.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return internalList.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => internalList.GetEnumerator();
 
-        public FormattedAddresses()
-        {
-            internalList = new List<string>();
-        }
-
-        public void Add(string firstname, string lastname, string street, string city, string state, string zipcode)
-        {
-            internalList.Add(
+        public void Add(string firstname, string lastname, string street, string city, string state, string zipcode) => internalList.Add(
                 $@"{firstname} {lastname}
 {street}
 {city}, {state} {zipcode}"
             );
-        }
     }
 
     class Program

--- a/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_8.cs
+++ b/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_8.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ExampleProject
+{
+    class RudimentaryMultiValuedDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, List<TValue>>>
+    {
+        private Dictionary<TKey, List<TValue>> internalDictionary;
+
+        public IEnumerator<KeyValuePair<TKey, List<TValue>>> GetEnumerator()
+        {
+            return internalDictionary.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return internalDictionary.GetEnumerator();
+        }
+
+        public RudimentaryMultiValuedDictionary()
+        {
+            internalDictionary = new Dictionary<TKey, List<TValue>>();
+        }
+
+        public List<TValue> this[TKey key]
+        {
+            get
+            {
+                return internalDictionary[key];
+            }
+            set
+            {
+                Add(key, value);
+            }
+        }
+
+        public void Add(TKey key, params TValue[] values)
+        {
+            Add(key, (IEnumerable<TValue>) values);
+        }
+
+        public void Add(TKey key, IEnumerable<TValue> values)
+        {
+            if (!internalDictionary.TryGetValue(key, out List<TValue> storedValues))
+                internalDictionary.Add(key, storedValues = new List<TValue>());
+
+            storedValues.AddRange(values);
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            RudimentaryMultiValuedDictionary<string, string> rudimentaryMultiValuedDictionary1
+                = new RudimentaryMultiValuedDictionary<string, string>()
+                {
+                    {"Group1", "Bob", "John", "Mary" },
+                    {"Group2", "Eric", "Emily", "Debbie", "Jesse" }
+                };
+            RudimentaryMultiValuedDictionary<string, string> rudimentaryMultiValuedDictionary2
+                = new RudimentaryMultiValuedDictionary<string, string>()
+                {
+                    ["Group1"] = new List<string>() { "Bob", "John", "Mary" },
+                    ["Group2"] = new List<string>() { "Eric", "Emily", "Debbie", "Jesse" }
+                };
+
+            Console.WriteLine("Using first multi-valued dictionary created with a collection initializer:");
+
+            foreach(KeyValuePair<string, List<string>> group in rudimentaryMultiValuedDictionary1)
+            {
+                Console.WriteLine($"\r\nMembers of group {group.Key}: ");
+
+                foreach(string member in group.Value)
+                {
+                    Console.WriteLine(member);
+                }
+            }
+
+            Console.WriteLine("\r\nUsing second multi-valued dictionary created with a collection initializer using indexing:");
+
+            foreach (KeyValuePair<string, List<string>> group in rudimentaryMultiValuedDictionary2)
+            {
+                Console.WriteLine($"\r\nMembers of group {group.Key}: ");
+
+                foreach (string member in group.Value)
+                {
+                    Console.WriteLine(member);
+                }
+            }
+        }
+
+        /*
+         * Prints:
+         
+            Using first multi-valued dictionary created with a collection initializer:
+
+            Members of group Group1:
+            Bob
+            John
+            Mary
+
+            Members of group Group2:
+            Eric
+            Emily
+            Debbie
+            Jesse
+
+            Using second multi-valued dictionary created with a collection initializer using indexing:
+
+            Members of group Group1:
+            Bob
+            John
+            Mary
+
+            Members of group Group2:
+            Eric
+            Emily
+            Debbie
+            Jesse
+         */
+    }
+}

--- a/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_8.cs
+++ b/docs/csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_8.cs
@@ -6,39 +6,19 @@ namespace ExampleProject
 {
     class RudimentaryMultiValuedDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, List<TValue>>>
     {
-        private Dictionary<TKey, List<TValue>> internalDictionary;
+        private Dictionary<TKey, List<TValue>> internalDictionary = new Dictionary<TKey, List<TValue>>();
 
-        public IEnumerator<KeyValuePair<TKey, List<TValue>>> GetEnumerator()
-        {
-            return internalDictionary.GetEnumerator();
-        }
+        public IEnumerator<KeyValuePair<TKey, List<TValue>>> GetEnumerator() => internalDictionary.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return internalDictionary.GetEnumerator();
-        }
-
-        public RudimentaryMultiValuedDictionary()
-        {
-            internalDictionary = new Dictionary<TKey, List<TValue>>();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => internalDictionary.GetEnumerator();
 
         public List<TValue> this[TKey key]
         {
-            get
-            {
-                return internalDictionary[key];
-            }
-            set
-            {
-                Add(key, value);
-            }
+            get => internalDictionary[key];
+            set => Add(key, value);
         }
 
-        public void Add(TKey key, params TValue[] values)
-        {
-            Add(key, (IEnumerable<TValue>) values);
-        }
+        public void Add(TKey key, params TValue[] values) => Add(key, (IEnumerable<TValue>)values);
 
         public void Add(TKey key, IEnumerable<TValue> values)
         {

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -76,9 +76,19 @@ var numbers = new Dictionary<int, string> {
 };  
 ```  
   
-## Example  
+## Examples
+
+ The following example combines the concepts of object and collection initializers.
+
  [!code-csharp[csProgGuideLINQ#46](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_6.cs)]  
-  
+ Shown in the below example, an object which implements <xref:System.Collections.IEnumerable> containing an `Add` method with multiple parameters allows for collection initializers with multiple elements per item in the list corresponding to the signature of the `Add` method. 
+ 
+ [!code-csharp[csProgGuideLINQ#84](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs)]
+ 
+ `Add` methods can use the `params` keyword to take a variable number of arguments as shown in the following example. This example demonstrates the custom implementation of an indexer as well to initialize a collection using indexes.
+ 
+ [!code-csharp[csProgGuideLINQ#85](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_8.cs)]
+ 
 ## See Also  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [LINQ Query Expressions](../../../csharp/programming-guide/linq-query-expressions/index.md)  

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -81,6 +81,7 @@ var numbers = new Dictionary<int, string> {
  The following example combines the concepts of object and collection initializers.
 
  [!code-csharp[csProgGuideLINQ#46](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_6.cs)]  
+ 
  Shown in the below example, an object which implements <xref:System.Collections.IEnumerable> containing an `Add` method with multiple parameters allows for collection initializers with multiple elements per item in the list corresponding to the signature of the `Add` method. 
  
  [!code-csharp[csProgGuideLINQ#84](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs)]

--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -82,7 +82,7 @@ var numbers = new Dictionary<int, string> {
 
  [!code-csharp[csProgGuideLINQ#46](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_6.cs)]  
  
- Shown in the below example, an object which implements <xref:System.Collections.IEnumerable> containing an `Add` method with multiple parameters allows for collection initializers with multiple elements per item in the list corresponding to the signature of the `Add` method. 
+ Shown in the following example, an object which implements <xref:System.Collections.IEnumerable> containing an `Add` method with multiple parameters allows for collection initializers with multiple elements per item in the list corresponding to the signature of the `Add` method. 
  
  [!code-csharp[csProgGuideLINQ#84](../../../csharp/programming-guide/arrays/codesnippet/CSharp/object-and-collection-initializers_7.cs)]
  


### PR DESCRIPTION
# Add Examples of Collection Initializers

## Summary

1. Added example showing an Add method with multiple parameters and its use with a collection initializer.

2. Added example with Add method using a variable number of parameters along with the use of indexers.

## Details

This change adds two examples to expound upon collection initializers.

The first example demonstrates using multiple parameters in an Add method and how to initialize a collection with multiple entries per item.

In the second example, a variable number of parameters is used with an Add method of a collection. Along with this, the example includes an implementation of an indexer.

## Suggested Reviewers

Current contributors: @mairaw, @svick, @PatrickHofman, @guardrex, @tompratt-AQ, @mjhoffman65, @mikeblome 
