### PR TITLE
Remove private setters to make a class truly immutable

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
@@ -84,13 +84,13 @@ In C#, a domain event is simply a data-holding structure or class, like a DTO, w
 ```csharp
 public class OrderStartedDomainEvent : INotification
 {
-    public string UserId { get; private set; }
-    public int CardTypeId { get; private set; }
-    public string CardNumber { get; private set; }
-    public string CardSecurityNumber { get; private set; }
-    public string CardHolderName { get; private set; }
-    public DateTime CardExpiration { get; private set; }
-    public Order Order { get; private set; }
+    public string UserId { get; }
+    public int CardTypeId { get; }
+    public string CardNumber { get; }
+    public string CardSecurityNumber { get; }
+    public string CardHolderName { get; }
+    public DateTime CardExpiration { get; }
+    public Order Order { get; }
 
     public OrderStartedDomainEvent(Order order,
                                    int cardTypeId, string cardNumber,


### PR DESCRIPTION
Remove private setters to make a class truly immutable. Otherwise, properties can be updated outside of constructor. This also makes code cleaner.

## Summary

Remove private setters

Fixes #Issue_Number (if available)
