### PR TITLE
null-conditional-operators.md: review

### DIFF
--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -73,7 +73,7 @@ PropertyChanged?.Invoke(e)
   
  The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in a temporary variable.  
   
- You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  There were too many ambiguous parsing situations to allow it.  
+ You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  
   
 ## Language Specifications  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  

--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -5,13 +5,23 @@ ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
 ms.topic: "article"
+dev_langs: 
+  - "csharp"
+  - "vb"
+helpviewer_keywords: 
+  - "null-conditional operators [C#]"
+  - "null-conditional operators [Visual Basic]"
+  - "?. operator [C#]"
+  - "?. operator [Visual Basic]"
+  - "?[] operator [C#]"
+  - "?[] operator [Visual Basic]"
 ms.assetid: 9c7b2c8f-a785-44ca-836c-407bfb6d27f5
 caps.latest.revision: 3
 author: "BillWagner"
 ms.author: "wiwagn"
 ---
-# Null-conditional Operators (C# and Visual Basic)
-Used to test for null before performing a member access (`?.`) or index (`?[`) operation.  These operators help you write less code to handle null checks, especially for descending into data structures.  
+# ?. and ?[] null-conditional Operators (C# and Visual Basic)
+Used to test for null before performing a member access (`?.`) or index (`?[]`) operation.  These operators help you write less code to handle null checks, especially for descending into data structures.  
   
 ```csharp  
 int? length = customers?.Length; // null if customers is null   
@@ -25,7 +35,7 @@ Dim first as Customer = customers?(0)  ' null if customers is null
 Dim count as Integer? = customers?(0)?.Orders?.Count()  ' null if customers, the first customer, or Orders is null  
 ```  
   
- The last example demonstrates that the null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  Other operations with lower precedence in the expression continue.  For example, `E` in the following executes in the second line, and the `??` and `==` operations execute.  In the first line, the `??` short circuits and `E` does not execute when the left side evaluates to non-null.
+ The last example demonstrates that the null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  Other operations with lower precedence in the expression continue.  For example, `E` in the following executes in the second line, and the `?.` and `==` operations execute.  In the first line, the `??` short circuits and `E` does not execute when the left side evaluates to non-null.
   
 ```csharp
 A?.B?.C?[0] ?? E  

--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -1,6 +1,6 @@
 ---
 title: "Null-conditional Operators (C# and Visual Basic)"
-ms.date: 07/20/2015
+ms.date: 04/03/2015
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -35,16 +35,16 @@ Dim first as Customer = customers?(0)  ' null if customers is null
 Dim count as Integer? = customers?(0)?.Orders?.Count()  ' null if customers, the first customer, or Orders is null  
 ```  
   
- The last example demonstrates that the null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  Other operations with lower precedence in the expression continue.  For example, `E` in the following executes in the second line, and the `==` operation executes.  In the first line, the `??` short circuits and `E` does not execute when the left side evaluates to non-null.
+ The null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  In the following example, `E` doesn't execute if `A`, `B`, or `C` evaluates to null.
   
 ```csharp
-A?.B?.C?[0] ?? E  
-A?.B?.C?[0] == E  
+A?.B?.C?.Do(E);
+A?.B?.C?[E];
 ```
 
 ```vb
-A?.B?.C?(0) ?? E  
-A?.B?.C?(0) == E  
+A?.B?.C?.Do(E);
+A?.B?.C?(E);
 ```  
   
  Another use for the null-condition member access is invoking delegates in a thread-safe way with much less code.  The old way requires code like the following:  

--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -35,7 +35,7 @@ Dim first as Customer = customers?(0)  ' null if customers is null
 Dim count as Integer? = customers?(0)?.Orders?.Count()  ' null if customers, the first customer, or Orders is null  
 ```  
   
- The last example demonstrates that the null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  Other operations with lower precedence in the expression continue.  For example, `E` in the following executes in the second line, and the `?.` and `==` operations execute.  In the first line, the `??` short circuits and `E` does not execute when the left side evaluates to non-null.
+ The last example demonstrates that the null-condition operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  Other operations with lower precedence in the expression continue.  For example, `E` in the following executes in the second line, and the `==` operation executes.  In the first line, the `??` short circuits and `E` does not execute when the left side evaluates to non-null.
   
 ```csharp
 A?.B?.C?[0] ?? E  


### PR DESCRIPTION
In #4784 @mairaw mentioned that metadata of the [null-conditional operators article](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-conditional-operators) should be updated. 

This PR
- does that by adding `dev_langs` and `helpviewer_keywords` metadata elements
- updates title and uses `?[]` notation instead of `?[`
- removes a remark about language design choices at the end of the article
- fixes minor error in the description of the second example

As for the second example, let's update it, as now it's confusing and obvious at the same time.

>Other operations with lower precedence in the expression continue.

What it says is *as soon as the expression containing the operator knows its result, remaining operators in the expression are evaluated*. Is that right? If yes, then it's not about null-conditional operators per se. One more thing: reading the article about an operator, I (and maybe other readers) focus on the operator itself and mentioning the expression that contains that operator is a context switch and unexpected introduction of a new entity.

>For example, `E` in the following executes in the second line, and the `??` and `==` operations execute.

First, there is no `??` operation in the second line (I'm fixing that), second, again we jump out of the operator context to the global expression context with an example: to compare results of two expressions, both expressions must be evaluated.

>In the first line, the `??` short circuits and `E` does not execute when the left side evaluates to non-null.

It's about the `??` operator, not about null-conditional operators. This example is more appropriate in the article about the `??` operator.

In both lines of the example 2 we leave the land of the `?.` and `?[]` operators and talk about how expressions in general are evaluated.

What would be a better example (which is also discussed in the thread below the article) is to state that in
```csharp
A?.B?.Do(E)
```
E is not evaluated if either A or B evaluates to null.
@BillWagner what do you think? If my reasoning above doesn't miss some important point, I'll make one more commit in this PR to update the example.

