### PR TITLE
fixed event handler delegate prototype

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/eventsoverview/cs/programtruncated.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/eventsoverview/cs/programtruncated.cs
@@ -47,6 +47,6 @@ namespace ConsoleApplication1
     // </snippet3>
 
     //<snippet4>
-    public delegate void ThresholdReachedEventHandler(ThresholdReachedEventArgs e);
+    public delegate void ThresholdReachedEventHandler(object sender, ThresholdReachedEventArgs e);
     //</snippet4>
 }


### PR DESCRIPTION
The delegates for Events require an object sender and Eventargs as method parameters but in the [docs](https://docs.microsoft.com/en-us/dotnet/standard/events/index) topic only the Eventarg is given. It compiles because the file the snippet is in used the general EventHandler delegate type.
