### PR TITLE
System.Numerics: mention that vectors are rows

### DIFF
--- a/includes/system-numerics-vectors-are-rows.md
+++ b/includes/system-numerics-vectors-are-rows.md
@@ -1,1 +1,1 @@
-The `System.Numerics` namespace represents vectors as rows for vector-matrix multiplication, so the product of a vector *v* and a matrix *M* is *vM*.
+The `System.Numerics` namespace represents vectors as rows. A vector *v* is transformed by a matrix *M* with *vM* multiplication.

--- a/includes/system-numerics-vectors-are-rows.md
+++ b/includes/system-numerics-vectors-are-rows.md
@@ -1,0 +1,1 @@
+The `System.Numerics` namespace represents vectors as rows for vector-matrix multiplication. For this reason, the matrix of the transformation that is composition of transformations *f* and *g* defined by matrices `Mf` and `Mg` respectively is `Mf * Mg` as `(v * Mf) * Mg = v * (Mf * Mg)` for any vector `v`.

--- a/includes/system-numerics-vectors-are-rows.md
+++ b/includes/system-numerics-vectors-are-rows.md
@@ -1,1 +1,1 @@
-The `System.Numerics` namespace represents vectors as rows for vector-matrix multiplication. For this reason, the matrix of the transformation that is composition of transformations *f* and *g* defined by matrices `Mf` and `Mg` respectively is `Mf * Mg` as `(v * Mf) * Mg = v * (Mf * Mg)` for any vector `v`.
+The `System.Numerics` namespace represents vectors as rows for vector-matrix multiplication, so the product of a vector *v* and a matrix *M* is *vM*.

--- a/includes/system-numerics-vectors-are-rows.md
+++ b/includes/system-numerics-vectors-are-rows.md
@@ -1,1 +1,1 @@
-The `System.Numerics` namespace represents vectors as rows. A vector *v* is transformed by a matrix *M* with *vM* multiplication.
+For matrix transformations, the <xref:System.Numerics.Vector2>, <xref:System.Numerics.Vector3>, and <xref:System.Numerics.Vector4> instances are represented as rows: a vector *v* is transformed by a matrix *M* with *vM* multiplication.

--- a/xml/System.Numerics/Matrix3x2.xml
+++ b/xml/System.Numerics/Matrix3x2.xml
@@ -27,7 +27,15 @@
   </Interfaces>
   <Docs>
     <summary>Represents a 3x2 matrix.</summary>
-    <remarks>To be added.</remarks>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ 
+ [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Numerics/Matrix4x4.xml
+++ b/xml/System.Numerics/Matrix4x4.xml
@@ -27,7 +27,15 @@
   </Interfaces>
   <Docs>
     <summary>Represents a 4x4 matrix.</summary>
-    <remarks>To be added.</remarks>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ 
+ [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Numerics/Plane.xml
+++ b/xml/System.Numerics/Plane.xml
@@ -26,8 +26,16 @@
     </Interface>
   </Interfaces>
   <Docs>
-    <summary>Represents a three-dimensional plane.</summary>
-    <remarks>To be added.</remarks>
+    <summary>Represents a plane in three-dimensional space.</summary>
+    <remarks>
+      <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ 
+ [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
+  
+ ]]></format>
+    </remarks>
   </Docs>
   <Members>
     <Member MemberName=".ctor">

--- a/xml/System.Numerics/Quaternion.xml
+++ b/xml/System.Numerics/Quaternion.xml
@@ -36,6 +36,8 @@
 ```  
 w = cos(theta/2)  
 ```  
+
+[!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
   
  ]]></format>
     </remarks>

--- a/xml/System.Numerics/Quaternion.xml
+++ b/xml/System.Numerics/Quaternion.xml
@@ -36,8 +36,6 @@
 ```  
 w = cos(theta/2)  
 ```  
-
-[!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
   
  ]]></format>
     </remarks>

--- a/xml/System.Numerics/Vector2.xml
+++ b/xml/System.Numerics/Vector2.xml
@@ -34,7 +34,9 @@
       <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Numerics.Vector2> structure provides support for hardware acceleration.  
+ The <xref:System.Numerics.Vector2> structure provides support for hardware acceleration.
+
+ [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
   
  ]]></format>
     </remarks>

--- a/xml/System.Numerics/Vector3.xml
+++ b/xml/System.Numerics/Vector3.xml
@@ -35,6 +35,8 @@
   
 ## Remarks  
  The <xref:System.Numerics.Vector3> structure provides support for hardware acceleration.  
+
+ [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
   
  ]]></format>
     </remarks>

--- a/xml/System.Numerics/Vector4.xml
+++ b/xml/System.Numerics/Vector4.xml
@@ -35,6 +35,8 @@
   
 ## Remarks  
  The <xref:System.Numerics.Vector4> structure provides support for hardware acceleration.  
+
+ [!INCLUDE[vectors-are-rows-paragraph](~/includes/system-numerics-vectors-are-rows.md)]  
   
  ]]></format>
     </remarks>


### PR DESCRIPTION
Added remark that vectors are treated as rows at the `System.Numerics` namespace.

Fixes #4356 

## Suggested Reviewers
@mairaw @rpetrusha 
@geoeo as you've noticed the issue, please review as well. I've placed the clarifying paragraph at the **Remarks** section of each geometry-related struct page.