### PR TITLE
adding missing language identifiers - 9/13

### DIFF
--- a/docs/csharp/misc/cs0820.md
+++ b/docs/csharp/misc/cs0820.md
@@ -28,7 +28,7 @@ Cannot assign array initializer to an implicitly typed local
 ## Example  
  The following code generates CS0820 and shows how to correctly initialize an implicitly typed array:  
   
-```  
+```csharp  
 //cs0820.cs  
 class G  
 {  

--- a/docs/csharp/misc/cs0821.md
+++ b/docs/csharp/misc/cs0821.md
@@ -26,7 +26,7 @@ Implicitly typed locals cannot be fixed
 ## Example  
  The following code generates CS0821:  
   
-```  
+```csharp  
 class A  
 {  
     static int x;  

--- a/docs/csharp/misc/cs0822.md
+++ b/docs/csharp/misc/cs0822.md
@@ -26,7 +26,7 @@ Implicitly typed locals cannot be const
 ## Example  
  The following code generates CS0822:  
   
-```  
+```csharp  
 // cs0822.cs  
 class A  
 {  

--- a/docs/csharp/misc/cs0824.md
+++ b/docs/csharp/misc/cs0824.md
@@ -28,7 +28,7 @@ Constructor 'name' is marked external.
 ## Example  
  The following code generates CS0824:  
   
-```  
+```csharp  
 // cs0824.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs0825.md
+++ b/docs/csharp/misc/cs0825.md
@@ -26,7 +26,7 @@ The contextual keyword 'var' may only appear within a local variable declaration
 ## Example  
  The following code generates CS0825 because `var` is used on a class field:  
   
-```  
+```csharp  
 // cs0825.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs0828.md
+++ b/docs/csharp/misc/cs0828.md
@@ -26,7 +26,7 @@ Cannot assign 'expression' to anonymous type property.
 ## Example  
  The following code generates CS0828 because a member of an anonymous type cannot be initialized with a null value.  
   
-```  
+```csharp  
 // cs0828.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0831.md
+++ b/docs/csharp/misc/cs0831.md
@@ -26,7 +26,7 @@ An expression tree may not contain a base access.
 ## Example  
  The following example generates CS0831:  
   
-```  
+```csharp  
 // cs0831.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0832.md
+++ b/docs/csharp/misc/cs0832.md
@@ -26,7 +26,7 @@ An expression tree may not contain an assignment operator.
 ## Example  
  In the example code, as in all lambda expressions, `x` is just an input parameter being passed by value. Its value cannot be changed in an expression tree. It can be changed in a delegate lambda.  
   
-```  
+```csharp  
 // cs0843.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0833.md
+++ b/docs/csharp/misc/cs0833.md
@@ -26,7 +26,7 @@ An anonymous type cannot have multiple properties with the same name.
 ## Example  
  The following example generates CS0833:  
   
-```  
+```csharp  
 // cs0833.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0835.md
+++ b/docs/csharp/misc/cs0835.md
@@ -26,7 +26,7 @@ Cannot convert lambda to an expression tree whose type argument 'type' is not a 
 ## Example  
  The following example generates CS0835:  
   
-```  
+```csharp  
 // cs0835.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0836.md
+++ b/docs/csharp/misc/cs0836.md
@@ -26,7 +26,7 @@ Cannot use anonymous type in a constant expression.
 ## Example  
  The following example shows one way to generate CS0836:  
   
-```  
+```csharp  
 // cs0836.cs  
 using System;  
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]  

--- a/docs/csharp/misc/cs0837.md
+++ b/docs/csharp/misc/cs0837.md
@@ -28,7 +28,7 @@ The first operand of an "is" or "as" operator may not be a lambda expression or 
 ## Example  
  The following example generates CS0837:  
   
-```  
+```csharp  
 // cs0837.cs  
 namespace TestNamespace  
 {  

--- a/docs/csharp/misc/cs0838.md
+++ b/docs/csharp/misc/cs0838.md
@@ -26,7 +26,7 @@ An expression tree may not contain a multidimensional array initializer.
 ## Example  
  The following example generates CS0838:  
   
-```  
+```csharp  
 // cs0838.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs0839.md
+++ b/docs/csharp/misc/cs0839.md
@@ -26,7 +26,7 @@ Argument missing.
 ## Example  
  The following example generates CS0839:  
   
-```  
+```csharp  
 // cs0839.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0841.md
+++ b/docs/csharp/misc/cs0841.md
@@ -26,7 +26,7 @@ Cannot use variable 'name' before it is declared.
 ## Example  
  The following example generates CS0841:  
   
-```  
+```csharp  
 // cs0841.cs  
 using System;  
   

--- a/docs/csharp/misc/cs0842.md
+++ b/docs/csharp/misc/cs0842.md
@@ -26,7 +26,7 @@ Automatically implemented properties cannot be used inside a type marked with St
 ## Example  
  The following example generates CS0842:  
   
-```  
+```csharp  
 // cs0842.cs  
 using System;  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs0844.md
+++ b/docs/csharp/misc/cs0844.md
@@ -28,7 +28,7 @@ Cannot use local variable 'name' before it is declared. The declaration of the l
 ## Example  
  The following code generates CS0844:  
   
-```  
+```csharp  
 class Test  
     {  
         int num;  

--- a/docs/csharp/misc/cs1002.md
+++ b/docs/csharp/misc/cs1002.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS1002:  
   
-```  
+```csharp  
 // CS1002.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs1003.md
+++ b/docs/csharp/misc/cs1003.md
@@ -21,7 +21,7 @@ Syntax error, 'char' expected
   
  The following sample generates CS1003:  
   
-```  
+```csharp  
 // CS1003.cs  
 public class b  
 {  

--- a/docs/csharp/misc/cs1004.md
+++ b/docs/csharp/misc/cs1004.md
@@ -21,7 +21,7 @@ Duplicate 'modifier' modifier
   
  The following sample generates CS1004:  
   
-```  
+```csharp  
 // CS1004.cs  
 public class clx  
 {  

--- a/docs/csharp/misc/cs1007.md
+++ b/docs/csharp/misc/cs1007.md
@@ -22,7 +22,7 @@ Property accessor already defined
 ## Example  
  The following sample generates CS1007:  
   
-```  
+```csharp  
 // CS1007.cs  
 public class clx  
 {  

--- a/docs/csharp/misc/cs1008.md
+++ b/docs/csharp/misc/cs1008.md
@@ -21,7 +21,7 @@ Type byte, sbyte, short, ushort, int, uint, long, or ulong expected
   
  The following sample generates CS1008:  
   
-```  
+```csharp  
 // CS1008.cs  
 abstract public class clx  
 {  

--- a/docs/csharp/misc/cs1010.md
+++ b/docs/csharp/misc/cs1010.md
@@ -21,7 +21,7 @@ Newline in constant
   
  The following sample generates CS1010:  
   
-```  
+```csharp  
 // CS1010.cs  
 class Sample  
 {  

--- a/docs/csharp/misc/cs1011.md
+++ b/docs/csharp/misc/cs1011.md
@@ -21,7 +21,7 @@ Empty character literal
   
  The following sample generates CS1011:  
   
-```  
+```csharp  
 // CS1011.cs  
 class Sample  
 {  

--- a/docs/csharp/misc/cs1012.md
+++ b/docs/csharp/misc/cs1012.md
@@ -29,7 +29,7 @@ Too many characters in character literal
   
  The following sample generates CS1012:  
   
-```  
+```csharp  
 // CS1012.cs  
 class Sample  
 {  

--- a/docs/csharp/misc/cs1013.md
+++ b/docs/csharp/misc/cs1013.md
@@ -22,7 +22,7 @@ Invalid number
 ## Example  
  The following sample generates CS1013:  
   
-```  
+```csharp  
 // CS1013.cs  
 class Sample  
 {  

--- a/docs/csharp/misc/cs1014.md
+++ b/docs/csharp/misc/cs1014.md
@@ -24,7 +24,7 @@ A get or set accessor expected
 ## Example  
  The following sample generates CS1014.  
   
-```  
+```csharp  
 // CS1014.cs  
 // compile with: /target:library  
 class Sample  

--- a/docs/csharp/misc/cs1015.md
+++ b/docs/csharp/misc/cs1015.md
@@ -22,7 +22,7 @@ An object, string, or class type expected
 ## Example  
  The following sample generates CS1015:  
   
-```  
+```csharp  
 // CS1015.cs  
 class Sample  
 {  

--- a/docs/csharp/misc/cs1016.md
+++ b/docs/csharp/misc/cs1016.md
@@ -22,7 +22,7 @@ Named attribute argument expected
 ## Example  
  The following sample generates CS1016:  
   
-```  
+```csharp  
 // CS1016.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1017.md
+++ b/docs/csharp/misc/cs1017.md
@@ -22,7 +22,7 @@ Catch clauses cannot follow the general catch clause of a try statement
 ## Example  
  The following sample generates CS1017:  
   
-```  
+```csharp  
 // CS1017.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1020.md
+++ b/docs/csharp/misc/cs1020.md
@@ -21,7 +21,7 @@ Overloadable binary operator expected
   
  The following sample generates CS1020:  
   
-```  
+```csharp  
 // CS1020.cs  
 public class iii  
 {  

--- a/docs/csharp/misc/cs1021.md
+++ b/docs/csharp/misc/cs1021.md
@@ -21,7 +21,7 @@ Integral constant is too large
   
  The following sample generates CS1021:  
   
-```  
+```csharp  
 // CS1021.cs  
 enum F : int  
 {  

--- a/docs/csharp/misc/cs1022.md
+++ b/docs/csharp/misc/cs1022.md
@@ -21,7 +21,7 @@ Type or namespace definition, or end-of-file expected
   
  The following sample generates CS1022:  
   
-```  
+```csharp  
 // CS1022.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs1023.md
+++ b/docs/csharp/misc/cs1023.md
@@ -21,7 +21,7 @@ Embedded statement cannot be a declaration or labeled statement
   
  The following sample generates CS1023 twice:  
   
-```  
+```csharp  
 // CS1023.cs  
 public class a  
 {  

--- a/docs/csharp/misc/cs1024.md
+++ b/docs/csharp/misc/cs1024.md
@@ -21,7 +21,7 @@ Preprocessor directive expected
   
  The following sample generates CS1024:  
   
-```  
+```csharp  
 // CS1024.cs  
 #import System   // CS1024  
 ```

--- a/docs/csharp/misc/cs1025.md
+++ b/docs/csharp/misc/cs1025.md
@@ -21,7 +21,7 @@ Single-line comment or end-of-line expected
   
  The following sample generates CS1025:  
   
-```  
+```csharp  
 #if true /* hello  
 */   // CS1025  
 #endif   // this is a good comment  
@@ -29,7 +29,7 @@ Single-line comment or end-of-line expected
   
  CS1025 could also occur if you attempt some invalid preprocessor directive, as follows:  
   
-```  
+```csharp  
 // CS1025.cs  
 #define a  
   

--- a/docs/csharp/misc/cs1027.md
+++ b/docs/csharp/misc/cs1027.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS1027:  
   
-```  
+```csharp  
 // CS1027.cs  
 #if true   // CS1027, uncomment next line to resolve  
 // #endif  

--- a/docs/csharp/misc/cs1028.md
+++ b/docs/csharp/misc/cs1028.md
@@ -23,7 +23,7 @@ Unexpected preprocessor directive
   
  The following sample generates CS1028:  
   
-```  
+```csharp  
 // CS1028.cs  
 #endif   // CS1028, no matching #if  
 namespace x  

--- a/docs/csharp/misc/cs1030.md
+++ b/docs/csharp/misc/cs1030.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample shows how to create a user-defined warning:  
   
-```  
+```csharp  
 // CS1030.cs  
 class Sample  
 {  

--- a/docs/csharp/misc/cs1031.md
+++ b/docs/csharp/misc/cs1031.md
@@ -22,7 +22,7 @@ Type expected
 ## Example  
  The following sample generates CS1031:  
   
-```  
+```csharp  
 // CS1031.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs1032.md
+++ b/docs/csharp/misc/cs1032.md
@@ -21,7 +21,7 @@ Cannot define/undefine preprocessor symbols after first token in file
   
  The following sample generates CS1032:  
   
-```  
+```csharp  
 // CS1032.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs1035.md
+++ b/docs/csharp/misc/cs1035.md
@@ -21,7 +21,7 @@ End-of-file found, '*/' expected
   
  The following sample generates CS1035:  
   
-```  
+```csharp  
 // CS1035.cs  
 public class a  
 {  

--- a/docs/csharp/misc/cs1038.md
+++ b/docs/csharp/misc/cs1038.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS1038:  
   
-```  
+```csharp  
 // CS1038.cs  
 #region testing  
   

--- a/docs/csharp/misc/cs1039.md
+++ b/docs/csharp/misc/cs1039.md
@@ -22,7 +22,7 @@ Unterminated string literal
 ## Example  
  The following sample generates CS1039. To resolve the error, add the terminating quotation mark.  
   
-```  
+```csharp  
 // CS1039.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs1040.md
+++ b/docs/csharp/misc/cs1040.md
@@ -21,7 +21,7 @@ Preprocessor directives must appear as the first non-whitespace character on a l
   
  The following sample generates CS1040:  
   
-```  
+```csharp  
 // CS1040.cs  
 /* Define a symbol, X */ #define X   // CS1040  
   

--- a/docs/csharp/misc/cs1041.md
+++ b/docs/csharp/misc/cs1041.md
@@ -22,7 +22,7 @@ Identifier expected, 'keyword' is a keyword
 ## Example  
  The following sample generates CS1041:  
   
-```  
+```csharp  
 // CS1041a.cs  
 class MyClass  
 {  
@@ -43,7 +43,7 @@ class MyClass
   
  An identifier with an `@` prefix is called a verbatim identifier.  
   
-```  
+```csharp  
 // CS1041b.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs1043.md
+++ b/docs/csharp/misc/cs1043.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS1043.  
   
-```  
+```csharp  
 // CS1043.cs  
 // compile with: /target:library  
 public class MyClass  

--- a/docs/csharp/misc/cs1044.md
+++ b/docs/csharp/misc/cs1044.md
@@ -21,7 +21,7 @@ Cannot use more than one type in a for, using, fixed, or declaration statement
   
  The following sample generates CS1044:  
   
-```  
+```csharp  
 // CS1044.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1055.md
+++ b/docs/csharp/misc/cs1055.md
@@ -21,7 +21,7 @@ An add or remove accessor expected
   
  The following sample generates CS1055:  
   
-```  
+```csharp  
 // CS1055.cs  
 delegate void del();  
 class Test  

--- a/docs/csharp/misc/cs1057.md
+++ b/docs/csharp/misc/cs1057.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS1057.  
   
-```  
+```csharp  
 // CS1057.cs  
 using System;  
   


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.