### PR TITLE
Actually use the interface in the example

### DIFF
--- a/docs/csharp/language-reference/keywords/codesnippet/CSharp/interface_2.cs
+++ b/docs/csharp/language-reference/keywords/codesnippet/CSharp/interface_2.cs
@@ -63,7 +63,7 @@
 
        static void Main()
        {
-          Point p = new Point(2, 3);
+          IPoint p = new Point(2, 3);
           Console.Write("My Point: ");
           PrintPoint(p);
        }


### PR DESCRIPTION
Seems like an interface was created but the actual usage example did not use it. Instead, it used the concrete type.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
