### PR TITLE
Verify that Strings Are in Valid Email Format: inform about the MailAddress class from start

### DIFF
--- a/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
+++ b/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
@@ -22,7 +22,10 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # How to: Verify that Strings Are in Valid Email Format
-The following example uses a regular expression to verify that a string is in valid email format.  
+The following example is more complex than previous examples and uses a regular expression to verify that a string is in valid email format.  
+
+> [!NOTE]
+>  Use the <xref:System.Net.Mail.MailAddress?displayProperty=nameWithType> class to check if a string is in valid email address format. To do that, pass the email address string to the <xref:System.Net.Mail.MailAddress.%23ctor%28System.String%29?displayProperty=nameWithType> class constructor that throws a <xref:System.FormatException> if the string has unrecongnized format.  
   
 ## Example  
  The example defines an `IsValidEmail` method, which returns `true` if the string contains a valid email address and `false` if it does not, but takes no other action.  
@@ -62,9 +65,6 @@ The following example uses a regular expression to verify that a string is in va
 |<code>&#124;(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+</code>|If the character that follows @ is not an opening bracket, match one alphanumeric character with a value of A-Z, a-z, or 0-9, followed by zero or more occurrences of a hyphen, followed by zero or one alphanumeric character with a value of A-Z, a-z, or 0-9, followed by a period. This pattern can be repeated one or more times, and must be followed by the top-level domain name.|  
 |`[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))`|The top-level domain name must begin and end with an alphanumeric character (a-z, A-Z, and 0-9). It can also include from zero to 22 ASCII characters that are either alphanumeric or hyphens.|  
 |`$`|End the match at the end of the string.|  
-  
-> [!NOTE]
->  Instead of using a regular expression to validate an email address, you can use the <xref:System.Net.Mail.MailAddress?displayProperty=nameWithType> class. To determine whether an email address is valid, pass the email address to the <xref:System.Net.Mail.MailAddress.%23ctor%28System.String%29?displayProperty=nameWithType> class constructor.  
   
 ## Compiling the Code  
  The `IsValidEmail` and `DomainMapper` methods can be included in a library of regular expression utility methods, or they can be included as private static or instance methods in the application class.  

--- a/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
+++ b/docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md
@@ -22,10 +22,10 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # How to: Verify that Strings Are in Valid Email Format
-The following example is more complex than previous examples and uses a regular expression to verify that a string is in valid email format.  
+The following example uses a regular expression to verify that a string is in valid email format.  
 
 > [!NOTE]
->  Use the <xref:System.Net.Mail.MailAddress?displayProperty=nameWithType> class to check if a string is in valid email address format. To do that, pass the email address string to the <xref:System.Net.Mail.MailAddress.%23ctor%28System.String%29?displayProperty=nameWithType> class constructor that throws a <xref:System.FormatException> if the string has unrecongnized format.  
+>  We recommend using the <xref:System.Net.Mail.MailAddress?displayProperty=nameWithType> class to check if a string is in valid email address format. To do that, pass the email address string to the <xref:System.Net.Mail.MailAddress.%23ctor%28System.String%29?displayProperty=nameWithType> class constructor, which throws a <xref:System.FormatException> if the string has an unrecognized format.  
   
 ## Example  
  The example defines an `IsValidEmail` method, which returns `true` if the string contains a valid email address and `false` if it does not, but takes no other action.  

--- a/docs/standard/base-types/regular-expression-examples.md
+++ b/docs/standard/base-types/regular-expression-examples.md
@@ -30,7 +30,7 @@ This section contains code examples that illustrate the use of regular expressio
  Provides an example that strips invalid non-alphanumeric characters from a string.  
   
  [How to: Verify that Strings Are in Valid Email Format](../../../docs/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format.md)  
- Provides an example that you can use to verify that a string is in valid email format.  
+ Provides an example that verifies that a string is in valid email format.  
   
 ## Reference  
  <xref:System.Text.RegularExpressions>  


### PR DESCRIPTION
- Moved the note about `System.Net.Mail.MailAddress` to the beginning of the topic. 
- Rephrased it such that it should be considered as the main alternative. Should it start with *We recommend...* to make even more stronger?
- Updated the first sentence to relate the whole topic to the set of regex examples.
 
Related to #5305
