### PR TITLE
Yield keyword function name fix

### DIFF
--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -74,7 +74,7 @@ foreach (string element in elements)
  On each subsequent iteration of the `foreach` loop, the execution of the iterator body continues from where it left off, again stopping when it reaches a `yield return` statement. The `foreach` loop completes when the end of the iterator method or a `yield break` statement is reached.  
   
 ## Example  
- The following example has a `yield return` statement that's inside a `for` loop. Each iteration of the `foreach` statement body in `Process` creates a call to the `Power` iterator function. Each call to the iterator function proceeds to the next execution of the `yield return` statement, which occurs during the next iteration of the `for` loop.  
+ The following example has a `yield return` statement that's inside a `for` loop. Each iteration of the `foreach` statement body in `Main` method creates a call to the `Power` iterator function. Each call to the iterator function proceeds to the next execution of the `yield return` statement, which occurs during the next iteration of the `for` loop.  
   
  The return type of the iterator method is <xref:System.Collections.IEnumerable>, which is an iterator interface type. When the iterator method is called, it returns an enumerable object that contains the powers of a number.  
   

--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -74,7 +74,7 @@ foreach (string element in elements)
  On each subsequent iteration of the `foreach` loop, the execution of the iterator body continues from where it left off, again stopping when it reaches a `yield return` statement. The `foreach` loop completes when the end of the iterator method or a `yield break` statement is reached.  
   
 ## Example  
- The following example has a `yield return` statement that's inside a `for` loop. Each iteration of the `foreach` statement body in `Main` method creates a call to the `Power` iterator function. Each call to the iterator function proceeds to the next execution of the `yield return` statement, which occurs during the next iteration of the `for` loop.  
+ The following example has a `yield return` statement that's inside a `for` loop. Each iteration of the `foreach` statement body in the `Main` method creates a call to the `Power` iterator function. Each call to the iterator function proceeds to the next execution of the `yield return` statement, which occurs during the next iteration of the `for` loop.  
   
  The return type of the iterator method is <xref:System.Collections.IEnumerable>, which is an iterator interface type. When the iterator method is called, it returns an enumerable object that contains the powers of a number.  
   


### PR DESCRIPTION
## Summary

The `Process` method (?) does not exist in the Example with powers of 2. I have changed it in order to inform we are referring to the `Main` method.

