### PR TITLE
Fix typo in System.Buffers namespace doc.

### DIFF
--- a/xml/ns-System.Buffers.xml
+++ b/xml/ns-System.Buffers.xml
@@ -1,6 +1,6 @@
 <Namespace Name="System.Buffers">
   <Docs>
-    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class, which represents a shared resource pool of resusable instances of type <see cref="T:T[]"/>.</summary>
+    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class, which represents a shared resource pool of reusable instances of type <see cref="T:T[]"/>.</summary>
     <remarks>
        <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
## Summary

Fix typo in documentation page of System.Buffers namespace.
