### PR TITLE
fix broken links

### DIFF
--- a/xml/Microsoft.VisualBasic.Compatibility.VB6/BaseControlArray.xml
+++ b/xml/Microsoft.VisualBasic.Compatibility.VB6/BaseControlArray.xml
@@ -680,7 +680,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Design environments typically use this method to start the initialization of a component that is used on a form or used by another component. The <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System%23ComponentModel%23ISupportInitialize%23EndInit> method ends the initialization. Using the `BeginInit` and <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System%23ComponentModel%23ISupportInitialize%23EndInit%2A> methods prevents the control from being used before it is fully initialized. The initialization occurs at run time.  
+ Design environments typically use this method to start the initialization of a component that is used on a form or used by another component. The <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System%23ComponentModel%23ISupportInitialize%23EndInit> method ends the initialization. Using the `BeginInit` and <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System%23ComponentModel%23ISupportInitialize%23EndInit> methods prevents the control from being used before it is fully initialized. The initialization occurs at run time.  
   
 > [!NOTE]
 >  Functions and objects in the <xref:Microsoft.VisualBasic.Compatibility.VB6> namespace are provided for use by the tools for upgrading from Visual Basic 6.0 to [!INCLUDE[vbprvb](~/includes/vbprvb-md.md)]. In most cases, these functions and objects duplicate functionality that you can find in other namespaces in the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)]. They are necessary only when the Visual Basic 6.0 code model differs significantly from the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)] implementation.  

--- a/xml/Microsoft.VisualBasic.Compatibility.VB6/BaseControlArray.xml
+++ b/xml/Microsoft.VisualBasic.Compatibility.VB6/BaseControlArray.xml
@@ -680,7 +680,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- Design environments typically use this method to start the initialization of a component that is used on a form or used by another component. The <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System#ComponentModel#ISupportInitialize#EndInit%2A> method ends the initialization. Using the `BeginInit` and <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System#ComponentModel#ISupportInitialize#EndInit%2A> methods prevents the control from being used before it is fully initialized. The initialization occurs at run time.  
+ Design environments typically use this method to start the initialization of a component that is used on a form or used by another component. The <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System%23ComponentModel%23ISupportInitialize%23EndInit> method ends the initialization. Using the `BeginInit` and <xref:Microsoft.VisualBasic.Compatibility.VB6.BaseControlArray.System%23ComponentModel%23ISupportInitialize%23EndInit%2A> methods prevents the control from being used before it is fully initialized. The initialization occurs at run time.  
   
 > [!NOTE]
 >  Functions and objects in the <xref:Microsoft.VisualBasic.Compatibility.VB6> namespace are provided for use by the tools for upgrading from Visual Basic 6.0 to [!INCLUDE[vbprvb](~/includes/vbprvb-md.md)]. In most cases, these functions and objects duplicate functionality that you can find in other namespaces in the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)]. They are necessary only when the Visual Basic 6.0 code model differs significantly from the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)] implementation.  


### PR DESCRIPTION
Engineering team investigated and pound signs on xref links should always be encoded. So trying that and see if that works.