### PR TITLE
adding missing language identifiers - 11/13

### DIFF
--- a/docs/csharp/misc/cs1576.md
+++ b/docs/csharp/misc/cs1576.md
@@ -21,7 +21,7 @@ The line number specified for #line directive is missing or invalid
   
  The following sample generates CS1576:  
   
-```  
+```csharp  
 // CS1576.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs1578.md
+++ b/docs/csharp/misc/cs1578.md
@@ -21,7 +21,7 @@ Filename, single-line comment or end-of-line expected
   
  The following sample generates CS1578:  
   
-```  
+```csharp  
 // CS1578.cs  
 class MyClass  
 {  

--- a/docs/csharp/misc/cs1580.md
+++ b/docs/csharp/misc/cs1580.md
@@ -21,7 +21,7 @@ Invalid type for parameter 'parameter number' in XML comment cref attribute
   
  The following sample generates CS1580:  
   
-```  
+```csharp  
 // CS1580.cs  
 // compile with: /W:1 /doc:x.xml  
 using System;  

--- a/docs/csharp/misc/cs1581.md
+++ b/docs/csharp/misc/cs1581.md
@@ -22,7 +22,7 @@ Invalid return type in XML comment cref attribute
 ## Example  
  The following sample generates CS1581:  
   
-```  
+```csharp  
 // CS1581.cs  
 // compile with: /W:1 /doc:x.xml  
   

--- a/docs/csharp/misc/cs1584.md
+++ b/docs/csharp/misc/cs1584.md
@@ -22,7 +22,7 @@ XML comment on 'member' has syntactically incorrect cref attribute 'invalid_synt
 ## Example  
  The following sample generates CS1584.  
   
-```  
+```csharp  
 // CS1584.cs  
 // compile with: /W:1 /doc:CS1584.xml  
 /// <remarks>Test class</remarks>  

--- a/docs/csharp/misc/cs1585.md
+++ b/docs/csharp/misc/cs1585.md
@@ -21,7 +21,7 @@ Member modifier 'keyword' must precede the member type and name
   
  The following sample generates CS1585:  
   
-```  
+```csharp  
 // CS1585.cs  
 public class Class1  
 {  

--- a/docs/csharp/misc/cs1586.md
+++ b/docs/csharp/misc/cs1586.md
@@ -21,7 +21,7 @@ Array creation must have array size or array initializer
   
  The following sample generates CS1586:  
   
-```  
+```csharp  
 // CS1586.cs  
 using System;  
 class MyClass  

--- a/docs/csharp/misc/cs1587.md
+++ b/docs/csharp/misc/cs1587.md
@@ -22,7 +22,7 @@ XML comment is not placed on a valid language element
 ## Example  
  The following sample generates CS1587:  
   
-```  
+```csharp  
 // CS1587.cs  
 // compile with: /W:2 /doc:x.xml  
   

--- a/docs/csharp/misc/cs1589.md
+++ b/docs/csharp/misc/cs1589.md
@@ -23,7 +23,7 @@ Unable to include XML fragment 'fragment' of file 'file' -- reason
   
  The following sample generates CS1589:  
   
-```  
+```csharp  
 // CS1589.cs  
 // compile with: /W:1 /doc:CS1589_out.xml  
   

--- a/docs/csharp/misc/cs1590.md
+++ b/docs/csharp/misc/cs1590.md
@@ -21,7 +21,7 @@ Invalid XML include element -- Missing file attribute
   
  The following sample generates CS1590:  
   
-```  
+```csharp  
 // CS1590.cs  
 // compile with: /W:1 /doc:x.xml  
   

--- a/docs/csharp/misc/cs1593.md
+++ b/docs/csharp/misc/cs1593.md
@@ -21,7 +21,7 @@ Delegate 'del' does not take 'number' arguments
   
  The following sample generates CS1593:  
   
-```  
+```csharp  
 // CS1593.cs  
 using System;  
 delegate string func(int i);   // declare delegate  

--- a/docs/csharp/misc/cs1594.md
+++ b/docs/csharp/misc/cs1594.md
@@ -21,7 +21,7 @@ Delegate 'delegate' has some invalid arguments
   
  The following sample generates CS1594:  
   
-```  
+```csharp  
 // CS1594.cs  
 using System;  
 delegate string func(int i);   // declare delegate  

--- a/docs/csharp/misc/cs1597.md
+++ b/docs/csharp/misc/cs1597.md
@@ -21,7 +21,7 @@ Semicolon after method or accessor block is not valid
   
  The following sample generates CS1597:  
   
-```  
+```csharp  
 // CS1597.cs  
 class TestClass  
 {  

--- a/docs/csharp/misc/cs1599.md
+++ b/docs/csharp/misc/cs1599.md
@@ -21,7 +21,7 @@ Method or delegate cannot return type 'type'
   
  The following sample generates CS1599:  
   
-```  
+```csharp  
 // CS1599.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1601.md
+++ b/docs/csharp/misc/cs1601.md
@@ -21,7 +21,7 @@ Method or delegate parameter cannot be of type 'type'
   
  The following sample generates CS1601:  
   
-```  
+```csharp  
 // CS1601.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1609.md
+++ b/docs/csharp/misc/cs1609.md
@@ -22,7 +22,7 @@ Modifiers cannot be placed on event accessor declarations
 ## Example  
  The following sample generates CS1609.  
   
-```  
+```csharp  
 // CS1609.cs  
 // compile with: /target:library  
 delegate int Del();  

--- a/docs/csharp/misc/cs1611.md
+++ b/docs/csharp/misc/cs1611.md
@@ -21,7 +21,7 @@ The params parameter cannot be declared as ref or out
   
  The following sample generates CS1611:  
   
-```  
+```csharp  
 // CS1611.cs  
 public class MyClass  
 {  

--- a/docs/csharp/misc/cs1613.md
+++ b/docs/csharp/misc/cs1613.md
@@ -27,7 +27,7 @@ The managed coclass wrapper class 'class' for interface 'interface' cannot be fo
   
  The following sample demonstrates correct usage of **CoClassAttribute**:  
   
-```  
+```csharp  
 // CS1613.cs  
 using System;  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs1615.md
+++ b/docs/csharp/misc/cs1615.md
@@ -21,7 +21,7 @@ Argument 'number' should not be passed with the 'keyword' keyword
   
  The following sample generates CS1615:  
   
-```  
+```csharp  
 // CS1615.cs  
 class C  
 {  

--- a/docs/csharp/misc/cs1618.md
+++ b/docs/csharp/misc/cs1618.md
@@ -21,7 +21,7 @@ Cannot create delegate with 'method' because it has a Conditional attribute
   
  The following sample generates CS1618:  
   
-```  
+```csharp  
 // CS1618.cs  
 using System;  
 using System.Diagnostics;  

--- a/docs/csharp/misc/cs1620.md
+++ b/docs/csharp/misc/cs1620.md
@@ -21,7 +21,7 @@ Argument 'number' must be passed with the 'keyword' keyword
   
  The following sample generates CS1620:  
   
-```  
+```csharp  
 // CS1620.cs  
 class C  
 {  

--- a/docs/csharp/misc/cs1621.md
+++ b/docs/csharp/misc/cs1621.md
@@ -22,7 +22,7 @@ The yield statement cannot be used inside an anonymous method or lambda expressi
 ## Example  
  The following sample generates CS1621:  
   
-```  
+```csharp  
 // CS1621.cs  
   
 using System.Collections;  

--- a/docs/csharp/misc/cs1622.md
+++ b/docs/csharp/misc/cs1622.md
@@ -21,7 +21,7 @@ Cannot return a value from an iterator. Use the yield return statement to return
   
  The following sample generates CS1622:  
   
-```  
+```csharp  
 // CS1622.cs  
 // compile with: /target:library  
 using System.Collections;  

--- a/docs/csharp/misc/cs1623.md
+++ b/docs/csharp/misc/cs1623.md
@@ -22,7 +22,7 @@ Iterators cannot have ref or out parameters
 ## Example  
  The following sample generates CS1623:  
   
-```  
+```csharp  
 // CS1623.cs  
 using System.Collections;  
   

--- a/docs/csharp/misc/cs1624.md
+++ b/docs/csharp/misc/cs1624.md
@@ -22,7 +22,7 @@ The body of 'accessor' cannot be an iterator block because 'type' is not an iter
 ## Example  
  The following sample generates CS1624:  
   
-```  
+```csharp  
 // CS1624.cs  
 using System;  
 using System.Collections;  

--- a/docs/csharp/misc/cs1625.md
+++ b/docs/csharp/misc/cs1625.md
@@ -21,7 +21,7 @@ Cannot yield in the body of a finally clause
   
  The following sample generates CS1625:  
   
-```  
+```csharp  
 // CS1625.cs  
 using System.Collections;  
   

--- a/docs/csharp/misc/cs1626.md
+++ b/docs/csharp/misc/cs1626.md
@@ -21,7 +21,7 @@ Cannot yield a value in the body of a try block with a catch clause
   
  The following sample generates CS1626:  
   
-```  
+```csharp  
 // CS1626.cs  
 using System.Collections;  
   

--- a/docs/csharp/misc/cs1627.md
+++ b/docs/csharp/misc/cs1627.md
@@ -21,7 +21,7 @@ Expression expected after yield return
   
  The following sample generates CS1627:  
   
-```  
+```csharp  
 // CS1627.cs  
 using System.Collections;  
   

--- a/docs/csharp/misc/cs1628.md
+++ b/docs/csharp/misc/cs1628.md
@@ -21,7 +21,7 @@ Cannot use ref or out parameter 'parameter' inside an anonymous method, lambda e
   
  The following sample generates CS1628:  
   
-```  
+```csharp  
 // CS1628.cs  
   
 delegate int MyDelegate();  

--- a/docs/csharp/misc/cs1629.md
+++ b/docs/csharp/misc/cs1629.md
@@ -21,7 +21,7 @@ Unsafe code may not appear in iterators
   
  The following sample generates CS1629:  
   
-```  
+```csharp  
 // CS1629.cs  
 // compile with: /unsafe    
 using System.Collections.Generic;  

--- a/docs/csharp/misc/cs1631.md
+++ b/docs/csharp/misc/cs1631.md
@@ -21,7 +21,7 @@ Cannot yield a value in the body of a catch clause
   
  The following sample generates CS1631:  
   
-```  
+```csharp  
 // CS1631.cs  
 using System;  
 using System.Collections;  

--- a/docs/csharp/misc/cs1632.md
+++ b/docs/csharp/misc/cs1632.md
@@ -21,7 +21,7 @@ Control cannot leave the body of an anonymous method or lambda expression
   
  The following sample generates CS1632:  
   
-```  
+```csharp  
 // CS1632.cs  
 // compile with: /target:library  
 delegate void MyDelegate();  

--- a/docs/csharp/misc/cs1633.md
+++ b/docs/csharp/misc/cs1633.md
@@ -21,7 +21,7 @@ Unrecognized #pragma directive
   
  The following sample generates CS1633:  
   
-```  
+```csharp  
 // CS1633.cs  
 // compile with: /W:1  
 #pragma unknown  // CS1633  

--- a/docs/csharp/misc/cs1634.md
+++ b/docs/csharp/misc/cs1634.md
@@ -22,7 +22,7 @@ Expected disable or restore
 ## Example  
  The following sample generates CS1634:  
   
-```  
+```csharp  
 // CS1634.cs  
 // compile with: /W:1  
   

--- a/docs/csharp/misc/cs1635.md
+++ b/docs/csharp/misc/cs1635.md
@@ -21,7 +21,7 @@ Cannot restore warning 'warning code' because it was disabled globally
   
  The following sample generates CS1635:  
   
-```  
+```csharp  
 // CS1635.cs  
 // compile with: /w:1 /nowarn:162  
   

--- a/docs/csharp/misc/cs1637.md
+++ b/docs/csharp/misc/cs1637.md
@@ -22,7 +22,7 @@ Iterators cannot have unsafe parameters or yield types
 ## Example  
  The following sample generates CS1637:  
   
-```  
+```csharp  
 // CS1637.cs  
 // compile with: /unsafe  
 using System.Collections;  

--- a/docs/csharp/misc/cs1638.md
+++ b/docs/csharp/misc/cs1638.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS1638:  
   
-```  
+```csharp  
 // CS1638.cs  
 // compile with: /langversion:ISO-1  
 class bad__identifer // CS1638 (double underscores are not ISO compliant)  

--- a/docs/csharp/misc/cs1641.md
+++ b/docs/csharp/misc/cs1641.md
@@ -21,7 +21,7 @@ A fixed size buffer field must have the array size specifier after the field nam
   
  The following sample generates CS1641:  
   
-```  
+```csharp  
 // CS1641.cs  
 // compile with: /unsafe /target:library  
 unsafe struct S {  

--- a/docs/csharp/misc/cs1642.md
+++ b/docs/csharp/misc/cs1642.md
@@ -22,7 +22,7 @@ Fixed size buffer fields may only be members of structs.
 ## Example  
  The following sample generates CS1642.  
   
-```  
+```csharp  
 // CS1642.cs  
 // compile with: /unsafe /target:library  
 unsafe class C  

--- a/docs/csharp/misc/cs1643.md
+++ b/docs/csharp/misc/cs1643.md
@@ -22,7 +22,7 @@ Not all code paths return a value in method of type 'type!'
 ## Example  
  The following sample generates CS1643:  
   
-```  
+```csharp  
 // CS1643.cs  
 delegate int MyDelegate();  
   

--- a/docs/csharp/misc/cs1645.md
+++ b/docs/csharp/misc/cs1645.md
@@ -19,7 +19,7 @@ Feature 'feature' is not part of the standardized ISO C# language specification,
   
  The feature you are using is not part of the ISO standard. Code using this feature may not compile on other compilers.  
   
-```  
+```csharp  
 // CS1645.cs  
 // compile with: /W:1 /t:module /langversion:ISO-1  
 [assembly:System.CLSCompliant(false)]  

--- a/docs/csharp/misc/cs1646.md
+++ b/docs/csharp/misc/cs1646.md
@@ -21,7 +21,7 @@ Keyword, identifier, or string expected after verbatim specifier: @
   
  The following sample generates CS1646:  
   
-```  
+```csharp  
 // CS1646  
 class C  
 {  

--- a/docs/csharp/misc/cs1648.md
+++ b/docs/csharp/misc/cs1648.md
@@ -21,7 +21,7 @@ Members of readonly field 'identifier' cannot be modified (except in a construct
   
  The following sample generates CS1648:  
   
-```  
+```csharp  
 // CS1648.cs  
 public struct Inner  
   {  

--- a/docs/csharp/misc/cs1649.md
+++ b/docs/csharp/misc/cs1649.md
@@ -22,7 +22,7 @@ Members of readonly field 'identifier' cannot be passed ref or out (except in a 
 ## Example  
  The following sample generates CS1649:  
   
-```  
+```csharp  
 // CS1649.cs  
 public struct Inner  
     {  

--- a/docs/csharp/misc/cs1650.md
+++ b/docs/csharp/misc/cs1650.md
@@ -19,7 +19,7 @@ Fields of static readonly field 'identifier' cannot be assigned to (except in a 
   
  This error occurs when you attempt to modify a member of a field which is readonly and static where it is not allowed to be modified. To resolve this error, limit assignments to readonly fields to the constructor or variable initializer, or remove the `readonly` keyword from the declaration of the field.  
   
-```  
+```csharp  
 // CS1650.cs  
 public struct Inner  
 {  

--- a/docs/csharp/misc/cs1651.md
+++ b/docs/csharp/misc/cs1651.md
@@ -21,7 +21,7 @@ Fields of static readonly field 'identifier' cannot be passed ref or out (except
   
  The following sample generates CS1651:  
   
-```  
+```csharp  
 // CS1651.cs  
 public struct Inner  
   {  

--- a/docs/csharp/misc/cs1654.md
+++ b/docs/csharp/misc/cs1654.md
@@ -24,7 +24,7 @@ Cannot modify members of 'variable' because it is a 'read-only variable type'
 ## Example  
  The following example generates error CS1654 because `Book` is a `struct`. To fix the error, change the `struct` to a [class](../../csharp/language-reference/keywords/class.md).  
   
-```  
+```csharp  
 using System.Collections.Generic;  
 using System.Text;  
   

--- a/docs/csharp/misc/cs1655.md
+++ b/docs/csharp/misc/cs1655.md
@@ -21,7 +21,7 @@ Cannot pass fields of 'variable' as a ref or out argument because it is a 'reado
   
  The following sample generates CS1655:  
   
-```  
+```csharp  
 // CS1655.cs  
 struct S   
 {  

--- a/docs/csharp/misc/cs1657.md
+++ b/docs/csharp/misc/cs1657.md
@@ -22,7 +22,7 @@ Cannot pass 'parameter' as a ref or out argument because 'reason''
 ## Example  
  The following sample generates CS1657:  
   
-```  
+```csharp  
 // CS1657.cs  
 using System;  
 class C : IDisposable  
@@ -49,7 +49,7 @@ class CMain
 ## Example  
  The following code illustrates the same problem in a `fixed` statement:  
   
-```  
+```csharp  
 // CS1657b.cs  
 // compile with: /unsafe  
 unsafe class C  

--- a/docs/csharp/misc/cs1660.md
+++ b/docs/csharp/misc/cs1660.md
@@ -21,7 +21,7 @@ Cannot convert anonymous method block to type 'type' because it is not a delegat
   
  The following sample generates CS1660:  
   
-```  
+```csharp  
 // CS1660.cs  
 delegate int MyDelegate();  
 class C {  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.