### PR TITLE
Fix special character in markdown table

### DIFF
--- a/docs/standard/base-types/custom-date-and-time-format-strings.md
+++ b/docs/standard/base-types/custom-date-and-time-format-strings.md
@@ -85,7 +85,7 @@ A date and time format string defines the text representation of a <xref:System.
 |"/"|The date separator.<br /><br /> More Information: [The "/" Custom Format Specifier](#dateSeparator).|2009-06-15T13:45:30 -> / (en-US)<br /><br /> 2009-06-15T13:45:30 -> - (ar-DZ)<br /><br /> 2009-06-15T13:45:30 -> . (tr-TR)|  
 |"*string*"<br /><br /> '*string*'|Literal string delimiter.<br /><br /> More information: [Character literals](#Literals).|2009-06-15T13:45:30 ("arr:" h:m t) -> arr: 1:45 P<br /><br /> 2009-06-15T13:45:30 ('arr:' h:m t) -> arr: 1:45 P|  
 |%|Defines the following character as a custom format specifier.<br /><br /> More information:[Using Single Custom Format Specifiers](#UsingSingleSpecifiers).|2009-06-15T13:45:30 (%h) -> 1|  
-|\|The escape character.<br /><br /> More information: [Character literals](#Literals) and [Using the Escape Character](#escape).|2009-06-15T13:45:30 (h \h) -> 1 h|  
+|\\|The escape character.<br /><br /> More information: [Character literals](#Literals) and [Using the Escape Character](#escape).|2009-06-15T13:45:30 (h \h) -> 1 h|  
 |Any other character|The character is copied to the result string unchanged.<br /><br /> More information: [Character literals](#Literals).|2009-06-15T01:45:30 (arr hh:mm t) -> arr 01:45 A|  
   
  The following sections provide additional information about each custom date and time format specifier. Unless otherwise noted, each specifier produces an identical string representation regardless of whether it is used with a <xref:System.DateTime> value or a <xref:System.DateTimeOffset> value.  

--- a/docs/standard/base-types/custom-timespan-format-strings.md
+++ b/docs/standard/base-types/custom-timespan-format-strings.md
@@ -61,7 +61,7 @@ A <xref:System.TimeSpan> format string defines the string representation of a <x
 |"FFFFFF"|The millionths of a second in a time interval. Any fractional trailing zeros are not displayed.<br /><br /> More information: [The "FFFFFF" Custom Format Specifier](#F6_Specifier).|`TimeSpan.Parse("00:00:06.3291791")`:<br /><br /> `FFFFFF`: 329179<br /><br /> `TimeSpan.Parse("0:0:3.1000009")`:<br /><br /> `ss\.FFFFFF`: 03.1|  
 |"FFFFFFF"|The ten-millions of a second in a time interval. Any fractional trailing zeros or seven zeros are not displayed.<br /><br /> More information: [The "FFFFFFF" Custom Format Specifier](#F7_Specifier).|`TimeSpan.Parse("00:00:06.3291791")`:<br /><br /> `FFFFFF`: 3291791<br /><br /> `TimeSpan.Parse("0:0:3.1900000")`:<br /><br /> `ss\.FFFFFF`: 03.19|  
 |*'string*'|Literal string delimiter.<br /><br /> More information: [Other Characters](#Other).|`new TimeSpan(14, 32, 17):`<br /><br /> `hh':'mm':'ss` --> "14:32:17"|  
-|\|The escape character.<br /><br /> More information:[Other Characters](#Other).|`new TimeSpan(14, 32, 17):`<br /><br /> `hh\:mm\:ss` --> "14:32:17"|  
+|\\|The escape character.<br /><br /> More information:[Other Characters](#Other).|`new TimeSpan(14, 32, 17):`<br /><br /> `hh\:mm\:ss` --> "14:32:17"|  
 |Any other character|Any other unescaped character is interpreted as a custom format specifier.<br /><br /> More Information: [Other Characters](#Other).|`new TimeSpan(14, 32, 17):`<br /><br /> `hh\:mm\:ss` --> "14:32:17"|  
   
 <a name="dSpecifier"></a>   


### PR DESCRIPTION
## Summary  
'\\' is also escape char in markdown, needs to escape it
