### PR TITLE
Update HttpClient.xml

### DIFF
--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -66,6 +66,8 @@ public class GoodController : ApiController
 }  
   
 ```  
+
+By default <xref:System.Net.ServicePointManager.DefaultConnectionLimit> will define the maximum number of concurrent connections to the same server. 
   
 The <xref:System.Net.Http.HttpClient> is a high-level API that wraps the lower-level functionality available on each platform where it runs.
 

--- a/xml/System.Net.Http/HttpClient.xml
+++ b/xml/System.Net.Http/HttpClient.xml
@@ -67,7 +67,7 @@ public class GoodController : ApiController
   
 ```  
 
-By default <xref:System.Net.ServicePointManager.DefaultConnectionLimit> will define the maximum number of concurrent connections to the same server. 
+By default, <xref:System.Net.ServicePointManager.DefaultConnectionLimit?displayProperty=nameWithType> defines the maximum number of concurrent connections to the same server. 
   
 The <xref:System.Net.Http.HttpClient> is a high-level API that wraps the lower-level functionality available on each platform where it runs.
 


### PR DESCRIPTION
# Title

Add additional remark about connection limit

## Summary

The documentation suggests using one HttpClient instance, which is reused in the application. However in multithreaded applications, doing http requests to the same server will quickly exhaust the maximum allowed concurrent connection limit (2 or 10 for web applications), which can degrade performance. I think developers following the guidance about one HttpClient in the application would benefit  having this piece of information.
