### PR TITLE
Update source.vb

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_Winforms/Classic CheckedListBox Example/VB/source.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_Winforms/Classic CheckedListBox Example/VB/source.vb
@@ -140,13 +140,9 @@ Namespace WindowsApplication1
                 e As System.EventArgs) Handles button3.Click
             ' Insert code to save a file.
             listBox1.Items.Clear()
-            Dim myEnumerator As IEnumerator
-            myEnumerator = checkedListBox1.CheckedIndices.GetEnumerator()
-            Dim y As Integer
-            While myEnumerator.MoveNext() <> False
-                y = CInt(myEnumerator.Current)
-                checkedListBox1.SetItemChecked(y, False)
-            End While
+            For Each index in checkedListBox1.CheckedIndices.Cast(Of Integer).ToArray()
+                checkedListBox1.SetItemChecked(index, False)
+            Next
             button3.Enabled = False
         End Sub 'button3_Click
     End Class 'Form1


### PR DESCRIPTION
Don't use IEnumerator and instead use Cast

# Title
Use Cast to turn the collection into an IEnumerable(Of Integer)

## Summary

Don't use an IEnumerator and instead use Cast.  


## Details

I suggest an IEnumerator not be used and instead a Cast call be used.  This is the modern way to do things.  

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
