### PR TITLE
Removed "Framework" mention

### DIFF
--- a/docs/csharp/language-reference/keywords/byte.md
+++ b/docs/csharp/language-reference/keywords/byte.md
@@ -12,7 +12,7 @@ ms.assetid: 111f1db9-ca32-4f0e-b497-4783517eda47
 
 `byte` denotes an integral type that stores values as indicated in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`byte`|0 to 255|Unsigned 8-bit integer|<xref:System.Byte?displayProperty=nameWithType>|  
   

--- a/docs/csharp/language-reference/keywords/char.md
+++ b/docs/csharp/language-reference/keywords/char.md
@@ -14,7 +14,7 @@ The `char` keyword is used to declare an instance of the <xref:System.Char?displ
 
  Unicode characters are used to represent most of the written languages throughout the world.
 
-|Type|Range|Size|.NET Framework type|
+|Type|Range|Size|.NET type|
 |----------|-----------|----------|-------------------------|
 |`char`|U+0000 to U+FFFF|Unicode 16-bit character|<xref:System.Char?displayProperty=nameWithType>|
 

--- a/docs/csharp/language-reference/keywords/decimal.md
+++ b/docs/csharp/language-reference/keywords/decimal.md
@@ -12,7 +12,7 @@ ms.assetid: b6522132-b5ee-4be3-ad13-3adfdb7de7a1
 
 The `decimal` keyword indicates a 128-bit data type. Compared to other floating-point types, the `decimal` type has more precision and a smaller range, which makes it appropriate for financial and monetary calculations. The approximate range and precision for the `decimal` type are shown in the following table.
 
-|Type|Approximate Range|Precision|.NET Framework type|
+|Type|Approximate Range|Precision|.NET type|
 |----------|-----------------------|---------------|-------------------------|
 |`decimal`|(-7.9 x 10<sup>28</sup> to 7.9 x 10<sup>28</sup>) / (10<sup>0</sup> to 10<sup>28</sup>)|28-29 significant digits|<xref:System.Decimal?displayProperty=nameWithType>|
 

--- a/docs/csharp/language-reference/keywords/double.md
+++ b/docs/csharp/language-reference/keywords/double.md
@@ -12,7 +12,7 @@ ms.assetid: 0980e11b-6004-4102-abcf-cfc280fc6991
 
 The `double` keyword signifies a simple type that stores 64-bit floating-point values. The following table shows the precision and approximate range for the `double` type.
 
-|Type|Approximate range|Precision|.NET Framework type|
+|Type|Approximate range|Precision|.NET type|
 |----------|-----------------------|---------------|-------------------------|
 |`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|<xref:System.Double?displayProperty=nameWithType>|
 

--- a/docs/csharp/language-reference/keywords/int.md
+++ b/docs/csharp/language-reference/keywords/int.md
@@ -12,9 +12,9 @@ ms.assetid: 212447b4-5d2a-41aa-88ab-84fe710bdb52
 
 `int` denotes an integral type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|Default Value|  
-|----------|-----------|----------|-------------------------|-------------------|  
-|`int`|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|<xref:System.Int32?displayProperty=nameWithType>|0|  
+|Type|Range|Size|.NET type|  
+|----------|-----------|----------|-------------------------|  
+|`int`|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|<xref:System.Int32?displayProperty=nameWithType>|  
   
 ## Literals  
  

--- a/docs/csharp/language-reference/keywords/long.md
+++ b/docs/csharp/language-reference/keywords/long.md
@@ -12,7 +12,7 @@ ms.assetid: f9b24319-1f39-48be-a42b-d528ee28a7fd
 
 `long` denotes an integral type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`long`|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|<xref:System.Int64?displayProperty=nameWithType>|  
   

--- a/docs/csharp/language-reference/keywords/sbyte.md
+++ b/docs/csharp/language-reference/keywords/sbyte.md
@@ -12,7 +12,7 @@ ms.assetid: 1a9c7b48-73d1-4d33-b485-c4faf0a816bc
 
 `sbyte` denotes an integral type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`sbyte`|-128 to 127|Signed 8-bit integer|<xref:System.SByte?displayProperty=nameWithType>|  
   

--- a/docs/csharp/language-reference/keywords/short.md
+++ b/docs/csharp/language-reference/keywords/short.md
@@ -12,7 +12,7 @@ ms.assetid: 04c10688-e51a-4a87-bfec-83f7fb42ff11
 
 `short` denotes an integral data type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`short`|-32,768 to 32,767|Signed 16-bit integer|<xref:System.Int16?displayProperty=nameWithType>|  
   

--- a/docs/csharp/language-reference/keywords/uint.md
+++ b/docs/csharp/language-reference/keywords/uint.md
@@ -12,7 +12,7 @@ ms.assetid: e93e42c6-ec72-4b0b-89df-2fd8d36f7a7b
 
 The `uint` keyword signifies an integral type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`uint`|0 to 4,294,967,295|Unsigned 32-bit integer|<xref:System.UInt32?displayProperty=nameWithType>|  
   

--- a/docs/csharp/language-reference/keywords/ulong.md
+++ b/docs/csharp/language-reference/keywords/ulong.md
@@ -12,7 +12,7 @@ ms.assetid: f2ece624-837a-40cf-92c5-343e7f33397c
 
 The `ulong` keyword denotes an integral type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`ulong`|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|<xref:System.UInt64?displayProperty=nameWithType>|  
   

--- a/docs/csharp/language-reference/keywords/ushort.md
+++ b/docs/csharp/language-reference/keywords/ushort.md
@@ -12,7 +12,7 @@ ms.assetid: 1a7dbaae-b7a0-4111-872a-c88a6d3981ac
 
 The `ushort` keyword indicates an integral data type that stores values according to the size and range shown in the following table.  
   
-|Type|Range|Size|.NET Framework type|  
+|Type|Range|Size|.NET type|  
 |----------|-----------|----------|-------------------------|  
 |`ushort`|0 to 65,535|Unsigned 16-bit integer|<xref:System.UInt16?displayProperty=nameWithType>|  
   


### PR DESCRIPTION
This PR updates tables in the topics about built-in value types by replacing *.NET Framework type* with *.NET type*

Also removed the column with the `int` default value, as other tables do not contain such a column.

Originates from #6144
