### PR TITLE
Remove unused variable

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Wpf/LayoutInformation/CSharp/Window1.xaml.cs
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/LayoutInformation/CSharp/Window1.xaml.cs
@@ -19,7 +19,6 @@ namespace layout_information
             // <Snippet3>
             RectangleGeometry myRectangleGeometry = new RectangleGeometry();
             myRectangleGeometry.Rect = LayoutInformation.GetLayoutSlot(txt1);
-            GeometryDrawing myGeometryDrawing = new GeometryDrawing();
             Path myPath = new Path();
             myPath.Data = myRectangleGeometry;
             //</Snippet3>


### PR DESCRIPTION
Remove unused variable creating confusion: GeometryDrawing myGeometryDrawing = new GeometryDrawing();

# Title

Remove unused variable in code sample

## Summary

Remove unused variable in code sample creating confusion.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

GeometryDrawing myGeometryDrawing = new GeometryDrawing(); Variable never used.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
