### PR TITLE
OS-based need for loadFromRemoteSources

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/loadfromremotesources-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/loadfromremotesources-element.md
@@ -69,7 +69,7 @@ Specifies whether assemblies from remote sources should be granted full trust.
  The `<loadFromRemoteSources>` element lets you specify that the assemblies that would have run partially trusted in earlier versions of the .NET Framework are to be run fully trusted in the [!INCLUDE[net_v40_short](../../../../../includes/net-v40-short-md.md)] and later versions. By default, remote assemblies do not run in the [!INCLUDE[net_v40_short](../../../../../includes/net-v40-short-md.md)] and later. To run a remote assembly, you must either run it as fully trusted or create a sandboxed <xref:System.AppDomain> in which to run it.  
   
 > [!NOTE]
->  In the [!INCLUDE[net_v45](../../../../../includes/net-v45-md.md)], assemblies on local network shares are run as full trust by default; you do not have to enable the `<loadFromRemoteSources>` element.  
+>  In the [!INCLUDE[net_v45](../../../../../includes/net-v45-md.md)], assemblies on local network shares are run as full trust by default on workstation versions of Windows. Therefore, in many cases, you do not have to enable the `<loadFromRemoteSources>` element. However, it is still required for some versions of Windows Server or if the default .NET machine configuration has been customized.
   
 > [!NOTE]
 >  If an application has been copied from the web, it is flagged by Windows as being a web application, even if it resides on the local computer. You can change that designation by changing the file properties, or you can use the `<loadFromRemoteSources>` element to grant the assembly full trust. As an alternative, you can use the <xref:System.Reflection.Assembly.UnsafeLoadFrom%2A> method to load a local assembly that the operating system has flagged as having been loaded from the web.  


### PR DESCRIPTION
I had a terribly frustrating debugging experience trying to figure out why a .NET DLL wasn't loading, but only on a small fraction of computers to which my app was deployed.  I was directed to this page based on an old Stack Overflow post on `loadFromRemoteSources`. Based on the previous text of the note, I discarded the idea that `loadFromRemoteSources` would be helpful, since all computers had .NET 4.6 or later. Only after hours of troubleshooting did I circle back to it and discover that `loadFromRemoteSources` was the fix.

I later discovered the SO post [Not allowed to load assembly from network location](https://stackoverflow.com/q/28339116/145173), which indicates that `loadFromRemoteSources` is still required on Windows Server 2012 R2. I don't know exactly what the rules are. Ideally, they'd be spelled out in detail, but at least make it clear that `loadFromRemoteSources` is still relevant, even for .NET 4.5+.