### PR TITLE
adding missing language identifiers - 13/13

### DIFF
--- a/docs/csharp/misc/cs1911.md
+++ b/docs/csharp/misc/cs1911.md
@@ -24,7 +24,7 @@ Access to member 'name' through a 'base' keyword from an anonymous method, lambd
 ## Example  
  The following sample generates CS1911.  
   
-```  
+```csharp  
 // CS1911.cs  
 // compile with: /W:1  
 using System;  

--- a/docs/csharp/misc/cs1912.md
+++ b/docs/csharp/misc/cs1912.md
@@ -26,7 +26,7 @@ Duplicate initialization of member 'name'.
 ## Example  
  The following code generates CS1912 because `memberA` is initialized two times:  
   
-```  
+```csharp  
 // cs1912.cs  
 using System.Linq;  
   

--- a/docs/csharp/misc/cs1913.md
+++ b/docs/csharp/misc/cs1913.md
@@ -26,7 +26,7 @@ Member 'name' cannot be initialized. It is not a field or property.
 ## Example  
  The following example generates CS1913:  
   
-```  
+```csharp  
 // cs1912.cs  
 class A  
 {  

--- a/docs/csharp/misc/cs1914.md
+++ b/docs/csharp/misc/cs1914.md
@@ -26,7 +26,7 @@ Static field 'name' cannot be assigned in an object initializer
 ## Example  
  The following code generates CS1914 because the initializer tries to initialize the `TestClass.Number` field, which is `static`:  
   
-```  
+```csharp  
 // cs1914.cs  
 using System.Linq;  
 public class TestClass  

--- a/docs/csharp/misc/cs1917.md
+++ b/docs/csharp/misc/cs1917.md
@@ -28,7 +28,7 @@ Members of read-only field 'name' of type 'struct name' cannot be assigned with 
 ## Example  
  The following code generates CS1917:  
   
-```  
+```csharp  
 // cs1917.cs  
 class CS1917  
 {  

--- a/docs/csharp/misc/cs1918.md
+++ b/docs/csharp/misc/cs1918.md
@@ -26,7 +26,7 @@ Members of property 'name' of type 'type' cannot be assigned with an object init
 ## Example  
  The following example generates CS1918:  
   
-```  
+```csharp  
 // cs1918.cs  
 public struct MyStruct  
 {  

--- a/docs/csharp/misc/cs1920.md
+++ b/docs/csharp/misc/cs1920.md
@@ -28,7 +28,7 @@ Element initializer cannot be empty.
 ## Example  
  The following example generates CS1920:  
   
-```  
+```csharp  
   // cs1920.cs  
 using System.Collections.Generic;  
 public class Test  

--- a/docs/csharp/misc/cs1922.md
+++ b/docs/csharp/misc/cs1922.md
@@ -30,7 +30,7 @@ Collection initializer requires its type 'type' to implement System.Collections.
 ## Example  
  The following code produces CS1922:  
   
-```  
+```csharp  
 // cs1922.cs  
 public class Test  
 {  

--- a/docs/csharp/misc/cs1925.md
+++ b/docs/csharp/misc/cs1925.md
@@ -26,7 +26,7 @@ Cannot initialize object of type 'type' with a collection initializer.
 ## Example  
  The following code generates CS1925:  
   
-```  
+```csharp  
 // cs1925.cs  
 public class Student  
 {  

--- a/docs/csharp/misc/cs1927.md
+++ b/docs/csharp/misc/cs1927.md
@@ -28,7 +28,7 @@ Ignoring /win32manifest for module because it only applies to assemblies.
 ## Example  
  The following example generates CS1927 when it is compiled with both the **/target:module** and **/win32manifest** compiler options.  
   
-```  
+```csharp  
 // cs1927.cs  
 // Compile with: /target:module /win32manifest  
 using System;  

--- a/docs/csharp/misc/cs1928.md
+++ b/docs/csharp/misc/cs1928.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code generates CS1928:  
   
-```  
+```csharp  
 // cs1928.cs  
 class Test  
 {  

--- a/docs/csharp/misc/cs1929.md
+++ b/docs/csharp/misc/cs1929.md
@@ -26,7 +26,7 @@ Instance argument: cannot convert from 'typeA' to 'typeB'.
 ## Example  
  The following code generates CS1928 and CS1929:  
   
-```  
+```csharp  
 // cs1929.cs  
 using System.Linq;  
     using System.Collections;  

--- a/docs/csharp/misc/cs1930.md
+++ b/docs/csharp/misc/cs1930.md
@@ -26,7 +26,7 @@ The range variable 'name' has already been declared
 ## Example  
  The following example generates CS1930 because the identifier `num` is used for the range variable in the `from` clause and for the range variable introduced by the `let` clause.  
   
-```  
+```csharp  
 // cs1930.cs  
 using System.Linq;  
 class Program  

--- a/docs/csharp/misc/cs1931.md
+++ b/docs/csharp/misc/cs1931.md
@@ -26,7 +26,7 @@ The range variable 'variable' conflicts with a previous declaration of 'variable
 ## Example  
  The following code generates CS1931 because the identifier `x` is used both as a local variable in `Main` and as the range variable in the query expression:  
   
-```  
+```csharp  
 // cs1931.cs  
 class Test  
     {  

--- a/docs/csharp/misc/cs1932.md
+++ b/docs/csharp/misc/cs1932.md
@@ -28,7 +28,7 @@ Cannot assign 'expression' to a range variable.
 ## Example  
  The following code generates CS1932 because the type of the range variable cannot be inferred. Cast the value to the intended type to fix the error, as shown in the following example.  
   
-```  
+```csharp  
 // CS1932.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/misc/cs1934.md
+++ b/docs/csharp/misc/cs1934.md
@@ -23,14 +23,14 @@ Could not find an implementation of the query pattern for source type 'type'. 'm
   
 1.  In the following example, the solution is to just specify the type of the range variable:  
   
-    ```  
+    ```csharp  
     var q = from int x in list  
     ```  
   
 ## Example  
  The following example shows one way to produce CS1934:  
   
-```  
+```csharp  
 // cs1934.cs  
 using System.Linq;  
 using System.Collections;  

--- a/docs/csharp/misc/cs1935.md
+++ b/docs/csharp/misc/cs1935.md
@@ -26,7 +26,7 @@ Could not find an implementation of the query pattern for source type 'type'. 'm
 ## Example  
  The following code generates CS1935 because the `using` directive for System.Linq is commented out:  
   
-```  
+```csharp  
 // cs1935.cs  
 // CS1935  
 using System;  

--- a/docs/csharp/misc/cs1937.md
+++ b/docs/csharp/misc/cs1937.md
@@ -26,7 +26,7 @@ The name 'name' is not in scope on the left side of 'equals'. Consider swapping 
 ## Example  
  The following example generates CS1937.  
   
-```  
+```csharp  
 // cs1937.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/misc/cs1938.md
+++ b/docs/csharp/misc/cs1938.md
@@ -26,7 +26,7 @@ The name 'name' is not in scope on the right side of 'equals'. Consider swapping
 ## Example  
  The following code generates CS1938:  
   
-```  
+```csharp  
 // cs1938.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/misc/cs1939.md
+++ b/docs/csharp/misc/cs1939.md
@@ -26,7 +26,7 @@ Cannot pass the range variable 'name' as an out or ref parameter.
 ## Example  
  The following example generates CS1939:  
   
-```  
+```csharp  
 // cs1939.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/misc/cs1940.md
+++ b/docs/csharp/misc/cs1940.md
@@ -26,7 +26,7 @@ Multiple implementations of the query pattern were found for source type 'type'.
 ## Example  
  The following code generates CS1940:  
   
-```  
+```csharp  
 // cs1940.cs  
 using System; //must include explicitly for types defined in 3.5  
 class Test  

--- a/docs/csharp/misc/cs1945.md
+++ b/docs/csharp/misc/cs1945.md
@@ -26,7 +26,7 @@ An expression tree may not contain an anonymous method expression.
 ## Example  
  The following code generates CS1945:  
   
-```  
+```csharp  
 // cs1945.cs  
 using System;  
 using System.Linq.Expressions;  

--- a/docs/csharp/misc/cs1947.md
+++ b/docs/csharp/misc/cs1947.md
@@ -28,7 +28,7 @@ Range variable 'variable name' cannot be assigned to -- it is read only.
 ## Example  
  The following code generates CS1947:  
   
-```  
+```csharp  
 // cs1947.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/misc/cs1948.md
+++ b/docs/csharp/misc/cs1948.md
@@ -26,7 +26,7 @@ The range variable 'name' cannot have the same name as a method type parameter
 ## Example  
  The following example generates CS1948 because the identifier `T` is used for the range variable and for the type parameter on method `TestMethod`:  
   
-```  
+```csharp  
 // cs1948.cs  
 using System.Linq;  
 class Test  

--- a/docs/csharp/misc/cs1949.md
+++ b/docs/csharp/misc/cs1949.md
@@ -26,7 +26,7 @@ The contextual keyword 'var' cannot be used in a range variable declaration.
 ## Example  
  The following example generates CS1949:  
   
-```  
+```csharp  
 // cs1949.cs  
 using System;  
 using System.Linq;  

--- a/docs/csharp/misc/cs1950.md
+++ b/docs/csharp/misc/cs1950.md
@@ -32,7 +32,7 @@ The best overloaded Add method 'name' for the collection initializer has some in
 ## Example  
  The following example generates CS1950:  
   
-```  
+```csharp  
 // cs1950.cs  
 using System.Collections;  
 class TestClass : CollectionBase  

--- a/docs/csharp/misc/cs1951.md
+++ b/docs/csharp/misc/cs1951.md
@@ -26,7 +26,7 @@ An expression tree lambda may not contain an out or ref parameter.
 ## Example  
  The following example generates CS1951:  
   
-```  
+```csharp  
 // cs1951.cs  
 using System.Linq;  
 public delegate int TestDelegate(ref int i);  

--- a/docs/csharp/misc/cs1952.md
+++ b/docs/csharp/misc/cs1952.md
@@ -26,7 +26,7 @@ An expression tree lambda may not contain a method with variable arguments
 ## Example  
  The following code produces CS1952:  
   
-```  
+```csharp  
 // cs1952.cs  
 using System;  
 using System.Linq.Expressions;  

--- a/docs/csharp/misc/cs1953.md
+++ b/docs/csharp/misc/cs1953.md
@@ -26,7 +26,7 @@ An expression tree lambda may not contain a method group.
 ## Example  
  The following example generates CS1953:  
   
-```  
+```csharp  
 // cs1953.cs  
 using System;  
 using System.Linq.Expressions;  

--- a/docs/csharp/misc/cs1954.md
+++ b/docs/csharp/misc/cs1954.md
@@ -28,7 +28,7 @@ The best overloaded method match 'method' for the collection initializer element
 ## Example  
  The following example produces CS1954 because the only available overload of the `Add` list in `MyList` has a `ref` parameter.  
   
-```  
+```csharp  
 // cs1954.cs  
 using System.Collections.Generic;  
 class MyList<T> : IEnumerable<T>  

--- a/docs/csharp/misc/cs1955.md
+++ b/docs/csharp/misc/cs1955.md
@@ -26,7 +26,7 @@ Non-invocable member 'name' cannot be used like a method.
 ## Example  
  The following code generates CS1955 because the code is trying to invoke a field and a property by using the method call operator [()](../../csharp/language-reference/operators/invocation-operator.md). You cannot call a field or property, but you can access the value it stores by using the member access operator ( [.](../../csharp/language-reference/operators/member-access-operator.md) ).  
   
-```  
+```csharp  
 // cs1955.cs  
 class A  
 {  

--- a/docs/csharp/misc/cs1957.md
+++ b/docs/csharp/misc/cs1957.md
@@ -26,7 +26,7 @@ Member 'name' overrides 'method'. There are multiple override candidates at run-
 ## Example  
  The following code generates CS1957:  
   
-```  
+```csharp  
 // cs1957.cs  
 class Base<T, S>  
 {  

--- a/docs/csharp/misc/cs1958.md
+++ b/docs/csharp/misc/cs1958.md
@@ -26,7 +26,7 @@ Object and collection initializer expressions may not be applied to a delegate c
 ## Example  
  The following code produces CS1958:  
   
-```  
+```csharp  
 // cs1958.cs  
 public class MemberInitializerTest  
 {     

--- a/docs/csharp/misc/cs1959.md
+++ b/docs/csharp/misc/cs1959.md
@@ -26,7 +26,7 @@ ms.author: "wiwagn"
 ## Example  
  The following code produces CS1959 because `null` is not a type.  
   
-```  
+```csharp  
 // cs1959.cs  
 class Program  
     {  

--- a/docs/csharp/misc/cs2002.md
+++ b/docs/csharp/misc/cs2002.md
@@ -23,7 +23,7 @@ Source file 'file' specified multiple times
   
  The following sample generates CS2002:  
   
-```  
+```csharp  
 // CS2002.cs  
 // compile with: CS2002.cs  
 public class A  

--- a/docs/csharp/misc/cs2005.md
+++ b/docs/csharp/misc/cs2005.md
@@ -24,7 +24,7 @@ Missing file specification for 'option' option
 ## Example  
  The following sample generates CS2005.  
   
-```  
+```csharp  
 // CS2005.cs  
 // compile with: /recurse:  
 // CS2005 expected  

--- a/docs/csharp/misc/cs2007.md
+++ b/docs/csharp/misc/cs2007.md
@@ -21,7 +21,7 @@ Unrecognized command-line option: 'option'
   
  The following sample generates CS2007:  
   
-```  
+```csharp  
 // CS2007.cs  
 // compile with: /recur  
 // CS2007 expected  

--- a/docs/csharp/misc/cs2013.md
+++ b/docs/csharp/misc/cs2013.md
@@ -21,7 +21,7 @@ Invalid image base number 'value'
   
  The following sample generates CS2013:  
   
-```  
+```csharp  
 // CS2013.cs  
 // compile with: /target:library /baseaddress:x  
 // CS2013 expected  

--- a/docs/csharp/misc/cs2016.md
+++ b/docs/csharp/misc/cs2016.md
@@ -21,7 +21,7 @@ Code page 'codepage' is invalid or not installed
   
  The following sample generates CS2016:  
   
-```  
+```csharp  
 // CS2016.cs  
 // compile with: /codepage:x  
 // CS2016 expected  

--- a/docs/csharp/misc/cs2017.md
+++ b/docs/csharp/misc/cs2017.md
@@ -21,7 +21,7 @@ Cannot specify /main if building a module or library
   
  The following sample generates CS2017:  
   
-```  
+```csharp  
 // CS2017.cs  
 // compile with: /main:MyClass /target:library  
 // CS2017 expected  

--- a/docs/csharp/misc/cs2019.md
+++ b/docs/csharp/misc/cs2019.md
@@ -21,7 +21,7 @@ Invalid target type for /target: must specify 'exe', 'winexe', 'library', or 'mo
   
  The following sample generates CS2017:  
   
-```  
+```csharp  
 // CS2019.cs  
 // compile with: /target:libra  
 // CS2019 expected  

--- a/docs/csharp/misc/cs2024.md
+++ b/docs/csharp/misc/cs2024.md
@@ -21,7 +21,7 @@ Invalid file section alignment number '#'
   
  The following sample generates CS2024:  
   
-```  
+```csharp  
 // CS2024.cs  
 // compile with: /filealign:ex  
 // CS2024 expected  

--- a/docs/csharp/misc/cs2034.md
+++ b/docs/csharp/misc/cs2034.md
@@ -22,7 +22,7 @@ A /reference option that declares an extern alias can only have one filename. To
 ## Example  
  The following code will generate error CS2034.  
   
-```  
+```csharp  
 // CS2034.cs  
 // compile with: /r:A1=cs2034a1.dll;A2=cs2034a2.dll  
 // to fix, compile with: /r:A1=cs2034a1.dll /r:A2=cs2034a2.dll  

--- a/docs/csharp/misc/cs2035.md
+++ b/docs/csharp/misc/cs2035.md
@@ -22,7 +22,7 @@ Command-line syntax error:  Missing ':\<number>' for 'compiler_option' option
 ## Example  
  The following sample generates CS2035.  
   
-```  
+```csharp  
 // CS2035.cs  
 // compile with: /baseaddress  
 // CS2035 expected  

--- a/docs/csharp/misc/cs2036.md
+++ b/docs/csharp/misc/cs2036.md
@@ -28,7 +28,7 @@ The /pdb option requires that the /debug option also be used.
 ## Example  
  The following example generates CS2036 when it is compiled with the **/pdb** option but not the /debug option:  
   
-```  
+```csharp  
 // cs2036.cs  
 // Compile with: /pdb  
 // CS2036  

--- a/docs/csharp/misc/cs3000.md
+++ b/docs/csharp/misc/cs3000.md
@@ -21,7 +21,7 @@ Methods with variable arguments are not CLS-compliant
   
  The following example generates the warning CS3000.  
   
-```  
+```csharp  
 // CS3000.cs  
 // compile with: /target:library  
 // CS3000 expected  

--- a/docs/csharp/misc/cs3001.md
+++ b/docs/csharp/misc/cs3001.md
@@ -22,7 +22,7 @@ Argument type 'type' is not CLS-compliant
 ## Example  
  The following example generates CS3001:  
   
-```  
+```csharp  
 // CS3001.cs  
   
 [assembly:System.CLSCompliant(true)]  

--- a/docs/csharp/misc/cs3002.md
+++ b/docs/csharp/misc/cs3002.md
@@ -22,7 +22,7 @@ Return type of 'method' is not CLS-compliant
 ## Example  
  The following example generates CS3002:  
   
-```  
+```csharp  
 // CS3002.cs  
   
 [assembly:System.CLSCompliant(true)]  

--- a/docs/csharp/misc/cs3005.md
+++ b/docs/csharp/misc/cs3005.md
@@ -22,7 +22,7 @@ Identifier 'identifier' differing only in case is not CLS-compliant
 ## Example  
  The following example generates CS3003:  
   
-```  
+```csharp  
 // CS3005.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3006.md
+++ b/docs/csharp/misc/cs3006.md
@@ -22,7 +22,7 @@ Overloaded method 'method' differing only in ref or out, or in array rank, is no
 ## Example  
  The following example generates CS3006. To resolve this warning, comment out the assembly-level attribute or remove one of the method definitions.  
   
-```  
+```csharp  
 // CS3006.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3008.md
+++ b/docs/csharp/misc/cs3008.md
@@ -22,7 +22,7 @@ Identifier 'identifier' differing only in case is not CLS-compliant
 ## Example  
  The following example generates CS3008:  
   
-```  
+```csharp  
 // CS3008.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3010.md
+++ b/docs/csharp/misc/cs3010.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS3010:  
   
-```  
+```csharp  
 // CS3010.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3011.md
+++ b/docs/csharp/misc/cs3011.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS3011:  
   
-```  
+```csharp  
 // CS3011.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3012.md
+++ b/docs/csharp/misc/cs3012.md
@@ -22,7 +22,7 @@ You cannot specify the CLSCompliant attribute on a module that differs from the 
 ## Example  
  The following example, when built without `/target:module`, generates CS3012:  
   
-```  
+```csharp  
 // CS3012.cs  
 // compile with: /W:1  
   

--- a/docs/csharp/misc/cs3014.md
+++ b/docs/csharp/misc/cs3014.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS3014:  
   
-```  
+```csharp  
 // CS3014.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3015.md
+++ b/docs/csharp/misc/cs3015.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates C3015.  
   
-```  
+```csharp  
 // CS3015.cs  
 // compile with: /target:library  
 using System;  

--- a/docs/csharp/misc/cs3016.md
+++ b/docs/csharp/misc/cs3016.md
@@ -22,7 +22,7 @@ Arrays as attribute arguments is not CLS-compliant
 ## Example  
  The following example generates CS3016:  
   
-```  
+```csharp  
 // CS3016.cs  
   
 using System;  

--- a/docs/csharp/misc/cs3017.md
+++ b/docs/csharp/misc/cs3017.md
@@ -22,7 +22,7 @@ You cannot specify the CLSCompliant attribute on a module that differs from the 
 ## Example  
  The following example generates CS3017:  
   
-```  
+```csharp  
 // CS3017.cs  
 // compile with: /target:module  
   

--- a/docs/csharp/misc/cs3018.md
+++ b/docs/csharp/misc/cs3018.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample generates CS3018.  
   
-```  
+```csharp  
 // CS3018.cs  
 // compile with: /target:library  
 using System;  

--- a/docs/csharp/misc/cs3019.md
+++ b/docs/csharp/misc/cs3019.md
@@ -22,7 +22,7 @@ CLS compliance checking will not be performed on 'type' because it is not visibl
 ## Example  
  The following sample generates CS3019:  
   
-```  
+```csharp  
 // CS3019.cs  
 // compile with: /W:2  
   

--- a/docs/csharp/misc/cs3021.md
+++ b/docs/csharp/misc/cs3021.md
@@ -24,7 +24,7 @@ ms.author: "wiwagn"
 ## Example  
  The following example generates CS3021:  
   
-```  
+```csharp  
 // CS3021.cs  
 using System;  
 // Uncomment the following line to declare the assembly CLS Compliant,  

--- a/docs/csharp/misc/cs3022.md
+++ b/docs/csharp/misc/cs3022.md
@@ -22,7 +22,7 @@ CLSCompliant attribute has no meaning when applied to parameters. Try putting it
 ## Example  
  The following sample generates CS3022:  
   
-```  
+```csharp  
 // CS3022.cs  
 // compile with: /W:1  
   

--- a/docs/csharp/misc/cs3023.md
+++ b/docs/csharp/misc/cs3023.md
@@ -22,7 +22,7 @@ CLSCompliant attribute has no meaning when applied to return types.  Try putting
 ## Example  
  The following example generates warning CS3023:  
   
-```  
+```csharp  
 // C3023.cs  
   
 [assembly:System.CLSCompliant(true)]  

--- a/docs/csharp/misc/cs3026.md
+++ b/docs/csharp/misc/cs3026.md
@@ -22,7 +22,7 @@ CLS-compliant field 'field' cannot be volatile
 ## Example  
  The following example generates CS3026.  
   
-```  
+```csharp  
 // CS3026.cs  
 [assembly:System.CLSCompliant(true)]  
 public class Test  

--- a/docs/csharp/misc/cs3027.md
+++ b/docs/csharp/misc/cs3027.md
@@ -22,7 +22,7 @@ ms.author: "wiwagn"
 ## Example  
  The following sample contains an interface with a method that uses a non-CLS compliant type in its signature, making the type non-CLS compliant.  
   
-```  
+```csharp  
 // CS3027.cs  
 // compile with: /target:library  
 public interface IBase  
@@ -34,7 +34,7 @@ public interface IBase
 ## Example  
  The following sample generates CS3027.  
   
-```  
+```csharp  
 // CS3027_b.cs  
 // compile with: /reference:CS3027.dll /target:library /W:1  
 [assembly:System.CLSCompliant(true)]  

--- a/docs/csharp/misc/cs5001.md
+++ b/docs/csharp/misc/cs5001.md
@@ -24,7 +24,7 @@ Program 'program' does not contain a static 'Main' method suitable for an entry 
 ## Example  
  The following example generates CS5001:  
   
-```  
+```csharp  
 // CS5001.cs  
 // CS5001 expected  
 public class a  


### PR DESCRIPTION
This PR addresses partially the issue #2192 . It adds missing language identifiers in 66 files in docs/csharp/misc (compiler errors). It is part of a batch (13 PRs) aiming to fix this issue in the entire docs/csharp/misc folder.