### PR TITLE
Replaced fwlinks

### DIFF
--- a/docs/csharp/programming-guide/statements-expressions-operators/conversion-operators.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/conversion-operators.md
@@ -47,4 +47,4 @@ C# enables programmers to declare conversions on classes or structs so that clas
 ## See Also  
  <xref:System.Convert>  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [Chained user-defined explicit conversions in C#](http://go.microsoft.com/fwlink/?LinkId=112384)
+ [Chained user-defined explicit conversions in C#](https://blogs.msdn.microsoft.com/ericlippert/2007/04/16/chained-user-defined-explicit-conversions-in-c/)

--- a/docs/csharp/programming-guide/statements-expressions-operators/how-to-use-operator-overloading-to-create-a-complex-number-class.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/how-to-use-operator-overloading-to-create-a-complex-number-class.md
@@ -26,4 +26,4 @@ This example shows how you can use operator overloading to create a complex numb
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [C# Operators](../../../csharp/language-reference/operators/index.md)  
  [operator (C# Reference)](../../../csharp/language-reference/keywords/operator.md)  
- [Why are overloaded operators always static in C#?](http://go.microsoft.com/fwlink/?LinkId=112383)
+ [Why are overloaded operators always static in C#?](https://blogs.msdn.microsoft.com/ericlippert/2007/05/14/why-are-overloaded-operators-always-static-in-c/)

--- a/docs/csharp/programming-guide/statements-expressions-operators/lambda-expressions.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/lambda-expressions.md
@@ -270,13 +270,13 @@ class Test
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
 ## Featured Book Chapter  
- [Delegates, Events, and Lambda Expressions](http://go.microsoft.com/fwlink/?LinkId=195395) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](http://go.microsoft.com/fwlink/?LinkId=195369)  
+ [Delegates, Events, and Lambda Expressions](https://msdn.microsoft.com/library/orm-9780596516109-03-09.aspx) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](https://msdn.microsoft.com/library/orm-9780596516109-03.aspx)  
   
 ## See Also  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [LINQ (Language-Integrated Query)](http://msdn.microsoft.com/library/a73c4aec-5d15-4e98-b962-1274021ea93d)  
+ [LINQ (Language-Integrated Query)](../../../csharp/programming-guide/concepts/linq/index.md)  
  [Anonymous Methods](../../../csharp/programming-guide/statements-expressions-operators/anonymous-methods.md)  
  [is](../../../csharp/language-reference/keywords/is.md)  
- [Expression Trees](http://msdn.microsoft.com/library/fb1d3ed8-d5b0-4211-a71f-dd271529294b)  
+ [Expression Trees](../../../csharp/programming-guide/concepts/expression-trees/index.md)  
  [Visual Studio 2008 C# Samples (see LINQ Sample Queries files and XQuery program)](http://code.msdn.microsoft.com/Visual-Studio-2008-C-d295cdba)  
- [Recursive lambda expressions](http://go.microsoft.com/fwlink/?LinkId=112395)
+ [Recursive lambda expressions](https://blogs.msdn.microsoft.com/madst/2007/05/11/recursive-lambda-expressions/)

--- a/docs/csharp/programming-guide/statements-expressions-operators/overloadable-operators.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/overloadable-operators.md
@@ -58,4 +58,4 @@ For more information, see [How to: Use Operator Overloading to Create a Complex 
 [Statements, Expressions, and Operators](../../../csharp/programming-guide/statements-expressions-operators/index.md)  
 [Operators](../../../csharp/programming-guide/statements-expressions-operators/operators.md)  
 [C# Operators](../../../csharp/language-reference/operators/index.md)  
-[Why are overloaded operators always static in C#?](http://go.microsoft.com/fwlink/?LinkId=112383)
+[Why are overloaded operators always static in C#?](https://blogs.msdn.microsoft.com/ericlippert/2007/05/14/why-are-overloaded-operators-always-static-in-c/)


### PR DESCRIPTION
Replaced fwlinks in **csharp/programming-guide/statements-expressions-operators** folder
Plus some msdn links are replaced with internal links.
Related to #3424 
