### PR TITLE
Add pascal case and parameter section to naming guidelines in F# formatting guide

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -516,7 +516,7 @@ type SchoolPerson =
 
 ### Use PascalCase for constructs intrinsic to .NET
 
-Namespaces, Exceptions, events, and project/`.dll` names should also use PascalCase. Not only will this make consumption from other .NET languages feel more natural to consumers, it will also be consistent with .NET naming conventions that you are likely to encounter.
+Namespaces, exceptions, events, and project/`.dll` names should also use PascalCase. Not only does this make consumption from other .NET languages feel more natural to consumers, it's also consistent with .NET naming conventions that you are likely to encounter.
 
 ### Avoid underscores in names
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -468,6 +468,56 @@ let emailMyBossTheLatestResults =
     ...
 ```
 
+### Use camelCase for parameters
+
+All parameters should use camelCase in accordance with .NET naming conventions.
+
+```fsharp
+module MyModule =
+    let myFunction paramOne paramTwo = ...
+
+type MyClass() =
+    member this.MyMethod(paramOne, paramTwo) = ...
+```
+
+### Use PascalCase for modules
+
+All modules (top-level, internal, private, nested) should use PascalCase.
+
+```fsharp
+module MyTopLevelModule
+
+module Helpers =
+    module private SuperHelpers =
+        ...
+
+    ...
+```
+
+### Use PascalCase for type declarations, members, and labels
+
+Classes, interfaces, structs, enumerations, delegates, records, and discriminated unions should all be named with PascalCase. Members within types and labels for records and discriminated unions should also use PascalCase.
+
+```fsharp
+type IMyInterface =
+    abstract Something: int
+
+type MyClass() =
+    member this.MyMethod(x, y) = x + y
+
+type MyRecord = { IntVal: int; StringVal: string }
+
+type SchoolPerson =
+    | Professor
+    | Student
+    | Advisor
+    | Administrator
+```
+
+### Use PascalCase for constructs intrinsic to .NET
+
+Namespaces, Exceptions, events, and project/`.dll` names should also use PascalCase. Not only will this make consumption from other .NET languages feel more natural to consumers, it will also be consistent with .NET naming conventions that you are likely to encounter.
+
 ### Avoid underscores in names
 
 Historically, some F# libraries have used underscores in names. However, this is no longer widely accepted, partly because it clashes with .NET naming conventions. That said, some F# programmers use underscores heavily, partly for historical reasons, and tolerance and respect is important. However, be aware that the style is often disliked by others who have a choice about whether to use it.


### PR DESCRIPTION
Fixes #5380