### PR TITLE
Added link to summary table per customer suggestion.

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/query-execution.md
+++ b/docs/framework/data/adonet/ef/language-reference/query-execution.md
@@ -12,7 +12,10 @@ After a LINQ query is created by a user, it is converted to a command tree. A co
  At what point query expressions are executed can vary. LINQ queries are always executed when the query variable is iterated over, not when the query variable is created. This is called *deferred execution*. You can also force a query to execute immediately, which is useful for caching query results. This is described later in this topic.  
   
  When a LINQ to Entities query is executed, some expressions in the query might be executed on the server and some parts might be executed locally on the client. Client-side evaluation of an expression takes place before the query is executed on the server. If an expression is evaluated on the client, the result of that evaluation is substituted for the expression in the query, and the query is then executed on the server. Because queries are executed on the data source, the data source configuration overrides the behavior specified in the client. For example, null value handling and numerical precision depend on the server settings. Any exceptions thrown during query execution on the server are passed directly up to the client.  
-  
+ 
+> [!TIP]
+> For a convenient summary of query operators in table format, which lets you quickly identify an operator's execution behavior, see [Classification of Standard Query Operators by Manner of Execution (C#)](../../../../../csharp/programming-guide/concepts/linq/classification-of-standard-query-operators-by-manner-of-execution.md).
+
 ## Deferred query execution  
  In a query that returns a sequence of values, the query variable itself never holds the query results and only stores the query commands. Execution of the query is deferred until the query variable is iterated over in a `foreach` or `For Each` loop. This is known as *deferred execution*; that is, query execution occurs some time after the query is constructed. This means that you can execute a query as frequently as you want to. This is useful when, for example, you have a database that is being updated by other applications. In your application, you can create a query to retrieve the latest information and repeatedly execute the query, returning the updated information every time.  
   


### PR DESCRIPTION
## Summary

Customer pointed out that it's hard to figure out from this page whether a query operator uses immediate or deferred execution, and suggested a link to the quick reference table in another article. I added that link as a Tip.

Fixes #5184 
