### PR TITLE
Fix indentation in sample XML config

### DIFF
--- a/docs/framework/deployment/how-the-runtime-locates-assemblies.md
+++ b/docs/framework/deployment/how-the-runtime-locates-assemblies.md
@@ -231,8 +231,8 @@ Al.exe /link:asm6.exe.config /out:policy.3.0.asm6.dll /keyfile: compatkey.dat /v
 ```xml  
 <dependentAssembly>  
    <assemblyIdentity name="Server" publicKeyToken="c0305c36380ba429" />   
-      <codeBase version="1.0.0.0" href="v1/Server.dll"/>  
-      <codeBase version="2.0.0.0" href="v2/Server.dll"/>  
+   <codeBase version="1.0.0.0" href="v1/Server.dll" />  
+   <codeBase version="2.0.0.0" href="v2/Server.dll" />  
 </dependentAssembly>  
 ```  
   


### PR DESCRIPTION
Use proper indentation for 'codeBase' tags.
The current formatting could suggest that the 'codeBase' tag is a child of 'assemblyIdentity'