### PR TITLE
Add information on pattern based fixed statement

### DIFF
--- a/docs/csharp/language-reference/keywords/fixed-statement.md
+++ b/docs/csharp/language-reference/keywords/fixed-statement.md
@@ -1,6 +1,6 @@
 ---
 title: "fixed Statement (C# Reference)"
-ms.date: 04/20/2018
+ms.date: 05/10/2018
 f1_keywords: 
   - "fixed_CSharpKeyword"
   - "fixed"
@@ -18,6 +18,12 @@ The `fixed` statement sets a pointer to a managed variable and "pins" that varia
 You can initialize a pointer by using an array, a string, a fixed-size buffer, or the address of a variable. The following example illustrates the use of variable addresses, arrays, and strings. For more information about fixed-size buffers, see [Fixed Size Buffers](../../programming-guide/unsafe-code-pointers/fixed-size-buffers.md).
 
 [!code-csharp[Initializing fixed size buffers](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#2)]
+
+Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed-size buffers, or unmanaged variables. Any type that implements a method named `DangerousGetPinnableReference` can be pinned. The `DangerousGetPinnableReference` must return a `ref` variable to an unmanaged type. See the topic on [pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md) for more information. The .NET Types <xref:System.Span%601?displayProperty=nameWithType>, <xref:System.ReadonlySpan%601?displayProperty=nameWithType> introduced in .NET Standard 2.0 make use of this pattern and can be pinned. This is shown in the following example:
+
+[!code-csharp[Accessing fixed memory](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#FixedSpan)]
+
+If you are created types that should participate in this pattern, see <xref:System.Span%601.DangerousGetPinnableReference?displayProperty=nameWithType> for an example of implementing the pattern.
 
 Multiple pointers can be initialized in one statement if they are all the same type:
 

--- a/docs/csharp/language-reference/keywords/fixed-statement.md
+++ b/docs/csharp/language-reference/keywords/fixed-statement.md
@@ -19,7 +19,7 @@ You can initialize a pointer by using an array, a string, a fixed-size buffer, o
 
 [!code-csharp[Initializing fixed size buffers](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#2)]
 
-Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed-size buffers, or unmanaged variables. Any type that implements a method named `DangerousGetPinnableReference` can be pinned. The `DangerousGetPinnableReference` must return a `ref` variable to an unmanaged type. See the topic on [pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md) for more information. The .NET Types <xref:System.Span%601?displayProperty=nameWithType>, <xref:System.ReadonlySpan%601?displayProperty=nameWithType> introduced in .NET Standard 2.0 make use of this pattern and can be pinned. This is shown in the following example:
+Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed-size buffers, or unmanaged variables. Any type that implements a method named `DangerousGetPinnableReference` can be pinned. The `DangerousGetPinnableReference` must return a `ref` variable to an unmanaged type. See the topic on [pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md) for more information. The .NET types <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadonlySpan%601?displayProperty=nameWithType> introduced in .NET Core 2.0 make use of this pattern and can be pinned. This is shown in the following example:
 
 [!code-csharp[Accessing fixed memory](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#FixedSpan)]
 


### PR DESCRIPTION
Fixes #4774 

Including example using `Span<T>`

Relies on sample added in dotnet/samples#62


