### PR TITLE
Fixed link to the full code for event-based-asynchronous-pattern

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md
@@ -55,7 +55,7 @@ If you are writing a class with some operations that may incur noticeable delays
   
 -   Implementing Start and Cancel Methods  
   
- To copy the code in this topic as a single listing, see [How to: Implement a Component That Supports the Event-based Asynchronous Pattern](../../../docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md).  
+ To copy the code in this topic as a single listing, see [How to: Implement a Client of the Event-based Asynchronous Pattern](../../../docs/standard/asynchronous-programming-patterns/how-to-implement-a-client-of-the-event-based-asynchronous-pattern.md).  
   
 ## Creating the Component  
  The first step is to create the component that will implement the Event-based Asynchronous Pattern.  


### PR DESCRIPTION
The link was back to the same page instead of the full code listing.

## Summary

This link is important because it's hard to follow this tutorial without comparing it to the actual code to see what it's talking about. I had to search the raw view to find where the actual code was. 

