### PR TITLE
adding missing language identifiers - 6/13

### DIFF
--- a/docs/csharp/misc/cs0533.md
+++ b/docs/csharp/misc/cs0533.md
@@ -23,7 +23,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0533:  
   
-```  
+```csharp  
 // CS0533.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0534.md
+++ b/docs/csharp/misc/cs0534.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0534:  
   
-```  
+```csharp  
 // CS0534.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0535.md
+++ b/docs/csharp/misc/cs0535.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0535.  
   
-```  
+```csharp  
 // CS0535.cs  
 public interface A  
 {  
@@ -41,7 +41,7 @@ public class C : A {
 ## Example  
  The following sample generates CS0535.  
   
-```  
+```csharp  
 // CS0535_b.cs  
 using System;  
 class C : IDisposable {}   // CS0535  

--- a/docs/csharp/misc/cs0538.md
+++ b/docs/csharp/misc/cs0538.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0538:  
   
-```  
+```csharp  
 // CS0538.cs  
 interface MyIFace  
 {  

--- a/docs/csharp/misc/cs0539.md
+++ b/docs/csharp/misc/cs0539.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0539:  
   
-```  
+```csharp  
 // CS0539.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0540.md
+++ b/docs/csharp/misc/cs0540.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0540.  
   
-```  
+```csharp  
 // CS0540.cs  
 interface I  
 {  
@@ -45,7 +45,7 @@ public class Cly : I
 ## Example  
  The following sample generates CS0540.  
   
-```  
+```csharp  
 // CS0540_b.cs  
 using System;  
 class C {  

--- a/docs/csharp/misc/cs0541.md
+++ b/docs/csharp/misc/cs0541.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0541:  
   
-```  
+```csharp  
 // CS0541.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0543.md
+++ b/docs/csharp/misc/cs0543.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0543:  
   
-```  
+```csharp  
 // CS0543.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0544.md
+++ b/docs/csharp/misc/cs0544.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0544:  
   
-```  
+```csharp  
 // CS0544.cs  
 // compile with: /target:library  
 public class a  

--- a/docs/csharp/misc/cs0546.md
+++ b/docs/csharp/misc/cs0546.md
@@ -30,7 +30,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0546 because the base class does not declare a set accessor for the property.  
   
-```  
+```csharp  
 // CS0546.cs  
 // compile with: /target:library  
 public class a  

--- a/docs/csharp/misc/cs0547.md
+++ b/docs/csharp/misc/cs0547.md
@@ -23,7 +23,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0547:  
   
-```  
+```csharp  
 // CS0547.cs  
 public class a  
 {  

--- a/docs/csharp/misc/cs0548.md
+++ b/docs/csharp/misc/cs0548.md
@@ -24,7 +24,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0548.  
   
-```  
+```csharp  
 // CS0548.cs  
 // compile with: /target:library  
 public class b  

--- a/docs/csharp/misc/cs0549.md
+++ b/docs/csharp/misc/cs0549.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0549:  
   
-```  
+```csharp  
 // CS0549.cs  
 // compile with: /target:library  
 sealed public class MyClass  

--- a/docs/csharp/misc/cs0550.md
+++ b/docs/csharp/misc/cs0550.md
@@ -24,7 +24,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0550.  
   
-```  
+```csharp  
 // CS0550.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0551.md
+++ b/docs/csharp/misc/cs0551.md
@@ -24,7 +24,7 @@ Explicit interface implementation 'implementation' is missing accessor 'accessor
 ## Example  
  The following sample generates CS0551.  
   
-```  
+```csharp  
 // CS0551.cs  
 // compile with: /target:library  
 interface ii  

--- a/docs/csharp/misc/cs0553.md
+++ b/docs/csharp/misc/cs0553.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0553:  
   
-```  
+```csharp  
 // CS0553.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0554.md
+++ b/docs/csharp/misc/cs0554.md
@@ -23,7 +23,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0554:  
   
-```  
+```csharp  
 // CS0554.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0555.md
+++ b/docs/csharp/misc/cs0555.md
@@ -21,7 +21,7 @@ User-defined operator cannot take an object of the enclosing type and convert to
   
  The fo3llowing sample generates CS0555:  
   
-```  
+```csharp  
 // CS0555.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0556.md
+++ b/docs/csharp/misc/cs0556.md
@@ -21,7 +21,7 @@ User-defined conversion must convert to or from the enclosing type
   
  The following sample generates CS0556:  
   
-```  
+```csharp  
 // CS0556.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0557.md
+++ b/docs/csharp/misc/cs0557.md
@@ -21,7 +21,7 @@ Duplicate user-defined conversion in type 'class'
   
  The following example generates CS0557:  
   
-```  
+```csharp  
 // CS0557.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0558.md
+++ b/docs/csharp/misc/cs0558.md
@@ -21,7 +21,7 @@ User-defined operator 'operator' must be declared static and public
   
  The following sample generates CS0558:  
   
-```  
+```csharp  
 // CS0558.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0559.md
+++ b/docs/csharp/misc/cs0559.md
@@ -22,7 +22,7 @@ The parameter type for ++ or -- operator must be the containing type
 ## Example  
  The following sample generates CS0559:  
   
-```  
+```csharp  
 // CS0559.cs  
 // compile with: /target:library  
 public class iii  
@@ -49,7 +49,7 @@ public class iii
 ## Example  
  The following sample generates CS0559.  
   
-```  
+```csharp  
 // CS0559_b.cs  
 // compile with: /target:library  
 public struct S  

--- a/docs/csharp/misc/cs0562.md
+++ b/docs/csharp/misc/cs0562.md
@@ -22,7 +22,7 @@ The parameter of a unary operator must be the containing type
 ## Example  
  The following sample generates CS0562:  
   
-```  
+```csharp  
 // CS0562.cs  
 public class iii  
 {  

--- a/docs/csharp/misc/cs0564.md
+++ b/docs/csharp/misc/cs0564.md
@@ -21,7 +21,7 @@ The first operand of an overloaded shift operator must have the same type as the
   
  The following sample generates CS0564:  
   
-```  
+```csharp  
 // CS0564.cs  
 using System;  
 class C  

--- a/docs/csharp/misc/cs0567.md
+++ b/docs/csharp/misc/cs0567.md
@@ -21,7 +21,7 @@ Interfaces cannot contain operators
   
  The following sample generates CS0567:  
   
-```  
+```csharp  
 // CS0567.cs  
 interface IA  
 {  

--- a/docs/csharp/misc/cs0568.md
+++ b/docs/csharp/misc/cs0568.md
@@ -21,7 +21,7 @@ Structs cannot contain explicit parameterless constructors
   
  The following sample generates CS0568:  
   
-```  
+```csharp  
 // CS0568.cs  
 public struct ClassY  
 {  

--- a/docs/csharp/misc/cs0572.md
+++ b/docs/csharp/misc/cs0572.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0572:  
   
-```  
+```csharp  
 // CS0572.cs  
 using System;  
 class C  

--- a/docs/csharp/misc/cs0573.md
+++ b/docs/csharp/misc/cs0573.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0573:  
   
-```  
+```csharp  
 // CS0573.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0574.md
+++ b/docs/csharp/misc/cs0574.md
@@ -21,7 +21,7 @@ Name of destructor must match name of class
   
  The following sample generates CS0574:  
   
-```  
+```csharp  
 // CS0574.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0575.md
+++ b/docs/csharp/misc/cs0575.md
@@ -21,7 +21,7 @@ Only class types can contain destructors
   
  The following sample generates CS0575:  
   
-```  
+```csharp  
 // CS0575.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0576.md
+++ b/docs/csharp/misc/cs0576.md
@@ -22,7 +22,7 @@ Namespace 'namespace' contains a definition conflicting with alias 'identifier'
 ## Example  
  The following sample generates CS0576:  
   
-```  
+```csharp  
 // CS0576.cs  
 using SysIO = System.IO;  
 public class SysIO  

--- a/docs/csharp/misc/cs0577.md
+++ b/docs/csharp/misc/cs0577.md
@@ -21,7 +21,7 @@ The Conditional attribute is not valid on 'function' because it is a constructor
   
  For example, you cannot use some attributes on an explicit interface definition. The following sample generates CS0577:  
   
-```  
+```csharp  
 // CS0577.cs  
 // compile with: /target:library  
 interface I  

--- a/docs/csharp/misc/cs0578.md
+++ b/docs/csharp/misc/cs0578.md
@@ -152,7 +152,7 @@ The Conditional attribute is not valid on 'function' because its return type is 
 ## Example  
  The following sample generates CS0578. To resolve this error, you must either delete <xref:System.Diagnostics.ConditionalAttribute>, or you must change the return value of the method to `void`.  
   
-```  
+```csharp  
 // CS0578.cs  
 // compile with: /target:library  
 public class MyClass  

--- a/docs/csharp/misc/cs0582.md
+++ b/docs/csharp/misc/cs0582.md
@@ -21,7 +21,7 @@ The Conditional not valid on interface members
   
  The following sample generates CS0582:  
   
-```  
+```csharp  
 // CS0582.cs  
 // compile with: /target:library  
 using System.Diagnostics;  

--- a/docs/csharp/misc/cs0590.md
+++ b/docs/csharp/misc/cs0590.md
@@ -21,7 +21,7 @@ User-defined operators cannot return void
   
  The following sample generates CS0590:  
   
-```  
+```csharp  
 // CS0590.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs0591.md
+++ b/docs/csharp/misc/cs0591.md
@@ -22,7 +22,7 @@ Invalid value for argument to 'attribute' attribute
 ## Example  
  The following sample generates CS0591:  
   
-```  
+```csharp  
 // CS0591.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0594.md
+++ b/docs/csharp/misc/cs0594.md
@@ -21,7 +21,7 @@ Floating-point constant is outside the range of type 'type'
   
  The following sample generates CS0594:  
   
-```  
+```csharp  
 // CS0594.cs  
 namespace MyNamespace  
 {  

--- a/docs/csharp/misc/cs0596.md
+++ b/docs/csharp/misc/cs0596.md
@@ -21,7 +21,7 @@ The Guid attribute must be specified with the ComImport attribute
   
  The following sample generates CS0596:  
   
-```  
+```csharp  
 // CS0596.cs  
 using System.Runtime.InteropServices;  
   

--- a/docs/csharp/misc/cs0601.md
+++ b/docs/csharp/misc/cs0601.md
@@ -21,7 +21,7 @@ The DllImport attribute must be specified on a method marked 'static' and 'exter
   
  The following sample generates CS0601:  
   
-```  
+```csharp  
 // CS0601.cs  
 using System.Runtime.InteropServices;  
 using System.Text;  

--- a/docs/csharp/misc/cs0609.md
+++ b/docs/csharp/misc/cs0609.md
@@ -21,7 +21,7 @@ Cannot set the IndexerName attribute on an indexer marked override
   
  The following sample generates CS0609:  
   
-```  
+```csharp  
 // CS0609.cs  
 using System;  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/misc/cs0610.md
+++ b/docs/csharp/misc/cs0610.md
@@ -21,7 +21,7 @@ Field or property cannot be of type 'type'
   
  The following sample generates CS0610 as a result of using **System.TypedReference** as a field:  
   
-```  
+```csharp  
 // CS0610.cs  
 public class MainClass  
 {  

--- a/docs/csharp/misc/cs0611.md
+++ b/docs/csharp/misc/cs0611.md
@@ -21,7 +21,7 @@ Array elements cannot be of type 'type'
   
  The following sample generates CS0611 as a result of using **System.TypedReference** as an array element:  
   
-```  
+```csharp  
 // CS0611.cs  
 public class a  
 {  

--- a/docs/csharp/misc/cs0612.md
+++ b/docs/csharp/misc/cs0612.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample shows how accessing an obsolete member generates CS0612:  
   
-```  
+```csharp  
 // CS0612.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/misc/cs0617.md
+++ b/docs/csharp/misc/cs0617.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0617.  
   
-```  
+```csharp  
 // CS0617.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0619.md
+++ b/docs/csharp/misc/cs0619.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0619:  
   
-```  
+```csharp  
 // CS0619.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0620.md
+++ b/docs/csharp/misc/cs0620.md
@@ -21,7 +21,7 @@ Indexers cannot have void type
   
  The following sample generates CS0620:  
   
-```  
+```csharp  
 // CS0620.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0621.md
+++ b/docs/csharp/misc/cs0621.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0621:  
   
-```  
+```csharp  
 // CS0621.cs  
 abstract class MyClass  
 {  

--- a/docs/csharp/misc/cs0622.md
+++ b/docs/csharp/misc/cs0622.md
@@ -22,7 +22,7 @@ Can only use array initializer expressions to assign to array types. Try using a
 ## Example  
  The following sample generates CS0622:  
   
-```  
+```csharp  
 // CS0622.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0623.md
+++ b/docs/csharp/misc/cs0623.md
@@ -22,7 +22,7 @@ Array initializers can only be used in a variable or field initializer. Try usin
 ## Example  
  The following example produces CS0623 because the compiler interprets the {4} as embedded array initializer inside the outer array initializer:  
   
-```  
+```csharp  
 //cs0632.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0628.md
+++ b/docs/csharp/misc/cs0628.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0628:  
   
-```  
+```csharp  
 // CS0628.cs  
 // compile with: /W:4  
 sealed class C  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.