### PR TITLE
Typo in page for `CLRCreateInstance`

### DIFF
--- a/docs/framework/unmanaged-api/hosting/clrcreateinstance-function.md
+++ b/docs/framework/unmanaged-api/hosting/clrcreateinstance-function.md
@@ -52,7 +52,7 @@ HRESULT CLRCreateInstance(
 ## Remarks  
  The following table shows the supported combinations for `clsid` and `riid`.  
   
-|`rclsid`|`riid`|  
+|`clsid`|`riid`|  
 |--------------|------------|  
 |CLSID_CLRMetaHost|IID_ICLRMetaHost|  
 |CLSID_CLRMetaHostPolicy|IID_ICLRMetaHostPolicy|  


### PR DESCRIPTION
## Summary

Just fixing a baby typo I noticed while reading docs online. (And possibly my smallest commit ever.)