### PR TITLE
Update broken links for networking samples

### DIFF
--- a/docs/framework/network-programming/network-programming-samples.md
+++ b/docs/framework/network-programming/network-programming-samples.md
@@ -31,8 +31,8 @@ This section contains descriptions and links to downloadable network programming
  [HttpListener Technology Sample](https://msdn.microsoft.com/en-us/library/y7cbb2y2(v=vs.85).aspx)  
  Shows how to process HTTP requests from within an application.  
  
- [HttpListener ASPX Host Application Sample](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/dd767375(v%3dvs.90)\)
- Demonstrates how to use the features of the xref:System.Net.HttpListener class to create an HTTP server that routes calls to a hosted ASP.NET application.
+ [HttpListener ASPX Host Application Sample](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/dd767375(v%3dvs.90))   
+ Demonstrates how to use the features of the <xref:System.Net.HttpListener?displayProperty=nameWithType> class to create an HTTP server that routes calls to a hosted ASP.NET application.
   
  [Mailer Technology Sample](https://msdn.microsoft.com/en-us/library/whw7xbk2(v=vs.85).aspx)  
  Shows how to send email messages from a client application.  

--- a/docs/framework/network-programming/network-programming-samples.md
+++ b/docs/framework/network-programming/network-programming-samples.md
@@ -16,59 +16,48 @@ ms.workload:
   - "dotnet"
 ---
 # Network Programming Samples
-This section contains descriptions and links to downloadable network programming samples that use classes in the <xref:System.Net>, <xref:System.Net.Cache>, <xref:System.Net.Configuration>, <xref:System.Net.Mail>, <xref:System.Net.Mime>, <xref:System.Net.NetworkInformation>, <xref:System.Net.PeerToPeer>, <xref:System.Net.Security>, <xref:System.Net.Sockets>, and related namespaces.  
+This section contains descriptions and links to downloadable network programming samples that use classes in the <xref:System.Net>, <xref:System.Net.Cache>, <xref:System.Net.Configuration>, <xref:System.Net.Mail>, <xref:System.Net.Mime>, <xref:System.Net.NetworkInformation>, <xref:System.Net.PeerToPeer>, <xref:System.Net.Security>, <xref:System.Net.Sockets>, and related namespaces.
+Note: all samples are available in the .NET Framework SDK version 2.0 Samples Download, which was released for the .NET Framework 2.0 and may be dated.
   
 ## In This Section  
- [Download Progress Indicator Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179556)  
+ [Download Progress Indicator Technology Sample](https://msdn.microsoft.com/en-us/library/t8w6294a(v=vs.85).aspx)  
  Shows how to display the progress of a file download.  
   
- [FTP Client Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179557)  
+ [FTP Client Technology Sample](https://msdn.microsoft.com/en-us/library/b7810t5c(v=vs.85).aspx)  
  Shows how to upload and download files to and from an FTP server.  
   
- [HttpListener Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179558)  
+ [HttpListener Technology Sample](https://msdn.microsoft.com/en-us/library/y7cbb2y2(v=vs.85).aspx)  
  Shows how to process HTTP requests from within an application.  
   
- [HttpListener ASPX Host Application Sample](http://go.microsoft.com/fwlink/?LinkID=179560)  
- Demonstrates how to use the features of the <xref:System.Net.HttpListener> class to create an HTTP server that routes calls to a hosted ASP.NET application.  
-  
- [Mailer Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179561)  
+ [Mailer Technology Sample](https://msdn.microsoft.com/en-us/library/whw7xbk2(v=vs.85).aspx)  
  Shows how to send email messages from a client application.  
   
- [NetStat Tool Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179562)  
+ [NetStat Tool Technology Sample](https://msdn.microsoft.com/en-us/library/ks32hs88(v=vs.85).aspx)  
  Demonstrates the NCLNetStat network information tool.  
   
- [Network Information Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179564)  
+ [Network Information Technology Sample](https://msdn.microsoft.com/en-us/library/2xatedhd(v=vs.85).aspx)  
  Shows how to monitor and display network information.  
   
- [Ping Client Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179565)  
+ [Ping Client Technology Sample](https://msdn.microsoft.com/en-us/library/5253acs7(v=vs.85).aspx)  
  Demonstrates a client application that can ping a remote host.  
   
- [WebClient Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179566)  
+ [WebClient Technology Sample](https://msdn.microsoft.com/en-us/library/fxk992zc(v=vs.85).aspx)  
  Demonstrates how to perform common operations, such as the upload or download of files or data.  
   
- [Secure Streams Sample](http://go.microsoft.com/fwlink/?LinkID=179567)  
+ [Secure Streams Sample](https://msdn.microsoft.com/en-us/library/ms180980(v=vs.85).aspx)  
  Shows how to use a secure stream to communicate between a client and a server.  
   
- [IPv6 Sockets Sample](http://go.microsoft.com/fwlink/?LinkID=179568)  
+ [IPv6 Sockets Sample](https://msdn.microsoft.com/en-us/library/ms180981(v=vs.85).aspx)  
  Demonstrates how to use sockets when IPv6 is enabled.  
   
- [FTP Explorer Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179569)  
+ [FTP Explorer Technology Sample](https://msdn.microsoft.com/en-us/library/ms233623(v=vs.85).aspx)  
  Demonstrates how to list the contents of an FTP server.  
   
- [Socket Performance Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179570)  
- Shows how to use enhancements in the <xref:System.Net.Sockets.Socket> class to build a server application that uses asynchronous network I/O to achieve the highest performance.  
-  
- [PeerToPeer Technology Sample](http://go.microsoft.com/fwlink/?LinkID=179571)  
- Shows how to use the new classes in the <xref:System.Net.PeerToPeer> namespace to register and publish a peer name and then resolve a peer name.  
   
 ## Reference  
  <xref:System.Net>  
   
  <xref:System.Net.NetworkInformation>  
-  
- <xref:System.Net.PeerToPeer>  
-  
- <xref:System.Net.Sockets>  
   
 ## See Also  
  [Network Programming in the .NET Framework](../../../docs/framework/network-programming/index.md)  

--- a/docs/framework/network-programming/network-programming-samples.md
+++ b/docs/framework/network-programming/network-programming-samples.md
@@ -16,9 +16,11 @@ ms.workload:
   - "dotnet"
 ---
 # Network Programming Samples
-This section contains descriptions and links to downloadable network programming samples that use classes in the <xref:System.Net>, <xref:System.Net.Cache>, <xref:System.Net.Configuration>, <xref:System.Net.Mail>, <xref:System.Net.Mime>, <xref:System.Net.NetworkInformation>, <xref:System.Net.PeerToPeer>, <xref:System.Net.Security>, <xref:System.Net.Sockets>, and related namespaces.
-Note: all samples are available in the .NET Framework SDK version 2.0 Samples Download, which was released for the .NET Framework 2.0 and may be dated.
+This section contains descriptions and links to downloadable network programming samples that use classes in the <xref:System.Net>, <xref:System.Net.Cache>, <xref:System.Net.Configuration>, <xref:System.Net.Mail>, <xref:System.Net.Mime>, <xref:System.Net.NetworkInformation>, <xref:System.Net.Security>, <xref:System.Net.Sockets>, and related namespaces. 
   
+> [!NOTE]
+> All samples are available in the [.NET Framework SDK version 2.0 Samples Download](https://www.microsoft.com/en-us/download/confirmation.aspx?id=22181), which was released for the .NET Framework 2.0 and may be dated.
+
 ## In This Section  
  [Download Progress Indicator Technology Sample](https://msdn.microsoft.com/en-us/library/t8w6294a(v=vs.85).aspx)  
  Shows how to display the progress of a file download.  
@@ -28,6 +30,9 @@ Note: all samples are available in the .NET Framework SDK version 2.0 Samples Do
   
  [HttpListener Technology Sample](https://msdn.microsoft.com/en-us/library/y7cbb2y2(v=vs.85).aspx)  
  Shows how to process HTTP requests from within an application.  
+ 
+ [HttpListener ASPX Host Application Sample](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/dd767375(v%3dvs.90)\)
+ Demonstrates how to use the features of the xref:System.Net.HttpListener class to create an HTTP server that routes calls to a hosted ASP.NET application.
   
  [Mailer Technology Sample](https://msdn.microsoft.com/en-us/library/whw7xbk2(v=vs.85).aspx)  
  Shows how to send email messages from a client application.  
@@ -62,4 +67,3 @@ Note: all samples are available in the .NET Framework SDK version 2.0 Samples Do
 ## See Also  
  [Network Programming in the .NET Framework](../../../docs/framework/network-programming/index.md)  
  [Network Programming How-to Topics](../../../docs/framework/network-programming/network-programming-how-to-topics.md)  
- [Networking Samples for .NET](http://code.msdn.microsoft.com/Wiki/View.aspx?ProjectName=nclsamples)


### PR DESCRIPTION
## Summary

Ron, I found links to all the samples except the following:
HttpListener ASPX Host Application Sample 
Socket Performance Technology Sample
PeerToPeer Technology Sample

But as you mentioned, they sample pages do exist in the .NET 2.0 documentation, for example https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/bb906998(v=vs.90)
However, I could not find the code files for the missing samples.

Would it be better to link to the old documentation for these, as opposed to removing them?
Fixes #4931
