### PR TITLE
Remove note on ambiguous grammar of casting

### DIFF
--- a/docs/csharp/language-reference/operators/invocation-operator.md
+++ b/docs/csharp/language-reference/operators/invocation-operator.md
@@ -27,8 +27,6 @@ In addition to being used to specify the order of operations in an expression, p
   
  For more information, see [Casting and Type Conversions](../../../csharp/programming-guide/types/casting-and-type-conversions.md).  
   
- A cast expression could lead to ambiguous syntax. For example, the expression `(x)–y` could be either interpreted as a cast expression (a cast of –y to type x) or as an additive expression combined with a parenthesized expression, which computes the value x – y.  
-  
  For more information about method invocation, see [Methods](../../../csharp/programming-guide/classes-and-structs/methods.md).  
   
 ## C# Language Specification  


### PR DESCRIPTION
## Summary

Removes a paragraph from the `() operator (C# reference)` page regarding the grammar ambiguity of a statement like `(x)-y`. This grammar ambiguity is solved by [an additional rule in the C# specification](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#cast-expressions) and the scenario necessitating it would be difficult to run into.

Fixes #5638