### PR TITLE
Added file exception information to Directory.GetParent

### DIFF
--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -2669,7 +2669,7 @@ Directory::CreateDirectory("Public\\Html");
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The `path` parameter is permitted to specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory. To obtain the current working directory, see <xref:System.IO.Directory.GetCurrentDirectory%2A>.  
+ The `path` parameter can specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory. To obtain the current working directory, see <xref:System.IO.Directory.GetCurrentDirectory%2A>.  
   
  Trailing spaces are removed from the end of the `path` parameter before getting the directory.  
   
@@ -2698,6 +2698,8 @@ Directory::CreateDirectory("Public\\Html");
           <paramref name="path" /> is <see langword="null" />.</exception>
         <exception cref="T:System.IO.PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. For example, on Windows-based platforms, paths must be less than 248 characters and file names must be less than 260 characters.</exception>
         <exception cref="T:System.IO.DirectoryNotFoundException">The specified path was not found.</exception>
+        <exception cref="T:System.NotSupportedException"><paramref name="path" /> is in an invalid format. </exception>
+        <exception cref="T:System.Security.SecurityException">.NET Framework only: The caller does not have the required permissions. </exception>
         <permission cref="T:System.Security.Permissions.FileIOPermission">for reading from files or directories. Associated enumeration: <see cref="F:System.Security.Permissions.FileIOPermissionAccess.Read" /></permission>
         <altmember cref="T:System.IO.DirectoryInfo" />
       </Docs>

--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -2696,7 +2696,7 @@ Directory::CreateDirectory("Public\\Html");
           <paramref name="path" /> is a zero-length string, contains only white space, or contains one or more invalid characters. You can query for invalid characters with the  <see cref="M:System.IO.Path.GetInvalidPathChars" /> method.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="path" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.IO.PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. For example, on Windows-based platforms, paths must be less than 248 characters and file names must be less than 260 characters.</exception>
+        <exception cref="T:System.IO.PathTooLongException">.NET Framework 4.6.1 and earlier versions only: The specified path, file name, or both exceed the system-defined maximum length. For example, on Windows-based platforms, paths must be less than 248 characters and file names must be less than 260 characters.</exception>
         <exception cref="T:System.IO.DirectoryNotFoundException">The specified path was not found.</exception>
         <exception cref="T:System.NotSupportedException"><paramref name="path" /> is in an invalid format. </exception>
         <exception cref="T:System.Security.SecurityException">.NET Framework only: The caller does not have the required permissions. </exception>

--- a/xml/System.IO/Directory.xml
+++ b/xml/System.IO/Directory.xml
@@ -2696,7 +2696,7 @@ Directory::CreateDirectory("Public\\Html");
           <paramref name="path" /> is a zero-length string, contains only white space, or contains one or more invalid characters. You can query for invalid characters with the  <see cref="M:System.IO.Path.GetInvalidPathChars" /> method.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="path" /> is <see langword="null" />.</exception>
-        <exception cref="T:System.IO.PathTooLongException">.NET Framework 4.6.1 and earlier versions only: The specified path, file name, or both exceed the system-defined maximum length. For example, on Windows-based platforms, paths must be less than 248 characters and file names must be less than 260 characters.</exception>
+        <exception cref="T:System.IO.PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. For more information, see the <see cref="T:System.IO.PathTooLongException" /> topic. </exception>
         <exception cref="T:System.IO.DirectoryNotFoundException">The specified path was not found.</exception>
         <exception cref="T:System.NotSupportedException"><paramref name="path" /> is in an invalid format. </exception>
         <exception cref="T:System.Security.SecurityException">.NET Framework only: The caller does not have the required permissions. </exception>


### PR DESCRIPTION
# Added file exception information to Directory.GetParent

## Summary

This incorporated the actionable items from the discussion in PR #3971. I'll also open an issue to:
- incorporate this exception information into other exceptions that call into GetFullPath
- to revise the description for PathTooLongException to reflect long path name support 

@JeremyKuhne, I've also revised the wording of the PathTooLongException; is this acceptable?

//cc @mriehm @mairaw @JeremyKuhne @pjanotti 

