### PR TITLE
Fix a text paragraph being interpreted as code

### DIFF
--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -1490,7 +1490,7 @@ SqlClient now automatically provides faster connections to an AlwaysOn Availabil
 
 - **Support for code page encodings**
 
-      [!INCLUDE[net_core](../../../includes/net-core-md.md)] primarily supports the Unicode encodings and by default provides limited support for code page encodings. You can add support for code page encodings available in the .NET Framework but unsupported in [!INCLUDE[net_core](../../../includes/net-core-md.md)] by registering code page encodings with the <xref:System.Text.Encoding.RegisterProvider%2A?displayProperty=nameWithType> method. For more information, see <xref:System.Text.CodePagesEncodingProvider?displayProperty=nameWithType>.
+     [!INCLUDE[net_core](../../../includes/net-core-md.md)] primarily supports the Unicode encodings and by default provides limited support for code page encodings. You can add support for code page encodings available in the .NET Framework but unsupported in [!INCLUDE[net_core](../../../includes/net-core-md.md)] by registering code page encodings with the <xref:System.Text.Encoding.RegisterProvider%2A?displayProperty=nameWithType> method. For more information, see <xref:System.Text.CodePagesEncodingProvider?displayProperty=nameWithType>.
 
 - **.NET Native**
 


### PR DESCRIPTION
The "Support for code page encodings" paragraph in the rendered page is broken: https://docs.microsoft.com/en-us/dotnet/framework/whats-new/

I believe it's because the text is interpreted as code because of the initial white space before the content, but I have no way to verify this before merging.

---

Note: This pull request replaces https://github.com/dotnet/docs/pull/5510

On the previous PR, @svick  commented that exactly 4 spaces where needed instead of the current 6, but I noticed everything around is indented by 5 spaces and not 4, so I used 5. I hope it's the right thing to do.