### PR TITLE
Removed excessive XAML codeblocks

### DIFF
--- a/docs/framework/wpf/data/how-to-create-a-simple-binding.md
+++ b/docs/framework/wpf/data/how-to-create-a-simple-binding.md
@@ -29,9 +29,7 @@ This example shows you how to create a simple <xref:System.Windows.Data.Binding>
   
  The following example instantiates the `Person` object with a `PersonName` property value of `Joe`. This is done in the `Resources` section and assigned an `x:Key`.  
   
- [!code-xaml[SimpleBinding#Instantiation](../../../../samples/snippets/csharp/VS_Snippets_Wpf/SimpleBinding/CSharp/Page1.xaml#instantiation)]  
-[!code-xaml[SimpleBinding#2](../../../../samples/snippets/csharp/VS_Snippets_Wpf/SimpleBinding/CSharp/Page1.xaml#2)]  
-[!code-xaml[SimpleBinding#EndWindow](../../../../samples/snippets/csharp/VS_Snippets_Wpf/SimpleBinding/CSharp/Page1.xaml#endwindow)]  
+ [!code-xaml[SimpleBinding](../../../../samples/snippets/csharp/VS_Snippets_Wpf/SimpleBinding/CSharp/Page1.xaml)]  
   
  To bind to the `PersonName` property you would do the following:  
   


### PR DESCRIPTION
Window.Resource and Window don't need to have their own codeblocks in the document. It draws unnecessary emphasis towards something you'd presumably have enough experience with already, if you were reading this kind of document (that you need to close XAML tags).

# Title 
Removed two reference lines and changed link.

## Summary
In the original page, there are three XAML codeblocks with the first having the majority of the code, while the last two have only closing tags. These can easily be merged into the first.

## Details
I removed the two reference lines in the XAML code for the closing tags, and changed the first link to point to the entire document instead. I believe the changes are correct, but they might be a little off. I'm not sure.