### PR TITLE
Replace IIF with IF

### DIFF
--- a/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple1.vb
+++ b/samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple1.vb
@@ -18,14 +18,14 @@ Module Module1
         ' </Snippet1>
         ' <Snippet2>
         Console.WriteLine($"{holiday.Item1} is {holiday.Item2}" +
-                          $"{IIf(holiday.Item3, ", a national holiday", String.Empty)}")
+                          $"{If(holiday.Item3, ", a national holiday", String.Empty)}")
         ' Output: 7/4/2017 12:00:00 AM Is Independence Day, a national holiday
         ' </Snippet2>
         ' <Snippet3>
         holiday.Item1 = #01/01/2018#
         holiday.Item2 = "New Year's Day"
         Console.WriteLine($"{holiday.Item1} is {holiday.Item2}" +
-                          $"{IIf(holiday.Item3, ", a national holiday", String.Empty)}")
+                          $"{If(holiday.Item3, ", a national holiday", String.Empty)}")
         ' Output: 1/1/2018 12:00:00 AM Is New Year's Day, a national holiday
         ' </Snippet3> 
     End Sub
@@ -34,11 +34,11 @@ Module Module1
         ' <Snippet4>
         Dim holiday = (EventDate:=#07/04/2017#, Name:="Independence Day", IsHoliday:=True)
         Console.WriteLine($"{holiday.EventDate} Is {holiday.Name}" +
-                          $"{IIf(holiday.IsHoliday, ", a national holiday", String.Empty)}")
+                          $"{If(holiday.IsHoliday, ", a national holiday", String.Empty)}")
         holiday.Item1 = #01/01/2018#
         holiday.Item2 = "New Year's Day"
         Console.WriteLine($"{holiday.Item1} is {holiday.Item2}" +
-                          $"{IIf(holiday.Item3, ", a national holiday", String.Empty)}")
+                          $"{If(holiday.Item3, ", a national holiday", String.Empty)}")
         ' The example displays the following output:
         '   7/4/2017 12:00:00 AM Is Independence Day, a national holiday
         '   1/1/2018 12:00:00 AM Is New Year's Day, a national holiday


### PR DESCRIPTION
## Summary

IIF should not be used if IF is available (VB9 or above), as it is a function not an operator and always evaluates both parameters.

Fixes #Issue_Number (if available)
