### PR TITLE
[WIP] Docs fix - drive-by shell quotes fix since # is a comment-character in most shells

### DIFF
--- a/docs/fsharp/get-started/get-started-command-line.md
+++ b/docs/fsharp/get-started/get-started-command-line.md
@@ -44,7 +44,7 @@ Change directories to *FSNetCore* and start adding projects to the solution fold
 Use the `dotnet new` command, create a Class Library project in the **src** folder named Library. 
 
 ```bash
-dotnet new lib -lang F# -o src/Library 
+dotnet new lib -lang "F#" -o src/Library 
 ```
 
 The following directory structure is produced as a result of the command completing:
@@ -88,7 +88,7 @@ Restore the NuGet dependencies, `dotnet restore` ([see note](#dotnet-restore-not
 Use the `dotnet new` command, create a Console app in the **src** folder named App. 
 
 ```bash
-dotnet new console -lang F# -o src/App 
+dotnet new console -lang "F#" -o src/App 
 ```
 
 The following directory structure is produced as a result of the command completing:


### PR DESCRIPTION
## Summary

2 issues:

0. My shell (zsh) treats `#` as a special character, and requires me to quote this. _This_ is _probably_ because zsh uses `#` for "pattern removal" - see [documentation (search on page for "Standard forms: pattern removal")](http://zsh.sourceforge.net/Guide/zshguide05.html). It's configurable, so users' mileages will vary.
0. The website's markdown rendering's syntax highlighting treats the text after the `#` differently (presumably as a comment, since the `#` character is a comment in most dialects of shell).

## Details

I've included shell output for item 1:

```sh
peter at peterm in ~/fsharp/FSNetCore
$ dotnet new lib -lang F# -o src/Library
zsh: no matches found: F#

peter at peterm in ~/fsharp/FSNetCore
$ dotnet new lib -lang "F#" -o src/Library
The template "Class library" was created successfully.

Processing post-creation actions...
Running 'dotnet restore' on src/Library/Library.fsproj...
  Restoring packages for /Users/peter/fsharp/FSNetCore/src/Library/Library.fsproj...
  Installing System.Net.WebHeaderCollection 4.0.1.
  Installing System.Net.Requests 4.0.11.
  Installing System.Threading.Tasks.Parallel 4.0.1.
  Installing FSharp.Core 4.2.3.
  Generating MSBuild file /Users/peter/fsharp/FSNetCore/src/Library/obj/Library.fsproj.nuget.g.props.
  Generating MSBuild file /Users/peter/fsharp/FSNetCore/src/Library/obj/Library.fsproj.nuget.g.targets.
  Restore completed in 5.59 sec for /Users/peter/fsharp/FSNetCore/src/Library/Library.fsproj.

Restore succeeded.
```

Item 2:
<img width="858" alt="fsharp-docs-without-quotes" src="https://user-images.githubusercontent.com/69720/35614596-8f883b32-0667-11e8-9b64-953feb77a19a.png">


## Suggested Reviewers

Sorry, no idea.