### PR TITLE
Declare unsafe context for pointer sample

### DIFF
--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -66,7 +66,7 @@ class C
 {
     static S s = new S();
 
-    public void M()
+    unsafe public void M()
     {
         fixed (int* ptr = s.myFixedField)
         {


### PR DESCRIPTION
The one sample did not compile without an `unsafe` context.

Fixes #6117