### PR TITLE
match breadcrumb name

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -6,7 +6,7 @@
     tocHref: /dotnet/
     topicHref: /dotnet/index
     items:     
-    - name: API reference
+    - name: .NET API Browser
       tocHref: /dotnet/api/
       topicHref: /dotnet/api/index
     - name: .NET Guide


### PR DESCRIPTION
Other products are calling this entry the .NET API Browser, so switching ours to match that too.
e.g.
https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore?view=efcore-2.0