### PR TITLE
LinkedList.CopyTo has never used Array.CopyTo

### DIFF
--- a/xml/System.Collections.Generic/LinkedList`1.xml
+++ b/xml/System.Collections.Generic/LinkedList`1.xml
@@ -815,8 +815,6 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This method uses <xref:System.Array.Copy%2A?displayProperty=nameWithType> to copy the elements.  
-  
  The elements are copied to the <xref:System.Array> in the same order in which the enumerator iterates through the <xref:System.Collections.Generic.LinkedList%601>.  
   
  This method is an O(`n`) operation, where `n` is <xref:System.Collections.Generic.LinkedList%601.Count%2A>.  


### PR DESCRIPTION
The documentation for `LinkedList<T>.CopyTo(T[], Int32)` appears to have stated:

> This method uses Array.Copy to copy the elements.

since the original version for .NET 2.0. However I am unable to find a version of the framework in which this is true.