### PR TITLE
Fixed Regex after replacement in vb program output

### DIFF
--- a/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.substitutions/vb/after1.vb
+++ b/samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.substitutions/vb/after1.vb
@@ -26,5 +26,5 @@ End Module
 '       4 at position 11
 '       5 at position 14
 '    Input string:  aa1bb2cc3dd4ee5
-'    Output string: aaaabbaa1bbccaa1bb2ccddaa1bb2cc3ddeeaa1bb2cc3dd4ee
+'    Output string: aabb2cc3dd4ee5bbcc3dd4ee5ccdd4ee5ddee5ee
 ' </Snippet5>


### PR DESCRIPTION
The output is correct in the text body but in the program code the output was copied from the example topic "Substituting the Text Before the Match" and doesn't match the program output.
