### PR TITLE
Case-sensitive issue in Dockerfile

### DIFF
--- a/docs/csharp/tutorials/microservices.md
+++ b/docs/csharp/tutorials/microservices.md
@@ -327,7 +327,7 @@ WORKDIR /app
 
 # copy csproj and restore as distinct layers
 
-COPY WeatherMicroservice.csproj .
+COPY WeatherMicroService.csproj .
 RUN dotnet restore 
 
 # copy and build everything else
@@ -348,7 +348,7 @@ publish command builds and packages your application.
 The final line of the file runs the application:
 
 ```
-ENTRYPOINT ["dotnet", "out/WeatherMicroservice.dll", "--server.urls", "http://0.0.0.0:5000"]
+ENTRYPOINT ["dotnet", "out/WeatherMicroService.dll", "--server.urls", "http://0.0.0.0:5000"]
 ```
 
 This configured port is referenced in the `--server.urls`


### PR DESCRIPTION
On macOS and other operating systems with case-sensitive file systems, the docker command will not find the WeatherMicroService.cs file.

## Summary

Changed `WeatherMicroservice` to `WeatherMicroService` in the Dockerfile.