### PR TITLE
Remove slash from MVC ViewImports item template

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -72,7 +72,7 @@ The command contains a default list of templates. Use `dotnet new -l` to obtain 
 | Web config                                   | `webconfig`   |               |
 | Solution file                                | `sln`         |               |
 | Razor page                                   | `page`        |               |
-| MVC/ViewImports                              | `viewimports` |               |
+| MVC ViewImports                              | `viewimports` |               |
 | MVC ViewStart                                | `viewstart`   |               |
 
 # [.NET Core 1.x](#tab/netcore1x)


### PR DESCRIPTION
There was a slash in the template name. It shouldn't be there.