### PR TITLE
CC59892: Removing "public" from  code

### DIFF
--- a/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
+++ b/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
@@ -29,7 +29,7 @@ Indexers can be declared on an [interface](../../../csharp/language-reference/ke
  In the preceding example, you could use the explicit interface member implementation by using the fully qualified name of the interface member. For example:  
   
 ```  
-public string ISomeInterface.this[int index]   
+string ISomeInterface.this[int index]   
 {   
 }   
 ```  
@@ -37,7 +37,7 @@ public string ISomeInterface.this[int index]
  However, the fully qualified name is only needed to avoid ambiguity when the class is implementing more than one interface with the same indexer signature. For example, if an `Employee` class is implementing two interfaces, `ICitizen` and `IEmployee`, and both interfaces have the same indexer signature, the explicit interface member implementation is necessary. That is, the following indexer declaration:  
   
 ```  
-public string IEmployee.this[int index]   
+string IEmployee.this[int index]   
 {   
 }   
 ```  
@@ -45,7 +45,7 @@ public string IEmployee.this[int index]
  implements the indexer on the `IEmployee` interface, while the following declaration:  
   
 ```  
-public string ICitizen.this[int index]
+string ICitizen.this[int index]
 {   
 }   
 ```  


### PR DESCRIPTION
Hello, @mairaw ,
This proposed file change comes from https://github.com/dotnet/docs.ru-ru/pull/110.
Contributor comment: "You can not use access modifiers with explicit implementation"

Could you review this contribution and help to merge if agreed?
Many thanks in advance.