### PR TITLE
Update dotnet-nuget-locals.md

### DIFF
--- a/docs/core/tools/dotnet-nuget-locals.md
+++ b/docs/core/tools/dotnet-nuget-locals.md
@@ -54,7 +54,7 @@ Forces command-line output in English.
 
 Displays the paths of all the local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
 
-`dotnet nuget locals –l all`
+`dotnet nuget locals all -l`
 
 Displays the path for the local http-cache directory:
 


### PR DESCRIPTION
The `all` directive needs to precede the `-l` directive, otherwise it will throw an error "Unrecognized command or argument 'all'."

## Summary

Describe your changes here.
The command as given (`dotnet nuget locals –l all`) will generate the following response from the dotnet CLI:
`Specify --help for a list of available options and commands.`
`error: Unrecognized command or argument 'all'`
Fixes #Issue_Number (if available)
