### PR TITLE
Dashes missing from no-dependencies .NET Core CLI2

### DIFF
--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -23,7 +23,7 @@ ms.workload:
 # [.NET Core 2.x](#tab/netcore2x)
 
 ```
-dotnet publish [<PROJECT>] [-c|--configuration] [-f|--framework] [--force] [--manifest] [no-dependencies] [--no-restore] [-o|--output] [-r|--runtime] [--self-contained] [-v|--verbosity] [--version-suffix]
+dotnet publish [<PROJECT>] [-c|--configuration] [-f|--framework] [--force] [--manifest] [--no-dependencies] [--no-restore] [-o|--output] [-r|--runtime] [--self-contained] [-v|--verbosity] [--version-suffix]
 dotnet publish [-h|--help]
 ```
 


### PR DESCRIPTION
# Title

Dashes missing from no-dependencies .NET Core CLI 2.x
## Summary

Usage of no dependecies switch should have 2 dashes.
![image](https://user-images.githubusercontent.com/1647294/34779326-26ebb858-f620-11e7-8a8b-6a3889b31c68.png)
