### PR TITLE
Documented Visual Basic 15.5 leading hex/binary/octal separator

### DIFF
--- a/docs/visual-basic/language-reference/data-types/byte-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/byte-data-type.md
@@ -14,7 +14,6 @@ helpviewer_keywords:
 ms.assetid: eed44dff-eaee-4937-a89f-444e418e74f6
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # Byte data type (Visual Basic)
 Holds unsigned 8-bit (1-byte) integers that range in value from 0 through 255.
@@ -46,13 +45,7 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As Byte = &H_6A
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 ## Programming tips
 

--- a/docs/visual-basic/language-reference/data-types/byte-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/byte-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "Byte Data Type (Visual Basic)"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -14,6 +14,7 @@ helpviewer_keywords:
 ms.assetid: eed44dff-eaee-4937-a89f-444e418e74f6
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # Byte data type (Visual Basic)
 Holds unsigned 8-bit (1-byte) integers that range in value from 0 through 255.
@@ -38,6 +39,20 @@ In the following example, integers equal to 201 that are represented as decimal,
 Starting with Visual Basic 2017, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
 
 [!code-vb[Byte](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#ByteS)]  
+
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As Byte = &H_6A
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
 
 ## Programming tips
 

--- a/docs/visual-basic/language-reference/data-types/integer-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/integer-data-type.md
@@ -28,7 +28,6 @@ helpviewer_keywords:
 ms.assetid: a8f233b4-4be3-455c-861b-05af2fbb6c60
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # Integer data type (Visual Basic)
 Holds signed 32-bit (4-byte) integers that range in value from -2,147,483,648 through 2,147,483,647.  
@@ -59,18 +58,12 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As Integer = &H_C305_F860
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 Numeric literals can also include the `I` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `Integer` data type, as the following example shows.
 
 ```vb
-Dim number = &H035826I
+Dim number = &H_035826I
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/integer-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/integer-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "Integer Data Type (Visual Basic)"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -28,6 +28,7 @@ helpviewer_keywords:
 ms.assetid: a8f233b4-4be3-455c-861b-05af2fbb6c60
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # Integer data type (Visual Basic)
 Holds signed 32-bit (4-byte) integers that range in value from -2,147,483,648 through 2,147,483,647.  
@@ -51,6 +52,20 @@ In the following example, integers equal to 16,342 that are represented as decim
 Starting with Visual Basic 2017, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
 
 [!code-vb[integer](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#IntS)]  
+
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As Integer = &H_C305_F860
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
 
 Numeric literals can also include the `I` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `Integer` data type, as the following example shows.
 

--- a/docs/visual-basic/language-reference/data-types/long-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/long-data-type.md
@@ -27,7 +27,6 @@ helpviewer_keywords:
 ms.assetid: b4770c34-1804-4f8c-b512-c10b0893e516
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # Long data type (Visual Basic)
 
@@ -60,17 +59,12 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As Long = &H_0FAC_0326_1489_D68C
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
 Numeric literals can also include the `L` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `Long` data type, as the following example shows.
 
 ```vb
-Dim number = &H0FAC0326L
+Dim number = &H_0FAC_0326_1489_D68CL
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/long-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/long-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "Long Data Type (Visual Basic)"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -27,6 +27,7 @@ helpviewer_keywords:
 ms.assetid: b4770c34-1804-4f8c-b512-c10b0893e516
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # Long data type (Visual Basic)
 
@@ -53,6 +54,19 @@ Starting with Visual Basic 2017, you can also use the underscore character, `_`,
 
 [!code-vb[long](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#LongS)]
 
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As Long = &H_0FAC_0326_1489_D68C
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
 Numeric literals can also include the `L` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `Long` data type, as the following example shows.
 
 ```vb

--- a/docs/visual-basic/language-reference/data-types/sbyte-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/sbyte-data-type.md
@@ -54,13 +54,7 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As SByte = &H_F9
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 If the integer literal is outside the range of `SByte` (that is, if it is less than <xref:System.SByte.MinValue?displayProperty=nameWithType> or greater than <xref:System.SByte.MaxValue?displayProperty=nameWithType>, a compilation error occurs. When an integer literal has no suffix, an [Integer](integer-data-type.md) is inferred. If the integer literal is outside the range of the `Integer` type, a [Long](long-data-type.md) is inferred. This means that, in the previous examples, the numeric literals `0x9A` and `0b10011010` are interpreted as 32-bit signed integers with a value of 156, which exceeds <xref:System.SByte.MaxValue?displayProperty=nameWithType>. To successfully compile code like this that assigns a non-decimal integer to an `SByte`, you can do either of the following:
 

--- a/docs/visual-basic/language-reference/data-types/sbyte-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/sbyte-data-type.md
@@ -48,6 +48,20 @@ Starting with Visual Basic 2017, you can also use the underscore character, `_`,
 
 [!code-vb[SByteSeparator](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#SByteS)]  
 
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As SByte = &H_F9
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
+
 If the integer literal is outside the range of `SByte` (that is, if it is less than <xref:System.SByte.MinValue?displayProperty=nameWithType> or greater than <xref:System.SByte.MaxValue?displayProperty=nameWithType>, a compilation error occurs. When an integer literal has no suffix, an [Integer](integer-data-type.md) is inferred. If the integer literal is outside the range of the `Integer` type, a [Long](long-data-type.md) is inferred. This means that, in the previous examples, the numeric literals `0x9A` and `0b10011010` are interpreted as 32-bit signed integers with a value of 156, which exceeds <xref:System.SByte.MaxValue?displayProperty=nameWithType>. To successfully compile code like this that assigns a non-decimal integer to an `SByte`, you can do either of the following:
 
 - Disable integer bounds checks by compiling with the `/removeintchecks` compiler switch.

--- a/docs/visual-basic/language-reference/data-types/short-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/short-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "Short Data Type (Visual Basic)"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -25,6 +25,7 @@ helpviewer_keywords:
 ms.assetid: 65fcbcf3-a841-400e-885e-301497729a8b
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # Short data type (Visual Basic)
 Holds signed 16-bit (2-byte) integers that range in value from -32,768 through 32,767.  
@@ -49,10 +50,24 @@ Starting with Visual Basic 2017, you can also use the underscore character, `_`,
 
 [!code-vb[Short](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#ShortS)]
 
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As Short = &H_3265
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
+
 Numeric literals can also include the `S` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `Short` data type, as the following example shows.
 
 ```vb
-Dim number = &H0326S
+Dim number = &H326S
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/short-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/short-data-type.md
@@ -25,7 +25,6 @@ helpviewer_keywords:
 ms.assetid: 65fcbcf3-a841-400e-885e-301497729a8b
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # Short data type (Visual Basic)
 Holds signed 16-bit (2-byte) integers that range in value from -32,768 through 32,767.  
@@ -53,21 +52,15 @@ Starting with Visual Basic 2017, you can also use the underscore character, `_`,
 Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
 
 ```vb
-Dim number As Short = &H_3265
+Dim number As Short = &H_3264
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 Numeric literals can also include the `S` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `Short` data type, as the following example shows.
 
 ```vb
-Dim number = &H326S
+Dim number = &H_3264S
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/uinteger-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/uinteger-data-type.md
@@ -23,7 +23,6 @@ helpviewer_keywords:
 ms.assetid: db7ddd34-4f23-46f5-84dd-8b0f83bb8729
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # UInteger data type
 
@@ -56,18 +55,12 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As UInteger = &H_0F8C_0326
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 Numeric literals can also include the `UI` or `ui` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `UInteger` data type, as the following example shows.
 
 ```vb
-Dim number = &H0FAC14D7ui
+Dim number = &H_0FAC_14D7ui
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/uinteger-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/uinteger-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "UInteger Data Type"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -21,9 +21,9 @@ helpviewer_keywords:
   - "UI literal type characters [Visual Basic]"
   - "data types [Visual Basic], integral"
 ms.assetid: db7ddd34-4f23-46f5-84dd-8b0f83bb8729
-caps.latest.revision: 19
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # UInteger data type
 
@@ -49,6 +49,20 @@ In the following example, integers equal to 3,000,000,000 that are represented a
 Starting with Visual Basic 2017, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
 
 [!code-vb[UInteger](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#UIntS)]  
+
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As UInteger = &H_0F8C_0326
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
 
 Numeric literals can also include the `UI` or `ui` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `UInteger` data type, as the following example shows.
 

--- a/docs/visual-basic/language-reference/data-types/ulong-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/ulong-data-type.md
@@ -23,7 +23,6 @@ helpviewer_keywords:
 ms.assetid: 017e0702-774e-44ae-bedc-786b424ca84e
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # ULong data type (Visual Basic)
 
@@ -55,18 +54,13 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 ```vb
 Dim number As ULong = &H_F9AC_0326_1489_D68C
 ```
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
 
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 Numeric literals can also include the `UL` or `ul` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `ULong` data type, as the following example shows.
 
 ```vb
-Dim number = &H00_00_0A_96_2F_AC_14_D7ul
+Dim number = &H_00_00_0A_96_2F_AC_14_D7ul
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/ulong-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/ulong-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "ULong Data Type (Visual Basic)"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -21,9 +21,9 @@ helpviewer_keywords:
   - "ULong data type"
   - "UL literal type characters [Visual Basic]"
 ms.assetid: 017e0702-774e-44ae-bedc-786b424ca84e
-caps.latest.revision: 21
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # ULong data type (Visual Basic)
 
@@ -49,6 +49,19 @@ In the following example, integers equal to 7,934,076,125 that are represented a
 Starting with Visual Basic 2017, you can also use the underscore character, `_`, as a digit separator to enhance readability, as the following example shows.
 
 [!code-vb[ULong](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#LongS)]
+
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As ULong = &H_F9AC_0326_1489_D68C
+```
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
 
 Numeric literals can also include the `UL` or `ul` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `ULong` data type, as the following example shows.
 

--- a/docs/visual-basic/language-reference/data-types/ushort-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/ushort-data-type.md
@@ -1,6 +1,6 @@
 ---
 title: "UShort Data Type (Visual Basic)"
-ms.date: 04/20/2017
+ms.date: 01/31/2018
 ms.prod: .net
 ms.suite: ""
 ms.technology: 
@@ -21,9 +21,9 @@ helpviewer_keywords:
   - "UShort data type"
   - "US literal type characters [Visual Basic]"
 ms.assetid: 138db892-665d-4ba8-9cae-d8d91c4a8f39
-caps.latest.revision: 16
 author: "rpetrusha"
 ms.author: "ronpet"
+ms.manager: "wpickett"
 ---
 # UShort data type (Visual Basic)
 
@@ -50,10 +50,24 @@ Starting with Visual Basic 2017, you can also use the underscore character, `_`,
 
 [!code-vb[UShort](../../../../samples/snippets/visualbasic/language-reference/data-types/numeric-literals.vb#UShortS)]
 
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As UShort = &H_FF8C
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
+
 Numeric literals can also include the `US` or `us` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `UShort` data type, as the following example shows.
 
 ```vb
-Dim number = &H035826us
+Dim number = &H5826us
 ```
 
 ## Programming tips

--- a/docs/visual-basic/language-reference/data-types/ushort-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/ushort-data-type.md
@@ -23,7 +23,6 @@ helpviewer_keywords:
 ms.assetid: 138db892-665d-4ba8-9cae-d8d91c4a8f39
 author: "rpetrusha"
 ms.author: "ronpet"
-ms.manager: "wpickett"
 ---
 # UShort data type (Visual Basic)
 
@@ -56,18 +55,12 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As UShort = &H_FF8C
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../includes/vb-separator-langversion.md)]
 
 Numeric literals can also include the `US` or `us` [type character](../../programming-guide\language-features\data-types/type-characters.md) to denote the `UShort` data type, as the following example shows.
 
 ```vb
-Dim number = &H5826us
+Dim number = &H_5826us
 ```
 
 ## Programming tips

--- a/docs/visual-basic/programming-guide/language-features/data-types/type-characters.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/type-characters.md
@@ -142,13 +142,7 @@ Starting with Visual Basic 15.5, you can also use the underscore character (`_`)
 Dim number As Integer = &H_C305_F860
 ```
 
-To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
-
-```xml
-<PropertyGroup>
-  <LangVersion>15.5</LangVersion>
-</PropertyGroup>
-```
+[!INCLUDE [supporting-underscores](../../../../../includes/vb-separator-langversion.md)]
 
 ## See Also
 

--- a/docs/visual-basic/programming-guide/language-features/data-types/type-characters.md
+++ b/docs/visual-basic/programming-guide/language-features/data-types/type-characters.md
@@ -1,7 +1,7 @@
 ---
 title: "Type Characters (Visual Basic)"
 ms.custom: ""
-ms.date: 07/20/2015
+ms.date: 01/31/2018
 ms.prod: .net
 ms.reviewer: ""
 ms.suite: ""
@@ -43,9 +43,9 @@ helpviewer_keywords:
   - "UL literal type characters [Visual Basic]"
   - "literal types [Visual Basic], default"
 ms.assetid: 6353cb9b-6ee4-4af6-a5a8-88ce39f90cc5
-caps.latest.revision: 22
-author: dotnet-bot
-ms.author: dotnetcontent
+author: rpetrusha
+ms.author: ronpet
+ms.manager: wpickett
 ---
 # Type characters (Visual Basic)
 
@@ -135,6 +135,20 @@ Dim flags As UShort = &H8000US
 ```
 
 In the previous example, `counter` has the decimal value of -32768, and `flags` has the decimal value of +32768.
+
+Starting with Visual Basic 15.5, you can also use the underscore character (`_`) as a leading separator between the prefix and the hexadecimal, binary, or octal digits. For example:
+
+```vb
+Dim number As Integer = &H_C305_F860
+```
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```
 
 ## See Also
 

--- a/docs/visual-basic/programming-guide/language-features/strings/how-to-convert-hexadecimal-strings-to-numbers.md
+++ b/docs/visual-basic/programming-guide/language-features/strings/how-to-convert-hexadecimal-strings-to-numbers.md
@@ -1,10 +1,8 @@
 ---
 title: "How to: Convert Hexadecimal Strings to Numbers (Visual Basic)"
 ms.custom: ""
-ms.date: 07/20/2015
+ms.date: 01/31/2018
 ms.prod: .net
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: 
   - "devlang-visual-basic"
 ms.topic: "article"
@@ -15,21 +13,28 @@ helpviewer_keywords:
   - "decimals [Visual Basic], hexadecimals"
   - "string conversion [Visual Basic], hexadecimal to numbers"
 ms.assetid: 76675807-eadb-4c08-bd50-e6c6ff4b8ced
-caps.latest.revision: 9
-author: dotnet-bot
-ms.author: dotnetcontent
+author: petrusha
+ms.author: ronpet
+ms.manager: wpickett
 ---
 # How to: Convert Hexadecimal Strings to Numbers (Visual Basic)
-This example converts a hexadecimal string to an integer using the <xref:System.Convert.ToInt32%2A> method.  
+This example converts a hexadecimal string to an integer using the <xref:System.Convert.ToInt32%2A?displayProperty=nameWithType> method.  
   
 ### To convert a hexadecimal string to a number  
   
--   Use the <xref:System.Convert.ToInt32%2A> method to convert the number expressed in base-16 to an integer.  
+-   Use the <xref:System.Convert.ToInt32(System.String,System.Int32)> method to convert the number expressed in base-16 to an integer.  
   
-     The first argument of the <xref:System.Convert.ToInt32%2A> method is the string to convert. The second argument describes what base the number is expressed in; hexadecimal is base 16.  
+     The first argument of the <xref:System.Convert.ToInt32(System.String,System.Int32)> method is the string to convert. The second argument describes what base the number is expressed in; hexadecimal is base 16.  
   
-     [!code-vb[VbVbalrStrings#62](../../../../visual-basic/language-reference/functions/codesnippet/VisualBasic/how-to-convert-hexadecimal-strings-to-numbers_1.vb)]  
-  
+     [!code-vb[HexConversion](../../../../visual-basic/language-reference/functions/codesnippet/VisualBasic/how-to-convert-hexadecimal-strings-to-numbers_1.vb)]  
+
+- Note that the hexadecimal string has the following restrictions:
+
+   - It cannot include the `&h` prefix.
+   - It cannot include the "_" digit separator.
+
+   If the prefix or a digit separator is present, the call to the <xref:System.Convert.ToInt32(System.String,System.Int32)> method throws a <xref:System.FormatException>.
+
 ## See Also  
  <xref:Microsoft.VisualBasic.Conversion.Hex%2A>  
- <xref:System.Convert.ToInt32%2A>
+ <xref:System.Convert.ToInt32%2A?displayProperty=nameWithType>

--- a/docs/visual-basic/programming-guide/language-features/strings/how-to-convert-hexadecimal-strings-to-numbers.md
+++ b/docs/visual-basic/programming-guide/language-features/strings/how-to-convert-hexadecimal-strings-to-numbers.md
@@ -20,7 +20,7 @@ ms.manager: wpickett
 # How to: Convert Hexadecimal Strings to Numbers (Visual Basic)
 This example converts a hexadecimal string to an integer using the <xref:System.Convert.ToInt32%2A?displayProperty=nameWithType> method.  
   
-### To convert a hexadecimal string to a number  
+## To convert a hexadecimal string to a number  
   
 -   Use the <xref:System.Convert.ToInt32(System.String,System.Int32)> method to convert the number expressed in base-16 to an integer.  
   

--- a/includes/vb-separator-langversion.md
+++ b/includes/vb-separator-langversion.md
@@ -1,0 +1,8 @@
+
+To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (\*.vbproj) file:
+
+```xml
+<PropertyGroup>
+  <LangVersion>15.5</LangVersion>
+</PropertyGroup>
+```


### PR DESCRIPTION
# Documented Visual Basic 15.5 leading hex/binary/octal separator

## Summary
Along with allowing digit separators in hex/binary/octal strings (introduced in Visual Basic 15), Visual Basic 15.5 allows leading digit separators that precede the prefix. This PR documents that feature.

Fixes #3946 

## Suggested Reviewers

@BillWagner 
