### PR TITLE
Remove private setters to make class immutable

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -27,8 +27,8 @@ The ordering microservice in eShopOnContainers provides a sample Enumeration bas
 ```csharp
 public abstract class Enumeration : IComparable
 {
-    public string Name { get; private set; }
-    public int Id { get; private set; }
+    public string Name { get; }
+    public int Id { get; }
 
     protected Enumeration()
     {


### PR DESCRIPTION
Remove private setters to make Enumeration immutable. Otherwise, it's possible to change the property values. 

 ```csharp
 public override string ToString()
        {
            Name = "Whatever";
            return Name;
        }
```

## Summary

Remove private setters for public properties
