### PR TITLE
Change ImagePath to AssemblyPath

### DIFF
--- a/docs/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer.md
+++ b/docs/framework/windows-services/walkthrough-creating-a-windows-service-application-in-the-component-designer.md
@@ -393,7 +393,7 @@ Protected Overrides Sub OnBeforeInstall(ByVal savedState As IDictionary)
 End Sub  
 ```  
   
-This code modifies the **ImagePath** registry key, which typically contains the full path to the executable for the Windows Service, by adding the default parameter values. The quotation marks around the path (and around each individual parameter) are required for the service to start up correctly. To change the startup parameters for this Windows Service, users can change the parameters given in the **ImagePath** registry key, although the better way is to change it programmatically and expose the functionality to users in a friendly way (for example, in a management or configuration utility).  
+This code modifies the **AssemblyPath** registry key, which typically contains the full path to the executable for the Windows Service, by adding the default parameter values. The quotation marks around the path (and around each individual parameter) are required for the service to start up correctly. To change the startup parameters for this Windows Service, users can change the parameters given in the **AssemblyPath** registry key, although the better way is to change it programmatically and expose the functionality to users in a friendly way (for example, in a management or configuration utility).  
   
 <a name="BK_Build"></a>   
 ## Building the Service  


### PR DESCRIPTION
The text says "This code modifies the **ImagePath** registry key" but in the example it shows ```Context.Parameters["assemblypath"]```

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
