### PR TITLE
Remove a pointless mention of global.json

### DIFF
--- a/docs/core/porting/libraries.md
+++ b/docs/core/porting/libraries.md
@@ -67,18 +67,6 @@ Similar to CAS, Security Transparency allows separating sandboxed code from secu
 
 Use security boundaries provided by the operating system, such as virtualization, containers, or user accounts for running processes with the least set of privileges.
 
-### global.json
-
-The *global.json* file is an optional file that allows you to set the .NET Core tools version of a project. If you're using nightly builds of .NET Core and wish to specify a specific version of the SDK, specify the version with a *global.json* file. It typically resides in the current working directory or one of its parent directories. 
-
-```json
-{
-  "sdk": {
-    "version": "2.1.0-preview1-006491"
-  }
-}
-```
-
 ## Converting a PCL project
 
 You can convert the targets of a PCL project to .NET Standard by loading the library in Visual Studio 2017 and performing the following steps:


### PR DESCRIPTION
This document covers porting libraries from .NET Framework to .NET Core. The particular section is talking about features that are available in .NET Framework but missing in .NET Core. global.json is not such a feature. It is, in fact, new in .NET Core.

This was actually introduced in PR #318 (commit 1a1b90f926) as the .NET Core alternative to missing solution (.sln) files. At that point, .NET Core did not support solution files and project.json was the alternative, where users defined a list of projects. In other words, it made sense for this item - as an alternative - to be in a list of features not supported in .NET Core.

This was changed in PR #2467 (commit 387721531d) which updated this doc to take account of solution files. With solution files being supported, this is no longer a feature missing in .NET Core. In fact, it's incorrect for global.json to be in this list of ".NET Framework technologies [that are] unavailable in .NET Core".
