### PR TITLE
Created include for standardized text on csharp-interactive

### DIFF
--- a/docs/csharp/how-to/concatenate-multiple-strings.md
+++ b/docs/csharp/how-to/concatenate-multiple-strings.md
@@ -19,6 +19,8 @@ ms.author: "wiwagn"
 
 *Concatenation* is the process of appending one string to the end of another string. You concatenate strings by using the + operator. For string literals and string constants, concatenation occurs at compile time; no run-time concatenation occurs. For string variables, concatenation occurs only at run time.
 
+[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
+
 The following example uses concatenation to split a long string literal into smaller strings in order to improve readability in the source code. These parts will be concatenated into a single string at compile time. There is no run-time performance cost regardless of the number of strings involved.  
   
  [!code-csharp-interactive[Combining strings at compile time](../../../samples/snippets/csharp/how-to/strings/Concatenate.cs#1)]  

--- a/docs/csharp/how-to/parse-strings-using-split.md
+++ b/docs/csharp/how-to/parse-strings-using-split.md
@@ -22,8 +22,9 @@ The <xref:System.String.Split%2A?displayProperty=nameWithType> method creates an
 array of substrings by splitting the input string based on one or more delimiters. It is often the easiest way to separate a string on word boundaries. It is also used
 to split strings on other specific characters or strings.
 
+[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
+
 The following code splits a common phrase into an array of strings for each word.
-Try it yourself by pressing the *Run* button.
 
 [!code-csharp-interactive[split strings on word boundaries](../../../samples/snippets/csharp/how-to/strings/ParseStringsUsingSplit.cs#1)]
 

--- a/includes/csharp-interactive-note.md
+++ b/includes/csharp-interactive-note.md
@@ -1,0 +1,3 @@
+
+> [!NOTE]
+> The C# examples in this article run in the [Try.NET](https://try.dot.net) inline code runner and playground. You can run an example in an interactive window by pressing the **Run** button. Once you execute the code, you can modify it and run the modified code by pressing **Run** again.  The modified code either runs in the interactive window or, if compilation fails, the interactive window displays all C# compiler error messages.  

--- a/xml/System/DateTime.xml
+++ b/xml/System/DateTime.xml
@@ -49,6 +49,8 @@
 
 ## Quick links to example code
 
+[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
+
 This article includes several examples that use the `DateTime` type:
 
 **Initialization Examples**      

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -4621,7 +4621,9 @@ In contrast, the use of interpolated strings in the following example produce mu
 
 ## Examples
 
-Numerous examples that call the <xref:System.String.Format%2A> method are interspersed through the [Remarks](#remarks) section of this article. The C# examples are runnable from your browser; just select the **Run** button. 
+Numerous examples that call the <xref:System.String.Format%2A> method are interspersed through the [Remarks](#remarks) section of this article.  
+
+[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
 You can also download a complete set of `String.Format` examples, which are included a [.NET Core 2.0 project for C#](https://github.com/dotnet/docs/raw/master/samples/snippets/csharp/downloads/api/System/String.Format.zip) and and a [.NET Core 2.0 project for Visual Basic](https://github.com/dotnet/docs/raw/master/samples/snippets/visualbasic/downloads/api/System/String.Format.zip), from the [dotnet/docs GitHub repository](https://github.com/dotnet/docs).
 


### PR DESCRIPTION
# Created include for standardized text on csharp-interactive

## Summary

This PR creates an include file for conceptual non-quick starts and API reference topics that use the C# interactive REPL. It also adds the boilerplate text to the two C# how-to and the two API reference topics that currently use the interactive REPL. 

## Details

As a separate step, we also should add a document with details about using the REPL (such as what namespaces are automatically imported) and limitations (such as the fact that the current culture is the invariant culture rather than the user's culture -- though this will be fixed in the near future). 

## Suggested Reviewers

@BillWagner 

