### PR TITLE
Fix type of (+@) operator example

### DIFF
--- a/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md
+++ b/docs/fsharp/language-reference/generics/statically-resolved-type-parameters.md
@@ -49,8 +49,8 @@ The resolved type of `(+@)` is based on the use of both `(+)` and `(*)`, both of
 
 ```fsharp
 ^a -> ^c -> ^d
-when (^a or ^b) : (static member (+) : ^a * ^b -> ^d) and
-(^a or ^c) : (static member (+) : ^a * ^c -> ^b)
+when (^a or ^b) : (static member ( + ) : ^a * ^b -> ^d) and
+(^a or ^c) : (static member ( * ) : ^a * ^c -> ^b)
 ```
 
 The output is as follows.


### PR DESCRIPTION
The plus sign was in it twice, whereas one needed to be an asterix.

Tested:

Microsoft (R) F# Interactive version 4.1
Copyright (c) Microsoft Corporation. All Rights Reserved.

For help type #help;;

> let inline (+@) x y = x + x * y ;;
val inline ( +@ ) :
  x: ^a -> y: ^c ->  ^d
    when ( ^a or  ^b) : (static member ( + ) :  ^a *  ^b ->  ^d) and
         ( ^a or  ^c) : (static member ( * ) :  ^a *  ^c ->  ^b)

>
