### PR TITLE
Fixed Quaternion.CreateFromAxisAngle description

### DIFF
--- a/xml/System.Numerics/Quaternion.xml
+++ b/xml/System.Numerics/Quaternion.xml
@@ -238,11 +238,18 @@ w = cos(theta/2)
         <Parameter Name="angle" Type="System.Single" />
       </Parameters>
       <Docs>
-        <param name="axis">The vector to rotate around.</param>
+        <param name="axis">The unit vector to rotate around.</param>
         <param name="angle">The angle, in radians, to rotate around the vector.</param>
-        <summary>Creates a quaternion from a vector and an angle to rotate about the vector.</summary>
+        <summary>Creates a quaternion from a unit vector and an angle to rotate around the vector.</summary>
         <returns>The newly created quaternion.</returns>
-        <remarks>To be added.</remarks>
+        <remarks>
+          <format type="text/markdown"><![CDATA[  
+  
+## Remarks  
+ `axis` vector must be normalized before calling this method or the resulting <xref:System.Numerics.Quaternion> will be incorrect.  
+  
+ ]]></format>
+        </remarks>
       </Docs>
     </Member>
     <Member MemberName="CreateFromRotationMatrix">


### PR DESCRIPTION
Fixed the description of the [Quaternion.CreateFromAxisAngle](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.quaternion.createfromaxisangle?view=netcore-2.0#System_Numerics_Quaternion_CreateFromAxisAngle_System_Numerics_Vector3_System_Single_) method based on [this comment in code](https://github.com/dotnet/corefx/blob/12715c4aac0ed144e36a7ef834a7f349196759de/src/System.Numerics.Vectors/src/System/Numerics/Quaternion.cs#L159) and my own check in the sandbox application:

```csharp
 var vectorToRotate = new Vector3(MathF.Sqrt(2), 0, 0);
 const float rotateBy45degrees = 0.25f * MathF.PI;
 var zAxis = new Vector3(0, 0, 1);

 var correctQuaternion = Quaternion.CreateFromAxisAngle(zAxis, rotateBy45degrees);
 var rotated = Vector3.Transform(vectorToRotate, correctQuaternion);
 Console.WriteLine(rotated); // (1, 1, 0). That's expected.

 var badQuaternion = Quaternion.CreateFromAxisAngle(2.0f * zAxis, rotateBy45degrees);
 var wronglyRotated = Vector3.Transform(vectorToRotate, badQuaternion);
 Console.WriteLine(wronglyRotated); // Not at all (1, 1, 0)
```