### PR TITLE
adding missing language identifiers - 3/13

### DIFF
--- a/docs/csharp/misc/cs0192.md
+++ b/docs/csharp/misc/cs0192.md
@@ -24,7 +24,7 @@ Fields of static readonly field 'name' cannot be passed ref or out (except in a 
 ## Example  
  The following sample generates CS0192.  
   
-```  
+```csharp 
 // CS0192.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0193.md
+++ b/docs/csharp/misc/cs0193.md
@@ -21,7 +21,7 @@ The * or -> operator must be applied to a pointer
   
  The following sample generates CS0193:  
   
-```  
+```csharp  
 // CS0193.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0196.md
+++ b/docs/csharp/misc/cs0196.md
@@ -21,7 +21,7 @@ A pointer must be indexed by only one value
   
  The following sample generates CS0196:  
   
-```  
+```csharp  
 // CS0196.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0197.md
+++ b/docs/csharp/misc/cs0197.md
@@ -22,7 +22,7 @@ Passing 'argument' as ref or out or taking its address may cause a runtime excep
 ## Example  
  The following sample generates CS0197.  
   
-```  
+```csharp  
 // CS0197.cs  
 // compile with: /W:1  
 class X : System.MarshalByRefObject  

--- a/docs/csharp/misc/cs0198.md
+++ b/docs/csharp/misc/cs0198.md
@@ -21,7 +21,7 @@ Fields of static readonly field 'name' cannot be assigned to (except in a static
   
  The following sample generates CS0198:  
   
-```  
+```csharp  
 // CS0198.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0199.md
+++ b/docs/csharp/misc/cs0199.md
@@ -22,7 +22,7 @@ Fields of static readonly field 'name' cannot be passed ref or out (except in a 
 ## Example  
  The following sample generates CS0199:  
   
-```  
+```csharp  
 // CS0199.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0200.md
+++ b/docs/csharp/misc/cs0200.md
@@ -22,7 +22,7 @@ Property or indexer 'property' cannot be assigned to — it is read only
 ## Example  
  The following sample generates CS0200:  
   
-```  
+```csharp  
 // CS0200.cs  
 public class MainClass  
 {  

--- a/docs/csharp/misc/cs0202.md
+++ b/docs/csharp/misc/cs0202.md
@@ -24,7 +24,7 @@ foreach requires that the return type 'type' of 'type.GetEnumerator()' must have
   
  The following sample generates CS0202:  
   
-```  
+```csharp  
 // CS0202.cs  
   
 public class C1  

--- a/docs/csharp/misc/cs0205.md
+++ b/docs/csharp/misc/cs0205.md
@@ -21,7 +21,7 @@ Cannot call an abstract base member: 'method'
   
  The following sample generates CS0205:  
   
-```  
+```csharp  
 // CS0205.cs  
 abstract public class MyClass  
 {  

--- a/docs/csharp/misc/cs0206.md
+++ b/docs/csharp/misc/cs0206.md
@@ -22,7 +22,7 @@ A property or indexer may not be passed as an out or ref parameter
 ## Example  
  The following sample generates CS0206:  
   
-```  
+```csharp  
 // CS0206.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0208.md
+++ b/docs/csharp/misc/cs0208.md
@@ -28,7 +28,7 @@ Cannot take the address of, get the size of, or declare a pointer to a managed t
 ## Example  
  The following sample generates CS0208:  
   
-```  
+```csharp  
 // CS0208.cs  
 // compile with: /unsafe  
   

--- a/docs/csharp/misc/cs0209.md
+++ b/docs/csharp/misc/cs0209.md
@@ -21,7 +21,7 @@ The type of local declared in a fixed statement must be a pointer type
   
  The following sample generates CS0209:  
   
-```  
+```csharp  
 // CS0209.cs  
 // compile with: /unsafe  
   

--- a/docs/csharp/misc/cs0210.md
+++ b/docs/csharp/misc/cs0210.md
@@ -21,7 +21,7 @@ You must provide an initializer in a fixed or using statement declaration
   
  The following sample generates CS0210:  
   
-```  
+```csharp  
 // CS0210a.cs  
 // compile with: /unsafe  
   
@@ -54,7 +54,7 @@ public class MyClass
   
  The following sample also generates CS0210 because the [using statement](../../csharp/language-reference/keywords/using-statement.md) has no initializer.  
   
-```  
+```csharp  
 // CS0210b.cs  
   
 using System.IO;  

--- a/docs/csharp/misc/cs0211.md
+++ b/docs/csharp/misc/cs0211.md
@@ -21,7 +21,7 @@ Cannot take the address of the given expression
   
  The following sample generates CS0211:  
   
-```  
+```csharp  
 // CS0211.cs  
 // compile with: /unsafe  
   

--- a/docs/csharp/misc/cs0212.md
+++ b/docs/csharp/misc/cs0212.md
@@ -21,7 +21,7 @@ You can only take the address of an unfixed expression inside of a fixed stateme
   
  The following sample shows how to take the address of an unfixed expression. The following sample generates CS0212.  
   
-```  
+```csharp  
 // CS0212a.cs  
 // compile with: /unsafe /target:library  
   
@@ -43,7 +43,7 @@ public class A {
   
  The following sample also generates CS0212 and shows how to resolve the error:  
   
-```  
+```csharp  
 // CS0212b.cs  
 // compile with: /unsafe /target:library  
 using System;  

--- a/docs/csharp/misc/cs0213.md
+++ b/docs/csharp/misc/cs0213.md
@@ -22,7 +22,7 @@ You cannot use the fixed statement to take the address of an already fixed expre
 ## Example  
  The following sample generates CS0213.  
   
-```  
+```csharp  
 // CS0213.cs  
 // compile with: /unsafe  
 public class MyClass  

--- a/docs/csharp/misc/cs0214.md
+++ b/docs/csharp/misc/cs0214.md
@@ -21,7 +21,7 @@ Pointers and fixed size buffers may only be used in an unsafe context
   
  The following sample generates CS0214:  
   
-```  
+```csharp  
 // CS0214.cs  
 // compile with: /target:library /unsafe  
 public struct S  

--- a/docs/csharp/misc/cs0215.md
+++ b/docs/csharp/misc/cs0215.md
@@ -21,7 +21,7 @@ The return type of operator True or False must be bool
   
  The following sample generates CS0215:  
   
-```  
+```csharp  
 // CS0215.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0216.md
+++ b/docs/csharp/misc/cs0216.md
@@ -21,7 +21,7 @@ The operator 'operator' requires a matching operator 'missing_operator' to also 
   
  The following sample generates CS0216:  
   
-```  
+```csharp  
 // CS0216.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0217.md
+++ b/docs/csharp/misc/cs0217.md
@@ -21,7 +21,7 @@ In order to be applicable as a short circuit operator a user-defined logical ope
   
  The following sample generates CS0217:  
   
-```  
+```csharp  
 // CS0217.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0218.md
+++ b/docs/csharp/misc/cs0218.md
@@ -21,7 +21,7 @@ The type ('type') must contain declarations of operator true and operator false
   
  The following sample generates CS0218:  
   
-```  
+```csharp  
 // CS0218.cs  
 using System;  
 public class MyClass  

--- a/docs/csharp/misc/cs0219.md
+++ b/docs/csharp/misc/cs0219.md
@@ -21,7 +21,7 @@ The variable 'variable' is assigned but its value is never used
   
  The following sample generates CS0219:  
   
-```  
+```csharp  
 // CS0219.cs  
 // compile with: /W:3  
 public class MyClass  

--- a/docs/csharp/misc/cs0220.md
+++ b/docs/csharp/misc/cs0220.md
@@ -21,7 +21,7 @@ The operation overflows at compile time in checked mode
   
  The following sample generates CS0220:  
   
-```  
+```csharp  
 // CS0220.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0221.md
+++ b/docs/csharp/misc/cs0221.md
@@ -21,7 +21,7 @@ Constant value 'value' cannot be converted to a 'type' (use 'unchecked' syntax t
   
  The following sample generates CS0221:  
   
-```  
+```csharp  
 // CS0221.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0225.md
+++ b/docs/csharp/misc/cs0225.md
@@ -22,7 +22,7 @@ The params parameter must be a single dimensional array
 ## Example  
  The following sample generates CS0225:  
   
-```  
+```csharp  
 // CS0225.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0226.md
+++ b/docs/csharp/misc/cs0226.md
@@ -22,7 +22,7 @@ An __arglist expression may only appear inside of a call or new expression.
 ## Example  
  The following code generates CS0226:  
   
-```  
+```csharp  
 // cs0226.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0227.md
+++ b/docs/csharp/misc/cs0227.md
@@ -23,7 +23,7 @@ Unsafe code may only appear if compiling with /unsafe
   
  The following sample, when compiled without **/unsafe**, will generate CS0227:  
   
-```  
+```csharp  
 // CS0227.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0230.md
+++ b/docs/csharp/misc/cs0230.md
@@ -21,7 +21,7 @@ Type and identifier are both required in a foreach statement
   
  The following sample generates CS0230:  
   
-```  
+```csharp  
 // CS0230.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0231.md
+++ b/docs/csharp/misc/cs0231.md
@@ -21,7 +21,7 @@ A params parameter must be the last parameter in a formal parameter list.
   
  The following sample generates CS0231:  
   
-```  
+```csharp  
 // CS0231.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs0236.md
+++ b/docs/csharp/misc/cs0236.md
@@ -21,7 +21,7 @@ A field initializer cannot reference the nonstatic field, method, or property 'f
   
  The following sample generates CS0236:  
   
-```  
+```csharp  
 // CS0236.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0238.md
+++ b/docs/csharp/misc/cs0238.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0238:  
   
-```  
+```csharp  
 // CS0238.cs  
 abstract class MyClass  
 {  

--- a/docs/csharp/misc/cs0239.md
+++ b/docs/csharp/misc/cs0239.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0239:  
   
-```  
+```csharp  
 // CS0239.cs  
 abstract class MyClass  
 {  

--- a/docs/csharp/misc/cs0241.md
+++ b/docs/csharp/misc/cs0241.md
@@ -26,7 +26,7 @@ Default parameter specifiers are not permitted
 ## Example  
  The following sample generates CS0241. In addition, the sample shows how to simulate, with overloading, a method with default arguments.  
   
-```  
+```csharp  
 // CS0241.cs  
 public class A  
 {  

--- a/docs/csharp/misc/cs0242.md
+++ b/docs/csharp/misc/cs0242.md
@@ -21,7 +21,7 @@ The operation in question is undefined on void pointers
   
  The following sample generates CS0242:  
   
-```  
+```csharp  
 // CS0242.cs  
 // compile with: /unsafe  
 class TestClass  

--- a/docs/csharp/misc/cs0243.md
+++ b/docs/csharp/misc/cs0243.md
@@ -23,7 +23,7 @@ The Conditional attribute is not valid on 'method' because it is an override met
   
  The following sample generates CS0243:  
   
-```  
+```csharp  
 // CS0243.cs  
 // compile with: /target:library  
 public class MyClass  

--- a/docs/csharp/misc/cs0244.md
+++ b/docs/csharp/misc/cs0244.md
@@ -21,7 +21,7 @@ Neither 'is' nor 'as' is valid on pointer types
   
  The following sample generates CS0244:  
   
-```  
+```csharp  
 // CS0244.cs  
 // compile with: /unsafe  
   

--- a/docs/csharp/misc/cs0245.md
+++ b/docs/csharp/misc/cs0245.md
@@ -21,7 +21,7 @@ Destructors and object.Finalize cannot be called directly. Consider calling IDis
   
  The following sample generates CS0245:  
   
-```  
+```csharp  
 // CS0245.cs  
 using System;  
 using System.Collections;  

--- a/docs/csharp/misc/cs0247.md
+++ b/docs/csharp/misc/cs0247.md
@@ -21,7 +21,7 @@ Cannot use a negative size with stackalloc
   
  The following sample generates CS0247:  
   
-```  
+```csharp  
 // CS0247.cs  
 // compile with: /unsafe  
 public class MyClass  

--- a/docs/csharp/misc/cs0248.md
+++ b/docs/csharp/misc/cs0248.md
@@ -22,7 +22,7 @@ Cannot create an array with a negative size
 ## Example  
  The following sample generates CS0248:  
   
-```  
+```csharp  
 // CS0248.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0249.md
+++ b/docs/csharp/misc/cs0249.md
@@ -23,7 +23,7 @@ Do not override object.Finalize. Instead, provide a destructor.
   
  The following sample generates CS0249:  
   
-```  
+```csharp  
 // CS0249.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0250.md
+++ b/docs/csharp/misc/cs0250.md
@@ -23,7 +23,7 @@ Do not directly call your base class Finalize method. It is called automatically
   
  The following sample generates CS0250  
   
-```  
+```csharp  
 // CS0250.cs  
 class B  
 {  

--- a/docs/csharp/misc/cs0251.md
+++ b/docs/csharp/misc/cs0251.md
@@ -21,7 +21,7 @@ Indexing an array with a negative index (array indices always start at zero)
   
  The following sample generates CS0251:  
   
-```  
+```csharp  
 // CS0251.cs  
 // compile with: /W:2  
 class MyClass  

--- a/docs/csharp/misc/cs0252.md
+++ b/docs/csharp/misc/cs0252.md
@@ -21,7 +21,7 @@ Possible unintended reference comparison; to get a value comparison, cast the le
   
  The following sample generates CS0252:  
   
-```  
+```csharp  
 // CS0252.cs  
 // compile with: /W:2  
 using System;  

--- a/docs/csharp/misc/cs0253.md
+++ b/docs/csharp/misc/cs0253.md
@@ -21,7 +21,7 @@ Possible unintended reference comparison; to get a value comparison, cast the ri
   
  The following sample generates CS0253:  
   
-```  
+```csharp 
 // CS0253.cs  
 // compile with: /W:2  
 using System;  

--- a/docs/csharp/misc/cs0254.md
+++ b/docs/csharp/misc/cs0254.md
@@ -21,7 +21,7 @@ The right hand side of a fixed statement assignment may not be a cast expression
   
  The following sample generates CS0254:  
   
-```  
+```csharp  
 // CS0254.cs  
 // compile with: /unsafe  
 class Point  

--- a/docs/csharp/misc/cs0255.md
+++ b/docs/csharp/misc/cs0255.md
@@ -21,7 +21,7 @@ stackalloc may not be used in a catch or finally block
   
  The following sample generates CS0255:  
   
-```  
+```csharp  
 // CS0255.cs  
 // compile with: /unsafe  
 using System;  

--- a/docs/csharp/misc/cs0261.md
+++ b/docs/csharp/misc/cs0261.md
@@ -21,7 +21,7 @@ Partial declarations of 'type' must be all classes, all structs, or all interfac
   
  The following sample generates CS0261:  
   
-```  
+```csharp  
 // CS0261.cs  
 partial class A  // CS0261 – A declared as a class here, but as a struct below  
 {  

--- a/docs/csharp/misc/cs0262.md
+++ b/docs/csharp/misc/cs0262.md
@@ -22,7 +22,7 @@ Partial declarations of 'type' have conflicting accessibility modifiers
 ## Example  
  The following sample generates CS0262:  
   
-```  
+```csharp  
 // CS0262.cs  
 class A  
 {  

--- a/docs/csharp/misc/cs0263.md
+++ b/docs/csharp/misc/cs0263.md
@@ -21,7 +21,7 @@ Partial declarations of 'type' must not specify different base classes
   
  The following sample generates CS0263:  
   
-```  
+```csharp  
 // CS0263.cs  
 // compile with: /target:library  
 class B1  

--- a/docs/csharp/misc/cs0264.md
+++ b/docs/csharp/misc/cs0264.md
@@ -22,7 +22,7 @@ Partial declarations of 'type' must have the same type parameter names in the sa
 ## Example  
  The following example generates CS0264.  
   
-```  
+```csharp  
 // CS0264.cs  
   
 partial class MyClass<T>  // CS0264  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.