### PR TITLE
Fixed typos and style in string interpolation sections

### DIFF
--- a/docs/csharp/language-reference/keywords/interpolated-strings.md
+++ b/docs/csharp/language-reference/keywords/interpolated-strings.md
@@ -38,11 +38,11 @@ where:
 - *format-string* is a format string appropriate for the type of object being formatted. For example, for a <xref:System.DateTime> value, it could be a standard date and time format string such as "D" or "d".
 
 > [!IMPORTANT]
-> You cannot have any whitespace between the `$` and the `"` that starts the string. Doing so causes a compile time error.
+> You cannot have any whitespace between the `$` and the `"` that starts the string. Doing so causes a compile-time error.
 
  You can use an interpolated string anywhere you can use a string literal.  The interpolated string is evaluated each time the code with the interpolated string executes. This allows you to separate the definition and evaluation of an interpolated string.  
   
- To include a curly brace ("{" or "}") in an interpolated string, use two curly braces, "{{" or "}}".  See the Implicit Conversions section for more details.  
+ To include a curly brace ("{" or "}") in an interpolated string, use two curly braces, "{{" or "}}".  See the [Implicit Conversions](#implicit-conversions) section for more details.  
 
 If the interpolated string contains other characters with special meaning in an interpolated string, such as the quotation mark ("), colon (:), or comma (,), they should be escaped if they occur in literal text, or they should be included in an expression delimited by parentheses if they are language elements included in an interpolated expression. The following example escapes quotation marks to include them in the result string, and it uses parentheses to delimit the expression `(age == 1 ? "" : "s")` so that the colon is not interpreted as beginning a format string.
 
@@ -68,7 +68,7 @@ There are three implicit type conversions from an interpolated string:
 
    This is the final result of a string interpretation. All occurrences of double curly braces ("{{" and "}}") are converted to a single curly brace. 
 
-2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the <xref:System.Object.ToString> method.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
+2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you to create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the <xref:System.Object.ToString> method.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
 
    The following example uses reflection to display the members as well as the field and property values of an <xref:System.IFormattable> variable that is created from an interpolated string. It also passes the <xref:System.IFormattable> variable to the <xref:System.Console.WriteLine(System.String)?displayProperty=nameWithType> method.
 
@@ -83,8 +83,11 @@ There are three implicit type conversions from an interpolated string:
 ## Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
+## See also  
  <xref:System.IFormattable?displayProperty=nameWithType>  
  <xref:System.FormattableString?displayProperty=nameWithType>  
+ <xref:System.String.Format%2A?displayProperty=nameWithType>  
+ [String Interpolation in C#](../../../csharp/tutorials/string-interpolation.md)  
+ [Interpolated strings in C#](../../../csharp/quick-starts/interpolated-strings.yml)  
  [C# Reference](../../../csharp/language-reference/index.md)  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -81,7 +81,7 @@ This is line number 5
 
 ## How string interpolation works
 
-Behind the scenes, this string interpolation syntax is translated into `String.Format` by the compiler. So, you can do the [same type of stuff you've done before with `String.Format`](../..//standard/base-types/formatting-types.md).
+Behind the scenes, this string interpolation syntax is translated into `String.Format` by the compiler. So, you can do the [same type of stuff you've done before with `String.Format`](../../standard/base-types/formatting-types.md).
 
 For instance, you can add padding and numeric formatting:
 

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -14,7 +14,7 @@ ms.assetid: f8806f6b-3ac7-4ee6-9b3e-c524d5301ae9
 
 # String Interpolation in C# #
 
-String Interpolation is the way that placeholders in a string are replaced by the value of a string variable. Before C# 6, the way to do this is with `System.String.Format`. This works okay, but since it uses numbered placeholders, it can be harder to read and more verbose.
+String Interpolation is the way that placeholders in a string are replaced by the value of a string variable. Before C# 6, the way to do this is with <xref:System.String.Format%2A?displayProperty=nameWithType>. This works okay, but since it uses numbered placeholders, it can be harder to read and more verbose.
 
 Other programming languages have had string interpolation built into the language for a while. For instance, in PHP:
 
@@ -45,7 +45,7 @@ application. To use the command line generator, create a directory for your proj
 dotnet new console
 ```
 
-This command will create a barebones .NET core project with a project file, *interpolated.csproj*, and a source code file, *Program.cs*. You will need to execute `dotnet restore` to restore the dependencies needed to compile this project.
+This command creates a barebones .NET Core project with a project file, *interpolated.csproj*, and a source code file, *Program.cs*. You will need to execute `dotnet restore` to restore the dependencies needed to compile this project.
 
 [!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
 
@@ -55,7 +55,7 @@ To execute the program, use `dotnet run`. You should see "Hello, World" output t
 
 ## Intro to String Interpolation
 
-With `System.String.Format`, you specify "placeholders" in a string that are replaced by the parameters following the string. For instance:
+With <xref:System.String.Format%2A?displayProperty=nameWithType>, you specify "placeholders" in a string that are replaced by the parameters following the string. For instance:
 
 [!code-csharp[String.Format example](../../../samples/snippets/csharp/new-in-6/string-interpolation.cs#StringFormatExample)]  
 
@@ -81,7 +81,7 @@ This is line number 5
 
 ## How string interpolation works
 
-Behind the scenes, this string interpolation syntax is translated into String.Format by the compiler. So, you can do the [same type of stuff you've done before with String.Format](https://msdn.microsoft.com/library/dwhawy9k(v=vs.110).aspx).
+Behind the scenes, this string interpolation syntax is translated into `String.Format` by the compiler. So, you can do the [same type of stuff you've done before with `String.Format`](../..//standard/base-types/formatting-types.md).
 
 For instance, you can add padding and numeric formatting:
 
@@ -99,7 +99,7 @@ The above would output something like:
 1004       6,227.77
 ```
 
-If a variable name is not found, then a compile time error will be generated.
+If a variable name is not found, then a compile-time error is generated.
 
 For instance:
 
@@ -110,21 +110,19 @@ var adj = "quick";
 Console.WriteLine(localizeMe);
 ```
 
-If you compile this, you'll get errors:
+If you compile this, you get errors:
  
 * `Cannot use local variable 'adj' before it is declared` - the `adj` variable wasn't declared until *after* the interpolated string.
 * `The name 'otheranimal' does not exist in the current context` - a variable called `otheranimal` was never even declared
 
 ## Localization and Internationalization
 
-An interpolated string supports `IFormattable` and `FormattableString`, which can be useful for internationalization.
+An interpolated string supports <xref:System.IFormattable?displayProperty=nameWithType> and <xref:System.FormattableString?displayProperty=nameWithType>, which can be useful for internationalization.
 
-By default, an interpolated string uses the current culture. To use a different culture, you could cast it as `IFormattable`
-
-For instance:
+By default, an interpolated string uses the current culture. To use a different culture, you could cast it as `IFormattable`. For instance:
 
 [!code-csharp[Interpolation internationalization example](../../../samples/snippets/csharp/new-in-6/string-interpolation.cs#InterpolationInternationalizationExample)]  
 
 ## Conclusion 
 
-In this tutorial, you learned how to use string interpolation features of C# 6. It's basically a more concise way of writing simple `String.Format` statements, with some caveats for more advanced uses of it.
+In this tutorial, you learned how to use string interpolation features of C# 6. It's basically a more concise way of writing simple `String.Format` statements, with some caveats for more advanced uses of it. For more information, see the [Interpolated Strings](../../csharp//language-reference/keywords/interpolated-strings.md) topic.

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -55,7 +55,7 @@ To execute the program, use `dotnet run`. You should see "Hello, World" output t
 
 ## Intro to String Interpolation
 
-With <xref:System.String.Format%2A?displayProperty=nameWithType>, you specify "placeholders" in a string that are replaced by the parameters following the string. For instance:
+With <xref:System.String.Format%2A?displayProperty=nameWithType>, you specify "placeholders" in a string that are replaced by the arguments following the string. For instance:
 
 [!code-csharp[String.Format example](../../../samples/snippets/csharp/new-in-6/string-interpolation.cs#StringFormatExample)]  
 
@@ -119,10 +119,10 @@ If you compile this, you get errors:
 
 An interpolated string supports <xref:System.IFormattable?displayProperty=nameWithType> and <xref:System.FormattableString?displayProperty=nameWithType>, which can be useful for internationalization.
 
-By default, an interpolated string uses the current culture. To use a different culture, you could cast it as `IFormattable`. For instance:
+By default, an interpolated string uses the current culture. To use a different culture, cast an interpolated string as `IFormattable`. For instance:
 
 [!code-csharp[Interpolation internationalization example](../../../samples/snippets/csharp/new-in-6/string-interpolation.cs#InterpolationInternationalizationExample)]  
 
 ## Conclusion 
 
-In this tutorial, you learned how to use string interpolation features of C# 6. It's basically a more concise way of writing simple `String.Format` statements, with some caveats for more advanced uses of it. For more information, see the [Interpolated Strings](../../csharp//language-reference/keywords/interpolated-strings.md) topic.
+In this tutorial, you learned how to use string interpolation features of C# 6. It's basically a more concise way of writing simple `String.Format` statements, with some caveats for more advanced uses. For more information, see the [Interpolated Strings](../../csharp//language-reference/keywords/interpolated-strings.md) topic.


### PR DESCRIPTION
Fixed typos ("compile-time" as adjective goes with dash) and style (use present tense instead of future).
Also added links connecting various pages on string interpolation in the documentation.