### PR TITLE
code sample, mixed indenting spaces/tabs

### DIFF
--- a/samples/snippets/visualbasic/programming-guide/language-features/data-types/named-tuples/Program.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/data-types/named-tuples/Program.vb
@@ -9,8 +9,8 @@ Module Program
     Private Sub CallExplicitlyNamed()
         ' <Snippet1>
         Dim state = "MI"
-	    Dim stateName = "Michigan"
-	    Dim capital = "Lansing"
+        Dim stateName = "Michigan"
+        Dim capital = "Lansing"
         Dim stateInfo = ( state:=state, stateName:=stateName, capital:=capital )
         Console.WriteLine($"{stateInfo.stateName}: 2-letter code: {stateInfo.State}, Capital {stateInfo.capital}")   
         ' The example displays the following output:
@@ -21,8 +21,8 @@ Module Program
     Private Sub CallImplicitlyNamed()
         ' <Snippet2>
         Dim state = "MI"
-	    Dim stateName = "Michigan"
-	    Dim capital = "Lansing"
+        Dim stateName = "Michigan"
+        Dim capital = "Lansing"
         Dim stateInfo = ( state, stateName, capital )
         Console.WriteLine($"{stateInfo.stateName}: 2-letter code: {stateInfo.State}, Capital {stateInfo.capital}")   
         ' The example displays the following output:


### PR DESCRIPTION
Fixing mixed indenting from tabs/spaces to all spaces.
Hopefully this also fixes the indenting on the docs page https://docs.microsoft.com/en-us/dotnet/visual-basic/getting-started/whats-new#visual-basic-153