### PR TITLE
keywords/string.md: link verbatim identifier page

### DIFF
--- a/docs/csharp/language-reference/keywords/string.md
+++ b/docs/csharp/language-reference/keywords/string.md
@@ -19,7 +19,7 @@ author: "BillWagner"
 ms.author: "wiwagn"
 ---
 # string (C# Reference)
-The `string` type represents a sequence of zero or more Unicode characters. `string` is an alias for <xref:System.String> in the .NET Framework.  
+The `string` type represents a sequence of zero or more Unicode characters. `string` is an alias for <xref:System.String> in .NET.  
   
  Although `string` is a reference type, the equality operators (`==` and `!=`) are defined to compare the values of `string` objects, not references. This makes testing for string equality more intuitive. For example:  
   
@@ -72,7 +72,7 @@ Console.WriteLine(a);
 > [!NOTE]
 >  The escape code `\udddd` (where `dddd` is a four-digit number) represents the Unicode character U+`dddd`. Eight-digit Unicode escape codes are also recognized: `\Udddddddd`.  
   
- Verbatim string literals start with @ and are also enclosed in double quotation marks. For example:  
+ Verbatim string literals start with `@` and are also enclosed in double quotation marks. For example:  
   
 ```csharp  
 @"good morning"  // a string literal  
@@ -90,7 +90,7 @@ Console.WriteLine(a);
 @"""Ahoy!"" cried the captain." // "Ahoy!" cried the captain.  
 ```  
   
- Another use of the @ symbol is to use referenced ([/reference](../../../csharp/language-reference/compiler-options/reference-compiler-option.md)) identifiers that are C# keywords.  
+ For other uses of the `@` special character, see [@ -- verbatim identifier](../tokens/verbatim.md).  
   
  For more information about strings in C#, see [Strings](../../../csharp/programming-guide/strings/index.md).  
   


### PR DESCRIPTION
The following line from the [string keyword page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/string)
>Another use of the @ symbol is to use referenced (/reference) identifiers that are C# keywords.

has two issues:
- there is one more use of `@`: to enable the compiler to distinguish between attributes in cases of a naming conflict
- the link to [-reference compiler option](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/reference-compiler-option). If that is not an issue, what does it mean?

I've replaced that sentence with a link to [@ page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim).

Plus replaced *.NET Framework* with *.NET* and style `@` as code.

