### PR TITLE
Add PowerShell sample to System.Collections.Hashtable

### DIFF
--- a/samples/snippets/powershell/VS_Snippets_CLR_System/system.collections.hashtable.class/ps/hashtable.ps1
+++ b/samples/snippets/powershell/VS_Snippets_CLR_System/system.collections.hashtable.class/ps/hashtable.ps1
@@ -1,0 +1,73 @@
+<#
+.Synopsis
+   PowerShell sample for the System.Collections.Hashtable class
+.DESCRIPTION
+   This is a PowerShell sample demonstrating operations on a hashtable.
+.NOTES
+   Submitted by:  DoctorDNS@Gmail.Com
+.FUNCTIONALITY
+   This sample duplicates the C# sample, adding in PowerShell specific syntax.
+#>
+
+#<snippet00>
+# Create new hash table using PowerShell syntax
+$OpenWith = @{}
+
+# Add one element to the hash table using the Add method
+$OpenWith.Add('txt', 'notepad.exe')
+
+# Add three eleements using PowerShell syntax three different ways
+$OpenWith.dib = 'paint.exe'
+
+$KeyBMP = 'bmp'
+$OpenWith[$KeyBMP] = 'paint.exe'
+
+$OpenWith += @{'rtf' = 'wordpad.exe'}
+
+# Display hash table
+"There are {0} in the `$OpenWith hash table as follows:" -f $OpenWith.Count
+''
+
+# Display hashtable properties
+'Count of items in the hashtable  : {0}' -f $OpenWith.Count
+'Is hashtable fixed size?         : {0}' -f $OpenWith.IsFixedSize
+'Is hashtable read-only?          : {0}' -f $OpenWith.IsReadonly
+'Is hashtabale synchronised?      : {0}' -f $OpenWith.IsSynchronized
+''
+'Keys in hashtable:'
+$OpenWith.Keys
+''
+'Values in hashtable:'
+$OpenWith.Values
+''
+
+<#
+This script produces the following output:
+
+There are 4 in the $OpenWith hash table as follows:
+
+Name                           Value                                                                            
+----                           -----                                                                            
+txt                            notepad.exe                                                                      
+dib                            paint.exe                                                                        
+bmp                            paint.exe                                                                        
+rtf                            wordpad.exe                                                                      
+
+Count of items in the hashtable  : 4
+Is hashtable fixed size?         : False
+Is hashtable read-only?          : False
+Is hashtabale synchronised?      : False
+
+Keys in hashtable:
+txt
+dib
+bmp
+rtf
+
+Values in hashtable:
+notepad.exe
+paint.exe
+paint.exe
+wordpad.exe
+#>
+#</snippet00>

--- a/xml/System.Collections/Hashtable.xml
+++ b/xml/System.Collections/Hashtable.xml
@@ -94,7 +94,7 @@
  [!code-cpp[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/cpp/hashtable_example.cpp#00)]
  [!code-csharp[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/cs/hashtable_example.cs#00)]
  [!code-vb[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/vb/hashtable_example.vb#00)]
- [!code-powershell[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/powershell/VS_Snippets_CLR_System/system.collections.hashtable.class/ps/hashtable#00.ps1)]  
+ [!code-powershell[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/powershell/VS_Snippets_CLR_System/system.collections.hashtable.class/ps/hashtable.ps1#00)]  
   
  ]]></format>
     </remarks>

--- a/xml/System.Collections/Hashtable.xml
+++ b/xml/System.Collections/Hashtable.xml
@@ -93,7 +93,8 @@
   
  [!code-cpp[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/cpp/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/cpp/hashtable_example.cpp#00)]
  [!code-csharp[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/cs/hashtable_example.cs#00)]
- [!code-vb[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/vb/hashtable_example.vb#00)]  
+ [!code-vb[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.Collections.Hashtable_ClassExample/vb/hashtable_example.vb#00)]
+ [!code-powershell[System.Collections.Hashtable_ClassExample#00](~/samples/snippets/powershell/VS_Snippets_CLR_System/system.collections.hashtable.class/ps/hashtable#00.ps1)]  
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
# Title
Add PowerShell sample to System.Collections.Hashtable

## Summary
This adds a Powershell sample for the System. Collections.Hashtable class, based on the C# 
sample. It is updated to demonstrate PowerShell based syntax.

This PR replaces #3700 .

## Details

The sample duplicates the C# sample and adds PowerShell specific Syntax.

## Suggested Reviewers
@mairaw 