### PR TITLE
Fix quoted XML identifiers in cref

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/xml-documentation-comments.md
+++ b/docs/csharp/programming-guide/xmldoc/xml-documentation-comments.md
@@ -31,7 +31,7 @@ public class MyClass{}
   
  When you compile with the [/doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md) option, the compiler will search for all XML tags in the source code and create an XML documentation file. To create the final documentation based on the compiler-generated file, you can create a custom tool or use a tool such as [Sandcastle](https://github.com/EWSoftware/SHFB).  
   
- To refer to XML elements (for example, your function processes specific XML elements that you want to describe in an XML documentation comment), you can use the standard quoting mechanism (`<` and `>`).  To refer to generic identifiers in code reference (`cref`) elements, you can use either the escape characters (for example, `cref="List<T>"`) or braces (`cref="List{T}"`).  As a special case, the compiler parses the braces as angle brackets to make the documentation comment less cumbersome to author when referring to generic identifiers.  
+ To refer to XML elements (for example, your function processes specific XML elements that you want to describe in an XML documentation comment), you can use the standard quoting mechanism (`<` and `>`).  To refer to generic identifiers in code reference (`cref`) elements, you can use either the escape characters (for example, `cref="List&lt;T&gt;"`) or braces (`cref="List{T}"`).  As a special case, the compiler parses the braces as angle brackets to make the documentation comment less cumbersome to author when referring to generic identifiers.  
   
 > [!NOTE]
 >  The XML documentation comments are not metadata; they are not included in the compiled assembly and therefore they are not accessible through reflection.  


### PR DESCRIPTION
Documentation says that standard quoted characters can be used for < and > but instead used the unquoted versions (< instead of `&lt;` and > instead of `&gt;`)

# Title

Replaced the '<' and '>' literals with the XML encoded &lt; and &gt; for cref links that included typeparams.

## Summary

Documentation says that standard quoted characters can be used for < and > but instead used the unquoted versions (< instead of `&lt;` and > instead of `&gt;`)


