### PR TITLE
clarify description of dotnet test

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -38,9 +38,9 @@ dotnet test [-h|--help]
 
 ## Description
 
-The `dotnet test` command is used to execute unit tests in a given project. Unit tests are console application projects that have dependencies on the unit test framework (for example, MSTest, NUnit, or xUnit) and the dotnet test runner for the unit testing framework. These are packaged as NuGet packages and are restored as ordinary dependencies for the project.
+The `dotnet test` command is used to execute unit tests in a given project. The `dotnet test` command launches the test runner console application specified for a project. The test runner executes the tests defined for a unit test framework (for example, MSTest, NUnit, or xUnit) and reports the success or failure of each test. The test runner and the unit test library are packaged as NuGet packages and are restored as ordinary dependencies for the project.
 
-Test projects also must specify the test runner. This is specified using an ordinary `<PackageReference>` element, as seen in the following sample project file:
+Test projects specify the test runner using an ordinary `<PackageReference>` element, as seen in the following sample project file:
 
 [!code-xml[XUnit Basic Template](../../../samples/snippets/csharp/xunit-test/xunit-test.csproj)]
 


### PR DESCRIPTION
Fixes #4269

The existing description could have been interpreted as defining a unit test, rather than the execution of unit tests in the dotnet CLI.


