### PR TITLE
Updated links to SQL Server security content.

### DIFF
--- a/docs/framework/data/adonet/sql/sql-server-security.md
+++ b/docs/framework/data/adonet/sql/sql-server-security.md
@@ -41,7 +41,7 @@ ms.workload:
  Describes security considerations for [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] Express.  
   
 ## Related Sections  
-[Security Center for SQL Server Database Engine and Azure SQL Database](https://docs.microsoft.com/sql/relational-databases/security/security-center-for-sql-server-database-engine-and-azure-sql-database)  
+[Security Center for SQL Server Database Engine and Azure SQL Database](/sql/relational-databases/security/security-center-for-sql-server-database-engine-and-azure-sql-database)  
 Describes security considerations for SQL Server and Azure SQL Database.
 
 ## See Also  

--- a/docs/framework/data/adonet/sql/sql-server-security.md
+++ b/docs/framework/data/adonet/sql/sql-server-security.md
@@ -44,7 +44,7 @@ ms.workload:
 [Security Center for SQL Server Database Engine and Azure SQL Database](/sql/relational-databases/security/security-center-for-sql-server-database-engine-and-azure-sql-database)  
 Describes security considerations for SQL Server and Azure SQL Database.
 
-[Security Considerations for a SQL Server Installation](/sql/sql-server/install/security-considerations-for-a-sql-server-installation)
+[Security Considerations for a SQL Server Installation](/sql/sql-server/install/security-considerations-for-a-sql-server-installation)  
 Describes security concerns to consider before installing SQL Server.
 
 ## See Also  

--- a/docs/framework/data/adonet/sql/sql-server-security.md
+++ b/docs/framework/data/adonet/sql/sql-server-security.md
@@ -44,7 +44,9 @@ ms.workload:
 [Security Center for SQL Server Database Engine and Azure SQL Database](/sql/relational-databases/security/security-center-for-sql-server-database-engine-and-azure-sql-database)  
 Describes security considerations for SQL Server and Azure SQL Database.
 
+[Security Considerations for a SQL Server Installation](/sql/sql-server/install/security-considerations-for-a-sql-server-installation)
+Describes security concerns to consider before installing SQL Server.
+
 ## See Also  
  [Securing ADO.NET Applications](../../../../../docs/framework/data/adonet/securing-ado-net-applications.md)  
  [SQL Server and ADO.NET](../../../../../docs/framework/data/adonet/sql/index.md)  
- [ADO.NET Managed Providers and DataSet Developer Center](http://go.microsoft.com/fwlink/?LinkId=217917)

--- a/docs/framework/data/adonet/sql/sql-server-security.md
+++ b/docs/framework/data/adonet/sql/sql-server-security.md
@@ -41,12 +41,9 @@ ms.workload:
  Describes security considerations for [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] Express.  
   
 ## Related Sections  
- [Security and Protection (Database Engine)](http://msdn2.microsoft.com/library/bb510589\(SQL.100\).aspx.)  
- [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] Books Online security topics.  
-  
- [Security Considerations for SQL Server](http://go.microsoft.com/fwlink/?LinkId=98587)  
- [!INCLUDE[ssNoVersion](../../../../../includes/ssnoversion-md.md)] Books Online security topics.  
-  
+[Security Center for SQL Server Database Engine and Azure SQL Database](https://docs.microsoft.com/sql/relational-databases/security/security-center-for-sql-server-database-engine-and-azure-sql-database)  
+Describes security considerations for SQL Server and Azure SQL Database.
+
 ## See Also  
  [Securing ADO.NET Applications](../../../../../docs/framework/data/adonet/securing-ado-net-applications.md)  
  [SQL Server and ADO.NET](../../../../../docs/framework/data/adonet/sql/index.md)  


### PR DESCRIPTION
Removed two outdated links to old SQL Server security content and replaced them with the correct, up-to-date link to the overview page for SQL Server and Azure SQL Database security.

FYI I used a full HTTPS URL since I don't believe we can (or don't know how to) easily link cross-repo with a relative link. If that's possible, please educate me.
