### PR TITLE
added BI metadata

### DIFF
--- a/docs/csharp/quick-starts/branches-and-loops.yml
+++ b/docs/csharp/quick-starts/branches-and-loops.yml
@@ -6,6 +6,8 @@ metadata:
   audience: Developer
   level: Beginner
   ms.custom: mvc
+  ms.prod: .net
+  ms.technology: devlang-csharp
   displayType: two-column
   interactive: csharp
   nextTutorialHref: list-collection

--- a/docs/csharp/quick-starts/hello-world.yml
+++ b/docs/csharp/quick-starts/hello-world.yml
@@ -10,6 +10,8 @@ metadata:
   displayType: two-column
   interactive: csharp
   ms.custom: mvc
+  ms.prod: .net
+  ms.technology: devlang-csharp
 items:
 - durationInMinutes: 1
   content: |

--- a/docs/csharp/quick-starts/list-collection.yml
+++ b/docs/csharp/quick-starts/list-collection.yml
@@ -8,6 +8,8 @@ metadata:
   level: Beginner
   displayType: two-column
   interactive: csharp
+  ms.prod: .net
+  ms.technology: devlang-csharp
 items:
 - durationInMinutes: 1
   content: |

--- a/docs/csharp/quick-starts/numbers-in-csharp.yml
+++ b/docs/csharp/quick-starts/numbers-in-csharp.yml
@@ -10,6 +10,8 @@ metadata:
   nextTutorialTitle: Branches and loops in C#
   displayType: two-column
   interactive: csharp
+  ms.prod: .net
+  ms.technology: devlang-csharp  
 items:
 - durationInMinutes: 1
   content: |


### PR DESCRIPTION
While trying to gather the BI data for @LadyNaggaga, I've noticed that the actual quickstarts are not tagged with ms.prod and ms.technology values, so they didn't show up in my queries.

@BillWagner @EisenbergEffect is it allowed to add that metadata values in the yml files?