### PR TITLE
Updated link to the C# specification 5.0

### DIFF
--- a/docs/csharp/index.md
+++ b/docs/csharp/index.md
@@ -58,7 +58,7 @@ There are several sections in the C# Guide. You can read them in order, or jump 
   * This section contains the reference material on the C# language. This material helps you understand the syntax and semantics of C#. It also includes reference material on types, operators, attributes, preprocessor directives, compiler switches, compiler errors, and compiler warnings.
 
 * [C# Language Specification](../csharp/language-reference/language-specification/index.md)
-  * Links to the latest version of the C# Specifications in Microsoft Word format.
+  * Links to the latest versions of the C# language specification.
 
 ## See also
 

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -32,11 +32,11 @@ This section provides reference material about C# keywords, operators, special c
  Includes code snippets that demonstrate the cause and correction of C# compiler errors and warnings.  
   
  [C# Language Specification](../../csharp/language-reference/language-specification/index.md)  
- Provides pointers to the latest version of the C# Language Specification in Microsoft Word format.  
+ Provides links to the latest versions of the C# language specification.  
   
 ## Related Sections  
 
- [C#](../../csharp/index.md)
+ [C# Guide](../../csharp/index.md)  
  Provides a portal to Visual C# documentation.  
   
  [Using the Visual Studio Development Environment for C#](/visualstudio/csharp-ide/using-the-visual-studio-development-environment-for-csharp)  

--- a/docs/csharp/language-reference/language-specification/index.md
+++ b/docs/csharp/language-reference/language-specification/index.md
@@ -1,6 +1,6 @@
 ---
-title: "C# 6.0 draft Language Specification"
-ms.date: 07/01/2017
+title: "C# 6.0 draft language specification"
+ms.date: 05/22/2018
 ms.topic: language-reference
 helpviewer_keywords: 
   - "C# language, specification"
@@ -9,18 +9,19 @@ helpviewer_keywords:
   - "language specification [C#]"
 ms.assetid: e5d5a5cc-636b-4bff-b9c8-a8edc6207c22
 ---
-# C# 6.0 draft Language Specification
-The C# Language Specification is the definitive source for C# syntax and usage. This specification contains detailed information about all aspects of the language, including many points that the documentation for Visual C# doesn't cover.
+# C# 6.0 draft language specification
 
-You can download version 5.0 of this specification from the [Microsoft Download Center](http://www.microsoft.com/download/details.aspx?id=7029). If you've installed Visual Studio 2015, you can also find the specification on your computer in the Program Files (x86)/Microsoft Visual Studio 14.0/VC#/Specifications/1033 folder. If you have another version of Visual Studio installed or if you installed Visual Studio in a language other than English, change the path as appropriate.
+The C# language specification is the definitive source for C# syntax and usage. This specification contains detailed information about all aspects of the language, including many points that the documentation for C# doesn't cover.
 
-Version 6.0 of the specification has not been approved as a standard. This site contains the [*draft* C# 6.0 specification](../../../../_csharplang/spec/introduction.md). It is built from the markdown files contained in [the dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md).
+Version 5.0 of the specification has been released in December 2017 as the [Standard ECMA-334 5th Edition](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf) document.
+
+Version 6.0 of the specification has not been approved as a standard. This site contains the [*draft* C# 6.0 specification](../../../../_csharplang/spec/introduction.md). It's built from the markdown files contained in the [dotnet/csharplang GitHub repository](https://github.com/dotnet/csharplang/blob/master/spec/README.md).
 
 Issues on the draft specification should be created in the [dotnet/csharplang](https://github.com/dotnet/csharplang/issues) repository. Or, if you are interested
 in fixing any errors you find, you may submit a [Pull Request](https://github.com/dotnet/csharplang/pulls) to the same repository.
 
-## See Also  
- [C# Reference](../../language-reference/index.md)  
+## See also
+ [C# Reference](../index.md)  
  [C# Programming Guide](../../programming-guide/index.md)
 
 >[!div class="step-by-step"]


### PR DESCRIPTION
In PR #5371 we've updated the link to the C# 5.0 language specification: [Ecma-334.pdf](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf)

This PR updates the language specification topic with the same link.
