### PR TITLE
Remove .NET Framework reference 

### DIFF
--- a/xml/System/UriParser.xml
+++ b/xml/System/UriParser.xml
@@ -27,7 +27,7 @@
 ## Remarks  
  The UriParser class enables you to create parsers for new URI schemes. You can write these parsers in their entirety, or the parsers can be derived from well-known schemes (HTTP, FTP, and other schemes based on network protocols). If you want to create a completely new parser, inherit from <xref:System.GenericUriParser>. If you want to create a parser that extends a well-known URI scheme, inherit from <xref:System.FtpStyleUriParser>, <xref:System.HttpStyleUriParser>, <xref:System.FileStyleUriParser>, <xref:System.GopherStyleUriParser>, or <xref:System.LdapStyleUriParser>.  
   
- Microsoft strongly recommends that you use a parser shipped with the .NET Framework. Building your own parser increases the complexity of your application, and will not perform as well as the shipped parsers.  
+ Microsoft strongly recommends that you use a parser shipped with .NET. Building your own parser increases the complexity of your application, and will not perform as well as the shipped parsers.  
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
# Remove .NET Framework Reference from UriParser API docs

## Summary

Docs suggest to use the UriParser shipped with the .NET Framework - which of course doesn't make sense when browsing the docs for .NET Core. I changed this to "the parser shipped with .NET" - is that the right way to refer to .NET in general?
