### PR TITLE
Update to address omissions

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
+++ b/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
@@ -11,29 +11,27 @@ ms.devlang: "csharp"
 ---
 # Ref returns and ref locals
 
-Starting with C# 7, C# supports reference return values (ref returns). A reference return value allows a method to return a reference to an object, rather than a value, back to a caller. The caller can then choose to treat the returned object  as if it were returned by value or by reference. A value returned by reference that the caller handles as a reference rather than a value is a ref local.
+Starting with C# 7, C# supports reference return values (ref returns). A reference return value allows a method to return a reference to a variable, rather than a value, back to a caller. The caller can then choose to treat the returned variable as if it were returned by value or by reference. The caller can create a new variable that is itself a reference to the returned value, called a ref local.
 
 ## What is a reference return value?
 
-Most developers are familiar with passing an argument to a called method *by reference*. A called method's argument list includes a value passed by reference, and any changes made to its value by the called method are returned to the caller. A *reference return value* means that a method returns a *reference* (or an alias) to some variable whose lifetime is greater than the method:
+Most developers are familiar with passing an argument to a called method *by reference*. A called method's argument list includes a variable passed by reference, and any changes made to its value by the called method are observed by the caller. A *reference return value* means that a method returns a *reference* (or an alias) to some variable whose scope includes the method and whose lifetime must extend beyond the return of the method.
 
 - The called method's return value, rather than an argument passed to it, is a reference.
 
-- Modifications to the method's return value by the caller are reflected in the state of the object whose method was called.
+- Modifications to the method's return value by the caller are made to the variable that is returned by the method.
 
-Declaring that a method returns a *reference return value* indicates that the method returns an alias to another variable. The design intent is often that the calling code should have access to that other variable through the alias, likely to modify it. 
+Declaring that a method returns a *reference return value* indicates that the method returns an alias to a variable. The design intent is often that the calling code should have access to that variable through the alias, including to modify it. It follows that methods returning by reference cannot have the return type `void`.
 
-There are some restrictions on the value that a method can return as a reference return value. These include:
+There are some restrictions on the expression that a method can return as a reference return value. These include:
 
-- The return value cannot be `void`. Attempting to define a method with a `void` reference return value generates compiler error CS1547, "Keyword 'void' cannot be used in this context."
- 
 - The return value must have a lifetime that extends beyond the execution of the method. In other words, it cannot be a local variable in the method that returns it. It can be an instance or static field of a class, or it can be an argument passed to the method. Attempting to return a local variable generates compiler error CS8168, "Cannot return local 'obj' by reference because it is not a ref local."
 
 - The return value cannot be the literal `null`. Attempting to return `null` generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
 
    A method with a ref return can return an alias to a variable whose value is currently the null (uninstantiated) value or a [nullable type](../nullable-types/index.md) for a value type.
  
-- The return value cannot be a constant, an enumeration member, or the return value from a property of a `class` or `struct`. Attempting to return these generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
+- The return value cannot be a constant, an enumeration member, or the by-value return value from a property, or a method of a `class` or `struct`. Attempting to return these generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
 
 In addition, because an asynchronous method may return before it has finished execution, while its return value is still unknown, reference return values are not allowed on async methods.
  
@@ -67,11 +65,10 @@ The ref return value is an alias to another variable in the called method's scop
 Assume the `GetContactInformation` method is declared as a ref return:
 
 ```csharp
-ref Person GetContactInformation(string firstName, string lastName)
+public ref Person GetContactInformation(string fname, string lname)
 ```
 
-A normal assignment reads the value of a variable and assigns it to a new variable:
-
+A by-value assignment reads the value of a variable and assigns it to a new variable:
 
 ```csharp
 Person p = contacts.GetContactInformation("Brandie", "Best");
@@ -85,7 +82,7 @@ You declare a *ref local* variable to copy the alias to the original value. In t
 ref Person p = ref contacts.GetContactInformation("Brandie", "Best");
 ```
 
-Subsequent usage of `p` is the same as using the variable returned by `GetContactInformation` because `p` is an alias for that variable.
+Subsequent usage of `p` is the same as using the variable returned by `GetContactInformation` because `p` is an alias for that variable. Changes to `p` also change the variable returned from `GetContactInformation`.
 
 Note that the `ref` keyword is used both before the local variable declaration *and* before the method call. Failure to include both `ref` keywords in the variable declaration and assignment results in compiler error CS8172, "Cannot initialize a by-reference variable with a value." 
  

--- a/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
+++ b/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
@@ -3,40 +3,37 @@ title: "Ref return values and ref locals (C# Guide)"
 description: "Learn how to define and use ref return and ref local values"
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.date: "05/30/2017"
+ms.date: "01/23/2017"
 ms.topic: "article"
 ms.prod: ".net"
 ms.technology: "devlang-csharp"
 ms.devlang: "csharp"
-ms.assetid: "18cf7a4b-29f0-4b14-85b8-80af754aabd8"
 ---
 # Ref returns and ref locals
 
-Starting with C# 7, C# supports reference return values (ref returns). A reference return value allows a method to return a reference to an object, rather than a value, back to a caller. The caller can then choose to treat the returned object returned as if it were returned by value or by reference. A value returned by reference that the caller handles as a reference rather than a value is a ref local.
+Starting with C# 7, C# supports reference return values (ref returns). A reference return value allows a method to return a reference to an object, rather than a value, back to a caller. The caller can then choose to treat the returned object  as if it were returned by value or by reference. A value returned by reference that the caller handles as a reference rather than a value is a ref local.
 
 ## What is a reference return value?
 
-Most developers are familiar with passing an argument to a called method *by reference*. A called method's argument list includes a value passed by reference, and any changes made to its value by the called method are returned to the caller. A *reference return value* is the opposite:
+Most developers are familiar with passing an argument to a called method *by reference*. A called method's argument list includes a value passed by reference, and any changes made to its value by the called method are returned to the caller. A *reference return value* means that a method returns a *reference* (or an alias) to some variable whose lifetime is greater than the method:
 
 - The called method's return value, rather than an argument passed to it, is a reference.
 
-- The caller, rather than the called method, can modify the value returned by the method.
+- Modifications to the method's return value by the caller are reflected in the state of the object whose method was called.
 
-- Instead of modifications to the argument that are reflected in state of the object on the caller, modifications to the method's return value by the caller are reflected in the state of the object whose method was called.
-
-Reference return values can produce more compact code, as well as allow an object to expose only the individual data items, such as an array element, that are of interest to the caller. This reduces the likelihood that the caller will inadvertently modify the object's state.
+Declaring that a method returns a *reference return value* indicates that the method returns an alias to another variable. The design intent is often that the calling code should have access to that other variable through the alias, likely to modify it. 
 
 There are some restrictions on the value that a method can return as a reference return value. These include:
 
 - The return value cannot be `void`. Attempting to define a method with a `void` reference return value generates compiler error CS1547, "Keyword 'void' cannot be used in this context."
  
-- The return value cannot be a local variable in the method that returns it; it must have a scope that is outside the method that returns it. It can be an instance or static field of a class, or it can be an argument passed to the method. Attempting to return a local variable generates compiler error CS8168, "Cannot return local 'obj' by reference because it is not a ref local."
+- The return value must have a lifetime that extends beyond the execution of the method. In other words, it cannot be a local variable in the method that returns it. It can be an instance or static field of a class, or it can be an argument passed to the method. Attempting to return a local variable generates compiler error CS8168, "Cannot return local 'obj' by reference because it is not a ref local."
 
-- The return value cannot be a `null`. Attempting to return `null` generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
+- The return value cannot be the literal `null`. Attempting to return `null` generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
 
-   If a method with a ref return needs to return a null value, you can either return a null (uninstantiated) value for a reference type or a [nullable type](../nullable-types/index.md) for a value type.
+   A method with a ref return can return an alias to a variable whose value is currently the null (uninstantiated) value or a [nullable type](../nullable-types/index.md) for a value type.
  
-- The return value cannot be a constant, an enumeration member, or a property of a `class` or `struct`. Attempting to return these generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
+- The return value cannot be a constant, an enumeration member, or the return value from a property of a `class` or `struct`. Attempting to return these generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
 
 In addition, because an asynchronous method may return before it has finished execution, while its return value is still unknown, reference return values are not allowed on async methods.
  
@@ -48,7 +45,7 @@ You define a ref return value by adding the [ref](../../language-reference/keywo
 public ref Person GetContactInformation(string fname, string lname);
 ```
 
-In addition, the name of the object returned by each [return](../../language-reference/keywords/return.md) statement in the method body must be preceded by the [ref](../../language-reference/keywords/ref.md) keyword. For example, the following `return` statement returns a `Person` object named `p` by reference:
+In addition, the name of the object returned by each [return](../../language-reference/keywords/return.md) statement in the method body must be preceded by the [ref](../../language-reference/keywords/ref.md) keyword. For example, the following `return` statement returns a reference to a `Person` object named `p`:
 
 ```csharp
 return ref p;
@@ -56,25 +53,41 @@ return ref p;
 
 ## Consuming a ref return value
 
-A caller can handle a ref return value in either of two ways:
+The ref return value is an alias to another variable in the called method's scope. You can interpret any use of the ref return as using the variable it aliases:
 
-- As an ordinary value returned by value from a method. The caller can choose to ignore that the return value is a reference return value. In this case, any changes made to the value returned by the method call are not reflected in the state of the called type. If the returned value is a value type, any changes made to the value returned by the method call are not reflected in the state of the called type.
+- When you assign its value, you are assigning a value to the variable it aliases.
+- When you read its value, you are reading the value of the variable it aliases.
+- If you return it *by reference* you are returning an alias to that same variable.
+- If you pass it to another method *by reference* you are passing a reference to the variable it aliases.
+- When you make a [ref local](#ref-local) alias, you make a new alias to the same variable.
 
-- As a reference return value. The caller must define the variable to which the reference return value is assigned as a [ref local](#ref-local), and any changes to the value returned by the method call are reflected in the state of the called type. 
 
 ## Ref locals
 
-To handle the reference return value as a reference, the caller must declare the value to be a *ref local* by using the `ref` keyword. For example, if the value returned by the `Person.GetContactInfomation` method is to be consumed as a reference rather than a value, the method call appears as:
+Assume the `GetContactInformation` method is declared as a ref return:
+
+```csharp
+ref Person GetContactInformation(string firstName, string lastName)
+```
+
+A normal assignment reads the value of a variable and assigns it to a new variable:
+
+
+```csharp
+Person p = contacts.GetContactInformation("Brandie", "Best");
+```
+
+The preceding assignment declares `p` as a local variable. Its initial value is copied from reading the value returned by `GetContactInformation`. Any future assignments to `p` will not change the value of the variable returned by `GetContactInformation`. The variable `p` is no longer an alias to the variable returned.
+
+You declare a *ref local* variable to copy the alias to the original value. In the following assignment, `p` is an alias to the variable returned from `GetContactInformation`.
 
 ```csharp
 ref Person p = ref contacts.GetContactInformation("Brandie", "Best");
 ```
 
-Note that the `ref` keyword is used both before the local variable declaration *and* before the method call. Failure to include both `ref` keywords in the variable declaration and assignment results in compiler error CS8172, "Cannot initialize a by-reference variable with a value." 
- 
-Subsequent changes to the `Person` object returned by the method are reflected in the `contacts` object.
+Subsequent usage of `p` is the same as using the variable returned by `GetContactInformation` because `p` is an alias for that variable.
 
-If `p` is not defined as a ref local by using the `ref` keyword, any changes made to `p` by the caller are not reflected in the `contacts` object.
+Note that the `ref` keyword is used both before the local variable declaration *and* before the method call. Failure to include both `ref` keywords in the variable declaration and assignment results in compiler error CS8172, "Cannot initialize a by-reference variable with a value." 
  
 ## Ref returns and ref locals: an example
 

--- a/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
+++ b/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
@@ -15,11 +15,7 @@ Starting with C# 7, C# supports reference return values (ref returns). A referen
 
 ## What is a reference return value?
 
-Most developers are familiar with passing an argument to a called method *by reference*. A called method's argument list includes a variable passed by reference, and any changes made to its value by the called method are observed by the caller. A *reference return value* means that a method returns a *reference* (or an alias) to some variable whose scope includes the method and whose lifetime must extend beyond the return of the method.
-
-- The called method's return value, rather than an argument passed to it, is a reference.
-
-- Modifications to the method's return value by the caller are made to the variable that is returned by the method.
+Most developers are familiar with passing an argument to a called method *by reference*. A called method's argument list includes a variable passed by reference, and any changes made to its value by the called method are observed by the caller. A *reference return value* means that a method returns a *reference* (or an alias) to some variable whose scope includes the method and whose lifetime must extend beyond the return of the method. Modifications to the method's return value by the caller are made to the variable that is returned by the method.
 
 Declaring that a method returns a *reference return value* indicates that the method returns an alias to a variable. The design intent is often that the calling code should have access to that variable through the alias, including to modify it. It follows that methods returning by reference cannot have the return type `void`.
 
@@ -31,7 +27,7 @@ There are some restrictions on the expression that a method can return as a refe
 
    A method with a ref return can return an alias to a variable whose value is currently the null (uninstantiated) value or a [nullable type](../nullable-types/index.md) for a value type.
  
-- The return value cannot be a constant, an enumeration member, or the by-value return value from a property, or a method of a `class` or `struct`. Attempting to return these generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
+- The return value cannot be a constant, an enumeration member, the by-value return value from a property, or a method of a `class` or `struct`. Attempting to return these generates compiler error CS8156, "An expression cannot be used in this context because it may not be returned by reference."
 
 In addition, because an asynchronous method may return before it has finished execution, while its return value is still unknown, reference return values are not allowed on async methods.
  


### PR DESCRIPTION
See issue #4103

This PR updates the topic on ref locals and returns to address a number of omissions in the earlier version.

[Internal review link](https://review.docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/ref-returns?branch=pr-en-us-4194)

