### PR TITLE
array designator on variable fix for initialize array example

### DIFF
--- a/docs/visual-basic/programming-guide/program-structure/codesnippet/VisualBasic/coding-conventions_10.vb
+++ b/docs/visual-basic/programming-guide/program-structure/codesnippet/VisualBasic/coding-conventions_10.vb
@@ -1,1 +1,1 @@
-    Dim letters5() As String = {"a", "b", "c"}
+    Dim letters5 As String() = {"a", "b", "c"}


### PR DESCRIPTION
## Summary

The initialize array example doesn't follow rule above it (vbVbVbalrGuidelines#10) stating:

"Put the array designator on the type, not on the variable"

