### PR TITLE
Fix typo in assembly naming recommendations.

### DIFF
--- a/docs/standard/design-guidelines/names-of-assemblies-and-dlls.md
+++ b/docs/standard/design-guidelines/names-of-assemblies-and-dlls.md
@@ -27,7 +27,7 @@ An assembly is the unit of deployment and identity for managed code programs. Al
   
  **✓ DO** choose names for your assembly DLLs that suggest large chunks of functionality, such as System.Data.  
   
- Assembly and DLL names don’t have to correspond to namespace names, but it is reasonable to follow the namespace name when naming assemblies. A good rule of thumb is to name the DLL based on the common prefix of the assemblies contained in the assembly. For example, an assembly with two namespaces, `MyCompany.MyTechnology.FirstFeature` and `MyCompany.MyTechnology.SecondFeature`, could be called `MyCompany.MyTechnology.dll`.  
+ Assembly and DLL names don’t have to correspond to namespace names, but it is reasonable to follow the namespace name when naming assemblies. A good rule of thumb is to name the DLL based on the common prefix of the namespaces contained in the assembly. For example, an assembly with two namespaces, `MyCompany.MyTechnology.FirstFeature` and `MyCompany.MyTechnology.SecondFeature`, could be called `MyCompany.MyTechnology.dll`.  
   
  **✓ CONSIDER** naming DLLs according to the following pattern:  
   


### PR DESCRIPTION
"**assemblies** contained in the assembly" -> "**namespaces** contained in the assembly"