### PR TITLE
Fix snippet tags

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLUriExamples/VB/uriexamples.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Remoting/NCLUriExamples/VB/uriexamples.vb
@@ -205,7 +205,7 @@ Public Class Test
         Dim uriAddress As New Uri("http://user:password@www.contoso.com/index.htm ")
         Console.WriteLine(uriAddress.UserInfo)
         Console.WriteLine("Fully Escaped {0}", IIf(uriAddress.UserEscaped, "yes", "no")) 'TODO: For performance reasons this should be changed to nested IF statements
-    
-    End Sub 'SampleUserInfo 
         '</snippet18>
+    End Sub 'SampleUserInfo 
+        
 End Class 'Test


### PR DESCRIPTION
This snippet tag was incorrectly placed, leading to the following code sample:

```vb
    Dim uriAddress As New Uri("http://user:password@www.contoso.com/index.htm ")
    Console.WriteLine(uriAddress.UserInfo)
    Console.WriteLine("Fully Escaped {0}", IIf(uriAddress.UserEscaped, "yes", "no")) 'TODO: For performance reasons this should be changed to nested IF statements

End Sub 'SampleUserInfo 
```


Seen on: https://docs.microsoft.com/en-gb/dotnet/api/system.uri.userinfo?view=netframework-4.7