### PR TITLE
Fixed broken links, restored deleted content

### DIFF
--- a/xml/System.Reflection.Emit/MethodBuilder.xml
+++ b/xml/System.Reflection.Emit/MethodBuilder.xml
@@ -247,7 +247,7 @@
 ## Remarks  
  A <xref:System.Reflection.Emit.MethodBuilder> always represents a generic method definition, and thus cannot be invoked.  
   
- For more information, see <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
+ For more information, see <xref:System.Reflection.MethodBase.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
   
  ]]></format>
         </remarks>
@@ -391,7 +391,7 @@
   
  By convention, a type parameter name is a single uppercase letter.  
   
- For more information, see <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.GetGenericMethodDefinition%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
+ For more information, see <xref:System.Reflection.MethodBase.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.GetGenericMethodDefinition%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
   
    
   
@@ -664,7 +664,7 @@
 ## Remarks  
  The type parameters of a generic method also are returned by the <xref:System.Reflection.Emit.MethodBuilder.DefineGenericParameters%2A> method that is used to define them.  
   
- For more information, see <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.GetGenericArguments%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
+ For more information, see <xref:System.Reflection.MethodBase.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.GetGenericArguments%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
   
  ]]></format>
         </remarks>
@@ -702,7 +702,7 @@
 ## Remarks  
  A <xref:System.Reflection.Emit.MethodBuilder> cannot be used to emit a constructed generic method directly. The emitted method is a generic method definition.  
   
- For more information, see <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.GetGenericMethodDefinition%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
+ For more information, see <xref:System.Reflection.MethodBase.IsGenericMethod%2A?displayProperty=nameWithType> and <xref:System.Reflection.MethodInfo.GetGenericMethodDefinition%2A?displayProperty=nameWithType>. For information on generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>.  
   
  ]]></format>
         </remarks>

--- a/xml/System.Reflection/MethodBase.xml
+++ b/xml/System.Reflection/MethodBase.xml
@@ -246,13 +246,13 @@
   
  Similarly, the <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> property parameter returns `true` for any constructor in an open type, even though constructors cannot have type parameters of their own.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
   
  ]]></format>
         </remarks>
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
-        <altmember cref="P:System.Reflection.MethodInfo.ContainsGenericParameters" />
+        <altmember cref="P:System.Reflection.MethodBase.ContainsGenericParameters" />
       </Docs>
     </Member>
     <Member MemberName="Equals">
@@ -332,7 +332,7 @@
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- If the currently executing method is defined on a generic type, the <xref:System.Reflection.MethodInfo> that is returned by <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> is obtained from the generic type definition (that is, <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A?displayProperty=nameWithType> returns `true`). Therefore, it does not reflect the type arguments that were used when the method was called. For example, if a method `M()` is defined on a generic type `C<T>` (`C(Of T)` in Visual Basic), and <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> is called from `C<string>.M()`, then <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> returns `C<T>.M()` (`C(Of T).M()` in Visual Basic).  
+ If the currently executing method is defined on a generic type, the <xref:System.Reflection.MethodInfo> that is returned by <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> is obtained from the generic type definition (that is, <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A?displayProperty=nameWithType> returns `true`). Therefore, it does not reflect the type arguments that were used when the method was called. For example, if a method `M()` is defined on a generic type `C<T>` (`C(Of T)` in Visual Basic), and <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> is called from `C<string>.M()`, then <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> returns `C<T>.M()` (`C(Of T).M()` in Visual Basic).  
   
  If the currently executing method is a generic method, <xref:System.Reflection.MethodBase.GetCurrentMethod%2A> returns the generic method definition. If the generic method is defined on a generic type, the <xref:System.Reflection.MethodInfo> is obtained from the generic type definition.  
   
@@ -402,7 +402,7 @@
   
  Generic constructors are not supported in the .NET Framework version 2.0. This property throws <xref:System.NotSupportedException> if not overridden in a derived class, so an exception is thrown if the current instance is of type <xref:System.Reflection.ConstructorInfo>.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
   
  ]]></format>
         </remarks>
@@ -410,7 +410,7 @@
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
         <altmember cref="M:System.Reflection.MethodInfo.GetGenericArguments" />
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethod" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
         <altmember cref="P:System.Type.IsGenericType" />
       </Docs>
     </Member>
@@ -1436,13 +1436,20 @@
 > [!NOTE]
 >  Generics are not supported by default; this property returns `false` if not overridden in a derived class. Generic constructors are not supported in the .NET Framework version 2.0, so this property returns `false` if the current instance is of type <xref:System.Reflection.ConstructorInfo>.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
-  
+The following table summarizes the invariant conditions for terms specific to generic methods. For other terms used in generic reflection, such as *generic type parameter* and *generic type*, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
+
+|Term|Invariant|
+|---|---|
+|generic method definition| The <xref:System.Reflection.MethodBase.IsGenericMethodDefinition> property is `true`. <br />Defines a generic method. A constructed method is created by calling the <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A?displayProperty=nameWithType> method on a <xref:System.Reflection.MethodInfo> object that represents a generic method definition, and specifying an array of type arguments. <br />The <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> method can be called only on generic method definitions. <br/>Any generic method definition is a generic method,m but the converse is not true.|   
+|generic method|The `IsGenericMethod` property is `true`. <br/> Can be a generic method definition, an open constructed method, or a closed constructed method.|
+|open constructed method|The <xref:System.Reflection.MethodBase.ContainsGenericParameters> property is `true`. <br/>It is not possible to invoke an open constructed method.| 
+|closed constructed method|The <xref:System.Reflection.MethodBase.ContainsGenericParameters> property is `false`. <br/>When examined recursively, the method has no unassigned generic parameters. The containing type has no generic type parameters, and none of the type arguments have generic type parameters. <br/>The method can be invoked.|  
+
  ]]></format>
         </remarks>
         <altmember cref="P:System.Reflection.MethodBase.ContainsGenericParameters" />
         <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethod" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
         <altmember cref="P:System.Type.IsGenericType" />
       </Docs>
     </Member>
@@ -1498,11 +1505,11 @@
 > [!NOTE]
 >  Generics are not supported by default; this property returns `false` if not overridden in a derived class. Generic constructors are not supported in the .NET Framework version 2.0, so this property returns `false` if the current instance is of type <xref:System.Reflection.ConstructorInfo>.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
   
  ]]></format>
         </remarks>
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethodDefinition" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
       </Docs>
     </Member>
     <Member MemberName="IsHideBySig">

--- a/xml/System.Reflection/MethodInfo.xml
+++ b/xml/System.Reflection/MethodInfo.xml
@@ -54,7 +54,7 @@
   
 -   You can discover what attributes are applied to the method by retrieving the value of the <xref:System.Reflection.MethodBase.Attributes%2A> property or calling the <xref:System.Reflection.Assembly.GetCustomAttributes%2A> method.  
   
--   You can determine whether the method is a generic method, an open constructed generic method, or a closed constructed generic method, by retrieving the values of the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> and <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A> properties.  
+-   You can determine whether the method is a generic method, an open constructed generic method, or a closed constructed generic method, by retrieving the values of the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> and <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> properties.  
   
 -   You can get information about the method's parameters and return type from the <xref:System.Reflection.MethodBase.GetParameters%2A> method and the <xref:System.Reflection.MethodInfo.ReturnParameter%2A>, <xref:System.Reflection.MethodInfo.ReturnType%2A>, and <xref:System.Reflection.MethodInfo.ReturnTypeCustomAttributes%2A> properties.  
   
@@ -64,7 +64,7 @@
   
  You can instantiate a <xref:System.Reflection.MethodInfo> instances by calling the <xref:System.Type.GetMethods%2A?displayProperty=nameWithType> or <xref:System.Type.GetMethod%2A?displayProperty=nameWithType> method, or by calling the <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A?displayProperty=nameWithType> method of a <xref:System.Reflection.MethodInfo> object that represents a generic method definition.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A> property.  
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A> property.  
   
  ]]></format>
     </remarks>
@@ -75,7 +75,7 @@
     </block>
     <altmember cref="Overload:System.Type.GetMethods" />
     <altmember cref="Overload:System.Type.GetMethod" />
-    <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethod" />
+    <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
   </Docs>
   <Members>
     <Member MemberName=".ctor">
@@ -359,15 +359,13 @@
 ## Remarks  
  The elements of the returned array are in the order in which they appear in the list of type parameters for the generic method.  
   
--   If the current method is a closed constructed method (that is, the <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A> property returns `false`), the array returned by the <xref:System.Reflection.MethodInfo.GetGenericArguments%2A> method contains the types that have been assigned to the generic type parameters of the generic method definition.  
+-   If the current method is a closed constructed method (that is, the <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> property returns `false`), the array returned by the <xref:System.Reflection.MethodInfo.GetGenericArguments%2A> method contains the types that have been assigned to the generic type parameters of the generic method definition.  
   
 -   If the current method is a generic method definition, the array contains the type parameters.  
   
--   If the current method is an open constructed method (that is, the <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A> property returns `true`) in which specific types have been assigned to some type parameters and type parameters of enclosing generic types have been assigned to other type parameters, the array contains both types and type parameters. Use the <xref:System.Type.IsGenericParameter%2A> property to tell them apart. For a demonstration of this scenario, see the code example for the <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A> property.  
+-   If the current method is an open constructed method (that is, the <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> property returns `true`) in which specific types have been assigned to some type parameters and type parameters of enclosing generic types have been assigned to other type parameters, the array contains both types and type parameters. Use the <xref:System.Type.IsGenericParameter%2A> property to tell them apart. For a demonstration of this scenario, see the code example for the <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> property.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
-  
-   
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A?displayProperty=nameWithType> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType> property.  
   
 ## Examples  
  The following code example shows how to get the type arguments of a generic method and display them.  
@@ -381,7 +379,7 @@
  ]]></format>
         </remarks>
         <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethod" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
         <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethodDefinition" />
         <altmember cref="M:System.Reflection.MethodInfo.GetGenericMethodDefinition" />
         <altmember cref="P:System.Type.IsGenericType" />
@@ -459,7 +457,7 @@ public:
   
  In the constructed type `C<int>` (`C(Of Integer)` in Visual Basic), the generic method `M` returns `B<int, S>`. In the open type `C<T>`, `M` returns `B<T, S>`. In both cases, the <xref:System.Reflection.MethodInfo.IsGenericMethodDefinition%2A> property returns `true` for the <xref:System.Reflection.MethodInfo> that represents `M`, so <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> can be called on both <xref:System.Reflection.MethodInfo> objects. In the case of the constructed type, the result of calling <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> is a <xref:System.Reflection.MethodInfo> that can be invoked. In the case of the open type, the <xref:System.Reflection.MethodInfo> returned by <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> cannot be invoked.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A> property.  
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A> property.  
   
    
   
@@ -480,11 +478,11 @@ public:
   
  ]]></format>
         </remarks>
-        <exception cref="T:System.InvalidOperationException">The current method is not a generic method. That is, <see cref="P:System.Reflection.MethodInfo.IsGenericMethod" /> returns <see langword="false" />.</exception>
+        <exception cref="T:System.InvalidOperationException">The current method is not a generic method. That is, <see cref="P:System.Reflection.MethodBase.IsGenericMethod" /> returns <see langword="false" />.</exception>
         <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
         <altmember cref="M:System.Reflection.MethodInfo.MakeGenericMethod(System.Type[])" />
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethod" />
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethodDefinition" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethod" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
       </Docs>
     </Member>
     <Member MemberName="GetHashCode">
@@ -572,7 +570,7 @@ public:
           <format type="text/markdown"><![CDATA[  
   
 ## Remarks  
- The <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> method allows you to write code that assigns specific types to the type parameters of a generic method definition, thus creating a <xref:System.Reflection.MethodInfo> object that represents a particular constructed method. If the <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A> property of this <xref:System.Reflection.MethodInfo> object returns `true`, you can use it to invoke the method or to create a delegate to invoke the method.  
+ The <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> method allows you to write code that assigns specific types to the type parameters of a generic method definition, thus creating a <xref:System.Reflection.MethodInfo> object that represents a particular constructed method. If the <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> property of this <xref:System.Reflection.MethodInfo> object returns `true`, you can use it to invoke the method or to create a delegate to invoke the method.  
   
  Methods constructed with the <xref:System.Reflection.MethodInfo.MakeGenericMethod%2A> method can be open, that is, some of their type arguments can be type parameters of enclosing generic types. You might use such open constructed methods when you generate dynamic assemblies. For example, consider the following C#, Visual Basic, and C++ code.  
   
@@ -607,9 +605,9 @@ public:
 };  
 ```  
   
- The method body of `M` contains a call to method `N`, specifying the type parameter of `M` and the type <xref:System.Int32>. The <xref:System.Reflection.MethodInfo.IsGenericMethodDefinition%2A> property returns `false` for method `N<V,int>`. The <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A> property returns `true`, so method `N<V,int>` cannot be invoked.  
+ The method body of `M` contains a call to method `N`, specifying the type parameter of `M` and the type <xref:System.Int32>. The <xref:System.Reflection.MethodBase.IsGenericMethodDefinition%2A> property returns `false` for method `N<V,int>`. The <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A> property returns `true`, so method `N<V,int>` cannot be invoked.  
   
- For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A> property.  
+ For a list of the invariant conditions for terms specific to generic methods, see the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property. For a list of the invariant conditions for other terms used in generic reflection, see the <xref:System.Type.IsGenericType%2A> property.  
   
    
   
@@ -634,7 +632,7 @@ public:
   
  ]]></format>
         </remarks>
-        <exception cref="T:System.InvalidOperationException">The current <see cref="T:System.Reflection.MethodInfo" /> does not represent a generic method definition. That is, <see cref="P:System.Reflection.MethodInfo.IsGenericMethodDefinition" /> returns <see langword="false" />.</exception>
+        <exception cref="T:System.InvalidOperationException">The current <see cref="T:System.Reflection.MethodInfo" /> does not represent a generic method definition. That is, <see cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" /> returns <see langword="false" />.</exception>
         <exception cref="T:System.ArgumentNullException">
           <paramref name="typeArguments" /> is <see langword="null" />.  
   
@@ -647,7 +645,7 @@ public:
   
  An element of <paramref name="typeArguments" /> does not satisfy the constraints specified for the corresponding type parameter of the current generic method definition.</exception>
         <exception cref="T:System.NotSupportedException">This method is not supported.</exception>
-        <altmember cref="P:System.Reflection.MethodInfo.IsGenericMethodDefinition" />
+        <altmember cref="P:System.Reflection.MethodBase.IsGenericMethodDefinition" />
         <altmember cref="M:System.Reflection.MethodInfo.GetGenericMethodDefinition" />
       </Docs>
     </Member>


### PR DESCRIPTION
## Fixed broken links, restored deleted content

These are the reflection-related broken links that have surfaced in our publishing reports recently. 

I've also restored some content. There are a number of links to this restored content, except that the content has been missing since .NET Framework 4.
