### PR TITLE
Remove FSI from VS get started article

### DIFF
--- a/docs/fsharp/get-started/get-started-visual-studio.md
+++ b/docs/fsharp/get-started/get-started-visual-studio.md
@@ -67,58 +67,6 @@ You should now see the following printed to the console window that Visual Studi
 
 Congratulations!  You've created your first F# project in Visual Studio, written an F# function printed the results of calling that function, and run the project to see some results.
 
-## Using F# Interactive
-
-One of the best features of the Visual F# tooling in Visual Studio is the F# Interactive Window.  It allows you to send code over to a process where you can call that code and see the result interactively.
-
-To begin using it, highlight the `square` function defined in your code.  Next, hold the **Alt** key and press **Enter**.  This executes the code in the F# Interactive Window.  You should see the F# Interactive Window appear with the following in it:
-
-```
->
-
-val square : x:int -> int
-
->
-```
-
-This shows the same function signature for the `square` function, which you saw earlier when you hovered over the function.  Because `square` is now defined in the F# Interactive process, you can call it with different values:
-
-```
-> square 12;;
-val it : int = 144
->square 13;;
-val it : int = 169
-```
-
-This executes the function, binds the result to a new name `it`, and displays the type and value of `it`.  Note that you must terminate each line with `;;`.  This is how F# Interactive knows when your function call is finished.  You can also define new functions in F# Interactive:
-
-```
-> let isOdd x = x % 2 <> 0;;
-
-val isOdd : x:int -> bool
-
-> isOdd 12;;
-val it : bool = false
-```
-
-The above defines a new function, `isOdd`, which takes an `int` and checks to see if it's odd! You can call this function to see what it returns with different inputs.  You can call functions within function calls:
-
-```
-> isOdd (square 15);;
-val it : bool = true
-```
-
-You can also use the [pipe-forward operator](../language-reference/symbol-and-operator-reference/index.md) to pipeline the value into the two functions:
-
-```
-> 15 |> square |> isOdd;;
-val it : bool = true
-```
-
-The pipe-forward operator, and more, are covered in later tutorials.
-
-This is only a glimpse into what you can do with F# Interactive. To learn more, check out [Interactive Programming with F#](../tutorials/fsharp-interactive/index.md).
-
 ## Next steps
 
 If you haven't already, check out the [Tour of F#](../tour.md), which covers some of the core features of the F# language.  It will give you an overview of some of the capabilities of F#, and provide ample code samples that you can copy into Visual Studio and run.  There are also some great external resources you can use, showcased in the [F# Guide](../index.md).


### PR DESCRIPTION
Fixes #5669

Since we cannot guarantee FSI will work unless people select .NET Framework, and .NET Core is the best place to route newcomers, I'm removing this section until our work is complete for FSI on .NET Core.