### PR TITLE
L21177: Show code on target version due to character that should be e…

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/processing-the-xml-file.md
+++ b/docs/csharp/programming-guide/xmldoc/processing-the-xml-file.md
@@ -37,7 +37,7 @@ The compiler generates an ID string for each construct in your code that is tagg
   
     -   ELEMENT_TYPE_PTR is represented as a '*' following the modified type.  
   
-    -   ELEMENT_TYPE_BYREF is represented as a '@' following the modified type.  
+    -   ELEMENT_TYPE_BYREF is represented as a '\@' following the modified type.  
   
     -   ELEMENT_TYPE_PINNED is represented as a '^' following the modified type. The C# compiler never generates this.  
   


### PR DESCRIPTION
…scaped

Hello, @mairaw,

Localization team has reported source content issue that causes localized version to have broken format compared to en-us version.  

Please, review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
