### PR TITLE
Corrected default output directory for dotnet publish

### DIFF
--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -84,7 +84,7 @@ Doesn't perform an implicit restore when running the command.
 
 `-o|--output <OUTPUT_DIRECTORY>`
 
-Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
+Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/publish/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]/publish/* for a self-contained deployment.
 If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory.
 
 `--self-contained`
@@ -123,7 +123,7 @@ Specifies one or several [target manifests](../deploying/runtime-store.md) to us
 
 `-o|--output <OUTPUT_DIRECTORY>`
 
-Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]* for a self-contained deployment.
+Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/publish/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]/publish/* for a self-contained deployment.
 If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory.
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/5309.

To verify this is indeed the behavior of `dotnet publish`, I looked at the source code ([cli](https://github.com/dotnet/cli/blob/da34f7e/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs#L24), [sdk](https://github.com/dotnet/sdk/blob/a8cf9e7/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.BeforeCommon.targets#L82-L88)) and also tried running the command myself.