### PR TITLE
Extra characters in warnaserror-compiler-option.md

### DIFF
--- a/docs/csharp/language-reference/compiler-options/warnaserror-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/warnaserror-compiler-option.md
@@ -22,7 +22,7 @@ The **-warnaserror+** option treats all warnings as errors
 ## Syntax  
   
 ```console  
--warnaserror[<U>+</U> | -][:warning-list]  
+-warnaserror[+ | -][:warning-list]  
 ```  
   
 ## Remarks  


### PR DESCRIPTION
Probably, `-warnaserror[<U>+</U> | -][:warning-list] ` is indeed meant to be `-warnaserror[+ | -][:warning-list] `.