### PR TITLE
adding missing language identifiers - 7/13

### DIFF
--- a/docs/csharp/misc/cs0629.md
+++ b/docs/csharp/misc/cs0629.md
@@ -21,7 +21,7 @@ Conditional member 'member' cannot implement interface member 'base class member
   
  The following sample generates CS0629:  
   
-```  
+```csharp  
 // CS0629.cs  
 interface MyInterface  
 {  

--- a/docs/csharp/misc/cs0631.md
+++ b/docs/csharp/misc/cs0631.md
@@ -22,7 +22,7 @@ ref and out are not valid in this context
 ## Example  
  The following sample generates CS0631:  
   
-```  
+```csharp  
 // CS0631.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs0633.md
+++ b/docs/csharp/misc/cs0633.md
@@ -22,7 +22,7 @@ The argument to the 'attribute' attribute must be a valid identifier
 ## Example  
  This example illustrates CS0633 using the <xref:System.Diagnostics.ConditionalAttribute>. The following sample generates CS0633.  
   
-```  
+```csharp  
 // CS0633a.cs  
 #define DEBUG  
 using System.Diagnostics;  
@@ -38,7 +38,7 @@ public class Test
 ## Example  
  This example illustrates CS0633 using the <xref:System.Runtime.CompilerServices.IndexerNameAttribute>.  
   
-```  
+```csharp  
 // CS0633b.cs  
 // compile with: /target:module  
 #define DEBUG  

--- a/docs/csharp/misc/cs0636.md
+++ b/docs/csharp/misc/cs0636.md
@@ -21,7 +21,7 @@ The FieldOffset attribute can only be placed on members of types marked with the
   
  The following sample generates CS0636:  
   
-```  
+```csharp  
 // CS0636.cs  
 using System;  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs0637.md
+++ b/docs/csharp/misc/cs0637.md
@@ -22,7 +22,7 @@ The FieldOffset attribute is not allowed on static or const fields.
   
  The following sample generates CS0637:  
   
-```  
+```csharp  
 // CS0637.cs  
 using System;  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs0641.md
+++ b/docs/csharp/misc/cs0641.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0641:  
   
-```  
+```csharp  
 // CS0641.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0642.md
+++ b/docs/csharp/misc/cs0642.md
@@ -23,7 +23,7 @@ Possible mistaken empty statement
   
  The following sample generates CS0642:  
   
-```  
+```csharp  
 // CS0642.cs  
 // compile with: /W:3  
 class MyClass  

--- a/docs/csharp/misc/cs0643.md
+++ b/docs/csharp/misc/cs0643.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0643:  
   
-```  
+```csharp  
 // CS0643.cs  
 using System;  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs0644.md
+++ b/docs/csharp/misc/cs0644.md
@@ -31,7 +31,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0644:  
   
-```  
+```csharp  
 // CS0644.cs  
 class MyClass : System.ValueType   // CS0644  
 {  

--- a/docs/csharp/misc/cs0646.md
+++ b/docs/csharp/misc/cs0646.md
@@ -21,7 +21,7 @@ Cannot specify the DefaultMember attribute on a type containing an indexer
   
  The following sample generates CS0646:  
   
-```  
+```csharp  
 // CS0646.cs  
 // compile with: /target:library  
 [System.Reflection.DefaultMemberAttribute("x")]   // CS0646  

--- a/docs/csharp/misc/cs0647.md
+++ b/docs/csharp/misc/cs0647.md
@@ -19,7 +19,7 @@ Error emitting 'attribute' attribute -- 'reason'
   
  The following sample generates CS0647:  
   
-```  
+```csharp  
 // CS0647.cs  
 using System.Runtime.InteropServices;  
   

--- a/docs/csharp/misc/cs0649.md
+++ b/docs/csharp/misc/cs0649.md
@@ -21,7 +21,7 @@ Field 'field' is never assigned to, and will always have its default value 'valu
   
  The following sample generates CS0649:  
   
-```  
+```csharp  
 // CS0649.cs  
 // compile with: /W:4  
 using System.Collections;  

--- a/docs/csharp/misc/cs0652.md
+++ b/docs/csharp/misc/cs0652.md
@@ -21,7 +21,7 @@ Comparison to integral constant is useless; the constant is outside the range of
   
  The following sample generates CS0652:  
   
-```  
+```csharp  
 // CS0652.cs  
 // compile with: /W:2  
 public class Class1  

--- a/docs/csharp/misc/cs0653.md
+++ b/docs/csharp/misc/cs0653.md
@@ -21,7 +21,7 @@ Cannot apply attribute class 'class' because it is abstract
   
  The following sample generates CS0653:  
   
-```  
+```csharp  
 // CS0653.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0655.md
+++ b/docs/csharp/misc/cs0655.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0655:  
   
-```  
+```csharp  
 // CS0655.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0657.md
+++ b/docs/csharp/misc/cs0657.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0657:  
   
-```  
+```csharp  
 // CS0657.cs  
 // compile with: /target:library  
 public class TestAttribute : System.Attribute {}  

--- a/docs/csharp/misc/cs0658.md
+++ b/docs/csharp/misc/cs0658.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0658:  
   
-```  
+```csharp  
 // CS0658.cs  
 using System;  
 public class TestAttribute : Attribute{}  

--- a/docs/csharp/misc/cs0659.md
+++ b/docs/csharp/misc/cs0659.md
@@ -31,7 +31,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0659:  
   
-```  
+```csharp  
 // CS0659.cs  
 // compile with: /W:3 /target:library  
 class Test     

--- a/docs/csharp/misc/cs0660.md
+++ b/docs/csharp/misc/cs0660.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0660:  
   
-```  
+```csharp  
 // CS0660.cs  
 // compile with: /W:3 /warnaserror  
 class Test   // CS0660  

--- a/docs/csharp/misc/cs0661.md
+++ b/docs/csharp/misc/cs0661.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0661:  
   
-```  
+```csharp  
 // CS0661.cs  
 // compile with: /W:3  
 class Test   // CS0661  

--- a/docs/csharp/misc/cs0663.md
+++ b/docs/csharp/misc/cs0663.md
@@ -21,7 +21,7 @@ Cannot define overloaded methods that differ only on ref and out.
   
  The following sample generates CS0663:  
   
-```  
+```csharp  
 // CS0663.cs  
 class TestClass  
 {  

--- a/docs/csharp/misc/cs0665.md
+++ b/docs/csharp/misc/cs0665.md
@@ -21,7 +21,7 @@ Assignment in conditional expression is always constant; did you mean to use == 
   
  The following sample generates CS0665:  
   
-```  
+```csharp  
 // CS0665.cs  
 // compile with: /W:3  
 class Test  

--- a/docs/csharp/misc/cs0666.md
+++ b/docs/csharp/misc/cs0666.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0666:  
   
-```  
+```csharp  
 // CS0666.cs  
 class M  
 {  

--- a/docs/csharp/misc/cs0670.md
+++ b/docs/csharp/misc/cs0670.md
@@ -21,7 +21,7 @@ Field cannot have void type
   
  The following sample generates CS0670:  
   
-```  
+```csharp  
 // CS0670.cs  
 class C  
 {  

--- a/docs/csharp/misc/cs0672.md
+++ b/docs/csharp/misc/cs0672.md
@@ -23,7 +23,7 @@ Member 'member1' overrides obsolete member 'member2. Add the Obsolete attribute 
   
  The following sample generates CS0672:  
   
-```  
+```csharp  
 // CS0672.cs  
 // compile with: /W:1  
 class MyClass  

--- a/docs/csharp/misc/cs0673.md
+++ b/docs/csharp/misc/cs0673.md
@@ -21,7 +21,7 @@ System.Void cannot be used from C# -- use typeof(void) to get the void type obje
   
  The following sample generates CS0673:  
   
-```  
+```csharp  
 // CS0673.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs0674.md
+++ b/docs/csharp/misc/cs0674.md
@@ -21,7 +21,7 @@ Do not use 'System.ParamArrayAttribute'. Use the 'params' keyword instead.
   
  The following sample generates CS0674:  
   
-```  
+```csharp  
 // CS0674.cs  
 using System;  
 public class MyClass   

--- a/docs/csharp/misc/cs0677.md
+++ b/docs/csharp/misc/cs0677.md
@@ -29,7 +29,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0677:  
   
-```  
+```csharp  
 // CS0677.cs  
 class TestClass  
 {  

--- a/docs/csharp/misc/cs0678.md
+++ b/docs/csharp/misc/cs0678.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0678:  
   
-```  
+```csharp  
 // CS0678.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0681.md
+++ b/docs/csharp/misc/cs0681.md
@@ -22,7 +22,7 @@ The modifier 'abstract' is not valid on fields. Try using a property instead
 ## Example  
  The following sample generates CS0681:  
   
-```  
+```csharp  
 // CS0681.cs  
 // compile with: /target:library  
 abstract class C  
@@ -34,7 +34,7 @@ abstract class C
 ## Example  
  Try the following code instead:  
   
-```  
+```csharp  
 // CS0681b.cs  
 // compile with: /target:library  
 abstract class C  

--- a/docs/csharp/misc/cs0683.md
+++ b/docs/csharp/misc/cs0683.md
@@ -19,7 +19,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0683:  
   
-```  
+```csharp  
 // CS0683.cs  
 interface IExample  
 {  

--- a/docs/csharp/misc/cs0684.md
+++ b/docs/csharp/misc/cs0684.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0684:  
   
-```  
+```csharp  
 // CS0684.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/misc/cs0685.md
+++ b/docs/csharp/misc/cs0685.md
@@ -22,7 +22,7 @@ Conditional member 'member' cannot have an out parameter
 ## Example  
  The following sample generates CS0685:  
   
-```  
+```csharp  
 // CS0685.cs  
 using System.Diagnostics;  
   

--- a/docs/csharp/misc/cs0687.md
+++ b/docs/csharp/misc/cs0687.md
@@ -22,7 +22,7 @@ The namespace alias qualifier '::' always resolves to a type or namespace so is 
 ## Example  
  The following sample generates CS0687:  
   
-```  
+```csharp  
 // CS0687.cs  
   
 using M = Test;  

--- a/docs/csharp/misc/cs0688.md
+++ b/docs/csharp/misc/cs0688.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0688. To resolve the warning without modifying the base class, remove the security attribute from the overriding method. This will not solve the security problem.  
   
-```  
+```csharp  
 // CS0688.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/misc/cs0689.md
+++ b/docs/csharp/misc/cs0689.md
@@ -21,7 +21,7 @@ Cannot derive from 'identifier' because it is a type parameter
   
  The following sample generates CS0689:  
   
-```  
+```csharp 
 // CS0689.cs  
 class A<T> : T   // CS0689  
 {  

--- a/docs/csharp/misc/cs0692.md
+++ b/docs/csharp/misc/cs0692.md
@@ -22,7 +22,7 @@ Duplicate type parameter 'identifier'
 ## Example  
  The following sample generates CS0692:  
   
-```  
+```csharp  
 // CS0692.cs  
 // compile with: /target:library  
 class C <T, A, T>   // CS0692  

--- a/docs/csharp/misc/cs0693.md
+++ b/docs/csharp/misc/cs0693.md
@@ -24,7 +24,7 @@ Type parameter 'type parameter' has the same name as the type parameter from out
 ## Example  
  The following sample generates CS0693.  
   
-```  
+```csharp  
 // CS0693.cs  
 // compile with: /W:3 /target:library  
 class Outer<T>  

--- a/docs/csharp/misc/cs0694.md
+++ b/docs/csharp/misc/cs0694.md
@@ -22,7 +22,7 @@ Type parameter 'identifier' has the same name as the containing type, or method
 ## Example  
  The following sample generates CS0694.  
   
-```  
+```csharp  
 // CS0694.cs  
 // compile with: /target:library  
 class C<C> {}   // CS0694  
@@ -31,7 +31,7 @@ class C<C> {}   // CS0694
 ## Example  
  In addition to the above case involving a generic class, this error may occur with a method:  
   
-```  
+```csharp  
 // CS0694_2.cs  
 // compile with: /target:library  
 class A  

--- a/docs/csharp/misc/cs0695.md
+++ b/docs/csharp/misc/cs0695.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0695:  
   
-```  
+```csharp  
 // CS0695.cs  
 // compile with: /target:library  
   

--- a/docs/csharp/misc/cs0698.md
+++ b/docs/csharp/misc/cs0698.md
@@ -21,7 +21,7 @@ A generic type cannot derive from 'class' because it is an attribute class
   
  The following sample generates CS0698:  
   
-```  
+```csharp  
 // CS0698.cs  
 class C<T> : System.Attribute  // CS0698  
 {  

--- a/docs/csharp/misc/cs0699.md
+++ b/docs/csharp/misc/cs0699.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0699:  
   
-```  
+```csharp  
 // CS0699.cs  
 class C<T> where U : I   // CS0699 – U is not a valid type parameter  
 {  

--- a/docs/csharp/misc/cs0701.md
+++ b/docs/csharp/misc/cs0701.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0701.  
   
-```  
+```csharp  
 // CS0701.cs  
 // compile with: /target:library  
 class C<T> where T : System.String {}   // CS0701  

--- a/docs/csharp/misc/cs0704.md
+++ b/docs/csharp/misc/cs0704.md
@@ -22,7 +22,7 @@ Cannot do member lookup in 'type' because it is a type parameter
 ## Example  
  The following sample generates CS0704:  
   
-```  
+```csharp  
 // CS0704.cs  
 class B  
 {  

--- a/docs/csharp/misc/cs0706.md
+++ b/docs/csharp/misc/cs0706.md
@@ -22,7 +22,7 @@ Invalid constraint type. A type used as a constraint must be an interface, a non
 ## Example  
  The following sample generates CS0706.  
   
-```  
+```csharp  
 // CS0706.cs  
 // compile with: /target:library  
 class A {}  

--- a/docs/csharp/misc/cs0708.md
+++ b/docs/csharp/misc/cs0708.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0708:  
   
-```  
+```csharp  
 // CS0708.cs  
 // compile with: /target:library  
 public static class C  

--- a/docs/csharp/misc/cs0709.md
+++ b/docs/csharp/misc/cs0709.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0709.  
   
-```  
+```csharp  
 // CS0709.cs  
 // compile with: /target:library  
 public static class Base {}  

--- a/docs/csharp/misc/cs0710.md
+++ b/docs/csharp/misc/cs0710.md
@@ -21,7 +21,7 @@ Static classes cannot have instance constructors
   
  The following sample generates CS0710:  
   
-```  
+```csharp  
 // CS0710.cs  
 public static class C  
 {  

--- a/docs/csharp/misc/cs0711.md
+++ b/docs/csharp/misc/cs0711.md
@@ -21,7 +21,7 @@ Static classes cannot contain destructors
   
  The following sample generates CS0711:  
   
-```  
+```csharp  
 // CS0711.cs  
 public static class C  
 {  

--- a/docs/csharp/misc/cs0712.md
+++ b/docs/csharp/misc/cs0712.md
@@ -22,7 +22,7 @@ Cannot create an instance of the static class 'static class'
 ## Example  
  The following sample generates CS0712:  
   
-```  
+```csharp  
 // CS0712.cs  
 public static class SC  
 {  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.