### PR TITLE
FwLinks replacement in visual-basic folder (4)

### DIFF
--- a/docs/visual-basic/getting-started/breaking-changes-in-visual-studio.md
+++ b/docs/visual-basic/getting-started/breaking-changes-in-visual-studio.md
@@ -16,4 +16,4 @@ No changes in Visual Basic in Visual Studio 2015 will prevent an application tha
  [Lambda Expressions](../../visual-basic/programming-guide/language-features/procedures/lambda-expressions.md)  
  [For Each...Next Statement](../../visual-basic/language-reference/statements/for-each-next-statement.md)  
  [Getting Started](../../visual-basic/getting-started/index.md)  
- [When is a non-breaking language fix breaking?](http://go.microsoft.com/fwlink/?LinkId=259542)
+ [When is a non-breaking language fix breaking?](https://blogs.msdn.microsoft.com/lucian/2012/07/19/when-is-a-non-breaking-language-fix-breaking)

--- a/docs/visual-basic/language-reference/modifiers/async.md
+++ b/docs/visual-basic/language-reference/modifiers/async.md
@@ -50,7 +50,7 @@ End Function
  For more information and examples, see [Async Return Types](../../../visual-basic/programming-guide/concepts/async/async-return-types.md).  
   
 ## Example  
- The following examples show an async event handler, an async lambda expression, and an async method. For a full example that uses these elements, see [Walkthrough: Accessing the Web by Using Async and Await](../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can download the walkthrough code from [Developer Code Samples](http://go.microsoft.com/fwlink/?LinkId=255191).  
+ The following examples show an async event handler, an async lambda expression, and an async method. For a full example that uses these elements, see [Walkthrough: Accessing the Web by Using Async and Await](../../../visual-basic/programming-guide/concepts/async/walkthrough-accessing-the-web-by-using-async-and-await.md). You can download the walkthrough code from [Developer Code Samples](https://code.msdn.microsoft.com/Async-Sample-Accessing-the-9c10497f).  
   
 ```vb  
 ' An event handler must be a Sub procedure.  

--- a/docs/visual-basic/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/visual-basic/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -12,7 +12,7 @@ By using <xref:System.Threading.Tasks.Task.WhenAny%2A?displayProperty=nameWithTy
 >  To run the examples, you must have Visual Studio 2012 or newer and  the .NET Framework 4.5 or newer installed on your computer.  
   
 ## Downloading the Example  
- You can download the complete Windows Presentation Foundation (WPF) project from [Async Sample: Fine Tuning Your Application](http://go.microsoft.com/fwlink/?LinkId=255046) and then follow these steps.  
+ You can download the complete Windows Presentation Foundation (WPF) project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea) and then follow these steps.  
   
 1.  Decompress the file that you downloaded, and then start Visual Studio.  
   
@@ -74,14 +74,14 @@ Dim downloadTasksQuery As IEnumerable(Of Task(Of Integer)) =
  You should run the project several times to verify that the downloaded lengths don't always appear in the same order.  
   
 > [!CAUTION]
->  You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing Tasks as they complete](http://go.microsoft.com/fwlink/?LinkId=260810).  
+>  You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing Tasks as they complete](https://blogs.msdn.microsoft.com/pfxteam/2012/08/02/processing-tasks-as-they-complete).  
   
 ## Complete Example  
  The following code is the complete text of the MainWindow.xaml.vb file for the example. Asterisks mark the elements that were added for this example.  
   
  Notice that you must add a reference for <xref:System.Net.Http>.  
   
- You can download the project from [Async Sample: Fine Tuning Your Application](http://go.microsoft.com/fwlink/?LinkId=255046).  
+ You can download the project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea).  
   
 ```vb  
 ' Add an Imports directive and a reference for System.Net.Http.  
@@ -203,4 +203,4 @@ End Class
  <xref:System.Threading.Tasks.Task.WhenAny%2A>  
  [Fine-Tuning Your Async Application (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/fine-tuning-your-async-application.md)  
  [Asynchronous Programming with Async and Await (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/index.md)  
- [Async Sample: Fine Tuning Your Application](http://go.microsoft.com/fwlink/?LinkId=255046)
+ [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea)

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
@@ -6,7 +6,7 @@ ms.assetid: 1cefd7f5-8e39-44c4-869c-f8021538a777
 # How to: Modify an Office Open XML Document (Visual Basic)
 This topic presents an example that opens an Office Open XML document, modifies it, and saves it.  
   
- For more information on Office Open XML, see [www.openxmldeveloper.org](http://go.microsoft.com/fwlink/?LinkID=95573).  
+ For more information on Office Open XML, see [www.openxmldeveloper.org](http://openxmldeveloper.org).  
   
 ## Example  
  This example finds the first paragraph element in the document. It retrieves the text from the paragraph, and then deletes all text runs in the paragraph. It creates a new text run that consists of the first paragraph text that has been converted to upper case. It then serializes the changed XML into the Open XML package and closes it.  

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
@@ -6,7 +6,7 @@ ms.assetid: 1cefd7f5-8e39-44c4-869c-f8021538a777
 # How to: Modify an Office Open XML Document (Visual Basic)
 This topic presents an example that opens an Office Open XML document, modifies it, and saves it.  
   
- For more information on Office Open XML, see [www.openxmldeveloper.org](http://openxmldeveloper.org).  
+ For more information on Office Open XML, see [Eric White's Blog](http://www.ericwhite.com).  
   
 ## Example  
  This example finds the first paragraph element in the document. It retrieves the text from the paragraph, and then deletes all text runs in the paragraph. It creates a new text run that consists of the first paragraph text that has been converted to upper case. It then serializes the changed XML into the Open XML package and closes it.  

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
@@ -6,7 +6,7 @@ ms.assetid: 66053f21-9217-473c-a6f3-a0897be07756
 # How to: Retrieve Paragraphs from an Office Open XML Document (Visual Basic)
 This topic presents an example that opens an Office Open XML document, and retrieves a collection of all of the paragraphs in the document.  
   
- For more information on Office Open XML, see [www.openxmldeveloper.org](http://openxmldeveloper.org).  
+ For more information on Office Open XML, see [http://www.ericwhite.com](http://www.ericwhite.com).  
   
 ## Example  
  This example opens an Office Open XML package, uses the relationships within the Open XML package to find the document and the style parts. It then queries the document, projecting a collection of an anonymous type that contains the paragraph <xref:System.Xml.Linq.XElement> node, the style name of each paragraph, and the text of each paragraph.  

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
@@ -6,7 +6,7 @@ ms.assetid: 66053f21-9217-473c-a6f3-a0897be07756
 # How to: Retrieve Paragraphs from an Office Open XML Document (Visual Basic)
 This topic presents an example that opens an Office Open XML document, and retrieves a collection of all of the paragraphs in the document.  
   
- For more information on Office Open XML, see [www.openxmldeveloper.org](http://go.microsoft.com/fwlink/?LinkID=95573).  
+ For more information on Office Open XML, see [www.openxmldeveloper.org](http://openxmldeveloper.org).  
   
 ## Example  
  This example opens an Office Open XML package, uses the relationships within the Open XML package to find the document and the style parts. It then queries the document, projecting a collection of an anonymous type that contains the paragraph <xref:System.Xml.Linq.XElement> node, the style name of each paragraph, and the text of each paragraph.  

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-retrieve-paragraphs-from-an-office-open-xml-document.md
@@ -6,7 +6,7 @@ ms.assetid: 66053f21-9217-473c-a6f3-a0897be07756
 # How to: Retrieve Paragraphs from an Office Open XML Document (Visual Basic)
 This topic presents an example that opens an Office Open XML document, and retrieves a collection of all of the paragraphs in the document.  
   
- For more information on Office Open XML, see [http://www.ericwhite.com](http://www.ericwhite.com).  
+ For more information on Office Open XML, see [Eric White's Blog](http://www.ericwhite.com).  
   
 ## Example  
  This example opens an Office Open XML package, uses the relationships within the Open XML package to find the document and the style parts. It then queries the document, projecting a collection of an anonymous type that contains the paragraph <xref:System.Xml.Linq.XElement> node, the style name of each paragraph, and the text of each paragraph.  

--- a/docs/visual-basic/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
@@ -6,7 +6,7 @@ ms.assetid: f8028ba8-2dd1-4425-930c-8cc23176ebbc
 # Tutorial: Manipulating Content in a WordprocessingML Document (Visual Basic)
 This tutorial shows how to apply the functional transformational approach and LINQ to XML to manipulate XML documents. The Visual Basic examples query and manipulate information in Office Open XML WordprocessingML documents that are saved by Microsoft Word.  
   
- For more information, see the [OpenXML Developer](http://go.microsoft.com/fwlink/?LinkID=95573) Web site.  
+ For more information, see the [OpenXML Developer](http://openxmldeveloper.org/) Web site.  
   
 ## In This Section  
   

--- a/docs/visual-basic/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
@@ -6,7 +6,7 @@ ms.assetid: f8028ba8-2dd1-4425-930c-8cc23176ebbc
 # Tutorial: Manipulating Content in a WordprocessingML Document (Visual Basic)
 This tutorial shows how to apply the functional transformational approach and LINQ to XML to manipulate XML documents. The Visual Basic examples query and manipulate information in Office Open XML WordprocessingML documents that are saved by Microsoft Word.  
   
- For more information, see the [OpenXML Developer](http://openxmldeveloper.org/) Web site.  
+ For more information, see the [http://www.ericwhite.com](http://www.ericwhite.com) Web site.  
   
 ## In This Section  
   

--- a/docs/visual-basic/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/tutorial-manipulating-content-in-a-wordprocessingml-document.md
@@ -6,7 +6,7 @@ ms.assetid: f8028ba8-2dd1-4425-930c-8cc23176ebbc
 # Tutorial: Manipulating Content in a WordprocessingML Document (Visual Basic)
 This tutorial shows how to apply the functional transformational approach and LINQ to XML to manipulate XML documents. The Visual Basic examples query and manipulate information in Office Open XML WordprocessingML documents that are saved by Microsoft Word.  
   
- For more information, see the [http://www.ericwhite.com](http://www.ericwhite.com) Web site.  
+ For more information, see the [Eric White's Blog](http://www.ericwhite.com).  
   
 ## In This Section  
   

--- a/docs/visual-basic/programming-guide/language-features/xml/overview-of-linq-to-xml.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/overview-of-linq-to-xml.md
@@ -14,7 +14,7 @@ Visual Basic provides support for [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-
 > [!NOTE]
 >  XML literals and XML axis properties are not supported in declarative code in an ASP.NET page. To use Visual Basic XML features, put your code in a code-behind page in your ASP.NET application.  
   
- ![link to video](../../../../visual-basic/programming-guide/language-features/xml/media/playvideo.gif "PlayVideo") For related video demonstrations, see [How Do I Get Started with LINQ to XML?](http://go.microsoft.com/fwlink/?LinkId=143034) and [How Do I Create Excel Spreadsheets using LINQ to XML?](http://go.microsoft.com/fwlink/?LinkId=143536).  
+ ![link to video](../../../../visual-basic/programming-guide/language-features/xml/media/playvideo.gif "PlayVideo") For related video demonstrations, see [How Do I Get Started with LINQ to XML?](https://docs.microsoft.com/en-us/aspnet/web-forms/videos/data-access/linq-videos-from-the-vb-team/how-do-i-get-started-with-linq-to-xml) and [How Do I Create Excel Spreadsheets using LINQ to XML?](https://docs.microsoft.com/en-us/aspnet/web-forms/videos/data-access/linq-videos-from-the-vb-team/how-do-i-create-excel-spreadsheets-using-linq-to-xml).  
   
 ## Creating XML  
  There are two ways to create XML trees in Visual Basic. You can declare an XML literal directly in code, or you can use the [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] APIs to create the tree. Both processes enable the code to reflect the final structure of the XML tree. For example, the following code example creates an XML element:  

--- a/docs/visual-basic/programming-guide/language-features/xml/overview-of-linq-to-xml.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/overview-of-linq-to-xml.md
@@ -14,7 +14,7 @@ Visual Basic provides support for [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-
 > [!NOTE]
 >  XML literals and XML axis properties are not supported in declarative code in an ASP.NET page. To use Visual Basic XML features, put your code in a code-behind page in your ASP.NET application.  
   
- ![link to video](../../../../visual-basic/programming-guide/language-features/xml/media/playvideo.gif "PlayVideo") For related video demonstrations, see [How Do I Get Started with LINQ to XML?](https://docs.microsoft.com/en-us/aspnet/web-forms/videos/data-access/linq-videos-from-the-vb-team/how-do-i-get-started-with-linq-to-xml) and [How Do I Create Excel Spreadsheets using LINQ to XML?](https://docs.microsoft.com/en-us/aspnet/web-forms/videos/data-access/linq-videos-from-the-vb-team/how-do-i-create-excel-spreadsheets-using-linq-to-xml).  
+ ![link to video](../../../../visual-basic/programming-guide/language-features/xml/media/playvideo.gif "PlayVideo") For related video demonstrations, see [How Do I Get Started with LINQ to XML?](/aspnet/web-forms/videos/data-access/linq-videos-from-the-vb-team/how-do-i-get-started-with-linq-to-xml) and [How Do I Create Excel Spreadsheets using LINQ to XML?](/aspnet/web-forms/videos/data-access/linq-videos-from-the-vb-team/how-do-i-create-excel-spreadsheets-using-linq-to-xml).  
   
 ## Creating XML  
  There are two ways to create XML trees in Visual Basic. You can declare an XML literal directly in code, or you can use the [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] APIs to create the tree. Both processes enable the code to reflect the final structure of the XML tree. For example, the following code example creates an XML element:  

--- a/docs/visual-basic/programming-guide/language-features/xml/xml-literals-and-the-xml-1-0-specification.md
+++ b/docs/visual-basic/programming-guide/language-features/xml/xml-literals-and-the-xml-1-0-specification.md
@@ -6,7 +6,7 @@ helpviewer_keywords:
 ms.assetid: 46f046e5-293c-41a3-b893-4e5f6e32e78a
 ---
 # XML Literals and the XML 1.0 Specification (Visual Basic)
-The XML literal syntax in Visual Basic supports most of the Extensible Markup Language (XML) 1.0 specification. For details about the XML 1.0 specification, see [Extensible Markup Language (XML) 1.0](http://go.microsoft.com/fwlink/?LinkId=73927) on the W3C Web site.  
+The XML literal syntax in Visual Basic supports most of the Extensible Markup Language (XML) 1.0 specification. For details about the XML 1.0 specification, see [Extensible Markup Language (XML) 1.0](https://www.w3.org/TR/xml) on the W3C Web site.  
   
 ## What Visual Basic Does Not Support  
   

--- a/docs/visual-basic/sample-applications.md
+++ b/docs/visual-basic/sample-applications.md
@@ -7,11 +7,11 @@ helpviewer_keywords:
 ms.assetid: 09c6bc12-25fd-4359-a5fc-8dab8dddbfd2
 ---
 # Visual Basic Sample Applications
-You can use Visual Studio to download and install samples of full, packaged Visual Basic applications from the [MSDN Code Gallery](http://go.microsoft.com/fwlink/?LinkId=254185)  
+You can use Visual Studio to download and install samples of full, packaged Visual Basic applications from the [MSDN Code Gallery](https://code.msdn.microsoft.com)  
   
  You can download each sample individually, or you can download a Sample Pack, which contains related samples that share a technology or topic. You’ll receive a notification when source code changes are published for any sample that you download.  
   
 ## See Also  
- [Visual Studio Samples](http://go.microsoft.com/fwlink/?LinkId=150928)  
+ [Visual Studio Samples](https://code.msdn.microsoft.com/vstudio)  
  [Visual Basic Programming Guide](../visual-basic/programming-guide/index.md)  
  [Visual Basic](../visual-basic/index.md)


### PR DESCRIPTION
Relates to #3391 and #3426.

I have encountered some pages having a broken forward link for downloading Northwind Database. The files can be found here: https://github.com/dotnet/docs/search?q=LinkID%3D98088&unscoped_q=LinkID%3D98088

How should we approach this problem?