### PR TITLE
Fixing predicate condition on Entity-SQL query

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/unsupported-expressions-entity-sql.md
+++ b/docs/framework/data/adonet/ef/language-reference/unsupported-expressions-entity-sql.md
@@ -21,7 +21,7 @@ sal > any (select salary from employees)
 [!INCLUDE[esql](../../../../../../includes/esql-md.md)], however, does not support such constructs. Equivalent expressions can be written in [!INCLUDE[esql](../../../../../../includes/esql-md.md)] as follows:
 
 ```sql
-not exists(select 0 from employees as e where sal > e.salary)
+not exists(select 0 from employees as e where sal <= e.salary)
 exists(select 0 from employees as e where sal > e.salary)
 ```
 


### PR DESCRIPTION
Not really Entity-SQL specific, when rewriting ALL as NOT EXISTS the condition needs to be inverted.

Fixes #5378