### PR TITLE
Updated OrderedDictionary.xml for Add()

### DIFF
--- a/xml/System.Collections.Specialized/OrderedDictionary.xml
+++ b/xml/System.Collections.Specialized/OrderedDictionary.xml
@@ -310,7 +310,7 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Specialized.OrderedDictionary" /> collection is read-only.</exception>
-        <exception cref="T:System.ArgumentException">An element with the same key already exists in the <see cref="T:System.Collections.Specialized.OrderedDictionary"> collection.</exception>
+        <exception cref="T:System.ArgumentException">An element with the same key already exists in the <see cref="T:System.Collections.Specialized.OrderedDictionary" /> collection.</exception>
       </Docs>
     </Member>
     <Member MemberName="AsReadOnly">

--- a/xml/System.Collections.Specialized/OrderedDictionary.xml
+++ b/xml/System.Collections.Specialized/OrderedDictionary.xml
@@ -296,7 +296,7 @@
 ## Remarks  
  A key cannot be `null`, but a value can be.  
   
- You can also use the <xref:System.Collections.Specialized.OrderedDictionary.Item%2A> property to add new elements by setting the value of a key that does not exist in the <xref:System.Collections.Specialized.OrderedDictionary> collection; however, if the specified key already exists in the <xref:System.Collections.Specialized.OrderedDictionary>, setting the <xref:System.Collections.Specialized.OrderedDictionary.Item%2A> property overwrites the old value. In contrast, the <xref:System.Collections.Specialized.OrderedDictionary.Add%2A> method does not modify existing elements.  
+ You can also use the <xref:System.Collections.Specialized.OrderedDictionary.Item%2A> property to add new elements by setting the value of a key that does not exist in the <xref:System.Collections.Specialized.OrderedDictionary> collection; however, if the specified key already exists in the <xref:System.Collections.Specialized.OrderedDictionary>, setting the <xref:System.Collections.Specialized.OrderedDictionary.Item%2A> property overwrites the old value. In contrast, the <xref:System.Collections.Specialized.OrderedDictionary.Add%2A> method does not modify existing elements but instead throws <xref:System.ArgumentException>.
   
    
   
@@ -310,6 +310,7 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Specialized.OrderedDictionary" /> collection is read-only.</exception>
+        <exception cref="T:System.ArgumentException">The <see cref="T:System.Collections.Specialized.OrderedDictionary.Add%2A" /> tries to add a key that already exist.</exception>
       </Docs>
     </Member>
     <Member MemberName="AsReadOnly">

--- a/xml/System.Collections.Specialized/OrderedDictionary.xml
+++ b/xml/System.Collections.Specialized/OrderedDictionary.xml
@@ -310,7 +310,7 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">The <see cref="T:System.Collections.Specialized.OrderedDictionary" /> collection is read-only.</exception>
-        <exception cref="T:System.ArgumentException">The <see cref="T:System.Collections.Specialized.OrderedDictionary.Add%2A" /> tries to add a key that already exist.</exception>
+        <exception cref="T:System.ArgumentException">An element with the same key already exists in the <see cref="T:System.Collections.Specialized.OrderedDictionary"> collection.</exception>
       </Docs>
     </Member>
     <Member MemberName="AsReadOnly">


### PR DESCRIPTION
`Add()` method throws `ArgumentException` when tried adding duplicate key. It is not clear in the documentation.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
