### PR TITLE
Removed a duplicate "the"

### DIFF
--- a/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
+++ b/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
@@ -58,7 +58,7 @@ OOB releases for core common language runtime (CLR) components are delivered thr
   
  To find both prerelease and stable packages, choose **Include Prerelease** in the NuGet Package Manager.  
   
- If you want to be notified of stable package releases, subscribe to the [the .NET Framework feed](https://nuget.org/api/v2/curated-feeds/dotnetframework/Packages/).  
+ If you want to be notified of stable package releases, subscribe to [the .NET Framework feed](https://nuget.org/api/v2/curated-feeds/dotnetframework/Packages/).  
   
 ## See Also  
  [Getting Started](../../../docs/framework/get-started/index.md)


### PR DESCRIPTION
# Removed a duplicate "the" 

## Summary

There was a sentence the had the word "the" and then an embedded link that also used "the".  I removed the first "the" from the sentence, leaving the link alone.
