### PR TITLE
M21588: Inconsistency: wrong screenshot of code on website?

### DIFF
--- a/docs/csharp/quick-starts/interpolated-strings-local.md
+++ b/docs/csharp/quick-starts/interpolated-strings-local.md
@@ -139,9 +139,9 @@ If the field width is a negative number, the field is left-aligned:
 Try removing the negative signs from the `{"Author",-25}` and `{title.Key,-25}` interpolated expressions and run the example again, as the following code does:
 
 ```csharp
-Console.WriteLine($"\n{"Author",-25}    {"Title",30}\n");
+Console.WriteLine($"\n{"Author",25}    {"Title",30}\n");
 foreach (var title in titles)
-   Console.WriteLine($"{title.Key,-25}     {title.Value,30}");
+   Console.WriteLine($"{title.Key,25}     {title.Value,30}");
 ```
 
 This time, the author information is right-aligned.


### PR DESCRIPTION
Hello, @rpetrusha, 

Translator has reported possible source content issue.   It seems that the negative signs (-25) should not be removed. 

Please, help to check my comment tag added into the article and reply with explanation if source text should be fixed, or it is by design. If fix is needed, please, let me know either if you would like me to fix it in this PR, or if you will fix it in another PR. In case of using another PR, please, let me know of your PR number, so we can confirm and close this PR. 

Many thanks in advance.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
