### PR TITLE
Update object-oriented-programming.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/object-oriented-programming.md
+++ b/docs/csharp/programming-guide/concepts/object-oriented-programming.md
@@ -91,7 +91,7 @@ struct SampleStruct
  To define a field:  
   
 ```csharp  
-Class SampleClass  
+class SampleClass  
 {  
     public string sampleField;  
 }  
@@ -379,7 +379,7 @@ class SampleClass : ISampleInterface
  To define a generic class:  
   
 ```csharp  
-Public class SampleGeneric<T>   
+public class SampleGeneric<T>   
 {  
     public T Field;  
 }  


### PR DESCRIPTION
changed the casing for the "public" (line 96) word and "class" (line 32).

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
