### PR TITLE
Updates Re SynchronizationContext & Exception-Handling

### DIFF
--- a/xml/System.Threading/CancellationTokenSource.xml
+++ b/xml/System.Threading/CancellationTokenSource.xml
@@ -218,9 +218,11 @@
   
  Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed.  
   
- It is recommended that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> do not throw exceptions. However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed.  
+ It is recommended that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> do not throw exceptions. However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed. 
+
+ The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.   
   
- The <xref:System.Threading.ExecutionContext> and, if captured, the <xref:System.Threading.SynchronizationContext>, in use when each callback was registered will be reestablished when the callback is invoked.  
+ If <xref:System.Threading.SynchronizationContext> was captured when a callback was registered, that callback will be executed on the captured context.  
   
    
   
@@ -282,7 +284,9 @@
   
  If `throwOnFirstException` is `false`, this overload will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed.  
   
- The <xref:System.Threading.ExecutionContext> and, if captured, the <xref:System.Threading.SynchronizationContext>, in use when each callback was registered will be reestablished when the callback is invoked.    
+ The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.   
+  
+ If <xref:System.Threading.SynchronizationContext> was captured when a callback was registered, that callback will be executed on the captured context.   
   
  ]]></format>
         </remarks>

--- a/xml/System.Threading/CancellationTokenSource.xml
+++ b/xml/System.Threading/CancellationTokenSource.xml
@@ -218,12 +218,9 @@
   
  Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed.  
   
- We recommend that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> not throw exceptions. However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed. 
-
- The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.   
-  
- If <xref:System.Threading.SynchronizationContext> was captured when a callback was registered, that callback will be executed on the captured context.  
-  
+ We recommend that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> not throw exceptions. 
+ 
+ This overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed. 
    
   
 ## Examples  
@@ -283,10 +280,6 @@
  If `throwOnFirstException` is `true`, an exception will immediately propagate out of the call to <xref:System.Threading.CancellationTokenSource.Cancel%2A>, preventing the remaining callbacks and cancelable operations from being processed.  
   
  If `throwOnFirstException` is `false`, this overload will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed.  
-  
- The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.   
-  
- If <xref:System.Threading.SynchronizationContext> was captured when a callback was registered, that callback will be executed on the captured context.   
   
  ]]></format>
         </remarks>

--- a/xml/System.Threading/CancellationTokenSource.xml
+++ b/xml/System.Threading/CancellationTokenSource.xml
@@ -218,11 +218,9 @@
   
  Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed.  
   
- Cancelable operations and callbacks registered with the token should not throw exceptions.  
+ It is recommended that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> do not throw exceptions. However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed.  
   
- However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed.  
-  
- The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.  
+ The <xref:System.Threading.ExecutionContext> and, if captured, the <xref:System.Threading.SynchronizationContext>, in use when each callback was registered will be reestablished when the callback is invoked.  
   
    
   
@@ -269,22 +267,22 @@
       <Docs>
         <param name="throwOnFirstException">
           <see langword="true" /> if exceptions should immediately propagate; otherwise, <see langword="false" />.</param>
-        <summary>Communicates a request for cancellation, and specifies whether remaining callbacks and cancelable operations should be processed.</summary>
+        <summary>Communicates a request for cancellation, and specifies whether remaining callbacks and cancelable operations should be processed if an exception occurs.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
  The associated <xref:System.Threading.CancellationToken> will be notified of the cancellation and will transition to a state where <xref:System.Threading.CancellationToken.IsCancellationRequested%2A> returns `true`.  
   
- Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed.  
+ Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed. Callbacks will be executed synchronously in LIFO order. 
   
- Cancelable operations and callbacks registered with the token should not throw exceptions.  
+ It is recommended that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> do not throw exceptions. 
   
  If `throwOnFirstException` is `true`, an exception will immediately propagate out of the call to <xref:System.Threading.CancellationTokenSource.Cancel%2A>, preventing the remaining callbacks and cancelable operations from being processed.  
   
  If `throwOnFirstException` is `false`, this overload will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed.  
   
- The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.  
+ The <xref:System.Threading.ExecutionContext> and, if captured, the <xref:System.Threading.SynchronizationContext>, in use when each callback was registered will be reestablished when the callback is invoked.    
   
  ]]></format>
         </remarks>

--- a/xml/System.Threading/CancellationTokenSource.xml
+++ b/xml/System.Threading/CancellationTokenSource.xml
@@ -218,7 +218,7 @@
   
  Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed.  
   
- It is recommended that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> do not throw exceptions. However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed. 
+ We recommend that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> not throw exceptions. However, this overload of Cancel will aggregate any exceptions thrown into an <xref:System.AggregateException>, such that one callback throwing an exception will not prevent other registered callbacks from being executed. 
 
  The <xref:System.Threading.ExecutionContext> that was captured when each callback was registered will be reestablished when the callback is invoked.   
   
@@ -278,7 +278,7 @@
   
  Any callbacks or cancelable operations registered with the <xref:System.Threading.CancellationToken> will be executed. Callbacks will be executed synchronously in LIFO order. 
   
- It is recommended that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> do not throw exceptions. 
+ We recommend that cancelable operations and callbacks registered with <xref:System.Threading.CancellationToken> not throw exceptions. 
   
  If `throwOnFirstException` is `true`, an exception will immediately propagate out of the call to <xref:System.Threading.CancellationTokenSource.Cancel%2A>, preventing the remaining callbacks and cancelable operations from being processed.  
   


### PR DESCRIPTION
## Summary

* Updating to reflect possible capture + reestablishment of Synchronization Context (see #4253).
* Updating exception-handling details.

## Details

### SynchronizationContext

Current description indicates that ExecutionContext is reestablished when delegates are invoked; however, nothing is mentioned about SynchronizationContext, if captured, also being reestablished. Text has been updated to reflect this. (A similar change was recently made to `CancellationToken` [see #4253].)

### Exception Handling

Currently, several sections mention not throwing exceptions then go on to explain what happens if an exception occurs. Saying it's wrong to throw exceptions then giving the details necessary on how to work with exceptions that are thrown seems somewhat contradictory. :-) Resolving this by rephrasing to indicate that not throwing exceptions is a _recommendation_.

Also, since the order of delegate invocation is significant when an exception is raised and `Cancel(throwOnFirstException: true)` is used, added a line stating that delegates are executed in LIFO order. ([Related code reference](https://github.com/dotnet/corefx/blob/3cbd3c98c8d28aa1510eb3021ed556b04934748d/src/System.Threading.Tasks/tests/CancellationTokenTests.cs#L447))


## Suggested Reviewers

@stephentoub 
