### PR TITLE
Corrected code to test for zero-length array

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_CLR/conceptual.attributes.usage/cpp/source3.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR/conceptual.attributes.usage/cpp/source3.cpp
@@ -45,7 +45,7 @@ public:
         array<DeveloperAttribute^>^ MyAttributes =
             (array<DeveloperAttribute^>^) Attribute::GetCustomAttributes(t, DeveloperAttribute::typeid);
 
-        if (MyAttributes == nullptr)
+        if (MyAttributes->Length == 0)
         {
             Console::WriteLine("The attribute was not found.");
         }

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.attributes.usage/vb/source3.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.attributes.usage/vb/source3.vb
@@ -35,7 +35,7 @@ Class GetAttribTest1
         Dim MyAttributes() As DeveloperAttribute =
             CType(Attribute.GetCustomAttributes(t, GetType(DeveloperAttribute)), DeveloperAttribute())
 
-        If MyAttributes Is Nothing Then
+        If MyAttributes.Length = 0 Then
             Console.WriteLine("The attribute was not found.")
         Else
             For i As Integer = 0 To MyAttributes.Length - 1


### PR DESCRIPTION
# Corrected code to test for zero-length array

This PR corrects the Visual Basic and C++ code for an example that calls the Attribute.GetCustomAttributes. The C# code was corrected separately by PR #4095.

The current code tests whether the method's return value is null. However, the method always returns a non-null array of Attribute. If no custom attribute was found, the array's length is zero. 

## Suggested Reviewers

@mairaw 

//cc @matthewspencerboxuk

