### PR TITLE
API name change

### DIFF
--- a/docs/csharp/language-reference/keywords/fixed-statement.md
+++ b/docs/csharp/language-reference/keywords/fixed-statement.md
@@ -19,11 +19,11 @@ You can initialize a pointer by using an array, a string, a fixed-size buffer, o
 
 [!code-csharp[Initializing fixed size buffers](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#2)]
 
-Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed-size buffers, or unmanaged variables. Any type that implements a method named `DangerousGetPinnableReference` can be pinned. The `DangerousGetPinnableReference` must return a `ref` variable to an unmanaged type. See the topic on [pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md) for more information. The .NET types <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> introduced in .NET Core 2.0 make use of this pattern and can be pinned. This is shown in the following example:
+Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed-size buffers, or unmanaged variables. Any type that implements a method named `GetPinnableReference` can be pinned. The `GetPinnableReference` must return a `ref` variable to an unmanaged type. See the topic on [pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md) for more information. The .NET types <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> introduced in .NET Core 2.0 make use of this pattern and can be pinned. This is shown in the following example:
 
 [!code-csharp[Accessing fixed memory](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#FixedSpan)]
 
-If you are creating types that should participate in this pattern, see <xref:System.Span%601.DangerousGetPinnableReference?displayProperty=nameWithType> for an example of implementing the pattern.
+If you are creating types that should participate in this pattern, see <xref:System.Span%601.GetPinnableReference?displayProperty=nameWithType> for an example of implementing the pattern.
 
 Multiple pointers can be initialized in one statement if they are all the same type:
 

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -110,7 +110,7 @@ For more information, see the [`stackalloc` statement](../language-reference/key
 
 ### More types support the `fixed` statement
 
-The `fixed` statement supported a limited set of types. Starting with C# 7.3, any type that contains a `DangerousGetPinnableReference()` method that returns a `ref T` or `ref readonly T` may be `fixed`. Adding this feature means that `fixed` can be used with <xref:System.Span%601?displayProperty=nameWithType> and related types.
+The `fixed` statement supported a limited set of types. Starting with C# 7.3, any type that contains a `GetPinnableReference()` method that returns a `ref T` or `ref readonly T` may be `fixed`. Adding this feature means that `fixed` can be used with <xref:System.Span%601?displayProperty=nameWithType> and related types.
 
 For more information, see the [`fixed` statement](../language-reference/keywords/fixed-statement.md) article in the language reference.
 


### PR DESCRIPTION
The API that was called `DangerousGetPinnableReference` was changed just before release. It is now `GetPinnableReference`.

Fixes #5767

cc /@jskeet @jcouv 

Note: If the OPS build fails, that indicates we need to update the API reference for Span and other types that support the pattern.

Internal review links:
- [fixed statement](https://review.docs.microsoft.com/dotnet/csharp/language-reference/keywords/fixed-statement?branch=pr-en-us-5845)
- [What's new](https://review.docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-7-3?branch=pr-en-us-5845)
