### PR TITLE
Updated Further Reading links for .NET parallel programming

### DIFF
--- a/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
+++ b/docs/standard/parallel-programming/for-further-reading-parallel-programming.md
@@ -1,17 +1,11 @@
 ---
 title: "For Further Reading (Parallel Programming)"
-ms.custom: ""
-ms.date: "03/30/2017"
+ms.date: "04/26/2018"
 ms.prod: ".net"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: dotnet-standard
-ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords: 
   - "tasks, further reading"
-ms.assetid: 98aee307-dde6-4cad-bb58-078497b8064f
-caps.latest.revision: 7
 author: "rpetrusha"
 ms.author: "ronpet"
 manager: "wpickett"
@@ -20,16 +14,17 @@ ms.workload:
   - "dotnetcore"
 ---
 # For Further Reading (Parallel Programming)
-The following resources contain additional information about Parallel Programming in the .NET Framework:  
-  
--   The [Parallel Computing Developer Center](https://msdn.microsoft.com/vstudio/bb964701) on the MSDN Web site has links to the content and forum posts about parallel programming in the .NET Framework, and in native C++.  
-  
--   The [Parallel Programming with .NET blog](https://blogs.msdn.microsoft.com/pfxteam/) on the MSDN blog site contains many in-depth articles about parallel programming in the .NET Framework.  
-  
--   The [Parallel Extensions forum](https://social.msdn.microsoft.com/Forums/en-US/home?forum=parallelextensions) on the MSDN forums site is where to ask and answer questions about parallel programming.  
-  
--   The [Parallel Extensions Samples](https://code.msdn.microsoft.com/ParExtSamples) page on the MSDN Code Gallery Web site contains many samples that demonstrate intermediate and advanced parallel programming techniques.  
-  
-## See Also  
- [Parallel Programming](../../../docs/standard/parallel-programming/index.md)  
- [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222)
+
+The following resources contain additional information about parallel programming in .NET:
+
+- The [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222) document describes common parallel patterns and best practices for developing parallel components utilizing those patterns.
+
+- The [Design Patterns for Decomposition and Coordination on Multicore Architectures](https://msdn.microsoft.com/library/ff963553.aspx) book describes patterns for parallel programming that use the parallel programming support introduced in the .NET Framework 4.
+
+- The [Parallel Programming with .NET](https://blogs.msdn.microsoft.com/pfxteam/) blog contains many in-depth articles about parallel programming in .NET.
+
+- The [Samples for Parallel Programming with the .NET Framework](https://code.msdn.microsoft.com/ParExtSamples) page contains many samples that demonstrate intermediate and advanced parallel programming techniques.
+
+## See also  
+ [Parallel Computing Developer Center](https://msdn.microsoft.com/vstudio/bb964701)  
+ [Parallel Programming in Visual C++](/cpp/parallel/parallel-programming-in-visual-cpp)  

--- a/docs/standard/parallel-programming/index.md
+++ b/docs/standard/parallel-programming/index.md
@@ -1,17 +1,11 @@
 ---
 title: "Parallel Programming in .NET"
-ms.custom: ""
 ms.date: "03/30/2017"
 ms.prod: ".net"
-ms.reviewer: ""
-ms.suite: ""
 ms.technology: dotnet-standard
-ms.tgt_pltfrm: ""
 ms.topic: "article"
 helpviewer_keywords: 
   - "parallel programming"
-ms.assetid: 4d83c690-ad2d-489e-a2e0-b85b898a672d
-caps.latest.revision: 19
 author: "rpetrusha"
 ms.author: "ronpet"
 manager: "wpickett"
@@ -20,9 +14,10 @@ ms.workload:
   - "dotnetcore"
 ---
 # Parallel Programming in .NET
-Many personal computers and workstations have two or four cores (that is, CPUs) that enable multiple threads to be executed simultaneously. Computers in the near future are expected to have significantly more cores. To take advantage of the hardware of today and tomorrow, you can parallelize your code to distribute work across multiple processors. In the past, parallelization required low-level manipulation of threads and locks. [!INCLUDE[vs_dev10_long](../../../includes/vs-dev10-long-md.md)] and the [!INCLUDE[net_v40_short](../../../includes/net-v40-short-md.md)] enhance support for parallel programming by providing a new runtime, new class library types, and new diagnostic tools. These features simplify parallel development so that you can write efficient, fine-grained, and scalable parallel code in a natural idiom without having to work directly with threads or the thread pool. The following illustration provides a high-level overview of the parallel programming architecture in the [!INCLUDE[net_v40_short](../../../includes/net-v40-short-md.md)].  
+
+Many personal computers and workstations have several CPU cores that enable multiple threads to be executed simultaneously. Computers in the near future are expected to have significantly more cores. To take advantage of the hardware of today and tomorrow, you can parallelize your code to distribute work across multiple processors. In the past, parallelization required low-level manipulation of threads and locks. Visual Studio 2010 and the .NET Framework 4 enhance support for parallel programming by providing a new runtime, new class library types, and new diagnostic tools. These features simplify parallel development so that you can write efficient, fine-grained, and scalable parallel code in a natural idiom without having to work directly with threads or the thread pool. The following illustration provides a high-level overview of the parallel programming architecture in the .NET Framework 4.
   
- ![.NET Parallel Programming Architecture](../../../docs/standard/parallel-programming/media/tpl-architecture.png "TPL_Architecture")  
+ ![.NET Parallel Programming Architecture](./media/tpl-architecture.png "TPL_Architecture")  
   
 ## Related Topics  
   
@@ -35,8 +30,8 @@ Many personal computers and workstations have two or four cores (that is, CPUs) 
 |[Custom Partitioners for PLINQ and TPL](../../../docs/standard/parallel-programming/custom-partitioners-for-plinq-and-tpl.md)|Describes how partitioners work and how to configure the default partitioners or create a new partitioner.|  
 |[Task Schedulers](http://msdn.microsoft.com/library/638f8ea5-21db-47a2-a934-86e1e961bf65)|Describes how schedulers work and how the default schedulers may be configured.|  
 |[Lambda Expressions in PLINQ and TPL](../../../docs/standard/parallel-programming/lambda-expressions-in-plinq-and-tpl.md)|Provides a brief overview of lambda expressions in C# and Visual Basic, and shows how they are used in PLINQ and the Task Parallel Library.|  
-|[For Further Reading](../../../docs/standard/parallel-programming/for-further-reading-parallel-programming.md)|Provides links to additional documentation and sample resources for parallel programming in the .NET Framework.|  
-  
-## See Also  
- [Patterns for Parallel Programming: Understanding and Applying Parallel Patterns with the .NET Framework 4](https://www.microsoft.com/download/details.aspx?id=19222)  
- [Samples for Parallel Programming with the .NET Framework](https://code.msdn.microsoft.com/Samples-for-Parallel-b4b76364)
+|[For Further Reading](../../../docs/standard/parallel-programming/for-further-reading-parallel-programming.md)|Provides links to additional information and sample resources for parallel programming in .NET.|  
+
+## See also  
+ [Async Overview](../async.md)  
+ [Managed Threading](../threading/index.md)  


### PR DESCRIPTION
Updated the [For Further Reading (Parallel Programming)](https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/for-further-reading-parallel-programming) page:
- Brought to the topic two links that refer to the documents that describe using of parallel patterns in .NET.
- Moved the Parallel Computing Developer Center link to the **See Also** section as its .NET-related links bring back to docs.microsoft.com while other links still might be interesting.
- Removed link to the Parallel Extensions forum as this forum was retired two years ago

/cc: @stephentoub 