### PR TITLE
Add codefence for markdown link sample

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -245,7 +245,7 @@ You can include the code using the following syntax:
 
 We recommend using the tag name option whenever possible. The tag name is the name of a region or of a code comment in the format of `Snippettagname` present in the source code. The following example shows how to refer to the tag name `1`:
 
-```
+```markdown
 [!code-csharp[csrefKeyword#1](../../../../samples/snippets/csharp/language-reference/keywords/throw/throw-1.cs#1)]
 ```
 


### PR DESCRIPTION
## Summary

Adds the language specifier missing for a markdown code sample, although doesn't really affect the rendering right now
