### PR TITLE
Dead link

### DIFF
--- a/docs/framework/app-domains/how-to-obtain-type-and-member-information-from-an-assembly.md
+++ b/docs/framework/app-domains/how-to-obtain-type-and-member-information-from-an-assembly.md
@@ -35,6 +35,5 @@ The <xref:System.Reflection> namespace contains many methods for obtaining infor
  [!code-vb[Conceptual.Types.ViewInfo#8](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.types.viewinfo/vb/source6.vb#8)]  
   
 ## See Also  
- [Programming with Application Domains](http://msdn.microsoft.com/library/bd36055b-56bd-43eb-b4d8-820c37172131)  
  [Reflection](../../../docs/framework/reflection-and-codedom/reflection.md)  
  [Using Application Domains](../../../docs/framework/app-domains/use.md)

--- a/docs/framework/app-domains/how-to-obtain-type-and-member-information-from-an-assembly.md
+++ b/docs/framework/app-domains/how-to-obtain-type-and-member-information-from-an-assembly.md
@@ -35,5 +35,6 @@ The <xref:System.Reflection> namespace contains many methods for obtaining infor
  [!code-vb[Conceptual.Types.ViewInfo#8](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.types.viewinfo/vb/source6.vb#8)]  
   
 ## See Also  
+ [Programming with Application Domains](./application-domains.md#programming-with-application-domains)
  [Reflection](../../../docs/framework/reflection-and-codedom/reflection.md)  
  [Using Application Domains](../../../docs/framework/app-domains/use.md)


### PR DESCRIPTION
Closest possible link I found is [Programming with Application Domains and Assemblies](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/) but that's the head topic of the side bar which seems unnecessary to link to. Edit the link as desired.
