### PR TITLE
Fix typo in csharp docs generics intro.

### DIFF
--- a/docs/csharp/programming-guide/generics/introduction-to-generics.md
+++ b/docs/csharp/programming-guide/generics/introduction-to-generics.md
@@ -19,7 +19,7 @@ Generic classes and methods combine reusability, type safety and efficiency in a
   
 -   As the type of a method parameter in the `AddHead` method.  
   
--   As the return type of the public method `GetNext` and the `Data` property in the nested `Node` class.  
+-   As the return type of the `Data` property in the nested `Node` class.  
   
 -   As the type of the private member data in the nested class.  
   

--- a/docs/csharp/programming-guide/generics/introduction-to-generics.md
+++ b/docs/csharp/programming-guide/generics/introduction-to-generics.md
@@ -21,7 +21,7 @@ Generic classes and methods combine reusability, type safety and efficiency in a
   
 -   As the return type of the `Data` property in the nested `Node` class.  
   
--   As the type of the private member data in the nested class.  
+-   As the type of the private member `data` in the nested class.  
   
  Note that T is available to the nested `Node` class. When `GenericList<T>` is instantiated with a concrete type, for example as a `GenericList<int>`, each occurrence of `T` will be replaced with `int`.  
   


### PR DESCRIPTION
Remove reference to non-existent GetNext method on line 22 of csharp docs generics intro.

[https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/introduction-to-generics]