### PR TITLE
Update object-oriented-programming.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/object-oriented-programming.md
+++ b/docs/csharp/programming-guide/concepts/object-oriented-programming.md
@@ -379,7 +379,7 @@ class SampleClass : ISampleInterface
  To define a generic class:  
   
 ```csharp  
-Public class SampleGeneric<T>   
+public class SampleGeneric<T>   
 {  
     public T Field;  
 }  


### PR DESCRIPTION
the declaration of the Generic class sample, should have the public keyword in lower case.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
