### PR TITLE
Stick to conventions

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/codesnippet/CSharp/paramref_1.cs
+++ b/docs/csharp/programming-guide/xmldoc/codesnippet/CSharp/paramref_1.cs
@@ -4,9 +4,9 @@
     public class TestClass
     {
         /// <summary>DoWork is a method in the TestClass class.  
-        /// The <paramref name="Int1"/> parameter takes a number.
+        /// The <paramref name="int1"/> parameter takes a number.
         /// </summary>
-        public static void DoWork(int Int1)
+        public static void DoWork(int int1)
         {
         }
 


### PR DESCRIPTION
# Stick to naming conventions in code example.

## Summary

Change the casing of the parameter name from `Int1` -> `int1` to stick to mainstream naming conventions.

Whether `int1` is a good name for a parameter is a question I will leave unanswered.
