### PR TITLE
Added output comment to verbatim string code snippet

### DIFF
--- a/samples/snippets/csharp/language-reference/keywords/verbatim1.cs
+++ b/samples/snippets/csharp/language-reference/keywords/verbatim1.cs
@@ -26,6 +26,9 @@ public class Example
       
       Console.WriteLine(filename1);
       Console.WriteLine(filename2);
+      // The example displays the following output:
+      //     c:\documents\files\u0066.txt
+      //     c:\documents\files\u0066.txt
       // </Snippet2>
       
       Console.WriteLine();


### PR DESCRIPTION
Updated a code example with its output to make code examples at the [verbatim identifier](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim) page consistent.