### PR TITLE
Checked and Unchecked: style update.

### DIFF
--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -27,7 +27,7 @@ C# statements can execute in either checked or unchecked context. In a checked c
   
  If neither `checked` nor `unchecked` is specified, the default context for non-constant expressions (expressions that are evaluated at run time) is defined by the value of the [-checked](../compiler-options/checked-compiler-option.md) compiler option. By default the value of that option is unset and arithmetic operations are executed in an unchecked context.
  
- For constant expressions (expressions that can be fully evaluated at compile time), the default overflow checking context is always checked. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
+ For constant expressions (expressions that can be fully evaluated at compile time), the default context is always checked. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
   
 ## See Also  
  [C# Reference](../index.md)  

--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 ms.assetid: a84bc877-2c7f-4396-8735-1ce97c42f35e
 ---
 # Checked and Unchecked (C# Reference)
-C# statements can execute in either checked or unchecked context. In a checked context, arithmetic overflow raises an exception. In an unchecked context, arithmetic overflow is ignored and the result is truncated.  
+C# statements can execute in either checked or unchecked context. In a checked context, arithmetic overflow raises an exception. In an unchecked context, arithmetic overflow is ignored and the result is truncated by discarding any high-order bits that don't fit in the destination type.  
   
 -   [checked](checked.md) Specify checked context.  
   

--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -1,6 +1,6 @@
 ---
 title: "Checked and Unchecked (C# Reference)"
-ms.date: 07/20/2015
+ms.date: 05/15/2018
 helpviewer_keywords: 
   - "operators [C#], checked and unchecked"
   - "exceptions [C#], overflow checking"
@@ -23,9 +23,11 @@ C# statements can execute in either checked or unchecked context. In a checked c
   
      `++`, `--`, unary `-`, `+`, `-`, `*`, `/`  
   
--   Explicit numeric conversions between integral types.  
+-   Explicit numeric conversions between integral types, or from `float` or `double` to an integral type.  
   
- If neither `checked` nor `unchecked` is specified, the default context is defined by the value of the [-checked](../compiler-options/checked-compiler-option.md) compiler option. That option lets you specify checked or unchecked context for all integer arithmetic statements that are not explicitly in the scope of a `checked` or `unchecked` keyword.  
+ If neither `checked` nor `unchecked` is specified, the default context for non-constant expressions (expressions that are evaluated at run time) is defined by the value of the [-checked](../compiler-options/checked-compiler-option.md) compiler option. The default value of that option is `unchecked`.
+ 
+ For constant expressions (expressions that can be fully evaluated at compile time), the default overflow checking context is always `checked`. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
   
 ## See Also  
  [C# Reference](../index.md)  

--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -13,24 +13,22 @@ ms.assetid: a84bc877-2c7f-4396-8735-1ce97c42f35e
 # Checked and Unchecked (C# Reference)
 C# statements can execute in either checked or unchecked context. In a checked context, arithmetic overflow raises an exception. In an unchecked context, arithmetic overflow is ignored and the result is truncated.  
   
--   [checked](../../../csharp/language-reference/keywords/checked.md) Specify checked context.  
+-   [checked](checked.md) Specify checked context.  
   
--   [unchecked](../../../csharp/language-reference/keywords/unchecked.md) Specify unchecked context.  
-  
- If neither `checked` nor `unchecked` is specified, the default context depends on external factors such as compiler options.  
+-   [unchecked](unchecked.md) Specify unchecked context.  
   
  The following operations are affected by the overflow checking:  
   
 -   Expressions using the following predefined operators on integral types:  
   
-     `++` `--` - (unary)   `+` -   `*` `/`  
+     `++`, `--`, unary `-`, `+`, `-`, `*`, `/`  
   
 -   Explicit numeric conversions between integral types.  
   
- The [/checked](../../../csharp/language-reference/compiler-options/checked-compiler-option.md) compiler option lets you specify checked or unchecked context for all integer arithmetic statements that are not explicitly in the scope of a `checked` or `unchecked` keyword.  
+ If neither `checked` nor `unchecked` is specified, the default context is defined by the value of the [-checked](../compiler-options/checked-compiler-option.md) compiler option. That option lets you specify checked or unchecked context for all integer arithmetic statements that are not explicitly in the scope of a `checked` or `unchecked` keyword.  
   
 ## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Keywords](../../../csharp/language-reference/keywords/index.md)  
- [Statement Keywords](../../../csharp/language-reference/keywords/statement-keywords.md)
+ [C# Reference](../index.md)  
+ [C# Programming Guide](../../programming-guide/index.md)  
+ [C# Keywords](index.md)  
+ [Statement Keywords](statement-keywords.md)

--- a/docs/csharp/language-reference/keywords/checked-and-unchecked.md
+++ b/docs/csharp/language-reference/keywords/checked-and-unchecked.md
@@ -25,9 +25,9 @@ C# statements can execute in either checked or unchecked context. In a checked c
   
 -   Explicit numeric conversions between integral types, or from `float` or `double` to an integral type.  
   
- If neither `checked` nor `unchecked` is specified, the default context for non-constant expressions (expressions that are evaluated at run time) is defined by the value of the [-checked](../compiler-options/checked-compiler-option.md) compiler option. The default value of that option is `unchecked`.
+ If neither `checked` nor `unchecked` is specified, the default context for non-constant expressions (expressions that are evaluated at run time) is defined by the value of the [-checked](../compiler-options/checked-compiler-option.md) compiler option. By default the value of that option is unset and arithmetic operations are executed in an unchecked context.
  
- For constant expressions (expressions that can be fully evaluated at compile time), the default overflow checking context is always `checked`. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
+ For constant expressions (expressions that can be fully evaluated at compile time), the default overflow checking context is always checked. Unless a constant expression is explicitly placed in an unchecked context, overflows that occur during the compile-time evaluation of the expression cause compile-time errors.
   
 ## See Also  
  [C# Reference](../index.md)  


### PR DESCRIPTION
Also combined two paragraphs about compiler option in one.

@BillWagner as for this sentence from the first paragraph:
>In an unchecked context, arithmetic overflow is ignored and the result is truncated.

Is *truncated* the correct word? Usually it is used in the context of a fractional number being truncated to its integral part.