### PR TITLE
replace wrong example

### DIFF
--- a/xml/System.Security.Cryptography/DES.xml
+++ b/xml/System.Security.Cryptography/DES.xml
@@ -33,18 +33,7 @@
  This algorithm supports a key length of 64 bits.  
   
 > [!NOTE]
->  A newer asymmetric encryption algorithm, Advanced Encryption Standard (AES), is available. Consider using the <xref:System.Security.Cryptography.Aes> class instead of the <xref:System.Security.Cryptography.DES> class. Use <xref:System.Security.Cryptography.DES> only for compatibility with legacy applications and data.  
-  
-   
-  
-## Examples  
- The following code example uses <xref:System.Security.Cryptography.DESCryptoServiceProvider> (an implementation of <xref:System.Security.Cryptography.DES>) to encrypt a string to an in-memory buffer. It then decrypts and displays the round-tripped string.  
-
- [!code-csharp[classic DES Example#1](~/samples/snippets/csharp/VS_Snippets_CLR_Classic/classic DES Example/CS/source.cs#1)]
- [!code-vb[classic DES Example#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_Classic/classic DES Example/VB/source.vb#1)]
- [!code-cpp[classic DES Example#1](~/samples/snippets/cpp/VS_Snippets_CLR_Classic/classic DES Example/CPP/source.cpp#1)]
-  
- Decryption can be handled in the same way; use <xref:System.Security.Cryptography.DESCryptoServiceProvider.CreateDecryptor%2A> instead of <xref:System.Security.Cryptography.DESCryptoServiceProvider.CreateEncryptor%2A>. The same key (<xref:System.Security.Cryptography.SymmetricAlgorithm.Key%2A>) and initialization vector (<xref:System.Security.Cryptography.SymmetricAlgorithm.IV%2A>) used to encrypt the file must be used to decrypt it.  
+> A newer asymmetric encryption algorithm, Advanced Encryption Standard (AES), is available. Consider using the <xref:System.Security.Cryptography.Aes> class instead of the <xref:System.Security.Cryptography.DES> class. Use <xref:System.Security.Cryptography.DES> only for compatibility with legacy applications and data.
   
  ]]></format>
     </remarks>

--- a/xml/System.Security.Cryptography/DES.xml
+++ b/xml/System.Security.Cryptography/DES.xml
@@ -39,9 +39,10 @@
   
 ## Examples  
  The following code example uses <xref:System.Security.Cryptography.DESCryptoServiceProvider> (an implementation of <xref:System.Security.Cryptography.DES>) to encrypt a string to an in-memory buffer. It then decrypts and displays the round-tripped string.  
-  
- [!code-csharp[TripleDESCryptoServiceProvider#1](~/samples/snippets/csharp/VS_Snippets_CLR/tripledescryptoserviceprovider/cs/program.cs#1)]
- [!code-vb[TripleDESCryptoServiceProvider#1](~/samples/snippets/visualbasic/VS_Snippets_CLR/tripledescryptoserviceprovider/vb/program.vb#1)]  
+
+ [!code-csharp[classic DES Example#1](~/samples/snippets/csharp/VS_Snippets_CLR_Classic/classic DES Example/CS/source.cs#1)]
+ [!code-vb[classic DES Example#1](~/samples/snippets/visualbasic/VS_Snippets_CLR_Classic/classic DES Example/VB/source.vb#1)]
+ [!code-cpp[classic DES Example#1](~/samples/snippets/cpp/VS_Snippets_CLR_Classic/classic DES Example/CPP/source.cpp#1)]
   
  Decryption can be handled in the same way; use <xref:System.Security.Cryptography.DESCryptoServiceProvider.CreateDecryptor%2A> instead of <xref:System.Security.Cryptography.DESCryptoServiceProvider.CreateEncryptor%2A>. The same key (<xref:System.Security.Cryptography.SymmetricAlgorithm.Key%2A>) and initialization vector (<xref:System.Security.Cryptography.SymmetricAlgorithm.IV%2A>) used to encrypt the file must be used to decrypt it.  
   


### PR DESCRIPTION
Fixes #4413 

@bartonjs can you take a look? Current [DES docs](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.des) have a sample for the wrong algorithm. This would bring the samples just like they existed in https://msdn.microsoft.com/en-us/library/system.security.cryptography.des(v=vs.90).aspx#Examples. 

Are you ok with that or do you prefer to just pull the sample here?

[Internal review URL](https://review.docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.des?branch=pr-en-us-4445)

/cc @doctordns 