### PR TITLE
unnecessary byte butter allocation

### DIFF
--- a/docs/framework/network-programming/synchronous-server-socket-example.md
+++ b/docs/framework/network-programming/synchronous-server-socket-example.md
@@ -58,7 +58,6 @@ Public Class SynchronousSocketListener
   
             ' An incoming connection needs to be processed.  
             While True  
-                bytes = New Byte(1024) {}  
                 Dim bytesRec As Integer = handler.Receive(bytes)  
                 data += Encoding.ASCII.GetString(bytes, 0, bytesRec)  
                 If data.IndexOf("<EOF>") > -1 Then  

--- a/docs/framework/network-programming/synchronous-server-socket-example.md
+++ b/docs/framework/network-programming/synchronous-server-socket-example.md
@@ -119,7 +119,6 @@ public class SynchronousSocketListener {
   
                 // An incoming connection needs to be processed.  
                 while (true) {  
-                    bytes = new byte[1024];  
                     int bytesRec = handler.Receive(bytes);  
                     data += Encoding.ASCII.GetString(bytes,0,bytesRec);  
                     if (data.IndexOf("<EOF>") > -1) {  


### PR DESCRIPTION
In my opinion, repetitive byte buffer allocations inside while loop look unnecessary since we can reuse allocated buffer.

I started to learn c# recently, so it might be wrong due to lack of my understanding. It would be nice opportunity to learn things that I missed if this proposal is incorrect. Otherwise, I believe it could improve the example.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
