### PR TITLE
Programming guide, strings: updated Related Topics table

### DIFF
--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -120,12 +120,14 @@ string s = String.Empty;
 |-----------|-----------------|  
 |[How to: Modify String Contents](../../how-to/modify-string-contents.md)|Illustrates techniques to transform strings and modify the contents of strings.|  
 |[How to: Compare Strings](../../how-to/compare-strings.md)|Shows how to perform ordinal and culture specific comparisons of strings.|  
-|[How to: Parse Strings Using String.Split ](../../how-to/parse-strings-using-split.md)|Contains a code example that illustrates how to use the `String.Split` method to parse strings.|  
+|[How to: Concatenate Multiple Strings](../../how-to/concatenate-multiple-strings.md)|Demonstrates various ways to join multiple strings into one.|
+|[How to: Parse Strings Using String.Split ](../../how-to/parse-strings-using-split.md)|Contains code examples that illustrate how to use the `String.Split` method to parse strings.|  
 |[How to: Search Strings](../../how-to/search-strings.md)|Explains how to use search for specific text or patterns in strings.|  
 |[How to: Determine Whether a String Represents a Numeric Value](../../../csharp/programming-guide/strings/how-to-determine-whether-a-string-represents-a-numeric-value.md)|Shows how to safely parse a string to see whether it has a valid numeric value.|  
-|[How to: Convert a String to a DateTime](../../../csharp/programming-guide/strings/how-to-convert-a-string-to-a-datetime.md)|Shows how to convert a string such as "01/24/2008" to a <xref:System.DateTime?displayProperty=nameWithType> object.|  
+|[String interpolation](../../language-reference/tokens/interpolated.md)|Describes the string interpolation feature that provides a convenient syntax to format strings.|
 |[Basic String Operations](../../../../docs/standard/base-types/basic-string-operations.md)|Provides links to topics that use <xref:System.String?displayProperty=nameWithType> and <xref:System.Text.StringBuilder?displayProperty=nameWithType> methods to perform basic string operations.|  
-|[Parsing Strings](../../../../docs/standard/base-types/parsing-strings.md)|Describes how to insert characters or empty spaces into a string.|  
+|[Parsing Strings](../../../standard/base-types/parsing-strings.md)|Describes how to convert string representations of .NET base types to instances of the corresponding types.|  
+|[Parsing Date and Time Strings in .NET](../../../standard/base-types/parsing-datetime.md)|Shows how to convert a string such as "01/24/2008" to a <xref:System.DateTime?displayProperty=nameWithType> object.|  
 |[Comparing Strings](../../../../docs/standard/base-types/comparing.md)|Includes information about how to compare strings and provides examples in C# and Visual Basic.|  
 |[Using the StringBuilder Class](../../../standard/base-types/stringbuilder.md)|Describes how to create and modify dynamic string objects by using the <xref:System.Text.StringBuilder> class.|  
 |[LINQ and Strings](../../../csharp/programming-guide/concepts/linq/linq-and-strings.md)|Provides information about how to perform various string operations by using LINQ queries.|  


### PR DESCRIPTION
C# Programming Guide, strings topic, [Related Topics table](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/strings/index#related-topics):
- missed link to the how-to on concatenation
- missed link to the string interpolation topic that looks like a fit to this table
- description of *Parsing Strings* was not correct
- *How to: Convert a String to a DateTime* topic redirects to the sub-topic of *Parsing Strings* (so, I've just renamed entry and updated the relative path)
