### PR TITLE
fix link break issue w/ Enum Naming Convention Link

### DIFF
--- a/docs/csharp/language-reference/keywords/enum.md
+++ b/docs/csharp/language-reference/keywords/enum.md
@@ -96,5 +96,5 @@ int x = (int)Day.Sun;
  [Integral Types Table](../../../csharp/language-reference/keywords/integral-types-table.md)  
  [Built-In Types Table](../../../csharp/language-reference/keywords/built-in-types-table.md)  
  [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md)  
- [Explicit Numeric Conversions Table](../../../csharp/language-reference/keywords/explicit-numeric-conversions-table.md)
+ [Explicit Numeric Conversions Table](../../../csharp/language-reference/keywords/explicit-numeric-conversions-table.md)  
  [Enum Naming Conventions](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#naming-enumerations)


### PR DESCRIPTION
## Summary

[Page Reference](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/enum)

![image](https://user-images.githubusercontent.com/14079228/35409518-6f27d96e-01e0-11e8-8d9d-52e5f84aca2e.png)

## Details

After Change:

![image](https://user-images.githubusercontent.com/14079228/35409527-7886a166-01e0-11e8-9954-b9c1a26dd16b.png)

Fix from #4196 
