### PR TITLE
-deterministic compiler switch for C# and VIsual Basic

### DIFF
--- a/docs/csharp/language-reference/compiler-options/deterministic-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/deterministic-compiler-option.md
@@ -11,8 +11,8 @@ helpviewer_keywords:
   - "-deterministic compiler option [C#]"
   - "deterministic compiler option [C#]"
   - "/deterministic compiler option [C#]"
-author: "BillWagner"
-ms.author: "wiwagn"
+author: "rpetrusha"
+ms.author: "ronpet"
 ---
 # -deterministic
 
@@ -26,7 +26,7 @@ Causes the compiler to produce an assembly whose byte-for-byte output is identic
 
 ## Remarks
 
-By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and a GUID that is generated from random numbers. You use the `-deterministic` option to produce a *deterministic assembly**, one whose binary content is identical across compilations as long as the input remains the same.
+By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and a GUID that is generated from random numbers. You use the `-deterministic` option to produce a *deterministic assembly*, one whose binary content is identical across compilations as long as the input remains the same.
 
 The compiler considers the following inputs for the purpose of determinism:
 

--- a/docs/csharp/language-reference/compiler-options/deterministic-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/deterministic-compiler-option.md
@@ -1,16 +1,18 @@
 ---
-title: "-deterministic"
-ms.date: 04/11/2018
+title: "-deterministic (C# Compiler Options)"
+ms.date: 04/12/2018
 ms.prod: .net
 ms.technology: 
-  - "devlang-visual-basic"
+  - "devlang-csharp"
 ms.topic: "article"
+f1_keywords: 
+  - "/deterministic"
 helpviewer_keywords: 
-  - "deterministic compiler option [Visual Basic]"
-  - "-deterministic compiler option [Visual Basic]"
-  - "-deterministic compiler option [Visual Basic]"
-author: rpetrusha
-ms.author: ronpet
+  - "-deterministic compiler option [C#]"
+  - "deterministic compiler option [C#]"
+  - "/deterministic compiler option [C#]"
+author: "BillWagner"
+ms.author: "wiwagn"
 ---
 # -deterministic
 
@@ -32,7 +34,7 @@ The compiler considers the following inputs for the purpose of determinism:
 - The contents of the compiler's .rsp response file.
 - The precise version of the compiler used, and its referenced assemblies.
 - The current directory path.
-- The binary contents of all files explicitly passed to the compiler either directly or indirectly, including: 
+- The binary contents of all files explicitly passed to the compiler either directly or indirectly, including:
     - Source files
     - Referenced assemblies
     - Referenced modules
@@ -50,6 +52,6 @@ The compiler considers the following inputs for the purpose of determinism:
 
 When sources are publicly available, deterministic compilation can be used for establishing whether a binary is compiled from a trusted source. It can also be useful in a continuous build system for determining whether build steps that are dependent on changes to a binary need to be executed. 
 
-## See Also
-[Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)  
-[Sample Compilation Command Lines](../../../visual-basic/reference/command-line-compiler/sample-compilation-command-lines.md)
+## See Also  
+ [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)  
+ [Managing Project and Solution Properties](/visualstudio/ide/managing-project-and-solution-properties)

--- a/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
+++ b/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
@@ -1,6 +1,6 @@
 ---
 title: "C# Compiler Options Listed Alphabetically"
-ms.date: 07/20/2015
+ms.date: 04/12/2018
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -16,69 +16,70 @@ author: "BillWagner"
 ms.author: "wiwagn"
 ---
 # C# Compiler Options Listed Alphabetically
-The following compiler options are sorted alphabetically. For a categorical list, see [C# Compiler Options Listed by Category](../../../csharp/language-reference/compiler-options/listed-by-category.md).  
+The following compiler options are sorted alphabetically. For a categorical list, see [C# Compiler Options Listed by Category](listed-by-category.md).  
   
 |Option|Purpose|  
 |------------|-------------|  
-|[@](../../../csharp/language-reference/compiler-options/response-file-compiler-option.md)|Reads a response file for more options.|  
-|[-?](../../../csharp/language-reference/compiler-options/help-compiler-option.md)|Displays a usage message to stdout.|  
+|[@](response-file-compiler-option.md)|Reads a response file for more options.|  
+|[-?](help-compiler-option.md)|Displays a usage message to stdout.|  
 |-additionalfile|Names additional files that don't directly affect code generation but may be used by analyzers for producing errors or warnings.|  
-|[-addmodule](../../../csharp/language-reference/compiler-options/addmodule-compiler-option.md)|Links the specified modules into this assembly|  
+|[-addmodule](addmodule-compiler-option.md)|Links the specified modules into this assembly|  
 |-analyzer|Run the analyzers from this assembly (Short form: -a)|  
-|[-appconfig](../../../csharp/language-reference/compiler-options/appconfig-compiler-option.md)|Specifies the location of app.config at assembly binding time.|  
-|[-baseaddress](../../../csharp/language-reference/compiler-options/baseaddress-compiler-option.md)|Specifies the base address for the library to be built.|  
-|[-bugreport](../../../csharp/language-reference/compiler-options/bugreport-compiler-option.md)|Creates a 'Bug Report' file. This file will be sent together with any crash information if it is used with -errorreport:prompt or -errorreport:send.|  
-|[-checked](../../../csharp/language-reference/compiler-options/checked-compiler-option.md)|Causes the compiler to generate overflow checks.|  
+|[-appconfig](appconfig-compiler-option.md)|Specifies the location of app.config at assembly binding time.|  
+|[-baseaddress](baseaddress-compiler-option.md)|Specifies the base address for the library to be built.|  
+|[-bugreport](bugreport-compiler-option.md)|Creates a 'Bug Report' file. This file will be sent together with any crash information if it is used with -errorreport:prompt or -errorreport:send.|  
+|[-checked](checked-compiler-option.md)|Causes the compiler to generate overflow checks.|  
 |-checksumalgorithm:\<alg>|Specify the algorithm for calculating the source file checksum stored in PDB.  Supported values are: SHA1 (default) or SHA256.|  
-|[-codepage](../../../csharp/language-reference/compiler-options/codepage-compiler-option.md)|Specifies the codepage to use when opening source files.|  
-|[-debug](../../../csharp/language-reference/compiler-options/debug-compiler-option.md)|Emits debugging information.|  
-|[-define](../../../csharp/language-reference/compiler-options/define-compiler-option.md)|Defines conditional compilation symbols.|  
-|[-delaysign](../../../csharp/language-reference/compiler-options/delaysign-compiler-option.md)|Delay-signs the assembly by using only the public part of the strong name key.|  
-|[-doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md)|Specifies an XML Documentation file to generate.|  
-|[-errorreport](../../../csharp/language-reference/compiler-options/errorreport-compiler-option.md)|Specifies how to handle internal compiler errors: prompt, send, or none. The default is none.|  
-|[-filealign](../../../csharp/language-reference/compiler-options/filealign-compiler-option.md)|Specifies the alignment used for output file sections.|  
-|[-fullpaths](../../../csharp/language-reference/compiler-options/fullpaths-compiler-option.md)|Causes the compiler to generate fully qualified paths.|  
-|[-help](../../../csharp/language-reference/compiler-options/help-compiler-option.md)|Displays a usage message to stdout.|  
-|[-highentropyva](../../../csharp/language-reference/compiler-options/highentropyva-compiler-option.md)|Specifies that high entropy ASLR is supported.|  
+|[-codepage](codepage-compiler-option.md)|Specifies the codepage to use when opening source files.|  
+|[-debug](debug-compiler-option.md)|Emits debugging information.|  
+|[-define](define-compiler-option.md)|Defines conditional compilation symbols.|  
+|[-delaysign](delaysign-compiler-option.md)|Delay-signs the assembly by using only the public part of the strong name key.|  
+|[-deterministic](deterministic-compiler-option.md)|Causes the compiler to output an assembly whose binary content is identical across compilations if inputs are identical.|
+|[-doc](doc-compiler-option.md)|Specifies an XML Documentation file to generate.|  
+|[-errorreport](errorreport-compiler-option.md)|Specifies how to handle internal compiler errors: prompt, send, or none. The default is none.|  
+|[-filealign](filealign-compiler-option.md)|Specifies the alignment used for output file sections.|  
+|[-fullpaths](fullpaths-compiler-option.md)|Causes the compiler to generate fully qualified paths.|  
+|[-help](help-compiler-option.md)|Displays a usage message to stdout.|  
+|[-highentropyva](highentropyva-compiler-option.md)|Specifies that high entropy ASLR is supported.|  
 |-incremental|Enables incremental compilation [obsolete].|  
-|[-keycontainer](../../../csharp/language-reference/compiler-options/keycontainer-compiler-option.md)|Specifies a strong name key container.|  
-|[-keyfile](../../../csharp/language-reference/compiler-options/keyfile-compiler-option.md)|Specifies a strong name key file.|  
-|[-langversion:\<string>](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, or Latest |  
-|[-lib](../../../csharp/language-reference/compiler-options/lib-compiler-option.md)|Specifies additional directories in which to search for references.|  
-|[-link](../../../csharp/language-reference/compiler-options/link-compiler-option.md)|Makes COM type information in specified assemblies available to the project.|  
-|[-linkresource](../../../csharp/language-reference/compiler-options/linkresource-compiler-option.md)|Links the specified resource to this assembly.|  
-|[-main](../../../csharp/language-reference/compiler-options/main-compiler-option.md)|Specifies the type that contains the entry point (ignore all other possible entry points).|  
-|[-moduleassemblyname](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md)|Specifies an assembly whose non-public types a .netmodule can access.|  
+|[-keycontainer](keycontainer-compiler-option.md)|Specifies a strong name key container.|  
+|[-keyfile](keyfile-compiler-option.md)|Specifies a strong name key file.|  
+|[-langversion:\<string>](langversion-compiler-option.md)|Specify language version mode: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, or Latest |  
+|[-lib](lib-compiler-option.md)|Specifies additional directories in which to search for references.|  
+|[-link](link-compiler-option.md)|Makes COM type information in specified assemblies available to the project.|  
+|[-linkresource](linkresource-compiler-option.md)|Links the specified resource to this assembly.|  
+|[-main](main-compiler-option.md)|Specifies the type that contains the entry point (ignore all other possible entry points).|  
+|[-moduleassemblyname](moduleassemblyname-compiler-option.md)|Specifies an assembly whose non-public types a .netmodule can access.|  
 |-modulename:\<string>|Specify the name of the source module|  
-|[-noconfig](../../../csharp/language-reference/compiler-options/noconfig-compiler-option.md)|Instructs the compiler not to auto include CSC.RSP file.|  
-|[-nologo](../../../csharp/language-reference/compiler-options/nologo-compiler-option.md)|Suppresses compiler copyright message.|  
-|[-nostdlib](../../../csharp/language-reference/compiler-options/nostdlib-compiler-option.md)|Instructs the compiler not to reference standard library (mscorlib.dll).|  
-|[-nowarn](../../../csharp/language-reference/compiler-options/nowarn-compiler-option.md)|Disables specific warning messages|  
-|[-nowin32manifest](../../../csharp/language-reference/compiler-options/nowin32manifest-compiler-option.md)|Instructs the compiler not to embed an application manifest in the executable file.|  
-|[-optimize](../../../csharp/language-reference/compiler-options/optimize-compiler-option.md)|Enables/disables optimizations.|  
-|[-out](../../../csharp/language-reference/compiler-options/out-compiler-option.md)|Specifies the output file name (default: base name of file with main class or first file).|  
+|[-noconfig](noconfig-compiler-option.md)|Instructs the compiler not to auto include CSC.RSP file.|  
+|[-nologo](nologo-compiler-option.md)|Suppresses compiler copyright message.|  
+|[-nostdlib](nostdlib-compiler-option.md)|Instructs the compiler not to reference standard library (mscorlib.dll).|  
+|[-nowarn](nowarn-compiler-option.md)|Disables specific warning messages|  
+|[-nowin32manifest](nowin32manifest-compiler-option.md)|Instructs the compiler not to embed an application manifest in the executable file.|  
+|[-optimize](optimize-compiler-option.md)|Enables/disables optimizations.|  
+|[-out](out-compiler-option.md)|Specifies the output file name (default: base name of file with main class or first file).|  
 |-parallel[+&#124;-]|Specifies whether to use concurrent build (+).|  
-|[-pdb](../../../csharp/language-reference/compiler-options/pdb-compiler-option.md)|Specifies the file name and location of the .pdb file.|  
-|[-platform](../../../csharp/language-reference/compiler-options/platform-compiler-option.md)|Limits which platforms this code can run on: x86, Itanium, x64, anycpu, or anycpu32bitpreferred. The default is anycpu.|  
-|[-preferreduilang](../../../csharp/language-reference/compiler-options/preferreduilang-compiler-option.md)|Specifies the language to be used for compiler output.|  
-|[-recurse](../../../csharp/language-reference/compiler-options/recurse-compiler-option.md)|Includes all files in the current directory and subdirectories according to the wildcard specifications.|  
-|[-reference](../../../csharp/language-reference/compiler-options/reference-compiler-option.md)|References metadata from the specified assembly files.|  
+|[-pdb](pdb-compiler-option.md)|Specifies the file name and location of the .pdb file.|  
+|[-platform](platform-compiler-option.md)|Limits which platforms this code can run on: x86, Itanium, x64, anycpu, or anycpu32bitpreferred. The default is anycpu.|  
+|[-preferreduilang](preferreduilang-compiler-option.md)|Specifies the language to be used for compiler output.|  
+|[-recurse](recurse-compiler-option.md)|Includes all files in the current directory and subdirectories according to the wildcard specifications.|  
+|[-reference](reference-compiler-option.md)|References metadata from the specified assembly files.|  
 |[-refout](refout-compiler-option.md)|Generate a reference assembly in addition to the primary assembly.|  
 |[-refonly](refonly-compiler-option.md)|Generate a reference assembly instead of a primary assembly.|  
-|[-resource](../../../csharp/language-reference/compiler-options/resource-compiler-option.md)|Embeds the specified resource.|  
+|[-resource](resource-compiler-option.md)|Embeds the specified resource.|  
 |-ruleset:\<file>|Specify a ruleset file that disables specific diagnostics.|  
-|[-subsystemversion](../../../csharp/language-reference/compiler-options/subsystemversion-compiler-option.md)|Specifies the minimum version of the subsystem that the executable file can use.|  
-|[-target](../../../csharp/language-reference/compiler-options/target-compiler-option.md)|Specifies the format of the output file by using one of four options: [-target:appcontainerexe](../../../csharp/language-reference/compiler-options/target-appcontainerexe-compiler-option.md), [-target:exe](../../../csharp/language-reference/compiler-options/target-exe-compiler-option.md), [-target:library](../../../csharp/language-reference/compiler-options/target-library-compiler-option.md), [-target:module](../../../csharp/language-reference/compiler-options/target-module-compiler-option.md), [-target:winexe](../../../csharp/language-reference/compiler-options/target-winexe-compiler-option.md),  [-target:winmdobj](../../../csharp/language-reference/compiler-options/target-winmdobj-compiler-option.md).|  
-|[-unsafe](../../../csharp/language-reference/compiler-options/unsafe-compiler-option.md)|Allows [unsafe](../../../csharp/language-reference/keywords/unsafe.md) code.|  
-|[-utf8output](../../../csharp/language-reference/compiler-options/utf8output-compiler-option.md)|Outputs compiler messages in UTF-8 encoding.|  
-|[-warn](../../../csharp/language-reference/compiler-options/warn-compiler-option.md)|Sets the warning level (0-4).|  
-|[-warnaserror](../../../csharp/language-reference/compiler-options/warnaserror-compiler-option.md)|Reports specific warnings as errors.|  
-|[-win32icon](../../../csharp/language-reference/compiler-options/win32icon-compiler-option.md)|Uses this icon for the output.|  
-|[-win32manifest](../../../csharp/language-reference/compiler-options/win32manifest-compiler-option.md)|Specifies a custom win32 manifest file.|  
-|[-win32res](../../../csharp/language-reference/compiler-options/win32res-compiler-option.md)|Specifies the win32 resource file (.res).|  
+|[-subsystemversion](subsystemversion-compiler-option.md)|Specifies the minimum version of the subsystem that the executable file can use.|  
+|[-target](target-compiler-option.md)|Specifies the format of the output file by using one of four options: [-target:appcontainerexe](target-appcontainerexe-compiler-option.md), [-target:exe](target-exe-compiler-option.md), [-target:library](target-library-compiler-option.md), [-target:module](target-module-compiler-option.md), [-target:winexe](target-winexe-compiler-option.md),  [-target:winmdobj](target-winmdobj-compiler-option.md).|  
+|[-unsafe](unsafe-compiler-option.md)|Allows [unsafe](../../../csharp/language-reference/keywords/unsafe.md) code.|  
+|[-utf8output](utf8output-compiler-option.md)|Outputs compiler messages in UTF-8 encoding.|  
+|[-warn](warn-compiler-option.md)|Sets the warning level (0-4).|  
+|[-warnaserror](warnaserror-compiler-option.md)|Reports specific warnings as errors.|  
+|[-win32icon](win32icon-compiler-option.md)|Uses this icon for the output.|  
+|[-win32manifest](win32manifest-compiler-option.md)|Specifies a custom win32 manifest file.|  
+|[-win32res](win32res-compiler-option.md)|Specifies the win32 resource file (.res).|  
   
 ## See Also  
- [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)  
- [C# Compiler Options Listed by Category](../../../csharp/language-reference/compiler-options/listed-by-category.md)  
- [How to: Set Environment Variables for the Visual Studio Command Line](../../../csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md)  
+ [C# Compiler Options](index.md)  
+ [C# Compiler Options Listed by Category](listed-by-category.md)  
+ [How to: Set Environment Variables for the Visual Studio Command Line](how-to-set-environment-variables-for-the-visual-studio-command-line.md)  
  [\<compiler> Element](../../../framework/configure-apps/file-schema/compiler/compiler-element.md)

--- a/docs/csharp/language-reference/compiler-options/listed-by-category.md
+++ b/docs/csharp/language-reference/compiler-options/listed-by-category.md
@@ -1,6 +1,6 @@
 ---
 title: "C# Compiler Options Listed by Category"
-ms.date: 07/20/2015
+ms.date: 04/12/2018
 ms.prod: .net
 ms.technology: 
   - "devlang-csharp"
@@ -15,40 +15,41 @@ author: "BillWagner"
 ms.author: "wiwagn"
 ---
 # C# Compiler Options Listed by Category
-The following compiler options are sorted by category. For an alphabetical list, see [C# Compiler Options Listed Alphabetically](../../../csharp/language-reference/compiler-options/listed-alphabetically.md).  
+The following compiler options are sorted by category. For an alphabetical list, see [C# Compiler Options Listed Alphabetically](listed-alphabetically.md).  
   
 ### Optimization  
   
 |Option|Purpose|  
 |------------|-------------|  
-|[-filealign](../../../csharp/language-reference/compiler-options/filealign-compiler-option.md)|Specifies the size of sections in the output file.|  
-|[-optimize](../../../csharp/language-reference/compiler-options/optimize-compiler-option.md)|Enables/disables optimizations.|  
+|[-filealign](filealign-compiler-option.md)|Specifies the size of sections in the output file.|  
+|[-optimize](optimize-compiler-option.md)|Enables/disables optimizations.|  
   
 ### Output Files  
   
 |Option|Purpose|  
-|------------|-------------|  
-|[-doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md)|Specifies an XML file where processed documentation comments are to be written.|  
-|[-out](../../../csharp/language-reference/compiler-options/out-compiler-option.md)|Specifies the output file.|  
-|[-pdb](../../../csharp/language-reference/compiler-options/pdb-compiler-option.md)|Specifies the file name and location of the .pdb file.|  
-|[-platform](../../../csharp/language-reference/compiler-options/platform-compiler-option.md)|Specify the output platform.|  
-|[-preferreduilang](../../../csharp/language-reference/compiler-options/preferreduilang-compiler-option.md)|Specify a language for compiler output.|  
+|------------|-------------| 
+|[-deterministic](deterministic-compiler-option.md)|Causes the compiler to output an assembly whose binary content is identical across compilations if inputs are identical.|
+|[-doc](doc-compiler-option.md)|Specifies an XML file where processed documentation comments are to be written.|  
+|[-out](out-compiler-option.md)|Specifies the output file.|  
+|[-pdb](pdb-compiler-option.md)|Specifies the file name and location of the .pdb file.|  
+|[-platform](platform-compiler-option.md)|Specify the output platform.|  
+|[-preferreduilang](preferreduilang-compiler-option.md)|Specify a language for compiler output.|  
 |[-refout](refout-compiler-option.md)|Generate a reference assembly in addition to the primary assembly.|  
 |[-refonly](refonly-compiler-option.md)|Generate a reference assembly instead of a primary assembly.|  
-|[-target](../../../csharp/language-reference/compiler-options/target-compiler-option.md)|Specifies the format of the output file using one of five options: [-target:appcontainerexe](../../../csharp/language-reference/compiler-options/target-appcontainerexe-compiler-option.md), [-target:exe](../../../csharp/language-reference/compiler-options/target-exe-compiler-option.md), [-target:library](../../../csharp/language-reference/compiler-options/target-library-compiler-option.md), [-target:module](../../../csharp/language-reference/compiler-options/target-module-compiler-option.md), [-target:winexe](../../../csharp/language-reference/compiler-options/target-winexe-compiler-option.md), or [-target:winmdobj](../../../csharp/language-reference/compiler-options/target-winmdobj-compiler-option.md).|  
+|[-target](target-compiler-option.md)|Specifies the format of the output file using one of five options: [-target:appcontainerexe](target-appcontainerexe-compiler-option.md), [-target:exe](target-exe-compiler-option.md), [-target:library](target-library-compiler-option.md), [-target:module](target-module-compiler-option.md), [-target:winexe](target-winexe-compiler-option.md), or [-target:winmdobj](target-winmdobj-compiler-option.md).|  
 |-modulename:\<string>|Specify the name of the source module|  
   
 ### .NET Framework Assemblies  
   
 |Option|Purpose|  
 |------------|-------------|  
-|[-addmodule](../../../csharp/language-reference/compiler-options/addmodule-compiler-option.md)|Specifies one or more modules to be part of this assembly.|  
-|[-delaysign](../../../csharp/language-reference/compiler-options/delaysign-compiler-option.md)|Instructs the compiler to add the public key but to leave the assembly unsigned.|  
-|[-keycontainer](../../../csharp/language-reference/compiler-options/keycontainer-compiler-option.md)|Specifies the name of the cryptographic key container.|  
-|[-keyfile](../../../csharp/language-reference/compiler-options/keyfile-compiler-option.md)|Specifies the filename containing the cryptographic key.|  
-|[-lib](../../../csharp/language-reference/compiler-options/lib-compiler-option.md)|Specifies the location of assemblies referenced by means of [-reference](../../../csharp/language-reference/compiler-options/reference-compiler-option.md).|  
-|[-nostdlib](../../../csharp/language-reference/compiler-options/nostdlib-compiler-option.md)|Instructs the compiler not to import the standard library (mscorlib.dll).|  
-|[-reference](../../../csharp/language-reference/compiler-options/reference-compiler-option.md)|Imports metadata from a file that contains an assembly.|  
+|[-addmodule](addmodule-compiler-option.md)|Specifies one or more modules to be part of this assembly.|  
+|[-delaysign](delaysign-compiler-option.md)|Instructs the compiler to add the public key but to leave the assembly unsigned.|  
+|[-keycontainer](keycontainer-compiler-option.md)|Specifies the name of the cryptographic key container.|  
+|[-keyfile](keyfile-compiler-option.md)|Specifies the filename containing the cryptographic key.|  
+|[-lib](lib-compiler-option.md)|Specifies the location of assemblies referenced by means of [-reference](reference-compiler-option.md).|  
+|[-nostdlib](nostdlib-compiler-option.md)|Instructs the compiler not to import the standard library (mscorlib.dll).|  
+|[-reference](reference-compiler-option.md)|Imports metadata from a file that contains an assembly.|  
 |-analyzer|Run the analyzers from this assembly (Short form: /a)|  
 |-additionalfile|Names additional files that don't directly affect code generation but may be used by analyzers for producing errors or warnings.|  
   
@@ -56,50 +57,50 @@ The following compiler options are sorted by category. For an alphabetical list,
   
 |Option|Purpose|  
 |------------|-------------|  
-|[-bugreport](../../../csharp/language-reference/compiler-options/bugreport-compiler-option.md)|Creates a file that contains information that makes it easy to report a bug.|  
-|[-checked](../../../csharp/language-reference/compiler-options/checked-compiler-option.md)|Specifies whether integer arithmetic that overflows the bounds of the data type will cause an exception at run time.|  
-|[-debug](../../../csharp/language-reference/compiler-options/debug-compiler-option.md)|Instruct the compiler to emit debugging information.|  
-|[-errorreport](../../../csharp/language-reference/compiler-options/errorreport-compiler-option.md)|Sets error reporting behavior.|  
-|[-fullpaths](../../../csharp/language-reference/compiler-options/fullpaths-compiler-option.md)|Specifies the absolute path to the file in compiler output.|  
-|[-nowarn](../../../csharp/language-reference/compiler-options/nowarn-compiler-option.md)|Suppresses the compiler's generation of specified warnings.|  
-|[-warn](../../../csharp/language-reference/compiler-options/warn-compiler-option.md)|Sets the warning level.|  
-|[-warnaserror](../../../csharp/language-reference/compiler-options/warnaserror-compiler-option.md)|Promotes warnings to errors.|  
+|[-bugreport](bugreport-compiler-option.md)|Creates a file that contains information that makes it easy to report a bug.|  
+|[-checked](checked-compiler-option.md)|Specifies whether integer arithmetic that overflows the bounds of the data type will cause an exception at run time.|  
+|[-debug](debug-compiler-option.md)|Instruct the compiler to emit debugging information.|  
+|[-errorreport](errorreport-compiler-option.md)|Sets error reporting behavior.|  
+|[-fullpaths](fullpaths-compiler-option.md)|Specifies the absolute path to the file in compiler output.|  
+|[-nowarn](nowarn-compiler-option.md)|Suppresses the compiler's generation of specified warnings.|  
+|[-warn](warn-compiler-option.md)|Sets the warning level.|  
+|[-warnaserror](warnaserror-compiler-option.md)|Promotes warnings to errors.|  
 |-ruleset:\<file>|Specify a ruleset file that disables specific diagnostics.|  
   
 ### Preprocessor  
   
 |Option|Purpose|  
 |------------|-------------|  
-|[-define](../../../csharp/language-reference/compiler-options/define-compiler-option.md)|Defines preprocessor symbols.|  
+|[-define](define-compiler-option.md)|Defines preprocessor symbols.|  
   
 ### Resources  
   
 |Option|Purpose|  
 |------------|-------------|  
-|[-link](../../../csharp/language-reference/compiler-options/link-compiler-option.md)|Makes COM type information in specified assemblies available to the project.|  
-|[-linkresource](../../../csharp/language-reference/compiler-options/linkresource-compiler-option.md)|Creates a link to a managed resource.|  
-|[-resource](../../../csharp/language-reference/compiler-options/resource-compiler-option.md)|Embeds a .NET Framework resource into the output file.|  
-|[-win32icon](../../../csharp/language-reference/compiler-options/win32icon-compiler-option.md)|Specifies an .ico file to insert into the output file.|  
-|[-win32res](../../../csharp/language-reference/compiler-options/win32res-compiler-option.md)|Specifies a Win32 resource to insert into the output file.|  
+|[-link](link-compiler-option.md)|Makes COM type information in specified assemblies available to the project.|  
+|[-linkresource](linkresource-compiler-option.md)|Creates a link to a managed resource.|  
+|[-resource](resource-compiler-option.md)|Embeds a .NET Framework resource into the output file.|  
+|[-win32icon](win32icon-compiler-option.md)|Specifies an .ico file to insert into the output file.|  
+|[-win32res](win32res-compiler-option.md)|Specifies a Win32 resource to insert into the output file.|  
   
 ### Miscellaneous  
   
 |Option|Purpose|  
 |------------|-------------|  
-|[@](../../../csharp/language-reference/compiler-options/response-file-compiler-option.md)|Specifies a response file.|  
-|[-?](../../../csharp/language-reference/compiler-options/help-compiler-option.md)|Lists compiler options to stdout.|  
-|[-baseaddress](../../../csharp/language-reference/compiler-options/baseaddress-compiler-option.md)|Specifies the preferred base address at which to load a DLL.|  
-|[-codepage](../../../csharp/language-reference/compiler-options/codepage-compiler-option.md)|Specifies the code page to use for all source code files in the compilation.|  
-|[-help](../../../csharp/language-reference/compiler-options/help-compiler-option.md)|Lists compiler options to stdout.|  
-|[-highentropyva](../../../csharp/language-reference/compiler-options/highentropyva-compiler-option.md)|Specifies that the executable file supports address space layout randomization (ASLR).|  
-|[-langversion](../../../csharp/language-reference/compiler-options/langversion-compiler-option.md)|Specify language version mode: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, or Latest |  
-|[-main](../../../csharp/language-reference/compiler-options/main-compiler-option.md)|Specifies the location of the **Main** method.|  
-|[-noconfig](../../../csharp/language-reference/compiler-options/noconfig-compiler-option.md)|Instructs the compiler not to compile with csc.rsp.|  
-|[-nologo](../../../csharp/language-reference/compiler-options/nologo-compiler-option.md)|Suppresses compiler banner information.|  
-|[-recurse](../../../csharp/language-reference/compiler-options/recurse-compiler-option.md)|Searches subdirectories for source files to compile.|  
-|[-subsystemversion](../../../csharp/language-reference/compiler-options/subsystemversion-compiler-option.md)|Specifies the minimum version of the subsystem that the executable file can use.|  
-|[-unsafe](../../../csharp/language-reference/compiler-options/unsafe-compiler-option.md)|Enables compilation of code that uses the [unsafe](../../../csharp/language-reference/keywords/unsafe.md) keyword.|  
-|[-utf8output](../../../csharp/language-reference/compiler-options/utf8output-compiler-option.md)|Displays compiler output using UTF-8 encoding.|  
+|[@](response-file-compiler-option.md)|Specifies a response file.|  
+|[-?](help-compiler-option.md)|Lists compiler options to stdout.|  
+|[-baseaddress](baseaddress-compiler-option.md)|Specifies the preferred base address at which to load a DLL.|  
+|[-codepage](codepage-compiler-option.md)|Specifies the code page to use for all source code files in the compilation.|  
+|[-help](help-compiler-option.md)|Lists compiler options to stdout.|  
+|[-highentropyva](highentropyva-compiler-option.md)|Specifies that the executable file supports address space layout randomization (ASLR).|  
+|[-langversion](langversion-compiler-option.md)|Specify language version mode: Default, ISO-1, ISO-2, 3, 4, 5, 6, 7, 7.1, or Latest |  
+|[-main](main-compiler-option.md)|Specifies the location of the **Main** method.|  
+|[-noconfig](noconfig-compiler-option.md)|Instructs the compiler not to compile with csc.rsp.|  
+|[-nologo](nologo-compiler-option.md)|Suppresses compiler banner information.|  
+|[-recurse](recurse-compiler-option.md)|Searches subdirectories for source files to compile.|  
+|[-subsystemversion](subsystemversion-compiler-option.md)|Specifies the minimum version of the subsystem that the executable file can use.|  
+|[-unsafe](unsafe-compiler-option.md)|Enables compilation of code that uses the [unsafe](../../../csharp/language-reference/keywords/unsafe.md) keyword.|  
+|[-utf8output](utf8output-compiler-option.md)|Displays compiler output using UTF-8 encoding.|  
 |-parallel[+&#124;-]|Specifies whether to use concurrent build (+).|  
 |-checksumalgorithm:\<alg>|Specify the algorithm for calculating the source file checksum stored in PDB.  Supported values are: SHA1 (default) or SHA256.|  
   
@@ -110,6 +111,6 @@ The following compiler options are sorted by category. For an alphabetical list,
 |-incremental|Enables incremental compilation.|  
   
 ## See Also  
- [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md)  
- [C# Compiler Options Listed Alphabetically](../../../csharp/language-reference/compiler-options/listed-alphabetically.md)  
- [How to: Set Environment Variables for the Visual Studio Command Line](../../../csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md)
+ [C# Compiler Options](index.md)  
+ [C# Compiler Options Listed Alphabetically](listed-alphabetically.md)  
+ [How to: Set Environment Variables for the Visual Studio Command Line](how-to-set-environment-variables-for-the-visual-studio-command-line.md)

--- a/docs/csharp/language-reference/compiler-options/toc.md
+++ b/docs/csharp/language-reference/compiler-options/toc.md
@@ -13,6 +13,7 @@
 ### [-debug](debug-compiler-option.md)
 ### [-define](define-compiler-option.md)
 ### [-delaysign](delaysign-compiler-option.md)
+### [-deterministic](deterministic-compiler-option.md)
 ### [-doc](doc-compiler-option.md)
 ### [-errorreport](errorreport-compiler-option.md)
 ### [-filealign](filealign-compiler-option.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1055,6 +1055,7 @@
 ##### [-debug](visual-basic/reference/command-line-compiler/debug.md)
 ##### [-define](visual-basic/reference/command-line-compiler/define.md)
 ##### [-delaysign](visual-basic/reference/command-line-compiler/delaysign.md)
+##### [-deterministic](visual-basic/reference/command-line-compiler/deterministic.md)
 ##### [-doc](visual-basic/reference/command-line-compiler/doc.md)
 ##### [-errorreport](visual-basic/reference/command-line-compiler/errorreport.md)
 ##### [-filealign](visual-basic/reference/command-line-compiler/filealign.md)

--- a/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
+++ b/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-alphabetically.md
@@ -1,6 +1,6 @@
 ---
 title: "Visual Basic Compiler Options Listed Alphabetically"
-ms.date: 03/09/2018
+ms.date: 04/12/2018
 ms.prod: .net
 ms.reviewer: ""
 ms.suite: ""
@@ -32,6 +32,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |[-debug](../../../visual-basic/reference/command-line-compiler/debug.md)|Produces debugging information.|  
 |[-define](../../../visual-basic/reference/command-line-compiler/define.md)|Defines symbols for conditional compilation.|  
 |[-delaysign](../../../visual-basic/reference/command-line-compiler/delaysign.md)|Specifies whether the assembly will be fully or partially signed.|  
+|[-deterministic](../../../visual-basic/reference/command-line-compiler/deterministic.md)|Causes the compiler to output an assembly whose binary content is identical across compilations if inputs are identical.|
 |[-doc](../../../visual-basic/reference/command-line-compiler/doc.md)|Processes documentation comments to an XML file.|  
 |[-errorreport](../../../visual-basic/reference/command-line-compiler/errorreport.md)|Specifies how the Visual Basic compiler should report internal compiler errors.|  
 |[-filealign](../../../visual-basic/reference/command-line-compiler/filealign.md)|Specifies where to align the sections of the output file.|  

--- a/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-by-category.md
+++ b/docs/visual-basic/reference/command-line-compiler/compiler-options-listed-by-category.md
@@ -1,6 +1,6 @@
 ---
 title: "Visual Basic Compiler Options Listed by Category"
-ms.date: 03/09/2018
+ms.date: 04/12/2018
 ms.prod: .net
 ms.reviewer: ""
 ms.suite: ""
@@ -26,7 +26,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |[-utf8output](../../../visual-basic/reference/command-line-compiler/utf8output.md)|Displays compiler output using UTF-8 encoding.|  
 |[-verbose](../../../visual-basic/reference/command-line-compiler/verbose.md)|Outputs extra information during compilation.|  
 |`-modulename:<string>`|Specify the name of the source module|  
-|[-preferreduilang](../../../csharp/language-reference/compiler-options/preferreduilang-compiler-option.md)|Specify a language for compiler output.|  
+|[-preferreduilang](../../../csharp/language-reference/compiler-options/preferreduilang-compiler-option.md)|Specify a language for compiler output.|
   
 ## Optimization  
   
@@ -40,6 +40,7 @@ The Visual Basic command-line compiler is provided as an alternative to compilin
 |Option|Purpose|  
 |---|---|  
 |[-doc](../../../visual-basic/reference/command-line-compiler/doc.md)|Process documentation comments to an XML file.|  
+|[-deterministic](../../../visual-basic/reference/command-line-compiler/deterministic.md)|Causes the compiler to output an assembly whose binary content is identical across compilations if inputs are identical.|
 |[-netcf](../../../visual-basic/reference/command-line-compiler/netcf.md)|Sets the compiler to target the [!INCLUDE[Compact](~/includes/compact-md.md)].|  
 |[-out](../../../visual-basic/reference/command-line-compiler/out.md)|Specifies an output file.|  
 |[-refonly](refonly-compiler-option.md)|Outputs only a reference assembly.|

--- a/docs/visual-basic/reference/command-line-compiler/deterministic.md
+++ b/docs/visual-basic/reference/command-line-compiler/deterministic.md
@@ -1,0 +1,51 @@
+---
+title: "-delaysign"
+ms.date: 03/10/2018
+ms.prod: .net
+ms.suite: ""
+ms.technology: 
+  - "devlang-visual-basic"
+ms.topic: "article"
+helpviewer_keywords: 
+  - "delaysign compiler option [Visual Basic]"
+  - "-delaysign compiler option [Visual Basic]"
+  - "-delaysign compiler option [Visual Basic]"
+ms.assetid: c76e61a4-1884-4252-9fb2-377f99caa690
+author: rpetrusha
+ms.author: ronpet
+---
+# -delaysign
+Specifies whether the assembly will be fully or partially signed.  
+  
+## Syntax  
+  
+```  
+-delaysign[+ | -]  
+```  
+  
+## Arguments  
+ `+` &#124; `-`  
+ Optional. Use `-delaysign-` if you want a fully signed assembly. Use `-delaysign+` if you want to place the public key in the assembly and reserve space for the signed hash. The default is `-delaysign-`.  
+  
+## Remarks  
+ The `-delaysign` option has no effect unless used with [-keyfile](../../../visual-basic/reference/command-line-compiler/keyfile.md) or [-keycontainer](../../../visual-basic/reference/command-line-compiler/keycontainer.md).  
+  
+ When you request a fully signed assembly, the compiler hashes the file that contains the manifest (assembly metadata) and signs that hash with the private key. The resulting digital signature is stored in the file that contains the manifest. When an assembly is delay signed, the compiler does not compute and store the signature but reserves space in the file so the signature can be added later.  
+  
+ For example, by using `-delaysign+`, a developer in an organization can distribute unsigned test versions of an assembly that testers can register with the global assembly cache and use. When work on the assembly is completed, the person responsible for the organization's private key can fully sign the assembly. This compartmentalization protects the organization's private key from disclosure, while allowing all developers to work on the assemblies.  
+  
+ See [Creating and Using Strong-Named Assemblies](../../../framework/app-domains/create-and-use-strong-named-assemblies.md) for more information on signing an assembly.  
+  
+### To set -delaysign in the Visual Studio integrated development environment  
+  
+1.  Have a project selected in **Solution Explorer**. On the **Project** menu, click **Properties**.   
+  
+2.  Click the **Signing** tab.  
+  
+3.  Set the value in the **Delay sign only** box.  
+  
+## See Also  
+ [Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)  
+ [-keyfile](../../../visual-basic/reference/command-line-compiler/keyfile.md)  
+ [-keycontainer](../../../visual-basic/reference/command-line-compiler/keycontainer.md)  
+ [Sample Compilation Command Lines](../../../visual-basic/reference/command-line-compiler/sample-compilation-command-lines.md)

--- a/docs/visual-basic/reference/command-line-compiler/deterministic.md
+++ b/docs/visual-basic/reference/command-line-compiler/deterministic.md
@@ -24,7 +24,7 @@ Causes the compiler to produce an assembly whose byte-for-byte output is identic
 
 ## Remarks
 
-By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and a GUID that is generated from random numbers. You use the `-deterministic` option to produce a *deterministic assembly**, one whose binary content is identical across compilations as long as the input remains the same.
+By default, compiler output from a given set of inputs is unique, since the compiler adds a timestamp and a GUID that is generated from random numbers. You use the `-deterministic` option to produce a *deterministic assembly*, one whose binary content is identical across compilations as long as the input remains the same.
 
 The compiler considers the following inputs for the purpose of determinism:
 


### PR DESCRIPTION
## -deterministic compiler switch for C# and VIsual Basic

This PR does the following:
- Documents the C# -deterministic compiler switch.
- Documents the VB -deterministic compiler switch.
- Adds the switches to the lists of switches ordered alphabetically and by category.
- Updates the TOC to list the switch.

An additional change, listing the MSBuild `Deterministic` flag, will be included in a separate PR.

This documentation still needs to list the starting compiler version that supports `-deterministic`.

Fixes #3828 

//cc @jcouv @gafter 


