### PR TITLE
Fix closing tag for multi-line XmlDoc

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/codesnippet/CSharp/how-to-use-the-xml-documentation-features_1.cs
+++ b/docs/csharp/programming-guide/xmldoc/codesnippet/CSharp/how-to-use-the-xml-documentation-features_1.cs
@@ -1,27 +1,33 @@
     // If compiling from the command line, compile with: /doc:YourFileName.xml
 
     /// <summary>
-    /// Class level summary documentation goes here.</summary>
+    /// Class level summary documentation goes here.
+    /// </summary>
     /// <remarks>
     /// Longer comments can be associated with a type or member through
-    /// the remarks tag.</remarks>
+    /// the remarks tag.
+    /// </remarks>
     public class TestClass : TestInterface
     {
         /// <summary>
-        /// Store for the name property.</summary>
+        /// Store for the name property.
+        /// </summary>
         private string _name = null;
 
         /// <summary>
-        /// The class constructor. </summary>
+        /// The class constructor.
+        /// </summary>
         public TestClass()
         {
             // TODO: Add Constructor Logic here.
         }
 
         /// <summary>
-        /// Name property. </summary>
+        /// Name property.
+        /// </summary>
         /// <value>
-        /// A value tag is used to describe the property value.</value>
+        /// A value tag is used to describe the property value.
+        /// </value>
         public string Name
         {
             get
@@ -35,21 +41,26 @@
         }
 
         /// <summary>
-        /// Description for SomeMethod.</summary>
+        /// Description for SomeMethod.
+        /// </summary>
         /// <param name="s"> Parameter description for s goes here.</param>
         /// <seealso cref="System.String">
         /// You can use the cref attribute on any tag to reference a type or member 
-        /// and the compiler will check that the reference exists. </seealso>
+        /// and the compiler will check that the reference exists.
+        /// </seealso>
         public void SomeMethod(string s)
         {
         }
 
         /// <summary>
-        /// Some other method. </summary>
+        /// Some other method.
+        /// </summary>
         /// <returns>
-        /// Return results are described through the returns tag.</returns>
+        /// Return results are described through the returns tag.
+        /// </returns>
         /// <seealso cref="SomeMethod(string)">
-        /// Notice the use of the cref attribute to reference a specific method. </seealso>
+        /// Notice the use of the cref attribute to reference a specific method.
+        /// </seealso>
         public int SomeOtherMethod()
         {
             return 0;


### PR DESCRIPTION
## Summary

For part of the file the closing tag for a multi-line XmlDoc was at the end of the last line instead of being on its own line.
