### PR TITLE
Change fake web service address

### DIFF
--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -63,7 +63,7 @@ dotnet new console
 dotnet restore
 ```
 
-5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file as follows:
+5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file which will be saved at _ServiceReference1/Reference.cs_
 
 ```console
 dotnet svcutil http://myhost/SayHello.svc

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -46,7 +46,7 @@ cd HelloSvcutil
 2. Create a new C# console project in that directory using the [`dotnet new`](../tools/dotnet-new.md) command as follows:
 
 ```console
-[`dotnet new`](../tools/dotnet-new.md) ([see note](#dotnet-new-note)) console
+dotnet new console
 ```
 
 3. Open the `HelloSvcutil.csproj` project file in your editor, edit the `Project` element, and add the [`dotnet-svcutil` NuGet package](https://nuget.org/packages/dotnet-svcutil) as a CLI tool reference, using the following code:
@@ -60,10 +60,10 @@ cd HelloSvcutil
 4. Restore the _dotnet-svcutil_ package using the [`dotnet restore`](../tools/dotnet-restore.md) command as follows:
 
 ```console
-[`dotnet restore`](../tools/dotnet-restore.md) ([see note](#dotnet-restore-note))
+dotnet restore
 ```
 
-5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file which will be saved as _HelloSvcutil/ServiceReference1/Reference.cs_
+5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file as follows:
 
 ```console
 dotnet svcutil http://myhost/SayHello.svc
@@ -73,7 +73,7 @@ The generated file is saved as _HelloSvcutil/ServiceReference1/Reference.cs_. Th
 6. Restore the WCF packages using the [`dotnet restore`](../tools/dotnet-restore.md) command as follows:
 
 ```console
-[`dotnet restore`](../tools/dotnet-restore.md) ([see note](#dotnet-restore-note))
+dotnet restore
 ```
 
 7. Open the `Program.cs` file in your editor, edit the `Main()` method, and replace the auto-generated code with the following code to invoke the web service:
@@ -89,7 +89,7 @@ static void Main(string[] args)
 8. Run the application using the [`dotnet run`](../tools/dotnet-run.md) command as follows:
 
 ```console
-[`dotnet run`](../tools/dotnet-run.md) ([see note](#dotnet-run-note))
+dotnet run
 ```
 You should see the following output:
 "Hello dotnet-svcutil!"

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -32,7 +32,7 @@ public interface ISayHello
     string Hello(string name);
 }
 ```
-For this example, the web service will be assumed to be hosted at the following address: `_http://contoso.com/SayHello.svc_`
+For this example, the web service will be assumed to be hosted at the following address: `http://contoso.com/SayHello.svc`
 
 From a `Windows`, `macOS`, or `Linux` command window perform the following steps:
 

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -46,7 +46,7 @@ cd HelloSvcutil
 2. Create a new C# console project in that directory using the [`dotnet new`](../tools/dotnet-new.md) command as follows:
 
 ```console
-dotnet new console
+[`dotnet new`](../tools/dotnet-new.md) ([see note](#dotnet-new-note)) console
 ```
 
 3. Open the `HelloSvcutil.csproj` project file in your editor, edit the `Project` element, and add the [`dotnet-svcutil` NuGet package](https://nuget.org/packages/dotnet-svcutil) as a CLI tool reference, using the following code:
@@ -60,7 +60,7 @@ dotnet new console
 4. Restore the _dotnet-svcutil_ package using the [`dotnet restore`](../tools/dotnet-restore.md) command as follows:
 
 ```console
-dotnet restore
+[`dotnet restore`](../tools/dotnet-restore.md) ([see note](#dotnet-restore-note))
 ```
 
 5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file which will be saved as _HelloSvcutil/ServiceReference1/Reference.cs_
@@ -73,7 +73,7 @@ The generated file is saved as _HelloSvcutil/ServiceReference1/Reference.cs_. Th
 6. Restore the WCF packages using the [`dotnet restore`](../tools/dotnet-restore.md) command as follows:
 
 ```console
-dotnet restore
+[`dotnet restore`](../tools/dotnet-restore.md) ([see note](#dotnet-restore-note))
 ```
 
 7. Open the `Program.cs` file in your editor, edit the `Main()` method, and replace the auto-generated code with the following code to invoke the web service:
@@ -89,7 +89,7 @@ static void Main(string[] args)
 8. Run the application using the [`dotnet run`](../tools/dotnet-run.md) command as follows:
 
 ```console
-dotnet run
+[`dotnet run`](../tools/dotnet-run.md) ([see note](#dotnet-run-note))
 ```
 You should see the following output:
 "Hello dotnet-svcutil!"

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -32,7 +32,7 @@ public interface ISayHello
     string Hello(string name);
 }
 ```
-For this example, the web service will be assumed to be hosted at the following address: _http://myhost/SayHello.svc_
+For this example, the web service will be assumed to be hosted at the following address: `_http://contoso.com/SayHello.svc_`
 
 From a `Windows`, `macOS`, or `Linux` command window perform the following steps:
 
@@ -66,7 +66,7 @@ dotnet restore
 5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file as follows:
 
 ```console
-dotnet svcutil http://myhost/SayHello.svc
+dotnet svcutil http://contoso.com/SayHello.svc
 ```
 The generated file is saved as _HelloSvcutil/ServiceReference1/Reference.cs_. The _dotnet_svcutil_ tool also adds to the project the appropriate WCF packages required by the proxy code as package references.
 

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -63,7 +63,7 @@ dotnet new console
 dotnet restore
 ```
 
-5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file which will be saved at _ServiceReference1/Reference.cs_
+5. Run _dotnet_ with the _svcutil_ command to generate the web service reference file which will be saved as _HelloSvcutil/ServiceReference1/Reference.cs_
 
 ```console
 dotnet svcutil http://myhost/SayHello.svc


### PR DESCRIPTION
## Summary

Members of our team raised concerns about the fake web service address used in the example because it uses a domain that may be owned by a third party and also the link is clickable which may be confusing.


