### PR TITLE
.NET does allow access to device names

### DIFF
--- a/xml/System.IO/Path.xml
+++ b/xml/System.IO/Path.xml
@@ -33,8 +33,6 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The .NET Framework does not support direct access to physical disks through paths that are device names, such as "\\\\.\PHYSICALDRIVE0 ".  
-  
  A path is a string that provides the location of a file or directory. A path does not necessarily point to a location on disk; for example, a path might map to a location in memory or on a device. The exact format of a path is determined by the current platform. For example, on some systems, a path can start with a drive or volume letter, while this element is not present in other systems. On some systems, file paths can contain extensions, which indicate the type of information stored in the file. The format of a file name extension is platform-dependent; for example, some systems limit extensions to three characters, and others do not. The current platform also determines the set of characters used to separate the elements of a path, and the set of characters that cannot be used when specifying paths. Because of these differences, the fields of the `Path` class as well as the exact behavior of some members of the `Path` class are platform-dependent.  
   
  A path can contain absolute or relative location information. Absolute paths fully specify a location: the file or directory can be uniquely identified regardless of the current location. Relative paths specify a partial location: the current location is used as the starting point when locating a file specified with a relative path. To determine the current directory, call <xref:System.IO.Directory.GetCurrentDirectory%2A?displayProperty=nameWithType>.  
@@ -753,8 +751,6 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The .NET Framework does not support direct access to physical disks through paths that are device names, such as "\\\\.\PHYSICALDRIVE0 ".  
-  
  The absolute path includes all information required to locate a file or directory on a system.  
   
  The file or directory specified by `path` is not required to exist. For example, if c:\temp\newdir is the current directory, calling `GetFullPath` on a file name such as test.txt returns c:\temp\newdir\test.txt. The file need not exist.  
@@ -937,9 +933,7 @@
 -   "X:/" (`path` specified an absolute path on a given drive).  
   
 -   "\\\ComputerName\SharedFolder" (a UNC path).  
-  
- The .NET Framework does not support direct access to physical disks through paths that are device names, such as "\\\\.\PHYSICALDRIVE0 ".  
-  
+ 
  For a list of common I/O tasks, see [Common I/O Tasks](~/docs/standard/io/common-i-o-tasks.md).  
   
    


### PR DESCRIPTION
# .NET does not block device paths

## Details

.NET does allow access to _any_ device path as long as the user has the appropriate rights. Devices paths are paths that begin with either the `\\.\` or the `\\?\` and are only relevant on Windows. These paths are fully supported on .NET Core 1.1 and higher and when targeting NetFX 4.6.2 and higher.

Very old versions of Windows didn't have appropriate protections against raw disk access. The need to block these went away with Windows Vista.