### PR TITLE
Correct time complexity of List<T>.InsertRange

### DIFF
--- a/xml/System.Collections.Generic/List`1.xml
+++ b/xml/System.Collections.Generic/List`1.xml
@@ -2430,7 +2430,7 @@ Public Function StartsWith(e As Employee) As Boolean
   
  The order of the elements in the collection is preserved in the <xref:System.Collections.Generic.List%601>.  
   
- This method is an O(*n* + *m*) operation, where *n* is the number of elements to be added and *m* is <xref:System.Collections.Generic.List%601.Count%2A>.  
+ This method is an O(*n* * *m*) operation, where *n* is the number of elements to be added and *m* is <xref:System.Collections.Generic.List%601.Count%2A>.  
   
    
   


### PR DESCRIPTION
As discussed in https://github.com/dotnet/coreclr/issues/14876, in general, the time complexity of `List<T>.InsertRange` is O(*n* * *m*), because it calls `Insert` *n* times and `Insert` is O(*m*).

The time complexity could be made more accurate (you could say it's O(*n* * (*m* - `index`)) or you could explain that it's better if the input is `ICollection<T>`), but I'm not sure if going into that kind of detail makes sense here.