### PR TITLE
Add link for byte reference

### DIFF
--- a/docs/csharp/language-reference/keywords/enum.md
+++ b/docs/csharp/language-reference/keywords/enum.md
@@ -40,7 +40,7 @@ enum Day {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};
 enum Day : byte {Sat=1, Sun, Mon, Tue, Wed, Thu, Fri};  
 ```  
   
- The approved types for an enum are `byte`, [sbyte](../../../csharp/language-reference/keywords/sbyte.md), [short](../../../csharp/language-reference/keywords/short.md), [ushort](../../../csharp/language-reference/keywords/ushort.md), [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), or [ulong](../../../csharp/language-reference/keywords/ulong.md).  
+ The approved types for an enum are [byte](../../../csharp/language-reference/keywords/byte.md), [sbyte](../../../csharp/language-reference/keywords/sbyte.md), [short](../../../csharp/language-reference/keywords/short.md), [ushort](../../../csharp/language-reference/keywords/ushort.md), [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), or [ulong](../../../csharp/language-reference/keywords/ulong.md).  
   
  A variable of type `Day` can be assigned any value in the range of the underlying type; the values are not limited to the named constants.  
   


### PR DESCRIPTION
The other elements in the list have links to the their corresponding page.
byte was the only one not having one.
