### PR TITLE
Corrected description of verbatim attribute usage

### DIFF
--- a/docs/csharp/language-reference/tokens/verbatim.md
+++ b/docs/csharp/language-reference/tokens/verbatim.md
@@ -31,7 +31,7 @@ The `@` special character serves as a verbatim identifier. It can be used in the
 
    [!code-csharp[verbatim3](../../../../samples/snippets/csharp/language-reference/keywords/verbatim1.cs#3)]
 
-1. To enable the compiler to distinguish between attributes in cases of a naming conflict. An attribute is a type that derives from <xref:System.Attribute>. Its type name typically includes the suffix **Attribute**, although the compiler does not enforce this convention. The attribute can then be referenced in code either by its full type name (for example, `[InfoAttribute]` or its shortened name (for example, `[Info]`). However, a naming conflict occurs if two shortened attribute type names are identical, and one type name includes the **Attribute** suffix but the other does not. For example, the following code fails to compile because the compiler cannot determine whether the `Info` or `InfoAttribute` attribute is applied to the `Main` method.
+1. To enable the compiler to distinguish between attributes in cases of a naming conflict. An attribute is a type that derives from <xref:System.Attribute>. Its type name typically includes the suffix **Attribute**, although the compiler does not enforce this convention. The attribute can then be referenced in code either by its full type name (for example, `[InfoAttribute]` or its shortened name (for example, `[Info]`). However, a naming conflict occurs if two shortened attribute type names are identical, and one type name includes the **Attribute** suffix but the other does not. For example, the following code fails to compile because the compiler cannot determine whether the `Info` or `InfoAttribute` attribute is applied to the `Example` class.
 
    ```csharp
    using System;


### PR DESCRIPTION
When I test the example code for the ambiguous attribute usage given at [this page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim), compiler complains on the attribute applied to the class, not the method.