### PR TITLE
change http links to https in F# folder

### DIFF
--- a/docs/fsharp/get-started/get-started-vscode.md
+++ b/docs/fsharp/get-started/get-started-vscode.md
@@ -14,7 +14,7 @@ ms.assetid: 49775139-082e-442f-b5a2-dd402399b5d2
 
 # Getting Started with F# in Visual Studio Code with Ionide
 
-You can write F# in [Visual Studio Code](https://code.visualstudio.com) with the [Ionide plugin](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp), to get a great cross-platform, lightweight IDE experience with IntelliSense and basic code refactorings.  Visit [Ionide.io](http://ionide.io) to learn more about the plugin suite.
+You can write F# in [Visual Studio Code](https://code.visualstudio.com) with the [Ionide plugin](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp), to get a great cross-platform, lightweight IDE experience with IntelliSense and basic code refactorings.  Visit [Ionide.io](https://ionide.io) to learn more about the plugin suite.
 
 ## Prerequisites
 
@@ -35,9 +35,9 @@ If you prefer not to install Visual Studio, use the following instructions:
 2. Install the Windows SDK for your OS:
 
     * [Windows 10 SDK](https://dev.windows.com/en-US/downloads/windows-10-sdk)
-    * [Windows 8.1 SDK](http://msdn.microsoft.com/windows/desktop/bg162891)
-    * [Windows 8 SDK](http://msdn.microsoft.com/windows/hardware/hh852363.aspx)
-    * [Windows 7 SDK](http://www.microsoft.com/download/details.aspx?id=8279)
+    * [Windows 8.1 SDK](https://developer.microsoft.com/windows/downloads/sdk-archive)
+    * [Windows 8 SDK](https://developer.microsoft.com/windows/downloads/sdk-archive)
+    * [Windows 7 SDK](https://www.microsoft.com/download/details.aspx?id=8279)
 
 3. Install the [Microsoft Build Tools 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48159).  You may also need to install [Microsoft Build Tools 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40760).
 
@@ -63,7 +63,7 @@ Ionide automatically detects the compiler and tools, but if it doesn't for some 
 
 ### macOS
 
-On macOS, Ionide uses [Mono](http://www.mono-project.com).  The easiest way to install Mono on macOS is via Homebrew.  Simply type the following into your terminal:
+On macOS, Ionide uses [Mono](https://www.mono-project.com).  The easiest way to install Mono on macOS is via Homebrew.  Simply type the following into your terminal:
 
 ```
 brew install mono
@@ -71,7 +71,7 @@ brew install mono
 
 ### Linux
 
-On Linux, Ionide also uses [Mono](http://www.mono-project.com).  If you're on Debian or Ubuntu, you can use the following:
+On Linux, Ionide also uses [Mono](https://www.mono-project.com).  If you're on Debian or Ubuntu, you can use the following:
 
 ```
 sudo apt-get update
@@ -92,7 +92,7 @@ You can install Visual Studio Code from the [code.visualstudio.com](https://code
 
     ![](media/getting-started-vscode/vscode-ext.png)
 
-The only plugin required for F# support in Visual Studio Code is [Ionide-fsharp](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp).  However, you can also install [Ionide-FAKE](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-FAKE) and to get [FAKE](http://fsharp.github.io/FAKE/) support and [Ionide-Paket](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-Paket) to get [Paket](https://fsprojects.github.io/Paket/) support.  FAKE and Paket are additonal F# community tools for building projects and managing dependencies, respectively.
+The only plugin required for F# support in Visual Studio Code is [Ionide-fsharp](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-fsharp).  However, you can also install [Ionide-FAKE](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-FAKE) and to get [FAKE](https://fake.build/) support and [Ionide-Paket](https://marketplace.visualstudio.com/items?itemName=Ionide.Ionide-Paket) to get [Paket](https://fsprojects.github.io/Paket/) support.  FAKE and Paket are additonal F# community tools for building projects and managing dependencies, respectively.
 
 ## Creating your first project with Ionide
 
@@ -117,7 +117,7 @@ Select "F#: New Project" by hitting **Enter**, which will take you to this step:
 
 ![](media/getting-started-vscode/vscode-proj-type.png)
 
-This will select a template for a specific type of project.  There are quite a few options here, such as an [FsLab](http://fslab.org) template for Data Science or [Suave](https://suave.io) template for Web Programming.  This article uses the `classlib` template, so highlight that and hit **Enter**.  You will then reach the following step:
+This will select a template for a specific type of project.  There are quite a few options here, such as an [FsLab](https://fslab.org) template for Data Science or [Suave](https://suave.io) template for Web Programming.  This article uses the `classlib` template, so highlight that and hit **Enter**.  You will then reach the following step:
 
 ![](media/getting-started-vscode/vscode-new-dir.png)
 
@@ -134,8 +134,8 @@ If you followed the previous step steps, you should get the Visual Studio Code W
 This template generates a few things you'll find useful:
 
 1. The F# project itself, underneath the `ClassLibraryDemo` folder.
-2. The correct directory structure for adding packages via [`Paket`](http://fsprojects.github.io/Paket/).
-3. A cross-platform build script with [`FAKE`](http://fsharp.github.io/FAKE/).
+2. The correct directory structure for adding packages via [`Paket`](https://fsprojects.github.io/Paket/).
+3. A cross-platform build script with [`FAKE`](https://fake.build/).
 4. The `paket.exe` executable which can fetch packages and resolve dependencies for you.
 5. A `.gitignore` file if you wish to add this project to Git-based source control.
 

--- a/docs/fsharp/language-reference/asynchronous-workflows.md
+++ b/docs/fsharp/language-reference/asynchronous-workflows.md
@@ -52,7 +52,7 @@ A method that performs a single asynchronous task and returns the result is call
 
 Several primitives for asynchronous I/O operations are included in the [`Microsoft.FSharp.Control.CommonExtensions`](https://msdn.microsoft.com/library/2edb67cb-6814-4a30-849f-b6dbdd042396) module. These extension methods of the `System.IO.Stream` class are [`Stream.AsyncRead`](https://msdn.microsoft.com/library/85698aaa-bdda-47e6-abed-3730f59fda5e) and [`Stream.AsyncWrite`](https://msdn.microsoft.com/library/1b0a2751-e42a-47e1-bd27-020224adc618).
 
-Additional asynchronous primitives are available in the [F# PowerTools](http://fsprojects.github.io/VisualFSharpPowerTools/). You can also write your own asynchronous primitives by defining a function whose complete body is enclosed in an async block.
+Additional asynchronous primitives are available in the [F# PowerTools](https://fsprojects.github.io/VisualFSharpPowerTools/). You can also write your own asynchronous primitives by defining a function whose complete body is enclosed in an async block.
 
 To use asynchronous methods in the .NET Framework that are designed for other asynchronous models with the F# asynchronous programming model, you create a function that returns an F# `Async` object. The F# library has functions that make this easy to do.
 

--- a/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
+++ b/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
@@ -40,7 +40,7 @@ let fetchHtmlAsync url =
         return html
     }
 
-let html = "http://dotnetfoundation.org" |> fetchHtmlAsync |> Async.RunSynchronously
+let html = "https://dotnetfoundation.org" |> fetchHtmlAsync |> Async.RunSynchronously
 printfn "%s" html
 ```
 
@@ -75,7 +75,7 @@ let fetchHtmlAsync url =
     }
 
  // Execution will pause until fetchHtmlAsync finishes
- let html = "http://dotnetfoundation.org" |> fetchHtmlAsync |> Async.RunSynchronously
+ let html = "https://dotnetfoundation.org" |> fetchHtmlAsync |> Async.RunSynchronously
 
  // you actually have the result from fetchHtmlAsync now!
  printfn "%s" html
@@ -94,7 +94,7 @@ let uploadDataAsync url data =
         webClient.UploadStringAsync(uri, data)
     }
 
-let workflow = uploadDataAsync "http://url-to-upload-to.com" "hello, world!"
+let workflow = uploadDataAsync "https://url-to-upload-to.com" "hello, world!"
 
 // Execution will continue after calling this!
 Async.Start(workflow)
@@ -119,10 +119,10 @@ open System
 open System.Net
 
 let urlList = 
-    [ "http://www.microsoft.com"
-      "http://www.google.com"
-      "http://www.amazon.com"
-      "http://www.facebook.com" ]
+    [ "https://www.microsoft.com"
+      "https://www.google.com"
+      "https://www.amazon.com"
+      "https://www.facebook.com" ]
 
 let fetchHtmlAsync url = 
     async {
@@ -204,7 +204,7 @@ let uploadDataAsync url data =
         webClient.UploadStringAsync(uri, data)
     }
 
-let workflow = uploadDataAsync "http://url-to-upload-to.com" "hello, world!"
+let workflow = uploadDataAsync "https://url-to-upload-to.com" "hello, world!"
 
 let token = new CancellationTokenSource()
 Async.Start (workflow, token)
@@ -218,5 +218,5 @@ And that’s it!
 ## Further resources:
 
 *   [Async Workflows on MSDN](https://msdn.microsoft.com/library/dd233250.aspx)
-*   [Asynchronous Sequences for F#](http://fsprojects.github.io/FSharp.Control.AsyncSeq/library/AsyncSeq.html)
+*   [Asynchronous Sequences for F#](https://fsprojects.github.io/FSharp.Control.AsyncSeq/library/AsyncSeq.html)
 *   [F# Data HTTP Utilities](https://fsharp.github.io/FSharp.Data/library/Http.html)

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database-entities.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database-entities.md
@@ -15,7 +15,7 @@ ms.assetid: dc82a932-5401-4d19-9fb3-92c50d8db514
 # Walkthrough: Accessing a SQL Database by Using Type Providers and Entities
 
 > [!NOTE]
-This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 > [!NOTE]
 The API reference links will take you to MSDN.  The docs.microsoft.com API reference is not complete.

--- a/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-sql-database.md
@@ -15,7 +15,7 @@ ms.assetid: 1c413eb0-16a5-4c1a-9a4e-ad6877e645d6
 # Walkthrough: Accessing a SQL Database by Using Type Providers
 
 > [!NOTE]
-This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 > [!NOTE]
 The API reference links will take you to MSDN.  The docs.microsoft.com API reference is not complete.

--- a/docs/fsharp/tutorials/type-providers/accessing-a-web-service.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-a-web-service.md
@@ -15,7 +15,7 @@ ms.assetid: 63374fa9-8fb8-43ac-bcb9-ef2290d9f851
 # Walkthrough: Accessing a Web Service by Using Type Providers
 
 > [!NOTE]
-This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 > [!NOTE]
 The API reference links will take you to MSDN.  The docs.microsoft.com API reference is not complete.
@@ -76,7 +76,7 @@ open Microsoft.FSharp.Data.TypeProviders
 <br />
 
 ```fsharp
-type TerraService = WsdlService<" HYPERLINK "http://terraserver-usa.com/TerraService2.asmx?WSDL" http://msrmaps.com/TerraService2.asmx?WSDL">
+type TerraService = WsdlService<" HYPERLINK "https://terraserver-usa.com/TerraService2.asmx?WSDL" https://msrmaps.com/TerraService2.asmx?WSDL">
 ```
 
   A red squiggle appears under this line of code if the service URI is misspelled or if the service itself is down or isn’t performing. If you point to the code, an error message describes the problem. You can find the same information in the **Error List** window or in the **Output Window** after you build.

--- a/docs/fsharp/tutorials/type-providers/accessing-an-odata-service.md
+++ b/docs/fsharp/tutorials/type-providers/accessing-an-odata-service.md
@@ -15,7 +15,7 @@ ms.assetid: 0adae84c-b0fa-455f-994b-274ecdc6df30
 # Walkthrough: Accessing an OData Service by Using Type Providers
 
 > [!NOTE]
-This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 > [!NOTE]
 The API reference links will take you to MSDN.  The docs.microsoft.com API reference is not complete.
@@ -65,7 +65,7 @@ In this step, you create a type provider that provides access to the types and d
 open Microsoft.FSharp.Data.TypeProviders
 
 
-type Northwind = ODataService<"http://services.odata.org/Northwind/Northwind.svc/">
+type Northwind = ODataService<"https://services.odata.org/Northwind/Northwind.svc/">
 
 let db = Northwind.GetDataContext()
 let fullContext = Northwind.ServiceTypes.NorthwindEntities()
@@ -238,7 +238,7 @@ db.DataContext.SendingRequest.Add (fun eventArgs -> printfn "Requesting %A" even
 ```
 
 The output of the previous code is:
-<br />`requesting http://services.odata.org/Northwind/Northwind.svc/Orders()?$orderby=ShippedDate&amp;$select=OrderID,ShippedDate`
+<br />`requesting https://services.odata.org/Northwind/Northwind.svc/Orders()?$orderby=ShippedDate&amp;$select=OrderID,ShippedDate`
 
 
 ## See Also

--- a/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
+++ b/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
@@ -52,7 +52,7 @@ Type providers are best suited to situations where the schema is stable at runti
 
 
 ## A Simple Type Provider
-This sample is Samples.HelloWorldTypeProvider in the `SampleProviders\Providers` directory of the [F# 3.0 Sample Pack](http://fsharp3sample.codeplex.com) on the Codeplex website. The provider makes available a "type space" that contains 100 erased types, as the following code shows by using F# signature syntax and omitting the details for all except `Type1`. For more information about erased types, see [Details About Erased Provided Types](#details-about-erased-provided-types) later in this topic.
+This sample is Samples.HelloWorldTypeProvider in the `SampleProviders\Providers` directory of the [F# 3.0 Sample Pack](https://fsharp3sample.codeplex.com) on the Codeplex website. The provider makes available a "type space" that contains 100 erased types, as the following code shows by using F# signature syntax and omitting the details for all except `Type1`. For more information about erased types, see [Details About Erased Provided Types](#details-about-erased-provided-types) later in this topic.
 
 ```fsharp
 namespace Samples.HelloWorldTypeProvider
@@ -495,7 +495,7 @@ Note the following points:
 - Each named group results in a provided property, and accessing the property results in a use of an indexer on a match’s `Groups` collection.
 <br />
 
-The following code is the core of the logic to implement such a provider, and this example omits the addition of all members to the provided type. For information about each added member, see the appropriate section later in this topic. For the full code, download the sample from the [F# 3.0 Sample Pack](http://fsharp3sample.codeplex.com) on the Codeplex website.
+The following code is the core of the logic to implement such a provider, and this example omits the addition of all members to the provided type. For information about each added member, see the appropriate section later in this topic. For the full code, download the sample from the [F# 3.0 Sample Pack](https://fsharp3sample.codeplex.com) on the Codeplex website.
 
 ```fsharp
 namespace Samples.FSharp.RegexTypeProvider
@@ -1136,7 +1136,7 @@ So far, this document has explained how provide erased types. You can also use t
 ```fsharp
 open Microsoft.FSharp.TypeProviders 
 
-type Service = ODataService<" http://services.odata.org/Northwind/Northwind.svc/">
+type Service = ODataService<" https://services.odata.org/Northwind/Northwind.svc/">
 ```
 
 The ProvidedTypes-0.2 helper code that is part of the F# 3.0 release has only limited support for providing generated types. The following statements must be true for a generated type definition:

--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-dbml.md
@@ -15,7 +15,7 @@ ms.assetid: 6fbb6ccc-248f-4226-95e9-f6f99541dbe4
 # Walkthrough: Generating F# Types from a DBML File
 
 > [!NOTE]
-This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 > [!NOTE]
 The API reference links will take you to MSDN.  The docs.microsoft.com API reference is not complete.

--- a/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-edmx.md
+++ b/docs/fsharp/tutorials/type-providers/generating-fsharp-types-from-edmx.md
@@ -15,7 +15,7 @@ ms.assetid: 81adb2eb-625f-4ad8-aeaa-8f672a6d79a2
 # Walkthrough: Generating F# Types from an EDMX Schema File
 
 > [!NOTE]
-This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written for F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 > [!NOTE]
 The API reference links will take you to MSDN.  The docs.microsoft.com API reference is not complete.
@@ -218,7 +218,7 @@ You should complete this procedure only if you want to know how to generate a fu
 1. On the menu bar, choose **SQL**, **Transact-SQL Editor**, **New Query** to create a database. If prompted, specify your database server and instance.
 <br />
 
-2. Copy and paste the contents of the database script that creates the Student database, as described in the [Entity Framework documentation](http://msdn.microsoft.com/data/JJ614587.aspx) in the Data Developer Center.
+2. Copy and paste the contents of the database script that creates the Student database, as described in the [Entity Framework documentation](https://msdn.microsoft.com/data/JJ614587.aspx) in the Data Developer Center.
 <br />
 
 3. Run the SQL script by choosing the toolbar button with the triangle symbol or choosing the Ctrl+Q keys.
@@ -271,7 +271,7 @@ Explore other queries by looking at the available query operators as listed in [
 
 [Walkthrough: Accessing a SQL Database by Using Type Providers and Entities](accessing-a-sql-database-entities.md)
 
-[Entity Framework](http://msdn.microsoft.com/data/ef)
+[Entity Framework](https://msdn.microsoft.com/data/ef)
 
 [.edmx File Overview](https://msdn.microsoft.com/library/f4c8e7ce-1db6-417e-9759-15f8b55155d4)
 

--- a/docs/fsharp/tutorials/type-providers/index.md
+++ b/docs/fsharp/tutorials/type-providers/index.md
@@ -15,7 +15,7 @@ ms.assetid: 25697ef6-465e-4248-9de5-1d199d4a8b59
 # Type Providers
 
 > [!NOTE]
-This guide was written from F# 3.0 and will be updated.  See [FSharp.Data](http://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
+This guide was written from F# 3.0 and will be updated.  See [FSharp.Data](https://fsharp.github.io/FSharp.Data/) for up-to-date, cross-platform type providers.
 
 An F# type provider is a component that provides types, properties, and methods for use in your program. Type providers are a significant part of F# 3.0 support for information-rich programming. The key to information-rich programming is to eliminate barriers to working with diverse information sources found on the Internet and in modern enterprise environments. One significant barrier to including a source of information into a program is the need to represent that information as types, properties, and methods for use in a programming language environment. Writing these types manually is very time-consuming and difficult to maintain. A common alternative is to use a code generator which adds files to your project; however, the conventional types of code generation do not integrate well into exploratory modes of programming supported by F# because the generated code must be replaced each time a service reference is adjusted.
 

--- a/docs/fsharp/using-fsharp-on-azure/blob-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/blob-storage.md
@@ -234,7 +234,7 @@ For details on encrypting blob data, see [the .NET guide for blob storage sectio
 Now that you've learned the basics of Blob storage, follow these links to learn more.
 
 ### Tools
-- [F# AzureStorageTypeProvider](http://fsprojects.github.io/AzureStorageTypeProvider/) An F# Type Provider which can be used to explore Blob, Table and Queue Azure Storage assets and easily apply CRUD operations on them.
+- [F# AzureStorageTypeProvider](https://fsprojects.github.io/AzureStorageTypeProvider/) An F# Type Provider which can be used to explore Blob, Table and Queue Azure Storage assets and easily apply CRUD operations on them.
 - [FSharp.Azure.Storage](https://github.com/fsprojects/FSharp.Azure.Storage) An F# API for using Microsoft Azure Table Storage service
 - [Microsoft Azure Storage Explorer (MASE)](/azure/vs-azure-tools-storage-manage-with-storage-explorer) is a free, standalone app from Microsoft that enables you to work visually with Azure Storage data on Windows, OS X, and Linux.
 
@@ -249,4 +249,4 @@ Now that you've learned the basics of Blob storage, follow these links to learn 
 - [Transfer data with the AzCopy command-line utility on Windows](/azure/storage/common/storage-use-azcopy)
 - [Transfer data with the AzCopy command-line utility on Linux](/azure/storage/common/storage-use-azcopy-linux)
 - [Configure Azure Storage connection strings](/azure/storage/common/storage-configure-connection-string)
-- [Azure Storage Team Blog](http://blogs.msdn.com/b/windowsazurestorage/)
+- [Azure Storage Team Blog](https://blogs.msdn.microsoft.com/windowsazurestorage/)

--- a/docs/fsharp/using-fsharp-on-azure/file-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/file-storage.md
@@ -157,5 +157,5 @@ See these links for more information about Azure File storage.
 
 - [Azure File storage is now generally available](https://azure.microsoft.com/blog/azure-file-storage-now-generally-available/)
 - [Inside Azure File Storage](https://azure.microsoft.com/blog/inside-azure-file-storage/) 
-- [Introducing Microsoft Azure File Service](http://blogs.msdn.com/b/windowsazurestorage/archive/2014/05/12/introducing-microsoft-azure-file-service.aspx)
-- [Persisting connections to Microsoft Azure Files](http://blogs.msdn.com/b/windowsazurestorage/archive/2014/05/27/persisting-connections-to-microsoft-azure-files.aspx)
+- [Introducing Microsoft Azure File Service](https://blogs.msdn.microsoft.com/windowsazurestorage/2014/05/12/introducing-microsoft-azure-file-service/)
+- [Persisting connections to Microsoft Azure Files](https://blogs.msdn.microsoft.com/windowsazurestorage/2014/05/26/persisting-connections-to-microsoft-azure-files/)

--- a/docs/fsharp/using-fsharp-on-azure/index.md
+++ b/docs/fsharp/using-fsharp-on-azure/index.md
@@ -37,7 +37,7 @@ Azure Functions support F# as a first-class language with efficient, reactive, s
 
 Other resources for using Azure Functions and F#:
 
-* [Scale Up Azure Functions in F# Using Suave](http://blog.tamizhvendan.in/blog/2016/09/19/scale-up-azure-functions-in-f-number-using-suave/)
+* [Scale Up Azure Functions in F# Using Suave](https://blog.tamizhvendan.in/blog/2016/09/19/scale-up-azure-functions-in-f-number-using-suave/)
 * [How to create Azure function in F#](https://mnie.github.io/2016-09-08-AzureFunctions/)
 * [Using the Azure Type Provider with Azure Functions](https://compositional-it.com/blog/2017/08-30-using-the-azure-type-provider-with-azure-functions/index.html)
 

--- a/docs/fsharp/using-fsharp-on-azure/package-management.md
+++ b/docs/fsharp/using-fsharp-on-azure/package-management.md
@@ -22,7 +22,7 @@ If you're using [Paket](https://fsprojects.github.io/Paket/) as your dependency 
 
     > paket add nuget WindowsAzure.Storage
 
-Or, if you're using [Mono](http://www.mono-project.com/) for cross-platform .NET development:
+Or, if you're using [Mono](https://www.mono-project.com/) for cross-platform .NET development:
 
     > mono paket.exe add nuget WindowsAzure.Storage
 

--- a/docs/fsharp/using-fsharp-on-azure/queue-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/queue-storage.md
@@ -173,6 +173,6 @@ to learn about more complex storage tasks.
 
 - [Azure Storage APIs for .NET](/dotnet/api/overview/azure/storage)
 - [Azure Storage Type Provider](https://github.com/fsprojects/AzureStorageTypeProvider)
-- [Azure Storage Team Blog](http://blogs.msdn.com/b/windowsazurestorage/)
+- [Azure Storage Team Blog](https://blogs.msdn.microsoft.com/windowsazurestorage/)
 - [Configure Azure Storage connection strings](/azure/storage/common/storage-configure-connection-string)
 - [Azure Storage Services REST API Reference](/rest/api/storageservices/Azure-Storage-Services-REST-API-Reference)

--- a/docs/fsharp/using-fsharp-on-azure/table-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/table-storage.md
@@ -184,7 +184,7 @@ Now that you've learned the basics of Table storage, follow these links
 to learn about more complex storage tasks:
 
 - [Azure Storage APIs for .NET](/dotnet/api/overview/azure/storage)
-- [Azure Storage Type Provider](http://fsprojects.github.io/AzureStorageTypeProvider/)
-- [Azure Storage Team Blog](http://blogs.msdn.com/b/windowsazurestorage/)
+- [Azure Storage Type Provider](https://fsprojects.github.io/AzureStorageTypeProvider/)
+- [Azure Storage Team Blog](https://blogs.msdn.microsoft.com/b/windowsazurestorage/)
 - [Configure Azure Storage connection strings](/azure/storage/common/storage-configure-connection-string)
 - [Getting Started with Azure Table Storage in .NET](https://azure.microsoft.com/documentation/samples/storage-table-dotnet-getting-started/)


### PR DESCRIPTION
Doing a PR as an example for #4504 

We have thousands of links without https in our repo. Started with the articles inside F# folder.
Kept links that don't support https like fsharp.org as http.