### PR TITLE
Fix HashSet example code

### DIFF
--- a/samples/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/cpp/source2.cpp
+++ b/samples/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/cpp/source2.cpp
@@ -4,28 +4,12 @@
 using namespace System;
 using namespace System::Collections::Generic;
 
-ref class SameVehicleComparer : public EqualityComparer<String^>
-{
-public:
-    virtual bool Equals(String^ s1, String^ s2) override
-    {
-        return s1->Equals(s2, StringComparison::CurrentCultureIgnoreCase);
-    }
-
-
-    virtual int GetHashCode(String^ s) override
-    {
-        return this->GetHashCode();
-    }
-};
-
 ref class Program
 {
 public:
     static void Main()
     {
-        SameVehicleComparer^ compareVehicles = gcnew SameVehicleComparer();
-        HashSet<String^> ^allVehicles = gcnew HashSet<String^>(compareVehicles);
+        HashSet<String^> ^allVehicles = gcnew HashSet<String^>(StringComparer::OrdinalIgnoreCase);
         List<String^>^ someVehicles = gcnew List<String^>();
 
         someVehicles->Add("Planes");
@@ -61,7 +45,7 @@ public:
             Console::WriteLine("'Some' vechicles list.");
         }
 
-        // Check for Rockets. Here the SameVehicleComparer will compare
+        // Check for Rockets. Here the OrdinalIgnoreCase comparer will compare
         // true for the mixed-case vehicle type.
         if (allVehicles->Contains("roCKeTs"))
         {

--- a/samples/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/cs/source2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/cs/source2.cs
@@ -6,8 +6,7 @@ class Program
 {
     public static void Main()
     {
-        SameVehicleComparer compareVehicles = new SameVehicleComparer();
-        HashSet<string> allVehicles = new HashSet<string>(compareVehicles);
+        HashSet<string> allVehicles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         List<string> someVehicles = new List<string>();
 
         someVehicles.Add("Planes");
@@ -43,7 +42,7 @@ class Program
             Console.WriteLine("'Some' vechicles list.");
         }
 
-        // Check for Rockets. Here the SameVehicleComparer will compare
+        // Check for Rockets. Here the OrdinalIgnoreCase comparer will compare
         // true for the mixed-case vehicle type.
         if (allVehicles.Contains("roCKeTs"))
         {
@@ -73,20 +72,6 @@ class Program
         bool superCool = (vehicle == "Helicopters") || (vehicle == "Motorcycles");
 
         return !superCool;
-    }
-}
-
-class SameVehicleComparer : EqualityComparer<string>
-{
-    public override bool Equals(string s1, string s2)
-    {
-        return s1.Equals(s2, StringComparison.CurrentCultureIgnoreCase);
-    }
-
-
-    public override int GetHashCode(string s)
-    {
-        return base.GetHashCode();
     }
 }
 

--- a/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/vb/source2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Generic.HashSet_ExceptWith/vb/source2.vb
@@ -4,8 +4,7 @@ Imports System.Collections.Generic
 
 Class Program
     Public Shared Sub Main()
-        Dim compareVehicles As New SameVehicleComparer()
-        Dim allVehicles As New HashSet(Of String)(compareVehicles)
+        Dim allVehicles As New HashSet(Of String)(StringComparer.OrdinalIgnoreCase)
         Dim someVehicles As New List(Of String)()
 
         someVehicles.Add("Planes")
@@ -38,7 +37,7 @@ Class Program
             Console.WriteLine("'Some' vechicles list.")
         End If
 
-        ' Check for Rockets. Here the SameVehicleComparer will compare
+        ' Check for Rockets. Here the OrdinalIgnoreCase comparer will compare
         ' True for the mixed-case vehicle type.
         If allVehicles.Contains("roCKeTs") Then
             Console.WriteLine(vbNewLine + "The 'All' vehicles set contains 'roCKeTs'")
@@ -65,18 +64,6 @@ Class Program
             (vehicle <> "Helicopters") And (vehicle <> "Motorcycles")
 
         Return notSuperCool
-    End Function
-End Class
-
-Class SameVehicleComparer
-    Inherits EqualityComparer(Of String)
-
-    Public Overrides Function Equals(s1 As String, s2 As String) As Boolean
-        Return s1.Equals(s2, StringComparison.CurrentCultureIgnoreCase)
-    End Function
-
-    Public Overrides Function GetHashCode(s As String) As Integer
-        return MyBase.GetHashCode()
     End Function
 End Class
 


### PR DESCRIPTION
Use `StringComparer.OrdinalIgnoreCase` (a built-in type) instead of providing a buggy custom hash code implementation.