### PR TITLE
Fix broken link

### DIFF
--- a/docs/standard/async.md
+++ b/docs/standard/async.md
@@ -31,7 +31,7 @@ Async code has the following characteristics:
 
 For more information, see the [Async in depth](async-in-depth.md) topic.
 
-The [Asynchronous Programming Patterns](/asynchronous-programming-patterns/index.md) topic provides an overview of the three asynchronous programming patterns supported in .NET:  
+The [Asynchronous Programming Patterns](asynchronous-programming-patterns/index.md) topic provides an overview of the three asynchronous programming patterns supported in .NET:  
   
 -   [Asynchronous Programming Model (APM)](asynchronous-programming-patterns/asynchronous-programming-model-apm.md) (legacy)  
   


### PR DESCRIPTION
Fix link to [Asynchronous Programming Patterns] overview page

## Summary
The link has extra / character that cause the doc fail to interpret the relative link
