### PR TITLE
Fix class name

### DIFF
--- a/docs/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md
+++ b/docs/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md
@@ -191,7 +191,7 @@ In this section, you'll add two pages and an image to the application.
     [!code-csharp[ExpenseIt#2_5](../../../../samples/snippets/csharp/VS_Snippets_Wpf/ExpenseIt/CSharp/ExpenseIt2/ExpenseItHome.xaml.cs#2_5)]
     [!code-vb[ExpenseIt#2_5](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/ExpenseIt/VB/ExpenseIt1_A/ExpenseItHome.xaml.vb#2_5)]
 
-    And like this for **ExpenseReport**:
+    And like this for **ExpenseReportPage**:
 
     [!code-csharp[ExpenseIt#5](../../../../samples/snippets/csharp/VS_Snippets_Wpf/ExpenseIt/CSharp/ExpenseIt/ExpenseReportPage.xaml.cs#5)]
     [!code-vb[ExpenseIt#5](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/ExpenseIt/VB/ExpenseIt1_A/ExpenseReportPage.xaml.vb#5)]


### PR DESCRIPTION
This is a small fix of the class name at step 9 in `Add files to the application` section:
https://docs.microsoft.com/en-us/dotnet/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application

## Summary

As same as above **ExpenseItHome** class in that page, this should be **ExpenseReportPage** as it is in the code (C\#).
