### PR TITLE
Replaced misc fwlinks in csharp folder

### DIFF
--- a/docs/csharp/language-reference/compiler-options/target-appcontainerexe-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/target-appcontainerexe-compiler-option.md
@@ -20,7 +20,7 @@ If you use the **-target:appcontainerexe** compiler option, the compiler creates
 ```  
   
 ## Remarks  
- To require the app to run in an app container, this option sets a bit in the [Portable Executable](http://go.microsoft.com/fwlink/p/?LinkId=236960) (PE) file. When that bit is set, an error occurs if the CreateProcess method tries to launch the executable file outside an app container.  
+ To require the app to run in an app container, this option sets a bit in the [Portable Executable](https://msdn.microsoft.com/library/windows/desktop/ms680547(v=vs.85).aspx?id=19509) (PE) file. When that bit is set, an error occurs if the CreateProcess method tries to launch the executable file outside an app container.  
   
  Unless you use the [-out](../../../csharp/language-reference/compiler-options/out-compiler-option.md) option, the output file name takes the name of the input file that contains the [Main](../../../csharp/programming-guide/main-and-command-args/index.md) method.  
   

--- a/docs/csharp/language-reference/keywords/new-modifier.md
+++ b/docs/csharp/language-reference/keywords/new-modifier.md
@@ -23,7 +23,7 @@ When used as a declaration modifier, the `new` keyword explicitly hides a member
   
  Name hiding through inheritance takes one of the following forms:  
   
--   Generally, a constant, field, property, or type that is introduced in a class or struct hides all base class members that share its name.  There are special cases.  For example, if you declare a new field with name `N` to have a type that is not invocable, and a base type declares `N` to be a method, the new field does not hide the base declaration in invocation syntax.  See the [C# 5.0 language specification](http://go.microsoft.com/fwlink/?LinkId=199552) for details (see section "Member Lookup" in section "Expressions").  
+-   Generally, a constant, field, property, or type that is introduced in a class or struct hides all base class members that share its name.  There are special cases.  For example, if you declare a new field with name `N` to have a type that is not invocable, and a base type declares `N` to be a method, the new field does not hide the base declaration in invocation syntax.  See the [C# 5.0 language specification](https://www.microsoft.com/download/details.aspx?id=7029) for details (see section "Member Lookup" in section "Expressions").  
   
 -   A method introduced in a class or struct hides properties, fields, and types that share that name in the base class. It also hides all base class methods that have the same signature.  
   

--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -893,13 +893,13 @@ ms.author: "wiwagn"
 # Sorry, we don&#39;t have specifics on this C# error
 We’re sorry, but we don’t have any specific information about this error. You can search for the error number and message text to find information on the web. Or you can ask other developers using one of these forums:  
   
- [Visual C# Language](http://go.microsoft.com/fwlink/?LinkId=146921)  
+ [Visual C# Language](https://social.msdn.microsoft.com/Forums/en-US/home?forum=csharplanguage)  
  Provides a forum for questions about and general discussions of the [!INCLUDE[csprcs](~/includes/csprcs-md.md)] language syntax and compiler.  
   
- [Visual C# IDE](http://go.microsoft.com/fwlink/?LinkId=146922)  
+ [Visual C# IDE](https://social.msdn.microsoft.com/Forums/en-US/home?forum=csharpide)  
  Provides a forum for questions about how to work in the [!INCLUDE[vsprvs](~/includes/vsprvs-md.md)] environment.  
   
- [Visual C# General](http://go.microsoft.com/fwlink/?LinkId=146920)  
+ [Visual C# General](https://social.msdn.microsoft.com/Forums/vstudio/en-US/home?forum=csharpgeneral)  
  Provides a forum for questions about and issues with [!INCLUDE[csprcs](~/includes/csprcs-md.md)] that are not discussed in other forums.  
   
  [StackOverflow](http://stackoverflow.com/questions/tagged/c%23)  
@@ -912,4 +912,3 @@ We’re sorry, but we don’t have any specific information about this error. Yo
  [C# Programming Guide](../../csharp/programming-guide/index.md)  
  [C# Reference](../../csharp/language-reference/index.md)  
  [Talk to Us](/visualstudio/ide/talk-to-us)  
- [Talk to Us](/visualstudio/ide/talk-to-us)


### PR DESCRIPTION
Replaced all found fwlinks in csharp folder that are not in **csharp\programming-guide** folder
Related to #3424