### PR TITLE
Order the definitions to match the order of terms

### DIFF
--- a/docs/standard/generics/covariance-and-contravariance.md
+++ b/docs/standard/generics/covariance-and-contravariance.md
@@ -26,7 +26,7 @@ ms.workload:
   - "dotnetcore"
 ---
 # Covariance and Contravariance in Generics
-<a name="top"></a> Covariance and contravariance are terms that refer to the ability to use a less derived (less specific) or more derived type (more specific) than originally specified. Generic type parameters support covariance and contravariance to provide greater flexibility in assigning and using generic types. When you are referring to a type system, covariance, contravariance, and invariance have the following definitions. The examples assume a base class named `Base` and a derived class named `Derived`.  
+<a name="top"></a> Covariance and contravariance are terms that refer to the ability to use a more derived type (more specific) or a less derived type (less specific) than originally specified. Generic type parameters support covariance and contravariance to provide greater flexibility in assigning and using generic types. When you are referring to a type system, covariance, contravariance, and invariance have the following definitions. The examples assume a base class named `Base` and a derived class named `Derived`.  
   
 -   `Covariance`  
   


### PR DESCRIPTION
# Reverse order of definitions in Introductory sentence

## Summary

If I read it correctly, the existing Introductory sentence gives the definition
for Contravariance before the definition of Covariance.  So, read by itself, 
the first sentence implies definitions that contradict the body of the article.

## Details

Put definition of covariance before definition of contravariance to match
the order in which those words appear.

## Suggested Reviewers

Somebody who understands covariance and contravariance a lot better than
I do.
