### PR TITLE
Fix markdown table

### DIFF
--- a/docs/fsharp/language-reference/compiler-directives.md
+++ b/docs/fsharp/language-reference/compiler-directives.md
@@ -71,7 +71,7 @@ The following table lists the compiler directive that is available in F#.
 
 |Directive|Description|
 |---------|-----------|
-|`#light` ["on"|"off"]|Enables or disables lightweight syntax, for compatibility with other versions of ML. By default, lightweight syntax is enabled. Verbose syntax is always enabled. Therefore, you can use both lightweight syntax and verbose syntax. The directive `#light` by itself is equivalent to `#light "on"`. If you specify `#light "off"`, you must use verbose syntax for all language constructs. Syntax in the documentation for F# is presented with the assumption that you are using lightweight syntax. For more information, see [Verbose Syntax](verbose-syntax.md).|
+|`#light` ["on"&#124;"off"]|Enables or disables lightweight syntax, for compatibility with other versions of ML. By default, lightweight syntax is enabled. Verbose syntax is always enabled. Therefore, you can use both lightweight syntax and verbose syntax. The directive `#light` by itself is equivalent to `#light "on"`. If you specify `#light "off"`, you must use verbose syntax for all language constructs. Syntax in the documentation for F# is presented with the assumption that you are using lightweight syntax. For more information, see [Verbose Syntax](verbose-syntax.md).|
 For interpreter (fsi.exe) directives, see [Interactive Programming with F#](../tutorials/fsharp-interactive/index.md).
 
 


### PR DESCRIPTION
Fix usage of `|` in markdown (use `&#124;` instead)

![image](https://user-images.githubusercontent.com/1866463/37245399-a75058a0-2497-11e8-93df-01f449ab0eac.png)

