### PR TITLE
Update to the sections, "DO NOT use underscores..." and "DO NOT use H…

### DIFF
--- a/docs/standard/design-guidelines/general-naming-conventions.md
+++ b/docs/standard/design-guidelines/general-naming-conventions.md
@@ -40,9 +40,16 @@ This section describes general naming conventions that relate to word choice, gu
   
  The property name `CanScrollHorizontally` is better than `ScrollableX` (an obscure reference to the X-axis).  
   
- **X DO NOT** use underscores, hyphens, or any other nonalphanumeric characters.  
-  
- **X DO NOT** use Hungarian notation.  
+ **X DO NOT** use underscores, hyphens, or any other nonalphanumeric characters. 
+ 
+ A well recognised exception to this rule is the use of an underscore to denote a private field, eg
+ ```cs
+ private readonly SomeType _field;
+ ```
+ 
+ **X DO NOT** use Hungarian notation. 
+ 
+ Two well established conventions within C# are often falsely cited as examples of Hungarian notation: the use of `I` as a suffix for an interface and `T` for a generic type name. Do use these conventions.  
   
  **X AVOID** using identifiers that conflict with keywords of widely used programming languages.  
   


### PR DESCRIPTION
…ungarian notation"

It is common to use an underscore in private fields. And `I` as a suffix for interfaces (and to a much lesser extent, `T` as a suffix for generic parameter names) are often (falsely) cited as examples of Hungarian notation. So I've made a stab at updating these guidelines to clarify those two points.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
