### PR TITLE
Included ML tasks into ML resources index

### DIFF
--- a/docs/machine-learning/resources/index.md
+++ b/docs/machine-learning/resources/index.md
@@ -1,11 +1,12 @@
 ---
 title: ML.NET resources
 description: Explore these ML.NET resources to assist with custom AI solutions creation and integration into your .NET applications.
-ms.date: 05/07/2018
+ms.date: 06/05/2018
 ---
 # ML.NET resources
 
-The following  [ML.NET](../index.md) resources may be helpful to build custom AI solutions and integrate them into your .NET applications.
+The following  [ML.NET](../index.md) resources may be helpful to build custom AI solutions and integrate them into your .NET applications:
 
-* [Machine learning glossary](glossary.md): a list of important machine learning terms.
-* [Machine learning basics](basics.md): learning resources to get started with machine learning concepts.
+- [Machine learning glossary](glossary.md): contains definitions of important machine learning terms.
+- [Machine learning basics](basics.md): provides links to learning resources to get started with machine learning.
+- [Machine learning tasks](tasks.md): describes various machine learning usage scenarios supported by ML.NET.

--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -1,5 +1,5 @@
 ---
-title: Use ML.NET to predict New York Taxi Fares (Regression)
+title: Use ML.NET to predict New York taxi fares (regression)
 description: Learn how to use ML.NET in a regression scenario.
 author: aditidugar
 ms.date: 05/21/2018
@@ -7,7 +7,7 @@ ms.topic: tutorial
 ms.custom: mvc
 #Customer intent: As a developer, I want to use ML.NET so that I can train and build a model in a regression scenario to predict New York taxi fares.
 ---
-# Tutorial: Use ML.NET to predict New York Taxi Fares (Regression)
+# Tutorial: Use ML.NET to predict New York taxi fares (regression)
 
 > [!NOTE]
 > This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit [the ML.NET introduction](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet).

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1131,12 +1131,12 @@
 <!-- ML.NET Content -->
 # [ML.NET Guide](machine-learning/index.md)
 ## [Tutorials](machine-learning/tutorials/index.md)
-### [Sentiment Analysis (Classification)](machine-learning/tutorials/sentiment-analysis.md)
-### [Taxi Fare Predictor (Regression)](machine-learning/tutorials/taxi-fare.md)
+### [Sentiment analysis (classification)](machine-learning/tutorials/sentiment-analysis.md)
+### [Taxi fare predictor (regression)](machine-learning/tutorials/taxi-fare.md)
 ## [Resources](machine-learning/resources/index.md)
-### [Machine Learning Glossary](machine-learning/resources/glossary.md)
-### [Machine Learning Basics](machine-learning/resources/basics.md)
-### [Machine Learning Tasks](machine-learning/resources/tasks.md)
+### [Machine learning glossary](machine-learning/resources/glossary.md)
+### [Machine learning basics](machine-learning/resources/basics.md)
+### [Machine learning tasks](machine-learning/resources/tasks.md)
 
 <!-- End ML.NET Content -->
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1131,7 +1131,7 @@
 <!-- ML.NET Content -->
 # [ML.NET Guide](machine-learning/index.md)
 ## [Tutorials](machine-learning/tutorials/index.md)
-### [Sentiment analysis (classification)](machine-learning/tutorials/sentiment-analysis.md)
+### [Sentiment analysis (binary classification)](machine-learning/tutorials/sentiment-analysis.md)
 ### [Taxi fare predictor (regression)](machine-learning/tutorials/taxi-fare.md)
 ## [Resources](machine-learning/resources/index.md)
 ### [Machine learning glossary](machine-learning/resources/glossary.md)


### PR DESCRIPTION
This PR:
- includes the link to [ML tasks](https://docs.microsoft.com/en-us/dotnet/machine-learning/resources/tasks) topic to the [ML.NET resources index](https://docs.microsoft.com/en-us/dotnet/machine-learning/resources/)
- updates titles to use sentence-style capitalization 
