### PR TITLE
missing release DWORD values

### DIFF
--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -136,12 +136,14 @@ Users can install and run multiple versions of the .NET Framework on their compu
     |.NET Framework 4.6 installed on all other Windows OS versions|393297|
     |.NET Framework 4.6.1 installed on Windows 10|394254|
     |.NET Framework 4.6.1 installed on all other Windows OS versions|394271|
+    |.NET Framework 4.6.1 installed on 6.1.7601.65536|394294|
     |.NET Framework 4.6.2 installed on Windows 10 Anniversary Update|394802|
     |.NET Framework 4.6.2 installed on all other Windows OS versions|394806|
     |.NET Framework 4.7 installed on Windows 10 Creators Update|460798|
     |.NET Framework 4.7 installed on all other Windows OS versions|460805|
     |.NET Framework 4.7.1 installed on Windows 10 Fall Creators Update|461308|
     |.NET Framework 4.7.1 installed on all other Windows OS versions|461310|
+    |.NET Framework 4.7.1 installed on 10.0.17025.0|461765|
 
      The following example checks the `Release` value in the registry to determine whether the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)] or a later version of the .NET Framework is installed.
 


### PR DESCRIPTION
# Missing Release DWORD Values
## Summary

We are using the registry locations described here to determine the installed .NET Framework version on our customers' computers. There are two values we are seeing which are not reflected in the chart here. I've add them as rows just to start a discussion around what should be done with these values.