### PR TITLE
Update TimeZoneInfo XML to move PS1 example to correct place

### DIFF
--- a/xml/System/TimeZoneInfo.xml
+++ b/xml/System/TimeZoneInfo.xml
@@ -1718,7 +1718,8 @@
  The following example retrieves a collection of time zone objects that represent the time zones defined on a computer and writes information about them to a text file.  
   
  [!code-csharp[System.TimeZone2.Class#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Class/CS/getsystemtimezones1.cs#6)]
- [!code-vb[System.TimeZone2.Class#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.Class/VB/getsystemtimezones1.vb#6)]  
+ [!code-vb[System.TimeZone2.Class#6](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.Class/VB/getsystemtimezones1.vb#6)]
+  [!code-powershell[System.TimeZone2.Class#6](~/samples/snippets/powershell/VS_Snippets_CLR_System/System.TimeZone2.Class/PS/Timezone2_Examples.ps1)]   
   
  ]]></format>
         </remarks>
@@ -2398,7 +2399,6 @@
   
  [!code-csharp[System.TimeZone2.Class#4](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Class/CS/TimeZone2_Examples.cs#4)]
  [!code-vb[System.TimeZone2.Class#4](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.Class/VB/TimeZone2_Examples.vb#4)]
- [!code-powershell[System.TimeZone2.Class#4](~/samples/snippets/powershell/VS_Snippets_CLR_System/System.TimeZone2.Class/PS/Timezone2_Examples.ps1)] 
   
  ]]></format>
         </remarks>


### PR DESCRIPTION
# Title

The XML file had a PowerShell example, but in the wrong place thus while the example displayed, it displayed on the wrong page. This PR attempts to correct that!

## Summary

The example was rendered under the SupportsDaylightSavingsTime property. It was moved to be on the correct page, demonstrating the GetSystemTimeZones method. 

## Details

I goofed when entering the sample in the first place. This fixes that mistake

## Suggested Reviewers
@mairaw 