### PR TITLE
fix link formatting

### DIFF
--- a/xml/System.Xml.Linq/XDocument.xml
+++ b/xml/System.Xml.Linq/XDocument.xml
@@ -22,7 +22,7 @@
   </Base>
   <Interfaces />
   <Docs>
-    <summary>Represents an XML document. For the components and usage of an <see cref="T:System.Xml.Linq.XDocument" /> object, see [XDocument Class Overview](http://msdn.microsoft.com/library/90f78331-1be8-42fb-93e7-bd1325826467).</summary>
+    <summary>Represents an XML document. For the components and usage of an <see cref="T:System.Xml.Linq.XDocument" /> object, see <see href="http://msdn.microsoft.com/library/90f78331-1be8-42fb-93e7-bd1325826467">XDocument Class Overview</see>.</summary>
     <remarks>
       <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
API browser search displays a broken link when summary uses Markdown instead of ECMAXML

![image](https://user-images.githubusercontent.com/12971179/37691536-e53bf3ce-2c6f-11e8-9caf-e3a58f28acaf.png)
