### PR TITLE
Fix incorrect spelling of MediatR

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md
@@ -661,7 +661,7 @@ public class CreateOrderCommandHandler
 
 That is the code that correlates commands with command handlers. The handler is just a simple class, but it inherits from RequestHandler&lt;T&gt;, and MediatR makes sure it is invoked with the correct payload.
 
-## Applying cross-cutting concerns when processing commands with the Behaviors in MeadiatR
+## Applying cross-cutting concerns when processing commands with the Behaviors in MediatR
 
 There is one more thing: being able to apply cross-cutting concerns to the mediator pipeline. You can also see at the end of the Autofac registration module code how it registers a behavior type, specifically, a custom LoggingBehavior class and a ValidatorBehavior class. But you could add other custom behaviours, too.
 


### PR DESCRIPTION
Change:

Applying cross-cutting concerns when processing commands with the Behaviors in MeadiatR

to:

Applying cross-cutting concerns when processing commands with the Behaviors in MediatR

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
