### PR TITLE
Correct variable naming in code sample

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/nosql-database-persistence-infrastructure.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/nosql-database-persistence-infrastructure.md
@@ -107,7 +107,7 @@ orderAggregate.AddOrderItem(orderItem2);
 Uri collectionUri = UriFactory.CreateDocumentCollectionUri(databaseName,
     collectionName);
 
-await client.CreateDocumentAsync(collectionUri, order);
+await client.CreateDocumentAsync(collectionUri, orderAggregate);
 
 // As your app evolves, let's say your object has a new schema. You can insert
 // OrderV2 objects without any changes to the database tier.


### PR DESCRIPTION
# Title

Fixed variable naming in _nosql-database-persistence-infrastructure.md_.

## Summary

Fixed variable naming in the parameter list fo `CreateDocumentAsync()`. Makes the example easier understandable.

## Details


## Suggested Reviewers
