### PR TITLE
Fix "offsetX" description

### DIFF
--- a/xml/System.Windows.Media/Matrix.xml
+++ b/xml/System.Windows.Media/Matrix.xml
@@ -80,7 +80,7 @@
  *offsetX*  
  <xref:System.Double?displayProperty=nameWithType>  
   
- The value in the third row and third column. For more information, see the <xref:System.Windows.Media.Matrix.OffsetX%2A> property.  
+ The value in the third row and first column. For more information, see the <xref:System.Windows.Media.Matrix.OffsetX%2A> property.  
   
  *offsetY*  
  <xref:System.Double?displayProperty=nameWithType>  


### PR DESCRIPTION
Fixed the description of the OffsetX property. For instance, the description of the OffsetX property [here](https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.matrix.offsetx?view=netframework-4.7.1) is correct.