### PR TITLE
Improve link titles

### DIFF
--- a/docs/csharp/language-reference/keywords/volatile.md
+++ b/docs/csharp/language-reference/keywords/volatile.md
@@ -42,7 +42,7 @@ The `volatile` keyword indicates that a field might be modified by multiple thre
  [!code-csharp[csrefKeywordsModifiers#24](../../../csharp/language-reference/keywords/codesnippet/CSharp/volatile_1.cs)]  
   
 ## Example  
- The following example demonstrates how an auxiliary or worker thread can be created and used to perform processing in parallel with that of the primary thread. For background information about multithreading, see [Threading](../../../standard/threading/index.md) and [Threading](../../programming-guide/concepts/threading/index.md).  
+ The following example demonstrates how an auxiliary or worker thread can be created and used to perform processing in parallel with that of the primary thread. For background information about multithreading, see [Threading (C#)](../../../standard/threading/index.md) and [Managed Threading](../../programming-guide/concepts/threading/index.md).  
   
  [!code-csharp[csProgGuideThreading#1](../../../csharp/language-reference/keywords/codesnippet/CSharp/volatile_2.cs)]  
   


### PR DESCRIPTION
This page previously directed you to refer to "Threading or Threading".

I used the actual titles of the pages linked to to improve this.
