### PR TITLE
Changed cross-reference, fenced xml

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
+++ b/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
@@ -11,58 +11,63 @@ The following sample provides a basic overview of a type that has been documente
   
 ## Example  
  [!code-csharp[csProgGuideDocComments#15](../../../csharp/programming-guide/xmldoc/codesnippet/CSharp/how-to-use-the-xml-documentation-features_1.cs)]  
-  
- **// This .xml file was generated with the previous code sample.**  
-**\<?xml version="1.0"?>**  
-**\<doc>**  
- **\<assembly>**  
- **\<name>xmlsample\</name>**  
- **\</assembly>**  
- **\<members>**  
- **\<member name="T:SomeClass">**  
- **\<summary>**  
- **Class level summary documentation goes here.\</summary>**  
- **\<remarks>**  
- **Longer comments can be associated with a type or member**  
- **through the remarks tag\</remarks>**  
- **\</member>**  
- **\<member name="F:SomeClass.m_Name">**  
- **\<summary>**  
- **Store for the name property\</summary>**  
- **\</member>**  
- **\<member name="M:SomeClass.#ctor">**  
- **\<summary>The class constructor.\</summary>**  
- **\</member>**  
- **\<member name="M:SomeClass.SomeMethod(System.String)">**  
- **\<summary>**  
- **Description for SomeMethod.\</summary>**  
- **\<param name="s"> Parameter description for s goes here\</param>**  
- **\<seealso cref="T:System.String">**  
- **You can use the cref attribute on any tag to reference a type or member**  
- **and the compiler will check that the reference exists. \</seealso>**  
- **\</member>**  
- **\<member name="M:SomeClass.SomeOtherMethod">**  
- **\<summary>**  
- **Some other method. \</summary>**  
- **\<returns>**  
- **Return results are described through the returns tag.\</returns>**  
- **\<seealso cref="M:SomeClass.SomeMethod(System.String)">**  
- **Notice the use of the cref attribute to reference a specific method \</seealso>**  
- **\</member>**  
- **\<member name="M:SomeClass.Main(System.String[])">**  
- **\<summary>**  
- **The entry point for the application.**  
- **\</summary>**  
- **\<param name="args"> A list of command line arguments\</param>**  
- **\</member>**  
- **\<member name="P:SomeClass.Name">**  
- **\<summary>**  
- **Name property \</summary>**  
- **\<value>**  
- **A value tag is used to describe the property value\</value>**  
- **\</member>**  
- **\</members>**  
-**\</doc>**   
+
+The example generates an .xml file with the following contents:
+
+```xml  
+ // This .xml file was generated with the previous code sample.  
+<?xml version="1.0"?>  
+<doc>  
+ <assembly>  
+ <name>xmlsample</name>  
+ </assembly>  
+ <members>  
+ <member name="T:SomeClass">  
+ <summary>  
+ Class level summary documentation goes here.</summary>  
+ <remarks>  
+ Longer comments can be associated with a type or member  
+ through the remarks tag</remarks>  
+ </member>  
+ <member name="F:SomeClass.m_Name">  
+ <summary>  
+ Store for the name property</summary>  
+ </member>  
+ <member name="M:SomeClass.#ctor">  
+ <summary>The class constructor.</summary>  
+ </member>  
+ <member name="M:SomeClass.SomeMethod(System.String)">  
+ <summary>  
+ Description for SomeMethod.</summary>  
+ <param name="s"> Parameter description for s goes here</param>  
+ <seealso cref="T:System.String">  
+ You can use the cref attribute on any tag to reference a type or member  
+ and the compiler will check that the reference exists. </seealso>  
+ </member>  
+ <member name="M:SomeClass.SomeOtherMethod">  
+ <summary>  
+ Some other method. </summary>  
+ <returns>  
+ Return results are described through the returns tag.</returns>  
+ <seealso cref="M:SomeClass.SomeMethod(System.String)">  
+ Notice the use of the cref attribute to reference a specific method </seealso>  
+ </member>  
+ <member name="M:SomeClass.Main(System.String[])">  
+ <summary>  
+ The entry point for the application.  
+ </summary>  
+ <param name="args"> A list of command line arguments</param>  
+ </member>  
+ <member name="P:SomeClass.Name">  
+ <summary>  
+ Name property </summary>  
+ <value>  
+ A value tag is used to describe the property value</value>  
+ </member>  
+ </members>  
+\</doc>   
+```
+
 ## Compiling the Code  
  To compile the example, type the following command line:  
   
@@ -75,7 +80,7 @@ The following sample provides a basic overview of a type that has been documente
   
 -   The documentation must be well-formed XML. If the XML is not well-formed, a warning is generated and the documentation file will contain a comment that says that an error was encountered.  
   
--   Developers are free to create their own set of tags. There is a recommended set of tags (see the Further Reading section). Some of the recommended tags have special meanings:  
+-   Developers are free to create their own set of tags. There is a recommended set of tags (see [Recommended tags for documentation comments](recommended-tags-for-documentation-comments.md)). Some of the recommended tags have special meanings:  
   
     -   The \<param> tag is used to describe parameters. If used, the compiler will verify that the parameter exists and that all parameters are described in the documentation. If the verification failed, the compiler issues a warning.  
   

--- a/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
+++ b/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
@@ -60,11 +60,10 @@ The example generates an .xml file with the following contents:
  <member name="P:SomeClass.Name">  
  <summary>  
  Name property </summary>  
- <value>  
- A value tag is used to describe the property value</value>  
+ <value>A value tag is used to describe the property value</value>  
  </member>  
  </members>  
-\</doc>   
+</doc>   
 ```
 
 ## Compiling the Code  

--- a/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
+++ b/docs/csharp/programming-guide/xmldoc/how-to-use-the-xml-documentation-features.md
@@ -15,7 +15,6 @@ The following sample provides a basic overview of a type that has been documente
 The example generates an .xml file with the following contents:
 
 ```xml  
- // This .xml file was generated with the previous code sample.  
 <?xml version="1.0"?>  
 <doc>  
  <assembly>  


### PR DESCRIPTION
## Changed cross-reference, fenced xml

This PR:

- Replaces mention of a non-existent **Further Reading** section with a link to a topic on XML doc elements.
- Replaces boldfaced XML (which seems to shout at the reader) with fenced XML.

Fixes #5529 

@Keboo 


