### PR TITLE
C# spec intro: link to C# spec introduction

### DIFF
--- a/docs/csharp/language-reference/language-specification/index.md
+++ b/docs/csharp/language-reference/language-specification/index.md
@@ -20,7 +20,7 @@ The C# Language Specification is the definitive source for C# syntax and usage. 
 
 You can download version 5.0 of this specification from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2015, you can also find the specification on your computer in the Program Files (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033 folder. If you have another version of Visual Studio installed or if you installed Visual Studio in a language other than English, change the path as appropriate.
 
-Version 6.0 of the specification has not been approved as a standard. This site contains the [*draft* C# 6.0 specification](../../../../_csharplang/spec/lexical-structure.md). It is built from the markdown files contained in [the dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md).
+Version 6.0 of the specification has not been approved as a standard. This site contains the [*draft* C# 6.0 specification](../../../../_csharplang/spec/introduction.md). It is built from the markdown files contained in [the dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md).
 
 Issues on the draft specification should be created in the [dotnet/csharplang](https://github.com/dotnet/csharplang/issues) repository. Or, if you are interested
 in fixing any errors you find, you may submit a [Pull Request](https://github.com/dotnet/csharplang/pulls) to the same repository.
@@ -30,4 +30,4 @@ in fixing any errors you find, you may submit a [Pull Request](https://github.co
  [C# Programming Guide](../../programming-guide/index.md)
 
 >[!div class="step-by-step"]
-[Next](../../../../_csharplang/spec/lexical-structure.md)
+[Next](../../../../_csharplang/spec/introduction.md)


### PR DESCRIPTION
PR #4725 added [C# spec introduction](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/introduction) to the spec TOC. Then it feels natural to reference that introduction article from the [index page](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/), not the lexical structure one that was first in the list before.


