### PR TITLE
Fixed XML comment in code snippet

### DIFF
--- a/docs/framework/wcf/samples/tracing-and-message-logging.md
+++ b/docs/framework/wcf/samples/tracing-and-message-logging.md
@@ -76,7 +76,7 @@ This sample demonstrates how to enable tracing and message logging. The resultin
   <system.serviceModel>  
     <diagnostics>  
       <!-- Enable Message Logging here. -->  
-      <!-- log all messages received or sent at the transport or service model levels >  
+      <!-- log all messages received or sent at the transport or service model levels -->  
       <messageLogging logEntireMessage="true"  
                       maxMessagesToLog="300"  
                       logMessagesAtServiceLevel="true"  


### PR DESCRIPTION
I fixed an XML comment in one of the code snippets.  The comment wasn't terminated correctly, so the syntax highlighting for everything past that comment was wrong.

# Title

Minor change to code snippet.

## Summary

The code snippet contained invalid XML.

## Details

Terminated XML comment in code snippet to make XML valid.
