### PR TITLE
Replaced fwlinks in csharp\programming-guide\generics folder

### DIFF
--- a/docs/csharp/programming-guide/generics/benefits-of-generics.md
+++ b/docs/csharp/programming-guide/generics/benefits-of-generics.md
@@ -15,7 +15,7 @@ ms.author: "wiwagn"
 # Benefits of Generics (C# Programming Guide)
 Generics provide the solution to a limitation in earlier versions of the common language runtime and the C# language in which generalization is accomplished by casting types to and from the universal base type <xref:System.Object>. By creating a generic class, you can create a collection that is type-safe at compile-time.  
   
- The limitations of using non-generic collection classes can be demonstrated by writing a short program that uses the <xref:System.Collections.ArrayList> collection class from the .NET Framework class library. <xref:System.Collections.ArrayList> is a highly convenient collection class that can be used without modification to store any reference or value type.  
+ The limitations of using non-generic collection classes can be demonstrated by writing a short program that uses the <xref:System.Collections.ArrayList> collection class from the .NET class library. <xref:System.Collections.ArrayList> is a highly convenient collection class that can be used without modification to store any reference or value type.  
   
  [!code-csharp[csProgGuideGenerics#4](../../../csharp/programming-guide/generics/codesnippet/CSharp/benefits-of-generics_1.cs)]  
   
@@ -29,7 +29,7 @@ Generics provide the solution to a limitation in earlier versions of the common 
   
  In versions 1.0 and 1.1 of the C# language, you could avoid the dangers of generalized code in the .NET Framework base class library collection classes only by writing your own type specific collections. Of course, because such a class is not reusable for more than one data type, you lose the benefits of generalization, and you have to rewrite the class for each type that will be stored.  
   
- What <xref:System.Collections.ArrayList> and other similar classes really need is a way for client code to specify, on a per-instance basis, the particular data type that they intend to use. That would eliminate the need for the upcast to `T:System.Object` and would also make it possible for the compiler to do type checking. In other words, <xref:System.Collections.ArrayList> needs a type parameter. That is exactly what generics provide. In the generic <xref:System.Collections.Generic.List%601> collection, in the `N:System.Collections.Generic` namespace, the same operation of adding items to the collection resembles this:  
+ What <xref:System.Collections.ArrayList> and other similar classes really need is a way for client code to specify, on a per-instance basis, the particular data type that they intend to use. That would eliminate the need for the upcast to <xref:System.Object> and would also make it possible for the compiler to do type checking. In other words, <xref:System.Collections.ArrayList> needs a type parameter. That is exactly what generics provide. In the generic <xref:System.Collections.Generic.List%601> collection, in the <xref:System.Collections.Generic> namespace, the same operation of adding items to the collection resembles this:  
   
  [!code-csharp[csProgGuideGenerics#6](../../../csharp/programming-guide/generics/codesnippet/CSharp/benefits-of-generics_3.cs)]  
   
@@ -40,4 +40,5 @@ Generics provide the solution to a limitation in earlier versions of the common 
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [Introduction to Generics](../../../csharp/programming-guide/generics/introduction-to-generics.md)  
  [Boxing and Unboxing](../../../csharp/programming-guide/types/boxing-and-unboxing.md)  
- [Collections Best Practices](http://go.microsoft.com/fwlink/?LinkId=112403)
+ [When to Use Generic Collections](../../../standard/collections/when-to-use-generic-collections.md)  
+ [Guidelines for Collections](../../../standard/design-guidelines/guidelines-for-collections.md)   

--- a/docs/csharp/programming-guide/generics/benefits-of-generics.md
+++ b/docs/csharp/programming-guide/generics/benefits-of-generics.md
@@ -15,7 +15,7 @@ ms.author: "wiwagn"
 # Benefits of Generics (C# Programming Guide)
 Generics provide the solution to a limitation in earlier versions of the common language runtime and the C# language in which generalization is accomplished by casting types to and from the universal base type <xref:System.Object>. By creating a generic class, you can create a collection that is type-safe at compile-time.  
   
- The limitations of using non-generic collection classes can be demonstrated by writing a short program that uses the <xref:System.Collections.ArrayList> collection class from the .NET class library. <xref:System.Collections.ArrayList> is a highly convenient collection class that can be used without modification to store any reference or value type.  
+ The limitations of using non-generic collection classes can be demonstrated by writing a short program that uses the <xref:System.Collections.ArrayList> collection class from the .NET class library. An instance of the <xref:System.Collections.ArrayList> class can store any reference or value type.  
   
  [!code-csharp[csProgGuideGenerics#4](../../../csharp/programming-guide/generics/codesnippet/CSharp/benefits-of-generics_1.cs)]  
   

--- a/docs/csharp/programming-guide/generics/generic-classes.md
+++ b/docs/csharp/programming-guide/generics/generic-classes.md
@@ -16,7 +16,7 @@ ms.author: "wiwagn"
 # Generic Classes (C# Programming Guide)
 Generic classes encapsulate operations that are not specific to a particular data type. The most common use for generic classes is with collections like linked lists, hash tables, stacks, queues, trees, and so on. Operations such as adding and removing items from the collection are performed in basically the same way regardless of the type of data being stored.  
   
- For most scenarios that require collection classes, the recommended approach is to use the ones provided in the .NET Framework class library. For more information about using these classes, see [Generics in the .NET Framework Class Library](../../../csharp/programming-guide/generics/generics-in-the-net-framework-class-library.md).  
+ For most scenarios that require collection classes, the recommended approach is to use the ones provided in the .NET class library. For more information about using these classes, see [Generic Collections in .NET](../../../standard/generics/collections.md).  
   
  Typically, you create generic classes by starting with an existing concrete class, and changing types into type parameters one at a time until you reach the optimal balance of generalization and usability. When creating your own generic classes, important considerations include the following:  
   
@@ -70,5 +70,5 @@ Generic classes encapsulate operations that are not specific to a particular dat
  <xref:System.Collections.Generic>  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [Generics](../../../csharp/programming-guide/generics/index.md)  
- [Saving the State of Enumerators](http://go.microsoft.com/fwlink/?LinkId=112390)  
- [An Inheritance Puzzle, Part One](http://go.microsoft.com/fwlink/?LinkId=112380)
+ [Saving the State of Enumerators](https://blogs.msdn.microsoft.com/wesdyer/2006/01/13/saving-the-state-of-enumerators/)  
+ [An Inheritance Puzzle, Part One](https://blogs.msdn.microsoft.com/ericlippert/2007/07/27/an-inheritance-puzzle-part-one/)


### PR DESCRIPTION
Replaced fwlinks in **csharp\programming-guide\generics** folder.
One link was broken, so I've found a couple of articles from the docs as replacement.
Related to #3424 

Moreover, replaced .NET Framework mention with .NET. Strictly speaking, that makes this PR contain changes of two kinds. Is it fine for such 'refinement' changes or it's better to create separate PRs in future?

