### PR TITLE
Required changes based on the new dotnet-docker repo

### DIFF
--- a/docs/core/docker/building-net-docker-images.md
+++ b/docs/core/docker/building-net-docker-images.md
@@ -131,13 +131,13 @@ The Docker client can be installed in:
 
 ### Getting the sample application
 
-The easiest way to get the sample is by cloning the [samples repository](https://github.com/dotnet/dotnet-docker) with git, using the following instructions: 
+The easiest way to get the sample is by cloning the [.NET Core Docker repository](https://github.com/dotnet/dotnet-docker) with git, using the following instructions: 
 
 ```console
 git clone https://github.com/dotnet/dotnet-docker
 ```
 
-You can also download the repository (it is small) as a zip from the .NET Core Docker samples repository.
+You can also download the repository (it is small) as a zip from the .NET Core Docker repository.
 
 ### Run the ASP.NET app locally
 

--- a/docs/core/docker/building-net-docker-images.md
+++ b/docs/core/docker/building-net-docker-images.md
@@ -52,7 +52,7 @@ When multiple applications use common images on the same machine, memory is shar
 
 To achieve the goals above, we provide image variants under [`microsoft/dotnet`](https://hub.docker.com/r/microsoft/dotnet/).
 
-* `microsoft/dotnet:<version>-sdk`(`microsoft/dotnet:2.0.0-sdk`) This image contains the .NET Core SDK, which includes the .NET Core and Command Line Tools (CLI). This image maps to the **development scenario**. You use this image for local development, debugging, and unit testing. This image can also be used for your **build** scenarios. Using `microsoft/dotnet:sdk` always gives you the latest version.
+* `microsoft/dotnet:<version>-sdk`(`microsoft/dotnet:2.1-sdk`) This image contains the .NET Core SDK, which includes the .NET Core and Command Line Tools (CLI). This image maps to the **development scenario**. You use this image for local development, debugging, and unit testing. This image can also be used for your **build** scenarios. Using `microsoft/dotnet:sdk` always gives you the latest version.
 
 > [!TIP]
 > If you are unsure about your needs, you want to use the `microsoft/dotnet:<version>-sdk` image. As the "de facto" image, it's designed to be used as a throw away container (mount your source code and start the container to start your app), and as the base image to build other images from.
@@ -74,9 +74,9 @@ Latest versions of each variant:
 
 ## Samples to explore
 
-* [This ASP.NET Core Docker sample](https://github.com/dotnet/dotnet-docker-samples/tree/master/aspnetapp) demonstrates a best practice pattern for building Docker images for ASP.NET Core apps for production. The sample works with both Linux and Windows containers.
+* [This ASP.NET Core Docker sample](https://github.com/dotnet/dotnet-docker/tree/master/samples/aspnetapp) demonstrates a best practice pattern for building Docker images for ASP.NET Core apps for production. The sample works with both Linux and Windows containers.
 
-* This .NET Core Docker sample demonstrates a best practice pattern for [building Docker images for .NET Core apps for production.](https://github.com/dotnet/dotnet-docker-samples/tree/master/dotnetapp-prod)
+* This .NET Core Docker sample demonstrates a best practice pattern for [building Docker images for .NET Core apps for production.](https://github.com/dotnet/dotnet-docker/tree/master/samples/dotnetapp)
 
 ## Your first ASP.NET Core Docker app
 
@@ -96,9 +96,9 @@ It uses the [Docker multi-stage build feature](https://docs.docker.com/engine/us
 
 To build and run, install the following items:
 
-#### .NET Core 2.0 SDK
+#### .NET Core 2.1 SDK
 
-* Install [.NET Core SDK 2.0](https://www.microsoft.com/net/core).
+* Install [.NET Core SDK 2.1](https://www.microsoft.com/net/core).
 
 * Install your favorite code editor, if you haven't already.
 
@@ -107,7 +107,7 @@ To build and run, install the following items:
 
 #### Installing Docker Client
 
-Install [Docker 17.06](https://docs.docker.com/release-notes/docker-ce/) or later of the Docker client.
+Install [Docker 18.03](https://docs.docker.com/release-notes/docker-ce/) or later of the Docker client.
 
 The Docker client can be installed in:
 
@@ -131,10 +131,10 @@ The Docker client can be installed in:
 
 ### Getting the sample application
 
-The easiest way to get the sample is by cloning the [samples repository](https://github.com/dotnet/dotnet-docker-samples) with git, using the following instructions: 
+The easiest way to get the sample is by cloning the [samples repository](https://github.com/dotnet/dotnet-docker) with git, using the following instructions: 
 
 ```console
-git clone https://github.com/dotnet/dotnet-docker-samples/
+git clone https://github.com/dotnet/dotnet-docker
 ```
 
 You can also download the repository (it is small) as a zip from the .NET Core Docker samples repository.
@@ -143,10 +143,14 @@ You can also download the repository (it is small) as a zip from the .NET Core D
 
 For a reference point, before we containerize the application, first run the application locally.
 
-You can build and run the application locally with the .NET Core 2.0 SDK using the following commands (The instructions assume the root of the repository):
+You can build and run the application locally with the .NET Core 2.1 SDK using the following commands (The instructions assume the root of the repository):
 
 ```console
-cd aspnetapp
+cd dotnet-docker
+cd samples
+cd aspnetapp // solution scope where the dockerfile is located
+cd aspnetapp // project scope
+
 dotnet run
 ```
 
@@ -157,7 +161,10 @@ After the application starts, visit **http://localhost:5000** in your web browse
 You can build and run the sample in Docker using Linux containers using the following commands (The instructions assume the root of the repository):
 
 ```console
-cd aspnetapp
+cd dotnet-docker
+cd samples
+cd aspnetapp // solution scope where the dockerfile is located
+
 docker build -t aspnetapp .
 docker run -it --rm -p 5000:80 --name aspnetcore_sample aspnetapp
 ```
@@ -172,7 +179,10 @@ After the application starts, visit **http://localhost:5000** in your web browse
 You can build and run the sample in Docker using Windows containers using the following commands (The instructions assume the root of the repository):
 
 ```console
-cd aspnetapp
+cd dotnet-docker
+cd samples
+cd aspnetapp // solution scope where the dockerfile is located
+
 docker build -t aspnetapp .
 docker run -it --rm --name aspnetcore_sample aspnetapp
 ```
@@ -230,10 +240,10 @@ dotnet published/aspnetapp.dll
 
 ### Docker Images used in this sample
 
-The following Docker images are used in this sample
+The following Docker images are used in this sample's dockerfile.
 
-* `microsoft/aspnetcore-build:2.0`
-* `microsoft/aspnetcore:2.0`
+* `microsoft/dotnet:2.1-sdk`
+* `microsoft/dotnet:2.1-aspnetcore-runtime`
 
 Congratulations! you have just:
 > [!div class="checklist"]


### PR DESCRIPTION
Since with the release of dotnet 2.1, Microsoft decided to move its docker samples to a new repo, some changes are required to reflect this new decision.

1. links
2. versions (dotnet, docker, docker images)
3. instructions

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
