### PR TITLE
adding missing language identifiers - 1/13

### DIFF
--- a/docs/csharp/misc/compiler-warning-cs3024.md
+++ b/docs/csharp/misc/compiler-warning-cs3024.md
@@ -26,7 +26,7 @@ Constraint type 'type' is not CLS-compliant.
 ## Example  
  The following example generates CS3024 in several locations:  
   
-```  
+```csharp  
 // cs3024.cs  
 // Compile with: /target:library  
  [assembly: System.CLSCompliant(true)]  

--- a/docs/csharp/misc/cs0011.md
+++ b/docs/csharp/misc/cs0011.md
@@ -23,7 +23,7 @@ The base class or interface 'class' in assembly 'assembly' referenced by type 't
   
 ## Example  
   
-```  
+```csharp  
 // CS0011_1.cs  
 // compile with: /target:library  
   
@@ -57,7 +57,7 @@ public class Outer {}
   
  The following sample generates CS0011.  
   
-```  
+```csharp  
 // CS0011_4.cs  
 // compile with: /reference:CS0011_1.dll /reference:CS0011_2.dll  
 // CS0011 expected  

--- a/docs/csharp/misc/cs0012.md
+++ b/docs/csharp/misc/cs0012.md
@@ -21,7 +21,7 @@ The type 'type' is defined in an assembly that is not referenced. You must add a
   
  The following sequence of compilations will result in CS0012:  
   
-```  
+```csharp  
 // cs0012a.cs  
 // compile with: /target:library  
 public class A {}  
@@ -29,7 +29,7 @@ public class A {}
   
  Then:  
   
-```  
+```csharp  
 // cs0012b.cs  
 // compile with: /target:library /reference:cs0012a.dll  
 public class B  
@@ -43,7 +43,7 @@ public class B
   
  Then:  
   
-```  
+```csharp  
 // cs0012c.cs  
 // compile with: /reference:cs0012b.dll  
 class C  

--- a/docs/csharp/misc/cs0017.md
+++ b/docs/csharp/misc/cs0017.md
@@ -23,7 +23,7 @@ Program 'output file name' has more than one entry point defined. Compile with /
   
  The following sample generates CS0017:  
   
-```  
+```csharp  
 // CS0017.cs  
 // compile with: /target:exe  
 public class clx  

--- a/docs/csharp/misc/cs0020.md
+++ b/docs/csharp/misc/cs0020.md
@@ -21,7 +21,7 @@ Division by constant zero
   
  The following sample generates CS0020:  
   
-```  
+```csharp  
 // CS0020.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0021.md
+++ b/docs/csharp/misc/cs0021.md
@@ -24,7 +24,7 @@ Cannot apply indexing with [] to an expression of type 'type'
 ## Example  
  This file compiles to a .dll file—with the `DefaultMember` attribute commented out—in order to generate the error.  
   
-```  
+```cpp  
 // CPP0021.cpp  
 // compile with: /clr /LD  
 using namespace System::Reflection;  
@@ -44,7 +44,7 @@ public ref class MyClassMC
 ## Example  
  The following is the C# file that calls the .dll file. This file attempts to access the class via an indexer, but because no member was declared as the default indexer to be used, the error is generated.  
   
-```  
+```csharp  
 // CS0021.cs  
 // compile with: /reference:CPP0021.dll  
 public class MyClass  

--- a/docs/csharp/misc/cs0022.md
+++ b/docs/csharp/misc/cs0022.md
@@ -22,7 +22,7 @@ Wrong number of indices inside [], expected 'number'
 ## Example  
  The following sample generates CS0022:  
   
-```  
+```csharp  
 // CS0022.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0023.md
+++ b/docs/csharp/misc/cs0023.md
@@ -21,7 +21,7 @@ Operator 'operator' cannot be applied to operand of type 'type'
   
  The following sample generates CS0023:  
   
-```  
+```csharp  
 // CS0023.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0026.md
+++ b/docs/csharp/misc/cs0026.md
@@ -22,7 +22,7 @@ Keyword 'this' is not valid in a static property, static method, or static field
 ## Example  
  The following example generates CS0026:  
   
-```  
+```csharp  
 // CS0026.cs  
 public class A  
 {  

--- a/docs/csharp/misc/cs0027.md
+++ b/docs/csharp/misc/cs0027.md
@@ -23,7 +23,7 @@ Keyword 'this' is not available in the current context
   
  The following example generates CS0027:  
   
-```  
+```csharp  
 using System;  
 using System.Collections.Generic;  
 using System.Text;  

--- a/docs/csharp/misc/cs0028.md
+++ b/docs/csharp/misc/cs0028.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0028:  
   
-```  
+```csharp  
 // CS0028.cs  
 // compile with: /W:4 /warnaserror  
 public class a  

--- a/docs/csharp/misc/cs0030.md
+++ b/docs/csharp/misc/cs0030.md
@@ -21,7 +21,7 @@ Cannot convert type 'type' to 'type'
   
  The following sample generates CS0030:  
   
-```  
+```csharp  
 // CS0030.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0031.md
+++ b/docs/csharp/misc/cs0031.md
@@ -21,7 +21,7 @@ Constant value 'value' cannot be converted to a 'type'. (use 'unchecked' syntax 
   
  The following sample generates CS0031 in both checked and unchecked contexts:  
   
-```  
+```csharp  
 // CS0031.cs  
 namespace CS0031  
 {  

--- a/docs/csharp/misc/cs0035.md
+++ b/docs/csharp/misc/cs0035.md
@@ -21,7 +21,7 @@ Operator 'operator' is ambiguous on an operand of type 'type'
   
  The following sample generates CS0035:  
   
-```  
+```csharp  
 // CS0035.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0036.md
+++ b/docs/csharp/misc/cs0036.md
@@ -21,7 +21,7 @@ An out parameter cannot have the '[In]' attribute
   
  The following sample generates CS0036:  
   
-```  
+```csharp  
 // CS0036.cs  
   
 using System;  

--- a/docs/csharp/misc/cs0037.md
+++ b/docs/csharp/misc/cs0037.md
@@ -21,7 +21,7 @@ Cannot convert null to 'type' because it is a non-nullable value type
   
  The following sample generates CS0037:  
   
-```  
+```csharp  
 // CS0037.cs  
 public struct s  
 {  

--- a/docs/csharp/misc/cs0053.md
+++ b/docs/csharp/misc/cs0053.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: property type 'type' is less accessible than propert
   
  The following sample generates CS0053:  
   
-```  
+```csharp  
 // CS0053.cs  
 class MyClass //defaults to private accessibility  
 // try the following line instead  

--- a/docs/csharp/misc/cs0054.md
+++ b/docs/csharp/misc/cs0054.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: indexer return type 'type' is less accessible than i
   
  The following sample generates CS0054:  
   
-```  
+```csharp  
 // CS0054.cs  
 class MyClass  
 // try the following line instead  

--- a/docs/csharp/misc/cs0055.md
+++ b/docs/csharp/misc/cs0055.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: parameter type 'type' is less accessible than indexe
   
  The following sample generates CS0055:  
   
-```  
+```csharp  
 // CS0055.cs  
 class MyClass //defaults to private accessibility  
 // try the following line instead  

--- a/docs/csharp/misc/cs0056.md
+++ b/docs/csharp/misc/cs0056.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: return type 'type' is less accessible than operator 
   
  The following sample generates CS0056:  
   
-```  
+```csharp  
 // CS0056.cs  
 class MyClass  
 // try the following line instead  

--- a/docs/csharp/misc/cs0057.md
+++ b/docs/csharp/misc/cs0057.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: parameter type 'type' is less accessible than operat
   
  The following sample generates CS0057:  
   
-```  
+```csharp  
 // CS0057.cs  
 class MyClass //defaults to private accessibility  
 // try the following line instead  

--- a/docs/csharp/misc/cs0058.md
+++ b/docs/csharp/misc/cs0058.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: return type 'type' is less accessible than delegate 
   
  The following sample generates CS0058 because no access modifier is applied to MyClass and therefore it is given private accessibility by default:  
   
-```  
+```csharp  
 // CS0058.cs  
 class MyClass  
 // try the following line instead  

--- a/docs/csharp/misc/cs0059.md
+++ b/docs/csharp/misc/cs0059.md
@@ -22,7 +22,7 @@ Inconsistent accessibility: parameter type 'type' is less accessible than delega
 ## Example  
  The following sample generates CS0059:  
   
-```  
+```csharp  
 // CS0059.cs  
 class MyClass //defaults to private accessibility  
 // try the following line instead  

--- a/docs/csharp/misc/cs0060.md
+++ b/docs/csharp/misc/cs0060.md
@@ -21,7 +21,7 @@ Inconsistent accessibility: base class 'class1' is less accessible than class 'c
   
  The following sample generates CS0060:  
   
-```  
+```csharp  
 // CS0060.cs  
 class MyClass  
 // try the following line instead  

--- a/docs/csharp/misc/cs0061.md
+++ b/docs/csharp/misc/cs0061.md
@@ -23,7 +23,7 @@ Inconsistent accessibility: base interface 'interface 1' is less accessible than
   
  The following sample generates CS0061.  
   
-```  
+```csharp  
 // CS0061.cs  
 // compile with: /target:library  
 internal interface A {}  

--- a/docs/csharp/misc/cs0065.md
+++ b/docs/csharp/misc/cs0065.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0065:  
   
-```  
+```csharp  
 // CS0065.cs  
 using System;  
 public delegate void Eventhandler(object sender, int e);  

--- a/docs/csharp/misc/cs0066.md
+++ b/docs/csharp/misc/cs0066.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0066:  
   
-```  
+```csharp  
 // CS0066.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0067.md
+++ b/docs/csharp/misc/cs0067.md
@@ -21,7 +21,7 @@ The event 'event' is never used
   
  The following sample generates CS0067:  
   
-```  
+```csharp  
 // CS0067.cs  
 // compile with: /W:3  
 using System;  

--- a/docs/csharp/misc/cs0068.md
+++ b/docs/csharp/misc/cs0068.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0068:  
   
-```  
+```csharp  
 // CS0068.cs  
   
 delegate void MyDelegate();  

--- a/docs/csharp/misc/cs0069.md
+++ b/docs/csharp/misc/cs0069.md
@@ -21,7 +21,7 @@ An event in an interface cannot have add or remove accessors
   
  The following sample generates CS0069:  
   
-```  
+```csharp  
 // CS0069.cs  
 // compile with: /target:library  
   

--- a/docs/csharp/misc/cs0070.md
+++ b/docs/csharp/misc/cs0070.md
@@ -21,7 +21,7 @@ The event 'event' can only appear on the left hand side of += or -= (except when
   
  The following sample generates CS0070:  
   
-```  
+```csharp  
 // CS0070.cs  
 using System;  
 public delegate void EventHandler();  

--- a/docs/csharp/misc/cs0072.md
+++ b/docs/csharp/misc/cs0072.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0072:  
   
-```  
+```csharp  
 // CS0072.cs  
 delegate void MyDelegate();  
   

--- a/docs/csharp/misc/cs0073.md
+++ b/docs/csharp/misc/cs0073.md
@@ -21,7 +21,7 @@ An add or remove accessor must have a body
   
  The following sample generates CS0073:  
   
-```  
+```csharp  
 // CS0073.cs  
 delegate void del();  
   

--- a/docs/csharp/misc/cs0074.md
+++ b/docs/csharp/misc/cs0074.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0074:  
   
-```  
+```csharp  
 // CS0074.cs  
 delegate void D();  
   

--- a/docs/csharp/misc/cs0075.md
+++ b/docs/csharp/misc/cs0075.md
@@ -23,7 +23,7 @@ To cast a negative value, you must enclose the value in parentheses
   
  The following code generates CS0075:  
   
-```  
+```csharp  
 // CS0075  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0077.md
+++ b/docs/csharp/misc/cs0077.md
@@ -21,7 +21,7 @@ The as operator must be used with a reference type or nullable type ('int' is a 
   
  The following sample generates CS0077:  
   
-```  
+```csharp  
 // CS0077.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0078.md
+++ b/docs/csharp/misc/cs0078.md
@@ -21,7 +21,7 @@ The 'l' suffix is easily confused with the digit '1' -- use 'L' for clarity
   
  The following sample generates CS0078:  
   
-```  
+```csharp  
 // CS0078.cs  
 // compile with: /W:4  
 class test {  

--- a/docs/csharp/misc/cs0079.md
+++ b/docs/csharp/misc/cs0079.md
@@ -21,7 +21,7 @@ The event 'event' can only appear on the left hand side of += or -=
   
  The following sample generates CS0079:  
   
-```  
+```csharp  
 // CS0079.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0080.md
+++ b/docs/csharp/misc/cs0080.md
@@ -21,7 +21,7 @@ Constraints are not allowed on non-generic declarations
   
  The following sample generates CS0080 because MyClass is not a generic class and Foo is not a generic method.  
   
-```  
+```csharp  
 namespace MyNamespace  
 {  
     public class MyClass where MyClass : System.IDisposable // CS0080    //the following line shows an example of correct syntax  

--- a/docs/csharp/misc/cs0081.md
+++ b/docs/csharp/misc/cs0081.md
@@ -19,7 +19,7 @@ Type parameter declaration must be an identifier not a type
   
  When you declare a generic method or type, specify the type parameter as an identifier, for example "T" or "inputType". When client code calls the method, it supplies the type, which replaces each occurrence of the identifier in the method or class body. For more information, see [Generic Type Parameters](../../csharp/programming-guide/generics/generic-type-parameters.md).  
   
-```  
+```csharp  
 // CS0081.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0082.md
+++ b/docs/csharp/misc/cs0082.md
@@ -22,7 +22,7 @@ Type 'type' already reserves a member called 'name' with the same parameter type
 ## Example  
  The following example generates CS0082:  
   
-```  
+```csharp  
 //cs0082.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0100.md
+++ b/docs/csharp/misc/cs0100.md
@@ -21,7 +21,7 @@ The parameter name 'parameter name' is a duplicate
   
  The following sample generates CS0100:  
   
-```  
+```csharp  
 // CS0100.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0101.md
+++ b/docs/csharp/misc/cs0101.md
@@ -21,7 +21,7 @@ The namespace 'namespace' already contains a definition for 'type'
   
  The following sample generates CS0101:  
   
-```  
+```csharp  
 // CS0101.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0102.md
+++ b/docs/csharp/misc/cs0102.md
@@ -22,7 +22,7 @@ The type 'type name' already contains a definition for 'identifier'
 ## Example  
  The following sample generates CS0102.  
   
-```  
+```csharp  
 // CS0102.cs  
 // compile with: /target:library  
 namespace MyApp  

--- a/docs/csharp/misc/cs0104.md
+++ b/docs/csharp/misc/cs0104.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0104:  
   
-```  
+```csharp  
 // CS0104.cs  
 using x;  
 using y;  

--- a/docs/csharp/misc/cs0105.md
+++ b/docs/csharp/misc/cs0105.md
@@ -21,7 +21,7 @@ The using directive for 'namespace' appeared previously in this namespace
   
  The following sample generates CS0105:  
   
-```  
+```csharp  
 // CS0105.cs  
 // compile with: /W:3  
 using System;  

--- a/docs/csharp/misc/cs0107.md
+++ b/docs/csharp/misc/cs0107.md
@@ -21,7 +21,7 @@ More than one protection modifier
   
  The following sample generates CS0107:  
   
-```  
+```csharp  
 // CS0107.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs0109.md
+++ b/docs/csharp/misc/cs0109.md
@@ -21,7 +21,7 @@ The member 'member' does not hide an inherited member. The new keyword is not re
   
  The following sample generates CS0109:  
   
-```  
+```csharp  
 // CS0109.cs  
 // compile with: /W:4  
 namespace x  

--- a/docs/csharp/misc/cs0110.md
+++ b/docs/csharp/misc/cs0110.md
@@ -21,7 +21,7 @@ The evaluation of the constant value for 'const declaration' involves a circular
   
  The following sample generates CS0110:  
   
-```  
+```csharp  
 // CS0110.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0111.md
+++ b/docs/csharp/misc/cs0111.md
@@ -22,7 +22,7 @@ Type 'class' already defines a member called 'member' with the same parameter ty
 ## Example  
  The following sample generates CS0111.  
   
-```  
+```csharp  
 // CS0111.cs  
 class A  
 {  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.