### PR TITLE
Replaced fwlinks in standard/parallel-programming folder

### DIFF
--- a/docs/standard/parallel-programming/data-parallelism-task-parallel-library.md
+++ b/docs/standard/parallel-programming/data-parallelism-task-parallel-library.md
@@ -40,7 +40,7 @@ ms.workload:
   
  Both the <xref:System.Threading.Tasks.Parallel.For%2A?displayProperty=nameWithType> and <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType> methods have several overloads that let you stop or break loop execution, monitor the state of the loop on other threads, maintain thread-local state, finalize thread-local objects, control the degree of concurrency, and so on. The helper types that enable this functionality include <xref:System.Threading.Tasks.ParallelLoopState>, <xref:System.Threading.Tasks.ParallelOptions>, <xref:System.Threading.Tasks.ParallelLoopResult>, <xref:System.Threading.CancellationToken>, and <xref:System.Threading.CancellationTokenSource>.  
   
- For more information, see [Patterns of Parallel Programming (download in PDF format)](https://download.microsoft.com/download/3/4/D/34D13993-2132-4E04-AE48-53D3150057BD/Patterns_of_Parallel_Programming_CSharp.pdf).  
+ For more information, see [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222).  
   
  Data parallelism with declarative, or query-like, syntax is supported by PLINQ. For more information, see [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md).  
   

--- a/docs/standard/parallel-programming/data-parallelism-task-parallel-library.md
+++ b/docs/standard/parallel-programming/data-parallelism-task-parallel-library.md
@@ -40,7 +40,7 @@ ms.workload:
   
  Both the <xref:System.Threading.Tasks.Parallel.For%2A?displayProperty=nameWithType> and <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType> methods have several overloads that let you stop or break loop execution, monitor the state of the loop on other threads, maintain thread-local state, finalize thread-local objects, control the degree of concurrency, and so on. The helper types that enable this functionality include <xref:System.Threading.Tasks.ParallelLoopState>, <xref:System.Threading.Tasks.ParallelOptions>, <xref:System.Threading.Tasks.ParallelLoopResult>, <xref:System.Threading.CancellationToken>, and <xref:System.Threading.CancellationTokenSource>.  
   
- For more information, see [Patterns of Parallel Programming](http://go.microsoft.com/fwlink/p/?LinkId=265491).  
+ For more information, see [Patterns of Parallel Programming (download in PDF format)](https://download.microsoft.com/download/3/4/D/34D13993-2132-4E04-AE48-53D3150057BD/Patterns_of_Parallel_Programming_CSharp.pdf).  
   
  Data parallelism with declarative, or query-like, syntax is supported by PLINQ. For more information, see [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md).  
   

--- a/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
+++ b/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
@@ -22,16 +22,14 @@ ms.workload:
 # For Further Reading (Parallel Programming)
 The following resources contain additional information about Parallel Programming in the .NET Framework:  
   
--   The [Parallel Computing Developer Center](http://go.microsoft.com/fwlink/?LinkID=160570) on the MSDN Web site has links to the latest content and forum posts about parallel programming in the .NET Framework, and in native C++.  
+-   The [Parallel Computing Developer Center](https://msdn.microsoft.com/vstudio/bb964701) on the MSDN Web site has links to the content and forum posts about parallel programming in the .NET Framework, and in native C++.  
   
--   The [Parallel Programming with .NET blog](http://go.microsoft.com/fwlink/?LinkID=169627) on the MSDN blog site contains many in-depth articles about parallel programming in the .NET Framework.  
+-   The [Parallel Programming with .NET blog](https://blogs.msdn.microsoft.com/pfxteam/) on the MSDN blog site contains many in-depth articles about parallel programming in the .NET Framework.  
   
--   The [Concurrency Visualizer blog](http://go.microsoft.com/fwlink/?LinkID=169630) on the MSDN blog site covers the new performance profiling tool that is included in some editions of [!INCLUDE[vs_dev10_long](../../../includes/vs-dev10-long-md.md)].  
+-   The [Parallel Extensions forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=parallelextensions) on the MSDN forums site is where to ask and answer questions about parallel programming.  
   
--   The [Parallel Extensions forum](http://go.microsoft.com/fwlink/?LinkID=169628) on the MSDN forums site is where to ask and answer questions about parallel programming.  
-  
--   The [Parallel Extensions Samples](http://go.microsoft.com/fwlink/?LinkID=165717) page on the MSDN Code Gallery Web site contains many samples that demonstrate intermediate and advanced parallel programming techniques.  
+-   The [Parallel Extensions Samples](https://code.msdn.microsoft.com/ParExtSamples) page on the MSDN Code Gallery Web site contains many samples that demonstrate intermediate and advanced parallel programming techniques.  
   
 ## See Also  
  [Parallel Programming](../../../docs/standard/parallel-programming/index.md)  
- [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](http://go.microsoft.com/fwlink/?LinkID=185142)
+ [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222)

--- a/docs/standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
+++ b/docs/standard/parallel-programming/how-to-iterate-file-directories-with-plinq.md
@@ -39,7 +39,7 @@ This example shows two simple ways to parallelize operations on file directories
   
  When using <xref:System.IO.Directory.GetFiles%2A>, be sure that you have sufficient permissions on all directories in the tree. Otherwise an exception will be thrown and no results will be returned. When using the <xref:System.IO.Directory.EnumerateDirectories%2A> in a PLINQ query, it is problematic to handle I/O exceptions in a graceful way that enables you to continue iterating. If your code must handle I/O or unauthorized access exceptions, then you should consider the approach described in [How to: Iterate File Directories with the Parallel Class](../../../docs/standard/parallel-programming/how-to-iterate-file-directories-with-the-parallel-class.md).  
   
- If I/O latency is an issue, for example with file I/O over a network, consider using one of the asynchronous I/O techniques described in [TPL and Traditional .NET Framework Asynchronous Programming](../../../docs/standard/parallel-programming/tpl-and-traditional-async-programming.md) and in this [blog post](http://go.microsoft.com/fwlink/?LinkID=186458).  
+ If I/O latency is an issue, for example with file I/O over a network, consider using one of the asynchronous I/O techniques described in [TPL and Traditional .NET Framework Asynchronous Programming](../../../docs/standard/parallel-programming/tpl-and-traditional-async-programming.md) and in this [blog post](https://blogs.msdn.microsoft.com/pfxteam/2009/08/04/parallel-extensions-and-io/).  
   
 ## See Also  
  [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md)

--- a/docs/standard/parallel-programming/index.md
+++ b/docs/standard/parallel-programming/index.md
@@ -38,5 +38,5 @@ Many personal computers and workstations have two or four cores (that is, CPUs) 
 |[For Further Reading](../../../docs/standard/parallel-programming/for-further-reading-parallel-programming.md)|Provides links to additional documentation and sample resources for parallel programming in the .NET Framework.|  
   
 ## See Also  
- [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](http://go.microsoft.com/fwlink/?LinkID=185142)  
+ [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222)  
  [Samples for Parallel Programming with the .NET Framework](http://code.msdn.microsoft.com/Samples-for-Parallel-b4b76364)

--- a/docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
+++ b/docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md
@@ -88,4 +88,4 @@ In many cases, <xref:System.Threading.Tasks.Parallel.For%2A?displayProperty=name
 ## See Also  
  [Parallel Programming](../../../docs/standard/parallel-programming/index.md)  
  [Potential Pitfalls with PLINQ](../../../docs/standard/parallel-programming/potential-pitfalls-with-plinq.md)  
- [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](http://go.microsoft.com/fwlink/?LinkID=185142)
+ [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222)

--- a/docs/standard/parallel-programming/tpl-and-traditional-async-programming.md
+++ b/docs/standard/parallel-programming/tpl-and-traditional-async-programming.md
@@ -122,7 +122,7 @@ The .NET Framework provides the following two standard patterns for performing I
  [!code-vb[FromAsync#09](../../../samples/snippets/visualbasic/VS_Snippets_Misc/fromasync/vb/module1.vb#09)]  
   
 ## Using the StreamExtensions Sample Code  
- The Streamextensions.cs file, in [Samples for Parallel Programming with the .NET Framework 4](http://go.microsoft.com/fwlink/?LinkID=165717) on the MSDN Web site, contains several reference implementations that use Task objects for asynchronous file and network I/O.  
+ The Streamextensions.cs file, in [Samples for Parallel Programming with the .NET Framework 4](https://code.msdn.microsoft.com/ParExtSamples), contains several reference implementations that use Task objects for asynchronous file and network I/O.  
   
 ## See Also  
  [Task Parallel Library (TPL)](../../../docs/standard/parallel-programming/task-parallel-library-tpl.md)


### PR DESCRIPTION
Replaced fwlinks in the **standard/parallel-programming** folder

I suggest to remove (fine to do it as part of this PR) the **for-further-reading-parallel-programming.md** file (and page) as its content looks to be outdated. The [Parallel Computing Developer Center](https://msdn.microsoft.com/vstudio/bb964701) contains links to msdn web-site, while docs.microsoft.com sites already have a lot of information covered by some of the links. [Parallel Programming with .NET blog](https://blogs.msdn.microsoft.com/pfxteam/) is not updated during the last three years. [Parallel Extensions forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=parallelextensions) also doesn't look active.

Relates to #3425 