### PR TITLE
F#: fixed keyword is not reserved anymore

### DIFF
--- a/docs/fsharp/language-reference/keyword-reference.md
+++ b/docs/fsharp/language-reference/keyword-reference.md
@@ -109,7 +109,6 @@ The following tokens are reserved as keywords for future expansion of the F# lan
 * `eager`
 * `event`
 * `external`
-* `fixed`
 * `functor`
 * `include`
 * `method`


### PR DESCRIPTION
Fixes #5187
