### PR TITLE
Format "+" and "*" as code

### DIFF
--- a/docs/csharp/language-reference/keywords/operator.md
+++ b/docs/csharp/language-reference/keywords/operator.md
@@ -19,7 +19,7 @@ ms.author: "wiwagn"
 Use the `operator` keyword to overload a built-in operator or to provide a user-defined conversion in a class or struct declaration.  
   
 ## Example  
- The following is a very simplified class for fractional numbers. It overloads the `+` and `*` operators to perform fractional addition and multiplication, and also provides a conversion operator that converts a Fraction type to a double type.  
+ The following is a very simplified class for fractional numbers. It overloads the `+` and `*` operators to perform fractional addition and multiplication, and also provides a conversion operator that converts a `Fraction` type to a `double` type.  
   
  [!code-csharp[csrefKeywordsConversion#6](../../../csharp/language-reference/keywords/codesnippet/CSharp/operator_1.cs)]  
   

--- a/docs/csharp/language-reference/keywords/operator.md
+++ b/docs/csharp/language-reference/keywords/operator.md
@@ -19,7 +19,7 @@ ms.author: "wiwagn"
 Use the `operator` keyword to overload a built-in operator or to provide a user-defined conversion in a class or struct declaration.  
   
 ## Example  
- The following is a very simplified class for fractional numbers. It overloads the + and * operators to perform fractional addition and multiplication, and also provides a conversion operator that converts a Fraction type to a double type.  
+ The following is a very simplified class for fractional numbers. It overloads the `+` and `*` operators to perform fractional addition and multiplication, and also provides a conversion operator that converts a Fraction type to a double type.  
   
  [!code-csharp[csrefKeywordsConversion#6](../../../csharp/language-reference/keywords/codesnippet/CSharp/operator_1.cs)]  
   


### PR DESCRIPTION
Format "+" and "*" as code to reconcile formatting across documents.