### PR TITLE
Use monospace for the whole method signature

### DIFF
--- a/docs/standard/design-guidelines/dispose-pattern.md
+++ b/docs/standard/design-guidelines/dispose-pattern.md
@@ -90,7 +90,7 @@ public class DisposableResourceHolder : IDisposable {
   
  Also, this section applies to classes with a base that does not already implement the Dispose Pattern. If you are inheriting from a class that already implements the pattern, simply override the `Dispose(bool)` method to provide additional resource cleanup logic.  
   
- **✓ DO** declare a protected virtual void `Dispose(bool disposing)` method to centralize all logic related to releasing unmanaged resources.  
+ **✓ DO** declare a `protected virtual void Dispose(bool disposing)` method to centralize all logic related to releasing unmanaged resources.  
   
  All resource cleanup should occur in this method. The method is called from both the finalizer and the `IDisposable.Dispose` method. The parameter will be false if being invoked from inside a finalizer. It should be used to ensure any code running during finalization is not accessing other finalizable objects. Details of implementing finalizers are described in the next section.  
   


### PR DESCRIPTION
Style guide reference link: https://docs.microsoft.com/en-us/style-guide/developer-content/formatting-developer-text-elements