### PR TITLE
Removed links to Reference Source

### DIFF
--- a/xml/System.Collections.Generic/Dictionary`2.xml
+++ b/xml/System.Collections.Generic/Dictionary`2.xml
@@ -69,10 +69,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/collections/generic/dictionary.cs#d3599058f8d79be0). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Collections.Generic.Dictionary%602> generic class provides a mapping from a set of keys to a set of values. Each addition to the dictionary consists of a value and its associated key. Retrieving a value by using its key is very fast, close to O(1), because the <xref:System.Collections.Generic.Dictionary%602> class is implemented as a hash table.  
   
 > [!NOTE]

--- a/xml/System.Collections.Generic/HashSet`1.xml
+++ b/xml/System.Collections.Generic/HashSet`1.xml
@@ -58,10 +58,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System.Core/System/Collections/Generic/HashSet.cs#2d265edc718b158b). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Collections.Generic.HashSet%601> class provides high-performance set operations. A set is a collection that contains no duplicate elements, and whose elements are in no particular order.  
   
 > [!NOTE]

--- a/xml/System.Collections.Generic/IEnumerable`1.xml
+++ b/xml/System.Collections.Generic/IEnumerable`1.xml
@@ -38,10 +38,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/collections/generic/ienumerable.cs#3acf01620172c7f0). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.Collections.Generic.IEnumerable%601> is the base interface for collections in the <xref:System.Collections.Generic> namespace such as <xref:System.Collections.Generic.List%601>, <xref:System.Collections.Generic.Dictionary%602>, and <xref:System.Collections.Generic.Stack%601> and other generic collections such as <xref:System.Collections.ObjectModel.ObservableCollection%601> and <xref:System.Collections.Concurrent.ConcurrentStack%601>. Collections that implement <xref:System.Collections.Generic.IEnumerable%601> can be enumerated by using the `foreach` statement. For the non-generic version of this interface, see <xref:System.Collections.IEnumerable?displayProperty=nameWithType>.  
   
  For the non-generic version of this interface, see <xref:System.Collections.IEnumerable?displayProperty=nameWithType>.  

--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -58,10 +58,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/collections/generic/list.cs#cf7f4095e4de7646). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Collections.Generic.List%601> class is the generic equivalent of the <xref:System.Collections.ArrayList> class. It implements the <xref:System.Collections.Generic.IList%601> generic interface by using an array whose size is dynamically increased as required.  
   
  You can add items to a <xref:System.Collections.Generic.List%601> by using the <xref:System.Collections.Generic.List%601.Add%2A> or <xref:System.Collections.Generic.List%601.AddRange%2A> methods.  

--- a/xml/System.Collections/ArrayList.xml
+++ b/xml/System.Collections/ArrayList.xml
@@ -47,10 +47,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/collections/arraylist.cs#3e3f6715773d6643). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Collections.ArrayList> class is designed to hold heterogeneous collections of objects. However, it does not always offer the best performance. Instead, we recommend the following:  
   
 -   For a heterogeneous collection of objects, use the `List<Object>` (in C#) or `List(Of Object)` (in Visual Basic) type.  

--- a/xml/System.Collections/Hashtable.xml
+++ b/xml/System.Collections/Hashtable.xml
@@ -53,10 +53,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/collections/hashtable.cs#10fefb6e0ae510dd). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Each element is a key/value pair stored in a <xref:System.Collections.DictionaryEntry> object. A key cannot be `null`, but a value can be.  
   
  The objects used as keys by a <xref:System.Collections.Hashtable> are required to override the <xref:System.Object.GetHashCode%2A?displayProperty=nameWithType> method (or the <xref:System.Collections.IHashCodeProvider> interface) and the <xref:System.Object.Equals%2A?displayProperty=nameWithType> method (or the <xref:System.Collections.IComparer> interface). The implementation of both methods and interfaces must handle case sensitivity the same way; otherwise, the <xref:System.Collections.Hashtable> might behave incorrectly. For example, when creating a <xref:System.Collections.Hashtable>, you must use the <xref:System.Collections.CaseInsensitiveHashCodeProvider> class (or any case-insensitive <xref:System.Collections.IHashCodeProvider> implementation) with the <xref:System.Collections.CaseInsensitiveComparer> class (or any case-insensitive <xref:System.Collections.IComparer> implementation).  

--- a/xml/System.Collections/IEnumerable.xml
+++ b/xml/System.Collections/IEnumerable.xml
@@ -34,10 +34,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/collections/ienumerable.cs#9be451ac13d86a97). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.Collections.IEnumerable> is the base interface for all non-generic collections that can be enumerated. For the generic version of this interface see <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType>. <xref:System.Collections.IEnumerable> contains a single method, <xref:System.Collections.IEnumerable.GetEnumerator%2A>, which returns an <xref:System.Collections.IEnumerator>. <xref:System.Collections.IEnumerator> provides the ability to iterate through the collection by exposing a <xref:System.Collections.IEnumerator.Current%2A> property and <xref:System.Collections.IEnumerator.MoveNext%2A> and <xref:System.Collections.IEnumerator.Reset%2A> methods.  
   
  It is a best practice to implement <xref:System.Collections.IEnumerable> and <xref:System.Collections.IEnumerator> on your collection classes to enable the `foreach` (`For Each` in Visual Basic) syntax, however implementing <xref:System.Collections.IEnumerable> is not required. If your collection does not implement <xref:System.Collections.IEnumerable>, you must still follow the iterator pattern to support this syntax by providing a `GetEnumerator` method that returns an interface, class or struct. When using Visual Basic, you must provide an <xref:System.Collections.IEnumerator> implementation, which is returned by `GetEnumerator`. When developing with C# you must provide a class that contains a `Current` property, and `MoveNext` and `Reset` methods as described by <xref:System.Collections.IEnumerator>, but the class does not have to implement <xref:System.Collections.IEnumerator>.  

--- a/xml/System.Diagnostics/Process.xml
+++ b/xml/System.Diagnostics/Process.xml
@@ -42,10 +42,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/Process.cs#f8b2e604d6f1fe04). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  A <xref:System.Diagnostics.Process> component provides access to a process that is running on a computer. A process, in the simplest terms, is a running app. A thread is the basic unit to which the operating system allocates processor time. A thread can execute any part of the code of the process, including parts currently being executed by another thread.  
   
  The <xref:System.Diagnostics.Process> component is a useful tool for starting, stopping, controlling, and monitoring apps. You can use the <xref:System.Diagnostics.Process> component, to obtain a list of the processes that are running, or you can start a new process. A <xref:System.Diagnostics.Process> component is used to access system processes. After a <xref:System.Diagnostics.Process> component has been initialized, it can be used to obtain information about the running process. Such information includes the set of threads, the loaded modules (.dll and .exe files), and performance information such as the amount of memory the process is using.  

--- a/xml/System.Diagnostics/Stopwatch.xml
+++ b/xml/System.Diagnostics/Stopwatch.xml
@@ -28,10 +28,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/Stopwatch.cs#ceb0ba9cc88de82e). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  A <xref:System.Diagnostics.Stopwatch> instance can measure elapsed time for one interval, or the total of elapsed time across multiple intervals. In a typical <xref:System.Diagnostics.Stopwatch> scenario, you call the <xref:System.Diagnostics.Stopwatch.Start%2A> method, then eventually call the <xref:System.Diagnostics.Stopwatch.Stop%2A> method, and then you check elapsed time using the <xref:System.Diagnostics.Stopwatch.Elapsed%2A> property.  
   
  A <xref:System.Diagnostics.Stopwatch> instance is either running or stopped; use <xref:System.Diagnostics.Stopwatch.IsRunning%2A> to determine the current state of a <xref:System.Diagnostics.Stopwatch>. Use <xref:System.Diagnostics.Stopwatch.Start%2A> to begin measuring elapsed time; use <xref:System.Diagnostics.Stopwatch.Stop%2A> to stop measuring elapsed time. Query the elapsed time value through the properties <xref:System.Diagnostics.Stopwatch.Elapsed%2A>, <xref:System.Diagnostics.Stopwatch.ElapsedMilliseconds%2A>, or <xref:System.Diagnostics.Stopwatch.ElapsedTicks%2A>. You can query the elapsed time properties while the instance is running or stopped. The elapsed time properties steadily increase while the <xref:System.Diagnostics.Stopwatch> is running; they remain constant when the instance is stopped.  

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -42,10 +42,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/globalization/cultureinfo.cs#e319c6636909012f). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Globalization.CultureInfo> class provides culture-specific information, such as the language, sublanguage, country/region, calendar, and conventions associated with a particular culture. This class also provides access to culture-specific instances of the <xref:System.Globalization.DateTimeFormatInfo>, <xref:System.Globalization.NumberFormatInfo>, <xref:System.Globalization.CompareInfo>, and <xref:System.Globalization.TextInfo> objects. These objects contain the information required for culture-specific operations, such as casing, formatting dates and numbers, and comparing strings. The <xref:System.Globalization.CultureInfo> class is used either directly or indirectly by classes that format, parse, or manipulate culture-specific data, such as <xref:System.String>, <xref:System.DateTime>, <xref:System.DateTimeOffset>, and the numeric types.  
   
  In this section:  

--- a/xml/System.IO.Ports/SerialPort.xml
+++ b/xml/System.IO.Ports/SerialPort.xml
@@ -25,10 +25,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System/sys/system/io/ports/SerialPort.cs#ae0a3218c6c9f7fe). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use this class to control a serial port file resource. This class provides synchronous and event-driven I/O, access to pin and break states, and access to serial driver properties. Additionally, the functionality of this class can be wrapped in an internal <xref:System.IO.Stream> object, accessible through the <xref:System.IO.Ports.SerialPort.BaseStream%2A> property, and passed to classes that wrap or use streams.  
   
  The <xref:System.IO.Ports.SerialPort> class supports the following encodings: <xref:System.Text.ASCIIEncoding>, <xref:System.Text.UTF8Encoding>, <xref:System.Text.UnicodeEncoding>, <xref:System.Text.UTF32Encoding>, and any encoding defined in mscorlib.dll where the code page is less than 50000 or the code page is 54936.  You can use alternate encodings, but you must use the <xref:System.IO.Ports.SerialPort.ReadByte%2A> or <xref:System.IO.Ports.SerialPort.Write%2A> method and perform the encoding yourself.  

--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -31,10 +31,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/directory.cs#b3ad5f0ba800bb28). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use the <xref:System.IO.Directory> class for typical operations such as copying, moving, renaming, creating, and deleting directories.  
   
 -   To create a directory, use one of the <xref:System.IO.Directory.CreateDirectory%2A> methods.  

--- a/xml/System.IO/DirectoryInfo.xml
+++ b/xml/System.IO/DirectoryInfo.xml
@@ -31,10 +31,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/directoryinfo.cs#30fa608717e5ce8e). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use the <xref:System.IO.DirectoryInfo> class for typical operations such as copying, moving, renaming, creating, and deleting directories.  
   
  If you are going to reuse an object several times, consider using the instance method of <xref:System.IO.DirectoryInfo> instead of the corresponding static methods of the <xref:System.IO.Directory> class, because a security check will not always be necessary.  

--- a/xml/System.IO/File.xml
+++ b/xml/System.IO/File.xml
@@ -31,10 +31,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/file.cs#1c7421e464f67b7e). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use the <xref:System.IO.File> class for typical operations such as copying, moving, renaming, creating, opening, deleting, and appending to a single file at a time. You can also use the <xref:System.IO.File> class to get and set file attributes or <xref:System.DateTime> information related to the creation, access, and writing of a file. If you want to perform operations on multiple files, see <xref:System.IO.Directory.GetFiles%2A?displayProperty=nameWithType> or <xref:System.IO.DirectoryInfo.GetFiles%2A?displayProperty=nameWithType>.  
   
  Many of the <xref:System.IO.File> methods return other I/O types when you create or open files. You can use these other types to further manipulate a file. For more information, see specific <xref:System.IO.File> members such as <xref:System.IO.File.OpenText%2A>, <xref:System.IO.File.CreateText%2A>, or <xref:System.IO.File.Create%2A>.  

--- a/xml/System.IO/FileInfo.xml
+++ b/xml/System.IO/FileInfo.xml
@@ -31,10 +31,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/fileinfo.cs#4ee673c1a4ecad41). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use the <xref:System.IO.FileInfo> class for typical operations such as copying, moving, renaming, creating, opening, deleting, and appending to files.  
   
  If you are performing multiple operations on the same file, it can be more efficient to use <xref:System.IO.FileInfo> instance methods instead of the corresponding static methods of the <xref:System.IO.File> class, because a security check will not always be necessary.  

--- a/xml/System.IO/FileStream.xml
+++ b/xml/System.IO/FileStream.xml
@@ -34,10 +34,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/filestream.cs#e23a38af5d11ddd3). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use the <xref:System.IO.FileStream> class to read from, write to, open, and close files on a file system, and to manipulate other file-related operating system handles, including pipes, standard input, and standard output. You can use the <xref:System.IO.FileStream.Read%2A>, <xref:System.IO.FileStream.Write%2A>, <xref:System.IO.Stream.CopyTo%2A>, and <xref:System.IO.FileStream.Flush%2A> methods to perform synchronous operations, or the <xref:System.IO.FileStream.ReadAsync%2A>, <xref:System.IO.FileStream.WriteAsync%2A>, <xref:System.IO.Stream.CopyToAsync%2A>, and <xref:System.IO.FileStream.FlushAsync%2A> methods to perform asynchronous operations. Use the asynchronous methods to perform resource-intensive file operations without blocking the main thread. This performance consideration is particularly important in a [!INCLUDE[win8_appname_long](~/includes/win8-appname-long-md.md)] app or [!INCLUDE[desktop_appname](~/includes/desktop-appname-md.md)] app where a time-consuming stream operation can block the UI thread and make your app appear as if it is not working. <xref:System.IO.FileStream> buffers input and output for better performance.  
   
 > [!IMPORTANT]

--- a/xml/System.IO/FileSystemWatcher.xml
+++ b/xml/System.IO/FileSystemWatcher.xml
@@ -39,10 +39,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System/services/io/system/io/FileSystemWatcher.cs#a9eb0249dc928b09). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use <xref:System.IO.FileSystemWatcher> to watch for changes in a specified directory. You can watch for changes in files and subdirectories of the specified directory. You can create a component to watch files on a local computer, a network drive, or a remote computer.  
   
  To watch for changes in all files, set the <xref:System.IO.FileSystemWatcher.Filter%2A> property to an empty string ("") or use wildcards ("*.\*"). To watch a specific file, set the <xref:System.IO.FileSystemWatcher.Filter%2A> property to the file name. For example, to watch for changes in the file MyDoc.txt, set the <xref:System.IO.FileSystemWatcher.Filter%2A> property to "MyDoc.txt". You can also watch for changes in a certain type of file. For example, to watch for changes in text files, set the <xref:System.IO.FileSystemWatcher.Filter%2A> property to "\*.txt".  

--- a/xml/System.IO/MemoryStream.xml
+++ b/xml/System.IO/MemoryStream.xml
@@ -36,10 +36,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/memorystream.cs#1a4dcb744a23ba6f). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The current position of a stream is the position at which the next read or write operation could take place. The current position can be retrieved or set through the <xref:System.IO.MemoryStream.Seek%2A> method. When a new instance of <xref:System.IO.MemoryStream> is created, the current position is set to zero.  
   
 [!INCLUDE[note_unnecessary_dispose](~/includes/note-unnecessary-dispose.md)]

--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -33,10 +33,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/path.cs#090eca8621a248ee). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The .NET Framework does not support direct access to physical disks through paths that are device names, such as "\\\\.\PHYSICALDRIVE0 ".  
   
  A path is a string that provides the location of a file or directory. A path does not necessarily point to a location on disk; for example, a path might map to a location in memory or on a device. The exact format of a path is determined by the current platform. For example, on some systems, a path can start with a drive or volume letter, while this element is not present in other systems. On some systems, file paths can contain extensions, which indicate the type of information stored in the file. The format of a file name extension is platform-dependent; for example, some systems limit extensions to three characters, and others do not. The current platform also determines the set of characters used to separate the elements of a path, and the set of characters that cannot be used when specifying paths. Because of these differences, the fields of the `Path` class as well as the exact behavior of some members of the `Path` class are platform-dependent.  

--- a/xml/System.IO/Stream.xml
+++ b/xml/System.IO/Stream.xml
@@ -41,10 +41,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/stream.cs#f956b0c07e86df64). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.IO.Stream> is the abstract base class of all streams. A stream is an abstraction of a sequence of bytes, such as a file, an input/output device, an inter-process communication pipe, or a TCP/IP socket. The <xref:System.IO.Stream> class and its derived classes provide a generic view of these different types of input and output, and isolate the programmer from the specific details of the operating system and the underlying devices.  
   
  Streams involve three fundamental operations:  

--- a/xml/System.IO/StreamReader.xml
+++ b/xml/System.IO/StreamReader.xml
@@ -36,10 +36,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/streamreader.cs#b5fe1efcec14de32). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.IO.StreamReader> is designed for character input in a particular encoding, whereas the <xref:System.IO.Stream> class is designed for byte input and output. Use <xref:System.IO.StreamReader> for reading lines of information from a standard text file.  
   
 > [!IMPORTANT]

--- a/xml/System.IO/StreamWriter.xml
+++ b/xml/System.IO/StreamWriter.xml
@@ -36,10 +36,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/io/streamwriter.cs#9e38cb1c84769eba). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.IO.StreamWriter> is designed for character output in a particular encoding, whereas classes derived from <xref:System.IO.Stream> are designed for byte input and output.  
   
 > [!IMPORTANT]

--- a/xml/System.Text.RegularExpressions/Regex.xml
+++ b/xml/System.Text.RegularExpressions/Regex.xml
@@ -33,10 +33,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System/regex/system/text/regularexpressions/Regex.cs#bbe3b2eb80ae5526). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Text.RegularExpressions.Regex> class represents the .NET Framework's regular expression engine. It can be used to quickly parse large amounts of text to find specific character patterns; to extract, edit, replace, or delete text substrings; and to add the extracted strings to a collection to generate a report.  
   
 > [!NOTE]

--- a/xml/System.Text/Encoding.xml
+++ b/xml/System.Text/Encoding.xml
@@ -39,10 +39,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/text/encoding.cs#3b6090c501893c25). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Encoding is the process of transforming a set of Unicode characters into a sequence of bytes. In contrast, decoding is the process of transforming a sequence of encoded bytes into a set of Unicode characters. For information about the Unicode Transformation Formats (UTFs) and other encodings supported by <xref:System.Text.Encoding>, see [Character Encoding in the .NET Framework](~/docs/standard/base-types/character-encoding.md).  
   
  Note that <xref:System.Text.Encoding> is intended to operate on Unicode characters instead of arbitrary binary data, such as byte arrays. If you must encode arbitrary binary data into text, you should use a protocol such as uuencode, which is implemented by methods such as <xref:System.Convert.ToBase64CharArray%2A?displayProperty=nameWithType>.  

--- a/xml/System.Text/StringBuilder.xml
+++ b/xml/System.Text/StringBuilder.xml
@@ -38,10 +38,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/text/stringbuilder.cs#adf60ee46ebd299f). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  This class represents a string-like object whose value is a mutable sequence of characters.  
   
  In this section:  

--- a/xml/System.Threading.Tasks/Task.xml
+++ b/xml/System.Threading.Tasks/Task.xml
@@ -45,10 +45,6 @@
       <format type="text/markdown"><![CDATA[  
    
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/threading/Tasks/Task.cs#045a746eb48cbaa9). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Threading.Tasks.Task> class represents a single operation that does not return a value and that usually executes asynchronously. <xref:System.Threading.Tasks.Task> objects are one of the central components of the  [task-based asynchronous pattern](~/docs/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md) first introduced in the .NET Framework 4. Because the work performed by a <xref:System.Threading.Tasks.Task> object typically executes asynchronously on a thread pool thread rather than synchronously on the main application thread, you can use the <xref:System.Threading.Tasks.Task.Status%2A> property, as well as the <xref:System.Threading.Tasks.Task.IsCanceled%2A>, <xref:System.Threading.Tasks.Task.IsCompleted%2A>, and <xref:System.Threading.Tasks.Task.IsFaulted%2A> properties, to determine the   state of a task. Most commonly, a lambda expression is used to specify the work that the task is to perform.  
   
  For operations that return values, you use the <xref:System.Threading.Tasks.Task%601> class.  

--- a/xml/System.Threading/Mutex.xml
+++ b/xml/System.Threading/Mutex.xml
@@ -32,10 +32,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/threading/mutex.cs#29b92e0e2832a8d6). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  When two or more threads need to access a shared resource at the same time, the system needs a synchronization mechanism to ensure that only one thread at a time uses the resource. <xref:System.Threading.Mutex> is a synchronization primitive that grants exclusive access to the shared resource to only one thread. If a thread acquires a mutex, the second thread that wants to acquire that mutex is suspended until the first thread releases the mutex.  
   
 > [!IMPORTANT]

--- a/xml/System.Threading/Thread.xml
+++ b/xml/System.Threading/Thread.xml
@@ -51,8 +51,7 @@
  [Foreground and background threads](#Foreground)   
  [Culture and threads](#Culture)   
  [Getting information about and controlling threads](#Properties)   
- [Accessing the source code for the Thread class](#Source)  
-  
+   
 <a name="Starting"></a>   
 ## Starting a thread  
  You start a thread by supplying a delegate that represents the method the thread is to execute in its class constructor. You then call the <xref:System.Threading.Thread.Start%2A> method to begin execution.  
@@ -163,12 +162,6 @@
 -   The read-only <xref:System.Threading.Thread.IsThreadPoolThread%2A> property, which indicates whether a thread is  a thread pool thread.  
   
 -   The <xref:System.Threading.Thread.IsBackground%2A> property. For more information, see the [Foreground and background threads](#Foreground) section.  
-  
-<a name="Source"></a>   
-## Accessing the source code for the Thread class  
- To view the .NET Framework source code for the <xref:System.Threading.Thread> class, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/threading/thread.cs#3980e012bae82e96). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
-   
   
 ## Examples  
  The following example demonstrates simple threading functionality.  

--- a/xml/System.Threading/Timer.xml
+++ b/xml/System.Threading/Timer.xml
@@ -36,10 +36,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/threading/timer.cs#051a39d380760b26). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Use a <xref:System.Threading.TimerCallback> delegate to specify the method you want the <xref:System.Threading.Timer> to execute. The signature of the <xref:System.Threading.TimerCallback> delegate is:  
   
 ```csharp  

--- a/xml/System.Timers/Timer.xml
+++ b/xml/System.Timers/Timer.xml
@@ -37,10 +37,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System/services/timers/system/timers/Timer.cs#897683f27faba082). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Timers.Timer> component is a server-based timer that raises an <xref:System.Timers.Timer.Elapsed> event in your application after the number of milliseconds in the <xref:System.Timers.Timer.Interval%2A> property has elapsed. You can configure the <xref:System.Timers.Timer> object to raise the event just once or repeatedly using the <xref:System.Timers.Timer.AutoReset%2A> property. Typically, a <xref:System.Timers.Timer> object is declared at the class level so that it stays in scope as long as it is needed. You can then handle its <xref:System.Timers.Timer.Elapsed> event to provide regular processing. For example, suppose you have a critical server that must be kept running 24 hours a day, 7 days a week. You could create a service that uses a <xref:System.Timers.Timer> object to periodically check the server and ensure that the system is up and running. If the system is not responding, the service could attempt to restart the server or notify an administrator.  
   
 > [!IMPORTANT]

--- a/xml/System.Xml.Linq/XDocument.xml
+++ b/xml/System.Xml.Linq/XDocument.xml
@@ -27,10 +27,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System.Xml.Linq/XLinq.cs#3354dac0913e417b). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  For details about the valid content of an <xref:System.Xml.Linq.XDocument>, see [Valid Content of XElement and XDocument Objects](http://msdn.microsoft.com/library/aee2d319-5c5f-4b99-9bb4-2f58232577ae).  
   
    

--- a/xml/System.Xml.Linq/XElement.xml
+++ b/xml/System.Xml.Linq/XElement.xml
@@ -39,10 +39,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System.Xml.Linq/XLinq.cs#3367036406d1344a). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  This class represents an XML element, the fundamental XML construct.  See [XElement Class Overview](http://msdn.microsoft.com/library/d35180fe-7016-4895-9bfc-ba1e3f7875ec) for other usage information.  
   
  An element has an <xref:System.Xml.Linq.XName>, optionally one or more attributes, and can optionally contain content (for more information, see <xref:System.Xml.Linq.XContainer.Nodes%2A>).  

--- a/xml/System.Xml/XmlReader.xml
+++ b/xml/System.Xml/XmlReader.xml
@@ -40,10 +40,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#System.Xml/Xml/System/Xml/Core/XmlReader.cs#086471e5cca0825f). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.Xml.XmlReader> provides forward-only, read-only access to XML data in adocument or stream. This class conforms to the W3C [Extensible Markup Language (XML) 1.0 (fourth edition)](http://www.w3.org/TR/2006/REC-xml-20060816/) and the [Namespaces in XML 1.0 (third edition)](http://www.w3.org/TR/REC-xml-names/) recommendations.  
   
  <xref:System.Xml.XmlReader> methods let you move through XML data and read the contents of a node. The properties of the class reflect the value of the current node, which is where the reader is positioned.The <xref:System.Xml.XmlReader.ReadState%2A> property value indicates the current state of the XML reader. For example, the property is set to <xref:System.Xml.ReadState.Initial> by the <xref:System.Xml.XmlReader.Read%2A?displayProperty=nameWithType> method and <xref:System.Xml.ReadState.Closed> by the <xref:System.Xml.XmlReader.Close%2A?displayProperty=nameWithType> method. <xref:System.Xml.XmlReader> also provides data conformance checks and validation against a DTD or schema.  

--- a/xml/System/Action`1.xml
+++ b/xml/System/Action`1.xml
@@ -43,10 +43,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/action.cs#486d58da4553e12d). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  You can use the <xref:System.Action%601> delegate to pass a method as a parameter without explicitly declaring a custom delegate. The encapsulated method must correspond to the method signature that is defined by this delegate. This means that the encapsulated method must have one parameter that is passed to it by value, and it must not return a value. (In C#, the method must return `void`. In Visual Basic, it must be defined by the `Sub`…`End Sub` construct. It can also be a method that returns a value that is ignored.) Typically, such a method is used to perform an operation.  
   
 > [!NOTE]

--- a/xml/System/Array.xml
+++ b/xml/System/Array.xml
@@ -47,10 +47,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/array.cs#156e066ecc4ccedf). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The <xref:System.Array> class is not part of the <xref:System.Collections> namespaces. However, it is still considered a collection because it is based on the <xref:System.Collections.IList> interface.  
   
  The <xref:System.Array> class is the base class for language implementations that support arrays. However, only the system and compilers can derive explicitly from the <xref:System.Array> class. Users should employ the array constructs provided by the language.  

--- a/xml/System/Console.xml
+++ b/xml/System/Console.xml
@@ -26,10 +26,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/console.cs#f907d79481da6ba4). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The console is an operating system window where users interact with the operating system or with a text-based console application by entering text input through the computer keyboard, and by reading text output from the computer terminal. For example, in the Windows operating system, the console is called the Command Prompt window and accepts MS-DOS commands. The <xref:System.Console> class provides basic support for applications that read characters from, and write characters to, the console.  
   
  For information about developing with the <xref:System.Console> class, see the following sections:  

--- a/xml/System/Exception.xml
+++ b/xml/System/Exception.xml
@@ -47,10 +47,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/exception.cs#f092fb2b893a0162). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  This class is the base class for all exceptions. When an error occurs, either the system or the currently executing application reports it by throwing an exception that contains information about the error. After an exception is thrown, it is handled by the application or by the default exception handler.  
   
  In this section:  

--- a/xml/System/Func`2.xml
+++ b/xml/System/Func`2.xml
@@ -55,10 +55,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/action.cs#7a86aba051da82dd). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  You can use this delegate to represent a method that can be passed as a parameter without explicitly declaring a custom delegate. The encapsulated method must correspond to the method signature that is defined by this delegate. This means that the encapsulated method must have one parameter that is passed to it by value, and that it must return a value.  
   
 > [!NOTE]

--- a/xml/System/Guid.xml
+++ b/xml/System/Guid.xml
@@ -47,10 +47,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/guid.cs#b622ef5f6b76c10a). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  A GUID is a 128-bit integer (16 bytes) that can be used across all computers and networks wherever a unique identifier is required. Such an identifier has a very low probability of being duplicated.  
   
    

--- a/xml/System/IDisposable.xml
+++ b/xml/System/IDisposable.xml
@@ -31,10 +31,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/idisposable.cs#1f55292c3174123d). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  The primary use of this interface is to release unmanaged resources. The garbage collector automatically releases the memory allocated to a managed object when that object is no longer used. However, it is not possible to predict when garbage collection will occur. Furthermore, the garbage collector has no knowledge of unmanaged resources such as window handles, or open files and streams.  
   
  Use the <xref:System.IDisposable.Dispose%2A> method of this interface to explicitly release unmanaged resources in conjunction with the garbage collector. The consumer of an object can call this method when the object is no longer needed.  

--- a/xml/System/Int32.xml
+++ b/xml/System/Int32.xml
@@ -50,10 +50,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/int32.cs#225942ed7b7a3252). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.Int32> is an immutable value type that represents signed integers with values that range from negative 2,147,483,648 (which is represented by the <xref:System.Int32.MinValue?displayProperty=nameWithType> constant) through positive 2,147,483,647 (which is represented by the <xref:System.Int32.MaxValue?displayProperty=nameWithType> constant. The .NET Framework also includes an unsigned 32-bit integer value type, <xref:System.UInt32>, which represents values that range from 0 to 4,294,967,295.  
   
 ## Instantiating an Int32 Value  

--- a/xml/System/Int64.xml
+++ b/xml/System/Int64.xml
@@ -50,10 +50,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/int64.cs). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  <xref:System.Int64> is an immutable value type that represents signed integers with values that range from negative 9,223,372,036,854,775,808 (which is represented by the <xref:System.Int64.MinValue?displayProperty=nameWithType> constant) through positive 9,223,372,036,854,775,807 (which is represented by the <xref:System.Int64.MaxValue?displayProperty=nameWithType> constant. The .NET Framework also includes an unsigned 64-bit integer value type, <xref:System.UInt64>, which represents values that range from 0 to 18,446,744,073,709,551,615.  
   
 ## Instantiating an Int64 Value  

--- a/xml/System/Math.xml
+++ b/xml/System/Math.xml
@@ -27,13 +27,6 @@
     <remarks>
       <format type="text/markdown"><![CDATA[  
   
-## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/math.cs#a4407e67b9a5afad). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
-   
-  
 ## Examples  
  The following example uses several mathematical and trigonometric functions from the <xref:System.Math> class to calculate the inner angles of a trapezoid.  
   

--- a/xml/System/Object.xml
+++ b/xml/System/Object.xml
@@ -34,10 +34,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/object.cs#d9262ceecc1719ab). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Languages typically do not require a class to declare inheritance from <xref:System.Object> because the inheritance is implicit.  
   
  Because all classes in the .NET Framework are derived from <xref:System.Object>, every method defined in the <xref:System.Object> class is available in all objects in the system. Derived classes can and do override some of these methods, including:  

--- a/xml/System/Random.xml
+++ b/xml/System/Random.xml
@@ -33,10 +33,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/random.cs#bb77e610694e64ca). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  Pseudo-random numbers are chosen with equal probability from a finite set of numbers. The chosen numbers are not completely random because a mathematical algorithm is used to select them, but they are sufficiently random for practical purposes. The current implementation of the <xref:System.Random> class is based on a modified version of Donald E. Knuth's subtractive random number generator algorithm. For more information, see D. E. Knuth. *The Art of Computer Programming, Volume 2: Seminumerical Algorithms*. Addison-Wesley, Reading, MA, third edition, 1997.  
   
  To generate a cryptographically secure random number, such as one that's suitable for creating a random password, use the <xref:System.Security.Cryptography.RNGCryptoServiceProvider> class or derive a class from <xref:System.Security.Cryptography.RandomNumberGenerator?displayProperty=nameWithType>.  

--- a/xml/System/TimeSpan.xml
+++ b/xml/System/TimeSpan.xml
@@ -47,10 +47,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/timespan.cs#865ef7b89f41b632). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  A <xref:System.TimeSpan> object represents a time interval (duration of time or elapsed time) that is measured as a positive or negative number of days, hours, minutes, seconds, and fractions of a second. The <xref:System.TimeSpan> structure can also be used to represent the time of day, but only if the time is unrelated to a particular date. Otherwise, the <xref:System.DateTime> or <xref:System.DateTimeOffset> structure should be used instead. (For more information about using the <xref:System.TimeSpan> structure to reflect the time of day, see [Choosing Between DateTime, DateTimeOffset, TimeSpan, and TimeZoneInfo](~/docs/standard/datetime/choosing-between-datetime.md).)  
   
 > [!NOTE]

--- a/xml/System/Tuple.xml
+++ b/xml/System/Tuple.xml
@@ -29,10 +29,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/tuple.cs#9124c4bea9ab0199). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  A tuple is a data structure that has a specific number and sequence of elements. An example of a tuple is a data structure with three elements (known as a 3-tuple or triple) that is used to store an identifier such as a person's name in the first element, a year in the second element, and the person's income for that year in the third element. The .NET Framework directly supports tuples with one to seven elements. In addition, you can create tuples of eight or more elements by nesting tuple objects in the <xref:System.Tuple%608.Rest%2A> property of a <xref:System.Tuple%608> object.  
   
  Tuples are commonly used in four ways:  

--- a/xml/System/Type.xml
+++ b/xml/System/Type.xml
@@ -48,10 +48,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
-  
-> [!NOTE]
->  To view the .NET Framework source code for this type, see the [Reference Source](http://referencesource.microsoft.com/#mscorlib/system/type.cs#3d00eeab9feb80f3). You can browse through the source code online, download the reference for offline viewing, and step through the sources (including patches and updates) during debugging; see [instructions](http://referencesource.microsoft.com/).  
-  
  `Type` is the root of the <xref:System.Reflection> functionality and is the primary way to access metadata. Use the members of <xref:System.Type> to get information about a type declaration, about the members of a type (such as the constructors, methods, fields, properties, and events of a class), as well as the module and the assembly in which the class is deployed.  
   
  No permissions are required for code to use reflection to get information about types and their members, regardless of their access levels. No permissions are required for code to use reflection to access public members, or other members whose access levels would make them visible during normal compilation. However, in order for your code to use reflection to access members that would normally be inaccessible, such as private or internal methods, or protected fields of a type your class does not inherit, your code must have <xref:System.Security.Permissions.ReflectionPermission>. See [Security Considerations for Reflection](~/docs/framework/reflection-and-codedom/security-considerations-for-reflection.md).  


### PR DESCRIPTION
Removed all notes containing links to the .NET Framework source code on the [Reference Source](http://referencesource.microsoft.com)

Fixes #4122 

### Suggested Reviewers

@mairaw please review
