### PR TITLE
Added include file for compiler options

### DIFF
--- a/includes/compiler-options.md
+++ b/includes/compiler-options.md
@@ -1,0 +1,2 @@
+
+Every compiler option is available in two forms: **-option** and **/option**. The documentation only shows the -option form. 


### PR DESCRIPTION
## Added include file for compiler options

The documentation for the C# and Visual Basic compilers uses a hyphen (`-`) to specify a compiler option, but both hyphen and slash (`/`) are supported. The top-level compiler topics for [C#](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/) and [Visual Basic](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/command-line-compiler/) note that, but the topics for individual compiler options do not.

This PR adds an include file that notes both hyphen and slash are supported. It can be included in each of the C# and Visual Basic topics for the individual compiler switches. 

