### PR TITLE
Fix some xrefs

### DIFF
--- a/xml/System.Data.SqlTypes/SqlByte.xml
+++ b/xml/System.Data.SqlTypes/SqlByte.xml
@@ -1943,7 +1943,7 @@
         <summary>Subtracts the second <see cref="T:System.Data.SqlTypes.SqlByte" /> operand from the first.</summary>
         <returns>The results of subtracting the second <see cref="T:System.Data.SqlTypes.SqlByte" /> operand from the first.</returns>
         <remarks>
-          <format type="text/markdown"><![CDATA[The equivalent method for this operator is <xref:System.Data.SqlTypes.SqlByte.Subtract(System.Data.SqlTypes.SqlByte, System.Data.SqlTypes.SqlByte)?displayProperty=nameWithType>.]]></format>
+          <format type="text/markdown"><![CDATA[The equivalent method for this operator is <xref:System.Data.SqlTypes.SqlByte.Subtract(System.Data.SqlTypes.SqlByte,System.Data.SqlTypes.SqlByte)?displayProperty=nameWithType>.]]></format>
         </remarks>
       </Docs>
     </Member>

--- a/xml/System.Windows.Forms.DataVisualization.Charting/LegendItemsCollection.xml
+++ b/xml/System.Windows.Forms.DataVisualization.Charting/LegendItemsCollection.xml
@@ -95,7 +95,7 @@
 ## Remarks  
  Appends a custom legend item to the collection with the specified text and image to be used as the symbol for the legend item.  
   
- To add a custom legend item that uses a color for its symbol, call the [Add(Color, String)](<xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Add(System.Drawing.Color,System.String)) method.  
+ To add a custom legend item that uses a color for its symbol, call the [Add(Color, String)](<xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Add(System.Drawing.Color,System.String)>) method.  
   
  To insert a <xref:System.Windows.Forms.DataVisualization.Charting.LegendItem> object into the collection use one of the <xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Insert%2A> methods of this class.  
   

--- a/xml/System.Windows.Forms.DataVisualization.Charting/LegendItemsCollection.xml
+++ b/xml/System.Windows.Forms.DataVisualization.Charting/LegendItemsCollection.xml
@@ -60,7 +60,7 @@
 ## Remarks  
  Appends a custom legend item with the specified text and symbol color to the end of the collection.  
   
- To add a custom legend item that uses an image for its symbol, call the [LegendItemsCollection.Add(String, String)](<xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Add(System.String,System.String)>) method.  
+ To add a custom legend item that uses an image for its symbol, call the <xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Add(System.String,System.String)> method.  
   
  To insert a custom <xref:System.Windows.Forms.DataVisualization.Charting.LegendItem> into the collection, use one of the <xref:System.Collections.ObjectModel.Collection%601.Insert%2A> methods of this class.  
   
@@ -95,7 +95,7 @@
 ## Remarks  
  Appends a custom legend item to the collection with the specified text and image to be used as the symbol for the legend item.  
   
- To add a custom legend item that uses a color for its symbol, call the [Add(Color, String)](<xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Add(System.Drawing.Color,System.String)>) method.  
+ To add a custom legend item that uses a color for its symbol, call the <xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Add(System.Drawing.Color,System.String)> method.  
   
  To insert a <xref:System.Windows.Forms.DataVisualization.Charting.LegendItem> object into the collection use one of the <xref:System.Windows.Forms.DataVisualization.Charting.LegendItemsCollection.Insert%2A> methods of this class.  
   

--- a/xml/System.Workflow.Runtime.Hosting/SqlWorkflowPersistenceService.xml
+++ b/xml/System.Workflow.Runtime.Hosting/SqlWorkflowPersistenceService.xml
@@ -519,7 +519,7 @@
         <param name="items">An <see cref="T:System.Collections.ICollection" /> of serialized state objects to be written to the database.</param>
         <summary>Returns a value that indicates whether the collection of serialized state objects should be written to the database.</summary>
         <returns>
-          <see langword="true" /> indicates that the batch should be committed; <see cref="M:System.Workflow.Runtime.Hosting.SqlWorkflowPersistenceService.System.Workflow.Runtime.IPendingWork.MustCommit(System.Collections.ICollection)" /> always returns <see langword="true" />.</returns>
+          <see langword="true" /> indicates that the batch should be committed.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   

--- a/xml/System.Workflow.Runtime.Hosting/SqlWorkflowPersistenceService.xml
+++ b/xml/System.Workflow.Runtime.Hosting/SqlWorkflowPersistenceService.xml
@@ -524,7 +524,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- <xref:System.Workflow.Runtime.Hosting.SqlWorkflowPersistenceService.System%23Workflow%23Runtime%23IPendingWork%23MustCommit(System.Collections.ICollection) always returns `true`, which instructs the workflow run-time engine to invoke <xref:System.Workflow.Runtime.Hosting.SqlWorkflowPersistenceService.System%23Workflow%23Runtime%23IPendingWork%23MustCommit(System.Collections.ICollection)> on the batch.  
+ <xref:System.Workflow.Runtime.Hosting.SqlWorkflowPersistenceService.System%23Workflow%23Runtime%23IPendingWork%23MustCommit(System.Collections.ICollection)> always returns `true`, which instructs the workflow run-time engine to invoke <xref:System.Workflow.Runtime.Hosting.SqlWorkflowPersistenceService.System%23Workflow%23Runtime%23IPendingWork%23MustCommit(System.Collections.ICollection)> on the batch.  
   
  ]]></format>
         </remarks>

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -4526,7 +4526,7 @@ In .NET Core, sorting and comparison operations are based on [Version 8.0.0 of t
 
 String interpolation is:
 
-- More flexible. It can be used in any string without requiring a call to a method that supports composite formatting. Otherwise, you have to call the <xref:System.String.Format%2A> method or another method that supports composite formatting, such as <xref:System.Console.WriteLine%2A?displayProperty=nameWithType> or <xref:System.Text StringBuilder AppendFormat%2A?displayProperty=nameWithType>. 
+- More flexible. It can be used in any string without requiring a call to a method that supports composite formatting. Otherwise, you have to call the <xref:System.String.Format%2A> method or another method that supports composite formatting, such as <xref:System.Console.WriteLine%2A?displayProperty=nameWithType> or <xref:System.Text.StringBuilder.AppendFormat%2A?displayProperty=nameWithType>. 
 
 - More readable. Because the expression to insert into a string appears in the interpolated expression rather than in a argument list, interpolated strings are far easier to code and to read. Because of their greater readability, interpolated strings can replace not only calls to composite format methods, but they can also be used in string concatenation operations to produce more concise, clearer code. 
 

--- a/xml/System/String.xml
+++ b/xml/System/String.xml
@@ -4530,7 +4530,7 @@ String interpolation is:
 
 - More readable. Because the expression to insert into a string appears in the interpolated expression rather than in a argument list, interpolated strings are far easier to code and to read. Because of their greater readability, interpolated strings can replace not only calls to composite format methods, but they can also be used in string concatenation operations to produce more concise, clearer code. 
 
-A comparison of the following two code examples illustrates the superiority of interpolated strings over string concatenation and calls to composite formatting methods. The use of mutiple string concatenation operations in the following example produces verbose and hard-to-read code.
+A comparison of the following two code examples illustrates the superiority of interpolated strings over string concatenation and calls to composite formatting methods. The use of multiple string concatenation operations in the following example produces verbose and hard-to-read code.
 
 [!code-csharp-interactive[non-interpolated string operations](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.String.Format/cs/qa-interpolated1.cs)]
 [!code-vb[non-interpolated string operations](~/samples/snippets/visualbasic/VS_Snippets_CLR_System/system.String.Format/vb/qa-interpolated1.vb)]  


### PR DESCRIPTION
Fixes https://github.com/MicrosoftDocs/feedback/issues/211.

This fixes `xref`s that contained spaces or were not closed, found by running `git grep '<xref:[^>]* '` and also the typo pointed out in https://github.com/MicrosoftDocs/feedback/issues/211.