### PR TITLE
adding missing language identifiers - 10/13

### DIFF
--- a/docs/csharp/misc/cs1059.md
+++ b/docs/csharp/misc/cs1059.md
@@ -30,7 +30,7 @@ The operand of an increment or decrement operator must be a variable, property o
 ## Example  
  The following example generates CS1059 because `i` is a constant, not a variable, and `E` is an `Enum` type, whose elements are also constant values.  
   
-```  
+```csharp  
 // CS1059.cs  
     class Program  
     {  

--- a/docs/csharp/misc/cs1100.md
+++ b/docs/csharp/misc/cs1100.md
@@ -26,7 +26,7 @@ Method 'name' has a parameter modifier 'this' which is not on the first paramete
 ## Example  
  The following code generates CS1100 because a `this` parameter is modifying the second parameter:  
   
-```  
+```csharp  
 // cs1100.cs  
 static class Test  
 {  

--- a/docs/csharp/misc/cs1101.md
+++ b/docs/csharp/misc/cs1101.md
@@ -22,7 +22,7 @@ The parameter modifier 'ref' cannot be used with 'this'.
 ## Example  
  The following example generates CS1101:  
   
-```  
+```csharp  
 // cs1101.cs  
 // Compile with: /target:library  
 public static class Extensions  

--- a/docs/csharp/misc/cs1102.md
+++ b/docs/csharp/misc/cs1102.md
@@ -26,7 +26,7 @@ The parameter modifier 'out' cannot be used with 'this'.
 ## Example  
  The following example generates CS1102:  
   
-```  
+```csharp  
 // cs1102.cs  
 // Compile with: /target:library.  
 public static class Extensions  

--- a/docs/csharp/misc/cs1103.md
+++ b/docs/csharp/misc/cs1103.md
@@ -22,7 +22,7 @@ The first parameter of an extension method cannot be of type 'type'.
 ## Example  
  The following example generates CS1103:  
   
-```  
+```csharp  
 // cs1103.cs  
 public static class Extensions  
 {  

--- a/docs/csharp/misc/cs1104.md
+++ b/docs/csharp/misc/cs1104.md
@@ -26,7 +26,7 @@ A parameter array cannot be used with 'this' modifier on an extension method.
 ## Example  
  The following example generates CS1104:  
   
-```  
+```csharp  
 // cs1104.cs  
 // Compile with: /target:library  
 public static class Extensions  

--- a/docs/csharp/misc/cs1105.md
+++ b/docs/csharp/misc/cs1105.md
@@ -22,7 +22,7 @@ Extension methods must be static.
 ## Example  
  The following example generates CS1105 because `Test` is not static:  
   
-```  
+```csharp  
 // cs1105.cs  
 // Compile with: /target:library  
 public class Extensions  

--- a/docs/csharp/misc/cs1106.md
+++ b/docs/csharp/misc/cs1106.md
@@ -22,7 +22,7 @@ Extension methods must be defined in a non generic static class.
 ## Example  
  The following example generates CS1106 because the class `Extensions` is not defined as `static`:  
   
-```  
+```csharp  
 // cs1106.cs  
 public class Extensions // CS1106  
 {  

--- a/docs/csharp/misc/cs1107.md
+++ b/docs/csharp/misc/cs1107.md
@@ -22,7 +22,7 @@ A parameter can only have one 'modifier name' modifier.
 ## Example  
  The following example generates CS1107:  
   
-```  
+```csharp  
 // cs1107.cs  
 public static class Test  
 {  

--- a/docs/csharp/misc/cs1108.md
+++ b/docs/csharp/misc/cs1108.md
@@ -22,7 +22,7 @@ A parameter cannot have all the specified modifiers; there are too many modifier
 ## Example  
  The following example generates CS1108:  
   
-```  
+```csharp  
 // cs1108.cs  
 // Compile with: /target:library  
 public class Test  

--- a/docs/csharp/misc/cs1109.md
+++ b/docs/csharp/misc/cs1109.md
@@ -22,7 +22,7 @@ Extension Methods must be defined on top level static classes, 'name' is a neste
 ## Example  
  The following example generates CS1109 because the class `Extension` is nested inside the class `Out`:  
   
-```  
+```csharp  
 // cs1109.cs  
 public class Test  
 {  

--- a/docs/csharp/misc/cs1110.md
+++ b/docs/csharp/misc/cs1110.md
@@ -26,7 +26,7 @@ Cannot use 'this' modifier on first parameter of method declaration without a re
 ## Example  
  The following example generates CS1110 if the file is not compiled with a reference to System.Core.dll:  
   
-```  
+```csharp  
 // cs1110.cs  
 // CS1110  
 // Compile with: /target:library  

--- a/docs/csharp/misc/cs1113.md
+++ b/docs/csharp/misc/cs1113.md
@@ -28,7 +28,7 @@ Extension methods 'name' defined on value type 'name' cannot be used to create d
 ## Example  
  The following example generates CS1113:  
   
-```  
+```csharp  
 // cs1113.cs  
 using System;  
 public static class Extensions  

--- a/docs/csharp/misc/cs1510.md
+++ b/docs/csharp/misc/cs1510.md
@@ -22,7 +22,7 @@ A ref or out argument must be an assignable variable
 ## Example  
  The following sample generates CS1510:  
   
-```  
+```csharp  
 // CS1510.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs1511.md
+++ b/docs/csharp/misc/cs1511.md
@@ -22,7 +22,7 @@ Keyword 'base' is not available in a static method
 ## Example  
  The following sample generates CS1511.  
   
-```  
+```csharp  
 // CS1511.cs  
 // compile with: /target:library  
 public class A  

--- a/docs/csharp/misc/cs1512.md
+++ b/docs/csharp/misc/cs1512.md
@@ -21,7 +21,7 @@ Keyword 'base' is not available in the current context
   
  The following example generates CS1512:  
   
-```  
+```csharp  
 // CS1512.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1513.md
+++ b/docs/csharp/misc/cs1513.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS1513:  
   
-```  
+```csharp  
 // CS1513  
 namespace y   // CS1513, no close curly brace  
 {  

--- a/docs/csharp/misc/cs1514.md
+++ b/docs/csharp/misc/cs1514.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following sample generates CS1514:  
   
-```  
+```csharp  
 // CS1514.cs  
 namespace x  
 // CS1514, no open curly brace  

--- a/docs/csharp/misc/cs1515.md
+++ b/docs/csharp/misc/cs1515.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS1515:  
   
-```  
+```csharp 
 using System;  
   
 class Driver  

--- a/docs/csharp/misc/cs1517.md
+++ b/docs/csharp/misc/cs1517.md
@@ -23,7 +23,7 @@ Invalid preprocessor expression
   
  The following sample shows some valid and invalid preprocessor expressions:  
   
-```  
+```csharp  
 // CS1517.cs  
 #if symbol      // OK  
 #endif  

--- a/docs/csharp/misc/cs1518.md
+++ b/docs/csharp/misc/cs1518.md
@@ -22,7 +22,7 @@ Expected class, delegate, enum, interface, or struct
 ## Example  
  The following sample generates CS1518:  
   
-```  
+```csharp  
 // CS1518.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs1520.md
+++ b/docs/csharp/misc/cs1520.md
@@ -19,7 +19,7 @@ Method must have a return type
   
  A method that is declared in a class, struct, or interface must have an explicit return type. In the following example, the Square method has a return value of [string](../../csharp/language-reference/keywords/string.md):  
   
-```  
+```csharp  
 class Test  
 {  
     string IntToString(int i)  
@@ -31,7 +31,7 @@ class Test
   
  The following sample generates CS1520:  
   
-```  
+```csharp  
 // CS1520a.cs  
 public class x  
 {  
@@ -50,7 +50,7 @@ public class x
   
  Alternatively, this error might be encountered when the case of a constructor's name differs from that of the class or struct declaration, as in the following sample. Because the name is not exactly the same as the class name, the compiler interprets it as a regular method, not a constructor, and produces the error:  
   
-```  
+```csharp  
 // CS1520b.cs  
 public class Class1  
 {  

--- a/docs/csharp/misc/cs1521.md
+++ b/docs/csharp/misc/cs1521.md
@@ -21,7 +21,7 @@ Invalid base type
   
  The following sample generates CS1521:  
   
-```  
+```csharp  
 // CS1521.cs  
 class CMyClass  
 {  

--- a/docs/csharp/misc/cs1522.md
+++ b/docs/csharp/misc/cs1522.md
@@ -21,7 +21,7 @@ Empty switch block
   
  The following sample generates CS1522:  
   
-```  
+```csharp  
 // CS1522.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/misc/cs1524.md
+++ b/docs/csharp/misc/cs1524.md
@@ -24,7 +24,7 @@ Expected catch or finally
 ## Example  
  The following sample generates CS1524:  
   
-```  
+```csharp  
 // CS1524.cs  
 class x  
 {  

--- a/docs/csharp/misc/cs1525.md
+++ b/docs/csharp/misc/cs1525.md
@@ -21,7 +21,7 @@ Invalid expression term 'character'
   
  The following sample generates CS1525:  
   
-```  
+```csharp  
 // CS1525.cs  
 class x  
 {  
@@ -40,7 +40,7 @@ class x
   
  An empty label can also generate CS1525, as in the following sample:  
   
-```  
+```csharp  
 // CS1525b.cs  
 using System;  
 public class MyClass  

--- a/docs/csharp/misc/cs1526.md
+++ b/docs/csharp/misc/cs1526.md
@@ -22,7 +22,7 @@ A new expression requires (), [], or {} after type
 ## Example  
  The following sample shows how to use `new` to allocate space for an array and an object.  
   
-```  
+```csharp  
 // CS1526.cs  
 public class y  
 {  

--- a/docs/csharp/misc/cs1527.md
+++ b/docs/csharp/misc/cs1527.md
@@ -21,7 +21,7 @@ Elements defined in a namespace cannot be explicitly declared as private, protec
   
  The following sample generates CS1527:  
   
-```  
+```csharp  
 // CS1527.cs  
 namespace Sample  
 {  
@@ -34,7 +34,7 @@ namespace Sample
   
  The following example generates CS1527 because when no namespace is explicitly declared in your program code, all type declarations are located implicitly within the global namespace.  
   
-```  
+```csharp  
 //cs1527_2.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1528.md
+++ b/docs/csharp/misc/cs1528.md
@@ -21,7 +21,7 @@ Expected ; or = (cannot specify constructor arguments in declaration)
   
  The following sample generates CS1528:  
   
-```  
+```csharp  
 // CS1528.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1529.md
+++ b/docs/csharp/misc/cs1529.md
@@ -22,7 +22,7 @@ A using clause must precede all other elements defined in the namespace except e
 ## Example  
  The following sample generates CS1529:  
   
-```  
+```csharp  
 // CS1529.cs  
 namespace X  
 {  

--- a/docs/csharp/misc/cs1530.md
+++ b/docs/csharp/misc/cs1530.md
@@ -21,7 +21,7 @@ Keyword 'new' is not allowed on elements defined in a namespace
   
  The following sample generates CS1530:  
   
-```  
+```csharp  
 // CS1530.cs  
 namespace a  
 {  

--- a/docs/csharp/misc/cs1534.md
+++ b/docs/csharp/misc/cs1534.md
@@ -21,7 +21,7 @@ Overloaded binary operator 'operator' takes two parameters
   
  The following sample generates CS1534:  
   
-```  
+```csharp  
 // CS1534.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs1535.md
+++ b/docs/csharp/misc/cs1535.md
@@ -22,7 +22,7 @@ Overloaded unary operator 'operator' takes one parameter
 ## Example  
  The following sample generates CS1535:  
   
-```  
+```csharp  
 // CS1535.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs1536.md
+++ b/docs/csharp/misc/cs1536.md
@@ -21,7 +21,7 @@ Invalid parameter type void
   
  The following sample generates CS1536:  
   
-```  
+```csharp  
 // CS1536.cs  
 class a  
 {  

--- a/docs/csharp/misc/cs1537.md
+++ b/docs/csharp/misc/cs1537.md
@@ -21,7 +21,7 @@ The using alias 'alias' appeared previously in this namespace
   
  The following sample generates CS1537:  
   
-```  
+```csharp  
 // CS1537.cs  
 namespace x  
 {  

--- a/docs/csharp/misc/cs1545.md
+++ b/docs/csharp/misc/cs1545.md
@@ -21,7 +21,7 @@ Property, indexer, or event 'property' is not supported by the language; try dir
   
 ## Example  
   
-```  
+```cpp  
 // CPP1545.cpp  
 // compile with: /clr /LD  
 // a Visual C++ program  
@@ -50,7 +50,7 @@ public ref struct Manager {
 ## Example  
  The following sample generates CS1545.  
   
-```  
+```csharp  
 // CS1545.cs  
 // compile with: /r:CPP1545.dll  
   

--- a/docs/csharp/misc/cs1547.md
+++ b/docs/csharp/misc/cs1547.md
@@ -21,7 +21,7 @@ Keyword 'void' cannot be used in this context
   
  The following sample generates CS1547:  
   
-```  
+```csharp  
 // CS1547.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs1551.md
+++ b/docs/csharp/misc/cs1551.md
@@ -21,7 +21,7 @@ Indexers must have at least one parameter
   
  The following sample generates CS1551:  
   
-```  
+```csharp  
 // CS1551.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs1552.md
+++ b/docs/csharp/misc/cs1552.md
@@ -22,7 +22,7 @@ Array type specifier, [], must appear before parameter name
 ## Example  
  The following sample generates CS1552:  
   
-```  
+```csharp  
 // CS1552.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs1553.md
+++ b/docs/csharp/misc/cs1553.md
@@ -21,7 +21,7 @@ Declaration is not valid; use 'modifier operator \<dest-type> (...' instead
   
  The following sample generates CS1553:  
   
-```  
+```csharp  
 // CS1553.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs1554.md
+++ b/docs/csharp/misc/cs1554.md
@@ -21,7 +21,7 @@ Declaration is not valid; use '\<type> operator op (...' instead
   
  The following sample generates CS1554:  
   
-```  
+```csharp  
 // CS1554.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs1558.md
+++ b/docs/csharp/misc/cs1558.md
@@ -21,7 +21,7 @@ ms.author: "wiwagn"
   
  The following example generates CS1558 because of invalid return type.  
   
-```  
+```csharp  
 // CS1558.cs  
 // compile with: /main:MyNamespace.MyClass  
   

--- a/docs/csharp/misc/cs1560.md
+++ b/docs/csharp/misc/cs1560.md
@@ -22,7 +22,7 @@ Invalid filename specified for preprocessor directive. Filename is too long or n
 ## Example  
  The following sample generates CS1560.  
   
-```  
+```csharp  
 // cs1560.cs   
 using System;   
 class MyClass   

--- a/docs/csharp/misc/cs1569.md
+++ b/docs/csharp/misc/cs1569.md
@@ -21,7 +21,7 @@ Error generating XML documentation file 'Filename' ('reason')
   
 ## Example  
   
-```  
+```csharp  
 // 1569a.cs  
 // compile with: /doc:CS1569.xml  
 // post-build command: attrib +r CS1569.xml  
@@ -35,7 +35,7 @@ class Test
 ## Example  
  The previous sample generated an .xml file that was then set to read only. This sample attempts to write to the same file. The following sample generates CS1569.  
   
-```  
+```csharp  
 // CS1569.cs  
 // compile with: /doc:CS1569.xml  
 // CS1569 expected  

--- a/docs/csharp/misc/cs1570.md
+++ b/docs/csharp/misc/cs1570.md
@@ -29,7 +29,7 @@ XML comment on 'construct' has badly formed XML — 'reason'
   
  The following sample generates CS1570:  
   
-```  
+```csharp  
 // CS1570.cs  
 // compile with: /W:1  
 namespace ns  

--- a/docs/csharp/misc/cs1571.md
+++ b/docs/csharp/misc/cs1571.md
@@ -21,7 +21,7 @@ XML comment on 'construct' has a duplicate param tag for 'parameter'
   
  The following sample generates CS1571:  
   
-```  
+```csharp  
 // CS1571.cs  
 // compile with: /W:2 /doc:x.xml  
   

--- a/docs/csharp/misc/cs1572.md
+++ b/docs/csharp/misc/cs1572.md
@@ -21,7 +21,7 @@ XML comment on 'construct' has a param tag for 'parameter', but there is no para
   
  The following sample generates CS1572:  
   
-```  
+```csharp  
 // CS1572.cs  
 // compile with: /W:2 /doc:x.xml  
   

--- a/docs/csharp/misc/cs1573.md
+++ b/docs/csharp/misc/cs1573.md
@@ -21,7 +21,7 @@ Parameter 'parameter' has no matching param tag in the XML comment for 'paramete
   
  The following sample generates CS1573:  
   
-```  
+```csharp  
 // CS1573.cs  
 // compile with: /W:4  
 public class MyClass  

--- a/docs/csharp/misc/cs1574.md
+++ b/docs/csharp/misc/cs1574.md
@@ -23,7 +23,7 @@ XML comment on 'construct' has syntactically incorrect cref attribute 'name'
   
  The following sample generates CS1574:  
   
-```  
+```csharp  
 // CS1574.cs  
 // compile with: /W:1 /doc:x.xml  
 using System;  

--- a/docs/csharp/misc/cs1575.md
+++ b/docs/csharp/misc/cs1575.md
@@ -21,7 +21,7 @@ A stackalloc expression requires [] after type
   
  The following sample generates CS1575:  
   
-```  
+```csharp  
 // CS1575.cs  
 // compile with: /unsafe  
 public class MyClass  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.