### PR TITLE
Fix flag

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -42,7 +42,7 @@ The only time `dotnet` is used as a command on its own is to run [framework-depe
 
 # [.NET Core 2.x](#tab/netcore2x)
 
-`--additionaldeps <PATH>`
+`--additional-deps <PATH>`
 
 Path to additional *deps.json* file.
 


### PR DESCRIPTION
Fix additional-deps as it is WITH a dash as opposed to additionalprobingpath

# Title
Additional dependencies are set with --addtional-deps which is inconsitent with --additionalprobingpath but that's how the current code is.
