### PR TITLE
Removed mentions of Visual Studio version (2015) in WPF docs

### DIFF
--- a/docs/framework/wpf/app-development/index.md
+++ b/docs/framework/wpf/app-development/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Application Development"
 ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "01/26/2018"
 ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
@@ -137,5 +137,5 @@ ms.workload:
 |[Navigation Overview](../../../../docs/framework/wpf/app-development/navigation-overview.md)|Provides an overview of managing navigation between pages of your application.|  
 |[Hosting](../../../../docs/framework/wpf/app-development/hosting-wpf-applications.md)|Provides an overview of [!INCLUDE[TLA#tla_xbap#plural](../../../../includes/tlasharptla-xbapsharpplural-md.md)].|  
 |[Build and Deploy](../../../../docs/framework/wpf/app-development/building-and-deploying-wpf-applications.md)|Describes how to build and deploy your WPF application.|  
-|[Introduction to WPF in Visual Studio 2015](../../../../docs/framework/wpf/getting-started/introduction-to-wpf-in-vs.md)|Describes the main features of WPF.|  
+|[Introduction to WPF in Visual Studio](../../../../docs/framework/wpf/getting-started/introduction-to-wpf-in-vs.md)|Describes the main features of WPF.|  
 |[Walkthrough: My first WPF desktop application](../../../../docs/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md)|A walkthrough that shows how to create a WPF application using page navigation, layout, controls, images, styles, and binding.|

--- a/docs/framework/wpf/getting-started/index.md
+++ b/docs/framework/wpf/getting-started/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started (WPF)"
 ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "01/26/2018"
 ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
@@ -31,10 +31,10 @@ Windows Presentation Foundation (WPF) is a UI framework that creates desktop cli
 |I want to jump right in…|[Walkthrough: My first WPF desktop application](../../../../docs/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md)|  
 |How do I design the application UI?|[Designing XAML in Visual Studio](/visualstudio/designers/designing-xaml-in-visual-studio)|  
 |New to .NET?|[Overview of the .NET Framework](https://msdn.microsoft.com/library/zw4w595w\(v=vs.140\).aspx)<br /><br /> [.NET Framework Application Essentials](../../../../docs/standard/application-essentials.md)<br /><br /> [Getting Started with Visual C# and Visual Basic](https://msdn.microsoft.com/library/dd492171\(v=vs.140\).aspx)|  
-|Tell me more about WPF…|[Introduction to WPF in Visual Studio 2015](../../../../docs/framework/wpf/getting-started/introduction-to-wpf-in-vs.md)<br /><br /> [XAML Overview (WPF)](../../../../docs/framework/wpf/advanced/xaml-overview-wpf.md)<br /><br /> [Controls](../../../../docs/framework/wpf/controls/index.md)<br /><br /> [Data Binding Overview](../../../../docs/framework/wpf/data/data-binding-overview.md)|  
+|Tell me more about WPF…|[Introduction to WPF in Visual Studio](../../../../docs/framework/wpf/getting-started/introduction-to-wpf-in-vs.md)<br /><br /> [XAML Overview (WPF)](../../../../docs/framework/wpf/advanced/xaml-overview-wpf.md)<br /><br /> [Controls](../../../../docs/framework/wpf/controls/index.md)<br /><br /> [Data Binding Overview](../../../../docs/framework/wpf/data/data-binding-overview.md)|  
 |Are you a Windows Forms developer?|[Windows Forms Controls and Equivalent WPF Controls](../../../../docs/framework/wpf/advanced/windows-forms-controls-and-equivalent-wpf-controls.md)<br /><br /> [WPF and Windows Forms Interoperation](../../../../docs/framework/wpf/advanced/wpf-and-windows-forms-interoperation.md)|  
   
 ## See Also  
  [Class Library](../../../../docs/framework/wpf/class-library-wpf.md)  
  [Application Development](../../../../docs/framework/wpf/app-development/index.md)  
- [.NET Framework Developer Center](http://go.microsoft.com/fwlink/?LinkId=187437)
+ [.NET Framework Developer Center](https://www.microsoft.com/net)

--- a/docs/framework/wpf/getting-started/introduction-to-wpf-in-vs.md
+++ b/docs/framework/wpf/getting-started/introduction-to-wpf-in-vs.md
@@ -1,7 +1,7 @@
 ---
-title: "Introduction to WPF in Visual Studio 2015"
+title: "Introduction to WPF in Visual Studio"
 ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "01/26/2018"
 ms.prod: ".net-framework"
 ms.reviewer: ""
 ms.suite: ""
@@ -30,10 +30,10 @@ manager: "wpickett"
 ms.workload: 
   - dotnet
 ---
-# Introduction to WPF in Visual Studio 2015
-Windows Presentation Foundation (WPF) in Visual Studio 2015 provides developers with a unified programming model for building modern line-of-business desktop applications on Windows.  
+# Introduction to WPF in Visual Studio
+Windows Presentation Foundation (WPF) in Visual Studio provides developers with a unified programming model for building line-of-business desktop applications on Windows.  
   
- [Create Modern Desktop Applications with Windows Presentation Foundation](/visualstudio/designers/create-modern-desktop-applications-with-windows-presentation-foundation)  
+ [Create Desktop Applications with Windows Presentation Foundation](/visualstudio/designers/create-modern-desktop-applications-with-windows-presentation-foundation)  
   
  [Designing XAML in Visual Studio and Blend for Visual Studio](/visualstudio/designers/designing-xaml-in-visual-studio)  
   

--- a/docs/framework/wpf/getting-started/toc.md
+++ b/docs/framework/wpf/getting-started/toc.md
@@ -1,5 +1,5 @@
 # [Getting Started](index.md)
-## [Introduction to WPF in Visual Studio 2015](introduction-to-wpf-in-vs.md)
+## [Introduction to WPF in Visual Studio](introduction-to-wpf-in-vs.md)
 ## [What's New in WPF Version 4.5](whats-new.md)
 ## [Walkthrough: My first WPF desktop application](walkthrough-my-first-wpf-desktop-application.md)
 ## [WPF Walkthroughs](wpf-walkthroughs.md)


### PR DESCRIPTION
To be consistent with changes made in #4209 I've removed mentioning of Visual Studio 2015 (leaving just 'Visual Studio') in WPF docs.
Plus: replaced fwlink to .NET Framework Developer center

## Suggested Reviewers
@mairaw please review
