### PR TITLE
Add "enable_uhf_ppe" feature flag to docfx.json.

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -95,7 +95,10 @@
       "ms.topic": "conceptual",
       "feedback_system": "GitHub",
       "feedback_github_repo": "dotnet/docs",
-      "feedback_product_url": "https://developercommunity.visualstudio.com/spaces/61/index.html" 
+      "feedback_product_url": "https://developercommunity.visualstudio.com/spaces/61/index.html",
+      "featureFlags": [
+        "enable_uhf_ppe"
+      ]
     },
     "fileMetadata": {
       "feedback_product_url": {


### PR DESCRIPTION
## Summary

This PR enables the feature flag to use the new UHF. See the work item here (https://ceapex.visualstudio.com/Engineering/UX%20Team/_backlogs/board/Stories) and the related feature ticket here (https://ceapex.visualstudio.com/Engineering/UX%20Team/_workitems/edit/18194).

This change can be merged into master for testing on our review site. The feature is not live yet so this merge would have no effect on production presentation.

[Internal review site](https://review.docs.microsoft.com/dotnet/index?branch=pr-en-us-5919)

edit by @billwagner: Add internal review link
