### PR TITLE
Update seedwork-domain-model-base-class-interface

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
@@ -141,7 +141,7 @@ public interface IRepository<T> where T : IAggregateRoot
 ## Additional resources
 
 -   **Martin Fowler. Separated Interface.**
-    [*http://www.martinfowler.com/eaaCatalog/separatedInterface.html*](http://www.martinfowler.com/eaaCatalog/separatedInterface.html%20)
+    [*http://www.martinfowler.com/eaaCatalog/separatedInterface.html*](http://www.martinfowler.com/eaaCatalog/separatedInterface.html)
 
 
 >[!div class="step-by-step"]


### PR DESCRIPTION
Fix martin fowler separatedInterface link.

# Fix link to Martin Fowler blog post

## Summary

Link to Martin Fowler blog post has special character (%20) and have error 404. this error fixes with removes this special character.
