### PR TITLE
Update docs index to link out to Azure

### DIFF
--- a/index.md
+++ b/index.md
@@ -361,7 +361,7 @@ ms.custom: "updateeachrelease"
                         </ul>
                     </li>
                     <li>
-                        <a href="https://docs.microsoft.com/dotnet/azure/">Cloud</a>
+                        <a href="#cloud">Cloud</a>
                         <ul id="cloud" class="cardsC">
                             <li>
                                 <div class="cardSize">
@@ -389,13 +389,14 @@ ms.custom: "updateeachrelease"
                                         <div class="card">
                                             <div class="cardImageOuter">
                                                 <div class="cardImage bgdAccent1">
-                                                    <img src="/dotnet/images/hub/net-docs-cloud-2.svg" alt="" />
+                                                    <img src="/dotnet/images/hub/net-docs-cloud-4.svg" alt="" />
                                                 </div>
                                             </div>
                                             <div class="cardText">
-                                                <a href="/azure/cloud-services/cloud-services-dotnet-get-started">
-                                                    <h3>Azure Cloud Services and ASP.NET</h3>
-                                                    <p>Learn to configure, monitor, and scale your cloud services in Azure.</p>
+                                                <a href="/azure/storage/">
+                                                    <h3>Azure Storage</h3>
+                                                    <p>Learn about Azure Storage, and how to create applications using Azure
+                                                        blobs, tables, queues, and files.</p>
                                                 </a>
                                             </div>
                                         </div>
@@ -416,26 +417,6 @@ ms.custom: "updateeachrelease"
                                                     <h3>Using F# on Azure</h3>
                                                     <p>Learn how to use various Azure services in F# such as Azure Storage,
                                                         Cloud Services, and Azure Functions.</p>
-                                                </a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </li>
-                            <li>
-                                <div class="cardSize">
-                                    <div class="cardPadding">
-                                        <div class="card">
-                                            <div class="cardImageOuter">
-                                                <div class="cardImage bgdAccent1">
-                                                    <img src="/dotnet/images/hub/net-docs-cloud-4.svg" alt="" />
-                                                </div>
-                                            </div>
-                                            <div class="cardText">
-                                                <a href="/azure/storage/">
-                                                    <h3>Azure Storage</h3>
-                                                    <p>Learn about Azure Storage, and how to create applications using Azure
-                                                        blobs, tables, queues, and files.</p>
                                                 </a>
                                             </div>
                                         </div>

--- a/index.md
+++ b/index.md
@@ -361,7 +361,7 @@ ms.custom: "updateeachrelease"
                         </ul>
                     </li>
                     <li>
-                        <a href="#cloud">Cloud</a>
+                        <a href="https://docs.microsoft.com/dotnet/azure/">Cloud</a>
                         <ul id="cloud" class="cardsC">
                             <li>
                                 <div class="cardSize">


### PR DESCRIPTION
This tab gets a nontrivial amount of clicks per month, but the actual content under the `#cloud` pivot is out of date and has poor engagement. There is an Azure .NET index page in the Azure docs which is actively improved, with the intention of it being our home page for Azure and .NET. I propose that we link to that page here.

Separately, I'd also like to remove each of these cards, since they would effectively be dead HTML with this change.

cc @Andrew-MSFT 