### PR TITLE
Added link to ML samples repo

### DIFF
--- a/docs/machine-learning/tutorials/index.md
+++ b/docs/machine-learning/tutorials/index.md
@@ -10,4 +10,4 @@ The following tutorials enable you to understand how to use [ML.NET](../index.md
 * [Sentiment Analysis](sentiment-analysis.md): demonstrates how to apply a binary classification task using ML.NET.
 * [Taxi Fare Predictor](taxi-fare.md): demonstrates how to apply a regression task using ML.NET.
 
-For more examples that use ML.NET, check the [dotnet/machinelearning-samples GitHub repository](https://github.com/dotnet/machinelearning-samples).
+For more examples that use ML.NET, check the [dotnet/machinelearning-samples](https://github.com/dotnet/machinelearning-samples) GitHub repository.

--- a/docs/machine-learning/tutorials/index.md
+++ b/docs/machine-learning/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 title: ML.NET tutorials
 description: Explore these ML.NET tutorials to learn how to build custom AI solutions and integrate them into your .NET applications.
-ms.date: 05/07/2018
+ms.date: 06/06/2018
 ---
 # ML.NET tutorials
 
@@ -9,3 +9,5 @@ The following tutorials enable you to understand how to use [ML.NET](../index.md
 
 * [Sentiment Analysis](sentiment-analysis.md): demonstrates how to apply a binary classification task using ML.NET.
 * [Taxi Fare Predictor](taxi-fare.md): demonstrates how to apply a regression task using ML.NET.
+
+For more examples that use ML.NET, check the [dotnet/machinelearning-samples GitHub repository](https://github.com/dotnet/machinelearning-samples).


### PR DESCRIPTION
Is it a good idea to add the link to the [ML samples repo](https://github.com/dotnet/machinelearning-samples) to the docs? If yes, I'll move it to another page in case of the tutorials index isn't perfect place (I've chosen that page because the related issue has been submitted under it).

Related to #5722 
