### PR TITLE
Improved C# spec links

### DIFF
--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -24,8 +24,8 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
 |Option|Meaning|  
 |------------|-------------|  
-|default|The compiler accepts all valid language syntax from the latest major version that it can support. <sup id="TDefault">[Default](#FDefault)</sup>| 
-|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.1) <sup id="TISO1">[ISO1](#FISO1)</sup>|  
+|default|The compiler accepts all valid language syntax from the latest major version that it can support.|
+|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2) <sup id="TISO1">[ISO1](#FISO1)</sup>|  
 |ISO-2|The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0) <sup id="TISO2">[ISO2](#FISO2)</sup>|
 |3|The compiler accepts only syntax that is included in C# 3.0 or lower <sup id="TCS3">[CS3](#FCS3)</sup>|
 |4|The compiler accepts only syntax that is included in C# 4.0 or lower <sup id="TCS4">[CS4](#FCS4)</sup>|
@@ -35,7 +35,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
 |7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS72">[CS72](#FCS72)</sup>|
 |7.3|The compiler accepts only syntax that is included in C# 7.3 or lower <sup id="TCS73">[CS73](#FCS73)</sup>|
-|latest|The compiler accepts all valid language syntax that it can support. <sup id="TLatest">[Latest](#FLatest)</sup>|
+|latest|The compiler accepts all valid language syntax that it can support.|
 
 <!--- Uncomment and move these above
 |8|The compiler accepts only syntax that is included in C# 8 or lower <sup id="TCS8">[CS8](#FCS8)</sup>|
@@ -80,7 +80,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |C# 7.0 and later||not currently available|
 
 ### Minimum compiler version needed to support all language features   
-[↩](#TDefault)<a name="FDefault">Default</a>, <a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler     
+[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler     
 [↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler    
 [↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler    
 [↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler    
@@ -89,7 +89,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 [↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017   
 [↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3    
 [↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5    
-[↩](#TCS73)<a name="FCS73">CS73</a>, <a name="FLatest">Latest</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7    
+[↩](#TCS73)<a name="FCS73">CS73</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7    
 
 <!--- Uncomment and add to the above when they become officially released
 [↩](#TCS8)<a name="FCS8">CS8</a>: Microsoft Visual Studio/Build Tools 20??    

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -68,19 +68,16 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
  [Managing Project and Solution Properties](/visualstudio/ide/managing-project-and-solution-properties)  
  
 ### C# Language Specification
- [C# Language Specification Reference](../language-specification/index.md) : .NET Foundation  
- C# 1.0/1.1 [ISO/IEC 23270:2003](https://www.iso.org/standard/36768.html) Information technology -- C# Language Specification : ISO Catalogue  
- C# 2.0 [ISO/IEC 23270:2006](https://www.iso.org/standard/42926.html) Information technology -- C# Language Specification : ISO Catalogue  
- C# 2.0 [c042926_ISO_IEC_23270_2006(E).zip](http://standards.iso.org/ittf/PubliclyAvailableStandards/c042926_ISO_IEC_23270_2006(E).zip) ISO/IEC 23270:2006 in PDF format : ISO Freely Available Standards  
- C# 3.0 [CSharp Language Specification.doc](http://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc) C# Language Specification Version 3.0 : Microsoft Corporation  
- C# 4.0 [Ecma-334.pdf](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf) Standard ECMA-334 4th Edition    
- C# 5.0 [Ecma-334.pdf](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf) Standard ECMA-334 5th Edition  
- C# 6.0 [README.md](https://github.com/dotnet/csharplang/blob/master/spec/README.md) C# Language Specification Version 6 - Unofficial Draft : .NET Foundation  
- C# 7.0 and later (not currently available)  
 
-<!--- Uncomment and add to the above when they become officially released
- C# 8.0 (spec is not yet finished)  
--->
+|Version|Link|Description|
+|-------|----|-----------|
+|C# 1.0|[Download DOC](http://download.microsoft.com/download/a/9/e/a9e229b9-fee5-4c3e-8476-917dee385062/csharp%20language%20specification%20v1.0.doc)|C# Language Specification Version 1.0: Microsoft Corporation|
+|C# 1.2|[Download DOC](http://download.microsoft.com/download/5/e/5/5e58be0a-b02b-41ac-a4a3-7a22286214ff/csharp%20language%20specification%20v1.2.doc)|C# Language Specification Version 1.2: Microsoft Corporation|
+|C# 2.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/Ecma-334%204th%20edition%20June%202006.pdf)|Standard ECMA-334 4th Edition|
+|C# 3.0|[Download DOC](http://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc)|C# Language Specification Version 3.0: Microsoft Corporation|
+|C# 5.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf)|Standard ECMA-334 5th Edition|
+|C# 6.0|[Link](../language-specification/index.md)|C# Language Specification Version 6 - Unofficial Draft: .NET Foundation|
+|C# 7.0 and later||not currently available|
 
 ### Minimum compiler version needed to support all language features   
 [↩](#TDefault)<a name="FDefault">Default</a>, <a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler     


### PR DESCRIPTION
What I did:

* Changed the list to a table, to make it easier to understand.
* Removed filenames, which don't add any useful information.
* Removed ISO links. The C# 1.0 link doesn't seem to lead to any kind of download. The first C# 2.0 link only leads to a paid version of the spec. The second C# 2.0 link is redundant with the ECMA version of the spec.
* Removed link to csharplang version of the spec, since it's the same as the docs.MS version.
* Corrected that the 4th edition of the ECMA spec actually refers to C# 2.0 and fixed the link.
* Included links to C# 1.0 and 1.2 specs from MS found on [Jon Skeet's site](http://csharpindepth.com/Articles/Chapter1/Specifications.aspx).

What I didn't do:

* I didn't include link to C# 4.0 spec from MS found on [Jon Skeet's site](http://csharpindepth.com/Articles/Chapter1/Specifications.aspx), because it's hosted by Jon Skeet: http://csharpindepth.com/Files/CSharp%204%20Specification.doc. Linking to that from the official documentation didn't seem right to me.

    One solution to that issue would be to download the file from Jon Skeet's site and host it in this repo.

* I didn't try to figure out which editions of the ECMA spec before the 4th (available for download from [the ECMA site](https://www.ecma-international.org/publications/standards/Ecma-334-arch.htm)) correspond to which version of C# before 2.0. These could potentially replace MS versions of the spec for C# 1.x.