### PR TITLE
Surface Forwarded Headers in Docker topic

### DIFF
--- a/docs/core/docker/building-net-docker-images.md
+++ b/docs/core/docker/building-net-docker-images.md
@@ -78,6 +78,17 @@ Latest versions of each variant:
 
 * This .NET Core Docker sample demonstrates a best practice pattern for [building Docker images for .NET Core apps for production.](https://github.com/dotnet/dotnet-docker-samples/tree/master/dotnetapp-prod)
 
+## Forward the request scheme and original IP address
+
+Proxy servers, load balancers, and other network appliances often obscure information about a request before it reaches the containerized app:
+
+* When HTTPS requests are proxied over HTTP, the original scheme (HTTPS) is lost and must be forwarded in a header.
+* Because an app receives a request from the proxy and not its true source on the Internet or corporate network, the original client IP address must also be forwarded in a header.
+
+This information may be important in request processing, for example in redirects, authentication, link generation, policy evaluation, and client geolocation.
+
+To forward the scheme and original IP address to a containerized ASP.NET Core app, use Forwarded Headers Middleware. For more information, see [Configure ASP.NET Core to work with proxy servers and load balancers](/aspnet/core/host-and-deploy/proxy-load-balancer).
+
 ## Your first ASP.NET Core Docker app
 
 For this tutorial, lets use an ASP.NET Core Docker sample application for the app we want to dockerize. This ASP.NET Core Docker sample application demonstrates a best practice pattern for building Docker images for ASP.NET Core apps for production. The sample works with both Linux and Windows containers.
@@ -242,7 +253,6 @@ Congratulations! you have just:
 > * Ran the ASP.NET sample app locally
 > * Built and ran the sample with Docker for Linux containers
 > * Built and ran the sample with Docker for Windows containers
-
 
 **Next Steps**
 


### PR DESCRIPTION
@JRAlexander This patch suggestion came about because a community member, @nrandell, didn't see our topic that pertains to the use of Forwarded Headers Middleware for a containerized app.

We have a link to the topic, [Configure ASP.NET Core to work with proxy servers and load balancers](https://docs.microsoft.com/aspnet/core/host-and-deploy/proxy-load-balancer), on our [Docker index page in the ASP.NET Core docs](https://docs.microsoft.com/aspnet/core/host-and-deploy/docker), but that wasn't enough to surface the existence of the topic.

Please feel free to close this, move it, hack it ... I'm guessing a bit that this would be a good spot. I placed it immediately before the first experience walk-through.

Cross-ref: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/556

[Internal Review Topic](https://review.docs.microsoft.com/en-us/dotnet/core/docker/building-net-docker-images?branch=pr-en-us-5764#forward-the-request-scheme-and-original-ip-address)

cc/ @jmprieur @Rick-Anderson @scottaddie 

Thanks to @nrandell for surfacing the problem. :rocket: