### PR TITLE
Replaced fwlink in samples-and-tutorials/index.md

### DIFF
--- a/docs/samples-and-tutorials/index.md
+++ b/docs/samples-and-tutorials/index.md
@@ -13,7 +13,7 @@ ms.assetid: 617310e7-336b-4864-8dab-7e2021512929
 
 # Samples and tutorials
 
-The .NET documentation contains a set of samples and tutorials that teach you about .NET. This topic describes how to find, view, and download .NET Core, ASP.NET Core, and C# samples and tutorials. Find resources to learn the F# programming language on the [F# Foundation's site](http://fsharp.org/learn.html). If you're interested in exploring C# using an online code editor, try these [interactive tutorials](http://go.microsoft.com/fwlink/p/?LinkId=817234). For instructions on how to view and download sample code, see the [Viewing and downloading samples](#viewing-and-downloading-samples) section.
+The .NET documentation contains a set of samples and tutorials that teach you about .NET. This topic describes how to find, view, and download .NET Core, ASP.NET Core, and C# samples and tutorials. Find resources to learn the F# programming language on the [F# Foundation's site](http://fsharp.org/learn.html). If you're interested in exploring C# using an online code editor, start with [this interactive tutorial](https://www.microsoft.com/net/learn/in-browser-tutorial/1) and continue with [C# interactive quickstarts](../csharp/quick-starts/index.md). For instructions on how to view and download sample code, see the [Viewing and downloading samples](#viewing-and-downloading-samples) section.
 
 ## .NET Core
 


### PR DESCRIPTION
Replaced fwlink in samples-and-tutorials/index.md
As the link was broken, I've replaced it with the link to the basic tutorial and the link to C# quickstarts.
Related to #3391

## Suggested Reviewers
@mairaw please review
