### PR TITLE
Revised CancellationToken to Clarify ExecutionContext/SynchronizationContext Capture Details

### DIFF
--- a/xml/System.Threading/CancellationToken.xml
+++ b/xml/System.Threading/CancellationToken.xml
@@ -512,8 +512,8 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
   
  The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
 
- The current <xref:System.Threading.SynchronizationContext> is not captured. When the delegate is executed, the <xref:System.Threading.SynchronizationContext> in use at that time, if one exists, is used. 
-
+ The current <xref:System.Threading.SynchronizationContext> is not captured.
+ 
  ]]></format>
         </remarks>
         <exception cref="T:System.ObjectDisposedException">The associated <see cref="T:System.Threading.CancellationTokenSource" /> has been disposed.</exception>
@@ -564,7 +564,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
   
  The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
 
- If `useSynchronizationContext` is `true`, the current <xref:System.Threading.SynchronizationContext>, if one exists, is also captured along with the delegate and will be used when executing it. Otherwise, the <xref:System.Threading.SynchronizationContext> in use when the delegate is executed, if one exists, is used.
+ If `useSynchronizationContext` is `true`, the current <xref:System.Threading.SynchronizationContext>, if one exists, is also captured along with the delegate and will be used when executing it. Otherwise, <xref:System.Threading.SynchronizationContext> is not captured.
   
  ]]></format>
         </remarks>
@@ -616,7 +616,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
   
  The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
 
- The current <xref:System.Threading.SynchronizationContext> is not captured. When the delegate is executed, the <xref:System.Threading.SynchronizationContext> in use at that time, if one exists, is used.
+ The current <xref:System.Threading.SynchronizationContext> is not captured.
   
  ]]></format>
         </remarks>
@@ -670,7 +670,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
   
  The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
 
- If `useSynchronizationContext` is `true`, the current <xref:System.Threading.SynchronizationContext>, if one exists, is also captured along with the delegate and will be used when executing it. Otherwise, the <xref:System.Threading.SynchronizationContext> in use when the delegate is executed, if one exists, is used.
+ If `useSynchronizationContext` is `true`, the current <xref:System.Threading.SynchronizationContext>, if one exists, is also captured along with the delegate and will be used when executing it. Otherwise, <xref:System.Threading.SynchronizationContext> is not captured.
   
  ]]></format>
         </remarks>

--- a/xml/System.Threading/CancellationToken.xml
+++ b/xml/System.Threading/CancellationToken.xml
@@ -510,8 +510,10 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
 ## Remarks  
  If this token is already in the canceled state, the delegate will be run immediately and synchronously. Any exception the delegate generates will be propagated out of this method call.  
   
- The current <xref:System.Threading.ExecutionContext>, if one exists, will be captured along with the delegate and will be used when executing it.  
-  
+ The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
+
+ The current <xref:System.Threading.SynchronizationContext> is not captured. When the delegate is executed, the <xref:System.Threading.SynchronizationContext> in use at that time, if one exists, is used. 
+
  ]]></format>
         </remarks>
         <exception cref="T:System.ObjectDisposedException">The associated <see cref="T:System.Threading.CancellationTokenSource" /> has been disposed.</exception>
@@ -560,7 +562,9 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
 ## Remarks  
  If this token is already in the canceled state, the delegate will be run immediately and synchronously. Any exception the delegate generates will be propogated out of this method call.  
   
- If `useSynchronizationContext` is `true`, the current <xref:System.Threading.ExecutionContext>, if one exists, will be captured along with the delegate and will be used when executing it.  
+ The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
+
+ If `useSynchronizationContext` is `true`, the current <xref:System.Threading.SynchronizationContext>, if one exists, is also captured along with the delegate and will be used when executing it. Otherwise, the <xref:System.Threading.SynchronizationContext> in use when the delegate is executed, if one exists, is used.
   
  ]]></format>
         </remarks>
@@ -610,7 +614,9 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
 ## Remarks  
  If this token is already in the canceled state, the delegate will be run immediately and synchronously. Any exception the delegate generates will be propogated out of this method call.  
   
- The current <xref:System.Threading.ExecutionContext>, if one exists, will be captured along with the delegate and will be used when executing it.  
+ The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
+
+ The current <xref:System.Threading.SynchronizationContext> is not captured. When the delegate is executed, the <xref:System.Threading.SynchronizationContext> in use at that time, if one exists, is used.
   
  ]]></format>
         </remarks>
@@ -662,7 +668,9 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
 ## Remarks  
  If this token is already in the canceled state, the delegate will be run immediately and synchronously. Any exception the delegate generates will be propogated out of this method call.  
   
- The current <xref:System.Threading.ExecutionContext>, if one exists, will be captured along with the delegate and will be used when executing it.  
+ The current <xref:System.Threading.ExecutionContext> is captured along with the delegate and will be used when executing it. 
+
+ If `useSynchronizationContext` is `true`, the current <xref:System.Threading.SynchronizationContext>, if one exists, is also captured along with the delegate and will be used when executing it. Otherwise, the <xref:System.Threading.SynchronizationContext> in use when the delegate is executed, if one exists, is used.
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
## Summary

Clarifies when `Register()` captures `ExecutionContext` and `SynchronizationContext`. 

Of particular note, this PR fixes an error where the documentation incorrectly states that `Register()`'s `useSynchronizationContext` parameter controls the capturing of `ExecutionContext` when it actually controls capturing of `SynchronizationContext`.

## Details

Details on how and when these two contexts are captured can be seen in [CancellationToken.cs](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Threading/CancellationToken.cs/). 

In the source, notice how all four public `Register()` methods are hardcoded to `useExecutionContext: true` (indicating that `ExecutionContext` is always captured) while the two that accept parameter `useSynchronizationContext` use that value to control capturing of SynchronizationContext. 

## Suggested Reviewers

@stephentoub
