### PR TITLE
Update docs about Regular Expressions

### DIFF
--- a/docs/standard/base-types/anchors-in-regular-expressions.md
+++ b/docs/standard/base-types/anchors-in-regular-expressions.md
@@ -66,9 +66,9 @@ ms.workload:
 |`(\w+\s\w+)`|Match one or more word characters followed by a space, followed by one or more word characters. This is the fourth capturing group.|  
 |`,`|Match a comma.|  
 |`\s\d{4}`|Match a space followed by four decimal digits.|  
-|(-`(\d{4}&#124;present))?`|Match zero or one occurrence of a hyphen followed by four decimal digits or the string "present". This is the sixth capturing group. It also includes a seventh capturing group.|  
+|<code>(-(\d{4}&#124;present))?</code>|Match zero or one occurrence of a hyphen followed by four decimal digits or the string "present". This is the sixth capturing group. It also includes a seventh capturing group.|  
 |`,?`|Match zero or one occurrence of a comma.|  
-|`(\s\d{4}(-(\d{4}&#124;present))?,?)+`|Match one or more occurrences of the following: a space, four decimal digits, zero or one occurrence of a hyphen followed by four decimal digits or the string "present", and zero or one comma. This is the fifth capturing group.|  
+|<code>(\s\d{4}(-(\d{4}&#124;present))?,?)+</code>|Match one or more occurrences of the following: a space, four decimal digits, zero or one occurrence of a hyphen followed by four decimal digits or the string "present", and zero or one comma. This is the fifth capturing group.|  
   
  [Back to top](#top)  
   

--- a/docs/standard/base-types/best-practices.md
+++ b/docs/standard/base-types/best-practices.md
@@ -145,8 +145,8 @@ ms.workload:
 |-------------|-----------------|  
 |`\b`|Begin the match at a word boundary.|  
 |`\w+`|Match one or more word characters.|  
-|`(\r?\n)&#124;,?\s)`|Match either zero or one carriage return followed by a newline character, or zero or one comma followed by a white-space character.|  
-|`(\w+((\r?\n)&#124;,?\s))*`|Match zero or more occurrences of one or more word characters that are followed either by zero or one carriage return and a newline character, or by zero or one comma followed by a white-space character.|  
+|<code>(\r?\n)&#124;,?\s)</code>|Match either zero or one carriage return followed by a newline character, or zero or one comma followed by a white-space character.|  
+|<code>(\w+((\r?\n)&#124;,?\s))*</code>|Match zero or more occurrences of one or more word characters that are followed either by zero or one carriage return and a newline character, or by zero or one comma followed by a white-space character.|  
 |`\w+`|Match one or more word characters.|  
 |`[.?:;!]`|Match a period, question mark, colon, semicolon, or exclamation point.|  
   

--- a/docs/standard/base-types/details-of-regular-expression-behavior.md
+++ b/docs/standard/base-types/details-of-regular-expression-behavior.md
@@ -103,7 +103,7 @@ The .NET Framework regular expression engine is a backtracking regular expressio
     |`^`|Begin the match at the beginning of a line.|  
     |`(?<Pvt>\<PRIVATE\>\s)?`|Match zero or one occurrence of the string `<PRIVATE>` followed by a white-space character. Assign the match to a capturing group named `Pvt`.|  
     |`(?(Pvt)((\w+\p{P}?\s)+)`|If the `Pvt` capturing group exists, match one or more occurrences of one or more word characters followed by zero or one punctuation separator followed by a white-space character. Assign the substring to the first capturing group.|  
-    |`&#124;((\w+\p{P}?\s)+))`|If the `Pvt` capturing group does not exist, match one or more occurrences of one or more word characters followed by zero or one punctuation separator followed by a white-space character. Assign the substring to the third capturing group.|  
+    |<code>&#124;((\w+\p{P}?\s)+))<code>|If the `Pvt` capturing group does not exist, match one or more occurrences of one or more word characters followed by zero or one punctuation separator followed by a white-space character. Assign the substring to the third capturing group.|  
     |`\r?$`|Match the end of a line or the end of the string.|  
   
      For more information about conditional evaluation, see [Alternation Constructs](../../../docs/standard/base-types/alternation-constructs-in-regular-expressions.md).  
@@ -140,7 +140,7 @@ The .NET Framework regular expression engine is a backtracking regular expressio
     |-------------|-----------------|  
     |`^`|Begin the match at the beginning of the string.|  
     |`[A-Z0-9]`|Match any numeric or alphanumeric character. (The comparison is case-insensitive.)|  
-    |`([-!#$%&'.*+/=?^`{}&#124;~\w])*`|Match zero or more occurrences of any word character, or any of the following characters:  -, !, #, $, %, &, ', ., *, +, /, =, ?, ^, `, {, }, &#124;, or ~.|  
+    |<code>([-!#$%&'.*+/=?^\`{}&#124;~\w])*<code>|Match zero or more occurrences of any word character, or any of the following characters:  -, !, #, $, %, &, ', ., *, +, /, =, ?, ^, \`, {, }, &#124;, or ~.|  
     |`(?<=[A-Z0-9])`|Look behind to the previous character, which must be numeric or alphanumeric. (The comparison is case-insensitive.)|  
     |`$`|End the match at the end of the string.|  
   

--- a/docs/standard/base-types/grouping-constructs-in-regular-expressions.md
+++ b/docs/standard/base-types/grouping-constructs-in-regular-expressions.md
@@ -416,7 +416,7 @@ Grouping constructs delineate the subexpressions of a regular expression and cap
 |`\w+`|Match one or more word characters followed by a white-space character.|  
 |`\d{1,2},`|Match either one or two decimal digits followed by a white-space character and a comma.|  
 |`\d{4}\b`|Match four decimal digits, and end the match at a word boundary.|  
-|`(?<!(Saturday&#124;Sunday) )`|If the match is preceded by something other than the strings "Saturday" or "Sunday" followed by a space, the match is successful.|  
+|<code>(?<!(Saturday&#124;Sunday) )</code>|If the match is preceded by something other than the strings "Saturday" or "Sunday" followed by a space, the match is successful.|  
   
 <a name="nonbacktracking_subexpression"></a>   
 ## Nonbacktracking Subexpressions  

--- a/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
+++ b/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
@@ -62,15 +62,15 @@ The following example uses a regular expression to verify that a string is in va
 |`^`|Begin the match at the start of the string.|  
 |`(?(")`|Determine whether the first character is a quotation mark. `(?(")` is the beginning of an alternation construct.|  
 |`(?("")("".+?(?<!\\)""@)`|If the first character is a quotation mark, match a beginning quotation mark followed by at least one occurrence of any character, followed by an ending quotation mark. The ending quotation mark must not be preceded by a backslash character (\\). `(?<!` is the beginning of a zero-width negative lookbehind assertion. The string should conclude with an at sign (@).|  
-|`&#124;(([0-9a-z]`|If the first character is not a quotation mark, match any alphabetic character from a to z or A to Z (the comparison is case insensitive), or any numeric character from 0 to 9.|  
+|<code>&#124;(([0-9a-z]</code>|If the first character is not a quotation mark, match any alphabetic character from a to z or A to Z (the comparison is case insensitive), or any numeric character from 0 to 9.|  
 |`(\.(?!\.))`|If the next character is a period, match it. If it is not a period, look ahead to the next character and continue the match. `(?!\.)` is a zero-width negative lookahead assertion that prevents two consecutive periods from appearing in the local part of an email address.|  
-|``&#124;[-!#\$%&'\*\+/=\?\^`{}\&#124;~\w]``|If the next character is not a period, match any word character or one of the following characters: -!#$%'*+=?^`{}&#124;~.|  
-|``((\.(?!\.))&#124;[-!#\$%'\*\+/=\?\^`{}\&#124;~\w])*``|Match the alternation pattern (a period followed by a non-period, or one of a number of characters) zero or more times.|  
+|<code>&#124;[-!#\$%&'\*\+/=\?\^\`{}\&#124;~\w]</code>|If the next character is not a period, match any word character or one of the following characters: -!#$%'*+=?^\`{}&#124;~.|  
+|<code>((\.(?!\.))&#124;[-!#\$%'\*\+/=\?\^\`{}\&#124;~\w])*</code>|Match the alternation pattern (a period followed by a non-period, or one of a number of characters) zero or more times.|  
 |`@`|Match the @ character.|  
 |`(?<=[0-9a-z])`|Continue the match if the character that precedes the @ character is A through Z, a through z, or 0 through 9. The `(?<=[0-9a-z])` construct defines a zero-width positive lookbehind assertion.|  
 |`(?(\[)`|Check whether the character that follows @ is an opening bracket.|  
 |`(\[(\d{1,3}\.){3}\d{1,3}\])`|If it is an opening bracket, match the opening bracket followed by an IP address (four sets of one to three digits, with each set separated by a period) and a closing bracket.|  
-|`&#124;(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+`|If the character that follows @ is not an opening bracket, match one alphanumeric character with a value of A-Z, a-z, or 0-9, followed by zero or more occurrences of a hyphen, followed by zero or one alphanumeric character with a value of A-Z, a-z, or 0-9, followed by a period. This pattern can be repeated one or more times, and must be followed by the top-level domain name.|  
+|<code>&#124;(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+</code>|If the character that follows @ is not an opening bracket, match one alphanumeric character with a value of A-Z, a-z, or 0-9, followed by zero or more occurrences of a hyphen, followed by zero or one alphanumeric character with a value of A-Z, a-z, or 0-9, followed by a period. This pattern can be repeated one or more times, and must be followed by the top-level domain name.|  
 |`[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))`|The top-level domain name must begin and end with an alphanumeric character (a-z, A-Z, and 0-9). It can also include from zero to 22 ASCII characters that are either alphanumeric or hyphens.|  
 |`$`|End the match at the end of the string.|  
   

--- a/docs/standard/base-types/quantifiers-in-regular-expressions.md
+++ b/docs/standard/base-types/quantifiers-in-regular-expressions.md
@@ -268,7 +268,7 @@ Quantifiers specify how many instances of a character, group, or character class
 |Pattern|Description|  
 |-------------|-----------------|  
 |`(a\1`|Either match "a" along with the value of the first captured group …|  
-|`&#124;(?(1)`|… or test whether the first captured group has been defined. (Note that the `(?(1)` construct does not define a capturing group.)|  
+|<code>&#124;(?(1)</code>|… or test whether the first captured group has been defined. (Note that the `(?(1)` construct does not define a capturing group.)|  
 |`\1))`|If the first captured group exists, match its value. If the group does not exist, the group will match <xref:System.String.Empty?displayProperty=nameWithType>.|  
   
  The first regular expression tries to match this pattern between zero and two times; the second, exactly two times. Because the first pattern reaches its minimum number of captures with its first capture of <xref:System.String.Empty?displayProperty=nameWithType>, it never repeats to try to match `a\1`; the `{0,2}` quantifier allows only empty matches in the last iteration. In contrast, the second regular expression does match "a" because it evaluates `a\1` a second time; the minimum number of iterations, 2, forces the engine to repeat after an empty match.  

--- a/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
+++ b/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
@@ -49,7 +49,7 @@ The following example searches an input string and displays all the href="…" v
 |`\s*`|Match zero or more white-space characters.|  
 |`=`|Match the equals sign.|  
 |`\s*`|Match zero or more white-space characters.|  
-|<code>(?:\["'\](?<1>\[^"'\]*)"&#124;(?<1>\S+))</code>|Match one of the following without assigning the result to a captured group:<br /><br /> -   A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.<br />-   One or more non-white-space characters. The group named `1` is included in this pattern.|  
+|<code>(?:\["'\](?<1>\[^"'\]*)"&#124;(?<1>\S+))</code>|Match one of the following without assigning the result to a captured group:<br /> <ul><li><p>A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.</p></li><li><p>One or more non-white-space characters. The group named `1` is included in this pattern.</p></li></ul>|  
 |`(?<1>[^"']*)`|Assign zero or more occurrences of any character other than a quotation mark or apostrophe to the capturing group named `1`.|  
 |`"(?<1>\S+)`|Assign one or more non-white-space characters to the capturing group named `1`.|  
   

--- a/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
+++ b/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
@@ -49,7 +49,7 @@ The following example searches an input string and displays all the href="…" v
 |`\s*`|Match zero or more white-space characters.|  
 |`=`|Match the equals sign.|  
 |`\s*`|Match zero or more white-space characters.|  
-|`(?:["'](?<1>[^"']*)"&#124;(?<1>\S+))`|Match one of the following without assigning the result to a captured group:<br /><br /> -   A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.<br />-   One or more non-white-space characters. The group named `1` is included in this pattern.|  
+|<code>(?:["'](?<1>[^"']*)"&#124;(?<1>\S+))</code>|Match one of the following without assigning the result to a captured group:<br /><br /> -   A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.<br />-   One or more non-white-space characters. The group named `1` is included in this pattern.|  
 |`(?<1>[^"']*)`|Assign zero or more occurrences of any character other than a quotation mark or apostrophe to the capturing group named `1`.|  
 |`"(?<1>\S+)`|Assign one or more non-white-space characters to the capturing group named `1`.|  
   

--- a/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
+++ b/docs/standard/base-types/regular-expression-example-scanning-for-hrefs.md
@@ -49,7 +49,7 @@ The following example searches an input string and displays all the href="…" v
 |`\s*`|Match zero or more white-space characters.|  
 |`=`|Match the equals sign.|  
 |`\s*`|Match zero or more white-space characters.|  
-|<code>(?:["'](?<1>[^"']*)"&#124;(?<1>\S+))</code>|Match one of the following without assigning the result to a captured group:<br /><br /> -   A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.<br />-   One or more non-white-space characters. The group named `1` is included in this pattern.|  
+|<code>(?:\["'\](?<1>\[^"'\]*)"&#124;(?<1>\S+))</code>|Match one of the following without assigning the result to a captured group:<br /><br /> -   A quotation mark or apostrophe, followed by zero or more occurrences of any character other than a quotation mark or apostrophe, followed by a quotation mark or apostrophe. The group named `1` is included in this pattern.<br />-   One or more non-white-space characters. The group named `1` is included in this pattern.|  
 |`(?<1>[^"']*)`|Assign zero or more occurrences of any character other than a quotation mark or apostrophe to the capturing group named `1`.|  
 |`"(?<1>\S+)`|Assign one or more non-white-space characters to the capturing group named `1`.|  
   

--- a/samples/snippets/csharp/VS_Snippets_CLR/RegularExpressions.Examples.Email/cs/example4.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/RegularExpressions.Examples.Email/cs/example4.cs
@@ -29,7 +29,7 @@ public class RegexUtilities
        try {
           return Regex.IsMatch(strIn,
                 @"^(?("")("".+?(?<!\\)""@)|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^`\{\}\|~\w])*)(?<=[0-9a-z])@))" +
-                @"(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-\w]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$",
+                @"(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$",
                 RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
        }
        catch (RegexMatchTimeoutException) {

--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex/cs/example2.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex/cs/example2.cs
@@ -14,6 +14,6 @@ public class Class1
    }
 }
 // The example displays the following output:
-//       This this (duplicates 'This)' at position 0
-//       a a (duplicates 'a)' at position 66
+//       This this (duplicates 'This') at position 0
+//       a a (duplicates 'a') at position 66
 // </Snippet3>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/RegularExpressions.Examples.Email/vb/example4.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/RegularExpressions.Examples.Email/vb/example4.vb
@@ -26,7 +26,7 @@ Public Class RegexUtilities
        Try
           Return Regex.IsMatch(strIn,
                  "^(?("")("".+?(?<!\\)""@)|(([0-9a-z]((\.(?!\.))|[-!#\$%&'\*\+/=\?\^`\{\}\|~\w])*)(?<=[0-9a-z])@))" +
-                 "(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-\w]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$",
+                 "(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$",
                  RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250))
        Catch e As RegexMatchTimeoutException
           Return False

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex/vb/example2.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex/vb/example2.vb
@@ -15,6 +15,6 @@ Module modMain
    End Sub
 End Module
 ' The example displays the following output:
-'       This this (duplicates 'This)' at position 0
-'       a a (duplicates 'a)' at position 66
+'       This this (duplicates 'This') at position 0
+'       a a (duplicates 'a') at position 66
 ' </Snippet3>


### PR DESCRIPTION
## Summary

1. In `anchors-in-regular-expressions.md`, `best-practices.md`, `details-of-regular-expression-behavior.md`, `grouping-constructs-in-regular-expressions.md`, `how-to-verify-that-strings-are-in-valid-email-format.md`, `quantifiers-in-regular-expressions.md`, `regular-expression-example-scanning-for-hrefs.md`:
   * fix vertical bars between grave accent mark showing `&#124;`

2. In `example2.vb` and `example2.cs`:
   * fix quotes position

3. In `example4.vb` and `example4.cs`:
   * accord with https://github.com/dotnet/docs/commit/5596e8567d22e899f207a7db833fd9bb05f88acf

4. Another change in `regular-expression-example-scanning-for-hrefs.md`:
   * add a ul style

## Details

### About point 1

I refereed to https://github.com/dotnet/docs.zh-cn/blob/live/docs/standard/base-types/alternation-constructs-in-regular-expressions.md, using `code` tag replaced with grave accent mark.

It seems vertical bars are recognized as part of the table in markdown syntax. And this syntax is superior to the effect of grave accent mark.

### About point 2

I misspelled `position` when I submitted the commits :scream:

### About point 4

I don't know whether the previous style was by design.