### PR TITLE
ML resources: reference the ML tasks topic from the glossary

### DIFF
--- a/docs/machine-learning/resources/glossary.md
+++ b/docs/machine-learning/resources/glossary.md
@@ -27,7 +27,7 @@ Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.Auc?di
 
 ## Binary classification
 
-A [classification](#classification) case where the [label](#label) is only one out of two classes. For more information, see the [Binary classification](https://en.wikipedia.org/wiki/Binary_classification) article on Wikipedia.
+A [classification](#classification) case where the [label](#label) is only one out of two classes. For more information, see the [Binary classification](tasks.md#binary-classification) section of the [Machine learning tasks](tasks.md) topic.
 
 ## Classification
 
@@ -79,7 +79,7 @@ Traditionally, the parameters for the prediction function. For example, the weig
 
 ## Multiclass classification
 
-A [classification](#classification) case where the [label](#label) is one out of three or more classes. For more information, see the [Multiclass classification](https://en.wikipedia.org/wiki/Multiclass_classification) article on Wikipedia.
+A [classification](#classification) case where the [label](#label) is one out of three or more classes. For more information, see the [Multiclass classification](tasks.md#multiclass-classification) section of the [Machine learning tasks](tasks.md) topic.
 
 ## N-gram
 
@@ -107,7 +107,7 @@ Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.Negati
 
 ## Regression
 
-A [supervised machine learning](#supervised-machine-learning) task where the output is a real value, for example, double. Examples include predicting stock prices.
+A [supervised machine learning](#supervised-machine-learning) task where the output is a real value, for example, double. Examples include predicting stock prices. For more information, see the [Regression](tasks.md#regression) section of the [Machine learning tasks](tasks.md) topic.
 
 ## Relative absolute error
 

--- a/docs/machine-learning/resources/tasks.md
+++ b/docs/machine-learning/resources/tasks.md
@@ -23,13 +23,17 @@ A [supervised machine learning](glossary.md#supervised-machine-learning) task th
 * Diagnosing whether a patient has a certain disease or not.
 * Making a decision to mark an email as "spam" or not.
 
-## Multi-class classification
+For more information, see the [Binary classification](https://en.wikipedia.org/wiki/Binary_classification) article on Wikipedia.
+
+## Multiclass classification
 
 A [supervised machine learning](glossary.md#supervised-machine-learning) task that is used to predict the class (category) of an instance of data. The input of a classification algorithm is a set of labeled examples. Each label is an integer between 0 and k-1, where k is the number of classes. The output of a classification algorithm is a classifier, which you can use to predict the class of new unlabeled instances. Examples of multi-class classification scenarios include:
 
 * Determining the breed of a dog as a "Siberian Husky", "Golden Retriever", "Poodle", etc.
 * Understanding movie reviews as "positive", "neutral", or "negative".
 * Categorizing hotel reviews as "location", "price", "cleanliness", etc.
+
+For more information, see the [Multiclass classification](https://en.wikipedia.org/wiki/Multiclass_classification) article on Wikipedia.
 
 ## Regression
 


### PR DESCRIPTION
As the [ML tasks](https://docs.microsoft.com/en-us/dotnet/machine-learning/resources/tasks) topic provides more details about some ML terms mentioned in the glossary, it's worth to be referenced from the glossary. That also moves Wikipedia links from the glossary to the tasks topic.
