### PR TITLE
Emitting Dynamic Methods and Assemblies typo

### DIFF
--- a/docs/framework/reflection-and-codedom/emitting-dynamic-methods-and-assemblies.md
+++ b/docs/framework/reflection-and-codedom/emitting-dynamic-methods-and-assemblies.md
@@ -40,7 +40,7 @@ Describes security issues related to creating dynamic assemblies using reflectio
 Shows how to execute a simple dynamic method and a dynamic method bound to an instance of a class.
 
 [How to: Define a generic type with reflection emit](how-to-define-a-generic-type-with-reflection-emit.md)   
-Shows how to create a simple generic type with two type parameters, how to apply class, interface, and special constraints to the type parameters, and how to create memers that use the type parameters of the class as parameter types and return types.
+Shows how to create a simple generic type with two type parameters, how to apply class, interface, and special constraints to the type parameters, and how to create members that use the type parameters of the class as parameter types and return types.
 
 [How to: Define a generic method with reflection emit](how-to-define-a-generic-method-with-reflection-emit.md)   
 Shows how to create, emit, and invoke a simple generic method.


### PR DESCRIPTION
"memers" -> "members"

## Summary

Small typo fix


