### PR TITLE
switch source file for include

### DIFF
--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -91,7 +91,7 @@ Next, create classes for the input data and the predictions:
 
 Add two classes into this file. `TaxiTrip`, the input data set class, has definitions for each of the columns discovered above and a `Label` attribute for the fare_amount column that you are predicting. Add the following code to the file:
 
-[!code-csharp[DefineTaxiTrip](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#2 "Define the taxi trip class")]
+[!code-csharp[DefineTaxiTrip](../../../samples/machine-learning/tutorials/TaxiFarePrediction/TaxiTrip.cs#2 "Define the taxi trip class")]
 
 The `TaxiTripFarePrediction` class is used for prediction after the model has been trained. It has a single float (fare_amount) and a `Score` `ColumnName` attribute. Add the following code into the file below the `TaxiTrip` class:
 

--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -95,7 +95,7 @@ Add two classes into this file. `TaxiTrip`, the input data set class, has defini
 
 The `TaxiTripFarePrediction` class is used for prediction after the model has been trained. It has a single float (fare_amount) and a `Score` `ColumnName` attribute. Add the following code into the file below the `TaxiTrip` class:
 
-[!code-csharp[DefineFarePrediction](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#3 "Define the fare predictions class")]
+[!code-csharp[DefineFarePrediction](../../../samples/machine-learning/tutorials/TaxiFarePrediction/TaxiTrip.cs#3 "Define the fare predictions class")]
 
 Now go back to the **Program.cs** file. In `Main`, replace the `Console.WriteLine("Hello World!")` with the following code:
 


### PR DESCRIPTION
Fixes #5295 

The include for the taxitrip classes had the wrong source file linked. Was program.cs, should be taxitrip.cs

[internal review link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/tutorials/taxi-fare?branch=pr-en-us-5298)


