### PR TITLE
Fixed typo in docs/core/tools/dotnet.md

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -242,7 +242,7 @@ Command | Function
 
 ### Global Tools commands
 
-[.NET Core Global Tools](global-tools.md) are available strating with .NET Core SDK 2.1.300:
+[.NET Core Global Tools](global-tools.md) are available starting with .NET Core SDK 2.1.300:
 
 Command | Function
 --- | ---


### PR DESCRIPTION
## Summary

Simple typo fix in the `dotnet command` documentation.

I didn't open an issue due to the fact that it's a one-word typo adjustment.

