### PR TITLE
adding missing language identifiers - 8/13

### DIFF
--- a/docs/csharp/misc/cs0713.md
+++ b/docs/csharp/misc/cs0713.md
@@ -21,7 +21,7 @@ Static class 'static type' cannot derive from type 'type'. Static classes must d
   
  The following sample generates CS0713:  
   
-```  
+```csharp  
 // CS0713.cs  
 public class Base  
 {  

--- a/docs/csharp/misc/cs0714.md
+++ b/docs/csharp/misc/cs0714.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0714:  
   
-```  
+```csharp  
 // CS0714.cs  
 interface I  
 {  

--- a/docs/csharp/misc/cs0715.md
+++ b/docs/csharp/misc/cs0715.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0715:  
   
-```  
+```csharp  
 // CS0715.cs  
 public static class C  
 {  

--- a/docs/csharp/misc/cs0716.md
+++ b/docs/csharp/misc/cs0716.md
@@ -22,7 +22,7 @@ Cannot convert to static type 'type'
 ## Example  
  The following sample generates CS0716:  
   
-```  
+```csharp  
 // CS0716.cs  
   
 public static class SC  

--- a/docs/csharp/misc/cs0717.md
+++ b/docs/csharp/misc/cs0717.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0717:  
   
-```  
+```csharp  
 // CS0717.cs  
   
 public static class SC  

--- a/docs/csharp/misc/cs0718.md
+++ b/docs/csharp/misc/cs0718.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0718:  
   
-```  
+```csharp  
 // CS0718.cs  
 public static class SC  
 {  

--- a/docs/csharp/misc/cs0719.md
+++ b/docs/csharp/misc/cs0719.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0719:  
   
-```  
+```csharp  
 // CS0719.cs  
 public static class SC  
 {  

--- a/docs/csharp/misc/cs0720.md
+++ b/docs/csharp/misc/cs0720.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS0720:  
   
-```  
+```csharp  
 // CS0720.cs  
   
 public static class Test  

--- a/docs/csharp/misc/cs0721.md
+++ b/docs/csharp/misc/cs0721.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0721:  
   
-```  
+```csharp  
 // CS0721.cs  
 public static class SC  
 {  

--- a/docs/csharp/misc/cs0722.md
+++ b/docs/csharp/misc/cs0722.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS0722:  
   
-```  
+```csharp  
 // CS0722.cs  
 public static class SC  
 {  

--- a/docs/csharp/misc/cs0723.md
+++ b/docs/csharp/misc/cs0723.md
@@ -21,7 +21,7 @@ Cannot declare variable of static type 'type'
   
  The following sample generates CS0723:  
   
-```  
+```csharp  
 // CS0723.cs  
 public static class SC  
 {  

--- a/docs/csharp/misc/cs0724.md
+++ b/docs/csharp/misc/cs0724.md
@@ -22,7 +22,7 @@ does not need a CLSCompliant attribute because the assembly does not have a CLSC
 ## Example  
  The following example generates CS0724.  
   
-```  
+```csharp  
 // CS0724.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0728.md
+++ b/docs/csharp/misc/cs0728.md
@@ -48,7 +48,7 @@ Possibly incorrect assignment to local 'variable' which is the argument to a usi
 ## Example  
  The following code will generate warning CS0728.  
   
-```  
+```csharp 
 // CS0728.cs  
   
 using System;  

--- a/docs/csharp/misc/cs0729.md
+++ b/docs/csharp/misc/cs0729.md
@@ -22,7 +22,7 @@ Type 'type' is defined in this assembly, but a type forwarder is specified for i
 ## Example  
  The following sample generates CS0729.  
   
-```  
+```csharp  
 // CS0729.cs  
 // compile with: /target:library  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/misc/cs0730.md
+++ b/docs/csharp/misc/cs0730.md
@@ -22,7 +22,7 @@ Cannot forward type 'type' because it is a nested type of 'type'
 ## Example  
  The following sample generates CS0730. It consists of two source files. First, compile the library file `CS0730a.cs`, and the compile the file `CS0730.cs` referencing the library file.  
   
-```  
+```csharp  
 // CS0730a.cs  
 // compile with: /t:library  
 public class Outer  
@@ -31,7 +31,7 @@ public class Outer
 }  
 ```  
   
-```  
+```csharp  
 // CS0730.cs  
 // compile with: /t:library /r:CS0730a.dll  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/misc/cs0733.md
+++ b/docs/csharp/misc/cs0733.md
@@ -20,7 +20,7 @@ Cannot forward generic type, 'GenericType<>'
 ## Example  
  The following example generates CS0733. Compile the first file as a library, and then reference it when you compile the second file.  
   
-```  
+```csharp  
 // CS0733a.cs  
 // compile with: /target:library  
 public class GenericType<T>   
@@ -28,7 +28,7 @@ public class GenericType<T>
 }  
 ```  
   
-```  
+```csharp  
 // CS0733.cs  
 // compile with: /target:library /r:CS0733a.dll  
 [assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(GenericType<int>))]   // CS0733  

--- a/docs/csharp/misc/cs0734.md
+++ b/docs/csharp/misc/cs0734.md
@@ -24,7 +24,7 @@ The /moduleassemblyname option may only be specified when building a target type
 ## Example  
  The following sample generates CS0734. To resolve, add **/target:module** to the compilation.  
   
-```  
+```csharp  
 // CS0734.cs  
 // compile with: /moduleassemblyname:A  
 // CS0734 expected  

--- a/docs/csharp/misc/cs0735.md
+++ b/docs/csharp/misc/cs0735.md
@@ -19,7 +19,7 @@ Invalid type specified as an argument for TypeForwardedTo attribute
   
  The following sample generates CS0735.  
   
-```  
+```csharp  
 // CS735.cs  
 // compile with: /target:library  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/misc/cs0736.md
+++ b/docs/csharp/misc/cs0736.md
@@ -30,7 +30,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code generates CS0736 because `Program.testMethod` is declared as static:  
   
-```  
+```csharp  
 // cs0736.cs  
 namespace CS0736  
 {     

--- a/docs/csharp/misc/cs0737.md
+++ b/docs/csharp/misc/cs0737.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code generates CS0737:  
   
-```  
+```csharp  
 // cs0737.cs  
 interface ITest  
 {  

--- a/docs/csharp/misc/cs0738.md
+++ b/docs/csharp/misc/cs0738.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code generates CS0738 because the class method returns `void` and the interface member of the same name returns `int`:  
   
-```  
+```csharp  
 using System;  
   
 interface ITest  

--- a/docs/csharp/misc/cs0739.md
+++ b/docs/csharp/misc/cs0739.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code generates CS0739:  
   
-```  
+```csharp  
 // CS0739.cs  
 // CS0739  
 // Assume that a class Test is declared in a separate dll  

--- a/docs/csharp/misc/cs0742.md
+++ b/docs/csharp/misc/cs0742.md
@@ -26,7 +26,7 @@ A query body must end with a select clause or a group clause
 ## Example  
  The following code generates CS0742:  
   
-```  
+```csharp  
 // cs0742.cs  
 using System.Linq;  
 public class Test  

--- a/docs/csharp/misc/cs0743.md
+++ b/docs/csharp/misc/cs0743.md
@@ -19,7 +19,7 @@ Expected contextual keyword 'on'
   
  The pattern for a `join` clause is `join`...`in`...`on`...`equals`, as shown in this example:  
   
-```  
+```csharp  
 var query = from x in array1  
             join y in array2 on x equals y  
             select x;  
@@ -32,7 +32,7 @@ var query = from x in array1
 ## Example  
  The following code generates CS0743:  
   
-```  
+```csharp  
 // cs0743.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0744.md
+++ b/docs/csharp/misc/cs0744.md
@@ -19,7 +19,7 @@ Expected contextual keyword 'equals'
   
  The pattern for a `join` clause is `join`...`in`...`on`...`equals`, as shown in this example:  
   
-```  
+```csharp  
 var query = from x in array1  
             join y in array2 on x equals y  
             select x;  
@@ -32,7 +32,7 @@ var query = from x in array1
 ## Example  
  The following code generates CS0744:  
   
-```  
+```csharp  
 // cs0744.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0745.md
+++ b/docs/csharp/misc/cs0745.md
@@ -19,7 +19,7 @@ Expected contextual keyword 'by'
   
  The pattern for the `group` clause is `group...by` followed by an optional `into`, as shown in the following example:  
   
-```  
+```csharp  
 string[] names = { "Bob", "Bill", "Jonetta", "Mary" };  
   
 var query = from name in names  
@@ -28,7 +28,7 @@ var query = from name in names
   
  or  
   
-```  
+```csharp  
 var query2 = from name in names  
              group name by name[0] into g  
              //...additional query clauses  
@@ -41,7 +41,7 @@ var query2 = from name in names
 ## Example  
  The following code generates CS0745:  
   
-```  
+```csharp  
 // cs0745.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0746.md
+++ b/docs/csharp/misc/cs0746.md
@@ -26,7 +26,7 @@ Invalid anonymous type member declarator. Anonymous type members must be declare
 ## Example  
  The following code generates CS0746 in the declaration of `incorrect_1` and `incorrect_2`. The following declarations show two of the correct ways to declare an anonymous type.  
   
-```  
+```csharp  
 // cs0746.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs0747.md
+++ b/docs/csharp/misc/cs0747.md
@@ -26,7 +26,7 @@ Invalid initializer member declarator.
 ## Example  
  The following code generates CS0747:  
   
-```  
+```csharp  
 // cs0747.cs  
 using System.Collections.Generic;  
   

--- a/docs/csharp/misc/cs0748.md
+++ b/docs/csharp/misc/cs0748.md
@@ -26,7 +26,7 @@ Inconsistent lambda parameter usage; all parameter types must either be explicit
 ## Example  
  The following code generates CS0748 because, in the lambda expression, only `alpha` is given an explicit type:  
   
-```  
+```csharp  
 // cs0748.cs  
 class CS0748  
 {  

--- a/docs/csharp/misc/cs0750.md
+++ b/docs/csharp/misc/cs0750.md
@@ -26,7 +26,7 @@ A partial method cannot have access modifiers or the virtual, abstract, override
 ## Example  
  The following example generates CS0750:  
   
-```  
+```csharp  
 // cs0750.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0751.md
+++ b/docs/csharp/misc/cs0751.md
@@ -26,7 +26,7 @@ A partial method must be declared in a partial class or partial struct
 ## Example  
  The following example generates CS0751:  
   
-```  
+```csharp  
 // cs0751.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0752.md
+++ b/docs/csharp/misc/cs0752.md
@@ -26,7 +26,7 @@ A partial method cannot have out parameters
 ## Example  
  The following code generates CS0752:  
   
-```  
+```csharp  
 // cs0752.cs  
 public partial class C  
 {  

--- a/docs/csharp/misc/cs0753.md
+++ b/docs/csharp/misc/cs0753.md
@@ -26,7 +26,7 @@ Only methods, classes, structs, or interfaces may be partial.
 ## Example  
  The following code generates CS0753:  
   
-```  
+```csharp  
 // cs0753.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0754.md
+++ b/docs/csharp/misc/cs0754.md
@@ -26,7 +26,7 @@ A partial method may not explicitly implement an interface method.
 ## Example  
  The following code generates CS0754:  
   
-```  
+```csharp  
 // cs0754.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0755.md
+++ b/docs/csharp/misc/cs0755.md
@@ -26,7 +26,7 @@ Both partial method declarations must be extension methods or neither may be an 
 ## Example  
  The following example generates CS0755:  
   
-```  
+```csharp  
 // cs0755.cs  
     public static partial class Ext  
     {  

--- a/docs/csharp/misc/cs0756.md
+++ b/docs/csharp/misc/cs0756.md
@@ -25,7 +25,7 @@ A partial method may not have multiple defining declarations.
   
 ## Example  
   
-```  
+```csharp  
 // cs0756.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0757.md
+++ b/docs/csharp/misc/cs0757.md
@@ -26,7 +26,7 @@ A partial method may not have multiple implementing declarations.
 ## Example  
  The following example generates CS0757:  
   
-```  
+```csharp  
 // cs0757.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0758.md
+++ b/docs/csharp/misc/cs0758.md
@@ -26,7 +26,7 @@ Both partial method declarations must use a params parameter or neither may use 
 ## Example  
  The following code generates CS0758:  
   
-```  
+```csharp  
 using System;  
   
     public partial class C  

--- a/docs/csharp/misc/cs0759.md
+++ b/docs/csharp/misc/cs0759.md
@@ -26,7 +26,7 @@ No defining declaration found for implementing declaration of partial method 'me
 ## Example  
  The following example generates CS0759:  
   
-```  
+```csharp  
 // cs0759.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0761.md
+++ b/docs/csharp/misc/cs0761.md
@@ -26,7 +26,7 @@ Partial method declarations of 'method\<T>' have inconsistent type parameter con
 ## Example  
  The following code generates CS0761:  
   
-```  
+```csharp  
 // cs0761.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0762.md
+++ b/docs/csharp/misc/cs0762.md
@@ -25,7 +25,7 @@ Cannot create delegate from method 'method' because it is a partial method witho
   
 ## Example  
   
-```  
+```csharp  
 public delegate void TestDel();  
   
     public partial class C  

--- a/docs/csharp/misc/cs0763.md
+++ b/docs/csharp/misc/cs0763.md
@@ -26,7 +26,7 @@ Both partial method declarations must be static or neither may be static.
 ## Example  
  The following code generates CS0763:  
   
-```  
+```csharp  
 // cs0763.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0764.md
+++ b/docs/csharp/misc/cs0764.md
@@ -25,7 +25,7 @@ Both partial method declarations must be unsafe or neither may be unsafe
   
 ## Example  
   
-```  
+```csharp  
 // cs0764.cs  
 //  Compile with: /target:library /unsafe  
 public partial class C  

--- a/docs/csharp/misc/cs0765.md
+++ b/docs/csharp/misc/cs0765.md
@@ -26,7 +26,7 @@ Partial methods with only a defining declaration or removed conditional methods 
 ## Example  
  The following code generates CS0765 in two locations:  
   
-```  
+```csharp  
 // cs0765.cs  
 using System;  
 using System.Collections;  

--- a/docs/csharp/misc/cs0766.md
+++ b/docs/csharp/misc/cs0766.md
@@ -26,7 +26,7 @@ Partial methods must have a void return type.
 ## Example  
  The following example generates CS0766:  
   
-```  
+```csharp  
 // cs0766.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0809.md
+++ b/docs/csharp/misc/cs0809.md
@@ -25,7 +25,7 @@ Obsolete member 'memberA' overrides non-obsolete member 'memberB'.
   
 ## Example  
   
-```  
+```csharp  
 // CS0809.cs  
 public class Base  
 {  

--- a/docs/csharp/misc/cs0811.md
+++ b/docs/csharp/misc/cs0811.md
@@ -26,7 +26,7 @@ The fully qualified name for 'name' is too long for debug information. Compile w
 ## Example  
  The following code generates CS0811:  
   
-```  
+```csharp  
 // cs0811.cs  
 //Compile with: /debug  
 using System;  

--- a/docs/csharp/misc/cs0815.md
+++ b/docs/csharp/misc/cs0815.md
@@ -26,7 +26,7 @@ Cannot assign 'expression' to an implicitly typed local
 ## Example  
  The following code generates CS0815:  
   
-```  
+```csharp  
 // cs0815.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs0818.md
+++ b/docs/csharp/misc/cs0818.md
@@ -26,7 +26,7 @@ Implicitly typed locals must be initialized
 ## Example  
  The following code generates CS0818:  
   
-```  
+```csharp  
 // cs0818.cs  
 class A  
 {  

--- a/docs/csharp/misc/cs0819.md
+++ b/docs/csharp/misc/cs0819.md
@@ -26,7 +26,7 @@ Implicitly typed locals cannot have multiple declarators.
 ## Example  
  The following code generates CS0819:  
   
-```  
+```csharp  
 // cs0819.cs  
 class A  
 {  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.