### PR TITLE
Use using statement instead of Close()

### DIFF
--- a/docs/framework/network-programming/how-to-upload-files-with-ftp.md
+++ b/docs/framework/network-programming/how-to-upload-files-with-ftp.md
@@ -24,27 +24,30 @@ namespace Examples.System.Net
         public static void Main ()  
         {  
             // Get the object used to communicate with the server.  
-            FtpWebRequest request = (FtpWebRequest)WebRequest.Create("ftp://www.contoso.com/test.htm");  
-            request.Method = WebRequestMethods.Ftp.UploadFile;  
-  
+            FtpWebRequest request = (FtpWebRequest)WebRequest.Create("ftp://www.contoso.com/test.htm");
+            request.Method = WebRequestMethods.Ftp.UploadFile;
+
             // This example assumes the FTP site uses anonymous logon.  
-            request.Credentials = new NetworkCredential ("anonymous","janeDoe@contoso.com");  
-  
+            request.Credentials = new NetworkCredential("anonymous", "janeDoe@contoso.com");
+
             // Copy the contents of the file to the request stream.  
-            StreamReader sourceStream = new StreamReader("testfile.txt");  
-            byte [] fileContents = Encoding.UTF8.GetBytes(sourceStream.ReadToEnd());  
-            sourceStream.Close();  
-            request.ContentLength = fileContents.Length;  
-  
-            Stream requestStream = request.GetRequestStream();  
-            requestStream.Write(fileContents, 0, fileContents.Length);  
-            requestStream.Close();  
-  
-            FtpWebResponse response = (FtpWebResponse)request.GetResponse();  
-  
-            Console.WriteLine("Upload File Complete, status {0}", response.StatusDescription);  
-  
-            response.Close();  
+            byte[] fileContents;
+            using (StreamReader sourceStream = new StreamReader("testfile.txt"))
+            {
+                fileContents = Encoding.UTF8.GetBytes(sourceStream.ReadToEnd());
+            }
+            
+            request.ContentLength = fileContents.Length;
+
+            using (Stream requestStream = request.GetRequestStream())
+            {
+                requestStream.Write(fileContents, 0, fileContents.Length);
+            }
+
+            using (FtpWebResponse response = (FtpWebResponse)request.GetResponse())
+            {
+                Console.WriteLine("Upload File Complete, status {0}", response.StatusDescription);
+            }
         }  
     }  
 }  


### PR DESCRIPTION
Using using statement is better practice than calling Close() explicitely on resources.
## Summary
It is better practice for begginers to learn using "using" statement.

