### PR TITLE
Change "deregister" to "unregister" in CancellationToken docs

### DIFF
--- a/xml/System.Threading/CancellationToken.xml
+++ b/xml/System.Threading/CancellationToken.xml
@@ -543,7 +543,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
       <Docs>
         <param name="callback">The delegate to be executed when the <see cref="T:System.Threading.CancellationToken" /> is canceled.</param>
         <summary>Registers a delegate that will be called when this <see cref="T:System.Threading.CancellationToken" /> is canceled.</summary>
-        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to deregister the callback.</returns>
+        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to unregister the callback.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -597,7 +597,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
         <param name="callback">The delegate to be executed when the <see cref="T:System.Threading.CancellationToken" /> is canceled.</param>
         <param name="useSynchronizationContext">A value that indicates whether to capture the current <see cref="T:System.Threading.SynchronizationContext" /> and use it when invoking the <c>callback</c>.</param>
         <summary>Registers a delegate that will be called when this <see cref="T:System.Threading.CancellationToken" /> is canceled.</summary>
-        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to deregister the callback.</returns>
+        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to unregister the callback.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -651,7 +651,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
         <param name="callback">The delegate to be executed when the <see cref="T:System.Threading.CancellationToken" /> is canceled.</param>
         <param name="state">The state to pass to the <c>callback</c> when the delegate is invoked. This may be null.</param>
         <summary>Registers a delegate that will be called when this <see cref="T:System.Threading.CancellationToken" /> is canceled.</summary>
-        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to deregister the callback.</returns>
+        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to unregister the callback.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   
@@ -707,7 +707,7 @@ For the definition of equality, see the <xref:System.Threading.CancellationToken
         <param name="state">The state to pass to the <c>callback</c> when the delegate is invoked. This may be null.</param>
         <param name="useSynchronizationContext">A Boolean value that indicates whether to capture the current <see cref="T:System.Threading.SynchronizationContext" /> and use it when invoking the <c>callback</c>.</param>
         <summary>Registers a delegate that will be called when this <see cref="T:System.Threading.CancellationToken" /> is canceled.</summary>
-        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to deregister the callback.</returns>
+        <returns>The <see cref="T:System.Threading.CancellationTokenRegistration" /> instance that can be used to unregister the callback.</returns>
         <remarks>
           <format type="text/markdown"><![CDATA[  
   


### PR DESCRIPTION
"unregister" is a much more commonly used form of the word.