### PR TITLE
StringBuilder character-based access and perf

### DIFF
--- a/includes/stringbuilder-perf-note.md
+++ b/includes/stringbuilder-perf-note.md
@@ -6,7 +6,7 @@ Using character-based indexing with the <xref:System.Text.StringBuilder.Chars%2A
 Performance is severely impacted because each character access walks the entire linked list of chunks to find the correct buffer to index into.
 
 > [!NOTE]
->  Even for a large "chunky" <xref:System.Text.StringBuilder> object, using the <xref:System.Text.StringBuilder.Chars%2A>property for index-based access to one or a small number of characters has a negligible performance impact; typically, it is an **0(n)** operation. The significant performance impact occurs when iterating the characters in the <xref:System.Text.StringBuilder> object, which is an **O(n^2)** operation. 
+>  Even for a large "chunky" <xref:System.Text.StringBuilder> object, using the <xref:System.Text.StringBuilder.Chars%2A> property for index-based access to one or a small number of characters has a negligible performance impact; typically, it is an **0(n)** operation. The significant performance impact occurs when iterating the characters in the <xref:System.Text.StringBuilder> object, which is an **O(n^2)** operation. 
 
 If you encounter performance issues when using character-based indexing with <xref:System.Text.StringBuilder> objects, you can use any of the following workarounds:
 

--- a/includes/stringbuilder-perf-note.md
+++ b/includes/stringbuilder-perf-note.md
@@ -6,7 +6,7 @@ Using character-based indexing with the <xref:System.Text.StringBuilder.Chars%2A
 Performance is severely impacted because each character access walks the entire linked list of chunks to find the correct buffer to index into.
 
 > [!NOTE]
->  Even for a large "chunky" <xref:System.Text.StringBuilder> object, using the <xref:System.Text.StringBuilder.Chars%2A>property for index-based access to one or a small number of characters has a negligible performance impact; typically, it is an **0(n)** operation. The significant performance impact occurs when iterating the characters in the  <xref:System.Text.StringBuilder> object, which is an **O(n^2)** operation. 
+>  Even for a large "chunky" <xref:System.Text.StringBuilder> object, using the <xref:System.Text.StringBuilder.Chars%2A>property for index-based access to one or a small number of characters has a negligible performance impact; typically, it is an **0(n)** operation. The significant performance impact occurs when iterating the characters in the <xref:System.Text.StringBuilder> object, which is an **O(n^2)** operation. 
 
 If you encounter performance issues when using character-based indexing with <xref:System.Text.StringBuilder> objects, you can use any of the following workarounds:
 
@@ -22,4 +22,4 @@ If you encounter performance issues when using character-based indexing with <xr
    ' sbOriginal is the existing StringBuilder object
    Dim sbNew = New StringBuilder(sbOriginal.ToString(), sbOriginal.Length)
    ```
-- Set the initial capacity of the <xref:System.Text.StringBuilder> object to a value that is approximately equal to its maximum expected size by calling the <xref:System.Text.StringBuilder.#ctor(System.Int32)> constructor. Note that this allocates the entire block of memory even if the <xref:System.Text.StringBuilder> rarely reaches its maximum capacity.
+- Set the initial capacity of the <xref:System.Text.StringBuilder> object to a value that is approximately equal to its maximum expected size by calling the <xref:System.Text.StringBuilder.%23ctor(System.Int32)> constructor. Note that this allocates the entire block of memory even if the <xref:System.Text.StringBuilder> rarely reaches its maximum capacity.

--- a/includes/stringbuilder-perf-note.md
+++ b/includes/stringbuilder-perf-note.md
@@ -5,6 +5,9 @@ Using character-based indexing with the <xref:System.Text.StringBuilder.Chars%2A
 
 Performance is severely impacted because each character access walks the entire linked list of chunks to find the correct buffer to index into.
 
+> [!NOTE]
+>  Even for a large "chunky" <xref:System.Text.StringBuilder> object, using the <xref:System.Text.StringBuilder.Chars%2A>property for index-based access to one or a small number of characters has a negligible performance impact; typically, it is an **0(n)** operation. The significant performance impact occurs when iterating the characters in the  <xref:System.Text.StringBuilder> object, which is an **O(n^2)** operation. 
+
 If you encounter performance issues when using character-based indexing with <xref:System.Text.StringBuilder> objects, you can use any of the following workarounds:
 
 - Convert the <xref:System.Text.StringBuilder> instance to a <xref:System.String> by calling the <xref:System.Text.StringBuilder.ToString%2A> method, then access the characters in the string.

--- a/includes/stringbuilder-perf-note.md
+++ b/includes/stringbuilder-perf-note.md
@@ -1,0 +1,22 @@
+Using character-based indexing with the <xref:System.Text.StringBuilder.Chars%2A> property can be extremely slow under the following conditions:
+
+- The <xref:System.Text.StringBuilder> instance is large (for example, it consists of several tens of thousands of characters).
+- The <xref:System.Text.StringBuilder> is "chunky." That is, repeated calls to methods such as <xref:System.Text.StringBuilder.Append%2A?displayProperty=nameWithType> have automatically expanded the object's <xref:System.Text.StringBuilder.Capacity%2A?displayProperty=nameWithType> property and allocated new chunks of memory to it.
+
+Performance is severely impacted because each character access walks the entire linked list of chunks to find the correct buffer to index into.
+
+If you encounter performance issues when using character-based indexing with <xref:System.Text.StringBuilder> objects, you can use any of the following workarounds:
+
+- Convert the <xref:System.Text.StringBuilder> instance to a <xref:System.String> by calling the <xref:System.Text.StringBuilder.ToString%2A> method, then access the characters in the string.
+
+- Copy the contents of the existing <xref:System.Text.StringBuilder> object to a new pre-sized <xref:System.Text.StringBuilder> object. Performance improves because the new <xref:System.Text.StringBuilder> object is not chunky. For example:
+
+   ```csharp
+   // sbOriginal is the existing StringBuilder object
+   var sbNew = new StringBuilder(sbOriginal.ToString(), sbOriginal.Length);
+   ```
+   ```vb
+   ' sbOriginal is the existing StringBuilder object
+   Dim sbNew = New StringBuilder(sbOriginal.ToString(), sbOriginal.Length)
+   ```
+- Set the initial capacity of the <xref:System.Text.StringBuilder> object to a value that is approximately equal to its maximum expected size by calling the <xref:System.Text.StringBuilder.#ctor(System.Int32)> constructor. Note that this allocates the entire block of memory even if the <xref:System.Text.StringBuilder> rarely reaches its maximum capacity.

--- a/xml/System.Text/StringBuilder.xml
+++ b/xml/System.Text/StringBuilder.xml
@@ -174,6 +174,8 @@
   
  [!code-csharp[System.Text.StringBuilder.Class#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.text.stringbuilder.class/cs/chars1.cs#7)]
  [!code-vb[System.Text.StringBuilder.Class#7](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.text.stringbuilder.class/vb/chars1.vb#7)]  
+
+[!INCLUDE[stringbuilder-performance-note](~/includes/stringbuilder-perf-note.md)]
   
 <a name="Adding"></a>   
 ### Adding text to a StringBuilder object  
@@ -2902,7 +2904,11 @@
   
  [!code-csharp[System.Text.StringBuilder.Chars#1](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.text.stringbuilder.chars/cs/chars1.cs#1)]
  [!code-vb[System.Text.StringBuilder.Chars#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.text.stringbuilder.chars/vb/chars1.vb#1)]  
-  
+
+### Performance and character-based indexing
+
+[!INCLUDE[stringbuilder-performance-note](~/includes/stringbuilder-perf-note.md)]
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ArgumentOutOfRangeException">

--- a/xml/System.Text/StringBuilder.xml
+++ b/xml/System.Text/StringBuilder.xml
@@ -218,7 +218,7 @@
 |---------------|----------|----------|  
 |Search string values before adding them to the <xref:System.Text.StringBuilder> object.|Useful for determining whether a substring exists.|Cannot be used when the index position of a substring is important.|  
 |Call <xref:System.Text.StringBuilder.ToString%2A> and search the returned <xref:System.String> object.|Easy to use if you assign all the text to a <xref:System.Text.StringBuilder> object, and then begin to modify it.|Cumbersome to repeatedly call <xref:System.Text.StringBuilder.ToString%2A> if you must make modifications before all text is added to the <xref:System.Text.StringBuilder> object.<br /><br /> You must remember to work from the end of the <xref:System.Text.StringBuilder> object's text if you're making changes.|  
-|Use the <xref:System.Text.StringBuilder.Chars%2A> property to sequentially search a range of characters.|Useful if you're concerned with individual characters or a small substring.|Cumbersome if the number of characters to search is large or if the search logic is complex.|  
+|Use the <xref:System.Text.StringBuilder.Chars%2A> property to sequentially search a range of characters.|Useful if you're concerned with individual characters or a small substring.|Cumbersome if the number of characters to search is large or if the search logic is complex.<br /><br />Results in very poor performance for objects that have grown very large through repeated method calls.  |  
 |Convert the <xref:System.Text.StringBuilder> object to a <xref:System.String> object, and perform modifications on the <xref:System.String> object.|Useful if the number of modifications is small.|Negates the performance benefit of the <xref:System.Text.StringBuilder> class if the number of modifications is large.|  
   
  Let's examine these techniques in greater detail.  
@@ -238,7 +238,7 @@
      [!code-csharp[System.Text.StringBuilder.Class#13](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.text.stringbuilder.class/cs/pattern2.cs#13)]
      [!code-vb[System.Text.StringBuilder.Class#13](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.text.stringbuilder.class/vb/pattern2.vb#13)]  
   
--   Use the <xref:System.Text.StringBuilder.Chars%2A?displayProperty=nameWithType> property to sequentially search a range of characters in a <xref:System.Text.StringBuilder> object. This approach may not be practical if the number of characters to be searched is large or the search logic is particularly complex.  
+-   Use the <xref:System.Text.StringBuilder.Chars%2A?displayProperty=nameWithType> property to sequentially search a range of characters in a <xref:System.Text.StringBuilder> object. This approach may not be practical if the number of characters to be searched is large or the search logic is particularly complex. For the performance implications of character-by-character index-based access for very large, chunked <xref:System.Text.StringBuilder> objects, see the documentation for the <xref:System.Text.StringBuilder.Chars%2A?displayProperty=nameWithType> property. 
   
      The following example is identical in functionality to the previous example but differs in implementation. It uses the <xref:System.Text.StringBuilder.Chars%2A> property to detect when a character value has changed, inserts an underscore at that position, and converts the first character in the new sequence to uppercase.  
   


### PR DESCRIPTION
# StringBuilder character-based access and perf

## Summary

Describes the perf impact of character-based access on chunky StringBuilder instances and provides workarounds.

Fixes #3909 

- edited by @jralexander to add Internal Review URL
[Internal Review URL](https://review.docs.microsoft.com/en-us/dotnet/api/system.text.stringbuilder?view=netcore-2.0&branch=pr-en-us-4108)

## Suggested Reviewers

@mairaw, @danmosemsft 