### PR TITLE
fix "te" to "the"

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Sockets.Socket/CS/socket.cs
+++ b/samples/snippets/csharp/VS_Snippets_Remoting/System.Net.Sockets.Socket/CS/socket.cs
@@ -69,7 +69,7 @@ public class GetSocket
         int bytes = 0;
         string page = "Default HTML page on " + server + ":\r\n";
 
-        // The following will block until te page is transmitted.
+        // The following will block until the page is transmitted.
         do {
             bytes = s.Receive(bytesReceived, bytesReceived.Length, 0);
             page = page + Encoding.ASCII.GetString(bytesReceived, 0, bytes);


### PR DESCRIPTION
# fix a spelling error ("te" to "the"

