### PR TITLE
Add direct link to foreach statement of C# language spec

### DIFF
--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -11,7 +11,8 @@ helpviewer_keywords:
 ms.assetid: 5a9c5ddc-5fd3-457a-9bb6-9abffcd874ec
 ---
 # foreach, in (C# Reference)
-The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The `foreach` statement is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
+
+The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The [foreach statement](~/docs/csharp/language-reference/language-specification/statements#the-foreach-statement) is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
   
  The embedded statements continue to execute for each element in the array or collection. After the iteration has been completed for all the elements in the collection, control is transferred to the next statement following the `foreach` block.
   
@@ -26,7 +27,8 @@ The `foreach` statement repeats a group of embedded statements for each element 
  [How to: Access a Collection Class with foreach](../../programming-guide/classes-and-structs/how-to-access-a-collection-class-with-foreach.md)  
 
 ## Example
- The following code shows three examples.
+
+The following code shows three examples.
 
 > [!TIP]
 > You can modify the examples to experiment with the syntax and try different
@@ -46,9 +48,12 @@ The `foreach` statement repeats a group of embedded statements for each element 
 [!code-csharp-interactive[csrefKeywordsIteration#4](./codesnippet/CSharp/foreach-in_1.cs#L51-L69)]
  
 ## C# Language Specification
+
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
 
 ## See Also  
+
+[The foreach statement (C# language specification)](~/docs/csharp/language-reference/language-specification/statements#the-foreach-statement)
 
 [C# Reference](../index.md)
 

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -12,7 +12,7 @@ ms.assetid: 5a9c5ddc-5fd3-457a-9bb6-9abffcd874ec
 ---
 # foreach, in (C# Reference)
 
-The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The [foreach statement](~/docs/csharp/language-reference/language-specification/statements#the-foreach-statement) is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
+The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The [foreach statement](~/docs/csharp/language-reference/language-specification/statements.md#the-foreach-statement) is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
   
  The embedded statements continue to execute for each element in the array or collection. After the iteration has been completed for all the elements in the collection, control is transferred to the next statement following the `foreach` block.
   
@@ -53,7 +53,7 @@ The following code shows three examples.
 
 ## See Also  
 
-[The foreach statement (C# language specification)](~/docs/csharp/language-reference/language-specification/statements#the-foreach-statement)
+[The foreach statement (C# language specification)](~/docs/csharp/language-reference/language-specification/statements.md#the-foreach-statement)
 
 [C# Reference](../index.md)
 

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -12,7 +12,7 @@ ms.assetid: 5a9c5ddc-5fd3-457a-9bb6-9abffcd874ec
 ---
 # foreach, in (C# Reference)
 
-The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The [foreach statement](~/docs/csharp/language-reference/language-specification/statements.md#the-foreach-statement) is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
+The `foreach` statement repeats a group of embedded statements for each element in an array or an object collection that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The [foreach statement](/dotnet/csharp/language-reference/language-specification/statements#the-foreach-statement) is used to iterate through the collection to get the information that you want, but can not be used to add or remove items from the source collection to avoid unpredictable side effects. If you need to add or remove items from the source collection, use a [for](for.md) loop.
   
  The embedded statements continue to execute for each element in the array or collection. After the iteration has been completed for all the elements in the collection, control is transferred to the next statement following the `foreach` block.
   
@@ -53,7 +53,7 @@ The following code shows three examples.
 
 ## See Also  
 
-[The foreach statement (C# language specification)](~/docs/csharp/language-reference/language-specification/statements.md#the-foreach-statement)
+[The foreach statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-foreach-statement)
 
 [C# Reference](../index.md)
 

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -28,7 +28,7 @@ The `foreach` statement repeats a group of embedded statements for each element 
 
 ## Example
 
-The following code shows three examples.
+The following code shows three examples:
 
 > [!TIP]
 > You can modify the examples to experiment with the syntax and try different


### PR DESCRIPTION
Add direct link to the foreach statement section of the C# language spec (added link in two places).
