### PR TITLE
escaping character

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/comparison-semantics-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/comparison-semantics-entity-sql.md
@@ -33,7 +33,7 @@ Performing any of the following [!INCLUDE[esql](../../../../../../includes/esql-
   
 -   \<=  
   
--   >  
+-   \>  
   
 -   \>=  
   


### PR DESCRIPTION
Character doesn't render without encoding:
https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/ef/language-reference/comparison-semantics-entity-sql

![image](https://user-images.githubusercontent.com/12971179/36237502-fc1d9306-11b0-11e8-9201-aeac518e642f.png)
