### PR TITLE
Updated How to concatenate strings with string.Join

### DIFF
--- a/docs/csharp/how-to/concatenate-multiple-strings.md
+++ b/docs/csharp/how-to/concatenate-multiple-strings.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Concatenate Multiple Strings (C# Guide)"
 description: There are multiple ways to concatenate strings in C#. Learn the options and the reasons behind different choices.
-ms.date: 01/11/2018
+ms.date: 02/20/2018
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -17,17 +17,16 @@ ms.author: "wiwagn"
 ---
 # How to: Concatenate Multiple Strings (C# Guide)
 
-*Concatenation* is the process of appending one string to the end of another string. You concatenate strings by using the + operator. For string literals and string constants, concatenation occurs at compile time; no run-time concatenation occurs. For string variables, concatenation occurs only at run time.
+*Concatenation* is the process of appending one string to the end of another string. You concatenate strings by using the `+` operator. For string literals and string constants, concatenation occurs at compile time; no run-time concatenation occurs. For string variables, concatenation occurs only at run time.
 
 [!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
-The following example uses concatenation to split a long string literal into smaller strings in order to improve readability in the source code. These parts will be concatenated into a single string at compile time. There is no run-time performance cost regardless of the number of strings involved.  
+The following example uses concatenation to split a long string literal into smaller strings in order to improve readability in the source code. These parts are concatenated into a single string at compile time. There is no run-time performance cost regardless of the number of strings involved.  
   
  [!code-csharp-interactive[Combining strings at compile time](../../../samples/snippets/csharp/how-to/strings/Concatenate.cs#1)]  
   
 
-To concatenate string variables, you can use the `+` or `+=` operators, [string interpolation](../tutorials/string-interpolation.md) or the <xref:System.String.Concat%2A?displayProperty=nameWithType>, <xref:System.String.Format%2A?displayProperty=nameWithType> or <xref:System.Text.StringBuilder.Append%2A?displayProperty=nameWithType> methods. The `+` operator is easy to use and makes for intuitive code. Even if you use several + operators in one statement, the string content is copied only once. The following code shows two examples of using the `+` operator to concatenate
-strings:
+To concatenate string variables, you can use the `+` or `+=` operators, [string interpolation](../tutorials/string-interpolation.md) or the <xref:System.String.Concat%2A?displayProperty=nameWithType>, <xref:System.String.Format%2A?displayProperty=nameWithType>, <xref:System.String.Join%2A?displayProperty=nameWithType> or <xref:System.Text.StringBuilder.Append%2A?displayProperty=nameWithType> methods. The `+` operator is easy to use and makes for intuitive code. Even if you use several `+` operators in one statement, the string content is copied only once. The following code shows two examples of using the `+` operator to concatenate strings:
 
 [!code-csharp-interactive[combining strings using +](../../../samples/snippets/csharp/how-to/strings/Concatenate.cs#2)]  
 
@@ -38,7 +37,7 @@ In some expressions, it is easier to concatenate strings using string interpolat
 > [!NOTE]
 >  In string concatenation operations, the C# compiler treats a null string the same as an empty string.
 
-Other methods to concatenate strings are <xref:System.String.Concat%2A?displayProperty=nameWithType> and <xref:System.String.Format%2A?displayProperty=nameWithType>. These methods work well when you are building a string from a small number of component strings. These methdos are also a great choice when you know the number of strings that make up your concatenated string.
+Other method to concatenate strings is <xref:System.String.Format%2A?displayProperty=nameWithType>. This method works well when you are building a string from a small number of component strings. This method is also a great choice when you know the number of strings that make up your concatenated string.
 
 In other cases you may be combining strings in a loop, where you don't know how many source strings you are combining, and the actual number of source strings may be quite large. The <xref:System.Text.StringBuilder> class was designed for these scenarios. The following code uses the <xref:System.Text.StringBuilder.Append%2A> method of the <xref:System.Text.StringBuilder> class to concatenate strings.  
   
@@ -46,13 +45,17 @@ In other cases you may be combining strings in a loop, where you don't know how 
 
 You can read more about the [reasons to choose string concatenation or the `StringBuilder` class](xref:System.Text.StringBuilder#StringAndSB)
 
-Another option to join strings from a collection is to use [LINQ](../programming-guide/concepts/linq/index.md)
-and the <xref:System.Linq.Enumerable.Aggregate%2A?displayProperty=nameWithType> method. This method combines 
+Another option to join strings from a collection is to use <xref:System.String.Concat%2A?displayProperty=nameWithType> method. Use <xref:System.String.Join%2A?displayProperty=nameWithType> method if strings should be separated by a delimeter. The following code combines an array of words using both methods:
+
+[!code-csharp-interactive[concatenation of string collection](../../../samples/snippets/csharp/how-to/strings/Concatenate.cs#5)]
+
+At last, you can use [LINQ](../programming-guide/concepts/linq/index.md)
+and the <xref:System.Linq.Enumerable.Aggregate%2A?displayProperty=nameWithType> method to join strings from a collection. This method combines 
 the source strings using a lambda expression. The lambda expression does the
 work to add each string to the existing accumulation. The following example
 combines an array of words by adding a space between each word in the array:
 
-[!code-csharp-interactive[string concatenation using LINQ expressions](../../../samples/snippets/csharp/how-to/strings/Concatenate.cs#5)]  
+[!code-csharp-interactive[string concatenation using LINQ expressions](../../../samples/snippets/csharp/how-to/strings/Concatenate.cs#6)]  
 
 
 ## See Also  

--- a/samples/snippets/csharp/how-to/strings/Concatenate.cs
+++ b/samples/snippets/csharp/how-to/strings/Concatenate.cs
@@ -13,6 +13,7 @@ namespace HowToStrings
             UsingAddWithVariables();
             UsingInterpolationWithVariables();
             UsingStringBuilder();
+            UsingConcatAndJoin();
             UsingAggregate();
         }
 
@@ -31,7 +32,7 @@ namespace HowToStrings
             "IntelliSense support in the IDE. Transferring data from SQL tables or XML trees to " +
             "objects in memory is often tedious and error-prone.";
 
-            Console.WriteLine(text);
+            System.Console.WriteLine(text);
             // </Snippet1>
         }
 
@@ -55,7 +56,7 @@ namespace HowToStrings
             string userName = "<Type your name here>";
             string date = DateTime.Today.ToShortDateString();
 
-            // Use the + and += operators for one-time concatenations.
+            // Use string interpolation to concatenate strings.
             string str = $"Hello {userName}. Today is {date}.";
             System.Console.WriteLine(str);
 
@@ -68,7 +69,7 @@ namespace HowToStrings
         {
             // <Snippet4>
             // Use StringBuilder for concatenation in tight loops.
-            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            var sb = new System.Text.StringBuilder();
             for (int i = 0; i < 20; i++)
             {
                 sb.AppendLine(i.ToString());
@@ -77,14 +78,27 @@ namespace HowToStrings
             // </Snippet4>
         }
 
-        private static void UsingAggregate()
+        private static void UsingConcatAndJoin()
         {
             // <Snippet5>
             string[] words = { "The", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog." };
 
-            var phrase = words.Aggregate((partialPhrase, word) =>$"{partialPhrase} {word}");
-            Console.WriteLine(phrase);
+            var unreadablePhrase = string.Concat(words);
+            System.Console.WriteLine(unreadablePhrase);
+
+            var readablePhrase = string.Join(" ", words);
+            System.Console.WriteLine(readablePhrase);
             // </Snippet5>
+        }
+
+        private static void UsingAggregate()
+        {
+            // <Snippet6>
+            string[] words = { "The", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog." };
+
+            var phrase = words.Aggregate((partialPhrase, word) =>$"{partialPhrase} {word}");
+            System.Console.WriteLine(phrase);
+            // </Snippet6>
         }
     }
 }


### PR DESCRIPTION
Updated the [How to concatenate strings](https://docs.microsoft.com/en-us/dotnet/csharp/how-to/concatenate-multiple-strings) section with mentioning string.Join and string.Concat use cases for string collections.

Fixes #4433 

Made changes:
- Mention that both string.Concat and string.Join can be used for collections
- Minor style updates (mostly, format `+` operator as code)
- Added code snippet for string.Concat and string.Join usage
- Minor code clean up.

@BillWagner please review:
- I've combined Concat and Join as they are alike for collections. Haven't I missed anything when I've moved Concat out of the paragraph with string.Format?
- How do we justify the LINQ usage now? Would be nice to give example where neither string.Concat nor string.Join is a feat.
