### PR TITLE
Revert "capitalizing titles in F# Style Guide"

### DIFF
--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -1,9 +1,9 @@
 ---
-title: F# Component Design Guidelines
+title: F# component design guidelines
 description: Learn the guidelines for writing F# components intended for consumption by other callers.
 ms.date: 05/14/2018
 ---
-# F# Component Design Guidelines
+# F# component design guidelines
 
 This document is a set of component design guidelines for F# programming, based on the F# Component Design Guidelines, v14, Microsoft Research, and [another version](https://fsharp.org/specs/component-design-guidelines/) originally curated and maintained by the F# Software Foundation.
 

--- a/docs/fsharp/style-guide/conventions.md
+++ b/docs/fsharp/style-guide/conventions.md
@@ -1,9 +1,9 @@
 ---
-title: F# Coding Conventions
+title: F# coding conventions
 description: Learn general guidelines and idioms when writing F# code.
 ms.date: 05/14/2018
 ---
-# F# Coding Conventions
+# F# coding conventions
 
 The following conventions are formulated from experience working with large F# codebases. The [Five principles of good F# code](index.md#five-principles-of-good-f-code) are the foundation of each recommendation. They are related to the [F# component design guidelines](component-design-guidelines.md), but are applicable for any F# code, not just components such as libraries.
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -1,9 +1,9 @@
 ---
-title: F# Formatting Guidelines
+title: F# code formatting guidelines
 description: Learn guidelines for formatting F# code.
 ms.date: 05/14/2018
 ---
-# F# Formatting Guidelines
+# F# code formatting guidelines
 
 This article offers guidelines for how to format your code so that your F# code is:
 

--- a/docs/fsharp/style-guide/index.md
+++ b/docs/fsharp/style-guide/index.md
@@ -1,9 +1,9 @@
 ---
-title: F# Style Guide
+title: F# style guide
 description: Learn the five principles of good F# code.
 ms.date: 05/14/2018
 ---
-# F# Style Guide
+# F# style guide
 
 The following articles describe guidelines for formatting F# code and topical guidance for features of the language and how they should be used.
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -286,10 +286,10 @@
 ### [Get Started with Visual Studio Code and Ionide](fsharp/get-started/get-started-vscode.md)
 ### [Get Started with with the .NET Core CLI](fsharp/get-started/get-started-command-line.md)
 
-## [F# Style Guide](fsharp/style-guide/index.md)
-### [F# Formatting Guidelines](fsharp/style-guide/formatting.md)
-### [F# Coding Conventions](fsharp/style-guide/conventions.md)
-### [F# Component Design Guidelines](fsharp/style-guide/component-design-guidelines.md)
+## [F# style guide](fsharp/style-guide/index.md)
+### [F# formatting guidelines](fsharp/style-guide/formatting.md)
+### [F# coding conventions](fsharp/style-guide/conventions.md)
+### [F# component design guidelines](fsharp/style-guide/component-design-guidelines.md)
 
 ## Tutorials
 ### [F# Interactive](fsharp/tutorials/fsharp-interactive/index.md)


### PR DESCRIPTION
Reverts dotnet/docs#5406