### PR TITLE
CommandManager.xml: event is weak because of custom implementation, not because of being static

### DIFF
--- a/xml/System.Windows.Input/CommandManager.xml
+++ b/xml/System.Windows.Input/CommandManager.xml
@@ -567,7 +567,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- This event is implemented in such a way that it only holds onto the handler as a weak reference.  Objects that listen for this event should keep a strong reference to their event handler to avoid it being garbage collected. This can be accomplished by having a private field and assigning the handler as the value before or after attaching to this event.  
+ This event holds onto the handler as a weak reference. Objects that listen for this event should keep a strong reference to their event handler to avoid it being garbage collected. This can be accomplished by having a private field and assigning the handler as the value before or after attaching to this event.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Windows.Input/CommandManager.xml
+++ b/xml/System.Windows.Input/CommandManager.xml
@@ -567,7 +567,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Since this event is static, it will only hold onto the handler as a weak reference.  Objects that listen for this event should keep a strong reference to their event handler to avoid it being garbage collected. This can be accomplished by having a private field and assigning the handler as the value before or after attaching to this event.  
+ This event is implemented in such a way that it only holds onto the handler as a weak reference.  Objects that listen for this event should keep a strong reference to their event handler to avoid it being garbage collected. This can be accomplished by having a private field and assigning the handler as the value before or after attaching to this event.  
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
Updated phrasing of RequerySuggested event: it is weak not because of being static.

Fixes #4235 

## Suggested Reviewers
@svick @jinek what do you think of updated phrasing

I would not mention `WeakEventManager` since there were too much implementation details in the documentation.
