### PR TITLE
Csharp 73 autoproperty field attributes

### DIFF
--- a/docs/csharp/programming-guide/concepts/attributes/attributeusage.md
+++ b/docs/csharp/programming-guide/concepts/attributes/attributeusage.md
@@ -1,141 +1,65 @@
 ---
 title: "AttributeUsage (C#)"
-ms.date: 07/20/2015
-ms.assetid: 22c45568-9a6a-4c2f-8480-f38c1caa0a99
+ms.date: 04/25/2018
 ---
 # AttributeUsage (C#)
-Determines how a custom attribute class can be used. `AttributeUsage` is an attribute that can be applied to custom attribute definitions to control how the new attribute can be applied. The default settings look like this when applied explicitly:  
-  
-```csharp  
-[System.AttributeUsage(System.AttributeTargets.All,  
-                   AllowMultiple = false,  
-                   Inherited = true)]  
-class NewAttribute : System.Attribute { }  
-```  
-  
- In this example, the `NewAttribute` class can be applied to any attribute-able code entity, but can be applied only once to each entity. It is inherited by derived classes when applied to a base class.  
-  
- The `AllowMultiple` and `Inherited` arguments are optional, so this code has the same effect:  
-  
-```csharp  
-[System.AttributeUsage(System.AttributeTargets.All)]  
-class NewAttribute : System.Attribute { }  
-```  
-  
- The first `AttributeUsage` argument must be one or more elements of the <xref:System.AttributeTargets> enumeration. Multiple target types can be linked together with the OR operator, like this:  
-  
-```csharp  
-using System;  
 
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]  
-class NewPropertyOrFieldAttribute : Attribute { }  
-```  
-  
- If the `AllowMultiple` argument is set to `true`, then the resulting attribute can be applied more than once to a single entity, like this:  
-  
-```csharp  
-using System;  
+Determines how a custom attribute class can be used. `AttributeUsage` is an attribute that can be applied to custom attribute definitions to control how the new attribute can be applied. The default settings look like this when applied explicitly:
 
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]  
-class MultiUseAttr : Attribute { }  
-  
-[MultiUseAttr]  
-[MultiUseAttr]  
-class Class1 { }  
-  
-[MultiUseAttr, MultiUseAttr]  
-class Class2 { }  
-```  
-  
- In this case `MultiUseAttr` can be applied repeatedly because `AllowMultiple` is set to `true`. Both formats shown for applying multiple attributes are valid.  
-  
- If `Inherited` is set to `false`, then the attribute is not inherited by classes that are derived from a class that is attributed. For example:  
-  
-```csharp  
-using System;  
+[!code-csharp[Define a new attribute](../../../../../samples/snippets/csharp/properties/NewAttribute.cs#1)]
 
-[AttributeUsage(AttributeTargets.Class, Inherited = false)]  
-class Attr1 : Attribute { }  
-  
-[Attr1]  
-class BClass { }  
-  
-class DClass : BClass { }  
-```  
-  
- In this case `Attr1` is not applied to `DClass` via inheritance.  
-  
-## Remarks  
- The `AttributeUsage` attribute is a single-use attribute--it cannot be applied more than once to the same class. `AttributeUsage` is an alias for <xref:System.AttributeUsageAttribute>.  
-  
- For more information, see [Accessing Attributes by Using Reflection (C#)](../../../../csharp/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md).  
-  
-## Example  
- The following example demonstrates the effect of the `Inherited` and `AllowMultiple` arguments to the `AttributeUsage` attribute, and how the custom attributes applied to a class can be enumerated.  
-  
-```csharp  
-using System;  
+In this example, the `NewAttribute` class can be applied to any attribute-able code entity, but can be applied only once to each entity. It is inherited by derived classes when applied to a base class.
 
-// Create some custom attributes:  
-[AttributeUsage(System.AttributeTargets.Class, Inherited = false)]  
-class A1 : System.Attribute { }  
-  
-[AttributeUsage(System.AttributeTargets.Class)]  
-class A2 : System.Attribute { }  
-  
-[AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]  
-class A3 : System.Attribute { }  
-  
-// Apply custom attributes to classes:  
-[A1, A2]  
-class BaseClass { }  
-  
-[A3, A3]  
-class DerivedClass : BaseClass { }  
-  
-public class TestAttributeUsage  
-{  
-    static void Main()  
-    {  
-        BaseClass b = new BaseClass();  
-        DerivedClass d = new DerivedClass();  
-  
-        // Display custom attributes for each class.  
-        Console.WriteLine("Attributes on Base Class:");  
-        object[] attrs = b.GetType().GetCustomAttributes(true);  
-        foreach (Attribute attr in attrs)  
-        {  
-            Console.WriteLine(attr);  
-        }  
-  
-        Console.WriteLine("Attributes on Derived Class:");  
-        attrs = d.GetType().GetCustomAttributes(true);  
-        foreach (Attribute attr in attrs)  
-        {  
-            Console.WriteLine(attr);  
-        }  
-    }  
-}  
-```  
-  
-## Sample Output  
-  
-```  
-Attributes on Base Class:  
-A1  
-A2  
-Attributes on Derived Class:  
-A3  
-A3  
-A2  
-```  
-  
-## See Also  
+The `AllowMultiple` and `Inherited` arguments are optional, so this code has the same effect:
+
+[!code-csharp[Omit optional attributes](../../../../../samples/snippets/csharp/properties/NewAttribute.cs#2)]
+
+The first `AttributeUsage` argument must be one or more elements of the <xref:System.AttributeTargets> enumeration. Multiple target types can be linked together with the OR operator, like this:
+
+[!code-csharp[Create an attribute for fields or properties](../../../../../samples/snippets/csharp/properties/NewPropertyOrFieldAttribute.cs#1)]
+
+If the `AllowMultiple` argument is set to `true`, then the resulting attribute can be applied more than once to a single entity, like this:
+
+[!code-csharp[Create and use an attribute that can be applied multiple times](../../../../../samples/snippets/csharp/properties/MultiUseAttribute.cs#1)]
+
+In this case `MultiUseAttribute` can be applied repeatedly because `AllowMultiple` is set to `true`. Both formats shown for applying multiple attributes are valid.
+
+If `Inherited` is set to `false`, then the attribute is not inherited by classes that are derived from a class that is attributed. For example:
+
+[!code-csharp[Create and use an attribute that can be applied multiple times](../../../../../samples/snippets/csharp/properties/NonInheritedAttribute.cs#1)]
+
+In this case `NonInheritedAttribute` is not applied to `DClass` via inheritance.
+
+## Remarks
+
+The `AttributeUsage` attribute is a single-use attribute--it cannot be applied more than once to the same class. `AttributeUsage` is an alias for <xref:System.AttributeUsageAttribute>.
+
+For more information, see [Accessing Attributes by Using Reflection (C#)](accessing-attributes-by-using-reflection.md).
+
+## Example
+
+The following example demonstrates the effect of the `Inherited` and `AllowMultiple` arguments to the `AttributeUsage` attribute, and how the custom attributes applied to a class can be enumerated.
+
+[!code-csharp[applying and querying attributes](../../../../../samples/snippets/csharp/properties/Program.cs#1)]
+
+## Sample Output
+
+```text
+Attributes on Base Class:
+FirstAttribute
+SecondAttribute
+Attributes on Derived Class:
+ThirdAttribute
+ThirdAttribute
+SecondAttribute
+```
+
+## See Also
  <xref:System.Attribute>  
  <xref:System.Reflection>  
- [C# Programming Guide](../../../../csharp/programming-guide/index.md)  
- [Attributes](../../../../../docs/standard/attributes/index.md)  
- [Reflection (C#)](../../../../csharp/programming-guide/concepts/reflection.md)  
- [Attributes](../../../../csharp/programming-guide/concepts/attributes/index.md)  
- [Creating Custom Attributes (C#)](../../../../csharp/programming-guide/concepts/attributes/creating-custom-attributes.md)  
- [Accessing Attributes by Using Reflection (C#)](../../../../csharp/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md)
+ [C# Programming Guide](../..//index.md)  
+ [Attributes](../../../..//standard/attributes/index.md)  
+ [Reflection (C#)](../reflection.md)  
+ [Attributes](index.md)  
+ [Creating Custom Attributes (C#)](creating-custom-attributes.md)  
+ [Accessing Attributes by Using Reflection (C#)](accessing-attributes-by-using-reflection.md)

--- a/docs/csharp/programming-guide/concepts/attributes/attributeusage.md
+++ b/docs/csharp/programming-guide/concepts/attributes/attributeusage.md
@@ -4,11 +4,26 @@ ms.date: 04/25/2018
 ---
 # AttributeUsage (C#)
 
-Determines how a custom attribute class can be used. <xref:System.AttributeUsageAttribute> is an attribute you apply to custom attribute definitions. It controls how the new attribute can be applied. The default settings look like the following example when applied explicitly:
+Determines how a custom attribute class can be used. <xref:System.AttributeUsageAttribute> is an attribute you apply to custom attribute definitions. The `AttributeUsage` attribute enables you to control:
+
+- Which program elements attribute may be applied to. Unless you restrict is usage, an attribute may be applied to any of the following program elements:
+  - assembly
+  - module
+  - field
+  - event
+  - method
+  - param
+  - property
+  - return
+  - type
+- Whether an attribute can be applied to a single program element multiple times.
+- Whether attributes are inherited by derived classes.
+
+The default settings look like the following example when applied explicitly:
 
 [!code-csharp[Define a new attribute](../../../../../samples/snippets/csharp/attributes/NewAttribute.cs#1)]
 
-In this example, the `NewAttribute` class can be applied to any attribute-able code entity. But it can be applied only once to each entity. The attribute is inherited by derived classes when applied to a base class.
+In this example, the `NewAttribute` class can be applied to any supported program element. But it can be applied only once to each entity. The attribute is inherited by derived classes when applied to a base class.
 
 The <xref:System.AttributeUsageAttribute.AllowMultiple> and <xref:System.AttributeUsageAttribute.Inherited> arguments are optional, so the following code has the same effect:
 

--- a/docs/csharp/programming-guide/concepts/attributes/attributeusage.md
+++ b/docs/csharp/programming-guide/concepts/attributes/attributeusage.md
@@ -4,43 +4,47 @@ ms.date: 04/25/2018
 ---
 # AttributeUsage (C#)
 
-Determines how a custom attribute class can be used. `AttributeUsage` is an attribute that can be applied to custom attribute definitions to control how the new attribute can be applied. The default settings look like this when applied explicitly:
+Determines how a custom attribute class can be used. <xref:System.AttributeUsageAttribute> is an attribute you apply to custom attribute definitions. It controls how the new attribute can be applied. The default settings look like the following example when applied explicitly:
 
-[!code-csharp[Define a new attribute](../../../../../samples/snippets/csharp/properties/NewAttribute.cs#1)]
+[!code-csharp[Define a new attribute](../../../../../samples/snippets/csharp/attributes/NewAttribute.cs#1)]
 
-In this example, the `NewAttribute` class can be applied to any attribute-able code entity, but can be applied only once to each entity. It is inherited by derived classes when applied to a base class.
+In this example, the `NewAttribute` class can be applied to any attribute-able code entity. But it can be applied only once to each entity. The attribute is inherited by derived classes when applied to a base class.
 
-The `AllowMultiple` and `Inherited` arguments are optional, so this code has the same effect:
+The <xref:System.AttributeUsageAttribute.AllowMultiple> and <xref:System.AttributeUsageAttribute.Inherited> arguments are optional, so the following code has the same effect:
 
-[!code-csharp[Omit optional attributes](../../../../../samples/snippets/csharp/properties/NewAttribute.cs#2)]
+[!code-csharp[Omit optional attributes](../../../../../samples/snippets/csharp/attributes/NewAttribute.cs#2)]
 
-The first `AttributeUsage` argument must be one or more elements of the <xref:System.AttributeTargets> enumeration. Multiple target types can be linked together with the OR operator, like this:
+The first <xref:System.AttributeUsageAttribute> argument must be one or more elements of the <xref:System.AttributeTargets> enumeration. Multiple target types can be linked together with the OR operator, like the following example shows:
 
-[!code-csharp[Create an attribute for fields or properties](../../../../../samples/snippets/csharp/properties/NewPropertyOrFieldAttribute.cs#1)]
+[!code-csharp[Create an attribute for fields or properties](../../../../../samples/snippets/csharp/attributes/NewPropertyOrFieldAttribute.cs#1)]
 
-If the `AllowMultiple` argument is set to `true`, then the resulting attribute can be applied more than once to a single entity, like this:
+Beginning in C# 7.3, attributes can be applied to either the property or the backing field for an auto-implemented property. The attribute applies to the property, unless you specify the `field` specifier on the attribute. Both are shown in the following example:
 
-[!code-csharp[Create and use an attribute that can be applied multiple times](../../../../../samples/snippets/csharp/properties/MultiUseAttribute.cs#1)]
+[!code-csharp[Create an attribute for fields or properties](../../../../../samples/snippets/csharp/attributes/NewPropertyOrFieldAttribute.cs#2)]
 
-In this case `MultiUseAttribute` can be applied repeatedly because `AllowMultiple` is set to `true`. Both formats shown for applying multiple attributes are valid.
+If the <xref:System.AttributeUsageAttribute.AllowMultiple> argument is `true`, then the resulting attribute can be applied more than once to a single entity, as shown in the following example:
 
-If `Inherited` is set to `false`, then the attribute is not inherited by classes that are derived from a class that is attributed. For example:
+[!code-csharp[Create and use an attribute that can be applied multiple times](../../../../../samples/snippets/csharp/attributes/MultiUseAttribute.cs#1)]
 
-[!code-csharp[Create and use an attribute that can be applied multiple times](../../../../../samples/snippets/csharp/properties/NonInheritedAttribute.cs#1)]
+In this case, `MultiUseAttribute` can be applied repeatedly because `AllowMultiple` is set to `true`. Both formats shown for applying multiple attributes are valid.
 
-In this case `NonInheritedAttribute` is not applied to `DClass` via inheritance.
+If <xref:System.AttributeUsageAttribute.Inherited> is `false`, then the attribute isn't inherited by classes derived from an attributed class. For example:
+
+[!code-csharp[Create and use an attribute that can be applied multiple times](../../../../../samples/snippets/csharp/attributes/NonInheritedAttribute.cs#1)]
+
+In this case `NonInheritedAttribute` isn't applied to `DClass` via inheritance.
 
 ## Remarks
 
-The `AttributeUsage` attribute is a single-use attribute--it cannot be applied more than once to the same class. `AttributeUsage` is an alias for <xref:System.AttributeUsageAttribute>.
+The `AttributeUsage` attribute is a single-use attribute--it can't be applied more than once to the same class. `AttributeUsage` is an alias for <xref:System.AttributeUsageAttribute>.
 
 For more information, see [Accessing Attributes by Using Reflection (C#)](accessing-attributes-by-using-reflection.md).
 
 ## Example
 
-The following example demonstrates the effect of the `Inherited` and `AllowMultiple` arguments to the `AttributeUsage` attribute, and how the custom attributes applied to a class can be enumerated.
+The following example demonstrates the effect of the <xref:System.AttributeUsageAttribute.Inherited> and <xref:System.AttributeUsageAttribute.AllowMultiple> arguments to the <xref:System.AttributeUsageAttribute> attribute, and how the custom attributes applied to a class can be enumerated.
 
-[!code-csharp[applying and querying attributes](../../../../../samples/snippets/csharp/properties/Program.cs#1)]
+[!code-csharp[Applying and querying attributes](../../../../../samples/snippets/csharp/attributes/Program.cs#1)]
 
 ## Sample Output
 

--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -1,171 +1,124 @@
 ---
 title: "Attributes (C#)"
-ms.date: 07/20/2015
-ms.assetid: f148f13f-a0d5-4f22-9c87-4b73d5dde270
+ms.date: 04/26/2018
 ---
 # Attributes (C#)
-Attributes provide a powerful method of associating metadata, or declarative information, with code (assemblies, types, methods, properties, and so forth). After an attribute is associated with a program entity, the attribute can be queried at run time by using a technique called *reflection*. For more information, see [Reflection (C#)](../../../../csharp/programming-guide/concepts/reflection.md).  
-  
- Attributes have the following properties:  
-  
--   Attributes add metadata to your program. *Metadata* is information about the types defined in a program. All .NET assemblies contain a specified set of metadata that describes the types and type members defined in the assembly. You can add custom attributes to specify any additional information that is required. For more information, see, [Creating Custom Attributes (C#)](../../../../csharp/programming-guide/concepts/attributes/creating-custom-attributes.md).  
-  
--   You can apply one or more attributes to entire assemblies, modules, or smaller program elements such as classes and properties.  
-  
--   Attributes can accept arguments in the same way as methods and properties.  
-  
--   Your program can examine its own metadata or the metadata in other programs by using reflection. For more information, see [Accessing Attributes by Using Reflection (C#)](../../../../csharp/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md).  
-  
-## Using Attributes  
- Attributes can be placed on most any declaration, though a specific attribute might restrict the types of declarations on which it is valid. In C#, you specify an attribute by placing the name of the attribute, enclosed in square brackets ([]), above the declaration of the entity to which it applies.  
-  
- In this example, the <xref:System.SerializableAttribute> attribute is used to apply a specific characteristic to a class:  
-  
-```csharp  
-[System.Serializable]  
-public class SampleClass  
-{  
-    // Objects of this type can be serialized.  
-}  
-```  
-  
- A method with the attribute <xref:System.Runtime.InteropServices.DllImportAttribute> is declared like this:  
-  
-```csharp  
-using System.Runtime.InteropServices;  
-```  
-  
-```csharp  
-[System.Runtime.InteropServices.DllImport("user32.dll")]  
-extern static void SampleMethod();  
-```  
-  
- More than one attribute can be placed on a declaration:  
-  
-```csharp  
-using System.Runtime.InteropServices;  
-```  
-  
-```csharp  
-void MethodA([In][Out] ref double x) { }  
-void MethodB([Out][In] ref double x) { }  
-void MethodC([In, Out] ref double x) { }  
-```  
-  
- Some attributes can be specified more than once for a given entity. An example of such a multiuse attribute is <xref:System.Diagnostics.ConditionalAttribute>:  
-  
-```csharp  
-[Conditional("DEBUG"), Conditional("TEST1")]  
-void TraceMethod()  
-{  
-    // ...  
-}  
-```  
-  
+
+Attributes provide a powerful method of associating metadata, or declarative information, with code (assemblies, types, methods, properties, and so forth). After an attribute is associated with a program entity, the attribute can be queried at run time by using a technique called *reflection*. For more information, see [Reflection (C#)](../reflection.md).
+
+Attributes have the following properties:
+
+- Attributes add metadata to your program. *Metadata* is information about the types defined in a program. All .NET assemblies contain a specified set of metadata that describes the types and type members defined in the assembly. You can add custom attributes to specify any additional information that is required. For more information, see, [Creating Custom Attributes (C#)](creating-custom-attributes.md).
+- You can apply one or more attributes to entire assemblies, modules, or smaller program elements such as classes and properties.
+- Attributes can accept arguments in the same way as methods and properties.
+- Your program can examine its own metadata or the metadata in other programs by using reflection. For more information, see [Accessing Attributes by Using Reflection (C#)](accessing-attributes-by-using-reflection.md).
+
+## Using attributes
+
+Attributes can be placed on most any declaration, though a specific attribute might restrict the types of declarations on which it is valid. In C#, you specify an attribute by placing the name of the attribute, enclosed in square brackets ([]), above the declaration of the entity to which it applies.
+
+In this example, the <xref:System.SerializableAttribute> attribute is used to apply a specific characteristic to a class:
+
+[!code-csharp[Using the serializable attribute](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#1)]
+
+A method with the attribute <xref:System.Runtime.InteropServices.DllImportAttribute> is declared like the following example:
+
+[!code-csharp[Declaring a method to import from an external library](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#2)]
+
+More than one attribute can be placed on a declaration as the following example shows:
+
+[!code-csharp[Including the interop namespace](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#3)]
+[!code-csharp[Declaring two way marshaling for arguments](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#4)]
+
+Some attributes can be specified more than once for a given entity. An example of such a multiuse attribute is <xref:System.Diagnostics.ConditionalAttribute>:
+
+[!code-csharp[Using the conditional attribute](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#5)]
+
 > [!NOTE]
->  By convention, all attribute names end with the word "Attribute" to distinguish them from other items in the .NET Framework. However, you do not need to specify the attribute suffix when using attributes in code. For example, `[DllImport]` is equivalent to `[DllImportAttribute]`, but `DllImportAttribute` is the attribute's actual name in the .NET Framework.  
-  
-### Attribute Parameters  
- Many attributes have parameters, which can be positional, unnamed, or named. Any positional parameters must be specified in a certain order and cannot be omitted; named parameters are optional and can be specified in any order. Positional parameters are specified first. For example, these three attributes are equivalent:  
-  
-```csharp  
-[DllImport("user32.dll")]  
-[DllImport("user32.dll", SetLastError=false, ExactSpelling=false)]  
-[DllImport("user32.dll", ExactSpelling=false, SetLastError=false)]  
-```  
-  
- The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Refer to the individual attribute's documentation for information on default parameter values.  
-  
-### Attribute Targets  
- The *target* of an attribute is the entity to which the attribute applies. For example, an attribute may apply to a class, a particular method, or an entire assembly. By default, an attribute applies to the element that it precedes. But you can also explicitly identify, for example, whether an attribute is applied to a method, or to its parameter, or to its return value.  
-  
- To explicitly identify an attribute target, use the following syntax:  
-  
-```csharp  
-[target : attribute-list]  
-```  
-  
- The list of possible `target` values is shown in the following table.  
-  
-|Target value|Applies to|  
-|------------------|----------------|  
-|`assembly`|Entire assembly|  
-|`module`|Current assembly module|  
-|`field`|Field in a class or a struct|  
-|`event`|Event|  
-|`method`|Method or `get` and `set` property accessors|  
-|`param`|Method parameters or `set` property accessor parameters|  
-|`property`|Property|  
-|`return`|Return value of a method, property indexer, or `get` property accessor|  
-|`type`|Struct, class, interface, enum, or delegate|  
-  
- The following example shows how to apply attributes to assemblies and modules. For more information, see [Common Attributes (C#)](../../../../csharp/programming-guide/concepts/attributes/common-attributes.md).  
-  
-```csharp  
-using System;  
-using System.Reflection;  
-[assembly: AssemblyTitleAttribute("Production assembly 4")]  
-[module: CLSCompliant(true)]  
-```  
-  
- The following example shows how to apply attributes to methods, method parameters, and method return values in C#.  
-  
-```csharp  
-// default: applies to method  
-[SomeAttr]  
-int Method1() { return 0; }  
-  
-// applies to method  
-[method: SomeAttr]  
-int Method2() { return 0; }  
-  
-// applies to return value  
-[return: SomeAttr]  
-int Method3() { return 0; }  
-```  
-  
+> By convention, all attribute names end with the word "Attribute" to distinguish them from other items in the .NET Framework. However, you do not need to specify the attribute suffix when using attributes in code. For example, `[DllImport]` is equivalent to `[DllImportAttribute]`, but `DllImportAttribute` is the attribute's actual name in the .NET Framework.
+
+### Attribute parameters
+
+Many attributes have parameters, which can be positional, unnamed, or named. Any positional parameters must be specified in a certain order and cannot be omitted. Named parameters are optional and can be specified in any order. Positional parameters are specified first. For example, these three attributes are equivalent:
+
+```csharp
+[DllImport("user32.dll")]
+[DllImport("user32.dll", SetLastError=false, ExactSpelling=false)]
+[DllImport("user32.dll", ExactSpelling=false, SetLastError=false)]
+```
+
+The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Refer to the individual attribute's documentation for information on default parameter values.
+
+### Attribute targets
+
+The *target* of an attribute is the entity to which the attribute applies. For example, an attribute may apply to a class, a particular method, or an entire assembly. By default, an attribute applies to the element that it precedes. But you can also explicitly identify, for example, whether an attribute is applied to a method, or to its parameter, or to its return value.
+
+To explicitly identify an attribute target, use the following syntax:
+
+```csharp
+[target : attribute-list]
+```
+
+The list of possible `target` values is shown in the following table.
+
+|Target value|Applies to|
+|------------------|----------------|
+|`assembly`|Entire assembly|
+|`module`|Current assembly module|
+|`field`|Field in a class or a struct|
+|`event`|Event|
+|`method`|Method or `get` and `set` property accessors|
+|`param`|Method parameters or `set` property accessor parameters|
+|`property`|Property|
+|`return`|Return value of a method, property indexer, or `get` property accessor|
+|`type`|Struct, class, interface, enum, or delegate|
+
+You would specify the `field` target value to apply an attribute to the backing field created for an [auto-implemented property](../../../properties.md).
+
+The following example shows how to apply attributes to assemblies and modules. For more information, see [Common Attributes (C#)](common-attributes.md).
+
+```csharp
+using System;
+using System.Reflection;
+[assembly: AssemblyTitleAttribute("Production assembly 4")]
+[module: CLSCompliant(true)]
+```
+
+The following example shows how to apply attributes to methods, method parameters, and method return values in C#.
+
+[!code-csharp[Applying attributes to different code elements](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#6)]
+
 > [!NOTE]
->  Regardless of the targets on which `SomeAttr` is defined to be valid, the `return` target has to be specified, even if `SomeAttr` were defined to apply only to return values. In other words, the compiler will not use `AttributeUsage` information to resolve ambiguous attribute targets. For more information, see [AttributeUsage (C#)](../../../../csharp/programming-guide/concepts/attributes/attributeusage.md).  
-  
-## Common Uses for Attributes  
- The following list includes a few of the common uses of attributes in code:  
-  
--   Marking methods using the `WebMethod` attribute in Web services to indicate that the method should be callable over the SOAP protocol. For more information, see <xref:System.Web.Services.WebMethodAttribute>.  
-  
--   Describing how to marshal method parameters when interoperating with native code. For more information, see <xref:System.Runtime.InteropServices.MarshalAsAttribute>.  
-  
--   Describing the COM properties for classes, methods, and interfaces.  
-  
--   Calling unmanaged code using the <xref:System.Runtime.InteropServices.DllImportAttribute> class.  
-  
--   Describing your assembly in terms of title, version, description, or trademark.  
-  
--   Describing which members of a class to serialize for persistence.  
-  
--   Describing how to map between class members and XML nodes for XML serialization.  
-  
--   Describing the security requirements for methods.  
-  
--   Specifying characteristics used to enforce security.  
-  
--   Controlling optimizations by the just-in-time (JIT) compiler so the code remains easy to debug.  
-  
--   Obtaining information about the caller to a method.  
-  
-## Related Sections  
- For more information, see:  
-  
--   [Creating Custom Attributes (C#)](../../../../csharp/programming-guide/concepts/attributes/creating-custom-attributes.md)  
-  
--   [Accessing Attributes by Using Reflection (C#)](../../../../csharp/programming-guide/concepts/attributes/accessing-attributes-by-using-reflection.md)  
-  
--   [How to: Create a C/C++ Union by Using Attributes (C#)](../../../../csharp/programming-guide/concepts/attributes/how-to-create-a-c-cpp-union-by-using-attributes.md)  
-  
--   [Common Attributes (C#)](../../../../csharp/programming-guide/concepts/attributes/common-attributes.md)  
-  
--   [Caller Information (C#)](../../../../csharp/programming-guide/concepts/caller-information.md)  
-  
-## See Also  
- [C# Programming Guide](../../../../csharp/programming-guide/index.md)  
- [Reflection (C#)](../../../../csharp/programming-guide/concepts/reflection.md)  
- [Attributes](../../../../../docs/standard/attributes/index.md)
+> Regardless of the targets on which `ValidatedContract` is defined to be valid, the `return` target has to be specified, even if `ValidatedContract` were defined to apply only to return values. In other words, the compiler will not use `AttributeUsage` information to resolve ambiguous attribute targets. For more information, see [AttributeUsage (C#)](attributeusage.md).
+
+## Common uses for attributes
+
+The following list includes a few of the common uses of attributes in code:
+
+- Marking methods using the `WebMethod` attribute in Web services to indicate that the method should be callable over the SOAP protocol. For more information, see <xref:System.Web.Services.WebMethodAttribute>.
+- Describing how to marshal method parameters when interoperating with native code. For more information, see <xref:System.Runtime.InteropServices.MarshalAsAttribute>.
+- Describing the COM properties for classes, methods, and interfaces.
+- Calling unmanaged code using the <xref:System.Runtime.InteropServices.DllImportAttribute> class.
+- Describing your assembly in terms of title, version, description, or trademark.
+- Describing which members of a class to serialize for persistence.
+- Describing how to map between class members and XML nodes for XML serialization.
+- Describing the security requirements for methods.
+- Specifying characteristics used to enforce security.
+- Controlling optimizations by the just-in-time (JIT) compiler so the code remains easy to debug.
+- Obtaining information about the caller to a method.
+
+## Related sections
+
+For more information, see:
+
+- [Creating Custom Attributes (C#)](creating-custom-attributes.md)  
+- [Accessing Attributes by Using Reflection (C#)](accessing-attributes-by-using-reflection.md)  
+- [How to: Create a C/C++ Union by Using Attributes (C#)](how-to-create-a-c-cpp-union-by-using-attributes.md)  
+- [Common Attributes (C#)](common-attributes.md)  
+- [Caller Information (C#)](caller-information.md)  
+
+## See also
+
+ [C# Programming Guide](../../index.md)  
+ [Reflection (C#)](../reflection.md)  
+ [Attributes](../../../../standard/attributes/index.md)

--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -115,7 +115,7 @@ For more information, see:
 - [Accessing Attributes by Using Reflection (C#)](accessing-attributes-by-using-reflection.md)  
 - [How to: Create a C/C++ Union by Using Attributes (C#)](how-to-create-a-c-cpp-union-by-using-attributes.md)  
 - [Common Attributes (C#)](common-attributes.md)  
-- [Caller Information (C#)](caller-information.md)  
+- [Caller Information (C#)](../caller-information.md)  
 
 ## See also
 

--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -15,7 +15,7 @@ Attributes have the following properties:
 
 ## Using attributes
 
-Attributes can be placed on most any declaration, though a specific attribute might restrict the types of declarations on which it is valid. In C#, you specify an attribute by placing the name of the attribute, enclosed in square brackets ([]), above the declaration of the entity to which it applies.
+Attributes can be placed on most any declaration, though a specific attribute might restrict the types of declarations on which it is valid. In C#, you specify an attribute by placing the name of the attribute enclosed in square brackets ([]) above the declaration of the entity to which it applies.
 
 In this example, the <xref:System.SerializableAttribute> attribute is used to apply a specific characteristic to a class:
 
@@ -35,7 +35,7 @@ Some attributes can be specified more than once for a given entity. An example o
 [!code-csharp[Using the conditional attribute](../../../../../samples/snippets/csharp/attributes/AttributesOverview.cs#5)]
 
 > [!NOTE]
-> By convention, all attribute names end with the word "Attribute" to distinguish them from other items in the .NET Framework. However, you do not need to specify the attribute suffix when using attributes in code. For example, `[DllImport]` is equivalent to `[DllImportAttribute]`, but `DllImportAttribute` is the attribute's actual name in the .NET Framework.
+> By convention, all attribute names end with the word "Attribute" to distinguish them from other items in the .NET libraries. However, you do not need to specify the attribute suffix when using attributes in code. For example, `[DllImport]` is equivalent to `[DllImportAttribute]`, but `DllImportAttribute` is the attribute's actual name in the .NET Framework Class Library.
 
 ### Attribute parameters
 
@@ -47,7 +47,7 @@ Many attributes have parameters, which can be positional, unnamed, or named. Any
 [DllImport("user32.dll", ExactSpelling=false, SetLastError=false)]
 ```
 
-The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Refer to the individual attribute's documentation for information on default parameter values.
+The first parameter, the DLL name, is positional and always comes first; the others are named. In this case, both named parameters default to false, so they can be omitted. Positional parameters correspond to the parameters of the attribute constructor. Named or optional parameters correspond to either properties or fields of the attribute. Refer to the individual attribute's documentation for information on default parameter values.
 
 ### Attribute targets
 

--- a/docs/csharp/programming-guide/concepts/attributes/index.md
+++ b/docs/csharp/programming-guide/concepts/attributes/index.md
@@ -121,4 +121,5 @@ For more information, see:
 
  [C# Programming Guide](../../index.md)  
  [Reflection (C#)](../reflection.md)  
- [Attributes](../../../../standard/attributes/index.md)
+ [Attributes](../../../../standard/attributes/index.md)  
+ [Using Attributes in C#](../../../tutorials/attributes)

--- a/docs/csharp/programming-guide/concepts/serialization/index.md
+++ b/docs/csharp/programming-guide/concepts/serialization/index.md
@@ -1,63 +1,73 @@
 ---
 title: "Serialization (C# )"
-ms.date: 07/20/2015
-ms.assetid: 704ff2bf-02ab-4fea-94ea-594107825645
+ms.date: 04/26/2018
 ---
-# Serialization (C# )
-Serialization is the process of converting an object into a stream of bytes in order to store the object or transmit it to memory, a database, or a file. Its main purpose is to save the state of an object in order to be able to recreate it when needed. The reverse process is called deserialization.  
-  
-## How Serialization Works  
- This illustration shows the overall process of serialization.  
-  
- ![Serialization Graphic](../../../../csharp/programming-guide/concepts/serialization/media/serialization.gif "serialization")  
-  
- The object is serialized to a stream, which carries not just the data, but information about the object's type, such as its version, culture, and assembly name. From that stream, it can be stored in a database, a file, or memory.  
-  
-### Uses for Serialization  
- Serialization allows the developer to save the state of an object and recreate it as needed, providing storage of objects as well as data exchange. Through serialization, a developer can perform actions like sending the object to a remote application by means of a Web Service, passing an object from one domain to another, passing an object through a firewall as an XML string, or maintaining security or user-specific information across applications.  
-  
-### Making an Object Serializable  
- To serialize an object, you need the object to be serialized, a stream to contain the serialized object, and a <xref:System.Runtime.Serialization.Formatter>. <xref:System.Runtime.Serialization> contains the classes necessary for serializing and deserializing objects.  
-  
- Apply the <xref:System.SerializableAttribute> attribute to a type to indicate that instances of this type can be serialized. A <xref:System.Runtime.Serialization.SerializationException> exception is thrown if you attempt to serialize but the type does not have the <xref:System.SerializableAttribute> attribute.  
-  
- If you do not want a field within your class to be serializable, apply the <xref:System.NonSerializedAttribute> attribute. If a field of a serializable type contains a pointer, a handle, or some other data structure that is specific to a particular environment, and the field cannot be meaningfully reconstituted in a different environment, then you may want to make it nonserializable.  
-  
- If a serialized class contains references to objects of other classes that are marked <xref:System.SerializableAttribute>, those objects will also be serialized.  
-  
-## Binary and XML Serialization  
- Either binary or XML serialization can be used. In binary serialization, all members, even those that are read-only, are serialized, and performance is enhanced. XML serialization provides more readable code, as well as greater flexibility of object sharing and usage for interoperability purposes.  
-  
-### Binary Serialization  
- Binary serialization uses binary encoding to produce compact serialization for uses such as storage or socket-based network streams.  
-  
-### XML Serialization  
- XML serialization serializes the public fields and properties of an object, or the parameters and return values of methods, into an XML stream that conforms to a specific XML Schema definition language (XSD) document. XML serialization results in strongly typed classes with public properties and fields that are converted to XML. <xref:System.Xml.Serialization> contains the classes necessary for serializing and deserializing XML.  
-  
- You can apply attributes to classes and class members in order to control the way the <xref:System.Xml.Serialization.XmlSerializer> serializes or deserializes an instance of the class.  
-  
-## Basic and Custom Serialization  
- Serialization can be performed in two ways, basic and custom. Basic serialization uses the .NET Framework to automatically serialize the object.  
-  
-### Basic Serialization  
- The only requirement in basic serialization is that the object has the <xref:System.SerializableAttribute> attribute applied. The <xref:System.NonSerializedAttribute> can be used to keep specific fields from being serialized.  
-  
- When you use basic serialization, the versioning of objects may create problems, in which case custom serialization may be preferable. Basic serialization is the easiest way to perform serialization, but it does not provide much control over the process.  
-  
-### Custom Serialization  
- In custom serialization, you can specify exactly which objects will be serialized and how it will be done. The class must be marked <xref:System.SerializableAttribute> and implement the <xref:System.Runtime.Serialization.ISerializable> interface.  
-  
- If you want your object to be deserialized in a custom manner as well, you must use a custom constructor.  
-  
-## Designer Serialization  
- Designer serialization is a special form of serialization that involves the kind of object persistence usually associated with development tools. Designer serialization is the process of converting an object graph into a source file that can later be used to recover the object graph. A source file can contain code, markup, or even SQL table information.  
-  
+# Serialization (C#)
+
+Serialization is the process of converting an object into a stream of bytes to store the object or transmit it to memory, a database, or a file. Its main purpose is to save the state of an object in order to be able to recreate it when needed. The reverse process is called deserialization.
+
+## How serialization works
+
+This illustration shows the overall process of serialization.
+
+![Serialization Graphic](./media/serialization.gif "serialization")
+
+The object is serialized to a stream, which carries not just the data, but information about the object's type, such as its version, culture, and assembly name. From that stream, it can be stored in a database, a file, or memory.
+
+### Uses for serialization
+
+Serialization allows the developer to save the state of an object and recreate it as needed, providing storage of objects as well as data exchange. Through serialization, a developer can perform actions like sending the object to a remote application by means of a Web Service, passing an object from one domain to another, passing an object through a firewall as an XML string, or maintaining security or user-specific information across applications.
+
+### Making an object serializable
+
+To serialize an object, you need the object to be serialized, a stream to contain the serialized object, and a <xref:System.Runtime.Serialization.Formatter>. <xref:System.Runtime.Serialization> contains the classes necessary for serializing and deserializing objects.
+
+Apply the <xref:System.SerializableAttribute> attribute to a type to indicate that instances of this type can be serialized. An  exception is thrown if you attempt to serialize but the type doesn't have the <xref:System.SerializableAttribute> attribute.
+
+If you don't want a field within your class to be serializable, apply the <xref:System.NonSerializedAttribute> attribute. If a field of a serializable type contains a pointer, a handle, or some other data structure that is specific to a particular environment, and the field cannot be meaningfully reconstituted in a different environment, then you may want to make it nonserializable.
+
+If a serialized class contains references to objects of other classes that are marked <xref:System.SerializableAttribute>, those objects will also be serialized.
+
+## Binary and XML serialization
+
+You can use binary or XML serialization. In binary serialization, all members, even members that are read-only, are serialized, and performance is enhanced. XML serialization provides more readable code, and greater flexibility of object sharing and usage for interoperability purposes.
+
+### Binary serialization
+
+Binary serialization uses binary encoding to produce compact serialization for uses such as storage or socket-based network streams.
+
+### XML serialization
+
+XML serialization serializes the public fields and properties of an object, or the parameters and return values of methods, into an XML stream that conforms to a specific XML Schema definition language (XSD) document. XML serialization results in strongly typed classes with public properties and fields that are converted to XML. <xref:System.Xml.Serialization> contains the classes necessary for serializing and deserializing XML.
+
+You apply attributes to classes and class members to control the way the <xref:System.Xml.Serialization.XmlSerializer> serializes or deserializes an instance of the class.
+
+## Basic and custom serialization
+
+Serialization can be performed in two ways, basic and custom. Basic serialization uses the .NET Framework to automatically serialize the object.
+
+### Basic serialization
+
+The only requirement in basic serialization is that the object has the <xref:System.SerializableAttribute> attribute applied. The <xref:System.NonSerializedAttribute> can be used to keep specific fields from being serialized.
+
+When you use basic serialization, the versioning of objects may create problems. You would use custom serialization when versioning issues are important. Basic serialization is the easiest way to perform serialization, but it does not provide much control over the process.
+
+### Custom serialization
+
+In custom serialization, you can specify exactly which objects will be serialized and how it will be done. The class must be marked <xref:System.SerializableAttribute> and implement the <xref:System.Runtime.Serialization.ISerializable> interface.
+
+If you want your object to be deserialized in a custom manner as well, you must use a custom constructor.
+
+## Designer serialization
+
+Designer serialization is a special form of serialization that involves the kind of object persistence associated with development tools. Designer serialization is the process of converting an object graph into a source file that can later be used to recover the object graph. A source file can contain code, markup, or even SQL table information.
+
 ##  <a name="BKMK_RelatedTopics"></a> Related Topics and Examples  
- [Walkthrough: Persisting an Object in Visual Studio (C#)](../../../../csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md)  
- Demonstrates how serialization can be used to persist an object's data between instances, allowing you to store values and retrieve them the next time the object is instantiated.  
-  
- [How to: Read Object Data from an XML File (C#)](../../../../csharp/programming-guide/concepts/serialization/how-to-read-object-data-from-an-xml-file.md)  
- Shows how to read object data that was previously written to an XML file using the <xref:System.Xml.Serialization.XmlSerializer> class.  
-  
- [How to: Write Object Data to an XML File (C#)](../../../../csharp/programming-guide/concepts/serialization/how-to-write-object-data-to-an-xml-file.md)  
- Shows how to write the object from a class to an XML file using the <xref:System.Xml.Serialization.XmlSerializer> class.
+[Walkthrough: Persisting an Object in Visual Studio (C#)](walkthrough-persisting-an-object-in-visual-studio.md)  
+Demonstrates how serialization can be used to persist an object's data between instances, allowing you to store values and retrieve them the next time the object is instantiated.
+
+[How to: Read Object Data from an XML File (C#)](how-to-read-object-data-from-an-xml-file.md)  
+ Shows how to read object data that was previously written to an XML file using the <xref:System.Xml.Serialization.XmlSerializer> class.
+
+[How to: Write Object Data to an XML File (C#)](how-to-write-object-data-to-an-xml-file.md)  
+Shows how to write the object from a class to an XML file using the <xref:System.Xml.Serialization.XmlSerializer> class.

--- a/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
+++ b/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
@@ -1,211 +1,98 @@
 ---
-title: "Walkthrough: Persisting an Object in Visual Studio (C#)"
-ms.date: 07/20/2015
-ms.assetid: a544ce46-ee25-49da-afd4-457a3d59bf63
+title: "Walkthrough: Persisting an Object using C#"
+ms.date: 04/26/2018
 ---
-# Walkthrough: Persisting an Object in Visual Studio (C#)
-Although you can set an object's properties to default values at design time, any values entered at run time are lost when the object is destroyed. You can use serialization to persist an object's data between instances, which enables you to store values and retrieve them the next time that the object is instantiated.  
-  
- In this walkthrough, you will create a simple `Loan` object and persist its data to a file. You will then retrieve the data from the file when you re-create the object.  
-  
+# Walkthrough: persisting an object using C# #
+
+You can use serialization to persist an object's data between instances, which enables you to store values and retrieve them the next time that the object is instantiated.
+
+In this walkthrough, you will create a basic `Loan` object and persist its data to a file. You will then retrieve the data from the file when you re-create the object.
+
 > [!IMPORTANT]
->  This example creates a new file if the file does not already exist. If an application must create a file, that application must `Create` permission for the folder. Permissions are set by using access control lists. If the file already exists, the application needs only `Write` permission, a lesser permission. Where possible, it is more secure to create the file during deployment, and only grant `Read` permissions to a single file (instead of Create permissions for a folder). Also, it is more secure to write data to user folders than to the root folder or the Program Files folder.  
-  
+> This example creates a new file if the file does not already exist. If an application must create a file, that application must have `Create` permission for the folder. Permissions are set by using access control lists. If the file already exists, the application needs only `Write` permission, a lesser permission. Where possible, it's more secure to create the file during deployment, and only grant `Read` permissions to a single file (instead of Create permissions for a folder). Also, it's more secure to write data to user folders than to the root folder or the Program Files folder.
+
 > [!IMPORTANT]
->  This example stores data in a binary format file. These formats should not be used for sensitive data, such as passwords or credit-card information.  
-  
-> [!NOTE]
->  The dialog boxes and menu commands you see might differ from those described in Help depending on your active settings or edition. To change your settings, click **Import and Export Settings** on the **Tools** menu. For more information, see [Customizing Development Settings in Visual Studio](http://msdn.microsoft.com/library/22c4debb-4e31-47a8-8f19-16f328d7dcd3).  
-  
-## Creating the Loan Object  
- The first step is to create a `Loan` class and a test application that uses the class.  
-  
-### To create the Loan class  
-  
-1.  Create a new Class Library project and name it "LoanClass". For more information, see [Creating Solutions and Projects](/visualstudio/ide/creating-solutions-and-projects).  
-  
-2.  In **Solution Explorer**, open the shortcut menu for the Class1 file and choose **Rename**. Rename the file to `Loan` and press ENTER. Renaming the file will also rename the class to `Loan`.  
-  
-3.  Add the following public members to the class:  
-  
-    ```csharp  
-    public class Loan : System.ComponentModel.INotifyPropertyChanged  
-    {  
-        public double LoanAmount {get; set;}  
-        public double InterestRate {get; set;}  
-        public int Term {get; set;}  
-  
-        private string p_Customer;  
-        public string Customer  
-        {  
-            get { return p_Customer; }  
-            set   
-            {  
-                p_Customer = value;  
-                PropertyChanged(this,  
-                  new System.ComponentModel.PropertyChangedEventArgs("Customer"));  
-            }  
-        }  
-  
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;  
-  
-        public Loan(double loanAmount,  
-                    double interestRate,  
-                    int term,  
-                    string customer)  
-        {  
-            this.LoanAmount = loanAmount;  
-            this.InterestRate = interestRate;  
-            this.Term = term;  
-            p_Customer = customer;  
-        }  
-    }  
-    ```  
-  
- You will also have to create a simple application that uses the `Loan` class.  
-  
-### To create a test application  
-  
-1.  To add a Windows Forms Application project to your solution, on the **File** menu, choose **Add**, **New Project**.  
-  
-2.  In the **Add New Project** dialog box, choose **Windows Forms Application**, and enter `LoanApp` as the name of the project, and then click **OK** to close the dialog box.  
-  
-3.  In **Solution Explorer**, choose the LoanApp project.  
-  
-4.  On the **Project** menu, choose **Set as StartUp Project**.  
-  
-5.  On the **Project** menu, choose **Add Reference**.  
-  
-6.  In the **Add Reference** dialog box, choose the **Projects** tab and then choose the LoanClass project.  
-  
-7.  Click **OK** to close the dialog box.  
-  
-8.  In the designer, add four <xref:System.Windows.Forms.TextBox> controls to the form.  
-  
-9. In the Code Editor, add the following code:  
-  
-    ```csharp  
-    private LoanClass.Loan TestLoan = new LoanClass.Loan(10000.0, 0.075, 36, "Neil Black");  
-  
-    private void Form1_Load(object sender, EventArgs e)  
-    {  
-        textBox1.Text = TestLoan.LoanAmount.ToString();  
-        textBox2.Text = TestLoan.InterestRate.ToString();  
-        textBox3.Text = TestLoan.Term.ToString();  
-        textBox4.Text = TestLoan.Customer;  
-    }  
-    ```  
-  
-10. Add an event handler for the `PropertyChanged` event to the form by using the following code:  
-  
-    ```csharp  
-    private void CustomerPropertyChanged(object sender,   
-        System.ComponentModel.PropertyChangedEventArgs e)  
-    {  
-        MessageBox.Show(e.PropertyName + " has been changed.");  
-    }  
-    ```  
-  
- At this point, you can build and run the application. Note that the default values from the `Loan` class appear in the text boxes. Try to change the interest-rate value from 7.5 to 7.1, and then close the application and run it again—the value reverts to the default of 7.5.  
-  
- In the real world, interest rates change periodically, but not necessarily every time that the application is run. Rather than making the user update the interest rate every time that the application runs, it is better to preserve the most recent interest rate between instances of the application. In the next step, you will do just that by adding serialization to the Loan class.  
-  
-## Using Serialization to Persist the Object  
- In order to persist the values for the Loan class, you must first mark the class with the `Serializable` attribute.  
-  
-### To mark a class as serializable  
-  
--   Change the class declaration for the Loan class as follows:  
-  
-    ```csharp  
-    [Serializable()]  
-    public class Loan : System.ComponentModel.INotifyPropertyChanged  
-    {  
-    ```  
-  
- The `Serializable` attribute tells the compiler that everything in the class can be persisted to a file. Because the `PropertyChanged` event is handled by a Windows Form object, it cannot be serialized. The `NonSerialized` attribute can be used to mark class members that should not be persisted.  
-  
-### To prevent a member from being serialized  
-  
--   Change the declaration for the `PropertyChanged` event as follows:  
-  
-    ```csharp  
-    [field: NonSerialized()]  
-    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;  
-    ```  
-  
- The next step is to add the serialization code to the LoanApp application. In order to serialize the class and write it to a file, you will use the <xref:System.IO> and <xref:System.Xml.Serialization> namespaces. To avoid typing the fully qualified names, you can add references to the necessary class libraries.  
-  
-### To add references to namespaces  
-  
--   Add the following statements to the top of the `Form1` class:  
-  
-    ```csharp  
-    using System.IO;  
-    using System.Runtime.Serialization.Formatters.Binary;  
-    ```  
-  
-     In this case, you are using a binary formatter to save the object in a binary format.  
-  
- The next step is to add code to deserialize the object from the file when the object is created.  
-  
-### To deserialize an object  
-  
-1.  Add a constant to the class for the serialized data's file name.  
-  
-    ```csharp  
-    const string FileName = @"..\..\SavedLoan.bin";  
-    ```  
-  
-2.  Modify the code in the `Form1_Load` event procedure as follows:  
-  
-    ```csharp  
-    private LoanClass.Loan TestLoan = new LoanClass.Loan(10000.0, 0.075, 36, "Neil Black");  
-  
-    private void Form1_Load(object sender, EventArgs e)  
-    {  
-        if (File.Exists(FileName))  
-        {  
-            Stream TestFileStream = File.OpenRead(FileName);  
-            BinaryFormatter deserializer = new BinaryFormatter();  
-            TestLoan = (LoanClass.Loan)deserializer.Deserialize(TestFileStream);  
-            TestFileStream.Close();  
-        }  
-  
-        TestLoan.PropertyChanged += this.CustomerPropertyChanged;  
-  
-        textBox1.Text = TestLoan.LoanAmount.ToString();  
-        textBox2.Text = TestLoan.InterestRate.ToString();  
-        textBox3.Text = TestLoan.Term.ToString();  
-        textBox4.Text = TestLoan.Customer;  
-    }  
-    ```  
-  
-     Note that you first must check that the file exists. If it exists, create a <xref:System.IO.Stream> class to read the binary file and a <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> class to translate the file. You also need to convert from the stream type to the Loan object type.  
-  
- Next you must add code to save the data entered in the text boxes to the `Loan` class, and then you must serialize the class to a file.  
-  
-### To save the data and serialize the class  
-  
--   Add the following code to the `Form1_FormClosing` event procedure:  
-  
-    ```csharp  
-    private void Form1_FormClosing(object sender, FormClosingEventArgs e)  
-    {  
-        TestLoan.LoanAmount = Convert.ToDouble(textBox1.Text);  
-        TestLoan.InterestRate = Convert.ToDouble(textBox2.Text);  
-        TestLoan.Term = Convert.ToInt32(textBox3.Text);  
-        TestLoan.Customer = textBox4.Text;  
-  
-        Stream TestFileStream = File.Create(FileName);  
-        BinaryFormatter serializer = new BinaryFormatter();  
-        serializer.Serialize(TestFileStream, TestLoan);  
-        TestFileStream.Close();  
-    }  
-    ```  
-  
- At this point, you can again build and run the application. Initially, the default values appear in the text boxes. Try to change the values and enter a name in the fourth text box. Close the application and then run it again. Note that the new values now appear in the text boxes.  
-  
-## See Also  
- [Serialization (C# )](../../../../csharp/programming-guide/concepts/serialization/index.md)  
- [C# Programming Guide](../../../../csharp/programming-guide/index.md)
+> This example stores data in a binary format file. These formats should not be used for sensitive data, such as passwords or credit-card information.
+
+## Prerequisites
+
+* To build and run, install the [.NET Core SDK](https://www.microsoft.com/net/core).
+
+* Install your favorite code editor, if you haven't already.
+
+> [!TIP]
+> Need to install a code editor? Try [Visual Studio](https://visualstudio.com/downloads)!
+
+You can examine the sample code online [at the .NET samples GitHub repository](https://github.com/dotnet/samples/tree/master/csharp/serialization).
+
+## Creating the loan object
+
+The first step is to create a `Loan` class and a console application that uses the class:
+
+1. Create a new application. Type `dotnet new console -o serialization` to
+create a new console application in a subdirectory named `serialization`.
+1. Open the application in your editor, and add a new class named `Loan.cs`.
+1. Add the following code to your `Loan` class:
+
+[!code-csharp[Loan class definition](../../../../../samples/csharp/serialization/Loan.cs#1)]
+
+You will also have to create an application that uses the `Loan` class.
+
+## Serialize the loan object
+
+1. Open `Program.cs`. Add the following code:
+
+[!code-csharp[Create a loan object](../../../../../samples/csharp/serialization/Program.cs#1)]
+
+Add an event handler for the `PropertyChanged` event, and a few lines to modify the `Loan` object and display the changes. You can see the additions in the following code:
+
+[!code-csharp[Listening for the PropertyChanged event](../../../../../samples/csharp/serialization/Program.cs#2)]
+
+At this point, you can run the code, and see the current output:
+
+```console
+New customer value: Henry Clay
+7.5
+7.1
+```
+
+Running this application repeatedly always writes the same values. A new Loan object is created every time you run the program. In the real world, interest rates change periodically, but not necessarily every time that the application is run. Serialization code means you preserve the most recent interest rate between instances of the application. In the next step, you will do just that by adding serialization to the Loan class.
+
+## Using Serialization to Persist the Object
+
+In order to persist the values for the Loan class, you must first mark the class with the `Serializable` attribute. Add the following code above the Loan class definition:
+
+[!code-csharp[Loan class definition](../../../../../samples/csharp/serialization/Loan.cs#2)]
+
+The <xref:System.SerializableAttribute> tells the compiler that everything in the class can be persisted to a file. Because the `PropertyChanged` event does not represent part of the object graph that should be stored, it should not be serialized. Doing so would serialize all objects that are attached to that event. You can add the <xref:System.NonSerializedAttribute> to the field declaration for the `PropertyChanged` event handler.
+
+[!code-csharp[Disable serialization for the event handler](../../../../../samples/csharp/serialization/Loan.cs#3)]
+
+Beginning with C# 7.3, you can attach attributes to the backing field of an auto-implemented property using the `field` target value. The following code adds a `TimeLastLoaded` property and marks it as not serializable:
+
+[!code-csharp[Disable serialization for an auto-implemented property](../../../../../samples/csharp/serialization/Loan.cs#4)]
+
+The next step is to add the serialization code to the LoanApp application. In order to serialize the class and write it to a file, you use the <xref:System.IO> and <xref:System.Runtime.Serialization.Formatters.Binary> namespaces. To avoid typing the fully qualified names, you can add references to the necessary class libraries as shown in the following code:
+
+[!code-csharp[Adding namespaces for serialization](../../../../../samples/csharp/serialization/Program.cs#4)]
+
+The next step is to add code to deserialize the object from the file when the object is created. Add a constant to the class for the serialized data's file name as shown in the following code:
+
+[!code-csharp[Define the name of the saved file](../../../../../samples/csharp/serialization/Program.cs#5)]
+
+Next, add the following code after the line that creates the `TestLoan` object:
+
+[!code-csharp[Read from a file if it exists](../../../../../samples/csharp/serialization/Program.cs#6)]
+
+You first must check that the file exists. If it exists, create a <xref:System.IO.Stream> class to read the binary file and a <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> class to translate the file. You also need to convert from the stream type to the Loan object type.
+
+Next you must add code to serialize the class to a file. Add the following code after the existing code in the `Main` method:
+
+[!code-csharp[Save the existing Loan object](../../../../../samples/csharp/serialization/Program.cs#7)]
+
+At this point, you can again build and run the application. The first time it runs, notice that the interest rates starts at 7.5, and then changes to 7.1. Close the application and then run it again. Now, the application prints the message that it has read the saved file, and the interest rate is 7.1 even before the code that changes it.
+
+## See also
+
+ [Serialization (C# )](index.md)  
+ [C# Programming Guide](../..//index.md)  

--- a/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
+++ b/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
@@ -74,21 +74,21 @@ Beginning with C# 7.3, you can attach attributes to the backing field of an auto
 
 The next step is to add the serialization code to the LoanApp application. In order to serialize the class and write it to a file, you use the <xref:System.IO> and <xref:System.Runtime.Serialization.Formatters.Binary> namespaces. To avoid typing the fully qualified names, you can add references to the necessary class libraries as shown in the following code:
 
-[!code-csharp[Adding namespaces for serialization](../../../../../samples/csharp/serialization/Program.cs#4)]
+[!code-csharp[Adding namespaces for serialization](../../../../../samples/csharp/serialization/Program.cs#3)]
 
 The next step is to add code to deserialize the object from the file when the object is created. Add a constant to the class for the serialized data's file name as shown in the following code:
 
-[!code-csharp[Define the name of the saved file](../../../../../samples/csharp/serialization/Program.cs#5)]
+[!code-csharp[Define the name of the saved file](../../../../../samples/csharp/serialization/Program.cs#4)]
 
 Next, add the following code after the line that creates the `TestLoan` object:
 
-[!code-csharp[Read from a file if it exists](../../../../../samples/csharp/serialization/Program.cs#6)]
+[!code-csharp[Read from a file if it exists](../../../../../samples/csharp/serialization/Program.cs#5)]
 
 You first must check that the file exists. If it exists, create a <xref:System.IO.Stream> class to read the binary file and a <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> class to translate the file. You also need to convert from the stream type to the Loan object type.
 
 Next you must add code to serialize the class to a file. Add the following code after the existing code in the `Main` method:
 
-[!code-csharp[Save the existing Loan object](../../../../../samples/csharp/serialization/Program.cs#7)]
+[!code-csharp[Save the existing Loan object](../../../../../samples/csharp/serialization/Program.cs#6)]
 
 At this point, you can again build and run the application. The first time it runs, notice that the interest rates starts at 7.5, and then changes to 7.1. Close the application and then run it again. Now, the application prints the message that it has read the saved file, and the interest rate is 7.1 even before the code that changes it.
 

--- a/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
+++ b/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
@@ -9,7 +9,7 @@ You can use serialization to persist an object's data between instances, which e
 In this walkthrough, you will create a basic `Loan` object and persist its data to a file. You will then retrieve the data from the file when you re-create the object.
 
 > [!IMPORTANT]
-> This example creates a new file if the file does not already exist. If an application must create a file, that application must have `Create` permission for the folder. Permissions are set by using access control lists. If the file already exists, the application needs only `Write` permission, a lesser permission. Where possible, it's more secure to create the file during deployment, and only grant `Read` permissions to a single file (instead of Create permissions for a folder). Also, it's more secure to write data to user folders than to the root folder or the Program Files folder.
+> This example creates a new file if the file does not already exist. If an application must create a file, that application must have `Create` permission for the folder. Permissions are set by using access control lists. If the file already exists, the application needs only `Write` permission, a lesser permission. Where possible, it's more secure to create the file during deployment and only grant `Read` permissions to a single file (instead of Create permissions for a folder). Also, it's more secure to write data to user folders than to the root folder or the Program Files folder.
 
 > [!IMPORTANT]
 > This example stores data in a binary format file. These formats should not be used for sensitive data, such as passwords or credit-card information.
@@ -72,7 +72,7 @@ Beginning with C# 7.3, you can attach attributes to the backing field of an auto
 
 [!code-csharp[Disable serialization for an auto-implemented property](../../../../../samples/csharp/serialization/Loan.cs#4)]
 
-The next step is to add the serialization code to the LoanApp application. In order to serialize the class and write it to a file, you use the <xref:System.IO> and <xref:System.Runtime.Serialization.Formatters.Binary> namespaces. To avoid typing the fully qualified names, you can add references to the necessary class libraries as shown in the following code:
+The next step is to add the serialization code to the LoanApp application. In order to serialize the class and write it to a file, you use the <xref:System.IO> and <xref:System.Runtime.Serialization.Formatters.Binary> namespaces. To avoid typing the fully qualified names, you can add references to the necessary namespaces as shown in the following code:
 
 [!code-csharp[Adding namespaces for serialization](../../../../../samples/csharp/serialization/Program.cs#3)]
 

--- a/docs/csharp/properties.md
+++ b/docs/csharp/properties.md
@@ -1,10 +1,8 @@
 ---
 title: Properties
 description: Learn about C# properties, which include features for validation, computed values, lazy evaluation, and property changed notifications.
-ms.date: 04/03/2017
-ms.assetid: 6950d25a-bba1-4744-b7c7-a3cc90438c55
+ms.date: 04/25/2018
 ---
-
 # Properties
 
 Properties are first class citizens in C#. The language
@@ -16,31 +14,18 @@ However, unlike fields, properties are implemented
 with accessors that define the statements executed
 when a property is accessed or assigned.
 
-## Property Syntax
+## Property syntax
 
 The syntax for properties is a natural extension to
 fields. A field defines a storage location:
 
-```csharp
-public class Person
-{
-    public string FirstName;
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[Person class with public fields](../../samples/snippets/csharp/properties/Person.cs#1)]
 
 A property definition contains declarations for a `get` and
 `set` accessor that retrieves and assigns the value of that
 property:
 
-```csharp
-public class Person
-{
-    public string FirstName { get; set; }
-
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[Person class with public properties](../../samples/snippets/csharp/properties/Person.cs#2)]
 
 The syntax shown above is the *auto property* syntax. The compiler
 generates the storage location for the field that backs up the
@@ -53,48 +38,19 @@ property. You may prefer the initial value for the `FirstName`
 property to be the empty string rather than `null`. You would
 specify that as shown below:
 
-```csharp
-public class Person
-{
-    public string FirstName { get; set; } = string.Empty;
-
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[Person class with properties and initializer](../../samples/snippets/csharp/properties/Person.cs#3)]
 
 This is most useful for read-only properties, as you'll see later
 in this topic.
 
 You can also define the storage yourself, as shown below:
 
-```csharp
-public class Person
-{
-    public string FirstName
-    {
-        get { return firstName; }
-        set { firstName = value; }
-    }
-    private string firstName;
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[Person class with properties and backing field](../../samples/snippets/csharp/properties/Person.cs#4)]
 
 When a property implementation is a single expression, you can
 use *expression-bodied members* for the getter or setter:
 
-```csharp
-public class Person
-{
-    public string FirstName
-    {
-        get => firstName;
-        set => firstName = value;
-    }
-    private string firstName;
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[Person class with properties and expression bodied getters and setters](../../samples/snippets/csharp/properties/Person.cs#5)]
 
 This simplified syntax will be used where applicable throughout this
 topic.
@@ -103,7 +59,7 @@ The property definition shown above is a read-write property. Notice
 the keyword `value` in the set accessor. The `set` accessor always has
 a single parameter named `value`. The `get` accessor must return a value
 that is convertible to the type of the property (`string` in this example).
- 
+
 That's the basics of the syntax. There are many different variations that support
 a variety of different design idioms. Let's explore those, and learn the syntax
 options for each.
@@ -121,23 +77,12 @@ by a property are always valid. For example, suppose one rule for the `Person`
 class is that the name cannot be blank or white space. You would write that as
 follows:
 
-```csharp
-public class Person
-{
-    public string FirstName
-    {
-        get => firstName;
-        set
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                throw new ArgumentException("First name must not be blank");
-            firstName = value;
-        }
-    }
-    private string firstName;
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[Validating property setters](../../samples/snippets/csharp/properties/Person.cs#6)]
+
+The preceding example can be simplified by using a`throw` expression as part
+of the property setter validation:
+
+[!code-csharp[Validating property setters](../../samples/snippets/csharp/properties/Person.cs#7)]
 
 The example above enforces the rule that the first name must not be blank
 or white space. If a developer writes
@@ -162,14 +107,7 @@ accessors. Suppose that your `Person` class should only enable changing the valu
 `FirstName` property from other methods in that class. You could give the set accessor
 `private` accessibility instead of `public`:
 
-```csharp
-public class Person
-{
-    public string FirstName { get; private set; }
-
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[using a private setter for a publicly readonly property](../../samples/snippets/csharp/properties/Person.cs#8)]
 
 Now, the `FirstName` property can be accessed from any code, but it can only be assigned
 from other code in the `Person` class.
@@ -187,21 +125,9 @@ in practice.
 You can also restrict modifications to a property so that it can only be set in a constructor
 or a property initializer. You can modify the `Person` class so as follows:
 
-```csharp
-public class Person
-{
-    public Person(string firstName)
-    {
-        this.FirstName = firstName;
-    }
+[!code-csharp[A readonly auto implemented property](../../samples/snippets/csharp/properties/Person.cs#9)]
 
-    public string FirstName { get; }
-
-    // remaining implementation removed from listing
-}
-```
-
-This feature is most commonly used for initializing collections that are exposed as 
+This feature is most commonly used for initializing collections that are exposed as
 read-only properties:
 
 ```csharp
@@ -211,22 +137,13 @@ public class Measurements
 }
 ```
 
-### Computed Properties
+### Computed properties
 
 A property does not need to simply return the value of a member field. You can create properties
 that return a computed value. Let's expand the `Person` object to return the full name, computed
 by concatenating the first and last names:
 
-```csharp
-public class Person
-{
-    public string FirstName { get; set; }
-
-    public string LastName { get; set; }
-
-    public string FullName { get { return $"{FirstName} {LastName}"; } }
-}
-```
+[!code-csharp[A computed property](../../samples/snippets/csharp/properties/Person.cs#10)]
 
 The example above uses the [string interpolation](../csharp/language-reference/tokens/interpolated.md) feature to create
 the formatted string for the full name.
@@ -234,47 +151,20 @@ the formatted string for the full name.
 You can also use *expression-bodied members*, which provides a more
 succinct way to create the computed `FullName` property:
 
-```csharp
-public class Person
-{
-    public string FirstName { get; set; }
+[!code-csharp[A computed property using an expression bodied member](../../samples/snippets/csharp/properties/Person.cs#11)]
 
-    public string LastName { get; set; }
-
-    public string FullName =>  $"{FirstName} {LastName}";
-}
-```
- 
 *Expression-bodied members* use the *lambda expression* syntax to
 define a method that contain a single expression. Here, that
 expression returns the full name for the person object.
 
-### Lazy Evaluated Properties
+### Cached evaluated properties
 
 You can mix the concept of a computed property with storage and create
-a *lazy evaluated property*.  For example, you could update the `FullName`
+a *cached evaluated property*.  For example, you could update the `FullName`
 property so that the string formatting only happened the first time it
 was accessed:
 
-```csharp
-public class Person
-{
-    public string FirstName { get; set; }
-
-    public string LastName { get; set; }
-
-    private string fullName;
-    public string FullName
-    {
-        get
-        {
-            if (fullName == null)
-                fullName = $"{FirstName} {LastName}";
-            return fullName;
-        }
-    }
-}
-```
+[!code-csharp[caching the value of a computed property](../../samples/snippets/csharp/properties/Person.cs#12)]
 
 The above code contains a bug though. If code updates the value of
 either the `FirstName` or `LastName` property, the previously evaluated
@@ -282,43 +172,7 @@ either the `FirstName` or `LastName` property, the previously evaluated
 `FirstName` and `LastName` property so that the `fullName` field is calculated
 again:
 
-```csharp
-public class Person
-{
-    private string firstName;
-    public string FirstName
-    {
-        get => firstName;
-        set
-        {
-            firstName = value;
-            fullName = null;
-        }
-    }
-
-    private string lastName;
-    public string LastName
-    {
-        get => lastName;
-        set
-        {
-            lastName = value;
-            fullName = null;
-        }
-    }
-
-    private string fullName;
-    public string FullName
-    {
-        get
-        {
-            if (fullName == null)
-                fullName = $"{FirstName} {LastName}";
-            return fullName;
-        }
-    }
-}
-```
+[!code-csharp[invalidating the cache correctly](../../samples/snippets/csharp/properties/Person.cs#13)]
 
 This final version evaluates the `FullName` property only when needed.
 If the previously calculated version is valid, it's used. If another
@@ -327,8 +181,8 @@ recalculated. Developers that use this class do not need to know the
 details of the implementation. None of these internal changes affect the
 use of the Person object. That's the key reason for using Properties to
 expose data members of an object.
- 
-### INotifyPropertyChanged
+
+### Implementing INotifyPropertyChanged
 
 A final scenario where you need to write code in a property accessor is to
 support the `INotifyPropertyChanged` interface used to notify data binding
@@ -338,30 +192,7 @@ to indicate the change. The data binding libraries, in turn, update display elem
 based on that change. The code below shows how you would implement `INotifyPropertyChanged`
 for the `FirstName` property of this person class.
 
-```csharp
-public class Person : INotifyPropertyChanged
-{
-    public string FirstName
-    {
-        get => firstName;
-        set
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                throw new ArgumentException("First name must not be blank");
-            if (value != firstName)
-            {
-                PropertyChanged?.Invoke(this, 
-                    new PropertyChangedEventArgs(nameof(FirstName)));
-            }
-            firstName = value;
-        }
-    }
-    private string firstName;
-
-    public event PropertyChangedEventHandler PropertyChanged;
-    // remaining implementation removed from listing
-}
-```
+[!code-csharp[invalidating the cache correctly](../../samples/snippets/csharp/properties/Person.cs#14)]
 
 The `?.` operator is called
 the *null conditional operator*. It checks for a null reference before evaluating

--- a/docs/csharp/properties.md
+++ b/docs/csharp/properties.md
@@ -185,7 +185,7 @@ expose data members of an object.
 ### Attaching attributes to auto-implemented properties
 
 Beginning with C# 7.3, field attributes can be attached to the compiler
-generate backing field in auto-implemented properties. For example, consider
+generated backing field in auto-implemented properties. For example, consider
 a revision to the `Person` class that adds a unique integer `Id` property.
 You write the`Id` property using an auto-implemented property, but your design does
 not call for persisting the `Id` property. The <xref:System.NonSerializedAttribute>

--- a/docs/csharp/properties.md
+++ b/docs/csharp/properties.md
@@ -40,8 +40,8 @@ specify that as shown below:
 
 [!code-csharp[Person class with properties and initializer](../../samples/snippets/csharp/properties/Person.cs#3)]
 
-This is most useful for read-only properties, as you'll see later
-in this topic.
+Specific initialization is most useful for read-only properties, as you'll see later
+in this article.
 
 You can also define the storage yourself, as shown below:
 
@@ -53,7 +53,7 @@ use *expression-bodied members* for the getter or setter:
 [!code-csharp[Person class with properties and expression bodied getters and setters](../../samples/snippets/csharp/properties/Person.cs#5)]
 
 This simplified syntax will be used where applicable throughout this
-topic.
+article.
 
 The property definition shown above is a read-write property. Notice
 the keyword `value` in the set accessor. The `set` accessor always has
@@ -61,7 +61,7 @@ a single parameter named `value`. The `get` accessor must return a value
 that is convertible to the type of the property (`string` in this example).
 
 That's the basics of the syntax. There are many different variations that support
-a variety of different design idioms. Let's explore those, and learn the syntax
+a variety of different design idioms. Let's explore, and learn the syntax
 options for each.
 
 ## Scenarios
@@ -94,7 +94,7 @@ hero.FirstName = "";
 That assignment throws an `ArgumentException`. Because a property set accessor
 must have a void return type, you report errors in the set accessor by throwing an exception.
 
-That is a simple case of validation. You can extend this same syntax to anything needed
+You can extend this same syntax to anything needed
 in your scenario. You can check the relationships between different properties, or validate
 against any external conditions. Any valid C# statements are valid in a property accessor.
 
@@ -107,7 +107,7 @@ accessors. Suppose that your `Person` class should only enable changing the valu
 `FirstName` property from other methods in that class. You could give the set accessor
 `private` accessibility instead of `public`:
 
-[!code-csharp[using a private setter for a publicly readonly property](../../samples/snippets/csharp/properties/Person.cs#8)]
+[!code-csharp[Using a private setter for a publicly readonly property](../../samples/snippets/csharp/properties/Person.cs#8)]
 
 Now, the `FirstName` property can be accessed from any code, but it can only be assigned
 from other code in the `Person` class.
@@ -116,7 +116,7 @@ You can add any restrictive access modifier to either the set or get accessors. 
 you place on the individual accessor must be more limited than the access modifier on the property
 definition. The above is legal because the `FirstName` property is `public`, but the set accessor is
 `private`. You could not declare a `private` property with a `public` accessor. Property declarations
-can also be declared `protected`, `internal`, `protected internal`, `private protected` or even `private`.   
+can also be declared `protected`, `internal`, `protected internal`, or, even `private`.
 
 It is also legal to place the more restrictive modifier on the `get` accessor. For example, you could
 have a `public` property, but restrict the `get` accessor to `private`. That scenario is rarely done
@@ -148,13 +148,13 @@ by concatenating the first and last names:
 The example above uses the [string interpolation](../csharp/language-reference/tokens/interpolated.md) feature to create
 the formatted string for the full name.
 
-You can also use *expression-bodied members*, which provides a more
+You can also use an *expression-bodied member*, which provides a more
 succinct way to create the computed `FullName` property:
 
 [!code-csharp[A computed property using an expression bodied member](../../samples/snippets/csharp/properties/Person.cs#11)]
 
 *Expression-bodied members* use the *lambda expression* syntax to
-define a method that contain a single expression. Here, that
+define methods that contain a single expression. Here, that
 expression returns the full name for the person object.
 
 ### Cached evaluated properties
@@ -164,15 +164,15 @@ a *cached evaluated property*.  For example, you could update the `FullName`
 property so that the string formatting only happened the first time it
 was accessed:
 
-[!code-csharp[caching the value of a computed property](../../samples/snippets/csharp/properties/Person.cs#12)]
+[!code-csharp[Caching the value of a computed property](../../samples/snippets/csharp/properties/Person.cs#12)]
 
 The above code contains a bug though. If code updates the value of
 either the `FirstName` or `LastName` property, the previously evaluated
-`fullName` field is invalid. You need to update the `set` accessors of the
+`fullName` field is invalid. You modify the `set` accessors of the
 `FirstName` and `LastName` property so that the `fullName` field is calculated
 again:
 
-[!code-csharp[invalidating the cache correctly](../../samples/snippets/csharp/properties/Person.cs#13)]
+[!code-csharp[Invalidating the cache correctly](../../samples/snippets/csharp/properties/Person.cs#13)]
 
 This final version evaluates the `FullName` property only when needed.
 If the previously calculated version is valid, it's used. If another
@@ -182,29 +182,45 @@ details of the implementation. None of these internal changes affect the
 use of the Person object. That's the key reason for using Properties to
 expose data members of an object.
 
+### Attaching attributes to auto-implemented properties
+
+Beginning with C# 7.3, field attributes can be attached to the compiler
+generate backing field in auto-implemented properties. For example, consider
+a revision to the `Person` class that adds a unique integer `Id` property.
+You write the`Id` property using an auto-implemented property, but your design does
+not call for persisting the `Id` property. The <xref:System.NonSerializedAttribute>
+can only be attached to fields, not properties. You can attach the
+<xref:System.NonSerializedAttribute> to the backing field for the `Id` property
+by using the `field:` specifier on the attribute, as shown in the following example:
+
+[!code-csharp[Attaching attributes to a backing field](../../samples/snippets/csharp/properties/Person.cs#14)]
+
+This technique works for any attribute you attach to the backing field on the
+auto-implemented property.
+
 ### Implementing INotifyPropertyChanged
 
 A final scenario where you need to write code in a property accessor is to
-support the `INotifyPropertyChanged` interface used to notify data binding
+support the <xref:System.ComponentModel.INotifyPropertyChanged> interface used to notify data binding
 clients that a value has changed. When the value of a property changes, the object
-raises the `PropertyChanged` event
-to indicate the change. The data binding libraries, in turn, update display elements
+raises the <xref:System.ComponentModel.INotifyPropertyChanged.PropertyChanged?displayProperty=nameWithType>
+event to indicate the change. The data binding libraries, in turn, update display elements
 based on that change. The code below shows how you would implement `INotifyPropertyChanged`
 for the `FirstName` property of this person class.
 
-[!code-csharp[invalidating the cache correctly](../../samples/snippets/csharp/properties/Person.cs#14)]
+[!code-csharp[invalidating the cache correctly](../../samples/snippets/csharp/properties/Person.cs#15)]
 
 The `?.` operator is called
 the *null conditional operator*. It checks for a null reference before evaluating
 the right side of the operator. The end result is that if there are no subscribers
 to the `PropertyChanged` event, the code to raise the event doesn't execute. It would
-throw a `NullReferenceException` without this check in that case. See the page on
-[`events`](delegates-events.md) for more details. This example also uses the new
+throw a `NullReferenceException` without this check in that case. For more information,
+see [`events`](delegates-events.md). This example also uses the new
 `nameof` operator to convert from the property name symbol to its text representation.
 Using `nameof` can reduce errors where you have mistyped the name of the property.
 
-Again, this is an example of a case where you can write code in your accessors to
-support the scenarios you need.
+Again, implementing <xref:System.ComponentModel.INotifyPropertyChanged> is an
+example of a case where you can write code in your accessors to support the scenarios you need.
 
 ## Summing up
 


### PR DESCRIPTION
Fixes #3962 

Update articles where attaching attributes to the backing field of an auto-implemented property should be mentioned.

Also, update the Serialization walkthrough to remove the Windows Forms dependency, and make it run on .NET Core.

Dependent on dotnet/samples#38  (Build will fail until that is merged.)

