### PR TITLE
Clarify note on when gotos are valid in switches

### DIFF
--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -138,7 +138,7 @@ end with a `break`, `return`, or `goto`.
 
 > [!NOTE]
 > The `goto` statements to jump to another label are valid only
-> for the constant pattern, the classic switch statement.
+> for the constant pattern (the classic switch statement).
 
 There are important new rules governing the `switch` statement. The restrictions
 on the type of the variable in the `switch` expression have been removed.


### PR DESCRIPTION
The previous note could be read as a mistyped 2 element list - that goto statements are valid for the constant pattern and the classic switch statement. Changing the comma to parentheses makes it clear that 'the classic switch statement' is to clarify 'the constant pattern' rather than be an alternative to it.

## Summary

Changed the note describing when gotos are valid in switches to reduce ambiguity. The original form could have been read as gotos being valid for the constant pattern _and_ the classic switch statement, given a not unreasonable assumption that the comma could have been a typo for 'and'. Putting 'the classic switch statement' in parentheses makes it clearer that it's an aside to clarify the original statement.

Of course, I might have misunderstood entirely and the correct change would be to replace the comma with 'and'...

