### PR TITLE
Add null remarks to the Name field.

### DIFF
--- a/xml/System.IO/FileSystemEventArgs.xml
+++ b/xml/System.IO/FileSystemEventArgs.xml
@@ -202,7 +202,8 @@
   
 ## Remarks  
  The name returned by the <xref:System.IO.FileSystemEventArgs.Name%2A> property is the relative path of the affected file or directory, with respect to the directory being watched. For example, if a <xref:System.IO.FileSystemWatcher> object is watching the directory "C:\temp" and the file at "C:\temp\test\file.txt" changes, the <xref:System.IO.FileSystemEventArgs.Name%2A> property will return "test\file.txt".  
-  
+ 
+ The <xref:System.IO.FileSystemEventArgs.Name%2A> property may be null for renamed events if the <xref:System.IO.FileSystemWatcher> does not get matching old and new name events from the OS.
  ]]></format>
         </remarks>
       </Docs>


### PR DESCRIPTION
# Title

Name field being null isn't documented

## Summary

It isn't documented that the Name field may potentially be null for rename events.

## Details

This can be unexpected, see: https://github.com/aspnet/Home/issues/2536. We need to document this to facilitate writing proper event handlers. We should consider adding the same detail to the Renamed and OnRename documentation.