### PR TITLE
.NET Core API reference link on the main page: update to 2.1

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ ms.custom: "updateeachrelease"
                 </a>
             </li>
             <li>
-                <a href="/dotnet/api/?view=netcore-2.0">
+                <a href="/dotnet/api/?view=netcore-2.1">
                     <div class="cardSize">
                         <div class="cardPadding">
                             <div class="card">


### PR DESCRIPTION
As .NET Core 2.1 is released and API docs look to be updated, is it a time also update the link on the [main](https://docs.microsoft.com/en-us/dotnet/) page?