### PR TITLE
Add note about predicate expressions

### DIFF
--- a/docs/csharp/language-reference/keywords/try-catch.md
+++ b/docs/csharp/language-reference/keywords/try-catch.md
@@ -37,7 +37,7 @@ catch (InvalidCastException e)
   
  It is possible to use more than one specific `catch` clause in the same try-catch statement. In this case, the order of the `catch` clauses is important because the `catch` clauses are examined in order. Catch the more specific exceptions before the less specific ones. The compiler produces an error if you order your catch blocks so that a later block can never be reached.  
   
- Using `catch` arguments is one way to filter for the exceptions you want to handle.  You can also use a predicate expression that further examines the exception to decide whether to handle it.  If the predicate expression returns false, then the search for a handler continues.  
+ Using `catch` arguments is one way to filter for the exceptions you want to handle.  You can also use a exception filter that further examines the exception to decide whether to handle it.  If the exception filter returns false, then the search for a handler continues.  
   
 ```csharp  
 catch (ArgumentException e) when (e.ParamName == "…")  
@@ -45,7 +45,7 @@ catch (ArgumentException e) when (e.ParamName == "…")
 }  
 ```  
   
- Exception filters are preferable to catching and rethrowing (explained below) because filters leave the stack unharmed.  If a later handler dumps the stack, you can see where the exception originally came from, rather than just the last place it was rethrown.  A common use of exception filter expressions is logging.  You can create a predicate function that always returns false that also outputs to a log, you can log exceptions as they go by without having to handle them and rethrow.  
+ Exception filters are preferable to catching and rethrowing (explained below) because filters leave the stack unharmed.  If a later handler dumps the stack, you can see where the exception originally came from, rather than just the last place it was rethrown.  A common use of exception filter expressions is logging.  You can create a filter that always returns false that also outputs to a log, you can log exceptions as they go by without having to handle them and rethrow.  
   
  A [throw](../../../csharp/language-reference/keywords/throw.md) statement can be used in a `catch` block to re-throw the exception that is caught by the `catch` statement. The following example extracts source information from an <xref:System.IO.IOException> exception, and then throws the exception to the parent method.  
   
@@ -91,7 +91,7 @@ catch (InvalidCastException e)
 ```  
 
 > [!NOTE]
-> It is also possible to use a predicate expression to get a similar result in a often cleaner fashion. The following example has a similar behavior for callers than the precedent example, the function throws the `InvalidCastException` back to the caller when `e.Data` is null.
+> It is also possible to use an exception filter to get a similar result in an often cleaner fashion (as well as not modifying the stack, as explained earlier in this document). The following example has a similar behavior for callers as the previous example. The function throws the `InvalidCastException` back to the caller when `e.Data` is `null`.
 > 
 > ```csharp
 > catch (InvalidCastException e) when (e.Data != null)   

--- a/docs/csharp/language-reference/keywords/try-catch.md
+++ b/docs/csharp/language-reference/keywords/try-catch.md
@@ -87,9 +87,19 @@ catch (InvalidCastException e)
     {  
         // Take some action.  
     }  
- }  
+}  
 ```  
-  
+
+> [!NOTE]
+> It is also possible to use a predicate expression to get a similar result in a often cleaner fashion. The following example has a similar behavior for callers than the precedent example, the function throws the `InvalidCastException` back to the caller when `e.Data` is null.
+> 
+> ```csharp
+> catch (InvalidCastException e) when (e.Data != null)   
+> {  
+>     // Take some action.  
+> }
+> ```   
+
  From inside a `try` block, initialize only variables that are declared therein. Otherwise, an exception can occur before the execution of the block is completed. For example, in the following code example, the variable `n` is initialized inside the `try` block. An attempt to use this variable outside the `try` block in the `Write(n)` statement will generate a compiler error.  
   
 ```csharp  


### PR DESCRIPTION
## Summary

I feel that quite a lot of uses of the `throw;` statement can be written in a more clean fashion by using a predicate expression (`catch (...) when(condition)`), so I've added a note in the try-catch documentation about it.