### PR TITLE
Fixed code in tables by HTML encoding <

### DIFF
--- a/docs/fsharp/language-reference/query-expressions.md
+++ b/docs/fsharp/language-reference/query-expressions.md
@@ -118,7 +118,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 
 <pre><code class="lang-fsharp">query {
     for number in data do
-    where (number < 0)
+    where (number &lt; 0)
     lastOrDefault
 }
 </code></pre>
@@ -412,7 +412,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 
 <pre><code class="lang-fsharp">query {
     for number in data do
-    skipWhile (number < 3)
+    skipWhile (number &lt; 3)
     select student
 }
 </code></pre>
@@ -441,7 +441,7 @@ let data = [ 1; 5; 7; 11; 18; 21]
 
 <pre><code class="lang-fsharp">query {
     for number in data do
-    takeWhile (number < 10)
+    takeWhile (number &lt; 10)
 }
 </code></pre>
 
@@ -875,7 +875,7 @@ WHERE Student.Age BETWEEN 10 AND 15
 <pre><code class="lang-fsharp">// Selecting students with ages between 10 and 15.
 query {
     for student in db.Student do
-    where (student.Age ?>= 10 && student.Age ?< 15)
+    where (student.Age ?>= 10 && student.Age ?&lt; 15)
     select student
 }
 </code></pre>


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/5639

I verified that this fixes the issue for me in docfx:

Before:

![](https://user-images.githubusercontent.com/287848/40605202-d5438c8e-6261-11e8-8763-eccd32ad3662.png)


After:

![](https://user-images.githubusercontent.com/287848/40605156-ad6a626e-6261-11e8-8e50-d95d29afaa04.png)
