### PR TITLE
fixed race condition in C# event keyword doc

### DIFF
--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/event_1.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/event_1.cs
@@ -14,10 +14,12 @@
 
         // Wrap the event in a protected virtual method
         // to enable derived classes to raise the event.
-        protected virtual void RaiseSampleEvent()
-        {
-            // Raise the event by using the () operator.
-            if (SampleEvent != null)
-                SampleEvent(this, new SampleEventArgs("Hello"));
-        }
+    protected virtual void RaiseSampleEvent()
+    {
+        //Create a temporary reference to guard against a race condition
+        //in case the last subscriber unsubscribes causing SampleEvent to become null
+        SampleEventHandler handler = SampleEvent;
+        // Raise the event by using the () operator.
+        if (handler != null)
+            SampleEvent(this, new SampleEventArgs("Hello"));
     }

--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/event_1.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/event_1.cs
@@ -16,10 +16,6 @@
         // to enable derived classes to raise the event.
     protected virtual void OnRaiseSampleEvent()
     {
-        //Create a temporary reference to guard against a race condition
-        //in case the last subscriber unsubscribes causing SampleEvent to become null
-        SampleEventHandler handler = SampleEvent;
         // Raise the event by using the () operator.
-        if (handler != null)
-            handler(this, new SampleEventArgs("Hello"));
+        SampleEvent?.Invoke(this, new SampleEventArgs("Hello"));
     }

--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/event_1.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/event_1.cs
@@ -14,12 +14,12 @@
 
         // Wrap the event in a protected virtual method
         // to enable derived classes to raise the event.
-    protected virtual void RaiseSampleEvent()
+    protected virtual void OnRaiseSampleEvent()
     {
         //Create a temporary reference to guard against a race condition
         //in case the last subscriber unsubscribes causing SampleEvent to become null
         SampleEventHandler handler = SampleEvent;
         // Raise the event by using the () operator.
         if (handler != null)
-            SampleEvent(this, new SampleEventArgs("Hello"));
+            handler(this, new SampleEventArgs("Hello"));
     }


### PR DESCRIPTION
Fixed a race condition found in [event keyword](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/event) that the other event examples already guard against and changed method name to conform with .Net conventions.
