### PR TITLE
Documenting additional members of CoreResponseData, and HttpWebRequest

### DIFF
--- a/docs/framework/additional-apis/coreresponsedata.md
+++ b/docs/framework/additional-apis/coreresponsedata.md
@@ -1,0 +1,43 @@
+---
+title: "CoreResponseData Class"
+ms.date: "01/29/2018"
+ms.prod: ".net-framework"
+ms.technology: ""
+ms.topic: "reference"
+topic_type: 
+  - "apiref"
+api_name: 
+  - "System.Net.CoreResponseData"
+api_location: 
+  - "System.dll"
+api_type: 
+  - "Assembly"
+author: "stevewhims"
+ms.author: "stwhi"
+manager: "markl"
+ms.workload: 
+  - "dotnet"
+---
+
+# CoreResponseData Class
+
+The `CoreResponseData` class represents the parsing of the HTTP headers and the response body.
+
+## Syntax
+  
+```csharp
+internal class CoreResponseData
+```
+
+> [!WARNING]
+> This API is internal, and it is not meant to be used directly in your code. Instead, you should use a <xref:System.Diagnostics.DiagnosticSource> to hook networking code. See [DiagnosticSource User's Guide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md).
+> 
+> Microsoft does not support the use of this class in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Net>
+
+**Assembly:** System (in System.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/coreresponsedata_m_responseheaders.md
+++ b/docs/framework/additional-apis/coreresponsedata_m_responseheaders.md
@@ -1,0 +1,43 @@
+---
+title: "CoreResponseData.m_ResponseHeaders Field"
+ms.date: "01/29/2018"
+ms.prod: ".net-framework"
+ms.technology: ""
+ms.topic: "reference"
+topic_type: 
+  - "apiref"
+api_name: 
+  - "System.Net.CoreResponseData.m_ResponseHeaders"
+api_location: 
+  - "System.dll"
+api_type: 
+  - "Assembly"
+author: "stevewhims"
+ms.author: "stwhi"
+manager: "markl"
+ms.workload: 
+  - "dotnet"
+---
+
+# CoreResponseData.m\_ResponseHeaders Field
+
+`CoreResponseData.m_ResponseHeaders` is a <xref:System.Net.WebHeaderCollection> of headers associated with the server response.
+
+## Syntax
+  
+```csharp
+public WebHeaderCollection m_ResponseHeaders
+```
+
+> [!WARNING]
+> This API is not meant to be used directly in your code. Instead, you should use a <xref:System.Diagnostics.DiagnosticSource> to hook networking code. See [DiagnosticSource User's Guide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md).
+> 
+> Microsoft does not support the use of this class in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Net>
+
+**Assembly:** System (in System.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/coreresponsedata_m_statuscode.md
+++ b/docs/framework/additional-apis/coreresponsedata_m_statuscode.md
@@ -1,0 +1,43 @@
+---
+title: "CoreResponseData.m_StatusCode Field"
+ms.date: "01/29/2018"
+ms.prod: ".net-framework"
+ms.technology: ""
+ms.topic: "reference"
+topic_type: 
+  - "apiref"
+api_name: 
+  - "System.Net.CoreResponseData.m_StatusCode"
+api_location: 
+  - "System.dll"
+api_type: 
+  - "Assembly"
+author: "stevewhims"
+ms.author: "stwhi"
+manager: "markl"
+ms.workload: 
+  - "dotnet"
+---
+
+# CoreResponseData.m\_StatusCode Field
+
+`CoreResponseData.m_StatusCode` is an <xref:System.Net.HttpStatusCode> containing the status of the response.
+
+## Syntax
+  
+```csharp
+public HttpStatusCode m_StatusCode
+```
+
+> [!WARNING]
+> This API is not meant to be used directly in your code. Instead, you should use a <xref:System.Diagnostics.DiagnosticSource> to hook networking code. See [DiagnosticSource User's Guide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md).
+> 
+> Microsoft does not support the use of this class in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Net>
+
+**Assembly:** System (in System.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/httpwebrequest__coreresponse.md
+++ b/docs/framework/additional-apis/httpwebrequest__coreresponse.md
@@ -1,0 +1,43 @@
+---
+title: "HttpWebRequest._CoreResponse Field"
+ms.date: "01/29/2018"
+ms.prod: ".net-framework"
+ms.technology: ""
+ms.topic: "reference"
+topic_type: 
+  - "apiref"
+api_name: 
+  - "System.Net.HttpWebRequest._CoreResponse"
+api_location: 
+  - "System.dll"
+api_type: 
+  - "Assembly"
+author: "stevewhims"
+ms.author: "stwhi"
+manager: "markl"
+ms.workload: 
+  - "dotnet"
+---
+
+# HttpWebRequest.\_CoreResponse Field
+
+`HttpWebRequest._CoreResponse` is an object (either a [CoreResponseData](coreresponsedata.md) or an <xref:System.Exception>) containing the result of HTTP response parsing.
+
+## Syntax
+  
+```csharp
+private object _CoreResponse
+```
+
+> [!WARNING]
+> This API is not meant to be used directly in your code. Instead, you should use a <xref:System.Diagnostics.DiagnosticSource> to hook networking code. See [DiagnosticSource User's Guide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md).
+> 
+> Microsoft does not support the use of this class in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Net>
+
+**Assembly:** System (in System.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/index.md
+++ b/docs/framework/additional-apis/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Additional class libraries and APIs"
 ms.custom: ""
-ms.date: "04/12/2017"
+ms.date: "01/29/2018"
 ms.prod: ".net-framework-oob"
 ms.reviewer: ""
 ms.suite: ""
@@ -54,8 +54,12 @@ These APIs support the product infrastructure and are not intended/supported to 
 | [System.Net.Connection.m\_WriteList Field](../../../docs/framework/additional-apis/m_writelist.md) |
 | [System.Net.ConnectionGroup Class](../../../docs/framework/additional-apis/connectiongroup.md) |
 | [System.Net.ConnectionGroup.m\_ConnectionList Field](../../../docs/framework/additional-apis/m_connectionlist.md) |
-| [System.Net.HttpWebRequest.\_HttpResponse Field](../../../docs/framework/additional-apis/_httpresponse.md) |
+| [System.Net.CoreResponseData Class](../../../docs/framework/additional-apis/coreresponsedata.md) |
+| [System.Net.CoreResponseData.m\_ResponseHeaders Field](../../../docs/framework/additional-apis/coreresponsedata_m_responseheaders.md) |
+| [System.Net.CoreResponseData.m\_StatusCode Field](../../../docs/framework/additional-apis/coreresponsedata_m_statuscode.md) |
 | [System.Net.HttpWebRequest.\_AutoRedirects Field](../../../docs/framework/additional-apis/_autoredirects.md) |
+| [System.Net.HttpWebRequest.\_CoreResponse Field](../../../docs/framework/additional-apis/httpwebrequest__coreresponse.md) |
+| [System.Net.HttpWebRequest.\_HttpResponse Field](../../../docs/framework/additional-apis/_httpresponse.md) |
 | [System.Net.ServicePoint.m\_ConnectionGroupList Field](../../../docs/framework/additional-apis/m_connectiongrouplist.md) |
 | [System.Net.ServicePointManager.s\_ServicePointTable Field](../../../docs/framework/additional-apis/s_servicepointtable.md) |
 | [System.Windows.Diagnostics.VisualDiagnostics.s\_isDebuggerCheckDisabledForTestPurposes Field](../../../docs/framework/additional-apis/s-isdebuggercheckdisabledfortestpurposes-field.md) |

--- a/docs/framework/additional-apis/toc.md
+++ b/docs/framework/additional-apis/toc.md
@@ -4,8 +4,12 @@
 #### [m_WriteList Field](m_writelist.md)
 ### [ConnectionGroup Class](connectiongroup.md)
 #### [m_ConnectionList Field](m_connectionlist.md)
+### [CoreResponseData Class](coreresponsedata.md)
+#### [m_ResponseHeaders Field](coreresponsedata_m_responseheaders.md)
+#### [m_StatusCode Field](coreresponsedata_m_statuscode.md)
 ### HttpWebRequest Class
 #### [_AutoRedirects Field](_autoredirects.md)
+#### [_CoreResponse Field](httpwebrequest__coreresponse.md)
 #### [_HttpResponse Field](_httpresponse.md)
 ### ServicePoint Class
 #### [m_ConnectionGroupList Field](m_connectiongrouplist.md)


### PR DESCRIPTION
# Documenting additional members of CoreResponseData, and HttpWebRequest

## Summary

Adding topics for two fields belonging to CoreResponseData, and one field belonging to HttpWebRequest, as per bug 533155. Updating TOC and index page to reflect the new APIs.