### PR TITLE
adding missing language identifiers - 5/13

### DIFF
--- a/docs/csharp/misc/cs0437.md
+++ b/docs/csharp/misc/cs0437.md
@@ -21,7 +21,7 @@ The type 'type' in 'assembly2' conflicts with the imported namespace 'namespace'
   
 ## Example  
   
-```  
+```csharp  
 // CS0437_a.cs  
 // compile with: /target:library  
 namespace Util   
@@ -37,7 +37,7 @@ namespace Util
 ## Example  
  The following sample generates CS0437.  
   
-```  
+```csharp  
 // CS0437_b.cs  
 // compile with: /reference:CS0437_a.dll /W:2  
 // CS0437 expected  

--- a/docs/csharp/misc/cs0438.md
+++ b/docs/csharp/misc/cs0438.md
@@ -23,7 +23,7 @@ The type 'type' in 'module_1' conflicts with the namespace 'namespace' in 'modul
   
  Compile this file first:  
   
-```  
+```csharp  
 // CS0438_1.cs  
 // compile with: /target:module  
 public class Util  
@@ -34,7 +34,7 @@ public class Util
   
  Then compile this file:  
   
-```  
+```csharp  
 // CS0438_2.cs  
 // compile with: /target:module  
 namespace Util   
@@ -45,7 +45,7 @@ namespace Util
   
  And then compile this file:  
   
-```  
+```csharp  
 // CS0438_3.cs  
 // compile with: /addmodule:CS0438_1.netmodule /addmodule:CS0438_2.netmodule  
 using System;  

--- a/docs/csharp/misc/cs0439.md
+++ b/docs/csharp/misc/cs0439.md
@@ -22,7 +22,7 @@ An extern alias declaration must precede all other elements defined in the names
 ## Example  
  The following example generates CS0439:  
   
-```  
+```csharp  
 // CS0439.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0440.md
+++ b/docs/csharp/misc/cs0440.md
@@ -22,7 +22,7 @@ Defining an alias named 'global' is ill-advised since 'global::' always referenc
 ## Example  
  The following example generates CS0440:  
   
-```  
+```csharp  
 // CS0440.cs  
 // Compile with: /W:1  
   

--- a/docs/csharp/misc/cs0441.md
+++ b/docs/csharp/misc/cs0441.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following example generates CS0441:  
   
-```  
+```csharp  
 // CS0441.cs  
 sealed static class MyClass { }   // CS0441  
 ```

--- a/docs/csharp/misc/cs0442.md
+++ b/docs/csharp/misc/cs0442.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0442:  
   
-```  
+```csharp  
 // CS0442.cs  
 public abstract class MyClass   
 {  

--- a/docs/csharp/misc/cs0443.md
+++ b/docs/csharp/misc/cs0443.md
@@ -22,7 +22,7 @@ Syntax error, value expected
 ## Example  
  The following code generates CS0443.  
   
-```  
+```csharp  
 // CS0443.cs   
 using System;   
 class MyClass   

--- a/docs/csharp/misc/cs0447.md
+++ b/docs/csharp/misc/cs0447.md
@@ -19,20 +19,20 @@ Attributes cannot be used on type arguments, only on type parameters
   
  This error occurs when you apply an attribute to a type argument that occurs in an invocation statement. It is acceptable to apply an attribute to a type parameter in a class or method declaration statement such as the following:  
   
-```  
+```csharp  
 class C<[some attribute] T> {…}  
 ```  
   
  The following line of code will generate this error. It is assumed that the class `C`, defined in the previous line of code, has a static method called `MyStaticMethod`.  
   
-```  
+```csharp  
 C<[some attribute] T>.MyStaticMethod();  
 ```  
   
 ## Example  
  The following code generates error CS0447.  
   
-```  
+```csharp  
 // CS0447.cs  
 using System;  
 namespace Test41  

--- a/docs/csharp/misc/cs0448.md
+++ b/docs/csharp/misc/cs0448.md
@@ -22,7 +22,7 @@ The return type for ++ or -- operator must be the containing type or derived fro
 ## Example  
  The following sample generates CS0448.  
   
-```  
+```csharp  
 // CS0448.cs  
 class C5  
 {  
@@ -35,7 +35,7 @@ class C5
 ## Example  
  The following sample generates CS0448.  
   
-```  
+```csharp  
 // CS0448_b.cs  
 public struct S  
 {  

--- a/docs/csharp/misc/cs0449.md
+++ b/docs/csharp/misc/cs0449.md
@@ -22,7 +22,7 @@ The 'class' or 'struct' constraint must come before any other constraints
 ## Example  
  The following sample generates CS0449.  
   
-```  
+```csharp  
 // CS0449.cs  
 // compile with: /target:library  
 interface I {}  

--- a/docs/csharp/misc/cs0450.md
+++ b/docs/csharp/misc/cs0450.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
 ## Example  
   
-```  
+```csharp  
 // CS0450.cs  
 // compile with: /t:library  
 public class GenericsErrors   

--- a/docs/csharp/misc/cs0451.md
+++ b/docs/csharp/misc/cs0451.md
@@ -22,7 +22,7 @@ The 'new()' constraint cannot be used with the 'struct' constraint
 ## Example  
  The following sample generates CS0451.  
   
-```  
+```csharp  
 // CS0451.cs  
 using System;  
 public class C4   

--- a/docs/csharp/misc/cs0452.md
+++ b/docs/csharp/misc/cs0452.md
@@ -22,7 +22,7 @@ The type 'type name' must be a reference type in order to use it as parameter 'p
 ## Example  
  The following code generates error CS0452.  
   
-```  
+```csharp  
 // CS0452.cs  
 using System;  
 public class BaseClass<S> where S : class { }  

--- a/docs/csharp/misc/cs0453.md
+++ b/docs/csharp/misc/cs0453.md
@@ -22,7 +22,7 @@ The type 'Type Name' must be a non-nullable value type in order to use it as par
 ## Example  
  The following code generates this error.  
   
-```  
+```csharp  
 // CS0453.cs  
 using System;  
 public class HV<S> where S : struct { }  

--- a/docs/csharp/misc/cs0454.md
+++ b/docs/csharp/misc/cs0454.md
@@ -22,7 +22,7 @@ Circular constraint dependency involving 'Type Parameter 1' and 'Type Parameter 
 ## Example  
  The following code generates error CS0454.  
   
-```  
+```csharp  
 // CS0554  
 using System;  
 public class GenericsErrors   
@@ -34,7 +34,7 @@ public class GenericsErrors
 ## Example  
  The following example demonstrates a circular dependency between two type constraints.  
   
-```  
+```csharp  
 public class Gen<T,U> where T : U where U : T  // CS0454  
 {  
 }  

--- a/docs/csharp/misc/cs0455.md
+++ b/docs/csharp/misc/cs0455.md
@@ -22,7 +22,7 @@ Type parameter 'Type Parameter Name' inherits conflicting constraints 'Constrain
 ## Example  
  The following code generates error CS0455.  
   
-```  
+```csharp  
 // CS0455.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0456.md
+++ b/docs/csharp/misc/cs0456.md
@@ -22,7 +22,7 @@ Type parameter 'Type Parameter Name 1' has the 'struct' constraint so 'Type Para
 ## Example  
  The following sample generates CS0456.  
   
-```  
+```csharp  
 // CS0456.cs  
 // compile with: /target:library  
 public class GenericsErrors  

--- a/docs/csharp/misc/cs0457.md
+++ b/docs/csharp/misc/cs0457.md
@@ -34,7 +34,7 @@ Ambiguous user defined conversions 'Conversion method name 1' and 'Conversion me
 ## Example  
  The following sample generates CS0457.  
   
-```  
+```csharp  
 // CS0457.cs  
 using System;  
 public class A { }  

--- a/docs/csharp/misc/cs0458.md
+++ b/docs/csharp/misc/cs0458.md
@@ -24,7 +24,7 @@ The result of the expression is always 'null' of type 'type name'
 ## Example  
  This example illustrates a number of the different operations with `nullable` types that will cause this error.  
   
-```  
+```csharp  
 // CS0458.cs  
 using System;  
 public  class Test   

--- a/docs/csharp/misc/cs0459.md
+++ b/docs/csharp/misc/cs0459.md
@@ -22,7 +22,7 @@ Cannot take the address of a read-only local variable
 ## Example  
  The following example generates CS0459 when an attempt is made to take the address of a read-only local variable in a `foreach` loop and in a `fixed` statement block.  
   
-```  
+```csharp  
 // CS0459.cs  
 // compile with: /unsafe  
   

--- a/docs/csharp/misc/cs0460.md
+++ b/docs/csharp/misc/cs0460.md
@@ -22,7 +22,7 @@ Constraints for override and explicit interface implementation methods are inher
 ## Example  
  The following sample generates CS0460.  
   
-```  
+```csharp  
 // CS0460.cs  
 // compile with: /target:library  
 class BaseClass   

--- a/docs/csharp/misc/cs0462.md
+++ b/docs/csharp/misc/cs0462.md
@@ -24,7 +24,7 @@ The inherited members 'member1' and 'member2' have the same signature in type 't
   
  The following sample generates CS0462.  
   
-```  
+```csharp  
 // CS0462.cs  
 // compile with: /target:library  
 class C<T>   

--- a/docs/csharp/misc/cs0463.md
+++ b/docs/csharp/misc/cs0463.md
@@ -24,7 +24,7 @@ Evaluation of the decimal constant expression failed with error: 'error'
 ## Example  
  The following code generates error CS0463.  
   
-```  
+```csharp  
 // CS0463.cs   
 using System;   
 class MyClass   

--- a/docs/csharp/misc/cs0464.md
+++ b/docs/csharp/misc/cs0464.md
@@ -22,7 +22,7 @@ Comparing with null of type 'type' always produces 'false'
 ## Example  
  The following sample generates CS0464.  
   
-```  
+```csharp  
 // CS0464.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0466.md
+++ b/docs/csharp/misc/cs0466.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0466.  
   
-```  
+```csharp  
 // CS0466.cs  
 interface I  
 {  

--- a/docs/csharp/misc/cs0469.md
+++ b/docs/csharp/misc/cs0469.md
@@ -22,7 +22,7 @@ The 'goto case' value is not implicitly convertible to type 'type'
 ## Example  
  The following sample generates CS0469.  
   
-```  
+```csharp  
 // CS0469.cs  
 // compile with: /W:2  
 class Test  

--- a/docs/csharp/misc/cs0470.md
+++ b/docs/csharp/misc/cs0470.md
@@ -22,7 +22,7 @@ Method 'method' cannot implement interface accessor 'accessor' for type 'type'. 
 ## Example  
  The following sample generates CS0470.  
   
-```  
+```csharp  
 // CS0470.cs  
 // compile with: /target:library  
   

--- a/docs/csharp/misc/cs0471.md
+++ b/docs/csharp/misc/cs0471.md
@@ -22,7 +22,7 @@ The method 'name' is not a generic method. If you intended an expression list, u
 ## Example  
  The following example generates CS0471.  
   
-```  
+```csharp  
 // CS0471.cs  
 // compile with: /t:library  
 class Test  

--- a/docs/csharp/misc/cs0472.md
+++ b/docs/csharp/misc/cs0472.md
@@ -22,7 +22,7 @@ The result of the expression is always 'value1' since a value of type 'value2' i
 ## Example  
  The following sample generates CS0472.  
   
-```  
+```csharp  
 public class Test  
 {  
     public static int Main()  

--- a/docs/csharp/misc/cs0473.md
+++ b/docs/csharp/misc/cs0473.md
@@ -29,7 +29,7 @@ Explicit interface implementation 'method name' matches more than one interface 
 ## Example  
  The following code generates CS0473:  
   
-```  
+```csharp  
 // cs0473.cs  
 public interface ITest<T>  
 {  

--- a/docs/csharp/misc/cs0500.md
+++ b/docs/csharp/misc/cs0500.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0500:  
   
-```  
+```csharp  
 // CS0500.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0501.md
+++ b/docs/csharp/misc/cs0501.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0501:  
   
-```  
+```csharp  
 // CS0501.cs  
 // compile with: /target:library  
 public class clx  

--- a/docs/csharp/misc/cs0502.md
+++ b/docs/csharp/misc/cs0502.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0502:  
   
-```  
+```csharp  
 // CS0502.cs  
 public class B  
 {  

--- a/docs/csharp/misc/cs0503.md
+++ b/docs/csharp/misc/cs0503.md
@@ -21,7 +21,7 @@ The abstract method 'method' cannot be marked virtual
   
  The following sample generates CS0503:  
   
-```  
+```csharp  
 // CS0503.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0505.md
+++ b/docs/csharp/misc/cs0505.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0505:  
   
-```  
+```csharp  
 // CS0505.cs  
 // compile with: /target:library  
 public class clx  

--- a/docs/csharp/misc/cs0506.md
+++ b/docs/csharp/misc/cs0506.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0506:  
   
-```  
+```csharp  
 // CS0506.cs  
 namespace MyNameSpace  
 {  

--- a/docs/csharp/misc/cs0508.md
+++ b/docs/csharp/misc/cs0508.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0508.  
   
-```  
+```csharp  
 // CS0508.cs  
 // compile with: /target:library  
 abstract public class Clx  

--- a/docs/csharp/misc/cs0509.md
+++ b/docs/csharp/misc/cs0509.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0509:  
   
-```  
+```csharp  
 // CS0509.cs  
 // compile with: /target:library  
 sealed public class clx {}  

--- a/docs/csharp/misc/cs0513.md
+++ b/docs/csharp/misc/cs0513.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0513:  
   
-```  
+```csharp  
 // CS0513.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0514.md
+++ b/docs/csharp/misc/cs0514.md
@@ -24,7 +24,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS0514:  
   
-```  
+```csharp  
 // CS0514.cs  
 class A  
 {  

--- a/docs/csharp/misc/cs0515.md
+++ b/docs/csharp/misc/cs0515.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0515:  
   
-```  
+```csharp  
 // CS0515.cs  
 public class Clx  
 {  

--- a/docs/csharp/misc/cs0516.md
+++ b/docs/csharp/misc/cs0516.md
@@ -21,7 +21,7 @@ Constructor 'constructor' can not call itself
   
  The following sample generates CS0516:  
   
-```  
+```csharp  
 // CS0516.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0522.md
+++ b/docs/csharp/misc/cs0522.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0522:  
   
-```  
+```csharp  
 // CS0522.cs  
 public class clx  
 {  

--- a/docs/csharp/misc/cs0524.md
+++ b/docs/csharp/misc/cs0524.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0524:  
   
-```  
+```csharp  
 // CS0524.cs  
 public interface Clx  
 {  

--- a/docs/csharp/misc/cs0525.md
+++ b/docs/csharp/misc/cs0525.md
@@ -21,7 +21,7 @@ Interfaces cannot contain fields
   
  The following sample generates CS0525:  
   
-```  
+```csharp  
 // CS0525.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0526.md
+++ b/docs/csharp/misc/cs0526.md
@@ -21,7 +21,7 @@ Interfaces cannot contain constructors
   
  The following sample generates CS0526:  
   
-```  
+```csharp  
 // CS0526.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0527.md
+++ b/docs/csharp/misc/cs0527.md
@@ -21,7 +21,7 @@ Type 'type' in interface list is not an interface
   
  The following sample generates CS0527:  
   
-```  
+```csharp  
 // CS0527.cs  
 // compile with: /target:library  
 public struct clx : int {}   // CS0527 int not an interface  

--- a/docs/csharp/misc/cs0528.md
+++ b/docs/csharp/misc/cs0528.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0528:  
   
-```  
+```csharp  
 // CS0528.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0529.md
+++ b/docs/csharp/misc/cs0529.md
@@ -21,7 +21,7 @@ Inherited interface 'interface1' causes a cycle in the interface hierarchy of 'i
   
  The following sample generates CS0529:  
   
-```  
+```csharp  
 // CS0529.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0531.md
+++ b/docs/csharp/misc/cs0531.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0531:  
   
-```  
+```csharp  
 // CS0531.cs  
 namespace x  
 {  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.