### PR TITLE
create "what's new in C# 7.3"

### DIFF
--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -34,6 +34,8 @@ productivity for developers. Features in this release include:
     - Collection initializers can rely on accessible extension methods, in addition to member methods.
 * [Improved overload resolution](#improved-overload-resolution):
     - Some constructs that previously generated ambiguous method calls now resolve correctly.
+* [`deterministic` compiler option](#deterministic-compiler-output):
+    - The deterministic compiler option ensures that subsequent compilations of the same source generate the same binary output.
 
 The overall effect of these features is that you write more concise code
 that is also more readable. The syntax contains less ceremony for many
@@ -570,3 +572,12 @@ a lambda expression as an argument:
 
 The C# 6 compiler correctly determines that `Task.Run(Func<Task>())` is
 a better choice.
+
+### Deterministic compiler output
+
+The `-deterministic` option instructs the compiler to produce a byte-for-byte identical output assembly for successive compilations of the same source files.
+
+By default, every compilation produces unique output on each compilation. The compiler adds a timestamp, and a GUID generated from random numbers. You use this option if you want to compare the byte-for-byte output to ensure consistency across builds.
+
+For more information, see the [-deterministic compiler option](../language-reference/compiler-options/deterministic-compiler-option.md) article.
+

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -45,60 +45,82 @@ unsafe struct S
 }
 ```
 
-In earlier versions of C#, you needed to pin a variable to access one of the integers that are part of `myFixedField`. Now, the following code compiles:
+In earlier versions of C#, you needed to pin a variable to access one of the integers that are part of `myFixedField`. Now, the following code compiles in a safe context:
 
 ```csharp
-var s = new S();
-int p = s.myFixedField[5];
+class C
+{
+    static S s = new S();
+
+    public void M()
+    {
+        int p = s.myFixedField[5];
+    }
+}
 ```
 
-The variable `p` doesn't need to be pinned. Note that you still need an `unsafe` context.
+The variable `p` doesn't need to be pinned. Note that you still need an `unsafe` context. In earlier versions of C#, you need to declare a second fixed pointer:
 
-You can learn more in the article on the [`fixed` statement](../language-reference/keywords/fixed-statement.md).
+```csharp
+class C
+{
+    static S s = new S();
+
+    public void M()
+    {
+        fixed (int* ptr = s.myFixedField)
+        {
+            int p = ptr[5];
+        }
+    }
+}
+```
+
+Fore more information, see the article on the [`fixed` statement](../language-reference/keywords/fixed-statement.md).
 
 ### `ref` local variables may be reassigned
 
-Now, `ref` locals may be reassigned to refer to different storage after being initialized. The following code now compiles:
+Now, `ref` locals may be reassigned to refer to different instances after being initialized. The following code now compiles:
 
-```csharp 
+```csharp
 ref VeryLargeStruct reflocal = ref veryLargeStruct; // initialization
 refLocal = ref anotherVeryLargeStruct; // reassigned, refLocal refers to different storage.
 ```
 
-You can learn more in the article on [`ref` returns and `ref` locals](../programming-guide/classes-and-structs/ref-returns.md).
+For more information, see the article on [`ref` returns and `ref` locals](../programming-guide/classes-and-structs/ref-returns.md).
 
 ### `stackalloc` arrays support initializers
 
-You have been able to specify the values for elements in an array when you initialize the array:
+You've been able to specify the values for elements in an array when you initialize it:
 
 ```csharp
 var arr = new int[3] {1, 2, 3};
-var arr2 = new int[] { 1, 2, 3};
+var arr2 = new int[] {1, 2, 3};
 ```
 
 Now, that same syntax can be applied to arrays that are declared with `stackalloc`:
 
 ```csharp
 int* pArr = stackalloc int[3] {1, 2, 3};
-int* pArr2 = stackalloc int[] { 1, 2, 3};
+int* pArr2 = stackalloc int[] {1, 2, 3};
 Span<int> arr = stackalloc [] {1, 2, 3};
 ```
 
-You can learn more in the article on the [`stackalloc` statement](../language-reference/keywords/stackalloc.md).
+For more information, see the [`stackalloc` statement](../language-reference/keywords/stackalloc.md) article in the language reference.
 
 ### More types support the `fixed` statement
 
 The `fixed` statement supported a limited set of types. Starting with C# 7.3, any type that contains a `DangerousGetPinnableReference()` method that returns a `ref T` or `ref readonly T` may be `fixed`. Adding this feature means that `fixed` can be used with <xref:System.Span%601?displayProperty=nameWithType> and related types.
 
-You can learn more in the article on the [`fixed` statement](../language-reference/keywords/fixed-statement.md).
+For more information, see the [`fixed` statement](../language-reference/keywords/fixed-statement.md) article in the language reference.
 
 ### Enhanced generic constraints
 
 You can now specify the type <xref:System.Enum?displayProperty=nameWithType> or <xref:System.Delegate?displayProperty=nameWithType> as base class constraints for a type parameter.
 
-You can also use the new `unmanaged` constraint, to specify that a type parameter must be an **unmanaged type**. An **unmanaged type** is a type that isn't a reference type, and doesn't contain any reference type at any level of nesting.
+You can also use the new `unmanaged` constraint, to specify that a type parameter must be an **unmanaged type**. An **unmanaged type** is a type that isn't a reference type and doesn't contain any reference type at any level of nesting.
 
-You can learn more in the articles on [`where` generic constraints](../language-reference/keywords/where-generic-type-constraints.md) and the article covering [constraints on type parameters](../programming-guide/generics/constraints-on-type-parameters.md).
+For more information, see the articles on [`where` generic constraints](../language-reference/keywords/where-generic-type-constraint.md) and [constraints on type parameters](../programming-guide/generics/constraints-on-type-parameters.md).
 
 ## Make existing features better
 
@@ -106,7 +128,7 @@ The second theme provides improvements to features in the language. These featur
 
 ### Tuples support `==` and `!=`
 
-The C# tuple types now support `==` and `!=`. You can learn more about the rules in the article on [tuples](../tuples.md#equality-and-tuples).
+The C# tuple types now support `==` and `!=`. Fore more information, see the section covering [equality](../tuples.md#equality-and-tuples) in the article on [tuples](../tuples.md#equality-and-tuples).
 
 ### Attach attributes to the backing fields for auto-implemented properties
 
@@ -117,7 +139,7 @@ This syntax is now supported:
 public int SomeProperty { get; set; }
 ```
 
-The attribute `SomeThingAboutFieldAttribute` is applied to the compiler generated backing field for `SomeProperty`. You can learn more in the articles on [attributes in C#](../programming-guide/concepts/attributes/index.md).
+The attribute `SomeThingAboutFieldAttribute` is applied to the compiler generated backing field for `SomeProperty`. For more information, see [attributes](../programming-guide/concepts/attributes/index.md) in the C# programming guide.
 
 ### `in` method overload resolution tiebreaker
 
@@ -128,7 +150,7 @@ static void M(S arg);
 static void M(in S arg);
 ```
 
-Now, the by value (first in the preceding example) overload is better than the by readonly reference version. To specify the by readonly reference version is called, you must include the `in` modifier when calling the method.
+Now, the by value (first in the preceding example) overload is better than the by readonly reference version. To call the version with the readonly reference argument, you must include the `in` modifier when calling the method.
 
 > [!NOTE]
 > This was implemented as a bug fix. This no longer is ambiguous even with the language version set to "7.2".
@@ -137,7 +159,7 @@ For more information, see the article on the [`in` parameter modifier](../langua
 
 ### Extend expression variables in initializers
 
-The syntax added in C# 7.0 to permit out variable declarations has been extended to include field initializers, property initializers, constructor initializers, and query clauses. It enables code such as the following example:
+The syntax added in C# 7.0 to aloow `out` variable declarations has been extended to include field initializers, property initializers, constructor initializers, and query clauses. It enables code such as the following example:
 
 ```csharp
 public class B
@@ -169,9 +191,9 @@ You'll only notice this change because you'll find fewer compiler errors for amb
 
 ## New compiler options
 
-New compiler options support new build and DevOps scenarios for C# programs
+New compiler options support new build and DevOps scenarios for C# programs.
 
-### Public or OSS signing
+### Public or Open Source signing
 
 The `-publicsign` compiler option instructs the compiler to sign the assembly using a public key. The assembly is marked as signed, but the signature is taken from the public key. This option enables you to build signed assemblies from open-source projects using a public key.
 
@@ -179,6 +201,6 @@ For more information, see the [-publicsign compiler option](../language-referenc
 
 ### pathmap
 
-The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The pathmap option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
+The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The `pathmap` option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
 
 For more information, see the [-pathmap compiler option](../language-reference/compiler-options/pathmap-compile-option.md) article.

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -1,0 +1,189 @@
+---
+title: What's new in C# 7.3
+description: An overview of new features in C# 7.3
+ms.date: 05/16/2018
+---
+# What's new in C# 7.3
+
+There are two main themes to the C# 7.3 release. One theme provides features that enable safe code to be as performant as unsafe code. The second theme provides incremental improvements to existing features. In addition, new compilers were added in this release.
+
+The following new features support the theme of better performance for safe code:
+
+- You can access fixed fields without pinning.
+- You can reassign `ref` local variables.
+- You can use initializers on `stackalloc` arrays.
+- You can use `fixed` statements with any type that supports a pattern.
+- You can use additional generic constraints.
+
+The following enhancements were made to existing features:
+
+- You can test `==` and `!=` with tuple types.
+- You can use expression variables in more locations.
+- You may attach attributes to the backing field of auto implemented properties.
+- Method resolution when arguments differ by `in` has been improved.
+- Overload resolution new has fewer ambiguous cases.
+
+The new compiler options are:
+
+- `deterministic` to ensure that subsequent compilations of the same source generate the same binary output.
+- `publicsign` to enable OSS signing of assemblies.
+- `pathmap` to provide a mapping for source directories.
+
+The remainder of this article provides details and links to learn more about each of the improvements.
+
+## Enabling more performant safe code
+
+You should be able to write C# code safely that performs as well as unsafe code. Safe code avoids classes of errors, such as buffer overruns, stray pointers, and other memory access errors. These new features expand the capabilities of verifiable safe code. Strive to write more of your code using safe constructs. These features make that easier.
+
+### Indexing `fixed` fields does not require pinning
+
+Consider this struct:
+
+```csharp
+unsafe struct S
+{
+    public fixed int myFixedField[10];
+}
+```
+
+In earlier versions of C#, you needed to pin a variable to access one of the integers that are part of `myFixedField`. Now, the following code compiles:
+
+```csharp
+var s = new S();
+int p = s.myFixedField[5];
+```
+
+The variable `p` doesn't need to be pinned. Note that you still need an `unsafe` context.
+
+You can learn more in the article on the [`fixed` statement](../language-reference/keywords/fixed-statement.md).
+
+### `ref` local variables may be reassigned
+
+Now, `ref` locals may be reassigned to refer to different storage after being initialized. The following code now compiles:
+
+```csharp 
+ref VeryLargeStruct reflocal = ref veryLargeStruct; // initialization
+refLocal = ref anotherVeryLargeStruct; // reassigned, refLocal refers to different storage.
+```
+
+You can learn more in the article on [`ref` returns and `ref` locals](../programming-guide/classes-and-structs/ref-returns.md).
+
+### `stackalloc` arrays support initializers
+
+You have been able to specify the values for elements in an array when you initialize the array:
+
+```csharp
+var arr = new int[3] {1, 2, 3};
+var arr2 = new int[] { 1, 2, 3};
+```
+
+Now, that same syntax can be applied to arrays that are declared with `stackalloc`:
+
+```csharp
+int* pArr = stackalloc int[3] {1, 2, 3};
+int* pArr2 = stackalloc int[] { 1, 2, 3};
+```
+
+You can learn more in the article on the [`stackalloc` statement](../language-reference/keywords/stackalloc.md).
+
+### More types support the `fixed` statement
+
+The `fixed` statement supported a limited set of types. Starting with C# 7.3, any type that contains a `DangerousGetPinnableReference()` method that returns a `ref T` or `ref readonly T` may be `fixed`. Adding this feature means that `fixed` can be used with <xref:System.Span%601?displayProperty=nameWithType> and related types.
+
+You can learn more in the article on the [`fixed` statement](../language-reference/keywords/fixed-statement.md).
+
+### Enhanced generic constraints
+
+You can now specify the type <xref:System.Enum?displayProperty=nameWithType> or <xref:System.Delegate?displayProperty=nameWithType> as base class constraints for a type parameter.
+
+You can also use the new `unmanaged` constraint, to specify that a type parameter must be an **unmanaged type**. An **unmanaged type** is a type that isn't a reference type, and doesn't contain any reference type at any level of nesting.
+
+You can learn more in the articles on [`where` generic constraints](../language-reference/keywords/where-generic-type-constraints.md) and the article covering [constraints on type parameters](../programming-guide/generics/constraints-on-type-parameters.md).
+
+## Make existing features better
+
+The second theme provides improvements to features in the language. These features improve productivity when writing C#.
+
+### Tuples support `==` and `!=`
+
+The C# tuple types now support `==` and `!=`. You can learn more about the rules in the article on [tuples](../tuples.md).
+
+### Attach attributes to the backing fields for auto-implemented properties
+
+This syntax is now supported:
+
+```csharp
+[field: SomeThingAboutFieldAttribute]
+public int SomeProperty { get; set; }
+```
+
+The attribute `SomeThingAboutFieldAttribute` is applied to the compiler generated backing field for `SomeProperty`. You can learn more in the articles on [attributes in C#](../programming-guide/concepts/attributes/index.md).
+
+### `in` method overload resolution tiebreaker
+
+When the `in` argument modifier was added, these two methods would cause an ambiguity:
+
+```csharp
+static void M(S arg);
+static void M(in S arg);
+```
+
+Now, the by value (first in the preceding example) overload is better than the by readonly reference version. To specify that by readonly reference version, you must include the `in` modifier when calling the method.
+
+For more information, see the article on the [`in` parameter modifier](../language-reference/keywords/in-parameter-modifier.md).
+
+### Extend expression variables in initializers
+
+The syntax added in C# 7.0 to permit out variable declarations has been extended to include field initializers, property initializers, constructor initializers, and query clauses. It enables code such as the following example:
+
+```csharp
+public class B
+{
+   public B(int i, out int j)
+   {
+      j = i;
+   }
+}
+
+public class D : B
+{
+   public D(int i) : B(i, out var j)
+   {
+      Console.WriteLine($"The value of 'j' is {j}");
+   }
+}
+```
+
+### Improved overload candidates
+
+In every release, the overload resolution rules get updated to address situations where ambiguous method invocations have an "obvious" choice. This release adds three new rules to help the compiler pick the obvious choice:
+
+1. When a method group contains both instance and static members, the compiler discards the instance members if the method was invoked without an instance receiver or context. The compiler discards the static members if the method was invoked with an instance receiver. When there is no receiver, the compiler includes only static members in a static context, otherwise both static and instance members. When the receiver is ambiguously an instance or type, the compiler includes both. A static context, where an implicit `this` instance receiver cannot be used, includes the body of members where no `this` is defined, such as static members, as well as places where `this` cannot be used, such as field initializers and constructor-initializers.
+1. When a method group contains some generic methods whose type arguments do not satisfy their constraints, these members are removed from the candidate set.
+1. For a method group conversion, candidate methods whose return type doesn't match up with the delegate's return type are removed from the set.
+
+You'll only notice this change because you'll find fewer compiler errors for ambiguous method overloads when you are sure which method is better.
+
+## New compiler options
+
+New compiler options support new build and DevOps scenarios for C# programs
+
+### Deterministic compiler output
+
+The `-deterministic` option instructs the compiler to produce a byte-for-byte identical output assembly for successive compilations of the same source files.
+
+By default, every compilation unique output on each compilation. The compiler adds a timestamp, and a GUID generated from random numbers. You use this option if you want to compare the byte-for-byte output to ensure consistency across builds.
+
+For more information, see the [deterministic compiler option](../language-reference/compiler-options/deterministic-compiler-option.md) article.
+
+### Public or OSS signing
+
+The `-publicsign` compiler option instructs the compiler to sign the assembly using a public key. The assembly is marked as signed, but the signature is taken from the public key. This option enables you to build signed assemblies from open-source projects using a public key.
+
+For more information, see the [publicsign compiler option](../language-reference/compiler-options/publicsign-compiler-option.md) article.
+
+### pathmap
+
+The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The pathmap option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
+
+For more information, see the [pathmap compiler option](../language-reference/compiler-options/pathmap-compile-option.md) article.

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -5,7 +5,7 @@ ms.date: 05/16/2018
 ---
 # What's new in C# 7.3
 
-There are two main themes to the C# 7.3 release. One theme provides features that enable safe code to be as performant as unsafe code. The second theme provides incremental improvements to existing features. In addition, new compilers were added in this release.
+There are two main themes to the C# 7.3 release. One theme provides features that enable safe code to be as performant as unsafe code. The second theme provides incremental improvements to existing features. In addition, new compiler options were added in this release.
 
 The following new features support the theme of better performance for safe code:
 
@@ -19,15 +19,14 @@ The following enhancements were made to existing features:
 
 - You can test `==` and `!=` with tuple types.
 - You can use expression variables in more locations.
-- You may attach attributes to the backing field of auto implemented properties.
+- You may attach attributes to the backing field of auto-implemented properties.
 - Method resolution when arguments differ by `in` has been improved.
-- Overload resolution new has fewer ambiguous cases.
+- Overload resolution now has fewer ambiguous cases.
 
 The new compiler options are:
 
-- `deterministic` to ensure that subsequent compilations of the same source generate the same binary output.
-- `publicsign` to enable OSS signing of assemblies.
-- `pathmap` to provide a mapping for source directories.
+- `-publicsign` to enable OSS signing of assemblies.
+- `-pathmap` to provide a mapping for source directories.
 
 The remainder of this article provides details and links to learn more about each of the improvements.
 
@@ -82,6 +81,7 @@ Now, that same syntax can be applied to arrays that are declared with `stackallo
 ```csharp
 int* pArr = stackalloc int[3] {1, 2, 3};
 int* pArr2 = stackalloc int[] { 1, 2, 3};
+Span<int> arr = stackalloc [] {1, 2, 3};
 ```
 
 You can learn more in the article on the [`stackalloc` statement](../language-reference/keywords/stackalloc.md).
@@ -106,7 +106,7 @@ The second theme provides improvements to features in the language. These featur
 
 ### Tuples support `==` and `!=`
 
-The C# tuple types now support `==` and `!=`. You can learn more about the rules in the article on [tuples](../tuples.md).
+The C# tuple types now support `==` and `!=`. You can learn more about the rules in the article on [tuples](../tuples.md#equality-and-tuples).
 
 ### Attach attributes to the backing fields for auto-implemented properties
 
@@ -128,7 +128,10 @@ static void M(S arg);
 static void M(in S arg);
 ```
 
-Now, the by value (first in the preceding example) overload is better than the by readonly reference version. To specify that by readonly reference version, you must include the `in` modifier when calling the method.
+Now, the by value (first in the preceding example) overload is better than the by readonly reference version. To specify the by readonly reference version is called, you must include the `in` modifier when calling the method.
+
+> [!NOTE]
+> This was implemented as a bug fix. This no longer is ambiguous even with the language version set to "7.2".
 
 For more information, see the article on the [`in` parameter modifier](../language-reference/keywords/in-parameter-modifier.md).
 
@@ -168,22 +171,14 @@ You'll only notice this change because you'll find fewer compiler errors for amb
 
 New compiler options support new build and DevOps scenarios for C# programs
 
-### Deterministic compiler output
-
-The `-deterministic` option instructs the compiler to produce a byte-for-byte identical output assembly for successive compilations of the same source files.
-
-By default, every compilation unique output on each compilation. The compiler adds a timestamp, and a GUID generated from random numbers. You use this option if you want to compare the byte-for-byte output to ensure consistency across builds.
-
-For more information, see the [deterministic compiler option](../language-reference/compiler-options/deterministic-compiler-option.md) article.
-
 ### Public or OSS signing
 
 The `-publicsign` compiler option instructs the compiler to sign the assembly using a public key. The assembly is marked as signed, but the signature is taken from the public key. This option enables you to build signed assemblies from open-source projects using a public key.
 
-For more information, see the [publicsign compiler option](../language-reference/compiler-options/publicsign-compiler-option.md) article.
+For more information, see the [-publicsign compiler option](../language-reference/compiler-options/publicsign-compiler-option.md) article.
 
 ### pathmap
 
 The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The pathmap option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
 
-For more information, see the [pathmap compiler option](../language-reference/compiler-options/pathmap-compile-option.md) article.
+For more information, see the [-pathmap compiler option](../language-reference/compiler-options/pathmap-compile-option.md) article.

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -25,7 +25,7 @@ The following enhancements were made to existing features:
 
 The new compiler options are:
 
-- `-publicsign` to enable OSS signing of assemblies.
+- `-publicsign` to enable Open Source Software (OSS) signing of assemblies.
 - `-pathmap` to provide a mapping for source directories.
 
 The remainder of this article provides details and links to learn more about each of the improvements.
@@ -52,14 +52,14 @@ class C
 {
     static S s = new S();
 
-    public void M()
+    unsafe public void M()
     {
         int p = s.myFixedField[5];
     }
 }
 ```
 
-The variable `p` doesn't need to be pinned. Note that you still need an `unsafe` context. In earlier versions of C#, you need to declare a second fixed pointer:
+The variable `p` accesses one element in `myFixedField`. You don't need to declare a separate `int*` variable. Note that you still need an `unsafe` context. In earlier versions of C#, you need to declare a second fixed pointer:
 
 ```csharp
 class C
@@ -83,7 +83,7 @@ Fore more information, see the article on the [`fixed` statement](../language-re
 Now, `ref` locals may be reassigned to refer to different instances after being initialized. The following code now compiles:
 
 ```csharp
-ref VeryLargeStruct reflocal = ref veryLargeStruct; // initialization
+ref VeryLargeStruct refLocal = ref veryLargeStruct; // initialization
 refLocal = ref anotherVeryLargeStruct; // reassigned, refLocal refers to different storage.
 ```
 

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -203,4 +203,4 @@ For more information, see the [-publicsign compiler option](../language-referenc
 
 The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The `-pathmap` option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
 
-For more information, see the [-pathmap compiler option](../language-reference/compiler-options/pathmap-compile-option.md) article.
+For more information, see the [-pathmap compiler option](../language-reference/compiler-options/pathmap-compiler-option.md) article.

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -128,7 +128,7 @@ The second theme provides improvements to features in the language. These featur
 
 ### Tuples support `==` and `!=`
 
-The C# tuple types now support `==` and `!=`. Fore more information, see the section covering [equality](../tuples.md#equality-and-tuples) in the article on [tuples](../tuples.md#equality-and-tuples).
+The C# tuple types now support `==` and `!=`. Fore more information, see the section covering [equality](../tuples.md#equality-and-tuples) in the article on [tuples](../tuples.md).
 
 ### Attach attributes to the backing fields for auto-implemented properties
 
@@ -159,7 +159,7 @@ For more information, see the article on the [`in` parameter modifier](../langua
 
 ### Extend expression variables in initializers
 
-The syntax added in C# 7.0 to aloow `out` variable declarations has been extended to include field initializers, property initializers, constructor initializers, and query clauses. It enables code such as the following example:
+The syntax added in C# 7.0 to allow `out` variable declarations has been extended to include field initializers, property initializers, constructor initializers, and query clauses. It enables code such as the following example:
 
 ```csharp
 public class B
@@ -201,6 +201,6 @@ For more information, see the [-publicsign compiler option](../language-referenc
 
 ### pathmap
 
-The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The `pathmap` option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
+The `-pathmap` compiler option instructs the compiler to replace source paths from the build environment with mapped source paths. The `-pathmap` option controls the source path written by the compiler to PDB files or for the <xref:System.Runtime.CompilerServices.CallerFilePathAttribute>.
 
 For more information, see the [-pathmap compiler option](../language-reference/compiler-options/pathmap-compile-option.md) article.

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -12,10 +12,10 @@ the C# language. The following links provide detailed information on the
 major features added in each release.
 
 > [!IMPORTANT]
-> The C# language relies on types and methods in a *standard library* for some of the features. One example is exception processing. Every `throw` statement or expression is checked to ensure the object being thrown is derived from <xref:System.Exception>. Similarly, every `catch` is checked to ensure that the type being caught is derived from <xref:System.Exception>. Each version may add new requirements. To use the latest language features in older environments, you may need to install specific libraries. These dependencies are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency.
+> The C# language relies on types and methods in a *standard library* for some of the features. One example is exception processing. Every `throw` statement or expression is checked to ensure the object being thrown is derived from <xref:System.Exception>. Similarly, every `catch` is checked to ensure that the type being caught is derived from <xref:System.Exception>. Each version may add new requirements. To use the latest language features in older environments, you may need to install specific libraries. These dependencies are documented in the page for each specific version. For more information, see the article on the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency.
 
 * [C# 7.3](csharp-7-3.md):
-  - This page describes the latest features in the C# language. C# 7.3 is currently available in [Visual Studio 2017 version 15.7](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.1 SDK Preview](../../core/whats-new/index.md).
+  - This page describes the latest features in the C# language. C# 7.3 is currently available in [Visual Studio 2017 version 15.7](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.1 SDK 2.1.300 RC1](../../core/whats-new/index.md).
 * [C# 7.2](csharp-7-2.md):
   - This page describes the features added in the C# language. C# 7.2 is currently available in [Visual Studio 2017 version 15.5](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 * [C# 7.1](csharp-7-1.md):

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -17,9 +17,9 @@ major features added in each release.
 * [C# 7.3](csharp-7-3.md):
   - This page describes the latest features in the C# language. C# 7.3 is currently available in [Visual Studio 2017 version 15.7](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.1 SDK Preview](../../core/whats-new/index.md).
 * [C# 7.2](csharp-7-2.md):
-  - This page describes the latest features in the C# language. C# 7.2 is currently available in [Visual Studio 2017 version 15.5](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
+  - This page describes the features added in the C# language. C# 7.2 is currently available in [Visual Studio 2017 version 15.5](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 * [C# 7.1](csharp-7-1.md):
-  - This page describes the features in C# 7.1. These features were added in [Visual Studio 2017 version 15.3](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
+  - This page describes the features added in C# 7.1. These features were added in [Visual Studio 2017 version 15.3](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 * [C# 7.0](csharp-7.md):
   - This page describes the features added in C# 7.0. These features were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
 * [C# 6](csharp-6.md):

--- a/docs/csharp/whats-new/index.md
+++ b/docs/csharp/whats-new/index.md
@@ -12,52 +12,38 @@ the C# language. The following links provide detailed information on the
 major features added in each release.
 
 > [!IMPORTANT]
-> The C# language relies on types and methods in a *standard library* for some of the features. One example is exception processing. Every `throw` statement or expression is checked to ensure the object being thrown is derived from <xref:System.Exception>. Similarly, every `catch` is checked to ensure that the type being caught is derived from <xref:System.Exception>. Each version may add new requirements. To use the latest language features in older environments, you may need to install specific libraries. These dependencies are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency. 
+> The C# language relies on types and methods in a *standard library* for some of the features. One example is exception processing. Every `throw` statement or expression is checked to ensure the object being thrown is derived from <xref:System.Exception>. Similarly, every `catch` is checked to ensure that the type being caught is derived from <xref:System.Exception>. Each version may add new requirements. To use the latest language features in older environments, you may need to install specific libraries. These dependencies are documented in the page for each specific version. You can learn more about the [relationships between language and library](relationships-between-language-and-library.md) for background on this dependency.
 
-
+* [C# 7.3](csharp-7-3.md):
+  - This page describes the latest features in the C# language. C# 7.3 is currently available in [Visual Studio 2017 version 15.7](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.1 SDK Preview](../../core/whats-new/index.md).
 * [C# 7.2](csharp-7-2.md):
-    - This page describes the latest features in the C# language. C# 7.2 is currently available in [Visual Studio 2017 version 15.5](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
-
+  - This page describes the latest features in the C# language. C# 7.2 is currently available in [Visual Studio 2017 version 15.5](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 * [C# 7.1](csharp-7-1.md):
-    - This page describes the features in C# 7.1. These features were added in [Visual Studio 2017 version 15.3](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
-
+  - This page describes the features in C# 7.1. These features were added in [Visual Studio 2017 version 15.3](https://www.visualstudio.com/vs/whatsnew/), and in the [.NET Core 2.0 SDK](../../core/whats-new/index.md).
 * [C# 7.0](csharp-7.md):
-    - This page describes the features added in C# 7.0. These features were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
-     
+  - This page describes the features added in C# 7.0. These features were added in [Visual Studio 2017](https://www.visualstudio.com/vs/whatsnew/) and [.NET Core 1.0](../../core/whats-new/index.md) and later
 * [C# 6](csharp-6.md):
-    - This page describes the features that were added in C# 6. These features are available in Visual Studio 2015 for Windows developers, and on .NET Core 1.0 for developers exploring C# on macOS and Linux.
-
-<!--* [C# Interactive](../interactive/index.md): 
-    - This page describes C# Interactive, an interactive Read Eval Print Loop (REPL) that you can use to explore the C# language. You can use it to write code interactively and see it execute immediately, without any compile or build step.
--->
+  - This page describes the features that were added in C# 6. These features are available in Visual Studio 2015 for Windows developers, and on .NET Core 1.0 for developers exploring C# on macOS and Linux.
 * [Cross Platform Support](../../core/index.md):
-    - C#, through .NET Core support, runs on multiple platforms. If you are interested in trying C# on macOS, or on one of the many supported Linux distributions, learn more about .NET Core.
+  - C#, through .NET Core support, runs on multiple platforms. If you are interested in trying C# on macOS, or on one of the many supported Linux distributions, learn more about .NET Core.
+* [.NET Compiler Platform SDK](../roslyn-sdk/index.md):
+  - The .NET Compiler Platform SDK enables you to write code that performs static analysis on C# code. You can use these APIs to find potential errors, or bad practices, suggest fixes, and even implement those fixes.
 
-<!--
-- [.NET Compiler Platform SDK](../roslyn/index.md):
-    - The .NET Compiler Platform SDK enables you to write code that performs static analysis on C# code. You can use these APIs to find potential errors, or bad practices, suggest fixes, and even implement those fixes.
--->
-  
 ## Previous Versions
-The following lists key features that were introduced in previous versions of the C# language and Visual Studio .NET.  
-  
- * Visual Studio .NET 2013: 
-     - This version of Visual Studio included bug fixes, performance improvements, and technology previews of .NET Compiler Platform ("Roslyn") which became the .NET Compiler Platform SDK<!--Link to ../roslyn/index.md-->.
 
- * C# 5, Visual Studio .NET 2012: 
-     - `Async` / `await`, and [caller information](../programming-guide/concepts/caller-information.md) attributes.
+The following lists key features that were introduced in previous versions of the C# language and Visual Studio .NET.
 
- * C# 4, Visual Studio .NET 2010: 
-     - `Dynamic`, [named arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md), optional parameters, and generic [covariance and contra variance](../programming-guide/concepts/covariance-contravariance/index.md).
-
- * C# 3, Visual Studio .NET 2008: 
-     - Object and collection initializers, lambda expressions, extension methods, anonymous types, automatic properties, local `var` type inference, and [Language Integrated Query (LINQ)](../programming-guide/concepts/linq/index.md).
-
- * C# 2, Visual Studio .NET 2005: 
-     - Anonymous methods, generics, nullable types, iterators/yield, `static` classes, and covariance and contra variance for delegates.
-
- * C# 1.1, Visual Studio .NET 2003: 
-     - `#line` pragma and xml doc comments.
-
- * C# 1, Visual Studio .NET 2002: 
-     - The first release of [C#](../csharp.md).   
+* Visual Studio .NET 2013:
+  - This version of Visual Studio included bug fixes, performance improvements, and technology previews of .NET Compiler Platform ("Roslyn") which became the [.NET Compiler Platform SDK](../roslyn-sdk/index.md).
+* C# 5, Visual Studio .NET 2012:
+  - `Async` / `await`, and [caller information](../programming-guide/concepts/caller-information.md) attributes.
+* C# 4, Visual Studio .NET 2010:
+  - `Dynamic`, [named arguments](../programming-guide/classes-and-structs/named-and-optional-arguments.md), optional parameters, and generic [covariance and contra variance](../programming-guide/concepts/covariance-contravariance/index.md).
+* C# 3, Visual Studio .NET 2008:
+  - Object and collection initializers, lambda expressions, extension methods, anonymous types, automatic properties, local `var` type inference, and [Language Integrated Query (LINQ)](../programming-guide/concepts/linq/index.md).
+* C# 2, Visual Studio .NET 2005:
+  - Anonymous methods, generics, nullable types, iterators/yield, `static` classes, and covariance and contra variance for delegates.
+* C# 1.1, Visual Studio .NET 2003:
+  - `#line` pragma and xml doc comments.
+* C# 1, Visual Studio .NET 2002:
+  - The first release of [C#](../csharp.md).

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -215,10 +215,11 @@
 <!-- The "What's New" section is short, and one level
     deep, so leave it in the main TOC -->
 ## [What's new in C#](csharp/whats-new/index.md)
-### [What's new in C# 7.2](csharp/whats-new/csharp-7-2.md)
-### [What's new in C# 7.1](csharp/whats-new/csharp-7-1.md)
-### [What's new in C# 7.0](csharp/whats-new/csharp-7.md)
-### [What's new in C# 6](csharp/whats-new/csharp-6.md)
+### [C# 7.3](csharp/whats-new/csharp-7-3.md)
+### [C# 7.2](csharp/whats-new/csharp-7-2.md)
+### [C# 7.1](csharp/whats-new/csharp-7-1.md)
+### [C# 7.0](csharp/whats-new/csharp-7.md)
+### [C# 6](csharp/whats-new/csharp-6.md)
 ### [C# Version History](csharp/whats-new/csharp-version-history.md)
 ### [Relationships between language and framework](csharp/whats-new/relationships-between-language-and-library.md)
 <!-- End What's New -->


### PR DESCRIPTION
Fixes #5289

This PR adds the overview to "What's new in C# 7.3". I updated the wording in the TOC to remove the repeated "What's new" phrasing.

/cc @jcouv @madstorgersen

/cc @Welchen

This PR relies on new files added in PR #5408

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
