### PR TITLE
Main function access modifier fixed

### DIFF
--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -135,7 +135,7 @@ program before that task finishes. Therefore, you must use the `Wait`
 method to block and wait for the task to finish:
 
 ```csharp
-public static void Main(string[] args)
+static void Main(string[] args)
 {
     ProcessRepositories().Wait();
 }


### PR DESCRIPTION
# Title

main function access modifier fixed

## Summary

when we create console app with "dotnet new console" main function access modifier is not public. Removed "public".