### PR TITLE
ClientWebSocket not reusable after Abort() is called

### DIFF
--- a/xml/System.Net.WebSockets/ClientWebSocket.xml
+++ b/xml/System.Net.WebSockets/ClientWebSocket.xml
@@ -90,8 +90,8 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Aborts the connection and cancels any pending IO operations. The ClientWebSocket cannot be reused once aborted.</summary>
-        <remarks>To be added.</remarks>
+        <summary>Aborts the connection and cancels any pending IO operations.</summary>
+        <remarks>The `ClientWebSocket` cannot be reused once once it is aborted.</remarks>
       </Docs>
     </Member>
     <Member MemberName="CloseAsync">

--- a/xml/System.Net.WebSockets/ClientWebSocket.xml
+++ b/xml/System.Net.WebSockets/ClientWebSocket.xml
@@ -90,7 +90,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Aborts the connection and cancels any pending IO operations.</summary>
+        <summary>Aborts the connection and cancels any pending IO operations. An Aborted connection cannot be used again.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>

--- a/xml/System.Net.WebSockets/ClientWebSocket.xml
+++ b/xml/System.Net.WebSockets/ClientWebSocket.xml
@@ -90,7 +90,7 @@
       </ReturnValue>
       <Parameters />
       <Docs>
-        <summary>Aborts the connection and cancels any pending IO operations. An Aborted connection cannot be used again.</summary>
+        <summary>Aborts the connection and cancels any pending IO operations. The ClientWebSocket cannot be reused once aborted.</summary>
         <remarks>To be added.</remarks>
       </Docs>
     </Member>


### PR DESCRIPTION
# ClientWebSocket not reusable after Abort() is called

## Summary

There was some confusion over whether or not a ClientWebSocket can be reused after Abort() is called. This change adds a line to the method summary stating that the ClientWebSocket cannot be reused. 

## Details

A user ran into this issue and reported it [here](https://github.com/dotnet/corefx/issues/22535).