### PR TITLE
Clarify that `when` in a `switch` was added in C#7

### DIFF
--- a/docs/csharp/language-reference/keywords/when.md
+++ b/docs/csharp/language-reference/keywords/when.md
@@ -37,7 +37,7 @@ The following example uses the `when` keyword to conditionally execute handlers 
   
 ## `when` in a `switch` statement
 
-Starting with C# 7, `case` labels no longer need be mutually exclusive, and the order in which `case` labels appear in a `switch` statement can determine which switch block executes. The `when` keyword can be used to specify a filter condition that causes its associated case label to be true only if the filter condition is also true. Its syntax is:
+Starting with C# 7.0, `case` labels no longer need be mutually exclusive, and the order in which `case` labels appear in a `switch` statement can determine which switch block executes. The `when` keyword can be used to specify a filter condition that causes its associated case label to be true only if the filter condition is also true. Its syntax is:
 
 ```csharp
 case (expr) when (when-condition):

--- a/docs/csharp/language-reference/keywords/when.md
+++ b/docs/csharp/language-reference/keywords/when.md
@@ -37,7 +37,7 @@ The following example uses the `when` keyword to conditionally execute handlers 
   
 ## `when` in a `switch` statement
 
-Starting with 7, `case` labels no longer need be mutually exclusive, and the order in which `case` labels appear in a `switch` statement can determine which switch block executes. The `when` keyword can be used to specify a filter condition that causes its associated case label to be true only if the filter condition is also true. Its syntax is:
+Starting with C# 7, `case` labels no longer need be mutually exclusive, and the order in which `case` labels appear in a `switch` statement can determine which switch block executes. The `when` keyword can be used to specify a filter condition that causes its associated case label to be true only if the filter condition is also true. Its syntax is:
 
 ```csharp
 case (expr) when (when-condition):


### PR DESCRIPTION
## Summary
See title.
