### PR TITLE
quickstarts SEO and spelling

### DIFF
--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -1,9 +1,8 @@
 ---
 title: C# Guide
 description: Learn how the C# Guide can help you gain extensive knowledge on C#, whether you're a new developer or a seasoned expert.
-keywords: .NET, .NET Core
 author: BillWagner
-ms.date: 08/23/2017
+ms.date: 01/30/2018
 ms.topic: article
 ms.prod: .net
 ms.technology: devlang-csharp
@@ -16,62 +15,59 @@ helpviewer_keywords:
   - "Visual C#"
 ms.author: "wiwagn"
 ---
-
 # C# Guide
 
-The C# guide provides a wealth of information about the C# language. This site has many different audiences. Depending on your experience with programming, or with the C# language and .NET, you may wish to explore different sections of this guide.
+The C# guide provides many resources about the C# language. This site has many different audiences. Depending on your experience with programming, or with the C# language and .NET, you may wish to explore different sections of this guide.
 
 * For brand-new developers:
-    - Start with our [Quick starts](quick-starts/index.md) section. These let you explore
-    the C# language interactively in your browser. From there, you can move on to our
-    [tutorials](tutorials/index.md) section. These tutorials show you how to create C# programs from scratch. The tutorials provide a step-by-step process to create programs. You'll learn the language concepts, and how to build C# programs on your own. If you prefer reading overview information first, try our [tour of the C# language](tour-of-csharp/index.md). It explains the concepts of the C# language. After reading this, you'll have a basic understanding of the language, and be ready to try the tutorials, or build something on your own.
+  * Start with the [Quickstarts](quick-starts/index.md) section. These quickstarts let you explore
+    the C# language interactively in your browser. From there, you can move on to the
+    [tutorials](tutorials/index.md) section. These tutorials show you how to create C# programs from scratch. The tutorials provide a step-by-step process to create programs. They show the language concepts, and how to build C# programs on your own. If you prefer reading overview information first, try the [tour of the C# language](tour-of-csharp/index.md). It explains the concepts of the C# language. After reading this, you'll have a basic understanding of the language, and be ready to try the tutorials, or build something on your own.
 
-* For developers new to C#: 
-    - If you've done development before, but are new to C#, read the [tour of the C# language](tour-of-csharp/index.md). You will learn the basic syntax and structure for the language, and you can use the language tour to contrast C# with other languages you've used. You can also browse the [tutorials](tutorials/index.md) to try basic C# programs.
+* For developers new to C#:
+  * If you've done development before, but are new to C#, read the [tour of the C# language](tour-of-csharp/index.md). It covers the basic syntax and structure for the language, and you can use the language tour to contrast C# with other languages you've used. You can also browse the [tutorials](tutorials/index.md) to try basic C# programs.
 
 * Experienced C# developers:
-    - If you've used C# before, you should start by reading what's in the latest version of the language. Check out [What's new in C#](whats-new/index.md) for the new features in the current version.
- 
+  * If you've used C# before, you should start by reading what's in the latest version of the language. Check out [What's new in C#](whats-new/index.md) for the new features in the current version.
+
 ## How the C# guide is organized
 
 There are several sections in the C# Guide. You can read them in order, or jump directly to what interests you the most. Some of the sections are heavily focused on the language. Others provide end-to-end scenarios that demonstrate a few of the types of programs you can create using C# and the .NET Framework.
 
-* [Getting Started](getting-started/index.md):
-    - This section covers what you need to install for a C# development environment on your preferred platform. The different topics under this section explain how to create your first C# program in different supported environments.
+* [Get Started](getting-started/index.md)
+  * This section covers what you need to install for a C# development environment on your preferred platform. The different topics under this section explain how to create your first C# program in different supported environments.
 
-* [Tutorials](tutorials/index.md):
-    - This section provides a variety of end to end scenarios, including descriptions and code. You'll learn why certain idioms are preferred, what C# features work best in different situations, and see reference implementations for common tasks. If you learn best by seeing code, start in this section. You can also download all the code and experiment in your own environment.
+* [C# Quickstarts](quick-starts/index.md):
+  * C# Quickstarts presents interactive tutorials for brand-new developers to explore and learn the C# language in the browser using a Read-Eval-Print Loop (REPL) interface. After you finish the interactive lessons, you can improve your coding skills by practicing the same lessons on your machine.
 
-* [A Tour of C#](tour-of-csharp/index.md): 
-    - This section provides an overview of the language. You'll learn the elements that make up C# programs and the capabilities of the language. You'll see small samples of all the syntax elements of C# and discussions of the major C# language topics. 
+* [Tutorials](tutorials/index.md)
+  * This section provides a variety of end-to-end scenarios, including descriptions and code. It shows why certain idioms are preferred, what C# features work best in different situations, and reference implementations for common tasks. If you learn best by seeing code, start in this section. You can also download all the code and experiment in your own environment.
 
-* [Latest Features](whats-new/index.md):
-    - Learn about new features in the language. Learn about new tools like C# Interactive (C#'s REPL), and the .NET Compiler Platform SDK. You'll learn how the language is evolving. You'll see how the new tools can make you more productive in exploring the language, and automating tasks. 
+* [Tour of C#](tour-of-csharp/index.md)
+  * This section provides an overview of the language. It covers the elements that make up C# programs and the capabilities of the language. It shows small samples of all the syntax elements of C# and discussions of the major C# language topics.
 
-<!--* [C# Interactive](interactive/index.md):
-    - C# Interactive is a Read-Eval-Print Loop (REPL) that you can use to interactively explore the language. It can also be used to explore different libraries and frameworks by trying different actions using an interactive approach. In this section you'll learn how to install and start C# interactive, and how to explore APIs with it. You'll also learn how to use C# interactive to export tested classes for later use.  
+* [Latest Features](whats-new/index.md)
+  * Learn about new features in the language. Learn about new tools like C# Interactive (C#'s REPL), and the .NET Compiler Platform SDK. This section shows how the language is evolving and how the new tools can make you more productive.
+
+<!--
+* [.NET Compiler Platform SDK](roslyn-sdk/index.md)
+  * The .NET Compiler Platform SDK enables you to write components that analyze code, and suggest or make improvements to that code. In this section, you'll learn how the APIs are organized, and how you can create code that enables rules and practices for your team. You'll also see samples, end-to-end scenarios, and links to other libraries with more examples using these APIs.
 -->
-<!--* [.NET Compiler Platform SDK](roslyn/index.md):
-    - The .NET Compiler Platform SDK enables you to write components that analyze code, and suggest or make improvements to that code. In this section, you'll learn how the APIs are organized, and how you can create code that enables rules and practices for your team. You'll also see samples, end to end scenarios, and links to other libraries with more examples using these APIs.
--->
-* [Using the Visual Studio Development Environment for C#](/visualstudio/csharp-ide/using-the-visual-studio-development-environment-for-csharp)  
-    - Introduces the [!INCLUDE[csprcs](~/includes/csprcs-md.md)] development environment.  
 
-* [C# Programming Guide](../csharp/programming-guide/index.md)  
-    - Provides information and practical examples about how to use C# language constructs.  
+* [C# Programming Guide](../csharp/programming-guide/index.md)
+  * Provides information and practical examples about how to use C# language constructs.
 
-* [C# Samples](http://code.msdn.microsoft.com/site/search?f%5B0%5D.Type=ProgrammingLanguage&f%5B0%5D.Value=C%23&f%5B0%5D.Text=C%23)  
-    - MSDN Code Gallery filtered for C#.  
-  
-* [Walkthroughs](../csharp/walkthroughs.md)  
-    - Provides links to programming walkthroughs that use C# and a brief description of each walkthrough.  
+* [Walkthroughs](../csharp/walkthroughs.md)
+  * Provides links to programming walkthroughs that use C# and a brief description of each walkthrough.
 
-* [Language Reference](language-reference/index.md):
-    - This section contains the reference material on the C# language. This material will help you understand the syntax and semantics of C#. It also includes reference material on types, operators, attributes, preprocessor directives, compiler switches, compiler errors, and compiler warnings.
-  
-* [C# Language Specification](../csharp/language-reference/language-specification/index.md)  
-    - Links to the latest version of the C# Specifications in Microsoft Word format.  
-  
-## See Also  
- [Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic)  
- [.NET Development](https://msdn.microsoft.com/library/ff361664)
+* [Language Reference](language-reference/index.md)
+  * This section contains the reference material on the C# language. This material helps you understand the syntax and semantics of C#. It also includes reference material on types, operators, attributes, preprocessor directives, compiler switches, compiler errors, and compiler warnings.
+
+* [C# Language Specification](../csharp/language-reference/language-specification/index.md)
+  * Links to the latest version of the C# Specifications in Microsoft Word format.
+
+## See also
+
+[Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic)  
+[.NET Development](https://msdn.microsoft.com/library/ff361664)  
+[C# Samples](http://code.msdn.microsoft.com/site/search?f%5B0%5D.Type=ProgrammingLanguage&f%5B0%5D.Value=C%23&f%5B0%5D.Text=C%23)  

--- a/docs/csharp/quick-starts/arrays-and-collections.md
+++ b/docs/csharp/quick-starts/arrays-and-collections.md
@@ -1,7 +1,6 @@
 ---
-title: Quick Start - Collections - C# Guide
-description: Learn C# by exploring the List collection in this quick start.
-keywords: C#, Get Started, tutorial, collections, List
+title: Collections tutorial - C# local quickstarts
+description: Learn C# by exploring the List collection in this tutorial.
 author: billwagner
 ms.author: wiwagn
 ms.date: 10/13/2017
@@ -11,20 +10,20 @@ ms.technology: devlang-csharp
 ms.devlang: csharp
 ms.custom: mvc
 ---
-# C# Quick start: Collections #
+# C# Quickstart: Collections
 
-This quick start provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601>
+This quickstart provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601>
 class.
 
-This quick start expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quick starts](local-environment.md) with links to more details.
+This quickstart expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quickstarts](local-environment.md) with links to more details.
 
-## A basic list example.
+## A basic list example
 
 Create a directory named **list-quickstart**. Make that the current directory and run `dotnet new console`.
 
 > [!NOTE]
 > If you just completed [Get started with .NET in 10 minutes](https://www.microsoft.com/net), you can keep using the myApp application that you just created.
- 
+
 Open **Program.cs** in your favorite editor, and replace the existing code with the following:
 
 ```csharp
@@ -49,16 +48,16 @@ namespace list_quickstart
 
 Replace `<name>` with your name. Save **Program.cs**. Type `dotnet run` in your console window to try it.
 
-You've just created a list of strings, added three names to that list, and printed out the names in all CAPS. You're using concepts that you've learned in earlier quick starts to loop through the list.
+You've just created a list of strings, added three names to that list, and printed out the names in all CAPS. You're using concepts that you've learned in earlier quickstarts to loop through the list.
 
 The code to display names makes use of **interpolated strings**.  When you precede a `string` with the `$` character, you can embed C# code in the string declaration. The actual string replaces that C# code with the value it generates. In this example, it replaces the `{name.ToUpper()}` with each name, converted to capital letters, because you called the <xref:System.String.ToUpper%2A> method.
 
 Let's keep exploring.
-    
+
 ## Modify list contents
 
 The collection you created uses the <xref:System.Collections.Generic.List%601> type. This type stores sequences of elements. You specify the type of the elements between the angle brackets.
-    
+
 One important aspect of this <xref:System.Collections.Generic.List%601> type is that it can grow or shrink, enabling you to add or remove elements. Add this code before the closing `}` in the `Main` method:
 
 ```csharp
@@ -73,7 +72,7 @@ foreach (var name in names)
 ```
 
 You've added two more names to the end of the list. You've also removed one as well. Save the file, and type `dotnet run` to try it.
-    
+
 The <xref:System.Collections.Generic.List%601> enables you to reference individual items by **index** as well. You place the index between `[` and `]` tokens following the list name. C# uses 0 for the first index. Add this code directly below the code you just added and try it:
 
 ```csharp
@@ -87,9 +86,10 @@ You cannot access an index beyond the end of the list. Remember that indices sta
 Console.WriteLine($"The list has {names.Count} people in it");
  ```
 
-Save the file, and type `dotnet run` again to see the results.    
+Save the file, and type `dotnet run` again to see the results.
 
 ## Search and sort lists
+
 Our samples use relatively small lists, but your applications may often create lists with many more elements, sometimes numbering in the thousands. To find elements in these larger collections, you need to search the list for different items. The <xref:System.Collections.Generic.List%601.IndexOf%2A> method searches for an item and returns the index of the item. Add this code to the bottom of your `Main` method:
 
 ```csharp
@@ -109,7 +109,7 @@ if (index == -1)
 } else
 {
     Console.WriteLine($"The name {names[index]} is at index {index}");
-    
+
 }
 ```
 
@@ -180,7 +180,7 @@ namespace list_quickstart
 
 ## Lists of other types
 
-You've been using the `string` type in lists so far. Let's make a <xref:System.Collections.Generic.List%601> using a different type. Let's build a set of numbers. 
+You've been using the `string` type in lists so far. Let's make a <xref:System.Collections.Generic.List%601> using a different type. Let's build a set of numbers.
 
 Add the following to the bottom of your new `Main` method:
 
@@ -200,12 +200,13 @@ foreach(var item in fibonacciNumbers)
     Console.WriteLine(item);
 ```
 
-Save the file and type `dotnet run` to see the results. 
+Save the file and type `dotnet run` to see the results.
 
 > [!TIP]
-> To concentrate on just this section, you can comment out the code that calls `WorkingWithStrings();`. Just put two `/` characters in front of the call like this:  `// WorkingWithStrings();`. 
+> To concentrate on just this section, you can comment out the code that calls `WorkingWithStrings();`. Just put two `/` characters in front of the call like this:  `// WorkingWithStrings();`.
 
 ## Challenge
+
 See if you can put together some of the concepts from this and earlier lessons. Expand on what you've built so far with Fibonacci Numbers. Try to write the code to generate the first 20 numbers in the sequence. (As a hint, the 20th Fibonacci number is 6765.)
 
 ## Complete challenge
@@ -214,8 +215,8 @@ You can see an example solution by [looking at the finished sample code on GitHu
 
 With each iteration of the loop, you're taking the last two integers in the list, summing them, and adding that value to the list. The loop repeats until you've added 20 items to the list.
 
-Congratulations, you've completed the list quick start. You can continue with
-the [Introduction to classes](introduction-to-classes.md) quick start in
+Congratulations, you've completed the list quickstart. You can continue with
+the [Introduction to classes](introduction-to-classes.md) quickstart in
 your own development environment.
 
 You can learn more about working with the `List` type in the

--- a/docs/csharp/quick-starts/branches-and-loops-local.md
+++ b/docs/csharp/quick-starts/branches-and-loops-local.md
@@ -1,6 +1,6 @@
 ---
-title: Quick Start - Branches and loops - C# Guide
-description: In this quick start about branches and loops, you write C# code to explore the language syntax that supports conditional branches and loops to execute statements repeatedly.
+title: Branches and loops tutorial - C# local quickstarts
+description: In this quickstart about branches and loops, you write C# code to explore the language syntax that supports conditional branches and loops to execute statements repeatedly.
 author: billwagner
 ms.author: wiwagn
 ms.date: 10/31/2017
@@ -10,16 +10,15 @@ ms.technology: devlang-csharp
 ms.devlang: csharp
 ms.custom: mvc
 ---
-
 # Branches and loops
 
-This quick start teaches you how to write code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The quick start contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
+This quickstart teaches you how to write code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The quickstart contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
-This quick start expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quick starts](local-environment.md) with links to more details.
+This quickstart expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quickstarts](local-environment.md) with links to more details.
 
 ## Make decisions using the `if` statement
 
-Create a directory named **branches-quickstart**. Make that the current directory and run `dotnet new console -n BranchesAndLoops -o .`. This command creates a new .NET Core console application in the current directory. 
+Create a directory named **branches-quickstart**. Make that the current directory and run `dotnet new console -n BranchesAndLoops -o .`. This command creates a new .NET Core console application in the current directory.
 
 Open **Program.cs** in your favorite editor, and replace the line `Console.Writeline("Hello World!");` with the following code:
 
@@ -46,12 +45,11 @@ written one of the possible branches for an `if` statement: the true branch.
 > make mistakes when you write code. The compiler will
 > find and report the errors. Look closely at the error 
 > output and the code that generated the error. The compler
-> error can usually help you find the problem. 
+> error can usually help you find the problem.
 
-This first sample shows the power of `if` and Boolean types. A *Boolean* is a variable that can have one of two values: `true` or `false`. C# defines a special type, `bool` for Boolean variables. The `if` statement checks the value of a `bool`. When the value is `true`, the statement following the `if` executes. Otherwise, it is skipped. 
+This first sample shows the power of `if` and Boolean types. A *Boolean* is a variable that can have one of two values: `true` or `false`. C# defines a special type, `bool` for Boolean variables. The `if` statement checks the value of a `bool`. When the value is `true`, the statement following the `if` executes. Otherwise, it is skipped.
 
 This process of checking conditions and executing statements based on those conditions is very powerful.
-
 
 ## Make if and else work together
 
@@ -73,7 +71,7 @@ The statement following the `else` keyword executes only when the condition bein
 > The indentation under the `if` and `else` statements is for human readers.
 > The C# language doesn't treat indentation or whitespace as significant. 
 > The statement following the `if` or `else` keyword will be executed based
-> on the condition. All the samples in this quick start follow a common
+> on the condition. All the samples in this quickstart follow a common
 > practice to indent lines based on the control flow of statements.
 
 Because indentation is not significant, you need to use `{` and `}` to
@@ -96,7 +94,7 @@ else
 ```
 
 > [!TIP]
-> Through the rest of this quick start, the code samples all include the braces,
+> Through the rest of this quickstart, the code samples all include the braces,
 > following accepted practices.
 
 You can test more complicated conditions. Add the following code in your `Main` method after the code you've written so far:
@@ -252,7 +250,7 @@ for(int index = 0; index < 10; index++)
 
 This does the same work as the `while` loop and the `do` loop you've
 already used. The `for` statement has three parts that control
-how it works. 
+how it works.
 
 The first part is the **for initializer**: `for index = 0;` declares
 that `index` is the loop variable, and sets its initial value to `0`.
@@ -286,15 +284,15 @@ by 3.  Here are a few hints:
 Try it yourself. Then check how you did. You should get 63 for an answer. You can see one possible answer by
 [viewing the completed code on GitHub](https://github.com/dotnet/docs/tree/master/samples/csharp/branches-quickstart/Program.cs#L46-L54).
 
-You've completed the "branches and loops" quick start.
+You've completed the "branches and loops" quickstart.
 
 You can continue with
-the [Interpolated strings](interpolated-strings-local.md) quick start in
+the [Interpolated strings](interpolated-strings-local.md) quickstart in
 your own development environment.
 
 You can learn more about these concepts in these topics:
 
-[If and else statement](../language-reference/keywords/if-else.md)   
-[While statement](../language-reference/keywords/while.md)   
-[Do statement](../language-reference/keywords/do.md)   
-[For statement](../language-reference/keywords/for.md)   
+[If and else statement](../language-reference/keywords/if-else.md)  
+[While statement](../language-reference/keywords/while.md)  
+[Do statement](../language-reference/keywords/do.md)  
+[For statement](../language-reference/keywords/for.md)  

--- a/docs/csharp/quick-starts/branches-and-loops.yml
+++ b/docs/csharp/quick-starts/branches-and-loops.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Branches and loops
 metadata:
-  title:  Branches and loops - C# interactive tutorial
+  title:  Branches and loops interactive tutorial - C# quickstarts
   description: In this quickstart about branches and loops, you'll use your browser to learn C# interactively. You'll write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   level: Beginner

--- a/docs/csharp/quick-starts/branches-and-loops.yml
+++ b/docs/csharp/quick-starts/branches-and-loops.yml
@@ -1,8 +1,8 @@
 ### YamlMime:Tutorial
 title: Branches and loops
 metadata:
-  title:  Branches and loops
-  description: In this quick start about branches and loops, you'll use your browser to learn C# interactively. You'll write C# code and see the results of compiling and running your code directly in the browser.
+  title:  Branches and loops - C# interactive tutorial
+  description: In this quickstart about branches and loops, you'll use your browser to learn C# interactively. You'll write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   level: Beginner
   ms.custom: mvc
@@ -16,7 +16,7 @@ metadata:
 items:
 - durationInMinutes: 1
   content: |
-    This quick start teaches you how to write code that examines variables and changes execution path based on those variables. You'll use your browser to write C# interactively and see the results of compiling and running your code. This quick start contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
+    This quickstart teaches you how to write code that examines variables and changes execution path based on those variables. You'll use your browser to write C# interactively and see the results of compiling and running your code. This quickstart contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 - title: Make decisions using the if statement
   durationInMinutes: 4
   content: |
@@ -75,7 +75,7 @@ items:
     > The indentation under the `if` and `else` statements is for human readers.
     > The C# language doesn't treat indentation or whitespace as significant. 
     > The statement following the `if` or `else` keyword will be executed based
-    > on the condition. All the samples in this quick start follow a common
+    > on the condition. All the samples in this quickstart follow a common
     > practice to indent lines based on the control flow of statements.
 
     Because indentation is not significant, you need to use `{` and `}` to
@@ -98,7 +98,7 @@ items:
     ```
 
     > [!TIP]
-    > Through the rest of this quick start, the code samples all include the braces,
+    > Through the rest of this quickstart, the code samples all include the braces,
     > following accepted practices.
 
     You can test more complicated conditions:
@@ -271,9 +271,9 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
   content: |
-    You've completed the "branches and loops" quick start. 
+    You've completed the "branches and loops" quickstart. 
     
-    You can continue these quick starts on your own development environment. Learn the basics of [local development](local-environment.md) and then pick a quick start. You can try this same exercise, move directly to the next quick start, or start again at with the [numbers in C#](numbers-in-csharp-local.md) quickstart.
+    You can continue these quickstarts on your own development environment. Learn the basics of [local development](local-environment.md) and then pick a quickstart. You can try this same exercise, move directly to the next quickstart, or start again at with the [numbers in C#](numbers-in-csharp-local.md) quickstart.
     
     You can learn more about these concepts in these topics:
 

--- a/docs/csharp/quick-starts/hello-world.yml
+++ b/docs/csharp/quick-starts/hello-world.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Hello C#
 metadata:
-  title: Hello World - C# interactive tutorial
+  title: Hello World interactive tutorial - C# quickstarts
   description: In this quickstart, you'll use your browser to learn C# interactively. You write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   level: Beginner

--- a/docs/csharp/quick-starts/hello-world.yml
+++ b/docs/csharp/quick-starts/hello-world.yml
@@ -1,8 +1,8 @@
 ### YamlMime:Tutorial
 title: Hello C#
 metadata:
-  title:  Hello C#. Your first introduction to the C# language.
-  description: In this quick start, you'll use your browser to learn C# interactively. You write C# code and see the results of compiling and running your code directly in the browser.
+  title: Hello World - C# interactive tutorial
+  description: In this quickstart, you'll use your browser to learn C# interactively. You write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   level: Beginner
   ms.topic: get-started-article
@@ -16,7 +16,7 @@ metadata:
 items:
 - durationInMinutes: 1
   content: |
-    This quick start teaches you C# interactively, using your browser to write C# and see the results of compiling and running your code. It contains a series of lessons that begin with a "Hello World" program. These lessons teach you the fundamentals of the C# language.
+    This quickstart teaches you C# interactively, using your browser to write C# and see the results of compiling and running your code. It contains a series of lessons that begin with a "Hello World" program. These lessons teach you the fundamentals of the C# language.
 - title: Run your first C# program
   durationInMinutes: 2
   content: |
@@ -220,7 +220,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
     
 - content: |
-    You've completed the "Hello C#" quick start.
+    You've completed the "Hello C#" quickstart.
 
     You can learn more about working with the `string` type in the
     [C# Programming Guide](../programming-guide/index.md) topic on [strings](../programming-guide/strings/index.md).

--- a/docs/csharp/quick-starts/index.md
+++ b/docs/csharp/quick-starts/index.md
@@ -1,55 +1,55 @@
 ---
-title: Quick Starts - C# Guide
+title: C# interactive tutorials - C# quickstarts
 description: Learn C# in your browser, and get started with your own development environment
 keywords: C#, Get Started, Lessons, Interactive
 author: billwagner
 ms.author: wiwagn
-ms.date: 09/18/2017
+ms.date: 01/30/2018
 ms.topic: get-started-article
 ms.prod: .net
 ms.technology: devlang-csharp
 ms.devlang: csharp
 ms.custom: mvc
 ---
-# C# Quick starts #
+# C# Quickstarts #
 
-Welcome to the C# Quick starts. These start with interactive lessons
+Welcome to the C# Quickstarts. These start with interactive lessons
 that you can run in your browser.
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,
 numbers, and booleans. It's all interactive, and you'll be writing code
 within minutes. These first lessons assume no prior knowledge of
-programming or the C# language. 
+programming or the C# language.
 
-All the quick starts following the Hello World lesson are available using
+All the quickstarts following the Hello World lesson are available using
 the online browser experience or on your own development
 environment. At the end of each lesson, you decide if you want to continue
-with the next quick start online or on your own machine. There are links
-to help you setup your environment and continue with the next quick start
+with the next quickstart online or on your own machine. There are links
+to help you setup your environment and continue with the next quickstart
 on your machine.
 
 ## [Hello world](hello-world.yml)
 
-In the [Hello world](hello-world.yml) quick start, you'll create the most basic
+In the [Hello world](hello-world.yml) quickstart, you'll create the most basic
 C# program. You'll explore the `string` type and how to work with text.
 
 ## [Numbers in C#](numbers-in-csharp.yml)
 
-In the [Numbers in C#](numbers-in-csharp.yml) quick start, you'll learn
+In the [Numbers in C#](numbers-in-csharp.yml) quickstart, you'll learn
 how computers store numbers and how to perform calculations with different
 numeric types. You'll learn the basics of rounding, and how to perform
-mathematical calculations using C#. This quick start is also available
+mathematical calculations using C#. This quickstart is also available
 [to run locally on your machine](numbers-in-csharp-local.md).
 
-This quick start assumes that you have finished the [Hello world](hello-world.yml) tutorial.
+This quickstart assumes that you have finished the [Hello world](hello-world.yml) tutorial.
 
 ## [Branches and loops](branches-and-loops.yml)
 
-The [Branches and loops](branches-and-loops.yml) quick start teaches the basics of selecting
+The [Branches and loops](branches-and-loops.yml) quickstart teaches the basics of selecting
 different paths of code execution based on the values stored in variables. You'll learn the
 basics of control flow, which is the basis of how programs make decisions and choose
-different actions. This quick start is also available
+different actions. This quickstart is also available
 [to run locally on your machine](branches-and-loops-local.md).
 
 This beginning lesson assumes that you have finished the [Hello World](hello-world.yml) and
@@ -57,21 +57,21 @@ This beginning lesson assumes that you have finished the [Hello World](hello-wor
 
 ## [Interpolated strings](interpolated-strings.yml)
 
-The [interpolated strings](interpolated-strings.yml) quick start shows you how to insert an expression into a larger string. You'll learn how to define an interpolated expression, how to create a result string from an interpolated string that has one or more interpolated expressions, and how to control the formatting, column width, and alignment of expressions included in the result string. 
+The [interpolated strings](interpolated-strings.yml) quickstart shows you how to insert an expression into a larger string. You'll learn how to define an interpolated expression, how to create a result string from an interpolated string that has one or more interpolated expressions, and how to control the formatting, column width, and alignment of expressions included in the result string. 
 
 This beginning lesson assumes that you have finished the [Hello World](hello-world.yml), [Numbers in C#](numbers-in-csharp.yml), and [Branches and loops](branches-and-loops.yml) lessons.
 
 ## [List collection](list-collection.yml)
 
 The [List collection](list-collection.yml) lesson gives you
-a tour of the List collection type that stores sequences of data. You'll learn how to add and remove items, search for items, and sort the lists. You'll explore different kinds of lists. This quick start is also
+a tour of the List collection type that stores sequences of data. You'll learn how to add and remove items, search for items, and sort the lists. You'll explore different kinds of lists. This quickstart is also
 available [to run locally on your machine](arrays-and-collections.md).
 
-This beginning quick start assumes that you have finished the quick starts listed above.
+This beginning quickstart assumes that you have finished the quickstarts listed above.
 
 ## [Introduction to classes](introduction-to-classes.md)
 
 This final quickstart is only available to run on your machine, using your own local development environment and .NET Core.
 You'll build a console application and see the basic object-oriented features that are part of the C# language.
 
-This quick start assumes you've finished the online quick starts, and you've installed [.NET Core SDK](http://dot.net/core) and [Visual Studio Code](https://code.visualstudio.com/).
+This quickstart assumes you've finished the online quickstarts, and you've installed [.NET Core SDK](http://dot.net/core) and [Visual Studio Code](https://code.visualstudio.com/).

--- a/docs/csharp/quick-starts/interpolated-strings-local.md
+++ b/docs/csharp/quick-starts/interpolated-strings-local.md
@@ -1,6 +1,6 @@
 ---
-title: Quick Start - Interpolated strings - C# Guide
-description: In this quick start about interpolated strings, you write C# code to incude the result of an expression in a larger string.
+title: Interpolated strings tutorial - C# local quickstarts
+description: In this quickstart about interpolated strings, you write C# code to incude the result of an expression in a larger string.
 author: rpetrusha
 ms.author: ronpet
 ms.date: 01/11/2018
@@ -12,9 +12,9 @@ ms.custom: mvc
 ---
 # Interpolated strings
 
-This quick start teaches you how to use interpolated strings in C# to insert values into a single ouput string. You write C# code and see the results of compiling and running it. The quick start contains a series of lessons that insert values into strings, and format those values in different ways.
+This quickstart teaches you how to use interpolated strings in C# to insert values into a single ouput string. You write C# code and see the results of compiling and running it. The quickstart contains a series of lessons that insert values into strings, and format those values in different ways.
 
-This quick start expects that you have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quick starts](local-environment.md) with links to more details. 
+This quickstart expects that you have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quickstarts](local-environment.md) with links to more details. 
 
 ## Create an interpolated string
 
@@ -157,9 +157,9 @@ The output looks something like the following:
 1/11/2018            Hour 09                1,063.34 feet
 ```
 
-You've completed the interpolated strings quick start. 
+You've completed the interpolated strings quickstart. 
     
-You can continue with the [Arrays and collections](arrays-and-collections.md) quick start in your own development environment.
+You can continue with the [Arrays and collections](arrays-and-collections.md) quickstart in your own development environment.
 
 You can learn more about working with interpolated strings in the [Interpolated Strings](../language-reference/keywords/interpolated-strings.md) topic in the C# Reference.
 

--- a/docs/csharp/quick-starts/interpolated-strings.yml
+++ b/docs/csharp/quick-starts/interpolated-strings.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Interpolated strings in C#
 metadata:
-  title: Interpolated strings - C# interactive tutorial
+  title: Interpolated strings interactive tutorial - C# quickstarts
   description: In this tutorial, you'll use your browser to use the C# interpolated string feature interactively. You write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   ms.custom: mvc

--- a/docs/csharp/quick-starts/interpolated-strings.yml
+++ b/docs/csharp/quick-starts/interpolated-strings.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Interpolated strings in C#
 metadata:
-  title:  Interpolated strings in C#. Learn to construct a string that includes other values, such as dates or numbers.
+  title: Interpolated strings - C# interactive tutorial
   description: In this tutorial, you'll use your browser to use the C# interpolated string feature interactively. You write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   ms.custom: mvc
@@ -14,7 +14,7 @@ metadata:
 items:
 - durationInMinutes: 2
   content: |
-    This quick start teaches you how to use interpolated strings in C# to insert values into a single ouput string interactively. You use your browser to write C# code and can immediately see the results of compiling and running your code. The quick start contains a series of lessons that concatenate strings, insert values into strings, and format those values in different ways.
+    This quickstart teaches you how to use interpolated strings in C# to insert values into a single ouput string interactively. You use your browser to write C# code and can immediately see the results of compiling and running your code. The quickstart contains a series of lessons that concatenate strings, insert values into strings, and format those values in different ways.
 - title: Create an interpolated string
   durationInMinutes: 2
   content: |
@@ -41,7 +41,7 @@ items:
 - title: Include different data types
   durationInMinutes: 3
   content: |
-    In the previous quick start, you used an interpolated string to insert one string inside of another. An interpolated string expression can be any data type, though. Let's try an interpolated string that has values of multiple data types. 
+    In the previous quickstart, you used an interpolated string to insert one string inside of another. An interpolated string expression can be any data type, though. Let's try an interpolated string that has values of multiple data types. 
     
     The following example includes interpolated expressions with a `Vegetable` object, a member of the `Unit` enumeration, a <xref:System.DateTime> value, and a <xref:System.Decimal> value. Run it in the interactive window.
 
@@ -143,9 +143,9 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the interpolated strings quick start. 
+    You've completed the interpolated strings quickstart. 
     
-    You can continue these quick starts on your own local development environment. Learn the basics of [local development](local-environment.md) and then pick a quick start. You can try this same exercise, move directly to the next quick start, or start again with the [numbers in C#](numbers-in-csharp-local.md) quickstart.
+    You can continue these quickstarts on your own local development environment. Learn the basics of [local development](local-environment.md) and then pick a quickstart. You can try this same exercise, move directly to the next quickstart, or start again with the [numbers in C#](numbers-in-csharp-local.md) quickstart.
 
     You can learn more about working with interpolated strings in the [Interpolated Strings](../language-reference/keywords/interpolated-strings.md) topic in the C# Reference.
 

--- a/docs/csharp/quick-starts/introduction-to-classes.md
+++ b/docs/csharp/quick-starts/introduction-to-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Quick Starts - Introduction to Classes - C# Guide
+title: Introduction to classes tutorial - C# local quickstarts
 description: Create your first C# program and explore object oriented concepts
 author: billwagner
 ms.author: wiwagn
@@ -12,7 +12,7 @@ ms.custom: mvc
 ---
 # Introduction to classes
 
-This quick start expects that you have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quick starts](local-environment.md) with links to more details.
+This quickstart expects that you have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quickstarts](local-environment.md) with links to more details.
 
 ## Create your application
 
@@ -33,9 +33,9 @@ namespace classes
 }
 ```
 
-In this quick start, you're going to create new types that represent a bank account. Typically developers define each class in a different text file. That makes it easier to manage as a program grows in size.  Create a new file named **BankAccount.cs** in the **classes** directory. 
+In this quickstart, you're going to create new types that represent a bank account. Typically developers define each class in a different text file. That makes it easier to manage as a program grows in size.  Create a new file named **BankAccount.cs** in the **classes** directory. 
 
-This file will contain the definition of a ***bank account***. Object Oriented programming organizes code by creating types in the form of ***classes***. These classes contain the code that represents a specific entity. The `BankAccount` class represents a bank account. The code implements specific operations through methods and properties. In this quick start, the bank account supports this behavior:
+This file will contain the definition of a ***bank account***. Object Oriented programming organizes code by creating types in the form of ***classes***. These classes contain the code that represents a specific entity. The `BankAccount` class represents a bank account. The code implements specific operations through methods and properties. In this quickstart, the bank account supports this behavior:
 
 1. It has a 10-digit number that uniquely identifies the bank account.
 1. It has a string that stores the name or names of the owners.
@@ -71,7 +71,7 @@ namespace classes
 }
 ```
 
-Before going on, let's take a look at what you've built.  The `namespace` declaration provides a way to logically organize your code. This quick start is relatively small, so you'll put all the code in one namespace. 
+Before going on, let's take a look at what you've built.  The `namespace` declaration provides a way to logically organize your code. This quickstart is relatively small, so you'll put all the code in one namespace. 
 
 `public class BankAccount` defines the class, or type, you are creating. Everything inside the `{` and `}` that follows the class declaration defines the behavior of the class. There are five ***members*** of the `BankAccount` class. The first three are ***properties***. Properties are data elements and can have code that enforces validation or other rules. The last two are ***methods***. Methods are blocks of code that peform a single function. Reading the names of each of the members should provide enough information for you or another developer to understand what the class does.
 
@@ -194,11 +194,11 @@ Save the file and type `dotnet run` to try it.
 
 ## Challenge - log all transactions
 
-To finish this quick start, you can write the `GetAccountHistory` method that creates a `string` for the transaction history. add this method to the `BankAccount` type:
+To finish this quickstart, you can write the `GetAccountHistory` method that creates a `string` for the transaction history. add this method to the `BankAccount` type:
 
 [!code-csharp[History](../../../samples/csharp/classes-quickstart/BankAccount.cs#History "Display transaction history")]
 
-This uses the <xref:System.Text.StringBuilder> class to format a string that contains one line for each transaction. You've seen the string formatting code earlier in these quick starts. One new character is `\t`. That inserts a tab to format the output.
+This uses the <xref:System.Text.StringBuilder> class to format a string that contains one line for each transaction. You've seen the string formatting code earlier in these quickstarts. One new character is `\t`. That inserts a tab to format the output.
 
 Add this line to test it in **Program.cs**:
 
@@ -210,6 +210,6 @@ Type `dotnet run` to see the results.
 
 ## Next Steps
 
-If you got stuck, you can see the source for this quick start [in our GitHub repo](https://github.com/dotnet/docs/tree/master/samples/csharp/classes-quickstart/)
+If you got stuck, you can see the source for this quickstart [in our GitHub repo](https://github.com/dotnet/docs/tree/master/samples/csharp/classes-quickstart/)
 
-Congratulations, you've finished all our Quick Starts. If you're eager to learn more, try our [tutorials](../tutorials/index.md)
+Congratulations, you've finished all our Quickstarts. If you're eager to learn more, try our [tutorials](../tutorials/index.md)

--- a/docs/csharp/quick-starts/list-collection.yml
+++ b/docs/csharp/quick-starts/list-collection.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Collections in C#
 metadata:
-  title:  Collections - C# interactive tutorial
+  title:  Collections interactive tutorial - C# quickstarts
   description: In this tutorial, you'll use your browser to learn C# interactively. You write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   ms.topic: get-started-article

--- a/docs/csharp/quick-starts/list-collection.yml
+++ b/docs/csharp/quick-starts/list-collection.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Collections in C#
 metadata:
-  title:  Collections in C#. Learn to use sequences and collections in C#.
+  title:  Collections - C# interactive tutorial
   description: In this tutorial, you'll use your browser to learn C# interactively. You write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   ms.topic: get-started-article
@@ -14,7 +14,7 @@ metadata:
 items:
 - durationInMinutes: 1
   content: |
-    This quick start teaches you C# interactively, using your browser to write C# code and see the results of compiling and running your code. It contains a series of lessons that create, modify and explore collections and arrays.
+    This quickstart teaches you C# interactively, using your browser to write C# code and see the results of compiling and running your code. It contains a series of lessons that create, modify and explore collections and arrays.
 - title: Create lists
   durationInMinutes: 2
   content: |
@@ -29,7 +29,7 @@ items:
     ```
 
     You've just created a list of strings, added three names to that list, and printed out the names in all CAPS. You're using concepts
-    that you've learned in earlier quick starts to loop through the list.
+    that you've learned in earlier quickstarts to loop through the list.
 
     The code to display names makes use of **interpolated strings**.  When you precede a `string` with the `$` character, you can embed C# code in the string declaration. The actual string replaces that C# code with the value it generates. In this example, it replaces the `{name.ToUpper()}` with each name, converted to capital letters, because you called the <xref:System.String.ToUpper%2A> method.
 
@@ -164,7 +164,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
     
 - content: |
-    You've completed the list quick start. This quick start is the final interactive quick start. You can continue these quick starts on your own development environment. Learn the basics of [local development](local-environment.md) and then pick a quick start. You can try this same exercise, move directly to the next quick start, or start again at with the [numbers in C#](numbers-in-csharp-local.md) quickstart.
+    You've completed the list quickstart. This quickstart is the final interactive quickstart. You can continue these quickstarts on your own development environment. Learn the basics of [local development](local-environment.md) and then pick a quickstart. You can try this same exercise, move directly to the next quickstart, or start again at with the [numbers in C#](numbers-in-csharp-local.md) quickstart.
 
     You can learn more about working with the `List` type in the
     [.NET Guide](../../standard/index.md) topic on [collections](../../standard/collections/index.md). You'll also learn about many other collection types.

--- a/docs/csharp/quick-starts/local-environment.md
+++ b/docs/csharp/quick-starts/local-environment.md
@@ -1,6 +1,6 @@
 ---
-title: Quick Start - Local Environment - C# Guide
-description: This quickstart provides the basics for running the quick starts locally
+title: Local environment tutorial - C# local quickstarts
+description: This quickstart provides the basics for running the quickstarts locally
 author: billwagner
 ms.topic: get-started-article
 ms.date: 12/07/2017
@@ -12,7 +12,7 @@ ms.custom: mvc
 ---
 # Local environment
 
-The first step to trying a quick start locally is to setup a development environment on your local machine.
+The first step to trying a quickstart locally is to setup a development environment on your local machine.
 The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting
 up your local development environment on Mac, PC or Linux.
 
@@ -30,20 +30,20 @@ and [`dotnet run`](../../core/tools/dotnet-run.md) to run the executable.
 
 ## Pick your quickstart
 
-You can start with any of the following quick starts:
+You can start with any of the following quickstarts:
 
 ## [Numbers in C#](numbers-in-csharp-local.md)
 
-In the [Numbers in C#](numbers-in-csharp-local.md) quick start, you'll learn
+In the [Numbers in C#](numbers-in-csharp-local.md) quickstart, you'll learn
 how computers store numbers and how to perform calculations with different
 numeric types. You'll learn the basics of rounding, and how to perform
 mathematical calculations using C#. 
 
-This quick start assumes that you have finished the [Hello world](hello-world.yml) tutorial.
+This quickstart assumes that you have finished the [Hello world](hello-world.yml) tutorial.
 
 ## [Branches and loops](branches-and-loops-local.md)
 
-The [Branches and loops](branches-and-loops-local.md) quick start teaches the basics of selecting
+The [Branches and loops](branches-and-loops-local.md) quickstart teaches the basics of selecting
 different paths of code execution based on the values stored in variables. You'll learn the
 basics of control flow, which is the basis of how programs make decisions and choose
 different actions. 
@@ -56,7 +56,7 @@ This beginning lesson assumes that you have finished the [Hello World](hello-wor
 The [List collection](arrays-and-collections.md) lesson gives you
 a tour of the List collection type that stores sequences of data. You'll learn how to add and remove items, search for items, and sort the lists. You'll explore different kinds of lists. 
 
-This beginning quick start assumes that you have finished the quick starts listed above.
+This beginning quickstart assumes that you have finished the quickstarts listed above.
 
 ## [Introduction to classes](introduction-to-classes.md)
 

--- a/docs/csharp/quick-starts/numbers-in-csharp-local.md
+++ b/docs/csharp/quick-starts/numbers-in-csharp-local.md
@@ -1,5 +1,5 @@
 ---
-title: Quick Start - Numbers in C# - C# Guide
+title: Numbers tutorial - C# local quickstarts
 description: Learn C# by exploring numeric types, their properties and methods.
 author: billwagner
 ms.author: wiwagn
@@ -11,11 +11,11 @@ ms.devlang: csharp
 ms.custom: mvc
 ---
 
-# Numbers in C# quick start #
+# Numbers in C# quickstart
 
-This quick start teaches you about the number types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The quick start contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
+This quickstart teaches you about the number types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The quickstart contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
-This quick start expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quick starts](local-environment.md) with links to more details.
+This quickstart expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [introduction to the local quickstarts](local-environment.md) with links to more details.
 
 ## Explore integer math
 
@@ -356,8 +356,8 @@ You can check your answer by [looking at the finished sample code on GitHub](htt
 
 Try some other formulas if you'd like. 
 
-You've completed the "Numbers in C#" quick start. You can continue with
-the [Branches and loops](branches-and-loops-local.md) quick start in
+You've completed the "Numbers in C#" quickstart. You can continue with
+the [Branches and loops](branches-and-loops-local.md) quickstart in
 your own development environment.
 
 You can learn more about numbers in C# in the following topics:

--- a/docs/csharp/quick-starts/numbers-in-csharp-local.md
+++ b/docs/csharp/quick-starts/numbers-in-csharp-local.md
@@ -1,5 +1,5 @@
 ---
-title: Numbers tutorial - C# local quickstarts
+title: Numbers in C# tutorial - C# local quickstarts
 description: Learn C# by exploring numeric types, their properties and methods.
 author: billwagner
 ms.author: wiwagn

--- a/docs/csharp/quick-starts/numbers-in-csharp.yml
+++ b/docs/csharp/quick-starts/numbers-in-csharp.yml
@@ -1,7 +1,7 @@
 ### YamlMime:Tutorial
 title: Numbers in C#
 metadata:
-  title:  Numbers in C#
+  title:  Numbers in C# interactive tutorial - C# quickstarts
   description: In this quick start about numeric types, you'll use your browser to learn C# interactively. You're going to write C# code and see the results of compiling and running your code directly in the browser.
   audience: Developer
   ms.topic: get-started-article

--- a/docs/csharp/quick-starts/toc.md
+++ b/docs/csharp/quick-starts/toc.md
@@ -1,4 +1,4 @@
-# [Quick Starts](index.md)
+# [Quickstarts](index.md)
 ## [Hello world](hello-world.yml)
 ## [Numbers in C#](numbers-in-csharp.yml)
 ## [Branches and loops](branches-and-loops.yml)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -209,7 +209,7 @@
 <!-- Start of C# Content -->
 # [C# Guide](csharp/index.md)
 ## [Get Started](csharp/getting-started/)
-## [Quick Starts](csharp/quick-starts/)
+## [Quickstarts](csharp/quick-starts/)
 ## [Tutorials](csharp/tutorials/)
 ## [Tour of C#](csharp/tour-of-csharp/)
 <!-- The "What's New" section is short, and one level

--- a/index.md
+++ b/index.md
@@ -163,7 +163,7 @@ description: Learn how to use .NET to create a variety of applications on any pl
                                             </div>
                                             <div class="cardText">
                                                 <h3><a href="/dotnet/csharp">C# Guide</a></h3>
-                                                <p><a href="/dotnet/csharp/quick-starts">Quick Starts</a></p>
+                                                <p><a href="/dotnet/csharp/quick-starts">Quickstarts</a></p>
                                                 <p><a href="/dotnet/csharp/getting-started">Get Started</a></p>
                                                 <p><a href="/dotnet/csharp/tour-of-csharp">Tour of C#</a></p>
                                                 <p><a href="/dotnet/csharp/language-reference">C# Language Reference</a></p>

--- a/toc.yml
+++ b/toc.yml
@@ -350,7 +350,7 @@
       tocHref: /dotnet/csharp/
       topicHref: /dotnet/csharp/index
       items:
-      - name: Quick Starts
+      - name: Quickstarts
         tocHref: /dotnet/csharp/quick-starts/
         topicHref: /dotnet/csharp/quick-starts/index
       - name: Getting started


### PR DESCRIPTION
What was done:
- Renamed quick starts to quickstarts (preferred spelling according to Acrolinx and contributing guide)
- Improved titles for SEO to account for the tutorial keyword which is commonly used
- Improved the C# guide homepage to improve Acrolinx rating and list quickstarts

Let me know what you think @BillWagner and @LadyNaggaga 