### PR TITLE
Minor refactoring

### DIFF
--- a/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/AgeRangeRule.cs
+++ b/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/AgeRangeRule.cs
@@ -49,7 +49,7 @@ namespace SDKSample
             }
             else
             {
-                return new ValidationResult(true, null);
+                return ValidationResult.ValidResult;
             }
         }
     }


### PR DESCRIPTION
# Title

Minor refactoring

## Summary

Change `new ValidationResult(true, null)` to `ValidationResult.ValidResult`.

## Details

Change `new ValidationResult(true, null)` to `ValidationResult.ValidResult`, since it looks a little cleaner and the property was explicitly designed for that use.
