### PR TITLE
Update Matrix4x4.xml

### DIFF
--- a/xml/System.Numerics/Matrix4x4.xml
+++ b/xml/System.Numerics/Matrix4x4.xml
@@ -26,7 +26,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Represents a 4x4 matrix.</summary>
+    <summary>Represents a 4x4 column-major matrix.</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>

--- a/xml/System.Numerics/Matrix4x4.xml
+++ b/xml/System.Numerics/Matrix4x4.xml
@@ -26,7 +26,7 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Represents a 4x4 column-major matrix.</summary>
+    <summary>Represents a 4x4 row-major matrix.</summary>
     <remarks>To be added.</remarks>
   </Docs>
   <Members>


### PR DESCRIPTION
It is not documented that this is stored as row major, nor is any reference given to Direct X conventions.

# Title

Matrix4x4 Docs

## Summary

Added the specification that Matrix4x4 is row major

## Details

It is not documented that this is row major.
Nor is any reference given to Direct X.

For the seasoned Direct X veteran this may be evident, but it is never stated.
For newcomers to graphics programming, making this explicit avoids unnecessary mistakes.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
