### PR TITLE
Updated C# -langversion compiler option topic

### DIFF
--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -47,19 +47,11 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
  Because each version of the C# compiler contains extensions to the language specification, **-langversion** does not give you the equivalent functionality of an earlier version of the compiler.  
  
- Additionally, while C# version updates generally coincide with major .Net Framework releases, the new syntax and features are not necessarily tied to that specific framework version. While the new features will definitely require a new compiler update that is also released alongside the C# revision, each specific feature has its own minimum .Net API or common language runtime requirements that may allow it to run on downlevel frameworks by including NuGet packages or other libraries.
+ Additionally, while C# version updates generally coincide with major .NET Framework releases, the new syntax and features are not necessarily tied to that specific framework version. While the new features definitely require a new compiler update that is also released alongside the C# revision, each specific feature has its own minimum .NET API or common language runtime requirements that may allow it to run on downlevel frameworks by including NuGet packages or other libraries.
   
  Regardless of which **-langversion** setting you use, you will use the current version of the common language runtime to create your .exe or .dll. One exception is friend assemblies and [-moduleassemblyname (C# Compiler Option)](../../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md), which work under **-langversion:ISO-1**.  
-  
-### To set this compiler option in the Visual Studio development environment  
-  
-1.  Open the project's **Properties** page.  
-  
-2.  Click the **Build** property page.  
-  
-3.  Click the **Advanced** button.  
-  
-4.  Modify the **Language Version** property.  
+ 
+ For other ways to specify the C# language version, see the [Select the C# language version](../configure-language-version.md) topic.
   
  For information about how to set this compiler option programmatically, see <xref:VSLangProj80.CSharpProjectConfigurationProperties3.LanguageVersion%2A>.  
     


### PR DESCRIPTION
Reference the [Select the C# language version](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version) topic instead of providing detailed description in the topic.
