### PR TITLE
Changed title of globalization topic

### DIFF
--- a/docs/standard/globalization-localization/index.md
+++ b/docs/standard/globalization-localization/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Globalizing and Localizing .NET Applications"
+title: "Globalizing and localizing .NET applications"
 ms.date: "06/08/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
@@ -14,13 +14,13 @@ ms.assetid: 9a59696b-d89b-45bd-946d-c75da4732d02
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Globalizing and Localizing .NET Applications
+# Globalizing and localizing .NET applications
 Developing a [world-ready application](http://msdn.microsoft.com/goglobal/bb978433.aspx), including an application that can be localized into one or more languages, involves three steps: globalization, localizability review, and localization.  
   
  [Globalization](../../../docs/standard/globalization-localization/globalization.md)  
  This step involves designing and coding an application that is culture-neutral and language-neutral, and that supports localized user interfaces and regional data for all users. It involves making design and programming decisions that are not based on culture-specific assumptions. While a globalized application is not localized, it nevertheless is designed and written so that it can be subsequently localized into one or more languages with relative ease.  
   
- [Localizability Review](../../../docs/standard/globalization-localization/localizability-review.md)  
+ [Localizability review](../../../docs/standard/globalization-localization/localizability-review.md)  
  This step involves reviewing an application's code and design to ensure that it can be localized easily and to identify potential roadblocks for localization, and verifying that the application's executable code is separated from its resources. If the globalization stage was effective, the localizability review will confirm the design and coding choices made during globalization. The localizability stage may also identify any remaining issues so that an application's source code doesn't have to be modified during the localization stage.  
   
  [Localization](../../../docs/standard/globalization-localization/localization.md)  
@@ -36,20 +36,20 @@ Developing a [world-ready application](http://msdn.microsoft.com/goglobal/bb9784
   
  For additional information, see the [Globalization documentation](/globalization/).  
   
-## In This Section  
+## In this section  
  [Globalization](../../../docs/standard/globalization-localization/globalization.md)  
  Discusses the first stage of creating a world-ready application, which involves designing and coding an application that is culture-neutral and language-neutral.  
   
- [Localizability Review](../../../docs/standard/globalization-localization/localizability-review.md)  
+ [Localizability review](../../../docs/standard/globalization-localization/localizability-review.md)  
  Discusses the second stage of creating a localized application, which involves identifying potential roadblocks to localization.  
   
  [Localization](../../../docs/standard/globalization-localization/localization.md)  
  Discusses the final stage of creating a localized application, which involves customizing an application's user interface for specific regions or cultures.  
   
- [Culture-Insensitive String Operations](../../../docs/standard/globalization-localization/culture-insensitive-string-operations.md)  
+ [Culture-insensitive string operations](../../../docs/standard/globalization-localization/culture-insensitive-string-operations.md)  
  Describes how to use .NET methods and classes that are culture-sensitive by default to obtain culture-insensitive results.  
   
- [Best Practices for Developing World-Ready Applications](../../../docs/standard/globalization-localization/best-practices-for-developing-world-ready-apps.md)  
+ [Best practices for developing world-ready applications](../../../docs/standard/globalization-localization/best-practices-for-developing-world-ready-apps.md)  
  Describes the best practices to follow for globalization, localization, and developing world-ready ASP.NET applications.  
   
 ## Reference  

--- a/docs/standard/globalization-localization/index.md
+++ b/docs/standard/globalization-localization/index.md
@@ -1,20 +1,20 @@
 ---
-title: "Globalizing and Localizing .NET Framework Applications"
-ms.date: "03/30/2017"
+title: "Globalizing and Localizing .NET Applications"
+ms.date: "06/08/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
-  - "international applications [.NET Framework]"
-  - "globalization [.NET Framework], encoding"
+  - "international applications [.NET]"
+  - "globalization [.NET], encoding"
   - "global applications"
   - "internationalization"
   - "world-ready applications"
-  - "application development [.NET Framework], globalization"
+  - "application development [.NET], globalization"
   - "multilingual application development"
 ms.assetid: 9a59696b-d89b-45bd-946d-c75da4732d02
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Globalizing and Localizing .NET Framework Applications
+# Globalizing and Localizing .NET Applications
 Developing a [world-ready application](http://msdn.microsoft.com/goglobal/bb978433.aspx), including an application that can be localized into one or more languages, involves three steps: globalization, localizability review, and localization.  
   
  [Globalization](../../../docs/standard/globalization-localization/globalization.md)  
@@ -32,7 +32,7 @@ Developing a [world-ready application](http://msdn.microsoft.com/goglobal/bb9784
   
 -   It results in localized applications that are more stable and have fewer bugs.  
   
- The .NET Framework provides extensive support for the development of world-ready and localized applications. In particular, many type members in the .NET Framework class library aid globalization by returning values that reflect the conventions of either the current user's culture or a specified culture. Also, the .NET Framework supports satellite assemblies, which facilitate the process of localizing an application.  
+ .NET provides extensive support for the development of world-ready and localized applications. In particular, many type members in the .NET class library aid globalization by returning values that reflect the conventions of either the current user's culture or a specified culture. Also, .NET supports satellite assemblies, which facilitate the process of localizing an application.  
   
  For additional information, see the [Globalization documentation](/globalization/).  
   
@@ -47,7 +47,7 @@ Developing a [world-ready application](http://msdn.microsoft.com/goglobal/bb9784
  Discusses the final stage of creating a localized application, which involves customizing an application's user interface for specific regions or cultures.  
   
  [Culture-Insensitive String Operations](../../../docs/standard/globalization-localization/culture-insensitive-string-operations.md)  
- Describes how to use .NET Framework methods and classes that are culture-sensitive by default to obtain culture-insensitive results.  
+ Describes how to use .NET methods and classes that are culture-sensitive by default to obtain culture-insensitive results.  
   
  [Best Practices for Developing World-Ready Applications](../../../docs/standard/globalization-localization/best-practices-for-developing-world-ready-apps.md)  
  Describes the best practices to follow for globalization, localization, and developing world-ready ASP.NET applications.  


### PR DESCRIPTION
## Changed title of globalization topic

This PR:
- Changes the title of the top-level globalization and localization topic to apply to .NET and not only .NET Framework. (See #5867)
- Replaces references to .NET Framework with .NET where appropriate.

I haven't made parallel changes to child topics, since these require some revision rather than simple replacement.

/cc @mairaw 

