### PR TITLE
Fixed Regex after replacement in C# program output

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.substitutions/cs/after1.cs
+++ b/samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.substitutions/cs/after1.cs
@@ -25,5 +25,5 @@ public class Example
 //       4 at position 11
 //       5 at position 14
 //    Input string:  aa1bb2cc3dd4ee5
-//    Output string: aaaabbaa1bbccaa1bb2ccddaa1bb2cc3ddeeaa1bb2cc3dd4ee
+//    Output string: aabb2cc3dd4ee5bbcc3dd4ee5ccdd4ee5ddee5ee
 // </Snippet5>


### PR DESCRIPTION
The output is correct in the text body but in the program code the output was copied from the example topic "Substituting the Text Before the Match" and doesn't match the program output.
