### PR TITLE
Update interpolated-strings.md

### DIFF
--- a/docs/csharp/language-reference/keywords/interpolated-strings.md
+++ b/docs/csharp/language-reference/keywords/interpolated-strings.md
@@ -19,7 +19,7 @@ The arguments of an interpolated string are easier to understand than a [composi
 ```csharp  
 Console.WriteLine($"Name = {name}, hours = {hours:hh}");
 ```  
-contains two interpolated expressions, '{name}' and '{hour:hh}'. The equivalent composite format string is:
+contains two interpolated expressions, '{name}' and '{hours:hh}'. The equivalent composite format string is:
 
 ```csharp
 Console.WriteLine("Name = {0}, hours = {1:hh}", name, hours); 


### PR DESCRIPTION
Corrected typo mistake

# Corrected typo error


## corrected typo error where interpolated expression is {hours:hh} instead of {hour:hh}


Fixes #Issue_Number


## corrected typo error where interpolated expression is {hours:hh} instead of {hour:hh}

## @rpetrusha 

If you know who should review this, use '@' to request a review.
