### PR TITLE
Fixed some broken links

### DIFF
--- a/docs/csharp/programming-guide/generics/generics-and-reflection.md
+++ b/docs/csharp/programming-guide/generics/generics-and-reflection.md
@@ -34,15 +34,15 @@ Because the Common Language Runtime (CLR) has access to generic type information
 |<xref:System.Type.DeclaringMethod%2A>|Returns the generic method that defined the current generic type parameter, or null if the type parameter was not defined by a generic method.|  
 |<xref:System.Type.MakeGenericType%2A>|Substitutes the elements of an array of types for the type parameters of the current generic type definition, and returns a <xref:System.Type> object representing the resulting constructed type.|  
   
- In addition, new members are added to the <xref:System.Reflection.MethodInfo> class to enable run-time information for generic methods. See the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> property remarks for a list of invariant conditions for terms used to reflect on generic methods.  
+ In addition, members of the <xref:System.Reflection.MethodInfo> class enable run-time information for generic methods. See the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property remarks for a list of invariant conditions for terms used to reflect on generic methods.  
   
 |System.Reflection.MemberInfo Member Name|Description|  
 |----------------------------------------------|-----------------|  
-|<xref:System.Reflection.MethodInfo.IsGenericMethod%2A>|Returns true if a method is generic.|  
+|<xref:System.Reflection.MethodBase.IsGenericMethod%2A>|Returns true if a method is generic.|  
 |<xref:System.Reflection.MethodInfo.GetGenericArguments%2A>|Returns an array of Type objects that represent the type arguments of a constructed generic method or the type parameters of a generic method definition.|  
 |<xref:System.Reflection.MethodInfo.GetGenericMethodDefinition%2A>|Returns the underlying generic method definition for the current constructed method.|  
-|<xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A>|Returns true if the method or any of its enclosing types contain any type parameters for which specific types have not been supplied.|  
-|<xref:System.Reflection.MethodInfo.IsGenericMethodDefinition%2A>|Returns true if the current <xref:System.Reflection.MethodInfo> represents the definition of a generic method.|  
+|<xref:System.Reflection.MethodBase.ContainsGenericParameters%2A>|Returns true if the method or any of its enclosing types contain any type parameters for which specific types have not been supplied.|  
+|<xref:System.Reflection.MethodBase.IsGenericMethodDefinition%2A>|Returns true if the current <xref:System.Reflection.MethodInfo> represents the definition of a generic method.|  
 |<xref:System.Reflection.MethodInfo.MakeGenericMethod%2A>|Substitutes the elements of an array of types for the type parameters of the current generic method definition, and returns a <xref:System.Reflection.MethodInfo> object representing the resulting constructed method.|  
   
 ## See Also  

--- a/docs/framework/reflection-and-codedom/reflection-and-generic-types.md
+++ b/docs/framework/reflection-and-codedom/reflection-and-generic-types.md
@@ -62,15 +62,15 @@ ms.workload:
   
 <a name="is_this_a_generic_type_or_method"></a>   
 ## Is This a Generic Type or Method?  
- When you use reflection to examine an unknown type, represented by an instance of <xref:System.Type>, use the <xref:System.Type.IsGenericType%2A> property to determine whether the unknown type is generic. It returns `true` if the type is generic. Similarly, when you examine an unknown method, represented by an instance of the <xref:System.Reflection.MethodInfo> class, use the <xref:System.Reflection.MethodInfo.IsGenericMethod%2A> property to determine whether the method is generic.  
+ When you use reflection to examine an unknown type, represented by an instance of <xref:System.Type>, use the <xref:System.Type.IsGenericType%2A> property to determine whether the unknown type is generic. It returns `true` if the type is generic. Similarly, when you examine an unknown method, represented by an instance of the <xref:System.Reflection.MethodInfo> class, use the <xref:System.Reflection.MethodBase.IsGenericMethod%2A> property to determine whether the method is generic.  
   
 ### Is This a Generic Type or Method Definition?  
- Use the <xref:System.Type.IsGenericTypeDefinition%2A> property to determine whether a <xref:System.Type> object represents a generic type definition, and use the <xref:System.Reflection.MethodInfo.IsGenericMethodDefinition%2A> method to determine whether a <xref:System.Reflection.MethodInfo> represents a generic method definition.  
+ Use the <xref:System.Type.IsGenericTypeDefinition%2A> property to determine whether a <xref:System.Type> object represents a generic type definition, and use the <xref:System.Reflection.MethodBase.IsGenericMethodDefinition%2A> method to determine whether a <xref:System.Reflection.MethodInfo> represents a generic method definition.  
   
  Generic type and method definitions are the templates from which instantiable types are created. Generic types in the .NET Framework class library, such as <xref:System.Collections.Generic.Dictionary%602>, are generic type definitions.  
   
 ### Is the Type or Method Open or Closed?  
- A generic type or method is closed if instantiable types have been substituted for all its type parameters, including all the type parameters of all enclosing types. You can only create an instance of a generic type if it is closed. The <xref:System.Type.ContainsGenericParameters%2A?displayProperty=nameWithType> property returns `true` if a type is open. For methods, the <xref:System.Reflection.MethodInfo.ContainsGenericParameters%2A?displayProperty=nameWithType> method performs the same function.  
+ A generic type or method is closed if instantiable types have been substituted for all its type parameters, including all the type parameters of all enclosing types. You can only create an instance of a generic type if it is closed. The <xref:System.Type.ContainsGenericParameters%2A?displayProperty=nameWithType> property returns `true` if a type is open. For methods, the <xref:System.Reflection.MethodBase.ContainsGenericParameters%2A?displayProperty=nameWithType> method performs the same function.  
   
  [Back to top](#top)  
   
@@ -146,7 +146,7 @@ generic<typename V, typename W> ref class D : B<int, V> {};
   
 <a name="invariants"></a>   
 ## Invariants  
- For a table of the invariant conditions for common terms in reflection for generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>. For additional terms relating to generic methods, see <xref:System.Reflection.MethodInfo.IsGenericMethod%2A?displayProperty=nameWithType>.  
+ For a table of the invariant conditions for common terms in reflection for generic types, see <xref:System.Type.IsGenericType%2A?displayProperty=nameWithType>. For additional terms relating to generic methods, see <xref:System.Reflection.MethodBase.IsGenericMethod%2A?displayProperty=nameWithType>.  
   
  [Back to top](#top)  
   

--- a/docs/framework/wpf/advanced/walkthrough-arranging-windows-forms-controls-in-wpf.md
+++ b/docs/framework/wpf/advanced/walkthrough-arranging-windows-forms-controls-in-wpf.md
@@ -1,13 +1,11 @@
 ---
 title: "Walkthrough: Arranging Windows Forms Controls in WPF"
 ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "04/03/2018"
 ms.prod: ".net-framework"
-ms.reviewer: ""
 ms.suite: ""
 ms.technology: 
   - "dotnet-wpf"
-ms.tgt_pltfrm: ""
 ms.topic: "article"
 dev_langs: 
   - "csharp"
@@ -16,7 +14,6 @@ helpviewer_keywords:
   - "hybrid applications [WPF interoperability]"
   - "arranging controls [WPF]"
 ms.assetid: a1db8049-15c7-45d6-ae3d-36a6735cb848
-caps.latest.revision: 31
 author: dotnet-bot
 ms.author: dotnetcontent
 manager: "wpickett"
@@ -158,8 +155,8 @@ This walkthrough shows you how to use [!INCLUDE[TLA2#tla_winclient](../../../../
 5.  Click the **Click me** button. The `button1_Click` event handler sets the <xref:System.Windows.Forms.Control.Top%2A> and <xref:System.Windows.Forms.Control.Left%2A> properties on the hosted control. This causes the hosted control to be repositioned within the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element. The host maintains the same screen area, but the hosted control is clipped. Instead, the hosted control should always fill the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element.  
   
 ## Understanding Z-Order Limitations  
- By default, visible <xref:System.Windows.Forms.Integration.WindowsFormsHost> elements are always drawn on top of other [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] elements, and they are unaffected by z-order. To enable z-ordering, set the <xref:System.Windows.Interop.HwndHost.IsRedirected%2A> property of the <xref:System.Windows.Forms.Integration.WindowsFormsHost> to true and the <xref:System.Windows.Interop.HwndHost.CompositionMode%2A> property to <xref:System.Windows.Interop.CompositionMode.Full> or <xref:System.Windows.Interop.CompositionMode.OutputOnly>.  
-  
+ Visible <xref:System.Windows.Forms.Integration.WindowsFormsHost> elements are always drawn on top of other WPF elements, and they are unaffected by z-order.
+
 #### To see the default z-order behavior  
   
 1.  Copy the following XAML into the <xref:System.Windows.Controls.Grid> element.  

--- a/docs/framework/wpf/advanced/walkthrough-arranging-windows-forms-controls-in-wpf.md
+++ b/docs/framework/wpf/advanced/walkthrough-arranging-windows-forms-controls-in-wpf.md
@@ -155,24 +155,15 @@ This walkthrough shows you how to use [!INCLUDE[TLA2#tla_winclient](../../../../
 5.  Click the **Click me** button. The `button1_Click` event handler sets the <xref:System.Windows.Forms.Control.Top%2A> and <xref:System.Windows.Forms.Control.Left%2A> properties on the hosted control. This causes the hosted control to be repositioned within the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element. The host maintains the same screen area, but the hosted control is clipped. Instead, the hosted control should always fill the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element.  
   
 ## Understanding Z-Order Limitations  
- Visible <xref:System.Windows.Forms.Integration.WindowsFormsHost> elements are always drawn on top of other WPF elements, and they are unaffected by z-order.
+ Visible <xref:System.Windows.Forms.Integration.WindowsFormsHost> elements are always drawn on top of other WPF elements, and they are unaffected by z-order. To see this z-order behavior, do the following:
 
-#### To see the default z-order behavior  
-  
-1.  Copy the following XAML into the <xref:System.Windows.Controls.Grid> element.  
-  
+1.  Copy the following XAML into the <xref:System.Windows.Controls.Grid> element.
+
      [!code-xaml[WpfLayoutHostingWfWithXaml#8](../../../../samples/snippets/csharp/VS_Snippets_Wpf/WpfLayoutHostingWfWithXaml/CSharp/Window1.xaml#8)]  
-  
+ 
 2.  Press F5 to build and run the application. The <xref:System.Windows.Forms.Integration.WindowsFormsHost> element is painted over the label element.  
-  
-#### To see the z-order behavior when IsRedirected is true  
-  
-1.  Replace the previous z-order example with the following XAML.  
-  
-     [!code-xaml[WpfLayoutHostingWfWithXaml#8b](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/WpfLayoutHostingWfWithXaml/VisualBasic/Window1.xaml#8b)]  
-  
-     Press F5 to build and run the application. The label element is painted over the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element.  
-  
+
+
 ## Docking  
  <xref:System.Windows.Forms.Integration.WindowsFormsHost> element supports [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] docking. Set the <xref:System.Windows.Controls.DockPanel.Dock%2A> attached property to dock the hosted control in a <xref:System.Windows.Controls.DockPanel> element.  
   
@@ -216,7 +207,7 @@ This walkthrough shows you how to use [!INCLUDE[TLA2#tla_winclient](../../../../
 2.  Press F5 to build and run the application. The <xref:System.Windows.Forms.Integration.WindowsFormsHost> element is centered in the grid row, but it is not stretched to fill the available space. If the window is large enough, you may see two or more months displayed by the hosted <xref:System.Windows.Forms.MonthCalendar> control, but these are centered in the row. The [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] layout engine centers elements that cannot be sized to fill the available space.  
   
 ## Scaling  
- Unlike [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] elements, most [!INCLUDE[TLA#tla_winforms](../../../../includes/tlasharptla-winforms-md.md)] controls are not continuously scalable. By default, the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element scales its hosted control when possible.  To enable full-fledged scaling, set the <xref:System.Windows.Interop.HwndHost.IsRedirected%2A> property of the <xref:System.Windows.Forms.Integration.WindowsFormsHost> to true and the <xref:System.Windows.Interop.HwndHost.CompositionMode%2A> property to <xref:System.Windows.Interop.CompositionMode.Full> or <xref:System.Windows.Interop.CompositionMode.OutputOnly>.  
+ Unlike WPF elements, most Windows Forms controls are not continuously scalable. To provide custom scaling, you override the <xref:System.Windows.Forms.Integration.WindowsFormsHost.ScaleChild%2A?displayProperty=nameWithType> method. 
   
 #### To scale a hosted control by using the default behavior  
   
@@ -224,19 +215,13 @@ This walkthrough shows you how to use [!INCLUDE[TLA2#tla_winclient](../../../../
   
      [!code-xaml[WpfLayoutHostingWfWithXaml#12](../../../../samples/snippets/csharp/VS_Snippets_Wpf/WpfLayoutHostingWfWithXaml/CSharp/Window1.xaml#12)]  
   
-2.  Press F5 to build and run the application. The hosted control and its surrounding elements are scaled by a factor of 0.5. However, the hosted control's font is not scaled.  
-  
-#### To scale a hosted control by setting IsRedirected to true  
-  
-1.  Replace the previous scaling example with the following XAML.  
-  
-     [!code-xaml[WpfLayoutHostingWfWithXaml#12b](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/WpfLayoutHostingWfWithXaml/VisualBasic/Window1.xaml#12b)]  
-  
-2.  Press F5 to build and run the application. The hosted control, its surrounding elements, and the hosted control's font are scaled by a factor of 0.5.  
-  
+2.  Press F5 to build and run the application. The hosted control and its surrounding elements are scaled by a factor of 0.5. However, the hosted control's font is not scaled.
+
+<!-- This could use an example of custom scaling. -->
+
 ## Rotating  
- Unlike [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] elements, [!INCLUDE[TLA#tla_winforms](../../../../includes/tlasharptla-winforms-md.md)] controls do not support rotation. By default, the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element does not rotate with other [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] elements when a rotation transformation is applied. Any rotation value other than 180 degrees raises the <xref:System.Windows.Forms.Integration.WindowsFormsHost.LayoutError> event.  To enable rotating to any angle, set the <xref:System.Windows.Interop.HwndHost.IsRedirected%2A> property of the <xref:System.Windows.Forms.Integration.WindowsFormsHost> to true and the <xref:System.Windows.Interop.HwndHost.CompositionMode%2A> property to <xref:System.Windows.Interop.CompositionMode.Full> or <xref:System.Windows.Interop.CompositionMode.OutputOnly>.  
-  
+ Unlike WPF elements, Windows Forms controls do not support rotation. The <xref:System.Windows.Forms.Integration.WindowsFormsHost> element does not rotate with other WPF elements when a rotation transformation is applied. Any rotation value other than 180 degrees raises the <xref:System.Windows.Forms.Integration.WindowsFormsHost.LayoutError> event.
+ 
 #### To see the effect of rotation in a hybrid application  
   
 1.  Copy the following XAML into the <xref:System.Windows.Controls.Grid> element.  
@@ -244,15 +229,8 @@ This walkthrough shows you how to use [!INCLUDE[TLA2#tla_winclient](../../../../
      [!code-xaml[WpfLayoutHostingWfWithXaml#13](../../../../samples/snippets/csharp/VS_Snippets_Wpf/WpfLayoutHostingWfWithXaml/CSharp/Window1.xaml#13)]  
   
 2.  Press F5 to build and run the application. The hosted control is not rotated, but its surrounding elements are rotated by an angle of 180 degrees. You may have to resize the window to see the elements.  
-  
-#### To see the effect of rotation in a hybrid application when IsRedirected is true  
-  
-1.  Replace the previous rotation example with the following XAML.  
-  
-     [!code-xaml[WpfLayoutHostingWfWithXaml#13b](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/WpfLayoutHostingWfWithXaml/VisualBasic/Window1.xaml#13b)]  
-  
-2.  Press F5 to build and run the application. The hosted control is rotated.  Note that the <xref:System.Windows.Media.RotateTransform.Angle%2A> property can be set to any value. You may have to resize the window to see the elements.  
-  
+ 
+
 ## Setting Padding and Margins  
  Padding and margins in [!INCLUDE[TLA2#tla_winclient](../../../../includes/tla2sharptla-winclient-md.md)] layout are similar to padding and margins in [!INCLUDE[TLA#tla_winforms](../../../../includes/tlasharptla-winforms-md.md)]. Simply set the <xref:System.Windows.Controls.Control.Padding%2A> and <xref:System.Windows.FrameworkElement.Margin%2A> properties on the <xref:System.Windows.Forms.Integration.WindowsFormsHost> element.  
   


### PR DESCRIPTION
## Fixed some broken links

Additional links that were broken when MethodInfo no longer overrode some MethodBase members in .NET Framework 4. In addition, support for changing the z-order in WinForms controls hosted in WPF was included in pre-release versions but removed from the released version.


