### PR TITLE
Updates to Articles Concerning Ref Locals, In Parameters, and Readonly Ref Structs

### DIFF
--- a/docs/csharp/language-reference/keywords/in-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-parameter-modifier.md
@@ -59,7 +59,7 @@ You can't use the `in`, `ref`, and `out` keywords for the following kinds of met
 You typically declare `in` arguments to avoid the copy operations necessary for passing arguments by value. This is most useful when arguments are value types such as structures where copy operations are more expensive than passing by reference.
 
 > [!WARNING]
->  `in` parameters can be even more expensive if misused. The compiler cannot know if any member method modifies the state of the struct. To ensure that the object is not modified, the compiler creates a copy and calls member references using that copy. Any modifications are to that defensive copy. Given this, you should consider defining structures as `readonly struct`.
+>  `in` parameters can be even more expensive if misused. The compiler may not know if member methods modify the state of the struct. Whenever the compiler cannot ensure that the object is not modified, it defensively creates a copy and calls member references using that copy. Any possible modifications are to that defensive copy. The two ways to avoid these copies are to pass `in` parameters as `in` arguments or to define structures as `readonly struct`.
 
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  

--- a/docs/csharp/language-reference/keywords/in-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-parameter-modifier.md
@@ -56,7 +56,10 @@ You can't use the `in`, `ref`, and `out` keywords for the following kinds of met
   
 - Iterator methods, which include a [yield return](../../../csharp/language-reference/keywords/yield.md) or `yield break` statement.  
 
-You typically declare `in` arguments to avoid the copy operations necessary for passing arguments by value. This is most useful when arguments are structures or arrays of structures.
+You typically declare `in` arguments to avoid the copy operations necessary for passing arguments by value. This is most useful when arguments are value types such as structures where copy operations are more expensive than passing by reference.
+
+> [!WARNING]
+>  `in` parameters can be even more expensive if misused. The compiler cannot know if any member method modifies the state of the struct. To ensure that the object is not modified, the compiler creates a copy and calls member references using that copy. Any modifications are to that defensive copy. Given this, you should consider defining structures as `readonly struct`.
 
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
@@ -66,3 +69,4 @@ You typically declare `in` arguments to avoid the copy operations necessary for 
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [C# Keywords](../../../csharp/language-reference/keywords/index.md)  
  [Method Parameters](../../../csharp/language-reference/keywords/method-parameters.md)
+ [Reference Semantics with Value Types](../../../csharp/reference-semantics-with-value-types.md)

--- a/docs/csharp/language-reference/keywords/in-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-parameter-modifier.md
@@ -68,5 +68,5 @@ You typically declare `in` arguments to avoid the copy operations necessary for 
  [C# Reference](../../../csharp/language-reference/index.md)  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  
  [C# Keywords](../../../csharp/language-reference/keywords/index.md)  
- [Method Parameters](../../../csharp/language-reference/keywords/method-parameters.md)
+ [Method Parameters](../../../csharp/language-reference/keywords/method-parameters.md)  
  [Reference Semantics with Value Types](../../../csharp/reference-semantics-with-value-types.md)

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -22,7 +22,7 @@ The `ref` keyword indicates a value that is passed by reference. It is used in t
 
 - In a method signature, to return a value to the caller by reference. See [Reference return values](#reference-return-values) for more information.
 
-- In a member body, to indicate that a reference return value is stored locally as a reference that the caller intends to modify. See [Ref locals](#ref-locals) for more information.
+- In a member body, to indicate that a reference return value is stored locally as a reference that the caller intends to modify or, in general, a local variable accesses another value by reference. See [Ref locals](#ref-locals) for more information.
 
 ## Passing an argument by reference
 
@@ -104,7 +104,13 @@ For example, the following statement defines a ref local value that is returned 
 ref decimal estValue = ref Building.GetEstimatedValue();
 ```
 
-Note that the `ref` keyword must be used in both places, or the compiler generates error CS8172, "Cannot initialize a by-reference variable with a value." 
+You can access a value by reference in the same way. In some cases, accessing a value by reference increases performance by avoiding a potentially expensive copy operation. For example, the following statement shows how one can define a ref local value that is used to reference a value.
+
+```csharp
+ref VeryLargeStruct reflocal = ref veryLargeStruct;
+```
+
+Note that in both examples the `ref` keyword must be used in both places, or the compiler generates error CS8172, "Cannot initialize a by-reference variable with a value." 
  
 ## A ref returns and ref locals example
 

--- a/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
+++ b/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
@@ -80,7 +80,15 @@ ref Person p = ref contacts.GetContactInformation("Brandie", "Best");
 
 Subsequent usage of `p` is the same as using the variable returned by `GetContactInformation` because `p` is an alias for that variable. Changes to `p` also change the variable returned from `GetContactInformation`.
 
-Note that the `ref` keyword is used both before the local variable declaration *and* before the method call. Failure to include both `ref` keywords in the variable declaration and assignment results in compiler error CS8172, "Cannot initialize a by-reference variable with a value." 
+Note that the `ref` keyword is used both before the local variable declaration *and* before the method call. 
+
+You can access a value by reference in the same way. In some cases, accessing a value by reference increases performance by avoiding a potentially expensive copy operation. For example, the following statement shows how one can define a ref local value that is used to reference a value.
+
+```csharp
+ref VeryLargeStruct reflocal = ref veryLargeStruct;
+```
+
+Note that the `ref` keyword is used both before the local variable declaration *and* before the value in the second example. Failure to include both `ref` keywords in the variable declaration and assignment in both examples results in compiler error CS8172, "Cannot initialize a by-reference variable with a value." 
  
 ## Ref returns and ref locals: an example
 
@@ -96,4 +104,5 @@ Without support for reference return values, such an operation is usually perfor
  
 ## See also
 
-[ref keyword](../../language-reference/keywords/ref.md)
+[ref keyword](../../language-reference/keywords/ref.md)  
+[Reference Semantics with Value Types](../../../csharp/reference-semantics-with-value-types.md)

--- a/docs/csharp/reference-semantics-with-value-types.md
+++ b/docs/csharp/reference-semantics-with-value-types.md
@@ -202,6 +202,20 @@ types.
 These restrictions ensure that you do not accidentally use a `ref struct`
 in a manner that could promote it to the managed heap.
 
+## `readonly ref struct` type
+
+Declaring a struct as `readonly ref` combines the benefits and restrictions of `ref struct` and `readonly struct` delcarations. 
+
+The following example demonstrates the declaration of `readonly ref struct`.
+
+```csharp
+readonly ref struct RefReadOnlyPoint2D
+{
+    public int X { get; }
+    public int Y { get; }
+}
+```
+
 ## Conclusions
 
 These enhancements to the C# language are designed for performance critical

--- a/docs/csharp/reference-semantics-with-value-types.md
+++ b/docs/csharp/reference-semantics-with-value-types.md
@@ -213,6 +213,8 @@ readonly ref struct ReadOnlyRefPoint2D
 {
     public int X { get; }
     public int Y { get; }
+    
+    ReadOnlyRefPoint2D(int x, int y) => (X, Y) = (x, y);
 }
 ```
 

--- a/docs/csharp/reference-semantics-with-value-types.md
+++ b/docs/csharp/reference-semantics-with-value-types.md
@@ -209,7 +209,7 @@ Declaring a struct as `readonly ref` combines the benefits and restrictions of `
 The following example demonstrates the declaration of `readonly ref struct`.
 
 ```csharp
-readonly ref struct RefReadOnlyPoint2D
+readonly ref struct ReadOnlyRefPoint2D
 {
     public int X { get; }
     public int Y { get; }


### PR DESCRIPTION
**Updates to Articles Concerning Ref Locals, In Parameters, and Readonly Ref Structs**

*Update to Article on In Parameter Modifiers*

Removed mention of "in" parameters being especially useful for arrays of structures given arrays are reference types already. Additional scrutiny by maintainers may be needed for this change as I may have misinterpreted the purpose of the original remark: "This is most useful when arguments are structures or arrays of structures."
Added note about benefit of copying by reference for value types.
Included warning about using "in" parameters with structs not defined as readonly.
Added "Reference Semantics with Value Types" to "See Also" section.

*Update to Article on Ref Keyword*

Added information concerning using "ref" keyword to handle variable by reference.

*Update to Article on "Reference semantics with value types"*

Added section on readonly ref structures.

*Update to Article "Ref returns and ref locals"*

Added example and brief explanation for ref locals used to reference variables.
