### PR TITLE
Updated default.md

### DIFF
--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -18,15 +18,13 @@ ms.author: "wiwagn"
 
 # default (C# Reference)
 
-The `default` keyword.
-
 The `default` keyword can be used in the `switch` statement or in a default value expression:
 
 - [The switch statement](switch.md): Specifies the default label.
 
-- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Produces the default value of the type. This will be null for reference types and zero for value types, and the 0 bit pattern for structs.
+- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Returns the default value of a type: `null` for reference types, zero for numeric types, and zero/`null` filled in members for struct types.
 
-## See Also
+## See also
 
  [C# Reference](../index.md)  
  [C# Programming Guide](../../programming-guide/index.md)  

--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -22,7 +22,7 @@ The `default` keyword can be used in the `switch` statement or in a default valu
 
 - [The switch statement](switch.md): Specifies the default label.
 
-- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Produces the default value of a type: `null` for reference types, zero for numeric types, and zero/`null` filled in members for struct types.
+- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Produces the default value of a type.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -22,7 +22,7 @@ The `default` keyword can be used in the `switch` statement or in a default valu
 
 - [The switch statement](switch.md): Specifies the default label.
 
-- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Returns the default value of a type: `null` for reference types, zero for numeric types, and zero/`null` filled in members for struct types.
+- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Produces the default value of a type: `null` for reference types, zero for numeric types, and zero/`null` filled in members for struct types.
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -58,7 +58,7 @@ C# provides many operators, which are symbols that specify which operations (mat
   
  [unchecked](../../../csharp/language-reference/keywords/unchecked.md) – disables overflow checking for integer operations. This is the default compiler behavior.  
   
- [default(T)](../../../csharp/programming-guide/statements-expressions-operators/default-value-expressions.md) – returns the default value of type T: `null` for reference types, zero for numeric types, and zero/`null` filled in members for struct types.  
+ [default(T)](../../../csharp/programming-guide/statements-expressions-operators/default-value-expressions.md) – produces the default value of type T.  
   
  [delegate](../../../csharp/programming-guide/statements-expressions-operators/anonymous-methods.md) – declares and returns a delegate instance.  
   


### PR DESCRIPTION
Removed not necessary first line.
Updated description of the default value expression to the one used in the [C# Operators](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/index) topic.
