### PR TITLE
adding missing language identifiers - 2/13

### DIFF
--- a/docs/csharp/misc/cs0112.md
+++ b/docs/csharp/misc/cs0112.md
@@ -23,7 +23,7 @@ A static member 'function' cannot be marked as override, virtual or abstract
   
  The following sample generates CS0112:  
   
-```  
+```csharp  
 // CS0112.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0113.md
+++ b/docs/csharp/misc/cs0113.md
@@ -21,7 +21,7 @@ A member 'function' marked as override cannot be marked as new or virtual
   
  The following sample generates CS0113:  
   
-```  
+```csharp  
 // CS0113.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0114.md
+++ b/docs/csharp/misc/cs0114.md
@@ -23,7 +23,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0114:  
   
-```  
+```csharp  
 // CS0114.cs  
 // compile with: /W:2 /warnaserror  
 abstract public class clx  

--- a/docs/csharp/misc/cs0117.md
+++ b/docs/csharp/misc/cs0117.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0117:  
   
-```  
+```csharp  
 // CS0117.cs  
 public class BaseClass { }  
   

--- a/docs/csharp/misc/cs0118.md
+++ b/docs/csharp/misc/cs0118.md
@@ -32,7 +32,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0118.  
   
-```  
+```csharp  
 // CS0118.cs  
 // compile with: /target:library  
 namespace MyNamespace  

--- a/docs/csharp/misc/cs0119.md
+++ b/docs/csharp/misc/cs0119.md
@@ -28,7 +28,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0119.  
   
-```  
+```csharp  
 // CS0119.cs  
 using System;  
 public class MyClass   

--- a/docs/csharp/misc/cs0121.md
+++ b/docs/csharp/misc/cs0121.md
@@ -33,7 +33,7 @@ The call is ambiguous between the following methods or properties: 'method1' and
 ## Example  
  The following sample generates CS0121:  
   
-```  
+```csharp  
 // CS0121.cs  
 public class C  
 {  
@@ -63,7 +63,7 @@ public class C
 ## Example  
  The following example produces CS0121 in the current version of Visual Studio, but not in Visual Studio 2005:  
   
-```  
+```csharp  
 //CS0121_2.cs  
 class Program2  
 {  

--- a/docs/csharp/misc/cs0123.md
+++ b/docs/csharp/misc/cs0123.md
@@ -23,7 +23,7 @@ No overload for 'method' matches delegate 'delegate'
   
  The following sample generates CS0123.  
   
-```  
+```csharp  
 // CS0123.cs  
 delegate void D();  
 delegate void D2(int i);  

--- a/docs/csharp/misc/cs0126.md
+++ b/docs/csharp/misc/cs0126.md
@@ -21,7 +21,7 @@ An object of a type convertible to 'type' is required
   
  The following sample generates CS0126:  
   
-```  
+```csharp  
 // CS0126.cs  
 public class a  
 {  

--- a/docs/csharp/misc/cs0127.md
+++ b/docs/csharp/misc/cs0127.md
@@ -21,7 +21,7 @@ Since 'function' returns void, a return keyword must not be followed by an objec
   
  The following sample generates CS0127:  
   
-```  
+```csharp  
 // CS0127.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0128.md
+++ b/docs/csharp/misc/cs0128.md
@@ -21,7 +21,7 @@ A local variable named 'variable' is already defined in this scope
   
  The following sample generates CS0128:  
   
-```  
+```csharp  
 // CS0128.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0131.md
+++ b/docs/csharp/misc/cs0131.md
@@ -24,7 +24,7 @@ The left-hand side of an assignment must be a variable, property or indexer
 ## Example  
  The following sample generates CS0131.  
   
-```  
+```csharp  
 // CS0131.cs  
 public class MyClass  
 {  
@@ -42,7 +42,7 @@ public class MyClass
 ## Example  
  This error can also occur if you attempt to perform arithmetic operations on the left hand side of an assignment operator, as in the following example.  
   
-```  
+```csharp  
 // CS0131b.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs0132.md
+++ b/docs/csharp/misc/cs0132.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0132:  
   
-```  
+```csharp  
 // CS0132.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0133.md
+++ b/docs/csharp/misc/cs0133.md
@@ -21,7 +21,7 @@ The expression being assigned to 'variable' must be constant
   
  The following sample generates CS0133:  
   
-```  
+```csharp  
 // CS0133.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0138.md
+++ b/docs/csharp/misc/cs0138.md
@@ -21,7 +21,7 @@ A using namespace directive can only be applied to namespaces; 'type' is a type 
   
  The following sample generates CS0138:  
   
-```  
+```csharp  
 // CS0138.cs  
 using System.Object;   // CS0138  
 ```

--- a/docs/csharp/misc/cs0139.md
+++ b/docs/csharp/misc/cs0139.md
@@ -23,7 +23,7 @@ No enclosing loop out of which to break or continue
   
  The following sample generates CS0139 twice:  
   
-```  
+```csharp  
 // CS0139.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0140.md
+++ b/docs/csharp/misc/cs0140.md
@@ -21,7 +21,7 @@ The label 'label' is a duplicate
   
  The following sample generates CS0140:  
   
-```  
+```csharp  
 // CS0140.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0143.md
+++ b/docs/csharp/misc/cs0143.md
@@ -21,7 +21,7 @@ The type 'class' has no constructors defined
   
  The following sample generates CS0143:  
   
-```  
+```csharp  
 // CS0143.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0144.md
+++ b/docs/csharp/misc/cs0144.md
@@ -21,7 +21,7 @@ Cannot create an instance of the abstract class or interface 'interface'
   
  The following sample generates CS0144:  
   
-```  
+```csharp  
 // CS0144.cs  
 interface MyInterface  
 {  

--- a/docs/csharp/misc/cs0145.md
+++ b/docs/csharp/misc/cs0145.md
@@ -21,7 +21,7 @@ A const field requires a value to be provided
   
  The following sample generates CS0145:  
   
-```  
+```csharp  
 // CS0145.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0146.md
+++ b/docs/csharp/misc/cs0146.md
@@ -21,7 +21,7 @@ Circular base class dependency involving 'class1' and 'class2'
   
  The following sample generates CS0146:  
   
-```  
+```csharp  
 // CS0146.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0149.md
+++ b/docs/csharp/misc/cs0149.md
@@ -21,7 +21,7 @@ Method name expected
   
  The following sample generates CS0149:  
   
-```  
+```csharp  
 // CS0149.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0150.md
+++ b/docs/csharp/misc/cs0150.md
@@ -21,7 +21,7 @@ A constant value is expected
   
  The following sample generates CS0150:  
   
-```  
+```csharp  
 // CS0150.cs  
 namespace MyNamespace  
 {  
@@ -45,7 +45,7 @@ namespace MyNamespace
   
  This error is also produced when an array size is specified with a variable value and initialized with an array initializer. To remove the error, initialize the array in a separate statement or statements.  
   
-```  
+```csharp  
 // CS0150.cs  
     namespace MyNamespace  
     {  

--- a/docs/csharp/misc/cs0152.md
+++ b/docs/csharp/misc/cs0152.md
@@ -21,7 +21,7 @@ The label 'label' already occurs in this switch statement
   
  The following sample generates CS0152:  
   
-```  
+```csharp  
 // CS0152.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0153.md
+++ b/docs/csharp/misc/cs0153.md
@@ -21,7 +21,7 @@ A goto case is only valid inside a switch statement
   
  The following sample generates CS0153:  
   
-```  
+```csharp  
 // CS0153.cs  
 public class a  
 {  

--- a/docs/csharp/misc/cs0154.md
+++ b/docs/csharp/misc/cs0154.md
@@ -22,7 +22,7 @@ The property or indexer 'property' cannot be used in this context because it lac
 ## Example  
  The following sample generates CS0154:  
   
-```  
+```csharp  
 // CS0154.cs  
 public class MyClass2  
 {  

--- a/docs/csharp/misc/cs0155.md
+++ b/docs/csharp/misc/cs0155.md
@@ -21,7 +21,7 @@ The type caught or thrown must be derived from System.Exception
   
  The following sample generates CS0155:  
   
-```  
+```csharp  
 // CS0155.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0156.md
+++ b/docs/csharp/misc/cs0156.md
@@ -23,7 +23,7 @@ A throw statement with no arguments is not allowed in a finally clause that is n
   
  The following sample generates CS0156:  
   
-```  
+```csharp  
 // CS0156.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0157.md
+++ b/docs/csharp/misc/cs0157.md
@@ -21,7 +21,7 @@ Control cannot leave the body of a finally clause
   
  The following sample generates CS0157:  
   
-```  
+```csharp  
 // CS0157.cs  
 using System;  
 namespace MyNamespace  

--- a/docs/csharp/misc/cs0158.md
+++ b/docs/csharp/misc/cs0158.md
@@ -21,7 +21,7 @@ The label 'label' shadows another label by the same name in a contained scope
   
  The following sample generates CS0158:  
   
-```  
+```csharp  
 // CS0158.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0159.md
+++ b/docs/csharp/misc/cs0159.md
@@ -21,7 +21,7 @@ No such label 'label' within the scope of the goto statement
   
  The following sample generates CS0159:  
   
-```  
+```csharp  
 // CS0159.cs  
 public class Class1  
 {  

--- a/docs/csharp/misc/cs0160.md
+++ b/docs/csharp/misc/cs0160.md
@@ -23,7 +23,7 @@ A previous catch clause already catches all exceptions of this or of a super typ
   
  The following sample generates CS0160:  
   
-```  
+```csharp  
 // CS0160.cs  
 public class MyClass2 : System.Exception {}  
 public class MyClass  

--- a/docs/csharp/misc/cs0161.md
+++ b/docs/csharp/misc/cs0161.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0161:  
   
-```  
+```csharp  
 // CS0161.cs  
 public class Test  
 {  

--- a/docs/csharp/misc/cs0162.md
+++ b/docs/csharp/misc/cs0162.md
@@ -21,7 +21,7 @@ Unreachable code detected
   
  The following sample generates CS0162:  
   
-```  
+```csharp  
 // CS0162.cs  
 // compile with: /W:2  
 public class A  

--- a/docs/csharp/misc/cs0164.md
+++ b/docs/csharp/misc/cs0164.md
@@ -21,7 +21,7 @@ This label has not been referenced
   
  The following sample generates CS0164:  
   
-```  
+```csharp  
 // CS0164.cs  
 // compile with: /W:2  
 public class a  

--- a/docs/csharp/misc/cs0169.md
+++ b/docs/csharp/misc/cs0169.md
@@ -21,7 +21,7 @@ The private field 'class member' is never used
   
  The following sample generates CS0169:  
   
-```  
+```csharp  
 // compile with: /W:3  
 using System;  
 public class ClassX  

--- a/docs/csharp/misc/cs0170.md
+++ b/docs/csharp/misc/cs0170.md
@@ -21,7 +21,7 @@ Use of possibly unassigned field 'field'
   
  The following sample generates CS0170:  
   
-```  
+```csharp  
 // CS0170.cs  
 public struct error  
 {  

--- a/docs/csharp/misc/cs0171.md
+++ b/docs/csharp/misc/cs0171.md
@@ -21,7 +21,7 @@ Backing field for automatically implemented property 'name' must be fully assign
   
  The following sample generates CS0171:  
   
-```  
+```csharp  
 // CS0171.cs  
 struct MyStruct  
 {  

--- a/docs/csharp/misc/cs0172.md
+++ b/docs/csharp/misc/cs0172.md
@@ -21,7 +21,7 @@ Type of conditional expression cannot be determined because 'type1' and 'type2' 
   
  The following sample generates CS0172:  
   
-```  
+```csharp  
 // CS0172.cs  
 public class Square  
 {  

--- a/docs/csharp/misc/cs0175.md
+++ b/docs/csharp/misc/cs0175.md
@@ -21,7 +21,7 @@ Use of keyword 'base' is not valid in this context
   
  The following sample generates CS0175:  
   
-```  
+```csharp  
 // CS0175.cs  
 using System;  
 class BaseClass  

--- a/docs/csharp/misc/cs0176.md
+++ b/docs/csharp/misc/cs0176.md
@@ -21,7 +21,7 @@ Static member 'member' cannot be accessed with an instance reference; qualify it
   
  The following sample generates CS0176:  
   
-```  
+```csharp  
 // CS0176.cs  
 public class MyClass2  
 {  

--- a/docs/csharp/misc/cs0177.md
+++ b/docs/csharp/misc/cs0177.md
@@ -21,7 +21,7 @@ The out parameter 'parameter' must be assigned to before control leaves the curr
   
  The following sample generates CS0177:  
   
-```  
+```csharp  
 // CS0177.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0179.md
+++ b/docs/csharp/misc/cs0179.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0179:  
   
-```  
+```csharp  
 // CS0179.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0180.md
+++ b/docs/csharp/misc/cs0180.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0180:  
   
-```  
+```csharp  
 // CS0180.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0182.md
+++ b/docs/csharp/misc/cs0182.md
@@ -34,7 +34,7 @@ An attribute argument must be a constant expression, typeof expression or array 
 ## Example  
  The following sample generates CS0182:  
   
-```  
+```csharp  
 // CS0182.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0183.md
+++ b/docs/csharp/misc/cs0183.md
@@ -21,7 +21,7 @@ The given expression is always of the provided ('type') type
   
  The following sample generates CS0183:  
   
-```  
+```csharp  
 // CS0183.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/misc/cs0184.md
+++ b/docs/csharp/misc/cs0184.md
@@ -21,7 +21,7 @@ The given expression is never of the provided ('type') type
   
  The following sample generates CS0184:  
   
-```  
+```csharp  
 // CS0184.cs  
 // compile with: /W:1  
 class MyClass  

--- a/docs/csharp/misc/cs0185.md
+++ b/docs/csharp/misc/cs0185.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0185:  
   
-```  
+```csharp  
 // CS0185.cs  
 public class MainClass  
 {  

--- a/docs/csharp/misc/cs0186.md
+++ b/docs/csharp/misc/cs0186.md
@@ -19,7 +19,7 @@ Use of null is not valid in this context
   
  The following sample generates CS0186:  
   
-```  
+```csharp  
 // CS0186.cs  
 using System;  
 using System.Collections;  

--- a/docs/csharp/misc/cs0191.md
+++ b/docs/csharp/misc/cs0191.md
@@ -24,7 +24,7 @@ Property or indexer 'name' cannot be assigned to -- it is read only
 ## Example  
  The following sample generates CS0191.  
   
-```  
+```csharp  
 // CS0191.cs  
 class MyClass  
 {  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.