### PR TITLE
fixed syntax error on indexers

### DIFF
--- a/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
+++ b/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
@@ -36,7 +36,7 @@ Indexers can be declared on an [interface](../../../csharp/language-reference/ke
  In the preceding example, you could use the explicit interface member implementation by using the fully qualified name of the interface member. For example:  
   
 ```  
-public string ISomeInterface.this   
+public string ISomeInterface.this[int index]   
 {   
 }   
 ```  
@@ -44,7 +44,7 @@ public string ISomeInterface.this
  However, the fully qualified name is only needed to avoid ambiguity when the class is implementing more than one interface with the same indexer signature. For example, if an `Employee` class is implementing two interfaces, `ICitizen` and `IEmployee`, and both interfaces have the same indexer signature, the explicit interface member implementation is necessary. That is, the following indexer declaration:  
   
 ```  
-public string IEmployee.this   
+public string IEmployee.this[int index]   
 {   
 }   
 ```  
@@ -52,7 +52,7 @@ public string IEmployee.this
  implements the indexer on the `IEmployee` interface, while the following declaration:  
   
 ```  
-public string ICitizen.this   
+public string ICitizen.this[int index]
 {   
 }   
 ```  


### PR DESCRIPTION
The inline examples would generate the error: CS1551 Indexers must have at least one parameter.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
