### PR TITLE
Fixed AltDirectorySeparatorChar value for UNIX

### DIFF
--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -104,9 +104,9 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The character stored in this field cannot be in <xref:System.IO.Path.InvalidPathChars>. This field can be set to the same value as <xref:System.IO.Path.DirectorySeparatorChar>. `AltDirectorySeparatorChar` and `DirectorySeparatorChar` are both valid for separating directory levels in a path string.  
+ The character stored in this field cannot be in <xref:System.IO.Path.InvalidPathChars>. This field can be set to the same value as <xref:System.IO.Path.DirectorySeparatorChar>. `AltDirectorySeparatorChar` and <xref:System.IO.Path.DirectorySeparatorChar> are both valid for separating directory levels in a path string.  
   
- The value of this field is a backslash ('\\') on UNIX, and a slash ('/') on Windows and Macintosh operating systems.  
+ The value of this field is a slash ('/') on Windows, UNIX and Macintosh operating systems.  
   
    
   


### PR DESCRIPTION
Fixed description of the [System.IO.Path.AltDirectorySeparatorChar](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.altdirectoryseparatorchar?view=netcore-2.0) field: slash ('/') is the only separator for UNIX.
Also added xref-link to [DirectorySeparatorChar](https://docs.microsoft.com/en-us/dotnet/api/system.io.path.directoryseparatorchar?view=netcore-2.0) to be consistent with the **Remarks** section there.

Fixes #3894 

## Suggested Reviewers

@mairaw or @rpetrusha please review