### PR TITLE
adding missing language identifiers - 4/13

### DIFF
--- a/docs/csharp/misc/cs0265.md
+++ b/docs/csharp/misc/cs0265.md
@@ -24,7 +24,7 @@ Partial declarations of 'type' have inconsistent constraints for type parameter 
 ## Example  
  In this code, the partial class definitions are all in a single file, but they could also be spread across multiple files.  
   
-```  
+```csharp  
 // CS0265.cs  
 public class GenericsErrors   
 {  

--- a/docs/csharp/misc/cs0267.md
+++ b/docs/csharp/misc/cs0267.md
@@ -21,7 +21,7 @@ The partial modifier can only appear immediately before 'class', 'struct', or 'i
   
  The following sample generates CS0267:  
   
-```  
+```csharp  
 // CS0267.cs  
 public partial class MyClass  
 {  

--- a/docs/csharp/misc/cs0271.md
+++ b/docs/csharp/misc/cs0271.md
@@ -21,7 +21,7 @@ The property or indexer 'property/indexer' cannot be used in this context becaus
   
  The following example generates CS0271:  
   
-```  
+```csharp  
 // CS0271.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0272.md
+++ b/docs/csharp/misc/cs0272.md
@@ -22,7 +22,7 @@ The property or indexer 'property/indexer' cannot be used in this context becaus
 ## Example  
  The following example generates CS0272:  
   
-```  
+```csharp  
 // CS0272.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0273.md
+++ b/docs/csharp/misc/cs0273.md
@@ -24,7 +24,7 @@ The accessibility modifier of the 'property_accessor' accessor must be more rest
 ## Example  
  This sample contains an internal property with an internal set method. The following sample generates CS0273.  
   
-```  
+```csharp  
 // CS0273.cs  
 // compile with: /target:library  
 public class MyClass  

--- a/docs/csharp/misc/cs0274.md
+++ b/docs/csharp/misc/cs0274.md
@@ -21,7 +21,7 @@ Cannot specify accessibility modifiers for both accessors of the property or ind
   
  The following example generates CS0274:  
   
-```  
+```csharp  
 // CS0274.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0275.md
+++ b/docs/csharp/misc/cs0275.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS0275:  
   
-```  
+```csharp  
 // CS0275.cs  
 public interface MyInterface  
 {  

--- a/docs/csharp/misc/cs0276.md
+++ b/docs/csharp/misc/cs0276.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS0276:  
   
-```  
+```csharp  
 // CS0276.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0277.md
+++ b/docs/csharp/misc/cs0277.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS0277:  
   
-```  
+```csharp  
 // CS0277.cs  
 public interface MyInterface  
 {  

--- a/docs/csharp/misc/cs0278.md
+++ b/docs/csharp/misc/cs0278.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0278.  
   
-```  
+```csharp  
 // CS0278.cs  
 using System.Collections.Generic;  
 public class myTest   

--- a/docs/csharp/misc/cs0279.md
+++ b/docs/csharp/misc/cs0279.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS0279:  
   
-```  
+```csharp  
 // CS0279.cs  
   
 using System;  

--- a/docs/csharp/misc/cs0280.md
+++ b/docs/csharp/misc/cs0280.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0280.  
   
-```  
+```csharp  
 // CS0280.cs  
 using System;  
 using System.Collections;  

--- a/docs/csharp/misc/cs0281.md
+++ b/docs/csharp/misc/cs0281.md
@@ -34,7 +34,7 @@ Friend access was granted to 'AssemblyName1', but the output assembly is named '
   
 -   sn -tp key.publickey  
   
-```  
+```csharp  
 // CS0281.cs  
 // compile with: /target:library /keyfile:CS0281.snk  
 public class A {}  
@@ -42,7 +42,7 @@ public class A {}
   
 ## Example  
   
-```  
+```csharp  
 // CS0281_b.cs  
 // compile with: /target:library /keyfile:CS0281.snk /reference:CS0281.dll  
 [assembly:System.Runtime.CompilerServices.InternalsVisibleTo("CS0281 , PublicKey=00240000048000009400000006020000002400005253413100040000010001004b2d4d56af7c50be2fcbbf97cb880b9e73ad84467a587191fef63aadc118a96cecf9d508cd679c907b6e20f71684300bdc2c0a851019af0c96b29bf8f1339753276041aefd67db46139e6348b3a12f29537b4dc6c2c19829df2c9ed6803f3c63c3b84cfa2728849386aea575c543a5f70fa85793d2946f15f7fe1ccb0c5e8fe0")]  
@@ -54,7 +54,7 @@ class B : A {}
   
  Notice that this sample creates an output file with the same name as the output file in the first sample. To resolve, do not change the assembly attributes of the component and add class C.  
   
-```  
+```csharp  
 // CS0281_c.cs  
 // compile with: /target:library /out:CS0281.dll /keyfile:CS0281.snk /reference:CS0281_b.dll  
 // CS0281 expected  

--- a/docs/csharp/misc/cs0282.md
+++ b/docs/csharp/misc/cs0282.md
@@ -28,7 +28,7 @@ There is no defined ordering between fields in multiple declarations of partial 
   
  `csc /targt:library cs0282_1.cs cs0282_2.cs`  
   
-```  
+```csharp  
 partial struct A  
 {  
     int i;  
@@ -38,7 +38,7 @@ partial struct A
 ## Example  
  This code contains a conflicting description of the same `struct`.  
   
-```  
+```csharp  
 partial struct A  
 {  
     int j;  

--- a/docs/csharp/misc/cs0283.md
+++ b/docs/csharp/misc/cs0283.md
@@ -22,7 +22,7 @@ The type 'type' cannot be declared const
 ## Example  
  The following example generates CS0283.  
   
-```  
+```csharp  
 // CS0283.cs  
 struct MyTest  
 {  

--- a/docs/csharp/misc/cs0305.md
+++ b/docs/csharp/misc/cs0305.md
@@ -22,7 +22,7 @@ Using the generic type 'generic type' requires 'number' type arguments
 ## Example  
  The following sample generates CS0305.  
   
-```  
+```csharp  
 // CS0305.cs  
 public class MyList<T> {}  
 public class MyClass<T> {}  

--- a/docs/csharp/misc/cs0306.md
+++ b/docs/csharp/misc/cs0306.md
@@ -21,7 +21,7 @@ The type 'type' may not be used as a type argument
   
  The following example generates CS0306:  
   
-```  
+```csharp  
 // CS0306.cs  
 class C<T>  
 {  

--- a/docs/csharp/misc/cs0307.md
+++ b/docs/csharp/misc/cs0307.md
@@ -21,7 +21,7 @@ The 'construct' 'identifier' is not a generic method. If you intended an express
   
  The following sample generates CS0307:  
   
-```  
+```csharp  
 // CS0307.cs  
 class C  
 {  

--- a/docs/csharp/misc/cs0308.md
+++ b/docs/csharp/misc/cs0308.md
@@ -21,7 +21,7 @@ The non-generic type-or-method 'identifier' cannot be used with type arguments.
   
  The following example generates CS0308:  
   
-```  
+```csharp  
 // CS0308a.cs  
 class MyClass  
 {  
@@ -37,7 +37,7 @@ class MyClass
   
  The following example also generates CS0308. To resolve the error, use the directive "using System.Collections.Generic."  
   
-```  
+```csharp  
 // CS0308b.cs  
 // compile with: /t:library  
 using System.Collections;  

--- a/docs/csharp/misc/cs0312.md
+++ b/docs/csharp/misc/cs0312.md
@@ -28,7 +28,7 @@ The type 'type1' cannot be used as type parameter 'name' in the generic type or 
 ## Example  
  The following code generates CS0312:  
   
-```  
+```csharp  
 // cs0312.cs  
 class Program  
 {  

--- a/docs/csharp/misc/cs0313.md
+++ b/docs/csharp/misc/cs0313.md
@@ -23,14 +23,14 @@ The type 'type1' cannot be used as type parameter 'parameter name' in the generi
   
 1.  Using the code that follows as an example, one solution is to specify an ordinary `ImplStruct` as the first type argument in the call to `TestMethod`. Then modify `TestMethod` to create a nullable version of `Implstruct` in its return statement:  
   
-    ```  
+    ```csharp  
     return new Nullable<T>(t);  
     ```  
   
 ## Example  
  The following code generates CS0313:  
   
-```  
+```csharp  
 // cs0313.cs  
 public interface BaseInterface { }  
 public struct ImplStruct : BaseInterface { }  

--- a/docs/csharp/misc/cs0314.md
+++ b/docs/csharp/misc/cs0314.md
@@ -26,7 +26,7 @@ The type 'type1' cannot be used as type parameter 'name' in the generic type or 
 ## Example  
  The following code generates CS0314:  
   
-```  
+```csharp  
 // cs0314.cs  
 // Compile with: /target:library  
 public class ClassConstraint { }  

--- a/docs/csharp/misc/cs0315.md
+++ b/docs/csharp/misc/cs0315.md
@@ -26,7 +26,7 @@ The type 'valueType' cannot be used as type parameter 'T' in the generic type or
 ## Example  
  The following example generates CS0315:  
   
-```  
+```csharp  
 // cs0315.cs  
 public class ClassConstraint { }  
 public struct ViolateClassConstraint { }  

--- a/docs/csharp/misc/cs0316.md
+++ b/docs/csharp/misc/cs0316.md
@@ -26,7 +26,7 @@ The parameter name 'name' conflicts with an automatically-generated parameter na
 ## Example  
  The following code generates CS0316:  
   
-```  
+```csharp  
 // cs0316.cs  
 // Compile with: /target:library  
 public class Test  

--- a/docs/csharp/misc/cs0400.md
+++ b/docs/csharp/misc/cs0400.md
@@ -21,7 +21,7 @@ The type or namespace name 'identifier' could not be found in the global namespa
   
  To avoid this error, locate the declaration of the identifier, verify the correct spelling, and if the declaration is in a separate assembly, make sure that you have the appropriate assembly reference. If the identifier is declared inside another type or namespace, use the fully-qualified name after the ::. The following sample generates CS0400:  
   
-```  
+```csharp  
 // CS0400.cs  
 class C  
 {  

--- a/docs/csharp/misc/cs0401.md
+++ b/docs/csharp/misc/cs0401.md
@@ -22,7 +22,7 @@ The new() constraint must be the last constraint specified
 ## Example  
  The following sample generates CS0401.  
   
-```  
+```csharp  
 // CS0401.cs  
 // compile with: /target:library  
 using System;  

--- a/docs/csharp/misc/cs0402.md
+++ b/docs/csharp/misc/cs0402.md
@@ -19,7 +19,7 @@ ms.author: "wiwagn"
   
  The entry point was found in a generic type. To remove this warning, implement Main in a non-generic class or struct.  
   
-```  
+```csharp  
 // CS0402.cs  
 // compile with: /W:4  
 class C<T>  

--- a/docs/csharp/misc/cs0403.md
+++ b/docs/csharp/misc/cs0403.md
@@ -22,7 +22,7 @@ Cannot convert null to type parameter 'name' because it could be a non-nullable 
 ## Example  
  The following sample generates CS0403.  
   
-```  
+```csharp  
 // CS0403.cs  
 // compile with: /target:library  
 class C<T>  

--- a/docs/csharp/misc/cs0404.md
+++ b/docs/csharp/misc/cs0404.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0404:  
   
-```  
+```csharp  
 // CS0404.cs  
 [MyAttrib<int>]  // CS0404  
 class C  

--- a/docs/csharp/misc/cs0405.md
+++ b/docs/csharp/misc/cs0405.md
@@ -21,7 +21,7 @@ Duplicate constraint 'constraint' for type parameter 'type parameter'
   
  The following sample generates CS0405:  
   
-```  
+```csharp  
 // CS0405.cs  
 interface I  
 {  

--- a/docs/csharp/misc/cs0406.md
+++ b/docs/csharp/misc/cs0406.md
@@ -22,7 +22,7 @@ The class type constraint 'constraint' must come before any other constraints
 ## Example  
  The following sample generates CS0406.  
   
-```  
+```csharp  
 // CS0406.cs  
 // compile with: /target:library  
 interface I {}  

--- a/docs/csharp/misc/cs0407.md
+++ b/docs/csharp/misc/cs0407.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0407:  
   
-```  
+```csharp  
 // CS0407.cs  
 public delegate int MyDelegate();  
   

--- a/docs/csharp/misc/cs0409.md
+++ b/docs/csharp/misc/cs0409.md
@@ -19,7 +19,7 @@ A constraint clause has already been specified for type parameter 'type paramete
   
  Multiple constraint clauses (where clauses) were found for a single type parameter. Remove the extraneous where clause, or correct the where clauses so that a unique type parameter in each clause.  
   
-```  
+```csharp  
 // CS0409.cs  
 interface I  
 {  

--- a/docs/csharp/misc/cs0410.md
+++ b/docs/csharp/misc/cs0410.md
@@ -22,7 +22,7 @@ No overload for 'method' has the correct parameter and return types
 ## Example  
  The following example generates CS0410:  
   
-```  
+```csharp  
 // CS0410.cs  
 // compile with: /langversion:ISO-1  
   

--- a/docs/csharp/misc/cs0411.md
+++ b/docs/csharp/misc/cs0411.md
@@ -22,7 +22,7 @@ The type arguments for method 'method' cannot be inferred from the usage. Try sp
 ## Example  
  The following sample generates CS0411:  
   
-```  
+```csharp  
 // CS0411.cs  
 class C  
 {  
@@ -42,7 +42,7 @@ class C
 ## Example  
  Other possible error cases include when the parameter is `null`, which has no type information:  
   
-```  
+```csharp  
 // CS0411b.cs  
 class C  
 {  

--- a/docs/csharp/misc/cs0412.md
+++ b/docs/csharp/misc/cs0412.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0412:  
   
-```  
+```csharp  
 // CS0412.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0414.md
+++ b/docs/csharp/misc/cs0414.md
@@ -31,7 +31,7 @@ The private field 'field' is assigned but its value is never used
   
  The following sample shows one way in which CS0414 will be generated:  
   
-```  
+```csharp  
 // CS0414  
 // compile with: /W3  
 class C  

--- a/docs/csharp/misc/cs0416.md
+++ b/docs/csharp/misc/cs0416.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0416:  
   
-```  
+```csharp  
 // CS0416.cs  
 public class MyAttribute : System.Attribute  
 {  

--- a/docs/csharp/misc/cs0418.md
+++ b/docs/csharp/misc/cs0418.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0418:  
   
-```  
+```csharp  
 // CS0418.cs  
 public abstract sealed class C  // CS0418  
 {  

--- a/docs/csharp/misc/cs0419.md
+++ b/docs/csharp/misc/cs0419.md
@@ -21,7 +21,7 @@ Ambiguous reference in cref attribute: 'Method Name1'.  Assuming 'Method Name2',
   
  The following sample generates CS0419.  
   
-```  
+```csharp  
 // cs0419.cs  
 // compile with: /doc:x.xml /W:3  
 interface I  

--- a/docs/csharp/misc/cs0423.md
+++ b/docs/csharp/misc/cs0423.md
@@ -21,7 +21,7 @@ Since 'class' has the ComImport attribute, 'method' must be extern or abstract
   
  The following sample generates CS0423:  
   
-```  
+```csharp  
 // CS0423.cs  
   
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs0424.md
+++ b/docs/csharp/misc/cs0424.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0424:  
   
-```  
+```csharp  
 // CS0424.cs  
 // compile with: /target:library  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs0425.md
+++ b/docs/csharp/misc/cs0425.md
@@ -22,7 +22,7 @@ The constraints for type parameter 'type parameter' of method 'method' must matc
 ## Example  
  The following example generates CS0425:  
   
-```  
+```csharp  
 // CS0425.cs  
   
 class C1  
@@ -56,7 +56,7 @@ class CMain
 ## Example  
  The constraints do not have to be a literal match, as long as the set of constraints has the same meaning. For example, the following is okay:  
   
-```  
+```csharp  
 // CS0425b.cs  
   
 interface J<Z>  

--- a/docs/csharp/misc/cs0426.md
+++ b/docs/csharp/misc/cs0426.md
@@ -21,7 +21,7 @@ The type name 'identifier' does not exist in the type 'type'
   
  The following sample generates CS0426 because class C has no nested type A:  
   
-```  
+```csharp  
 // CS0426.cs  
   
 class C  

--- a/docs/csharp/misc/cs0430.md
+++ b/docs/csharp/misc/cs0430.md
@@ -21,7 +21,7 @@ The extern alias 'alias' was not specified in a /reference option
   
 ## Example  
   
-```  
+```csharp  
 // CS0430_a.cs  
 // compile with: /target:library   
 public class MyClass {}  
@@ -30,7 +30,7 @@ public class MyClass {}
 ## Example  
  Compiling with **/reference:MyType=cs0430_a.dll** to refer to the DLL created in the previous sample resolves this error. The following sample generates CS0430.  
   
-```  
+```csharp  
 // CS0430_b.cs  
 extern alias MyType;   // CS0430  
 public class Test   

--- a/docs/csharp/misc/cs0431.md
+++ b/docs/csharp/misc/cs0431.md
@@ -21,7 +21,7 @@ Cannot use alias 'identifier' with '::' since the alias references a type. Use '
   
  The following sample generates CS0431:  
   
-```  
+```csharp  
 // CS0431.cs  
 using A = Outer;  
   

--- a/docs/csharp/misc/cs0432.md
+++ b/docs/csharp/misc/cs0432.md
@@ -21,7 +21,7 @@ Alias 'identifier' not found
   
  The following example generates CS0432:  
   
-```  
+```csharp  
 // CS0432.cs  
 namespace A {  
     public class B {  

--- a/docs/csharp/misc/cs0434.md
+++ b/docs/csharp/misc/cs0434.md
@@ -24,7 +24,7 @@ The namespace NamespaceName1 in NamespaceName2 conflicts with the type TypeName1
 ## Example  
  This code creates the first copy of the type with the identical fully qualified name.  
   
-```  
+```csharp  
 // CS0434_1.cs  
 // compile with: /t:library  
 namespace TypeBindConflicts   
@@ -39,7 +39,7 @@ namespace TypeBindConflicts
 ## Example  
  This code creates the second copy of the type with the identical fully qualified name.  
   
-```  
+```csharp  
 // CS0434_2.cs  
 // compile with: /t:library  
 namespace TypeBindConflicts {  
@@ -53,7 +53,7 @@ namespace TypeBindConflicts {
 ## Example  
  This code references the type with the identical fully qualified name.  
   
-```  
+```csharp  
 // CS0434.cs  
 // compile with: /r:cs0434_1.dll /r:cs0434_2.dll  
 using TypeBindConflicts;  

--- a/docs/csharp/misc/cs0435.md
+++ b/docs/csharp/misc/cs0435.md
@@ -23,7 +23,7 @@ The namespace 'namespace' in 'assembly' conflicts with the imported type 'type' 
   
  Compile this file first:  
   
-```  
+```csharp  
 // CS0435_1.cs  
 // compile with: /t:library  
 public class Util   
@@ -34,7 +34,7 @@ public class Util
   
  Then, compile this file:  
   
-```  
+```csharp  
 // CS0435_2.cs  
 // compile with: /r:CS0435_1.dll  
   

--- a/docs/csharp/misc/cs0436.md
+++ b/docs/csharp/misc/cs0436.md
@@ -21,7 +21,7 @@ The type 'type' in 'assembly' conflicts with the imported type 'type2' in 'assem
   
 ## Example  
   
-```  
+```csharp  
 // CS0436_a.cs  
 // compile with: /target:library  
 public class A {  
@@ -34,7 +34,7 @@ public class A {
 ## Example  
  The following example generates CS0436.  
   
-```  
+```csharp  
 // CS0436_b.cs  
 // compile with: /reference:CS0436_a.dll  
 // CS0436 expected  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.