### PR TITLE
Following Naming Convention for Enums

### DIFF
--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/enum_1.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/enum_1.cs
@@ -1,12 +1,12 @@
 
     public class EnumTest
     {
-        enum Days { Sun, Mon, Tue, Wed, Thu, Fri, Sat };
+        enum Day { Sun, Mon, Tue, Wed, Thu, Fri, Sat };
 
         static void Main()
         {
-            int x = (int)Days.Sun;
-            int y = (int)Days.Fri;
+            int x = (int)Day.Sun;
+            int y = (int)Day.Fri;
             Console.WriteLine("Sun = {0}", x);
             Console.WriteLine("Fri = {0}", y);
         }

--- a/docs/csharp/language-reference/keywords/enum.md
+++ b/docs/csharp/language-reference/keywords/enum.md
@@ -52,7 +52,7 @@ enum Day : byte {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};
  The underlying type specifies how much storage is allocated for each enumerator. However, an explicit cast is necessary to convert from `enum` type to an integral type. For example, the following statement assigns the enumerator `Sun` to a variable of the type [int](../../../csharp/language-reference/keywords/int.md) by using a cast to convert from `enum` to `int`.  
   
 ```  
-int x = (int)Days.Sun;  
+int x = (int)Day.Sun;  
 ```  
   
  When you apply <xref:System.FlagsAttribute?displayProperty=nameWithType> to an enumeration that contains elements that can be combined with a bitwise `OR` operation, the attribute affects the behavior of the `enum` when it is used with some tools. You can notice these changes when you use tools such as the <xref:System.Console> class methods and the Expression Evaluator. (See the third example.)  
@@ -65,7 +65,7 @@ int x = (int)Days.Sun;
  If other developers use your code, you should provide guidelines about how their code should react if new elements are added to any `enum` types.  
   
 ## Example  
- In the following example, an enumeration, `Days`, is declared. Two enumerators are explicitly converted to integer and assigned to integer variables.  
+ In the following example, an enumeration, `Day`, is declared. Two enumerators are explicitly converted to integer and assigned to integer variables.  
   
  [!code-csharp[csrefKeywordsTypes#10](../../../csharp/language-reference/keywords/codesnippet/CSharp/enum_1.cs)]  
   

--- a/docs/csharp/language-reference/keywords/enum.md
+++ b/docs/csharp/language-reference/keywords/enum.md
@@ -23,13 +23,13 @@ The `enum` keyword is used to declare an enumeration, a distinct type that consi
  By default, the first enumerator has the value 0, and the value of each successive enumerator is increased by 1. For example, in the following enumeration, `Sat` is `0`, `Sun` is `1`, `Mon` is `2`, and so forth.  
   
 ```  
-enum Days {Sat, Sun, Mon, Tue, Wed, Thu, Fri};  
+enum Day {Sat, Sun, Mon, Tue, Wed, Thu, Fri};  
 ```  
   
  Enumerators can use initializers to override the default values, as shown in the following example.  
   
 ```  
-enum Days {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};  
+enum Day {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};  
 ```  
   
  In this enumeration, the sequence of elements is forced to start from `1` instead of `0`. However, including a constant that has the value of 0 is recommended. For more information, see [Enumeration Types](../../../csharp/programming-guide/enumeration-types.md).  
@@ -37,12 +37,12 @@ enum Days {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};
  Every enumeration type has an underlying type, which can be any integral type except [char](../../../csharp/language-reference/keywords/char.md). The default underlying type of enumeration elements is [int](../../../csharp/language-reference/keywords/int.md). To declare an enum of another integral type, such as [byte](../../../csharp/language-reference/keywords/byte.md), use a colon after the identifier followed by the type, as shown in the following example.  
   
 ```  
-enum Days : byte {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};  
+enum Day : byte {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};  
 ```  
   
  The approved types for an enum are `byte`, [sbyte](../../../csharp/language-reference/keywords/sbyte.md), [short](../../../csharp/language-reference/keywords/short.md), [ushort](../../../csharp/language-reference/keywords/ushort.md), [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), or [ulong](../../../csharp/language-reference/keywords/ulong.md).  
   
- A variable of type `Days` can be assigned any value in the range of the underlying type; the values are not limited to the named constants.  
+ A variable of type `Day` can be assigned any value in the range of the underlying type; the values are not limited to the named constants.  
   
  The default value of an `enum E` is the value produced by the expression `(E)0`.  
   
@@ -97,3 +97,4 @@ int x = (int)Days.Sun;
  [Built-In Types Table](../../../csharp/language-reference/keywords/built-in-types-table.md)  
  [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md)  
  [Explicit Numeric Conversions Table](../../../csharp/language-reference/keywords/explicit-numeric-conversions-table.md)
+ [Enum Naming Conventions](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#naming-enumerations)


### PR DESCRIPTION
## Summary

Change the Enum example to use[ the naming convention](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#naming-enumerations) of:

> DO use a singular type name for an enumeration unless its values are bit fields.

## Details

I made this change because this example violates the recommended naming convention.