### PR TITLE
C# get started page: removed self-link

### DIFF
--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -40,10 +40,6 @@ The following topics are available:
 
    This topic shows you how to create and run a simple Hello World application with Visual Studio Code and .NET Core.
 
-* [Additional Resources for Visual C# Programmers](additional-resources.md)
-
-   Provides links to Web sites and newsgroups that can help you find answers to common problems.
-
 ## Related Sections
 
 * [Using the Visual Studio Development Environment for C#](/visualstudio/csharp-ide/using-the-visual-studio-development-environment-for-csharp)  


### PR DESCRIPTION
Some time ago the *docs/csharp/getting-started/additional-resources.md* file was deleted and [redirect was setup](https://github.com/dotnet/docs/blob/8009854a9d975c589937c30b8c56e138424c9c80/.openpublishing.redirection.json#L259) to [Get Started with C# page](https://docs.microsoft.com/en-us/dotnet/csharp/getting-started/). That made that page have the link to itself. Obviously, that link can be removed.
