### PR TITLE
Prefer C# 7.0 to C# 7

### DIFF
--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -28,8 +28,8 @@ major features added in each release.
 * [C# 7.1](csharp-7-1.md):
     - This page describes the features in C# 7.1. These features were added in [Visual Studio 2017 version 15.3](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 
-* [C# 7](csharp-7.md):
-    - This page describes the features added in C# 7. These features were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
+* [C# 7.0](csharp-7.md):
+    - This page describes the features added in C# 7.0. These features were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
      
 * [C# 6](csharp-6.md):
     - This page describes the features that were added in C# 6. These features are available in Visual Studio 2015 for Windows developers, and on .NET Core 1.0 for developers exploring C# on macOS and Linux.


### PR DESCRIPTION
## Summary
The preference from the C# language design group is to refer to C# 7 as "C# 7.0".
See [language history](https://github.com/dotnet/csharplang/blob/master/Language-Version-History.md) for example.