### PR TITLE
Update source3.cs

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/source3.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.attributes.usage/cs/source3.cs
@@ -43,7 +43,7 @@ class GetAttribTest1
         DeveloperAttribute[] MyAttributes =
             (DeveloperAttribute[]) Attribute.GetCustomAttributes(t, typeof (DeveloperAttribute));
 
-        if (MyAttributes == null)
+        if (MyAttributes.Length == 0)
         {
             Console.WriteLine("The attribute was not found.");
         }


### PR DESCRIPTION
# Title

Updated source3.cs to check the array length is zero, instead of checking for null

## Summary

GetCustomAttributes never returns null, but instead returns an empty array when no attributes are found, as outlined here: https://msdn.microsoft.com/en-us/library/ms130871(v=vs.110).aspx. I have updated the docs to check that the array length is zero instead of checking for null.

