### PR TITLE
Fixed typo. Changed colon to comma

### DIFF
--- a/samples/snippets/csharp/concepts/linq/how-to-group-query-results_1.cs
+++ b/samples/snippets/csharp/concepts/linq/how-to-group-query-results_1.cs
@@ -69,7 +69,7 @@
 
             foreach (var item in highScores)
             {
-                Console.WriteLine($"{item.Name:-15}{item.Score}");
+                Console.WriteLine($"{item.Name,-15}{item.Score}");
             }
         }
     }


### PR DESCRIPTION
Colon was used incorrectly in interpolated string. It is clear from context that comma was intended.