### PR TITLE
fix broken links and content dropout

### DIFF
--- a/xml/System.Buffers/ArrayPool`1.xml
+++ b/xml/System.Buffers/ArrayPool`1.xml
@@ -23,7 +23,7 @@
   
 ## Remarks  
   
- Using the <see cref="T:System.Buffers.ArrayPool{T}"/> class to rent and return buffers (using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)"/> and <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)"/> methods) can improve performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.
+ Using the <xref:System.Buffers.ArrayPool%601> class to rent and return buffers (using the <xref:System.Buffers.ArrayPool%601.Rent%2A> and <xref:System.Buffers.ArrayPool%601.Return%2A> methods) can improve performance in situations where arrays are created and destroyed frequently, resulting in significant memory pressure on the garbage collector.
   
  ]]></format>
     </remarks>
@@ -43,13 +43,13 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Initializes a new instance of the <see cref="ArrayPool{T}" /> class.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.Buffers.ArrayPool`1" /> class.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
-Note that this constructor is protected; it can only be called by classes derived from the <see cref="ArrayPool{T}"/> class. 
+Note that this constructor is protected; it can only be called by classes derived from the <xref:System.Buffers.ArrayPool%601> class. 
  ]]></format>
         </remarks>
       </Docs>
@@ -70,8 +70,8 @@ Note that this constructor is protected; it can only be called by classes derive
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Creates a new instance of the <see cref="ArrayPool{T}" /> class.</summary>
-        <returns>A new instance of the <see cref="ArrayPool{T}" /> class.</returns>
+        <summary>Creates a new instance of the <see cref="T:System.Buffers.ArrayPool`1" /> class.</summary>
+        <returns>A new instance of the <see cref="T:System.Buffers.ArrayPool`1" /> class.</returns>
         <remarks>
         </remarks>
       </Docs>
@@ -97,14 +97,14 @@ Note that this constructor is protected; it can only be called by classes derive
       <Docs>
         <param name="maxArrayLength">The maximum length of an array instance that may be stored in the pool.</param>
         <param name="maxArraysPerBucket">The maximum number of array instances that may be stored in each bucket in the pool. The pool groups arrays of similar lengths into buckets for faster access.</param>
-        <summary>Creates a new instance of the <see cref="ArrayPool{T}" /> class using the specifed configuration.</summary>
-        <returns>A new instance of the <see cref="ArrayPool{T}" /> class with the specified configuration.</returns>
+        <summary>Creates a new instance of the <see cref="T:System.Buffers.ArrayPool`1" /> class using the specifed configuration.</summary>
+        <returns>A new instance of the <see cref="T:System.Buffers.ArrayPool`1" /> class with the specified configuration.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
-The instance of the <see cref="ArrayPool{T}"/> class created by this method will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/> in each bucket, and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
+The instance of the <xref:System.Buffers.ArrayPool%601> class created by this method will group arrays into buckets, with no more than `maxArraysPerBucket` in each bucket, and with those arrays not exceeding `maxArrayLength` in length.
  ]]></format>
         </remarks>
       </Docs>
@@ -135,7 +135,7 @@ The instance of the <see cref="ArrayPool{T}"/> class created by this method will
   
 ## Remarks  
 
-This buffer is loaned to the caller and should be returned to the same pool using the <see cref="Return"/> method, so that it can be reused in subsequent calls to the <see cref="Rent"/> method. Failure to return a rented buffer is not a fatal error. However, it may lead to decreased application performance, as the pool may need to create a new buffer to replace the lost one.
+This buffer is loaned to the caller and should be returned to the same pool using the <xref:System.Buffers.ArrayPool%601.Return%2A> method, so that it can be reused in subsequent calls to the <xref:System.Buffers.ArrayPool%601.Rent%2A> method. Failure to return a rented buffer is not a fatal error. However, it may lead to decreased application performance, as the pool may need to create a new buffer to replace the lost one.
  ]]></format>
         </remarks>
       </Docs>
@@ -159,15 +159,15 @@ This buffer is loaned to the caller and should be returned to the same pool usin
         <Parameter Name="clearArray" Type="System.Boolean" />
       </Parameters>
       <Docs>
-        <param name="array">A buffer to return to the pool that was previously obtained using the <see cref="Rent" /> method.</param>
-        <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse. If <paramref name="clearArray" /> is set to <see langword="true" />, and if the pool will store the buffer to enable subsequent reuse, the <see cref="Return" /> method will clear the <paramref name="array" /> of its contents so that a subsequent caller using the <see cref="Rent" /> method will not see the content of the previous caller. If <paramref name="clearArray" /> is set to <see langword="false" /> or if the pool will release the buffer, the array's contents are left unchanged.</param>
-        <summary>Returns an array to the pool that was previously obtained using the <see cref="Rent" /> method on the same <see cref="ArrayPool{T}" /> instance.</summary>
+        <param name="array">A buffer to return to the pool that was previously obtained using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)" /> method.</param>
+        <param name="clearArray">Indicates whether the contents of the buffer should be cleared before reuse. If <paramref name="clearArray" /> is set to <see langword="true" />, and if the pool will store the buffer to enable subsequent reuse, the <see cref="M:System.Buffers.ArrayPool`1.Return(`0[],System.Boolean)" /> method will clear the <paramref name="array" /> of its contents so that a subsequent caller using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)" /> method will not see the content of the previous caller. If <paramref name="clearArray" /> is set to <see langword="false" /> or if the pool will release the buffer, the array's contents are left unchanged.</param>
+        <summary>Returns an array to the pool that was previously obtained using the <see cref="M:System.Buffers.ArrayPool`1.Rent(System.Int32)" /> method on the same <see cref="T:System.Buffers.ArrayPool`1" /> instance.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
 
-Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer and must not use it. The reference returned from a given call to the <see cref="Rent"/> method must only be returned using the <see cref="Return"/> method once. The default <see cref="ArrayPool{T}"/> may hold onto the returned buffer in order to rent it again, or it may release the returned buffer if it's determined that the pool already has enough buffers stored.
+Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer and must not use it. The reference returned from a given call to the <xref:System.Buffers.ArrayPool%601.Rent%2A> method must only be returned using the <xref:System.Buffers.ArrayPool%601.Return%2A> method once. The default <xref:System.Buffers.ArrayPool%601> may hold onto the returned buffer in order to rent it again, or it may release the returned buffer if it's determined that the pool already has enough buffers stored.
  ]]></format>
         </remarks>
       </Docs>
@@ -187,14 +187,14 @@ Once a buffer has been returned to the pool, the caller gives up all ownership o
         <ReturnType>System.Buffers.ArrayPool&lt;T&gt;</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>Gets a shared <see cref="ArrayPool{T}" /> instance.</summary>
-        <value>A shared <see cref="ArrayPool{T}" /> instance.</value>
+        <summary>Gets a shared <see cref="T:System.Buffers.ArrayPool`1" /> instance.</summary>
+        <value>A shared <see cref="T:System.Buffers.ArrayPool`1" /> instance.</value>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
 
-The shared pool provides a default implementation of the <see cref="ArrayPool{T}"/> class that's intended for general applicability. A shared class maintains arrays of multiple sizes, and may hand back a larger array than was actually requested, but it will never hand back a smaller array than was requested. Renting a buffer from a shared class using the <see cref="Rent"/> method will result in an existing buffer being taken from the pool if an appropriate buffer is available or in a new buffer being allocated if one is not available.
+The shared pool provides a default implementation of the <xref:System.Buffers.ArrayPool%601> class that's intended for general applicability. A shared class maintains arrays of multiple sizes, and may hand back a larger array than was actually requested, but it will never hand back a smaller array than was requested. Renting a buffer from a shared class using the <xref:System.Buffers.ArrayPool%601.Rent%2A> method will result in an existing buffer being taken from the pool if an appropriate buffer is available or in a new buffer being allocated if one is not available.
  ]]></format>
         </remarks>
       </Docs>

--- a/xml/ns-System.Buffers.xml
+++ b/xml/ns-System.Buffers.xml
@@ -1,12 +1,12 @@
 <Namespace Name="System.Buffers">
   <Docs>
-    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="ArrayPool{T}"/> class, which represents a shared resource pool of reusable instances of type <see cref="T:T[]"/>.</summary>
+    <summary>The <see cref="N:System.Buffers" /> namespace contains the <see cref="T:System.Buffers.ArrayPool`1" /> class, which represents a shared resource pool of reusable instances of type <see cref="T:T[]"/>.</summary>
     <remarks>
        <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
   
-The <see cref="ArrayPool{T}"/> class, by allocating a shared buffer for array values, can offer significant improvements in performance for apps that make extensive use of arrays.
+The <see cref="T:System.Buffers.ArrayPool`1" /> class, by allocating a shared buffer for array values, can offer significant improvements in performance for apps that make extensive use of arrays.
  ]]></format>
     </remarks>
   </Docs>


### PR DESCRIPTION
Noticed broken links and content dropout in the System.Buffers.* APIs such as https://docs.microsoft.com/en-us/dotnet/api/system.buffers.arraypool-1.create?view=netcore-2.0