### PR TITLE
Update button-styles-and-templates.md

### DIFF
--- a/docs/framework/wpf/controls/button-styles-and-templates.md
+++ b/docs/framework/wpf/controls/button-styles-and-templates.md
@@ -42,8 +42,8 @@ This topic describes the styles and templates for the <xref:System.Windows.Contr
 |Focused|FocusStates|The control has focus.|  
 |Unfocused|FocusStates|The control does not have focus.|  
 |Valid|ValidationStates|The control uses the <xref:System.Windows.Controls.Validation> class and the <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `false`.|  
-|InvalidFocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` has the control has focus.|  
-|InvalidUnfocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` has the control does not have focus.|  
+|InvalidFocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` and the control has focus.|  
+|InvalidUnfocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` and the control does not have focus.|  
   
 ## Button ControlTemplate Example  
  The following example shows how to define a <xref:System.Windows.Controls.ControlTemplate> for the <xref:System.Windows.Controls.Button> control.  


### PR DESCRIPTION
Fixed typo - replaced "has" with "and" in two places.

# Fixed typos in the Button States table

## Summary

Replaced the mistyped "has" with "and" in the last two rows of the table which lists the visual states for the Button control.
