### PR TITLE
Improve FileNotFoundException ctor definitions

### DIFF
--- a/xml/System.IO/FileNotFoundException.xml
+++ b/xml/System.IO/FileNotFoundException.xml
@@ -71,7 +71,7 @@
       </AssemblyInfo>
       <Parameters />
       <Docs>
-        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with its message string set to a system-supplied message and its HRESULT set to COR_E_FILENOTFOUND.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with its message string set to a system-supplied message.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -111,7 +111,7 @@
       </Parameters>
       <Docs>
         <param name="message">A description of the error. The content of <c>message</c> is intended to be understood by humans. The caller of this constructor is required to ensure that this string has been localized for the current system culture.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with its message string set to <paramref name="message" /> and its HRESULT set to COR_E_FILENOTFOUND.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with a specified error message.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -234,7 +234,7 @@
       <Docs>
         <param name="message">A description of the error. The content of <c>message</c> is intended to be understood by humans. The caller of this constructor is required to ensure that this string has been localized for the current system culture.</param>
         <param name="fileName">The full name of the file with the invalid image.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with its message string set to <paramref name="message" />, specifying the file name that cannot be found, and its HRESULT set to COR_E_FILENOTFOUND.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with a specified message, and the file name that cannot be found.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -278,7 +278,7 @@
         <param name="message">The error message that explains the reason for the exception.</param>
         <param name="fileName">The full name of the file with the invalid image.</param>
         <param name="innerException">The exception that is the cause of the current exception. If the <c>innerException</c> parameter is not <see langword="null" />, the current exception is raised in a <see langword="catch" /> block that handles the inner exception.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with a specified error message, the file name that cannot be found, and a reference to the inner exception that is the cause of this exception.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.IO/FileNotFoundException.xml
+++ b/xml/System.IO/FileNotFoundException.xml
@@ -234,7 +234,7 @@
       <Docs>
         <param name="message">A description of the error. The content of <c>message</c> is intended to be understood by humans. The caller of this constructor is required to ensure that this string has been localized for the current system culture.</param>
         <param name="fileName">The full name of the file with the invalid image.</param>
-        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with a specified message, and the file name that cannot be found.</summary>
+        <summary>Initializes a new instance of the <see cref="T:System.IO.FileNotFoundException" /> class with a specified error message, and the file name that cannot be found.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
I initially started on this as the `FileNotFoundException(String, String, Exception)` summary was missing a mention of the fact it took a file name parameter. 

I also then standardised the descriptions, including:
- the HRESULT values was specified in 3/6 ctor definitions. In my opinion, this is fine being specified in the remarks of the class, rather than the ctor definition.
- The `message` parameter was referred to in different ways for different ctor's, when behaviour is the same. I used the phrase `specified error message` - which seemed consistent with other docs pages. 

Here's the current page: https://docs.microsoft.com/en-us/dotnet/api/system.io.filenotfoundexception?view=netframework-4.7.1#Constructors
(Hooray for section links!)