### PR TITLE
TOC and links for private protected and protected internal

### DIFF
--- a/docs/csharp/language-reference/keywords/access-modifiers.md
+++ b/docs/csharp/language-reference/keywords/access-modifiers.md
@@ -15,27 +15,24 @@ ms.author: "wiwagn"
 # Access Modifiers (C# Reference)
 Access modifiers are keywords used to specify the declared accessibility of a member or a type. This section introduces the four access modifiers:  
   
--   [public](../../../csharp/language-reference/keywords/public.md)  
-  
--   [protected](../../../csharp/language-reference/keywords/protected.md)  
-  
--   [internal](../../../csharp/language-reference/keywords/internal.md)  
-  
--   [private](../../../csharp/language-reference/keywords/private.md)  
+-   `public`
+-   `protected`
+-   `internal`
+-   `private`
   
  The following six accessibility levels can be specified using the access modifiers:  
   
- `public`: Access is not restricted.  
+- [`public`](public.md): Access is not restricted.  
   
- `protected`: Access is limited to the containing class or types derived from the containing class.  
+- [`protected`](protected.md): Access is limited to the containing class or types derived from the containing class.  
   
- `internal`: Access is limited to the current assembly.  
+- [`internal`](internal.md): Access is limited to the current assembly.  
   
- [`protected internal`](../../../csharp/language-reference/keywords/protected-internal.md): Access is limited to the current assembly or types derived from the containing class.  
+- [`protected internal`](protected-internal.md): Access is limited to the current assembly or types derived from the containing class.  
   
- `private`: Access is limited to the containing type.  
+- [`private`](private.md): Access is limited to the containing type.  
 
- [`private protected`](../../../csharp/language-reference/keywords/private-protected.md): Access is limited to the containing class or types derived from the containing class within the current assembly.  
+- [`private protected`](private-protected.md): Access is limited to the containing class or types derived from the containing class within the current assembly.  
   
  This section also introduces the following:  
   

--- a/docs/csharp/language-reference/keywords/accessibility-levels.md
+++ b/docs/csharp/language-reference/keywords/accessibility-levels.md
@@ -21,9 +21,9 @@ Use the access modifiers, [public](../../../csharp/language-reference/keywords/p
 |`public`|Access is not restricted.|  
 |`protected`|Access is limited to the containing class or types derived from the containing class.|  
 |`internal`|Access is limited to the current assembly.|  
-|`protected internal`|Access is limited to the current assembly or types derived from the containing class.|  
+|[`protected internal`](protected-internal.md)|Access is limited to the current assembly or types derived from the containing class.|  
 |`private`|Access is limited to the containing type.|  
-|`private protected`|Access is limited to the containing class or types derived from the containing class within the current assembly. Available since C# 7.2. |  
+|[`private protected`](private-protected.md)|Access is limited to the containing class or types derived from the containing class within the current assembly. Available since C# 7.2. |  
   
  Only one access modifier is allowed for a member or type, except when you use the `protected internal` or `private protected` combinations.  
   

--- a/docs/csharp/language-reference/keywords/accessibility-levels.md
+++ b/docs/csharp/language-reference/keywords/accessibility-levels.md
@@ -14,15 +14,15 @@ ms.author: "wiwagn"
 ---
 # Accessibility Levels (C# Reference)
 
-Use the access modifiers, [public](../../../csharp/language-reference/keywords/public.md), [protected](../../../csharp/language-reference/keywords/protected.md), [internal](../../../csharp/language-reference/keywords/internal.md), or [private](../../../csharp/language-reference/keywords/private.md), to specify one of the following declared accessibility levels for members.  
+Use the access modifiers, `public`, `protected`, `internal`, or `private`, to specify one of the following declared accessibility levels for members.  
   
 |Declared accessibility|Meaning|  
 |----------------------------|-------------|  
-|`public`|Access is not restricted.|  
-|`protected`|Access is limited to the containing class or types derived from the containing class.|  
-|`internal`|Access is limited to the current assembly.|  
+|[`public`](public.md)|Access is not restricted.|  
+|[`protected`](protected.md)|Access is limited to the containing class or types derived from the containing class.|  
+|[`internal`](internal.md)|Access is limited to the current assembly.|  
 |[`protected internal`](protected-internal.md)|Access is limited to the current assembly or types derived from the containing class.|  
-|`private`|Access is limited to the containing type.|  
+|[`private`](private.md)|Access is limited to the containing type.|  
 |[`private protected`](private-protected.md)|Access is limited to the containing class or types derived from the containing class within the current assembly. Available since C# 7.2. |  
   
  Only one access modifier is allowed for a member or type, except when you use the `protected internal` or `private protected` combinations.  

--- a/docs/csharp/language-reference/keywords/toc.md
+++ b/docs/csharp/language-reference/keywords/toc.md
@@ -44,6 +44,8 @@
 #### [private](private.md)
 #### [protected](protected.md)
 #### [public](public.md)
+#### [protected internal](protected-internal.md)
+#### [private protected](private-protected.md)
 ### [abstract](abstract.md)
 ### [async](async.md)
 ### [const](const.md)


### PR DESCRIPTION
The access levels `private protected` and `protected private` have their own articles, but they weren't included in the TOC and also weren't linked from accessibility-levels.md (they were linked from access-modifiers.md, though). This PR fixes that.