### PR TITLE
Clarified relative paths for dotnet publish

### DIFF
--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -85,7 +85,7 @@ Doesn't perform an implicit restore when running the command.
 `-o|--output <OUTPUT_DIRECTORY>`
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/publish/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]/publish/* for a self-contained deployment.
-If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory.
+If the path is relative, the output directory generated is relative to the project file location, not to the current working directory.
 
 `--self-contained`
 
@@ -124,7 +124,7 @@ Specifies one or several [target manifests](../deploying/runtime-store.md) to us
 `-o|--output <OUTPUT_DIRECTORY>`
 
 Specifies the path for the output directory. If not specified, it defaults to *./bin/[configuration]/[framework]/publish/* for a framework-dependent deployment or *./bin/[configuration]/[framework]/[runtime]/publish/* for a self-contained deployment.
-If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory.
+If the path is relative, the output directory generated is relative to the project file location, not to the current working directory.
 
 `-r|--runtime <RUNTIME_IDENTIFIER>`
 


### PR DESCRIPTION
This is a followup to https://github.com/dotnet/docs/pull/5500, see there for an initial discussion of this small change.

cc: @dasMulli, @BillWagner 