### PR TITLE
Experiment: CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,10 +29,37 @@
 # The Visual Basic Guide:
 /docs/visual-basic/** rpetrusha
 
+# Visual Basic snippets:
+/samples/snippets/visualbasic/** rpetrusha
+
+# C++ snippets
+/samples/snippets/cpp/** rpetrusha
+
 # .NET Framework migration guide
 /docs/framework/migration-guide/** rpetrusha
 
 # .NET base types
 /docs/standard/base-types/formatting-types/** rpetrusha
+
+# .NET Framework unmanaged API
+/docs/framework/unmanaged-api/** rpetrusha
+
+# What's New
+/docs/core/whats-new/** rpetrusha
+/docs/framework/whats-new/** rpetrusha
+/docs/standard/whats-new/** rpetrusha
+
+# .NET Core
+/docs/core/** mairaw
+
+# .NET Framework Security
+/docs/framework/security/** mairaw
+
+# .NET I/O
+/docs/standard/io/** mairaw
+
+# Docker
+/docs/core/docker/** JRAlexander
+
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+# Not adding in this PR, but I'd like to try adding a global owner set with the entire team.
+# One interpretation of their docs is that global owners are added only if not removed
+# by a more local rule.
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+
+
+# The C# Guide:
+
+/docs/csharp/** BillWagner
+
+# C# samples:
+/samples/csharp/**  BillWagner
+
+# C# Snippets:
+/samples/snippets/** BillWagner
+
+# Analyzers:
+/docs/standard/analyzers/** BillWagner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,14 @@
 
 # Analyzers:
 /docs/standard/analyzers/** BillWagner
+
+# The Visual Basic Guide:
+/docs/visual-basic/** rpetrusha
+
+# .NET Framework migration guide
+/docs/framework/migration-guide/** rpetrusha
+
+# .NET base types
+/docs/standard/base-types/formatting-types/** rpetrusha
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,4 +27,4 @@ sufficient to describe that PR.
 
 ## Suggested Reviewers
 
-If you know who should review this, use '@' to request a review.
+If you know who should review this, tag them as a suggested reviewer in the list of reviewers.


### PR DESCRIPTION
Trying an experiment to see how we might use use the CODEOWNERS file to get reviews routed to the right person.

@mairaw @rpetrusha This experiment would work better if we had another ID or two participating. If you want to add a section each, we can learn more about how it works.

Note: I did not turn on any of the features that would block PRs unless an owner reviewed. I don't think that's necessary. I just want to see if it makes us more efficient reviewing PRs.