### PR TITLE
Typo in docs/core/tools/index.md

### DIFF
--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -99,7 +99,7 @@ The CLI adopts an extensibility model that allows you to specify additional tool
 
 ## Command structure
 
-CLI command structure consists of the [the driver ("dotnet")](#driver), [the command (or "verb")](#command-verb), and possibly command [arguments](#arguments) and [options](#options). You see this pattern in most CLI operations, such as creating a new console app and running it from the command line as the following commands show when executed from a directory named *my_app*:
+CLI command structure consists of [the driver ("dotnet")](#driver), [the command (or "verb")](#command-verb), and possibly command [arguments](#arguments) and [options](#options). You see this pattern in most CLI operations, such as creating a new console app and running it from the command line as the following commands show when executed from a directory named *my_app*:
 
 # [.NET Core 2.x](#tab/netcore2x)
 


### PR DESCRIPTION
Remove duplicated 'the'.