### PR TITLE
Removed unsupported configuration attributes

### DIFF
--- a/docs/framework/network-programming/proxy-configuration.md
+++ b/docs/framework/network-programming/proxy-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: "Proxy Configuration"
-ms.date: "03/30/2017"
+ms.date: "06/18/2018"
 helpviewer_keywords: 
   - "Networking"
   - "adaptive proxies"
@@ -25,7 +25,7 @@ A proxy server handles client requests for resources. A proxy can return a reque
   
  Changes in the network environment may require that the system use a new set of proxies. If a network connection goes down or a new network connection is initialized, the system must discover the appropriate source of the configuration script in the new environment and run the new script.  
   
- You can use the `usesystemdefault` attribute of the [`<proxy>`](../configure-apps/file-schema/network/proxy-element-network-settings.md) element in your configuration file. The `usesystemdefault` attribute controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to `true`, the static proxy settings from Internet Explorer will be used. If this value is `false` or not set, the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to `false` or not set for adaptive proxies to be enabled.|  
+ You can use the `usesystemdefault` attribute of the [`<proxy>`](../configure-apps/file-schema/network/proxy-element-network-settings.md) element in your configuration file. The `usesystemdefault` attribute controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to `true`, the static proxy settings from Internet Explorer will be used. If this value is `false` or not set, the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to `false` or not set for adaptive proxies to be enabled.  
   
  The following example shows a typical adaptive proxy configuration.  
   

--- a/docs/framework/network-programming/proxy-configuration.md
+++ b/docs/framework/network-programming/proxy-configuration.md
@@ -23,38 +23,16 @@ A proxy server handles client requests for resources. A proxy can return a reque
   
  Adaptive proxies are configured by a configuration script (see [Automatic Proxy Detection](../../../docs/framework/network-programming/automatic-proxy-detection.md)). The script generates a set of application protocols and a proxy for each protocol.  
   
- Several options control how the configuration script is run. You can specify the following:  
-  
--   How often the configuration script is downloaded and run.  
-  
--   How long to wait for the script to download.  
-  
--   Which credentials your system should use to access the proxy.  
-  
--   Which credentials your system should use to download the configuration script.  
-  
  Changes in the network environment may require that the system use a new set of proxies. If a network connection goes down or a new network connection is initialized, the system must discover the appropriate source of the configuration script in the new environment and run the new script.  
   
- The following table shows configuration options for an adaptive proxy.  
-  
-|Attribute, property, or configuration file setting|Description|  
-|--------------------------------------------------------|-----------------|  
-|`scriptDownloadInterval`|Elapsed time in seconds between script downloads.|  
-|`scriptDownloadTimeout`|Time to wait (in seconds) for the script to download.|  
-|`useDefaultCredentials` or <xref:System.Net.WebProxy.UseDefaultCredentials>|Controls whether the system uses the default network credentials to access a proxy.|  
-|`useDefaultCredentialForScriptDownload`|Controls whether the system uses the default network credentials to download the configuration script.|  
-|`usesystemdefaults`|Controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to "true", then the static proxy settings from Internet Explorer will be used.<br /><br /> If this value is "false" or not set, then the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to "false" or not set for adaptive proxies to be enabled.|  
+ You can use the `usesystemdefault` attribute of the [`<proxy>`](../configure-apps/file-schema/network/proxy-element-network-settings.md) element in your configuration file. The `usesystemdefault` attribute controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to `true`, the static proxy settings from Internet Explorer will be used. If this value is `false` or not set, the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to `false` or not set for adaptive proxies to be enabled.|  
   
  The following example shows a typical adaptive proxy configuration.  
   
 ```xml  
 <system.net>  
     <defaultProxy>  
-      <proxy  scriptDownloadInterval="600"  
-              scriptDownloadTimeout="30"  
-              useDefaultCredentials="true"  
-              usesystemdefaults="true"  
-      />  
+      <proxy usesystemdefault="true" />
     </defaultProxy>  
 </system.net>  
 ```  
@@ -77,7 +55,7 @@ A proxy server handles client requests for resources. A proxy can return a reque
 |`proxyaddress` or <xref:System.Net.WebProxy.Address>|The address of the proxy to use.|  
 |`bypassonlocal` or <xref:System.Net.WebProxy.BypassProxyOnLocal>|Controls whether the proxy is bypassed for local addresses.|  
 |`bypasslist` or <xref:System.Net.WebProxy.BypassArrayList>|Describes, with regular expressions, a set of addresses that bypass the proxy.|  
-|`usesystemdefaults`|Controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to "true", then the static proxy settings from Internet Explorer will be used. On .NET Framework 2.0 when this value is set to "true", the Internet Explorer proxy settings are not overridden by other proxy settings in the configuration file. On .NET Framework 1.1, the Internet Explorer proxy settings can be overridden by other proxy settings in the configuration file.<br /><br /> If this value is "false" or not set, then the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to "false" or not set for adaptive proxies to be enabled.|  
+|`usesystemdefaults`|Controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to `true`, then the static proxy settings from Internet Explorer will be used. On .NET Framework 2.0 when this value is set to `true`, the Internet Explorer proxy settings are not overridden by other proxy settings in the configuration file. On .NET Framework 1.1, the Internet Explorer proxy settings can be overridden by other proxy settings in the configuration file.<br /><br /> If this value is `false` or not set, then the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to `false` or not set for adaptive proxies to be enabled.|  
   
  The following example shows a typical static proxy configuration.  
   

--- a/docs/framework/network-programming/proxy-configuration.md
+++ b/docs/framework/network-programming/proxy-configuration.md
@@ -32,7 +32,7 @@ A proxy server handles client requests for resources. A proxy can return a reque
 ```xml  
 <system.net>  
     <defaultProxy>  
-      <proxy usesystemdefault="true" />
+      <proxy usesystemdefault="false" />
     </defaultProxy>  
 </system.net>  
 ```  
@@ -55,7 +55,7 @@ A proxy server handles client requests for resources. A proxy can return a reque
 |`proxyaddress` or <xref:System.Net.WebProxy.Address>|The address of the proxy to use.|  
 |`bypassonlocal` or <xref:System.Net.WebProxy.BypassProxyOnLocal>|Controls whether the proxy is bypassed for local addresses.|  
 |`bypasslist` or <xref:System.Net.WebProxy.BypassArrayList>|Describes, with regular expressions, a set of addresses that bypass the proxy.|  
-|`usesystemdefaults`|Controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to `true`, then the static proxy settings from Internet Explorer will be used. On .NET Framework 2.0 when this value is set to `true`, the Internet Explorer proxy settings are not overridden by other proxy settings in the configuration file. On .NET Framework 1.1, the Internet Explorer proxy settings can be overridden by other proxy settings in the configuration file.<br /><br /> If this value is `false` or not set, then the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to `false` or not set for adaptive proxies to be enabled.|  
+|`usesystemdefault`|Controls whether the static proxy settings (proxy address, bypass list, and bypass on local) should be read from the Internet Explorer proxy settings for the user. If this value is set to `true`, then the static proxy settings from Internet Explorer will be used. On .NET Framework 2.0 when this value is set to `true`, the Internet Explorer proxy settings are not overridden by other proxy settings in the configuration file. On .NET Framework 1.1, the Internet Explorer proxy settings can be overridden by other proxy settings in the configuration file.<br /><br /> If this value is `false` or not set, then the static proxy settings can be specified in the configuration and will override the Internet Explorer proxy settings. This value must also be set to `false` or not set for adaptive proxies to be enabled.|  
   
  The following example shows a typical static proxy configuration.  
   


### PR DESCRIPTION
## Removed unsupported configuration attributes

@davidsh, I've just removed the unsupported attributes. Would you mind taking a closer look at the topic, though? In addition, the description for `usesystemdefault` says that it must be set to false to enable an adaptive proxy, but the "typical adaptive proxy" example sets it to true. Should it be set to false, or is the description inaccurate?

