### PR TITLE
adding missing language identifiers - 12/13

### DIFF
--- a/docs/csharp/misc/cs1661.md
+++ b/docs/csharp/misc/cs1661.md
@@ -21,7 +21,7 @@ Cannot convert anonymous method block to delegate type 'delegate type' because t
   
  The following sample generates CS1661:  
   
-```  
+```csharp  
 // CS1661.cs  
   
 delegate void MyDelegate(int i);  

--- a/docs/csharp/misc/cs1662.md
+++ b/docs/csharp/misc/cs1662.md
@@ -21,7 +21,7 @@ Cannot convert anonymous method block to delegate type 'delegate type' because s
   
  The following sample generates CS1662:  
   
-```  
+```csharp  
 // CS1662.cs  
   
 delegate int MyDelegate(int i);  

--- a/docs/csharp/misc/cs1663.md
+++ b/docs/csharp/misc/cs1663.md
@@ -22,7 +22,7 @@ Fixed size buffer type must be one of the following: bool, byte, short, int, lon
 ## Example  
  The following sample generates CS1663.  
   
-```  
+```csharp  
 // CS1663.cs  
 // compile with: /unsafe /target:library  
   

--- a/docs/csharp/misc/cs1665.md
+++ b/docs/csharp/misc/cs1665.md
@@ -22,7 +22,7 @@ Fixed size buffers must have a length greater than zero
 ## Example  
  The following sample generates CS1665.  
   
-```  
+```csharp  
 // CS1665.cs  
 // compile with: /unsafe /target:library  
 struct S  

--- a/docs/csharp/misc/cs1666.md
+++ b/docs/csharp/misc/cs1666.md
@@ -22,7 +22,7 @@ You cannot use fixed size buffers contained in unfixed expressions. Try using th
 ## Example  
  The following sample generates CS1666.  
   
-```  
+```csharp  
 // CS1666.cs  
 // compile with: /unsafe /target:library  
 unsafe struct S  

--- a/docs/csharp/misc/cs1667.md
+++ b/docs/csharp/misc/cs1667.md
@@ -22,7 +22,7 @@ Attribute 'attribute' is not valid on property or event accessors. It is valid o
 ## Example  
  The following sample generates CS1670:  
   
-```  
+```csharp  
 // CS1667.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1670.md
+++ b/docs/csharp/misc/cs1670.md
@@ -26,7 +26,7 @@ params is not valid in this context
 ## Example  
  The following sample generates CS1670:  
   
-```  
+```csharp  
 // CS1670.cs  
 public class C  
 {  

--- a/docs/csharp/misc/cs1671.md
+++ b/docs/csharp/misc/cs1671.md
@@ -21,7 +21,7 @@ A namespace declaration cannot have modifiers or attributes
   
  The following sample generates CS1671:  
   
-```  
+```csharp  
 // CS1671.cs  
 public namespace NS // CS1671  
 {  

--- a/docs/csharp/misc/cs1673.md
+++ b/docs/csharp/misc/cs1673.md
@@ -19,7 +19,7 @@ Anonymous methods, lambda expressions, and query expressions inside structs cann
   
  The following sample generates CS1673:  
   
-```  
+```csharp  
 // CS1673.cs  
 delegate int MyDelegate();  
   

--- a/docs/csharp/misc/cs1675.md
+++ b/docs/csharp/misc/cs1675.md
@@ -22,7 +22,7 @@ Enums cannot have type parameters
 ## Example  
  The following sample generates CS1675:  
   
-```  
+```csharp  
 // CS1675.cs  
 enum E<T>  // CS1675  
 {  

--- a/docs/csharp/misc/cs1676.md
+++ b/docs/csharp/misc/cs1676.md
@@ -21,7 +21,7 @@ Parameter 'number' must be declared with the 'keyword' keyword
   
  The following sample generates CS1676:  
   
-```  
+```csharp  
 // CS1676.cs  
 delegate void E(ref int i);  
 class Errors   

--- a/docs/csharp/misc/cs1677.md
+++ b/docs/csharp/misc/cs1677.md
@@ -22,7 +22,7 @@ Parameter 'number' should not be declared with the 'keyword' keyword
 ## Example  
  The following sample generates CS1677:  
   
-```  
+```csharp  
 // CS1677.cs  
 delegate void D(int i);  
 class Errors  

--- a/docs/csharp/misc/cs1678.md
+++ b/docs/csharp/misc/cs1678.md
@@ -21,7 +21,7 @@ Parameter 'number' is declared as type 'type1' but should be 'type2'
   
  The following sample generates CS1678:  
   
-```  
+```csharp  
 // CS1678  
 delegate void D(int i);  
 class Errors   

--- a/docs/csharp/misc/cs1679.md
+++ b/docs/csharp/misc/cs1679.md
@@ -24,7 +24,7 @@ Invalid extern alias for '/reference'; 'identifier' is not a valid identifier
 ## Example  
  The following example generates CS1679.  
   
-```  
+```csharp  
 // CS1679.cs  
 // compile with: /reference:123$BadIdentifier%=System.dll  
 class TestClass {  

--- a/docs/csharp/misc/cs1680.md
+++ b/docs/csharp/misc/cs1680.md
@@ -21,7 +21,7 @@ Invalid reference alias option: 'alias=' -- missing filename.
   
  The following sample generates CS1680.  
   
-```  
+```csharp  
 // CS1680.cs  
 // compile with: /reference:alias=  
 // CS1680 expected  

--- a/docs/csharp/misc/cs1681.md
+++ b/docs/csharp/misc/cs1681.md
@@ -22,7 +22,7 @@ You cannot redefine the global extern alias
 ## Example  
  The following sample generates CS1681.  
   
-```  
+```csharp  
 // CS1681.cs  
 // compile with: /reference:global=System.dll  
 // CS1681 expected  

--- a/docs/csharp/misc/cs1682.md
+++ b/docs/csharp/misc/cs1682.md
@@ -21,7 +21,7 @@ Reference to type 'type' claims it is nested within 'nested type', but it could 
   
 ## Example  
   
-```  
+```csharp  
 // CS1682.cs  
 // compile with: /target:library /keyfile:mykey.snk  
 public class A {  
@@ -31,7 +31,7 @@ public class A {
   
 ## Example  
   
-```  
+```csharp  
 // CS1682_b.cs  
 // compile with: /target:library /reference:CS1682.dll  
 using System;  
@@ -49,7 +49,7 @@ public class Ref {
   
 ## Example  
   
-```  
+```csharp  
 // CS1682_c.cs  
 // compile with: /target:library /keyfile:mykey.snk /out:CS1682.dll  
 public class A {  
@@ -60,7 +60,7 @@ public class A {
 ## Example  
  The following sample generates CS1682.  
   
-```  
+```csharp  
 // CS1682_d.cs  
 // compile with: /reference:CS1682.dll /reference:CS1682_b.dll /W:1  
 // CS1682 expected  

--- a/docs/csharp/misc/cs1684.md
+++ b/docs/csharp/misc/cs1684.md
@@ -23,7 +23,7 @@ Reference to type 'Type Name' claims it is defined in 'Namespace', but it could 
   
 ## Example  
   
-```  
+```csharp  
 // CS1684_a.cs  
 // compile with: /target:library /keyfile:CS1684.key  
 public class A {  
@@ -35,7 +35,7 @@ public class C2 {}
   
 ## Example  
   
-```  
+```csharp  
 // CS1684_b.cs  
 // compile with: /target:library /r:cs1684_a.dll  
 // post-build command: del /f CS1684_a.dll  
@@ -50,7 +50,7 @@ public class Ref
 ## Example  
  We now rebuild the first assembly, leaving out the definition of the class C2 not to be defined in the recompilation.  
   
-```  
+```csharp  
 // CS1684_c.cs  
 // compile with: /target:library /keyfile:CS1684.key /out:CS1684_a.dll  
 public class A {  
@@ -61,7 +61,7 @@ public class A {
 ## Example  
  This module references the second module by means of the identifier `Ref`. But the second module contains a reference to the class `C2`, which no longer exists because of the compilation in the previous step, and therefore the CS1684 error message is returned from the compilation of this module.  
   
-```  
+```csharp  
 // CS1684_d.cs  
 // compile with: /reference:cs1684_a.dll /reference:cs1684_b.dll  
 // CS1684 expected  

--- a/docs/csharp/misc/cs1686.md
+++ b/docs/csharp/misc/cs1686.md
@@ -22,7 +22,7 @@ Local 'variable' or its members cannot have their address taken and be used insi
 ## Example  
  The following sample generates CS1686.  
   
-```  
+```csharp  
 // CS1686.cs  
 // compile with: /unsafe /target:library  
 class MyClass  

--- a/docs/csharp/misc/cs1688.md
+++ b/docs/csharp/misc/cs1688.md
@@ -22,7 +22,7 @@ Cannot convert anonymous method block without a parameter list to delegate type 
 ## Example  
  The following code generates error CS1688.  
   
-```  
+```csharp  
 // CS1688.cs  
 using System;  
 delegate void OutParam(out int i);  

--- a/docs/csharp/misc/cs1689.md
+++ b/docs/csharp/misc/cs1689.md
@@ -22,7 +22,7 @@ Attribute 'Attribute Name' is only valid on methods or attribute classes
 ## Example  
  The following sample generates CS1689.  
   
-```  
+```csharp  
 // CS1689.cs  
 // compile with: /target:library  
 [System.Diagnostics.Conditional("A")]   // CS1689  

--- a/docs/csharp/misc/cs1692.md
+++ b/docs/csharp/misc/cs1692.md
@@ -22,7 +22,7 @@ Invalid number
 ## Example  
  The following example generates CS1692.  
   
-```  
+```csharp  
 // CS1692.cs  
   
 #pragma warning disable a  // CS1692  

--- a/docs/csharp/misc/cs1694.md
+++ b/docs/csharp/misc/cs1694.md
@@ -22,7 +22,7 @@ Invalid filename specified for preprocessor directive. Filename is too long or n
 ## Example  
  The following sample generates CS1694.  
   
-```  
+```csharp  
 // cs1694.cs  
 #pragma checksum "MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890MyFile1234567890.txt" {00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F}   // CS1694  
 class MyClass {}  

--- a/docs/csharp/misc/cs1695.md
+++ b/docs/csharp/misc/cs1695.md
@@ -24,7 +24,7 @@ Invalid #pragma checksum syntax; should be #pragma checksum "filename" "{XXXXXXX
 ## Example  
  The following example generates CS1695.  
   
-```  
+```csharp  
 // CS1695.cs  
   
 #pragma checksum "12345"  // CS1695  

--- a/docs/csharp/misc/cs1696.md
+++ b/docs/csharp/misc/cs1696.md
@@ -22,7 +22,7 @@ Single-line comment or end-of-line expected
 ## Example  
  The following sample generates CS1696.  
   
-```  
+```csharp  
 // CS1696.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs1698.md
+++ b/docs/csharp/misc/cs1698.md
@@ -21,7 +21,7 @@ Circular assembly reference 'AssemblyName1' does not match the output assembly n
   
 ## Example  
   
-```  
+```csharp  
 // CS1698_a.cs  
 // compile with: /target:library /keyfile:mykey.snk  
 [assembly:System.Reflection.AssemblyVersion("2")]  
@@ -30,7 +30,7 @@ public class CS1698_a {}
   
 ## Example  
   
-```  
+```csharp  
 // CS1698_b.cs  
 // compile with: /target:library /reference:CS1698_a.dll /keyfile:mykey.snk  
 public class CS1698_b : CS1698_a {}  
@@ -39,7 +39,7 @@ public class CS1698_b : CS1698_a {}
 ## Example  
  The following sample generates CS1698.  
   
-```  
+```csharp  
 // CS1698_c.cs  
 // compile with: /target:library /out:cs1698_a.dll /reference:cs1698_b.dll /keyfile:mykey.snk  
 // CS1698 expected  

--- a/docs/csharp/misc/cs1706.md
+++ b/docs/csharp/misc/cs1706.md
@@ -26,7 +26,7 @@ Expression cannot contain anonymous methods  or lambda expressions
 ## Example  
  The following example generates CS1706.  
   
-```  
+```csharp  
 // CS1706.cs  
 using System;  
   

--- a/docs/csharp/misc/cs1709.md
+++ b/docs/csharp/misc/cs1709.md
@@ -22,7 +22,7 @@ Filename specified for preprocessor directive is empty
 ## Example  
  The following example generates CS1709.  
   
-```  
+```csharp  
 // CS1709.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs1710.md
+++ b/docs/csharp/misc/cs1710.md
@@ -22,7 +22,7 @@ XML comment on 'type' has a duplicate typeparam tag for 'parameter'
 ## Example  
  The following code will cause warning CS1710 to appear.  
   
-```  
+```csharp  
 // CS1710.cs  
 // compile with: /doc:cs1710.xml  
 // To resolve this warning, delete one of the duplicate <typeparam>'s.  

--- a/docs/csharp/misc/cs1711.md
+++ b/docs/csharp/misc/cs1711.md
@@ -22,7 +22,7 @@ XML comment on 'type' has a typeparam tag for 'parameter', but there is no type 
 ## Example  
  The following code generates warning CS1711.  
   
-```  
+```csharp  
 // cs1711.cs  
 // compile with: /doc:cs1711.xml  
 // CS1711 expected  

--- a/docs/csharp/misc/cs1712.md
+++ b/docs/csharp/misc/cs1712.md
@@ -22,7 +22,7 @@ Type parameter 'type parameter' has no matching typeparam tag in the XML comment
 ## Example  
  The following code generates warning CS1712. To resolve this error, add a **typeparam** tag for the type parameter S.  
   
-```  
+```csharp  
 // CS1712.cs  
 // compile with: /doc:cs1712.xml  
 using System;  

--- a/docs/csharp/misc/cs1715.md
+++ b/docs/csharp/misc/cs1715.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code generates CS1715.  
   
-```  
+```csharp  
 // CS1715.cs  
 abstract public class Base  
 {  

--- a/docs/csharp/misc/cs1717.md
+++ b/docs/csharp/misc/cs1717.md
@@ -30,7 +30,7 @@ Assignment made to same variable; did you mean to assign something else?
 ## Example  
  The following sample generates CS1717.  
   
-```  
+```csharp  
 // CS1717.cs  
 // compile with: /W:3  
 public class Test  

--- a/docs/csharp/misc/cs1718.md
+++ b/docs/csharp/misc/cs1718.md
@@ -28,7 +28,7 @@ Comparison made to same variable; did you mean to compare something else?
 ## Example  
  The following code generates warning CS1718.  
   
-```  
+```csharp  
 // CS1718.cs  
 using System;  
 public class Tester   

--- a/docs/csharp/misc/cs1720.md
+++ b/docs/csharp/misc/cs1720.md
@@ -19,7 +19,7 @@ Expression will always cause a System.NullReferenceException because the default
   
  If you write an expression involving the default of a generic type variable that is a reference type (for example, a class), this error will occur. Consider the following expression:  
   
-```  
+```csharp  
 default(T).ToString()  
 ```  
   
@@ -30,7 +30,7 @@ default(T).ToString()
   
  The following sample generates CS1720.  
   
-```  
+```csharp  
 // CS1720.cs  
 using System;  
 public class Tester   

--- a/docs/csharp/misc/cs1722.md
+++ b/docs/csharp/misc/cs1722.md
@@ -22,7 +22,7 @@ Base class 'class' must come before any interfaces
 ## Example  
  The following sample generates CS1722.  
   
-```  
+```csharp  
 // CS1722.cs  
 // compile with: /target:library  
 public class A {}  

--- a/docs/csharp/misc/cs1723.md
+++ b/docs/csharp/misc/cs1723.md
@@ -22,7 +22,7 @@ XML comment on 'param' has cref attribute 'attribute' that refers to a type para
 ## Example  
  The following example generates CS1723.  
   
-```  
+```csharp  
 // CS1723.cs  
 // compile with: /t:library /doc:filename.XML  
 ///<summary>A generic list class.</summary>  

--- a/docs/csharp/misc/cs1724.md
+++ b/docs/csharp/misc/cs1724.md
@@ -22,7 +22,7 @@ Value specified for the argument to 'System.Runtime.InteropServices.DefaultCharS
 ## Example  
  The following example generates CS1724.  
   
-```  
+```csharp  
 // CS1724.cs  
 using System.Runtime.InteropServices;  
 // To resolve, replace 42 with a valid CharSet value.  

--- a/docs/csharp/misc/cs1725.md
+++ b/docs/csharp/misc/cs1725.md
@@ -22,7 +22,7 @@ Friend assembly reference 'reference' is invalid. InternalsVisibleTo declaration
 ## Example  
  The following sample generates CS1725.  
   
-```  
+```csharp  
 // CS1725.cs  
 // compile with: /target:library  
 using System.Runtime.CompilerServices;  

--- a/docs/csharp/misc/cs1727.md
+++ b/docs/csharp/misc/cs1727.md
@@ -22,7 +22,7 @@ Cannot send error report automatically without authorization. Please visit '' to
 ## Example  
  The following sample generates CS1727.  
   
-```  
+```csharp  
 // CS1727.cs  
 // compile with: /errorreport:send  
 // CS1727 expected  

--- a/docs/csharp/misc/cs1728.md
+++ b/docs/csharp/misc/cs1728.md
@@ -22,7 +22,7 @@ Cannot bind delegate to 'member' because it is a member of 'type'
 ## Example  
  The following sample generates CS1728:  
   
-```  
+```csharp  
 // CS1728.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs1730.md
+++ b/docs/csharp/misc/cs1730.md
@@ -26,7 +26,7 @@ Assembly and module attributes must precede all other elements defined in a file
 ## Example  
  The following code generates CS1730:  
   
-```  
+```csharp  
 // cs1730.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs1731.md
+++ b/docs/csharp/misc/cs1731.md
@@ -26,7 +26,7 @@ Cannot convert 'expression' to delegate because some of the return types in the 
 ## Example  
  The following code generates CS1731:  
   
-```  
+```csharp  
 class CS1731  
 {  
     delegate double D();  

--- a/docs/csharp/misc/cs1732.md
+++ b/docs/csharp/misc/cs1732.md
@@ -26,7 +26,7 @@ Expected parameter.
 ## Example  
  The following example produces CS1732:  
   
-```  
+```csharp  
 // cs1732.cs  
 // compile with: /target:library  
 class Test  

--- a/docs/csharp/misc/cs1733.md
+++ b/docs/csharp/misc/cs1733.md
@@ -28,7 +28,7 @@ Expected expression.
 ## Example  
  The following example produces CS1733 because of the trailing comma:  
   
-```  
+```csharp  
 // cs1733.cs  
 using System.Collections.Generic;  
 public class Test  

--- a/docs/csharp/misc/cs1900.md
+++ b/docs/csharp/misc/cs1900.md
@@ -21,7 +21,7 @@ Warning level must be in the range 0-4
   
  The following sample generates CS1900:  
   
-```  
+```csharp  
 // CS1900.cs  
 // compile with: /W:5  
 // CS1900 expected  

--- a/docs/csharp/misc/cs1902.md
+++ b/docs/csharp/misc/cs1902.md
@@ -21,7 +21,7 @@ Invalid option 'option' for /debug; must be full or pdbonly
   
  The following sample generates CS1902:  
   
-```  
+```csharp  
 // CS1902.cs  
 // compile with: /debug:x  
 // CS1902 expected  

--- a/docs/csharp/misc/cs1908.md
+++ b/docs/csharp/misc/cs1908.md
@@ -22,7 +22,7 @@ The type of the argument to the DefaultValue attribute must match the parameter 
 ## Example  
  The following sample generates CS1908.  
   
-```  
+```csharp  
 // CS1908.cs  
 // compile with: /target:library  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs1909.md
+++ b/docs/csharp/misc/cs1909.md
@@ -22,7 +22,7 @@ The DefaultValue attribute is not applicable on parameters of type 'type'
 ## Example  
  The following sample generates CS1909.  
   
-```  
+```csharp  
 // CS1909.cs  
 // compile with: /target:library  
 using System.Runtime.InteropServices;  

--- a/docs/csharp/misc/cs1910.md
+++ b/docs/csharp/misc/cs1910.md
@@ -22,7 +22,7 @@ Argument of type 'type' is not applicable for the DefaultValue attribute
 ## Example  
  The following sample generates CS1910.  
   
-```  
+```csharp  
 // CS1910.cs  
 // compile with: /target:library  
 using System.Runtime.InteropServices;  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 50 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.