### PR TITLE
[WIP] fix QuickStart build warnings

### DIFF
--- a/docs/csharp/quick-starts/branches-and-loops.yml
+++ b/docs/csharp/quick-starts/branches-and-loops.yml
@@ -11,7 +11,7 @@ metadata:
   ms.topic: get-started-article
   displayType: two-column
   interactive: csharp
-  nextTutorialHref: interpolated-strings
+  nextTutorialHref: interpolated-strings.yml
   nextTutorialTitle: String interpolation in C#
 items:
 - durationInMinutes: 1

--- a/docs/csharp/quick-starts/hello-world.yml
+++ b/docs/csharp/quick-starts/hello-world.yml
@@ -6,7 +6,7 @@ metadata:
   audience: Developer
   level: Beginner
   ms.topic: get-started-article
-  nextTutorialHref: numbers-in-csharp
+  nextTutorialHref: numbers-in-csharp.yml
   nextTutorialTitle: Numbers in C#
   displayType: two-column
   interactive: csharp

--- a/docs/csharp/quick-starts/interpolated-strings.yml
+++ b/docs/csharp/quick-starts/interpolated-strings.yml
@@ -9,7 +9,7 @@ metadata:
   level: Beginner
   displayType: two-column
   interactive: csharp
-  nextTutorialHref: list-collection
+  nextTutorialHref: list-collection.yml
   nextTutorialTitle: Collections in C#
 items:
 - durationInMinutes: 2

--- a/docs/csharp/quick-starts/numbers-in-csharp.yml
+++ b/docs/csharp/quick-starts/numbers-in-csharp.yml
@@ -7,7 +7,7 @@ metadata:
   ms.topic: get-started-article
   ms.custom: mvc
   level: Beginner
-  nextTutorialHref: branches-and-loops
+  nextTutorialHref: branches-and-loops.yml
   nextTutorialTitle: Branches and loops in C#
   displayType: two-column
   interactive: csharp


### PR DESCRIPTION
The parser now requires the `.yml` extension on the `nextTutorialHref`

