### PR TITLE
C26950: Escaping sample URL to show it as text.

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/remove-element-for-webrequestmodules-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/remove-element-for-webrequestmodules-network-settings.md
@@ -51,7 +51,7 @@ Removes a custom Web request module from the application.
 ## Remarks  
  The `remove` element removes the registered Web request module for the specified URI prefix.  
   
- The value for the `prefix` attribute should be the leading characters of a valid URI -- for example, "http", or "http://www.contoso.com".  
+ The value for the `prefix` attribute should be the leading characters of a valid URI -- for example, "http", or "`http://www.contoso.com` ".  
   
 ## Configuration Files  
  This element can be used in the application configuration file or the machine configuration file (Machine.config).  


### PR DESCRIPTION
Hello, @mairaw   ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"This is an instance of source issue since links for products that have migrated to markdig should be written in the []() form. Nonetheless, this link reported as missing in the targets does not redirect to any URL, thus it should be escaped"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.