### PR TITLE
CC54041: Missing language code: ```vb

### DIFF
--- a/docs/visual-basic/language-reference/statements/namespace-statement.md
+++ b/docs/visual-basic/language-reference/statements/namespace-statement.md
@@ -27,7 +27,7 @@ Declares the name of a namespace and causes the source code that follows the dec
   
 ## Syntax  
   
-```  
+```vb  
 Namespace [Global.] { name | name.name }  
     [ componenttypes ]  
 End Namespace  


### PR DESCRIPTION
Hi, @mairaw,
This contirbution comes from https://github.com/dotnet/docs.pl-pl/pull/4/files.
Could you help to review and merge this PR, please?
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
