### PR TITLE
Prefer '-' over '/' as compiler option prefix

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/see.md
+++ b/docs/csharp/programming-guide/xmldoc/see.md
@@ -32,7 +32,7 @@ ms.author: "wiwagn"
 ## Remarks  
  The \<see> tag lets you specify a link from within text. Use [\<seealso>](../../../csharp/programming-guide/xmldoc/seealso.md) to indicate that text should be placed in a See Also section. Use the [cref Attribute](../../../csharp/programming-guide/xmldoc/cref-attribute.md) to create internal hyperlinks to documentation pages for code elements.  
   
- Compile with [/doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
+ Compile with [-doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md) to process documentation comments to a file.  
   
  The following example shows a \<see> tag within a summary section.  
   


### PR DESCRIPTION
This is an additional fix for issue #4072.