### PR TITLE
Replaced fwlinks in csharp\programming-guide\concepts\linq folder

### DIFF
--- a/docs/csharp/programming-guide/concepts/expression-trees/index.md
+++ b/docs/csharp/programming-guide/concepts/expression-trees/index.md
@@ -95,7 +95,7 @@ Console.WriteLine(factorial);
 // Prints 120.  
 ```
 
-For more information, see [Generating Dynamic Methods with Expression Trees in Visual Studio 2010](http://go.microsoft.com/fwlink/p/?LinkId=169513), which also applies to later versions of Visual Studio.
+For more information, see [Generating Dynamic Methods with Expression Trees in Visual Studio 2010](https://blogs.msdn.microsoft.com/csharpfaq/2009/09/14/generating-dynamic-methods-with-expression-trees-in-visual-studio-2010/), which also applies to later versions of Visual Studio.
   
 ## Parsing Expression Trees  
  The following code example demonstrates how the expression tree that represents the lambda expression `num => num < 5` can be decomposed into its parts.  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
@@ -18,7 +18,7 @@ ms.author: "wiwagn"
 # How to: Modify an Office Open XML Document (C#)
 This topic presents an example that opens an Office Open XML document, modifies it, and saves it.  
   
- For more information on Office Open XML, see [www.ericwhite.com](http://ericwhite.com/).  
+ For more information on Office Open XML, see [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK) and [www.ericwhite.com](http://ericwhite.com/).  
   
 ## Example  
  This example finds the first paragraph element in the document. It retrieves the text from the paragraph, and then deletes all text runs in the paragraph. It creates a new text run that consists of the first paragraph text that has been converted to upper case. It then serializes the changed XML into the Open XML package and closes it.  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
@@ -18,7 +18,7 @@ ms.author: "wiwagn"
 # How to: Modify an Office Open XML Document (C#)
 This topic presents an example that opens an Office Open XML document, modifies it, and saves it.  
   
- For more information on Office Open XML, see [www.openxmldeveloper.org](http://go.microsoft.com/fwlink/?LinkID=95573).  
+ For more information on Office Open XML, see [www.ericwhite.com](http://ericwhite.com/).  
   
 ## Example  
  This example finds the first paragraph element in the document. It retrieves the text from the paragraph, and then deletes all text runs in the paragraph. It creates a new text run that consists of the first paragraph text that has been converted to upper case. It then serializes the changed XML into the Open XML package and closes it.  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
@@ -18,7 +18,7 @@ ms.author: "wiwagn"
 # How to: Retrieve Paragraphs from an Office Open XML Document (C#)
 This topic presents an example that opens an Office Open XML document, and retrieves a collection of all of the paragraphs in the document.  
   
- For more information on Office Open XML, see [www.ericwhite.com](http://ericwhite.com/).  
+ For more information on Office Open XML, see [Open XML SDK](https://github.com/OfficeDev/Open-XML-SDK) and [www.ericwhite.com](http://ericwhite.com/).  
   
 ## Example  
  This example opens an Office Open XML package, uses the relationships within the Open XML package to find the document and the style parts. It then queries the document, projecting a collection of an anonymous type that contains the paragraph <xref:System.Xml.Linq.XElement> node, the style name of each paragraph, and the text of each paragraph.  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
@@ -18,7 +18,7 @@ ms.author: "wiwagn"
 # How to: Retrieve Paragraphs from an Office Open XML Document (C#)
 This topic presents an example that opens an Office Open XML document, and retrieves a collection of all of the paragraphs in the document.  
   
- For more information on Office Open XML, see [www.openxmldeveloper.org](http://go.microsoft.com/fwlink/?LinkID=95573).  
+ For more information on Office Open XML, see [www.ericwhite.com](http://ericwhite.com/).  
   
 ## Example  
  This example opens an Office Open XML package, uses the relationships within the Open XML package to find the document and the style parts. It then queries the document, projecting a collection of an anonymous type that contains the paragraph <xref:System.Xml.Linq.XElement> node, the style name of each paragraph, and the text of each paragraph.  

--- a/docs/csharp/programming-guide/concepts/linq/shape-of-wordprocessingml-documents.md
+++ b/docs/csharp/programming-guide/concepts/linq/shape-of-wordprocessingml-documents.md
@@ -94,11 +94,11 @@ using (Package wdPackage = Package.Open("SampleDoc.docx", FileMode.Open, FileAcc
 ```  
   
 ## External Resources  
- [Introducing the Office (2007) Open XML File Formats](http://go.microsoft.com/fwlink/?LinkId=98093)  
-  
- [Overview of WordprocessingML](http://go.microsoft.com/fwlink/?LinkId=98094)  
-  
- [Office 2003: XML Reference Schemas Download page](http://go.microsoft.com/fwlink/?LinkId=98095)  
+ [Introducing the Office (2007) Open XML File Formats](https://msdn.microsoft.com/library/ms406049.aspx)  
+ [Overview of WordprocessingML](https://msdn.microsoft.com/library/aa212812(office.11).aspx)  
+ [Anatomy of a WordProcessingML File](http://officeopenxml.com/anatomyofOOXML.php)  
+ [Introduction to WordprocessingML](http://ericwhite.com/blog/introduction-to-wordprocessingml-series/)  
+ [Office 2003: XML Reference Schemas Download page](https://www.microsoft.com/en-us/download/details.aspx?id=101)  
   
 ## See Also  
  [Tutorial: Manipulating Content in a WordprocessingML Document (C#)](../../../../csharp/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md)

--- a/docs/csharp/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
@@ -18,7 +18,7 @@ ms.author: "wiwagn"
 # Tutorial: Manipulating Content in a WordprocessingML Document (C#)
 This tutorial shows how to apply the functional transformational approach and LINQ to XML to manipulate XML documents. The C# examples query and manipulate information in Office Open XML WordprocessingML documents that are saved by Microsoft Word.  
   
- For more information, see the [OpenXML Developer](http://go.microsoft.com/fwlink/?LinkID=95573) Web site.  
+ For more information, see [Introduction to WordprocessingML](http://ericwhite.com/blog/introduction-to-wordprocessingml-series/).  
   
 ## In This Section  
   


### PR DESCRIPTION
Replaced fwlinks in **csharp\programming-guide\concepts\linq** and **csharp\programming-guide\concepts\expression-trees** folders. Related to #3424 

The [www.openxmldeveloper.org](http://openxmldeveloper.org/) site is shutting down with content being moved to [www.ericwhite.com](http://www.ericwhite.com/), that's why I've replaced actual links as well.