### PR TITLE
Remove an unnecessary hyphen in dotnet-sln command

### DIFF
--- a/docs/core/tools/dotnet-sln.md
+++ b/docs/core/tools/dotnet-sln.md
@@ -16,7 +16,7 @@ ms.workload:
 
 ## Name
 
-`dotnet-sln` - Modifies a .NET Core solution file.
+`dotnet sln` - Modifies a .NET Core solution file.
 
 ## Synopsis
 


### PR DESCRIPTION
# Title

An unnecessary hyphen in `dotnet-sln` command was removed.

## Summary

Fix typo in `dotnet-sln` command.