### PR TITLE
Update URL of external resource.

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md
@@ -113,7 +113,7 @@ When using DI in .NET Core, you might want to be able to scan an assembly and au
 #### Additional resources
 
 -   **Matthew King. Registering services with Scrutor**
-    [*https://mking.io/blog/registering-services-with-scrutor*](https://mking.io/blog/registering-services-with-scrutor)
+    [*https://mking.net/blog/registering-services-with-scrutor*](https://mking.net/blog/registering-services-with-scrutor)
 
 <!-- -->
 


### PR DESCRIPTION
## Summary

I noticed one of my blog posts was getting traffic from docs.microsoft.com, and was excited to find it was linked from one of your documents. However, the URL used in the document points to an old domain name (mking.io) which will probably be retired in the next few years - I've updated the URL in the document to use the new domain name (mking.net) in order to prevent link rot in the future.
