### PR TITLE
Fixed a * swapped for a ? in regex

### DIFF
--- a/docs/standard/base-types/alternation-constructs-in-regular-expressions.md
+++ b/docs/standard/base-types/alternation-constructs-in-regular-expressions.md
@@ -121,18 +121,18 @@ ms.workload:
  [!code-csharp[RegularExpressions.Language.Alternation#4](../../../samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.alternation/cs/alternation4.cs#4)]
  [!code-vb[RegularExpressions.Language.Alternation#4](../../../samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.alternation/vb/alternation4.vb#4)]  
   
- The regular expression pattern `\b(?<n2>\d{2}-)*(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b` is interpreted as shown in the following table.  
+ The regular expression pattern `\b(?<n2>\d{2}-)?(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b` is interpreted as shown in the following table.  
   
 |Pattern|Description|  
 |-------------|-----------------|  
 |`\b`|Start at a word boundary.|  
-|`(?<n2>\d{2}-)*`|Match zero or one occurrence of two digits followed by a hyphen. Name this capturing group `n2`.|  
+|`(?<n2>\d{2}-)?`|Match zero or one occurrence of two digits followed by a hyphen. Name this capturing group `n2`.|  
 |`(?(n2)`|Test whether `n2` was matched in the input string.|  
 |`)\d{7}`|If `n2` was matched, match seven decimal digits.|  
 |<code>&#124;\d{3}-\d{2}-\d{4}</code>|If `n2` was not matched, match three decimal digits, a hyphen, two decimal digits, another hyphen, and four decimal digits.|  
 |`\b`|Match a word boundary.|  
   
- A variation of this example that uses a numbered group instead of a named group is shown in the following example. Its regular expression pattern is `\b(\d{2}-)*(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b`.  
+ A variation of this example that uses a numbered group instead of a named group is shown in the following example. Its regular expression pattern is `\b(\d{2}-)?(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b`.  
   
  [!code-csharp[RegularExpressions.Language.Alternation#5](../../../samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.alternation/cs/alternation5.cs#5)]
  [!code-vb[RegularExpressions.Language.Alternation#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.alternation/vb/alternation5.vb#5)]  

--- a/samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.alternation/cs/alternation4.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.alternation/cs/alternation4.cs
@@ -6,7 +6,7 @@ public class Example
 {
    public static void Main()
    {
-      string pattern = @"\b(?<n2>\d{2}-)*(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b";
+      string pattern = @"\b(?<n2>\d{2}-)?(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b";
       string input = "01-9999999 020-333333 777-88-9999";
       Console.WriteLine("Matches for {0}:", pattern);
       foreach (Match match in Regex.Matches(input, pattern))
@@ -14,7 +14,7 @@ public class Example
    }
 }
 // The example displays the following output:
-//       Matches for \b(?<n2>\d{2}-)*(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b:
+//       Matches for \b(?<n2>\d{2}-)?(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b:
 //          01-9999999 at position 0
 //          777-88-9999 at position 22
 // </Snippet4>

--- a/samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.alternation/cs/alternation5.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/regularexpressions.language.alternation/cs/alternation5.cs
@@ -6,7 +6,7 @@ public class Example
 {
    public static void Main()
    {
-      string pattern = @"\b(\d{2}-)*(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b";
+      string pattern = @"\b(\d{2}-)?(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b";
       string input = "01-9999999 020-333333 777-88-9999";
       Console.WriteLine("Matches for {0}:", pattern);
       foreach (Match match in Regex.Matches(input, pattern))
@@ -14,7 +14,7 @@ public class Example
    }
 }
 // The example display the following output:
-//       Matches for \b(\d{2}-)*(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b:
+//       Matches for \b(\d{2}-)?(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b:
 //          01-9999999 at position 0
 //          777-88-9999 at position 22
 // </Snippet5>

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.alternation/vb/alternation4.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.alternation/vb/alternation4.vb
@@ -6,8 +6,8 @@ Imports System.Text.RegularExpressions
 
 Module Example
    Public Sub Main()
-      Dim pattern As String = "\b(?<n2>\d{2}-)*(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b"
-      Dim input As String = "01-9999999 020-333333 777-88-9999"
+        Dim pattern As String = "\b(?<n2>\d{2}-)?(?(n2)\d{7}|\d{3}-\d{2}-\d{4})\b"
+        Dim input As String = "01-9999999 020-333333 777-88-9999"
       Console.WriteLine("Matches for {0}:", pattern)
       For Each match As Match In Regex.Matches(input, pattern)
          Console.WriteLine("   {0} at position {1}", match.Value, match.Index)

--- a/samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.alternation/vb/alternation5.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/regularexpressions.language.alternation/vb/alternation5.vb
@@ -6,8 +6,8 @@ Imports System.Text.RegularExpressions
 
 Module Example
    Public Sub Main()
-      Dim pattern As String = "\b(\d{2}-)*(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b"
-      Dim input As String = "01-9999999 020-333333 777-88-9999"
+        Dim pattern As String = "\b(\d{2}-)?(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b"
+        Dim input As String = "01-9999999 020-333333 777-88-9999"
       Console.WriteLine("Matches for {0}:", pattern)
       For Each match As Match In Regex.Matches(input, pattern)
          Console.WriteLine("   {0} at position {1}", match.Value, match.Index)
@@ -15,7 +15,7 @@ Module Example
    End Sub
 End Module
 ' The example displays the following output:
-'       Matches for \b(\d{2}-)*(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b:
+'       Matches for \b(\d{2}-)?(?(1)\d{7}|\d{3}-\d{2}-\d{4})\b:
 '          01-9999999 at position 0
 '          777-88-9999 at position 22
 ' </Snippet5>


### PR DESCRIPTION
The regular expression meant to use 0 or 1 occurences (?), but accidentally used 0 or more *, which would match any number of XX- repeats instead of one found in a matching tax id number.

# Title

On the title describe
what you've fixed (or created) with this Pull Request (PR).

## Summary

Insert a short (one or two sentence) summary here.

Fixes #Issue_Number

>Note: The "Fixes #nnn" syntax in the PR description causes
>GitHub to automatically close the issue when this PR is merged.
> Remove that line if you don't have issues associated with this
> PR. Click on the Guidelines for Contributing link above for details.

## Details

Explain your changes, and why you made them. If that
information is already available in the issue referenced
above, just referencing the issue is preferred to copying
the text.

This may not be necessary depending on the scope of the PR 
changes. For example, "fix typo in introduction.md" is
sufficient to describe that PR.

## Suggested Reviewers

If you know who should review this, use '@' to request a review.
