### PR TITLE
Modified article "How to: Sort a GridView Column When a Header Is Clicked"

### DIFF
--- a/docs/framework/wpf/controls/how-to-sort-a-gridview-column-when-a-header-is-clicked.md
+++ b/docs/framework/wpf/controls/how-to-sort-a-gridview-column-when-a-header-is-clicked.md
@@ -126,8 +126,18 @@ public partial class Window1 : Window
                     }  
                 }  
   
-                string header = headerClicked.Column.Header as string;  
-                Sort(header, direction);  
+                string sortBy;
+                Binding columnBinding = headerClicked.Column.DisplayMemberBinding as Binding;
+                if (columnBinding != null)
+                {
+                    sortBy = columnBinding.Path.Path;
+                }
+                else
+                {
+                    sortBy = headerClicked.Column.Header as string;
+                }
+
+                Sort(sortBy, direction);
   
                 if (direction == ListSortDirection.Ascending)  
                 {  
@@ -178,9 +188,16 @@ Partial Public Class Window1
 							direction = ListSortDirection.Ascending  
 						End If  
 					End If  
-  
-					Dim header As String = TryCast(headerClicked.Column.Header, String)  
-					Sort(header, direction)  
+
+					Dim sortBy As String
+					Dim columnBinding as Binding = TryCast(headerClicked.Column.DisplayMemberBinding, Binding)
+					If columnBinding IsNot Nothing Then
+						sortBy = columnBinding.Path.Path
+					Else
+						sortBy = TryCast(headerClicked.Column.Header, String)
+					End If
+
+					Sort(sortBy, direction)  
   
 					If direction = ListSortDirection.Ascending Then  
 						headerClicked.Column.HeaderTemplate = TryCast(Resources("HeaderTemplateArrowUp"), DataTemplate)  

--- a/docs/framework/wpf/controls/how-to-sort-a-gridview-column-when-a-header-is-clicked.md
+++ b/docs/framework/wpf/controls/how-to-sort-a-gridview-column-when-a-header-is-clicked.md
@@ -222,13 +222,13 @@ private void Sort(string sortBy, ListSortDirection direction)
   
 ```vb  
 Private Sub Sort(ByVal sortBy As String, ByVal direction As ListSortDirection)  
-			Dim dataView As ICollectionView = CollectionViewSource.GetDefaultView(lv.ItemsSource)  
+	Dim dataView As ICollectionView = CollectionViewSource.GetDefaultView(lv.ItemsSource)  
   
-			dataView.SortDescriptions.Clear()  
-			Dim sd As New SortDescription(sortBy, direction)  
-			dataView.SortDescriptions.Add(sd)  
-			dataView.Refresh()  
-		End Sub  
+	dataView.SortDescriptions.Clear()  
+	Dim sd As New SortDescription(sortBy, direction)  
+	dataView.SortDescriptions.Add(sd)  
+	dataView.Refresh()  
+End Sub  
 ```  
   
 ## See Also  

--- a/docs/framework/wpf/controls/how-to-sort-a-gridview-column-when-a-header-is-clicked.md
+++ b/docs/framework/wpf/controls/how-to-sort-a-gridview-column-when-a-header-is-clicked.md
@@ -102,8 +102,7 @@ public partial class Window1 : Window
     void GridViewColumnHeaderClickedHandler(object sender,  
                                             RoutedEventArgs e)  
     {  
-        GridViewColumnHeader headerClicked =  
-              e.OriginalSource as GridViewColumnHeader;  
+        var headerClicked = e.OriginalSource as GridViewColumnHeader;  
         ListSortDirection direction;  
   
         if (headerClicked != null)  
@@ -126,16 +125,8 @@ public partial class Window1 : Window
                     }  
                 }  
   
-                string sortBy;
-                Binding columnBinding = headerClicked.Column.DisplayMemberBinding as Binding;
-                if (columnBinding != null)
-                {
-                    sortBy = columnBinding.Path.Path;
-                }
-                else
-                {
-                    sortBy = headerClicked.Column.Header as string;
-                }
+                var columnBinding = headerClicked.Column.DisplayMemberBinding as Binding;
+                var sortBy = columnBinding?.Path.Path ?? headerClicked.Column.Header as string;
 
                 Sort(sortBy, direction);
   
@@ -160,61 +151,58 @@ public partial class Window1 : Window
                 _lastDirection = direction;  
             }  
         }  
-    }  
+    }
+}
 ```  
   
 ```vb  
 Partial Public Class Window1  
-		Inherits Window  
-		Public Sub New()  
-			InitializeComponent()  
-		End Sub  
+	Inherits Window
+	Public Sub New()  
+		InitializeComponent()  
+	End Sub  
   
-		Private _lastHeaderClicked As GridViewColumnHeader = Nothing  
-		Private _lastDirection As ListSortDirection = ListSortDirection.Ascending  
+	Private _lastHeaderClicked As GridViewColumnHeader = Nothing  
+	Private _lastDirection As ListSortDirection = ListSortDirection.Ascending  
   
-		Private Sub GridViewColumnHeaderClickedHandler(ByVal sender As Object, ByVal e As RoutedEventArgs)  
-			Dim headerClicked As GridViewColumnHeader = TryCast(e.OriginalSource, GridViewColumnHeader)  
-			Dim direction As ListSortDirection  
+	Private Sub GridViewColumnHeaderClickedHandler(ByVal sender As Object, ByVal e As RoutedEventArgs)  
+		Dim headerClicked = TryCast(e.OriginalSource, GridViewColumnHeader)  
+		Dim direction As ListSortDirection  
   
-			If headerClicked IsNot Nothing Then  
-				If headerClicked.Role <> GridViewColumnHeaderRole.Padding Then  
-					If headerClicked IsNot _lastHeaderClicked Then  
+		If headerClicked IsNot Nothing Then  
+			If headerClicked.Role <> GridViewColumnHeaderRole.Padding Then  
+				If headerClicked IsNot _lastHeaderClicked Then  
+					direction = ListSortDirection.Ascending  
+				Else  
+					If _lastDirection = ListSortDirection.Ascending Then  
+						direction = ListSortDirection.Descending  
+					Else  
 						direction = ListSortDirection.Ascending  
-					Else  
-						If _lastDirection = ListSortDirection.Ascending Then  
-							direction = ListSortDirection.Descending  
-						Else  
-							direction = ListSortDirection.Ascending  
-						End If  
 					End If  
-
-					Dim sortBy As String
-					Dim columnBinding as Binding = TryCast(headerClicked.Column.DisplayMemberBinding, Binding)
-					If columnBinding IsNot Nothing Then
-						sortBy = columnBinding.Path.Path
-					Else
-						sortBy = TryCast(headerClicked.Column.Header, String)
-					End If
-
-					Sort(sortBy, direction)  
-  
-					If direction = ListSortDirection.Ascending Then  
-						headerClicked.Column.HeaderTemplate = TryCast(Resources("HeaderTemplateArrowUp"), DataTemplate)  
-					Else  
-						headerClicked.Column.HeaderTemplate = TryCast(Resources("HeaderTemplateArrowDown"), DataTemplate)  
-					End If  
-  
-					' Remove arrow from previously sorted header  
-					If _lastHeaderClicked IsNot Nothing AndAlso _lastHeaderClicked IsNot headerClicked Then  
-						_lastHeaderClicked.Column.HeaderTemplate = Nothing  
-					End If  
-  
-					_lastHeaderClicked = headerClicked  
-					_lastDirection = direction  
 				End If  
+
+				Dim columnBinding = TryCast(headerClicked.Column.DisplayMemberBinding, Binding)
+				Dim sortBy = If(columnBinding?.Path.Path, TryCast(headerClicked.Column.Header, String))
+
+				Sort(sortBy, direction)  
+
+				If direction = ListSortDirection.Ascending Then
+					headerClicked.Column.HeaderTemplate = TryCast(Resources("HeaderTemplateArrowUp"), DataTemplate)  
+				Else  
+					headerClicked.Column.HeaderTemplate = TryCast(Resources("HeaderTemplateArrowDown"), DataTemplate)  
+				End If  
+  
+				' Remove arrow from previously sorted header  
+				If _lastHeaderClicked IsNot Nothing AndAlso _lastHeaderClicked IsNot headerClicked Then  
+					_lastHeaderClicked.Column.HeaderTemplate = Nothing  
+				End If  
+  
+				_lastHeaderClicked = headerClicked  
+				_lastDirection = direction  
 			End If  
-		End Sub  
+		End If  
+	End Sub
+End Class
 ```  
   
  The following example shows the sorting algorithm that is called by the event handler to sort the data. The sort is performed by creating a new <xref:System.ComponentModel.SortDescription> structure.  


### PR DESCRIPTION
# Modified article "How to: Sort a GridView Column When a Header Is Clicked"

## Summary

The way the article's code example was written before this commit, the sorting was working only if the column's header text was exactly the same as the bound properties used to display, which is rarely the case in real world use.

I changed the code so that it gets the `DisplayMemberBinding` of the column and, if it is not present, will fall back to the previous implementation by getting the column header's text.
