### PR TITLE
Revised generics topic to make it implementation-independent

### DIFF
--- a/docs/standard/generics/collections.md
+++ b/docs/standard/generics/collections.md
@@ -1,5 +1,5 @@
 ---
-title: "Generic Collections in the .NET Framework"
+title: "Generic Collections in .NET"
 ms.custom: ""
 ms.date: "03/30/2017"
 ms.prod: ".net"
@@ -13,10 +13,10 @@ dev_langs:
   - "vb"
   - "cpp"
 helpviewer_keywords: 
-  - "generics [.NET Framework], collections"
-  - "generic collections [.NET Framework]"
+  - "generics [.NET], collections"
+  - "generic collections [.NET]"
+  - "generic types [.NET]"
 ms.assetid: 5b646751-6ab7-465c-916c-b1a76aefa9f5
-caps.latest.revision: 8
 author: "mairaw"
 ms.author: "mairaw"
 manager: "wpickett"
@@ -24,11 +24,9 @@ ms.workload:
   - "dotnet"
   - "dotnetcore"
 ---
-# Generic Collections in the .NET Framework
-This topic provides an overview of the generic collection classes and other generic types in the .NET Framework.  
-  
-## Generic Collections in the .NET Framework  
- The .NET Framework class library provides a number of generic collection classes in the <xref:System.Collections.Generic> and <xref:System.Collections.ObjectModel> namespaces. For more information about these classes, see [Commonly Used Collection Types](../../../docs/standard/collections/commonly-used-collection-types.md).  
+# Generic Collections in .NET
+
+ The .NET class library provides a number of generic collection classes in the <xref:System.Collections.Generic> and <xref:System.Collections.ObjectModel> namespaces. For more detailed information about these classes, see [Commonly Used Collection Types](../../../docs/standard/collections/commonly-used-collection-types.md).  
   
 ### System.Collections.Generic  
  Many of the generic collection types are direct analogs of nongeneric types. <xref:System.Collections.Generic.Dictionary%602> is a generic version of <xref:System.Collections.Hashtable>; it uses the generic structure <xref:System.Collections.Generic.KeyValuePair%602> for enumeration instead of <xref:System.Collections.DictionaryEntry>.  
@@ -46,7 +44,7 @@ This topic provides an overview of the generic collection classes and other gene
  The <xref:System.Nullable%601> generic structure allows you to use value types as if they could be assigned `null`. This can be useful when working with database queries, where fields that contain value types can be missing. The generic type parameter can be any value type.  
   
 > [!NOTE]
->  In C# it is not necessary to use <xref:System.Nullable%601> explicitly because the language has syntax for nullable types.  
+>  In C# and Visual Basic, it is not necessary to use <xref:System.Nullable%601> explicitly because the language has syntax for nullable types. See [Nullable types (C# Programming Guide)](../../csharp/programming-guide/nullable-types/index.md) and [Nullable value types (Visual Basic)](../../visual-basic/programming-guide/language-features/data-types/nullable-value-types.md). 
   
  The <xref:System.ArraySegment%601> generic structure provides a way to delimit a range of elements within a one-dimensional, zero-based array of any type. The generic type parameter is the type of the array's elements.  
   

--- a/docs/standard/generics/collections.md
+++ b/docs/standard/generics/collections.md
@@ -1,7 +1,7 @@
 ---
 title: "Generic Collections in .NET"
 ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "02/15/2018"
 ms.prod: ".net"
 ms.reviewer: ""
 ms.suite: ""

--- a/docs/standard/generics/toc.md
+++ b/docs/standard/generics/toc.md
@@ -1,5 +1,5 @@
 # [Generics](index.md)
-## [Generic Collections in the .NET Framework](collections.md)
+## [Generic Collections in .NET](collections.md)
 ## [Generic Delegates for Manipulating Arrays and Lists](delegates-for-manipulating-arrays-and-lists.md)
 ## [Generic Interfaces](interfaces.md)
 ## [Covariance and Contravariance](covariance-and-contravariance.md)


### PR DESCRIPTION
# Revised generics topic to make it implementation-independent

## Summary

In looking at the link targets in PR #4384, I noticed that this generic topic included numerous references to the .NET Framework. I've removed them.

I've also made a few other changes, including:
- Eliminating a B-Head that was identical to the topic title.
- Noting that VB also has language support for nullable types, and including a link to a topic for both C# and VB.

Review URL: https://review.docs.microsoft.com/en-us/dotnet/standard/generics/collections?branch=pr-en-us-4387

## Suggested Reviewers

@mairaw 

//cc @pkulikov 

