### PR TITLE
Update comments to have correct parameter type

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/extension-methods_3.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/extension-methods_3.cs
@@ -90,8 +90,8 @@ namespace ExtensionMethodsDemo1
 
             // A contains no MethodA, so each call to MethodA resolves to 
             // the extension method that has a matching signature.
-            a.MethodA(1);           // Extension.MethodA(object, int)
-            a.MethodA("hello");     // Extension.MethodA(object, string)
+            a.MethodA(1);           // Extension.MethodA(IMyInterface, int)
+            a.MethodA("hello");     // Extension.MethodA(IMyInterface, string)
 
             // A has a method that matches the signature of the following call
             // to MethodB.
@@ -104,7 +104,7 @@ namespace ExtensionMethodsDemo1
 
             // B has no matching method for the following call, but 
             // class Extension does.
-            b.MethodA("hello");     // Extension.MethodA(object, string)
+            b.MethodA("hello");     // Extension.MethodA(IMyInterface, string)
 
             // C contains an instance method that matches each of the following
             // method calls.


### PR DESCRIPTION
The in line comments when showing that the extension methods would be called incorrectly indicate that the method would be called because it matches a signature with the type `object`, when it would actually match because it is type `IMyInterface`.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
