### PR TITLE
Update language compilers link

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -26,7 +26,7 @@ The following characteristics best define .NET Core:
 
 - A [.NET runtime](https://github.com/dotnet/coreclr), which provides a type system, assembly loading, a garbage collector, native interop and other basic services. 
 - A set of [framework libraries](https://github.com/dotnet/corefx), which provide primitive data types, app composition types and fundamental utilities. 
-- A [set of SDK tools](https://github.com/dotnet/cli) and [language compilers](https://github.com/dotnet/roslyn) that enable the base developer experience, available in the [.NET Core SDK](sdk.md).
+- A [set of SDK tools](https://github.com/dotnet/cli) and language compilers ([Roslyn](https://github.com/dotnet/roslyn) and [F#](https://github.com/microsoft/visualfsharp)) that enable the base developer experience, available in the [.NET Core SDK](sdk.md).
 - The 'dotnet' app host, which is used to launch .NET Core apps. It selects the runtime and hosts the runtime, provides an assembly loading policy and launches the app. The same host is also used to launch SDK tools in much the same way.
 
 ### Languages


### PR DESCRIPTION
It previously pointed to Roslyn only. It now points to both Roslyn and F#.