### PR TITLE
System.Reflection docs for ProcessorArchitecture is misleading

### DIFF
--- a/xml/System.Reflection/ProcessorArchitecture.xml
+++ b/xml/System.Reflection/ProcessorArchitecture.xml
@@ -61,7 +61,7 @@
         <ReturnType>System.Reflection.ProcessorArchitecture</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A 64-bit processor based on the x86-64 architecture.</summary>
+        <summary>A 64-bit processor based on the [x64 architecture](/windows-hardware/drivers/debugger/x64-architecture). </summary>
       </Docs>
     </Member>
     <Member MemberName="Arm">

--- a/xml/System.Reflection/ProcessorArchitecture.xml
+++ b/xml/System.Reflection/ProcessorArchitecture.xml
@@ -61,7 +61,7 @@
         <ReturnType>System.Reflection.ProcessorArchitecture</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A 64-bit AMD processor only.</summary>
+        <summary>A 64-bit processor based on the x86-64 architecture.</summary>
       </Docs>
     </Member>
     <Member MemberName="Arm">
@@ -115,7 +115,7 @@
         <ReturnType>System.Reflection.ProcessorArchitecture</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>A 64-bit Intel processor only.</summary>
+        <summary>A 64-bit Intel Itanium processor only.</summary>
       </Docs>
     </Member>
     <Member MemberName="MSIL">


### PR DESCRIPTION
# System.Reflection docs for ProcessorArchitecture are misleading

## Summary

The documentation for ProcessorArchitecture is slightly misleading. It states that "IA64" indicates Intel 64 bit processors and "AMD64" indicates AMD 64 bit processors. This is _kinda_ true but is quite misleading since:

* IA64 = Intel Itanium only, mostly dead architecture that I imagine few people need to care about
* AMD64 = All modern Intel and AMD processors, possibly some other companies too?

No issue raised as it's a two-line wording fix. 

## Details

I have changed the description to make sure that "Itanium" is mentioned in the IA64 summary, and changed the AMD64 wording to reference "x86-64" architecture. I think the IA64 summary is fine, I don't know what the preferred Microsoft wording is for AMD64/x86-64 however.