### PR TITLE
Added sample line of code to handle nullable data types.

### DIFF
--- a/docs/framework/data/adonet/implement-copytodatatable-where-type-not-a-datarow.md
+++ b/docs/framework/data/adonet/implement-copytodatatable-where-type-not-a-datarow.md
@@ -19,7 +19,13 @@ The <xref:System.Data.DataTable> object is often used for data binding. The <xre
   
      [!code-csharp[DP Custom CopyToDataTable Examples#ObjectShredderClass](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DP Custom CopyToDataTable Examples/CS/Program.cs#objectshredderclass)]
      [!code-vb[DP Custom CopyToDataTable Examples#ObjectShredderClass](../../../../samples/snippets/visualbasic/VS_Snippets_ADO.NET/DP Custom CopyToDataTable Examples/VB/Module1.vb#objectshredderclass)]  
-  
+
+    The preceding example assumes that the properties of the `DataColumn` are not nullable types. To handle properties with nullable types, use the following code:
+
+    ```csharp
+    DataColumn dc = table.Columns.Contains(p.Name) ? table.Columns[p.Name] : table.Columns.Add(p.Name, Nullable.GetUnderlyingType(p.PropertyType) ?? p.PropertyType);
+    ```
+
 2.  Implement the custom `CopyToDataTable<T>` extension methods in a class:  
   
      [!code-csharp[DP Custom CopyToDataTable Examples#CustomCopyToDataTableMethods](../../../../samples/snippets/csharp/VS_Snippets_ADO.NET/DP Custom CopyToDataTable Examples/CS/Program.cs#customcopytodatatablemethods)]


### PR DESCRIPTION
## Summary

In step 1 of the article, I added a sample line of code to show how to handle DataColumn properties that have nullable data types.

Fixes #5706 
