### PR TITLE
Update StartListening method desciption

### DIFF
--- a/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
+++ b/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
@@ -479,7 +479,7 @@
       </Parameters>
       <Docs>
         <param name="data">Optional initialization information.</param>
-        <summary>Instructs the current channel to start listening on a channel after the <see cref="Overload:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening> method has been called to stop listening on the channel.</summary>
+        <summary>Instructs the current channel to start listening on a channel after the <see cref="M:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening(System.Object)> method has been called to stop listening on the channel.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
+++ b/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
@@ -479,7 +479,7 @@
       </Parameters>
       <Docs>
         <param name="data">Optional initialization information.</param>
-        <summary>Instructs the current channel to start listening on a channel after the <see cref="M:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening(System.Object)> method has been called to stop listening on the channel.</summary>
+        <summary>Instructs the current channel to start listening on a channel after the <see cref="M:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening(System.Object)"> method has been called to stop listening on the channel.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
+++ b/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
@@ -479,7 +479,7 @@
       </Parameters>
       <Docs>
         <param name="data">Optional initialization information.</param>
-        <summary>Instructs the current channel to start listening on a channel after the <see cref="M:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening(System.Object)"> method has been called to stop listening on the channel.</summary>
+        <summary>Instructs the current channel to start listening on a channel after the <see cref="M:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening(System.Object)" /> method has been called to stop listening on the channel.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
+++ b/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
@@ -479,7 +479,7 @@
       </Parameters>
       <Docs>
         <param name="data">Optional initialization information.</param>
-        <summary>Instructs the current channel to start listening on a channel after the <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening%2A> method has been called to stop listening on the channel.</summary>
+        <summary>Instructs the current channel to start listening on a channel after the <see cref="Overload:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening> method has been called to stop listening on the channel.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
+++ b/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
@@ -484,9 +484,9 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The constructor of TcpServerChannel automatically calls StartListening() so one should not call this method unless <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening%2A> was previously called.  
+ The <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel> constructor automatically calls `StartListening`, so you shouldn't call this method unless <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening%2A> was previously called.  
   
- Calling StartListening on an already listening channel may lead to unexpected behaviors and should be avoided.  
+ Calling `StartListening` on an already listening channel may lead to unexpected behaviors and should be avoided.  
   
  If your channel uses a dynamically assigned port number, your port number might change when you restart listening.  
   

--- a/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
+++ b/xml/System.Runtime.Remoting.Channels.Tcp/TcpServerChannel.xml
@@ -479,14 +479,14 @@
       </Parameters>
       <Docs>
         <param name="data">Optional initialization information.</param>
-        <summary>Instructs the current channel to start listening for requests.</summary>
+        <summary>Instructs the current channel to start listening on a channel after the <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening%2A> method has been called to stop listening on the channel.</summary>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- It is not necessary to call this method to begin listening on a newly initialized channel.  
+ The constructor of TcpServerChannel automatically calls StartListening() so one should not call this method unless <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening%2A> was previously called.  
   
- Use this method to restart listening on a channel after the <xref:System.Runtime.Remoting.Channels.Tcp.TcpServerChannel.StopListening%2A> method has been called to stop listening on the channel.  
+ Calling StartListening on an already listening channel may lead to unexpected behaviors and should be avoided.  
   
  If your channel uses a dynamically assigned port number, your port number might change when you restart listening.  
   


### PR DESCRIPTION
The current description might mislead user calling this method unnecessarily, this change will help user understand clearly at the correct way to use this method.

# Title

Update StartListening method description

## Summary

Customer might use this API is a wrong way and lead to issues.

## Details

Provide usage in details to prevent customer calling it unexpectedly.

