### PR TITLE
Make Address value object truly immutable. Update implement-value-objects.md

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/implement-value-objects.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/implement-value-objects.md
@@ -103,11 +103,11 @@ You can use this class when implementing your actual value object, as with the A
 ```csharp
 public class Address : ValueObject
 {
-    public String Street { get; private set; }
-    public String City { get; private set; }
-    public String State { get; private set; }
-    public String Country { get; private set; }
-    public String ZipCode { get; private set; }
+    public String Street { get; }
+    public String City { get; }
+    public String State { get; }
+    public String Country { get; }
+    public String ZipCode { get; }
 
     private Address() { }
 


### PR DESCRIPTION
It's better to remove private property setters to make Address value object truly immutable. Otherwise, it's possible to change the object by setting properties inside its methods for example.

``` 
protected override IEnumerable<object> GetAtomicValues()
    {
       Street = "Blah blah blah";
       City = "Blah blah blah";

        // Using a yield return statement to return each element one at a time
        yield return Street;
        yield return City;
        yield return State;
        yield return Country;
        yield return ZipCode;
    }
```
## Summary

Remove private property setters. Make public properties readonly.

Fixes #Issue_Number (if available)
