### PR TITLE
Remove >> from F# tour

### DIFF
--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -49,11 +49,11 @@ It's important to note that because `struct` tuples are value types, they cannot
 
 ## Pipelines and Composition
 
-Pipe operators (`|>`, `<|`, `||>`, `<||`, `|||>`, `<|||`) and composition operators (`>>` and `<<`) are used extensively when processing data in F#.  These operators are functions which allow you to establish "pipelines" of functions in a flexible manner.  The following example walks through how you could take advantage of these operators to build a simple functional pipeline.
+Pipe operators such as `|>` are used extensively when processing data in F#. These operators are functions which allow you to establish "pipelines" of functions in a flexible manner.  The following example walks through how you could take advantage of these operators to build a simple functional pipeline.
 
-[!code-fsharp[Pipelines](../../samples/snippets/fsharp/tour.fs#L227-L300)]
+[!code-fsharp[Pipelines](../../samples/snippets/fsharp/tour.fs#L227-L282)]
 
-The above sample made use of many features of F#, including list processing functions, first-class functions, and [partial application](language-reference/functions/index.md#partial-application-of-arguments).  Although a deep understanding of each of those concepts can become somewhat advanced, it should be clear how easily functions can be used to process data when building pipelines.
+The above sample made use of many features of F#, including list processing functions, first-class functions, and [partial application](language-reference/functions/index.md#partial-application-of-arguments). Although a deep understanding of each of those concepts can become somewhat advanced, it should be clear how easily functions can be used to process data when building pipelines.
 
 ## Lists, Arrays, and Sequences
 

--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -49,7 +49,7 @@ It's important to note that because `struct` tuples are value types, they cannot
 
 ## Pipelines and Composition
 
-Pipe operators such as `|>` are used extensively when processing data in F#. These operators are functions that allow you to establish "pipelines" of functions in a flexible manner. The following example walks through how you could take advantage of these operators to build a simple functional pipeline:
+Pipe operators such as `|>` are used extensively when processing data in F#. These operators are functions that allow you to establish "pipelines" of functions in a flexible manner. The following example walks through how you can take advantage of these operators to build a simple functional pipeline:
 
 [!code-fsharp[Pipelines](../../samples/snippets/fsharp/tour.fs#L227-L282)]
 

--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -49,11 +49,11 @@ It's important to note that because `struct` tuples are value types, they cannot
 
 ## Pipelines and Composition
 
-Pipe operators such as `|>` are used extensively when processing data in F#. These operators are functions which allow you to establish "pipelines" of functions in a flexible manner.  The following example walks through how you could take advantage of these operators to build a simple functional pipeline.
+Pipe operators such as `|>` are used extensively when processing data in F#. These operators are functions that allow you to establish "pipelines" of functions in a flexible manner. The following example walks through how you could take advantage of these operators to build a simple functional pipeline:
 
 [!code-fsharp[Pipelines](../../samples/snippets/fsharp/tour.fs#L227-L282)]
 
-The above sample made use of many features of F#, including list processing functions, first-class functions, and [partial application](language-reference/functions/index.md#partial-application-of-arguments). Although a deep understanding of each of those concepts can become somewhat advanced, it should be clear how easily functions can be used to process data when building pipelines.
+The previous sample made use of many features of F#, including list processing functions, first-class functions, and [partial application](language-reference/functions/index.md#partial-application-of-arguments). Although a deep understanding of each of those concepts can become somewhat advanced, it should be clear how easily functions can be used to process data when building pipelines.
 
 ## Lists, Arrays, and Sequences
 


### PR DESCRIPTION
This is based on watching @csharpfritz's stream and seeing that the advanced `>>` feature (and listing other possible pipeline operators) is really an intermediate thing and not a beginner thing. Putting on a beginner hat makes it obvious that these things are best left to be discovered _after_ one is fairly comfortable with basic F# syntax and concepts.