### PR TITLE
Fixed code snippet

### DIFF
--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -24,7 +24,7 @@ var linqExperts = from p in programmers
 Same example using the `IEnumerable<T>` API:
 
 ```csharp
-var linqExperts = programmers.Where(p => IsNewToLINQ)
+var linqExperts = programmers.Where(p => p.IsNewToLINQ)
                              .Select(p => new LINQExpert(p));
 ```
 


### PR DESCRIPTION
Fixed the code snippet that is equivalent to the following code snippet (above in the article):
 ```csharp
 var linqExperts = from p in programmers
                   where p.IsNewToLINQ
                   select new LINQExpert(p);
 ```