### PR TITLE
Added missing Introduction to C# spec TOC

### DIFF
--- a/docs/csharp/language-reference/language-specification/toc.md
+++ b/docs/csharp/language-reference/language-specification/toc.md
@@ -1,4 +1,5 @@
 # [C# 6.0 draft specification](index.md)
+## [Introduction](../../../../_csharplang/spec/introduction.md)
 ## [Lexical structure](../../../../_csharplang/spec/lexical-structure.md)
 ## [Basic concepts](../../../../_csharplang/spec/basic-concepts.md)
 ## [Types](../../../../_csharplang/spec/types.md)


### PR DESCRIPTION
[The *Introduction* article](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/introduction) exists, but is not part of the C# spec TOC. This PR fixes that.