### PR TITLE
Removed gender specific exclusionary terms

### DIFF
--- a/docs/csharp/roslyn-sdk/index.md
+++ b/docs/csharp/roslyn-sdk/index.md
@@ -75,14 +75,14 @@ There are three main scenarios for writing analyzers and code fixes:
 
 Many teams have coding standards that are enforced through code reviews
 with other team members. Analyzers and code fixes can make this process
-much more efficient. Code reviews happen when a developer shares his work
-with others on the team. He will have invested all the time needed to
+much more efficient. Code reviews happen when a developer shares their work
+with others on the team. The developer will have invested all the time needed to
 complete a new feature before getting any comments. Weeks may go by
-while he reinforces habits that don't match the team's practices.
+while the developer reinforces habits that don't match the team's practices.
 
-Analyzers run as a developer writes code. He gets immediate feedback that
-encourages following the guidance immediately. He builds habits to write
-compliant code as soon as he begins prototyping. When the feature is
+Analyzers run as a developer writes code. The developer gets immediate feedback that
+encourages following the guidance immediately. The developer builds habits to write
+compliant code as soon as they begin prototyping. When the feature is
 ready for humans to review, all the standard guidance has been enforced.
 
 Teams can build analyzers and code fixes that look for the most common


### PR DESCRIPTION
Replaced `he` with `the developer` or `they`

## Summary

`He` has been replaced with one of the following (based on context):
`The developer`
`they`
`their`

This was done to remove gender specific terms and allow more inclusion.
