### PR TITLE
Fix incorrect description

### DIFF
--- a/xml/System.IO/SearchOption.xml
+++ b/xml/System.IO/SearchOption.xml
@@ -35,7 +35,7 @@
    
   
 ## Examples  
- The following example lists all the directories and files that begin with the letter "c", as in "c:\\". In this example, the <xref:System.IO.SearchOption.AllDirectories> is used to specify that only the top-level directory should be searched.  
+ The following example lists all the directories and files that begin with the letter "c", as in "c:\\". In this example, <xref:System.IO.SearchOption.TopDirectoryOnly> is used to specify that only the top-level directory should be searched.  
   
  [!code-cpp[System.IO.DirectoryInfo_SearchOptions#00](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.IO.DirectoryInfo_SearchOptions/cpp/searchoption.cpp#00)]
  [!code-csharp[System.IO.DirectoryInfo_SearchOptions#00](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.IO.DirectoryInfo_SearchOptions/cs/searchoption.cs#00)]


### PR DESCRIPTION
The description for this code sample states it uses `SearchOption.AllDirectories`, however rest of the sentence is describing the behaviour of `SearchOption.TopLevelOnly`, which is what is actually used by the code samples.