### PR TITLE
Replaced fwlinks in csharp\programming-guide folder

### DIFF
--- a/docs/csharp/programming-guide/delegates/index.md
+++ b/docs/csharp/programming-guide/delegates/index.md
@@ -62,9 +62,9 @@ A [delegate](../../../csharp/language-reference/keywords/delegate.md) is a type 
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
 ## Featured Book Chapters  
- [Delegates, Events, and Lambda Expressions](http://go.microsoft.com/fwlink/?LinkId=195395) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](http://go.microsoft.com/fwlink/?LinkId=195369)  
+ [Delegates, Events, and Lambda Expressions](https://msdn.microsoft.com/library/orm-9780596516109-03-09.aspx) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](https://msdn.microsoft.com/library/orm-9780596516109-03.aspx)  
   
- [Delegates and Events](http://go.microsoft.com/fwlink/?LinkId=195418) in [Learning C# 3.0: Master the fundamentals of C# 3.0](http://go.microsoft.com/fwlink/?LinkId=195412)  
+ [Delegates and Events](https://msdn.microsoft.com/library/orm-9780596521066-01-17.aspx) in [Learning C# 3.0: Master the fundamentals of C# 3.0](https://msdn.microsoft.com/library/orm-9780596521066-01.aspx)  
   
 ## See Also  
  <xref:System.Delegate>  

--- a/docs/csharp/programming-guide/events/index.md
+++ b/docs/csharp/programming-guide/events/index.md
@@ -55,9 +55,9 @@ Events enable a [class](../../../csharp/language-reference/keywords/class.md) or
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
 ## Featured Book Chapters  
- [Delegates, Events, and Lambda Expressions](http://go.microsoft.com/fwlink/?LinkId=195395) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](http://go.microsoft.com/fwlink/?LinkId=195369)  
+ [Delegates, Events, and Lambda Expressions](https://msdn.microsoft.com/library/orm-9780596516109-03-09.aspx) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](https://msdn.microsoft.com/library/orm-9780596516109-03.aspx)  
   
- [Delegates and Events](http://go.microsoft.com/fwlink/?LinkId=195418) in [Learning C# 3.0: Master the fundamentals of C# 3.0](http://go.microsoft.com/fwlink/?LinkId=195412)  
+ [Delegates and Events](https://msdn.microsoft.com/library/orm-9780596521066-01-17.aspx) in [Learning C# 3.0: Master the fundamentals of C# 3.0](https://msdn.microsoft.com/library/orm-9780596521066-01.aspx)  
   
 ## See Also  
  <xref:System.EventHandler>  

--- a/docs/csharp/programming-guide/exceptions/index.md
+++ b/docs/csharp/programming-guide/exceptions/index.md
@@ -44,7 +44,7 @@ The C# language's exception handling features help you deal with any unexpected 
   
 -   Code in a `finally` block is executed even if an exception is thrown. Use a `finally` block to release resources, for example to close any streams or files that were opened in the `try` block.  
   
--   Managed exceptions in the .NET Framework are implemented on top of the Win32 structured exception handling mechanism. For more information, see [Structured Exception Handling (C/C++)](/cpp/cpp/structured-exception-handling-c-cpp) and [A Crash Course on the Depths of Win32 Structured Exception Handling](http://go.microsoft.com/fwlink/?LinkId=119654).  
+-   Managed exceptions in the .NET Framework are implemented on top of the Win32 structured exception handling mechanism. For more information, see [Structured Exception Handling (C/C++)](/cpp/cpp/structured-exception-handling-c-cpp) and [A Crash Course on the Depths of Win32 Structured Exception Handling](http://bytepointer.com/resources/pietrek_crash_course_depths_of_win32_seh.htm).  
   
 ## Related Sections  
  See the following topics for more information about exceptions and exception handling:  
@@ -73,6 +73,3 @@ The C# language's exception handling features help you deal with any unexpected 
  [try-finally](../../../csharp/language-reference/keywords/try-finally.md)  
  [try-catch-finally](../../../csharp/language-reference/keywords/try-catch-finally.md)  
  [Exceptions](../../../standard/exceptions/index.md)  
- [Exception Hierarchy](http://msdn.microsoft.com/library/f7d68675-be06-40fb-a555-05f0c5a6f66b)  
- [Writing Reliable .NET Code](http://go.microsoft.com/fwlink/?LinkId=112400)  
- [Minidumps for Specific Exceptions](http://go.microsoft.com/fwlink/?LinkId=112408)

--- a/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
+++ b/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
@@ -55,7 +55,7 @@ root.GetDirectories("*.*", System.IO.SearchOption.AllDirectories);
  If you must store the contents of a directory tree, either in memory or on disk, the best option is to store only the <xref:System.IO.FileSystemInfo.FullName%2A> property (of type `string`) for each file. You can then use this string to create a new <xref:System.IO.FileInfo> or <xref:System.IO.DirectoryInfo> object as necessary, or open any file that requires additional processing.  
   
 ## Robust Programming  
- Robust file iteration code must take into account many complexities of the file system. For more information, see [NTFS Technical Reference](https://technet.microsoft.com/library/81cc8a8a-bd32-4786-a849-03245d68d8e4).  
+ Robust file iteration code must take into account many complexities of the file system. For more information on the Windows file system, see [NTFS Technical Reference](https://technet.microsoft.com/library/81cc8a8a-bd32-4786-a849-03245d68d8e4).  
   
 ## See Also  
  <xref:System.IO>  

--- a/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
+++ b/docs/csharp/programming-guide/file-system/how-to-iterate-through-a-directory-tree.md
@@ -55,9 +55,9 @@ root.GetDirectories("*.*", System.IO.SearchOption.AllDirectories);
  If you must store the contents of a directory tree, either in memory or on disk, the best option is to store only the <xref:System.IO.FileSystemInfo.FullName%2A> property (of type `string`) for each file. You can then use this string to create a new <xref:System.IO.FileInfo> or <xref:System.IO.DirectoryInfo> object as necessary, or open any file that requires additional processing.  
   
 ## Robust Programming  
- Robust file iteration code must take into account many complexities of the file system. For more information, see [NTFS Technical Reference](http://go.microsoft.com/fwlink/?LinkId=79488).  
+ Robust file iteration code must take into account many complexities of the file system. For more information, see [NTFS Technical Reference](https://technet.microsoft.com/library/81cc8a8a-bd32-4786-a849-03245d68d8e4).  
   
 ## See Also  
  <xref:System.IO>  
- [LINQ and File Directories](http://msdn.microsoft.com/library/5a5d516c-0279-4a84-ac84-b87f54caa808)  
+ [LINQ and File Directories](../../../csharp/programming-guide/concepts/linq/linq-and-file-directories.md)  
  [File System and the Registry (C# Programming Guide)](../../../csharp/programming-guide/file-system/index.md)

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -15,8 +15,6 @@ author: "BillWagner"
 ms.author: "wiwagn"
 ---
 # C# Coding Conventions (C# Programming Guide)
-The [C# Language Specification](http://go.microsoft.com/fwlink/?LinkId=199552) does not define a coding standard. However, the guidelines in this topic are used by Microsoft to develop samples and documentation.  
-  
  Coding conventions serve the following purposes:  
   
 -   They create a consistent look to the code, so that readers can focus on content, not layout.  
@@ -26,6 +24,8 @@ The [C# Language Specification](http://go.microsoft.com/fwlink/?LinkId=199552) d
 -   They facilitate copying, changing, and maintaining the code.  
   
 -   They demonstrate C# best practices.  
+
+ The guidelines in this topic are used by Microsoft to develop samples and documentation.  
   
 ## Naming Conventions  
   

--- a/docs/csharp/programming-guide/nullable-types/index.md
+++ b/docs/csharp/programming-guide/nullable-types/index.md
@@ -63,4 +63,4 @@ For more examples, see [Using Nullable Types](../../../csharp/programming-guide/
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [C#](../../../csharp/index.md)  
  [C# Reference](../../../csharp/language-reference/index.md)  
- [What exactly does 'lifted' mean?](http://go.microsoft.com/fwlink/?LinkId=112382)
+ [What exactly does 'lifted' mean?](https://blogs.msdn.microsoft.com/ericlippert/2007/06/27/what-exactly-does-lifted-mean/)


### PR DESCRIPTION
Replaced (in several cases deleted broken or not really necessary) remaining fwlinks in the **csharp\programming-guide** folder

Fixes #3424