### PR TITLE
Fixing broken link to MVA course

### DIFF
--- a/docs/visual-basic/getting-started/index.md
+++ b/docs/visual-basic/getting-started/index.md
@@ -43,7 +43,7 @@ Provides a list of Web sites and newsgroups that can help you find answers to co
  [Get Visual Basic](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs)  
  Provides download links for Visual Studio versions that include Visual basic support, including free versions.  
 
- [Visual Basic Fundamentals for Absolute Beginners](https://mva.microsoft.com/training-courses/visual-basic-fundamentals-for-absolute-beginners-16507)  
+ [Visual Basic Fundamentals for Absolute Beginners](https://mva.microsoft.com/en-US/training-courses/visual-basic-fundamentals-for-absolute-beginners-16507)  
  Microsoft Virtual Academy course that teaches the fundamentals of Visual Basic programming.
 
  [Object-Oriented Programming](../programming-guide/concepts/object-oriented-programming.md)  


### PR DESCRIPTION
Visual Basic Fundamentals for Absolute Beginners link was directing to a list of courses, not really related to VB.  I've updated the link directly to the course, which is a better user experience for those visiting this page.  I did check to see if the course was in other languages before putting in the en-US link - looks like it's available only in English.

## Suggested Reviewers
@mairaw 