### PR TITLE
lock template names for loc

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -54,43 +54,43 @@ The template to instantiate when the command is invoked. Each template might hav
 
 The command contains a default list of templates. Use `dotnet new -l` to obtain a list of the available templates. The following table shows the templates that come pre-installed with the .NET Core 2.0 SDK. The default language for the template is shown inside the brackets.
 
-|Template description                          | Template name  | Languages     |
-|----------------------------------------------|----------------|---------------|
-| Console application                          | console        | [C#], F#, VB  |
-| Class library                                | classlib       | [C#], F#, VB  |
-| Unit test project                            | mstest         | [C#], F#, VB  |
-| xUnit test project                           | xunit          | [C#], F#, VB  |
-| ASP.NET Core empty                           | web            | [C#], F#      |
-| ASP.NET Core Web App (Model-View-Controller) | mvc            | [C#], F#      |
-| ASP.NET Core Web App                         | razor          | [C#]          |
-| ASP.NET Core with Angular                    | angular        | [C#]          |
-| ASP.NET Core with React.js                   | react          | [C#]          |
-| ASP.NET Core with React.js and Redux         | reactredux     | [C#]          |
-| ASP.NET Core Web API                         | webapi         | [C#], F#      |
-| global.json file                             | globaljson     |               |
-| Nuget config                                 | nugetconfig    |               |
-| Web config                                   | webconfig      |               |
-| Solution file                                | sln            |               |
-| Razor page                                   | page           |               |
-| MVC/ViewImports                              | viewimports    |               |
-| MVC ViewStart                                | viewstart      |               |
+|Template description                          | Template name | Languages     |
+|----------------------------------------------|---------------|---------------|
+| Console application                          | `console`     | [C#], F#, VB  |
+| Class library                                | `classlib`    | [C#], F#, VB  |
+| Unit test project                            | `mstest`      | [C#], F#, VB  |
+| xUnit test project                           | `xunit`       | [C#], F#, VB  |
+| ASP.NET Core empty                           | `web`         | [C#], F#      |
+| ASP.NET Core Web App (Model-View-Controller) | `mvc`         | [C#], F#      |
+| ASP.NET Core Web App                         | `razor`       | [C#]          |
+| ASP.NET Core with Angular                    | `angular`     | [C#]          |
+| ASP.NET Core with React.js                   | `react`       | [C#]          |
+| ASP.NET Core with React.js and Redux         | `reactredux`  | [C#]          |
+| ASP.NET Core Web API                         | `webapi`      | [C#], F#      |
+| global.json file                             | `globaljson`  |               |
+| Nuget config                                 | `nugetconfig` |               |
+| Web config                                   | `webconfig`   |               |
+| Solution file                                | `sln`         |               |
+| Razor page                                   | `page`        |               |
+| MVC/ViewImports                              | `viewimports` |               |
+| MVC ViewStart                                | `viewstart`   |               |
 
 # [.NET Core 1.x](#tab/netcore1x)
 
 The command contains a default list of templates. Use `dotnet new -all` to obtain a list of the available templates. The following table shows the templates that come pre-installed with the .NET Core 1.x SDK. The default language for the template is shown inside the brackets.
 
-|Template description  | Template name  | Languages |
-|----------------------|----------------|-----------|
-| Console application  | console        | [C#], F#  |
-| Class library        | classlib       | [C#], F#  |
-| Unit test project    | mstest         | [C#], F#  |
-| xUnit test project   | xunit          | [C#], F#  |
-| ASP.NET Core empty   | web            | [C#]      |
-| ASP.NET Core Web App | mvc            | [C#], F#  |
-| ASP.NET Core Web API | webapi         | [C#]      |
-| Nuget config         | nugetconfig    |           |
-| Web config           | webconfig      |           |
-| Solution file        | sln            |           |
+|Template description  | Template name | Languages |
+|----------------------|---------------|-----------|
+| Console application  | `console`     | [C#], F#  |
+| Class library        | `classlib`    | [C#], F#  |
+| Unit test project    | `mstest`      | [C#], F#  |
+| xUnit test project   | `xunit`       | [C#], F#  |
+| ASP.NET Core empty   | `web`         | [C#]      |
+| ASP.NET Core Web App | `mvc`         | [C#], F#  |
+| ASP.NET Core Web API | `webapi`      | [C#]      |
+| Nuget config         | `nugetconfig` |           |
+| Web config           | `webconfig`   |           |
+| Solution file        | `sln`         |           |
 
 ---
 


### PR DESCRIPTION
The template names are getting translated in the localized versions (see https://github.com/dotnet/docs.de-de/pull/54/files). Locking the template names so they don't get translated in future versions.