### PR TITLE
Bulk fix to uppercase includes for LOC

### DIFF
--- a/docs/framework/migration-guide/retargeting/4.0-4.5.1.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.5.1.md
@@ -8,73 +8,73 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.5.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.5.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
 ## Core
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Windows Forms
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.5.2.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.5.2.md
@@ -8,77 +8,77 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.5.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.5.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
 ## Core
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Forms
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.5.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.5.md
@@ -8,59 +8,59 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.5
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.5, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
 ## Core
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## Windows Forms
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.6.1.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.6.1.md
@@ -8,119 +8,119 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.6.2.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.6.2.md
@@ -8,139 +8,139 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.6.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.6.md
@@ -8,109 +8,109 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
 ## Windows Forms
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.7.1.md
@@ -8,177 +8,177 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.7.2.md
@@ -8,205 +8,205 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.0-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.0-4.7.md
@@ -8,157 +8,157 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.0 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
+[!INCLUDE[MachineKey.Encode and MachineKey.Decode methods are now obsolete](~/includes/migration-guide/retargeting/asp/machinekeyencode-machinekeydecode-methods-are-now-obsolete.md)]
 
-[!include[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
+[!INCLUDE[Multi-line ASP.Net TextBox spacing changed when using AntiXSSEncoder](~/includes/migration-guide/retargeting/asp/multi-line-aspnet-textbox-spacing-changed-when-using-antixssencoder.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
-[!include[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
+[!INCLUDE[WebUtility.HtmlEncode and WebUtility.HtmlDecode round-trip BMP correctly](~/includes/migration-guide/retargeting/asp/webutilityhtmlencode-webutilityhtmldecode-round-trip-bmp-correctly.md)]
 
 ## ClickOnce
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
+[!INCLUDE[Foreach iterator variable is now scoped within the iteration, so closure capturing semantics are different (in C#5)](~/includes/migration-guide/retargeting/core/foreach-iterator-variable-now-scoped-within-iteration-so-closure-capturing.md)]
 
-[!include[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
+[!INCLUDE[IAsyncResult.CompletedSynchronously property must be correct for the resulting task to complete](~/includes/migration-guide/retargeting/core/iasyncresultcompletedsynchronously-property-must-be-correct-for-resulting.md)]
 
-[!include[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
+[!INCLUDE[List&lt;T&gt;.ForEach can throw exception when modifying list item](~/includes/migration-guide/retargeting/core/listlttgtforeach-can-throw-exception-when-modifying-list-item.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
+[!INCLUDE[System.Uri parsing adheres to RFC 3987](~/includes/migration-guide/retargeting/core/systemuri-parsing-adheres-rfc-3987.md)]
 
-[!include[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
+[!INCLUDE[System.Uri.IsWellFormedUriString method returns false for relative URIs with a colon char in first segment](~/includes/migration-guide/retargeting/core/systemuriiswellformeduristring-method-returns-false-for-relative-uris-with.md)]
 
 ## Entity Framework
 
-[!include[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
+[!INCLUDE[Entity Framework version must match the .NET Framework version](~/includes/migration-guide/retargeting/ef/entity-framework-version-must-match-net.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
+[!INCLUDE[EncoderParameter ctor is obsolete](~/includes/migration-guide/retargeting/winforms/encoderparameter-ctor-obsolete.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
+[!INCLUDE[WPF TextBox.Text can be out-of-sync with databinding](~/includes/migration-guide/retargeting/wpf/wpf-textboxtext-can-be-out-of-sync-with-databinding.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
+[!INCLUDE[New (ambiguous) Dispatcher.Invoke overloads could result in different behavior](~/includes/migration-guide/retargeting/wf/new-ambiguous-dispatcherinvoke-overloads-could-result-different-behavior.md)]
 
-[!include[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
+[!INCLUDE[Some WorkFlow drag-and-drop APIs are obsolete](~/includes/migration-guide/retargeting/wf/some-workflow-drag-and-drop-apis-are-obsolete.md)]
 
-[!include[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
+[!INCLUDE[WorkFlow 3.0 types are obsolete](~/includes/migration-guide/retargeting/wf/workflow-30-types-are-obsolete.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
 ## XML, XSLT
 
-[!include[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
+[!INCLUDE[XML schema validation is stricter](~/includes/migration-guide/retargeting/xml/xml-schema-validation-stricter.md)]
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.5.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.5.1.md
@@ -8,29 +8,29 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.5.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.5.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## Core
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.5.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.5.2.md
@@ -8,41 +8,41 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.5.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.5.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## Core
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Forms
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.6.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.6.1.md
@@ -8,91 +8,91 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.6.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.6.2.md
@@ -8,111 +8,111 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.6.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.6.md
@@ -8,81 +8,81 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
 ## Windows Forms
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.7.1.md
@@ -8,149 +8,149 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.7.2.md
@@ -8,177 +8,177 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.5-4.7.md
@@ -8,129 +8,129 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
+[!INCLUDE[DbParameter.Precision and DbParameter.Scale are now public virtual members](~/includes/migration-guide/retargeting/adonet/dbparameterprecision-dbparameterscale-are-now-public-virtual-members.md)]
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
+[!INCLUDE[ObsoleteAttribute exports as both ObsoleteAttribute and DeprecatedAttribute in WinMD scenarios](~/includes/migration-guide/retargeting/core/obsoleteattribute-exports-both-deprecatedattribute-winmd-scenarios.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## MSBuild
 
-[!include[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
+[!INCLUDE[ResolveAssemblyReference task now warns of dependencies with the wrong architecture](~/includes/migration-guide/retargeting/msbuild/resolveassemblyreference-task-now-warns-dependencies-with-wrong-architecture.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
+[!INCLUDE[Two-way data-binding to a property with a non-public setter is not supported](~/includes/migration-guide/retargeting/wpf/two-way-data-binding-property-with-non-public-setter-not-supported.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.5.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.5.2.md
@@ -8,21 +8,21 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.5.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.5.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Forms
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.6.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.6.1.md
@@ -8,83 +8,83 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.6.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.6.2.md
@@ -8,103 +8,103 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.6.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.6.md
@@ -8,73 +8,73 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
 ## Windows Forms
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.7.1.md
@@ -8,141 +8,141 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.7.2.md
@@ -8,169 +8,169 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.1-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.5.1-4.7.md
@@ -8,121 +8,121 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.1 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Visual Basic .NET
 
-[!include[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
+[!INCLUDE[VB.NET no longer supports partial namespace qualification for System.Windows APIs](~/includes/migration-guide/retargeting/vb/vbnet-no-longer-supports-partial-namespace-qualification-for-systemwindows.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
+[!INCLUDE[DataObject.GetData now retrieves data as UTF-8](~/includes/migration-guide/retargeting/winforms/dataobjectgetdata-now-retrieves-data-utf-8.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
-[!include[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
+[!INCLUDE[WorkflowDesigner.Load doesn't remove symbol property](~/includes/migration-guide/retargeting/wf/workflowdesignerload-doesnt-remove-symbol-property.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.2-4.6.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5.2-4.6.1.md
@@ -8,73 +8,73 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.2-4.6.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5.2-4.6.2.md
@@ -8,93 +8,93 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.2-4.6.md
+++ b/docs/framework/migration-guide/retargeting/4.5.2-4.6.md
@@ -8,63 +8,63 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
 ## Windows Forms
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.2-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.5.2-4.7.1.md
@@ -8,133 +8,133 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.2-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.5.2-4.7.2.md
@@ -8,161 +8,161 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.5.2-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.5.2-4.7.md
@@ -8,113 +8,113 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.5.2 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
+[!INCLUDE[HtmlTextWriter does not render `<br/>` element correctly](~/includes/migration-guide/retargeting/asp/htmltextwriter-does-not-render-br-element-correctly.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## ClickOnce
 
-[!include[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
+[!INCLUDE[Apps published with ClickOnce that use a SHA-256 code-signing certificate may fail on Windows 2003](~/includes/migration-guide/retargeting/clickonce/apps-published-with-clickonce-that-use-sha-256-code-signing-certificate-may.md)]
 
-[!include[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
+[!INCLUDE[ClickOnce supports SHA-256 on 4.0-targeted apps](~/includes/migration-guide/retargeting/clickonce/clickonce-supports-sha-256-on-40-targeted-apps.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Entity Framework
 
-[!include[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
+[!INCLUDE[Building an Entity Framework edmx with Visual Studio 2013 can fail with error MSB4062 if using the EntityDeploySplit or EntityClean tasks](~/includes/migration-guide/retargeting/ef/building-an-entity-framework-edmx-with-visual-studio-2013-can-fail-error.md)]
 
 ## JIT
 
-[!include[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
+[!INCLUDE[IL ret not allowed in a try region](~/includes/migration-guide/retargeting/jit/il-ret-not-allowed-try-region.md)]
 
-[!include[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
+[!INCLUDE[New 64-bit JIT compiler in the .NET Framework 4.6](~/includes/migration-guide/retargeting/jit/new-64-bit-jit-compiler-net-framework-46.md)]
 
 ## Networking
 
-[!include[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
+[!INCLUDE[Certificate EKU OID validation](~/includes/migration-guide/retargeting/networking/certificate-eku-oid-validation.md)]
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
+[!INCLUDE[Only Tls 1.0, 1.1 and 1.2 protocols supported in System.Net.ServicePointManager and System.Net.Security.SslStream](~/includes/migration-guide/retargeting/networking/only-tls-10-11-12-protocols-supported-systemnetservicepointmanager.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
-[!include[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
+[!INCLUDE[TLS 1.x by default passes the SCH_SEND_AUX_RECORD flag to the underlying SCHANNEL API](~/includes/migration-guide/retargeting/networking/tls-1x-by-default-passes-schsendauxrecord-flag-underlying-schannel-api.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
+[!INCLUDE[Calling CreateDefaultAuthorizationContext with a null argument has changed](~/includes/migration-guide/retargeting/wcf/calling-createdefaultauthorizationcontext-with-null-argument-has-changed.md)]
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
+[!INCLUDE[Icon.ToBitmap successfully converts icons with PNG frames into Bitmap objects](~/includes/migration-guide/retargeting/winforms/icontobitmap-successfully-converts-icons-with-png-frames-into-bitmap-objects.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
+[!INCLUDE[WPF layout rounding of margins has changed](~/includes/migration-guide/retargeting/wpf/wpf-layout-rounding-margins-has-changed.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 
 ## XML, XSLT
 
-[!include[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
+[!INCLUDE[XmlWriter throws on invalid surrogate pairs](~/includes/migration-guide/retargeting/xml/xmlwriter-throws-on-invalid-surrogate-pairs.md)]
 
-[!include[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
+[!INCLUDE[XSD Schema validation now correctly detects violations of unique constraints if compound keys are used and one key is empty](~/includes/migration-guide/retargeting/xml/xsd-schema-validation-now-correctly-detects-violations-unique-constraints-if.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6-4.6.1.md
+++ b/docs/framework/migration-guide/retargeting/4.6-4.6.1.md
@@ -8,27 +8,27 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6-4.6.2.md
+++ b/docs/framework/migration-guide/retargeting/4.6-4.6.2.md
@@ -8,61 +8,61 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Security
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.6-4.7.1.md
@@ -8,103 +8,103 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.6-4.7.2.md
@@ -8,131 +8,131 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.6-4.7.md
@@ -8,83 +8,83 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
+[!INCLUDE[Change in path separator character in FullName property of ZipArchiveEntry objects](~/includes/migration-guide/retargeting/core/change-path-separator-character-fullname-property-ziparchiveentry-objects.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
+[!INCLUDE[WCF binding with the TransportWithMessageCredential security mode](~/includes/migration-guide/retargeting/wcf/wcf-binding-with-transportwithmessagecredential-security-mode.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
-[!include[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
+[!INCLUDE[X509CertificateClaimSet.FindClaims Considers All claimTypes](~/includes/migration-guide/retargeting/wcf/x509certificateclaimsetfindclaims-considers-all-claimtypes.md)]
 
 ## Windows Forms
 
-[!include[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
+[!INCLUDE[Application.FilterMessage no longer throws for re-entrant implementations of IMessageFilter.PreFilterMessage](~/includes/migration-guide/retargeting/winforms/applicationfiltermessage-no-longer-throws-for-re-entrant-implementations.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.1-4.6.2.md
+++ b/docs/framework/migration-guide/retargeting/4.6.1-4.6.2.md
@@ -8,51 +8,51 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.1 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Security
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
 ## Windows Forms
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.1-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.6.1-4.7.1.md
@@ -8,97 +8,97 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.1 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.1-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.6.1-4.7.2.md
@@ -8,125 +8,125 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.1 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.1-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.6.1-4.7.md
@@ -8,77 +8,77 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.1 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
+[!INCLUDE[AesCryptoServiceProvider decryptor provides a reusable transform](~/includes/migration-guide/retargeting/core/aescryptoserviceprovider-decryptor-provides-reusable-transform.md)]
 
-[!include[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
+[!INCLUDE[Calls to ClaimsIdentity constructors](~/includes/migration-guide/retargeting/core/calls-claimsidentity-constructors.md)]
 
-[!include[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
+[!INCLUDE[Changes in path normalization](~/includes/migration-guide/retargeting/core/changes-path-normalization.md)]
 
-[!include[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
+[!INCLUDE[CurrentCulture and CurrentUICulture flow across tasks](~/includes/migration-guide/retargeting/core/currentculture-currentuiculture-flow-across-tasks.md)]
 
-[!include[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
+[!INCLUDE[ETW event names cannot differ only by a "Start" or "Stop" suffix](~/includes/migration-guide/retargeting/core/etw-event-names-cannot-differ-only-by-start-stop-suffix.md)]
 
-[!include[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
+[!INCLUDE[Long path support](~/includes/migration-guide/retargeting/core/long-path-support.md)]
 
-[!include[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
+[!INCLUDE[Path colon checks are stricter](~/includes/migration-guide/retargeting/core/path-colon-checks-are-stricter.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
+[!INCLUDE[RSACng now correctly loads RSA keys of non-standard key size](~/includes/migration-guide/retargeting/security/rsacng-now-correctly-loads-rsa-keys-non-standard-key-size.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
+[!INCLUDE[Deadlock may result when using Reentrant services](~/includes/migration-guide/retargeting/wcf/deadlock-may-result-when-using-reentrant-services.md)]
 
-[!include[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
+[!INCLUDE[OperationContext.Current may return null when called in a using clause](~/includes/migration-guide/retargeting/wcf/operationcontextcurrent-may-return-null-when-called-using-clause.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
-[!include[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
+[!INCLUDE[WCF transport security supports certificates stored using CNG](~/includes/migration-guide/retargeting/wcf/wcf-transport-security-supports-certificates-stored-using-cng.md)]
 
 ## Windows Forms
 
-[!include[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
+[!INCLUDE[Incorrect implementation of MemberDescriptor.Equals](~/includes/migration-guide/retargeting/winforms/incorrect-implementation-memberdescriptorequals.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
+[!INCLUDE[CurrentCulture is not preserved across WPF Dispatcher operations](~/includes/migration-guide/retargeting/wpf/currentculture-not-preserved-across-wpf-dispatcher-operations.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.2-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.6.2-4.7.1.md
@@ -8,75 +8,75 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.2 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.2 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.2-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.6.2-4.7.2.md
@@ -8,103 +8,103 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.2 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.2 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Core
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.6.2-4.7.md
+++ b/docs/framework/migration-guide/retargeting/4.6.2-4.7.md
@@ -8,47 +8,47 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.6.2 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.2 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
+[!INCLUDE[HttpRuntime.AppDomainAppPath Throws a NullReferenceException](~/includes/migration-guide/retargeting/asp/httpruntimeappdomainapppath-throws-nullreferenceexception.md)]
 
-[!include[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
+[!INCLUDE[Throttle concurrent requests per session](~/includes/migration-guide/retargeting/asp/throttle-concurrent-requests-per-session.md)]
 
 ## Networking
 
-[!include[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
+[!INCLUDE[Default value of ServicePointManager.SecurityProtocol is SecurityProtocolType.System.Default](~/includes/migration-guide/retargeting/networking/default-value-servicepointmanagersecurityprotocol.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Security
 
-[!include[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
+[!INCLUDE[CspParameters.ParentWindowHandle now expects HWND value](~/includes/migration-guide/retargeting/security/cspparametersparentwindowhandle-now-expects-hwnd-value.md)]
 
-[!include[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
+[!INCLUDE[SslStream supports TLS Alerts](~/includes/migration-guide/retargeting/networking/sslstream-supports-tls-alerts.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
+[!INCLUDE[Serialization of control characters with DataContractJsonSerializer is now compatible with ECMAScript V6 and V8](~/includes/migration-guide/retargeting/wcf/serialization-control-characters-with-datacontractjsonserializer-now.md)]
 
-[!include[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
+[!INCLUDE[WCF message security now is able to use TLS1.1 and TLS1.2](~/includes/migration-guide/retargeting/wcf/wcf-message-security-now-able-use-tls11-tls12.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
+[!INCLUDE[Calls to System.Windows.Input.PenContext.Disable on touch-enabled systems may throw an ArgumentException](~/includes/migration-guide/retargeting/wpf/calls-systemwindowsinputpencontextdisable-on-touch-enabled-systems-may-throw.md)]
 
-[!include[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
+[!INCLUDE[NullReferenceException in exception handling code from ImageSourceConverter.ConvertFrom](~/includes/migration-guide/retargeting/wpf/nullreferenceexception-exception-handling-code-from.md)]
 
-[!include[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
+[!INCLUDE[WPF Grid allocation of space to star-columns](~/includes/migration-guide/retargeting/wpf/wpf-grid-allocation-space-star-columns.md)]
 
-[!include[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
+[!INCLUDE[WPF Pointer-Based Touch Stack](~/includes/migration-guide/retargeting/wpf/wpf-pointer-based-touch-stack.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
+[!INCLUDE[Workflow checksums changed from MD5 to SHA1](~/includes/migration-guide/retargeting/wf/workflow-checksums-changed-from-md5-sha1.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.7-4.7.1.md
+++ b/docs/framework/migration-guide/retargeting/4.7-4.7.1.md
@@ -8,47 +8,47 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.7 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.7 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
 ## Core
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
 ## Security
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.7-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.7-4.7.2.md
@@ -8,75 +8,75 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.7 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.7 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
+[!INCLUDE[ASP.NET Accessibility Improvements in .NET Framework 4.7.1](~/includes/migration-guide/retargeting/asp/aspnet-accessibility-improvements-net-framework-471.md)]
 
 ## Core
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
+[!INCLUDE[SerialPort background thread exceptions](~/includes/migration-guide/retargeting/core/serialport-background-thread-exceptions.md)]
 
-[!include[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
+[!INCLUDE[ServiceBase doesn't propagate OnStart exceptions](~/includes/migration-guide/retargeting/core/servicebase-doesnt-propagate-onstart-exceptions.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Security
 
-[!include[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
+[!INCLUDE[Default SignedXML and SignedXMS algorithms changed to SHA256](~/includes/migration-guide/retargeting/security/default-signedxml-signedxms-algorithms-changed-sha256.md)]
 
-[!include[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
+[!INCLUDE[SignedXml.GetPublicKey returns RSACng on net462 (or lightup) without retargeting change](~/includes/migration-guide/retargeting/security/signedxmlgetpublickey-returns-rsacng-on-net462-or-lightup-without.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
+[!INCLUDE[Improved accessibility for some .NET SDK tools](~/includes/migration-guide/retargeting/wcf/improved-accessibility-for-some-net-sdk-tools.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
+[!INCLUDE[Accessibility improvements in WPF](~/includes/migration-guide/retargeting/wpf/accessibility-improvements-wpf.md)]
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
+[!INCLUDE[Selector SelectionChanged event and SelectedValue property](~/includes/migration-guide/retargeting/wpf/selector-selectionchanged-event-selectedvalue-property.md)]
 
-[!include[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
+[!INCLUDE[TabControl SelectionChanged event and SelectedContent property](~/includes/migration-guide/retargeting/wpf/tabcontrol-selectionchanged-event-selectedcontent-property.md)]
 
-[!include[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF PackageDigitalSignatureManager is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpf-packagedigitalsignaturemanager-now-sha256.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
+[!INCLUDE[Accessibility improvements in Windows Workflow Foundation (WF) workflow designer](~/includes/migration-guide/retargeting/wf/accessibility-improvements-windows-workflow-foundation-wf-designer.md)]
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 

--- a/docs/framework/migration-guide/retargeting/4.7.1-4.7.2.md
+++ b/docs/framework/migration-guide/retargeting/4.7.1-4.7.2.md
@@ -8,45 +8,45 @@ ms.author: "ronpet"
 
 # Retargeting Changes for Migration from .NET Framework 4.7.1 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/retargeting/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/retargeting/introduction.md)]
 
 If you are migrating from the .NET Framework 4.7.1 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
+[!INCLUDE[Allow Unicode Bidirectional Control Characters in URIs](~/includes/migration-guide/retargeting/core/allow-unicode-bidirectional-control-characters-uris.md)]
 
-[!include[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
+[!INCLUDE[DeflateStream uses native APIs for decompression](~/includes/migration-guide/retargeting/core/deflatestream-uses-native-apis-for-decompression.md)]
 
-[!include[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
+[!INCLUDE[Ensure System.Uri uses a consistent reserved character set](~/includes/migration-guide/retargeting/core/ensure-systemuri-uses-consistent-reserved-character-set.md)]
 
-[!include[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
+[!INCLUDE[Stack traces obtained when using portable PDBs now include source file and line information if requested](~/includes/migration-guide/retargeting/core/stack-traces-obtained-when-using-portable-pdbs-now-include-source-file-line.md)]
 
 ## Windows Forms
 
-[!include[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
+[!INCLUDE[Accessibility improvements in Windows Forms controls for .NET 4.7.2](~/includes/migration-guide/retargeting/winforms/accessibility-improvements-windows-forms-controls-for-net-472.md)]
 
-[!include[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
+[!INCLUDE[ContextMenuStrip.SourceControl property contains a valid control in the case of nested ToolStripMenuItems](~/includes/migration-guide/retargeting/winforms/contextmenustripsourcecontrol-property-contains-valid-control-case-nested.md)]
 
-[!include[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
+[!INCLUDE[PrivateFontCollection.AddFontFile method releases Font resources](~/includes/migration-guide/retargeting/winforms/privatefontcollectionaddfontfile-method-releases-font-resources.md)]
 
-[!include[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
+[!INCLUDE[WinForm's Domain upbutton and downbutton actions are in sync now](~/includes/migration-guide/retargeting/winforms/winforms-domain-upbutton-downbutton-actions-are-sync-now.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
+[!INCLUDE[Keyboard focus now moves correctly across multiple layers of WinForms/WPF hosting](~/includes/migration-guide/retargeting/wpf/keyboard-focus-now-moves-correctly-across-multiple-layers-winformswpf.md)]
 
-[!include[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
+[!INCLUDE[The default hash algorithm for WPF's Markup Compiler is now SHA256](~/includes/migration-guide/retargeting/wpf/default-hash-algorithm-for-wpfs-markup-compiler-now-sha256.md)]
 
-[!include[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
+[!INCLUDE[WPF Changing a primary key when displaying ADO data in a Master/Detail scenario](~/includes/migration-guide/retargeting/wpf/wpf-changing-primary-key-when-displaying-ado-data-masterdetail-scenario.md)]
 
-[!include[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
+[!INCLUDE[WPF FocusVisual for RadioButton and CheckBox Now Displays Correctly When The Controls Have No Content](~/includes/migration-guide/retargeting/wpf/wpf-focusvisual-for-radiobutton-checkbox-now-displays-correctly-when.md)]
 
-[!include[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
+[!INCLUDE[WPF TextBox/PasswordBox Text Selection Does Not Follow System Colors](~/includes/migration-guide/retargeting/wpf/wpf-textboxpasswordbox-text-selection-does-not-follow-system-colors.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
+[!INCLUDE[Avoiding endless recursion for IWorkflowInstanceManagement.TransactedCancel and IWorkflowInstanceManagement.TransactedTerminate](~/includes/migration-guide/retargeting/wf/avoiding-endless-recursion-for-iworkflowinstancemanagementtransactedcancel.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.5.1.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.5.1.md
@@ -8,193 +8,193 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.5.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.5.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.5.2.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.5.2.md
@@ -8,195 +8,195 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.5.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.5.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.5.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.5.md
@@ -8,175 +8,175 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.5
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.5, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
 ## Data
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.6.2.md
@@ -8,229 +8,229 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.6.md
@@ -8,205 +8,205 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.7.1.md
@@ -8,235 +8,235 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.7.2.md
@@ -8,247 +8,247 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.0-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.0-4.7.md
@@ -8,237 +8,237 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.0 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.0 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
+[!INCLUDE[HttpRequest.ContentEncoding property prohibits UTF7](~/includes/migration-guide/runtime/asp/httprequestcontentencoding-property-prohibits-utf7.md)]
 
-[!include[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
+[!INCLUDE[HttpUtility.JavaScriptStringEncode escapes ampersand](~/includes/migration-guide/runtime/asp/httputilityjavascriptstringencode-escapes-ampersand.md)]
 
-[!include[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
+[!INCLUDE[IPad should not be used in custom capabilities file because it is now a browser capability](~/includes/migration-guide/runtime/asp/ipad-should-not-be-used-custom-capabilities-file-because-it-now-browser.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
+[!INCLUDE[Page.LoadComplete event no longer causes System.Web.UI.WebControls.EntityDataSource control to invoke data binding](~/includes/migration-guide/runtime/asp/pageloadcomplete-event-no-longer-causes.md)]
 
-[!include[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
+[!INCLUDE[Sharing session state with Asp.Net StateServer requires all servers in the web farm to use the same .NET Framework version](~/includes/migration-guide/runtime/asp/sharing-session-state-with-aspnet-stateserver-requires-all-servers-web-farm.md)]
 
-[!include[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
+[!INCLUDE[WebUtility.HtmlDecode no longer decodes invalid input sequences](~/includes/migration-guide/runtime/asp/webutilityhtmldecode-no-longer-decodes-invalid-input-sequences.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
+[!INCLUDE[Assemblies compiled with Regex.CompileToAssembly breaks between 4.0 and 4.5](~/includes/migration-guide/runtime/core/assemblies-compiled-with-regexcompiletoassembly-breaks-between-40-45.md)]
 
-[!include[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
+[!INCLUDE[BlockingCollection&lt;T&gt;.TryTakeFromAny does not throw anymore](~/includes/migration-guide/runtime/core/blockingcollectionlttgttrytakefromany-does-not-throw-anymore.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
+[!INCLUDE[Change in behavior for Task.WaitAll methods with time-out arguments](~/includes/migration-guide/runtime/core/change-behavior-for-taskwaitall-methods-with-time-out-arguments.md)]
 
-[!include[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
+[!INCLUDE[Compiler support for type forwarding when multi-targeting mscorlib](~/includes/migration-guide/runtime/core/compiler-support-for-type-forwarding-when-multi-targeting-mscorlib.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
+[!INCLUDE[Exceptions during unobserved processing in System.Threading.Tasks.Task no longer propagate on finalizer thread](~/includes/migration-guide/runtime/core/exceptions-during-unobserved-processing-systemthreadingtaskstask-no-longer.md)]
 
-[!include[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
+[!INCLUDE[List.Sort algorithm changed](~/includes/migration-guide/runtime/core/listsort-algorithm-changed.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
+[!INCLUDE[Missing Target Framework Moniker results in 4.0 behavior](~/includes/migration-guide/runtime/core/missing-target-framework-moniker-results-40-behavior.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
+[!INCLUDE[System.Threading.Tasks.Task no longer throw ObjectDisposedException after object is disposed](~/includes/migration-guide/runtime/core/systemthreadingtaskstask-no-longer-throw-objectdisposedexception-after.md)]
 
-[!include[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
+[!INCLUDE[System.Uri escaping now supports RFC 3986](~/includes/migration-guide/runtime/core/systemuri-escaping-now-supports-rfc-3986.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
+[!INCLUDE[Sql_variant data uses sql_variant collation rather than database collation](~/includes/migration-guide/runtime/data/sqlvariant-data-uses-collation-rather-than-database.md)]
 
-[!include[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
+[!INCLUDE[SqlBulkCopy uses destination column encoding for strings](~/includes/migration-guide/runtime/data/sqlbulkcopy-uses-destination-column-encoding-for-strings.md)]
 
-[!include[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
+[!INCLUDE[SqlConnection can no longer connect to SQL Server 1997 or databases using the VIA adapter](~/includes/migration-guide/runtime/data/sqlconnection-can-no-longer-connect-sql-server-1997-databases-using-via.md)]
 
 ## Entity Framework
 
-[!include[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
+[!INCLUDE[Change in behavior in Data Definition Language (DDL) APIs](~/includes/migration-guide/runtime/ef/change-behavior-data-definition-language-ddl-apis.md)]
 
-[!include[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
+[!INCLUDE[Different exception handling for ObjectContext.CreateDatabase and DbProviderServices.CreateDatabase methods](~/includes/migration-guide/runtime/ef/different-exception-handling-for-objectcontextcreatedatabase.md)]
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
+[!INCLUDE[EntityFramework 6.0 loads very slowly in apps launched from Visual Studio](~/includes/migration-guide/runtime/ef/entityframework-60-loads-very-slowly-apps-launched-from-visual-studio.md)]
 
-[!include[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
+[!INCLUDE[Log file name created by the ObjectContext.CreateDatabase method has changed to match SQL Server specifications](~/includes/migration-guide/runtime/ef/log-file-name-created-by-objectcontextcreatedatabase-method-has-changed.md)]
 
-[!include[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
+[!INCLUDE[ObjectContext.Translate and ObjectContext.ExecuteStoreQuery now support enum type](~/includes/migration-guide/runtime/ef/objectcontexttranslate-objectcontextexecutestorequery-now-support-enum-type.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## LINQ
 
-[!include[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
+[!INCLUDE[Enumerable.Empty&lt;TResult&gt; always returns cached instance](~/includes/migration-guide/runtime/linq/enumerableemptylttresultgt-always-returns-cached-instance.md)]
 
 ## Managed Extensibility Framework (MEF)
 
-[!include[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
+[!INCLUDE[MEF catalogs implement IEnumerable and therefore can no longer be used to create a serializer](~/includes/migration-guide/runtime/mef/mef-catalogs-implement-ienumerable-therefore-can-no-longer-be-used-create.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
-[!include[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
+[!INCLUDE[Deserialization of MailMessage objects serialized under the .NET Framework 4.5 may fail](~/includes/migration-guide/runtime/networking/deserialization-mailmessage-objects-serialized-under-net-framework-45-may.md)]
 
-[!include[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
+[!INCLUDE[System.Net.PeerToPeer.Collaboration unavailable on Windows 8](~/includes/migration-guide/runtime/networking/systemnetpeertopeercollaboration-unavailable-on-windows-8.md)]
 
 ## Printing
 
-[!include[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
+[!INCLUDE[Data written to PrintSystemJobInfo.JobStream must be in XPS format](~/includes/migration-guide/runtime/printing/data-written-printsystemjobinfojobstream-must-be-xps-format.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
+[!INCLUDE[BinaryFormatter can fail to find type from LoadFrom context](~/includes/migration-guide/runtime/serialization/binaryformatter-can-fail-find-type-from-loadfrom-context.md)]
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
-[!include[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
+[!INCLUDE[SoapFormatter cannot deserialize Hashtable and similar ordered collection objects](~/includes/migration-guide/runtime/serialization/soapformatter-cannot-deserialize-hashtable-similar-ordered-collection.md)]
 
-[!include[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
+[!INCLUDE[XmlSerializer fails while serializing a type that hides an accessible member with an inaccessible one](~/includes/migration-guide/runtime/serialization/xmlserializer-fails-while-serializing-type-that-hides-an-accessible-member.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
+[!INCLUDE[Managed browser hosting controls from the .NET Framework 1.1 and 2.0 are blocked](~/includes/migration-guide/runtime/web/managed-browser-hosting-controls-from-net-framework-11-20-are-blocked.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
+[!INCLUDE[Error codes for maxRequestLength or maxReceivedMessageSize are different](~/includes/migration-guide/runtime/wcf/error-codes-for-maxrequestlength-maxreceivedmessagesize-are-different.md)]
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
+[!INCLUDE[System.ServiceModel.Web.WebServiceHost object no longer adds a default endpoint](~/includes/migration-guide/runtime/wcf/systemservicemodelwebwebservicehost-object-no-longer-adds-default-endpoint.md)]
 
-[!include[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
+[!INCLUDE[The Replace method in OData URLs is disabled by default](~/includes/migration-guide/runtime/wcf/replace-method-odata-urls-disabled-by-default.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Forms
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
+[!INCLUDE[WinForm's CheckForOverflowUnderflow property is now true for System.Drawing](~/includes/migration-guide/runtime/winforms/winforms-checkforoverflowunderflow-property-now-true-for-systemdrawing.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
+[!INCLUDE[FlowDocument may show an extra line of text](~/includes/migration-guide/runtime/wpf/flowdocument-may-show-an-extra-line-text.md)]
 
-[!include[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
+[!INCLUDE[GlyphRun.ComputeInkBoundingBox() and FormattedText.Extent return different values beginning in .NET Framework 4.5](~/includes/migration-guide/runtime/wpf/glyphruncomputeinkboundingbox-formattedtextextent-return-different-values.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
+[!INCLUDE[New enum values in WPF's PageRangeSelection](~/includes/migration-guide/runtime/wpf/new-enum-values-wpfs-pagerangeselection.md)]
 
-[!include[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
+[!INCLUDE[PreviewLostKeyboardFocus is called repeatedly if its handler shows a Windows Forms message box](~/includes/migration-guide/runtime/winforms/previewlostkeyboardfocus-called-repeatedly-if-its-handler-shows-windows.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
+[!INCLUDE[WPF DataTemplate elements are now visible to UIA](~/includes/migration-guide/runtime/wpf/wpf-datatemplate-elements-are-now-visible-uia.md)]
 
-[!include[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
+[!INCLUDE[WPF DispatcherSynchronizationContext.CreateCopy now returns a new copy instead of the current instance](~/includes/migration-guide/runtime/wpf/wpf-dispatchersynchronizationcontextcreatecopy-now-returns-new-copy-instead.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
+[!INCLUDE[WPF TextBox defaults to undo limit of 100](~/includes/migration-guide/runtime/wpf/wpf-textbox-defaults-undo-limit-100.md)]
 
-[!include[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
+[!INCLUDE[WPF TextBox selected text appears a different color when the text box is inactive](~/includes/migration-guide/runtime/wpf/wpf-textbox-selected-text-appears-different-color-when-box-inactive.md)]
 
-[!include[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
+[!INCLUDE[WPF TreeViewItem must be used within a TreeView](~/includes/migration-guide/runtime/wpf/wpf-treeviewitem-must-be-used-within-treeview.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
+[!INCLUDE[System.Activities is now APTCA](~/includes/migration-guide/runtime/wf/systemactivities-now-aptca.md)]
 
-[!include[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
+[!INCLUDE[WF serializes Expressions.Literal&lt;T&gt; DateTimes differently now (breaks custom XAML parsers)](~/includes/migration-guide/runtime/wf/wf-serializes-expressionsliterallttgt-datetimes-differently-now-breaks.md)]
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 
 ## XML, XSLT
 
-[!include[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
+[!INCLUDE[XmlSchemaException now sets line positions properly](~/includes/migration-guide/runtime/xml/xmlschemaexception-now-sets-line-positions-properly.md)]
 
-[!include[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
+[!INCLUDE[XmlTextReader DTD entity expansion is limited to 10,000,000 characters](~/includes/migration-guide/runtime/xml/xmltextreader-dtd-entity-expansion-limited-10000000-characters.md)]
 
-[!include[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
+[!INCLUDE[XSLT forward compat now works](~/includes/migration-guide/runtime/xml/xslt-forward-compat-now-works.md)]
 
-[!include[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
+[!INCLUDE[XSLT style sheet exception message changed](~/includes/migration-guide/runtime/xml/xslt-style-sheet-exception-message-changed.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.5.1.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.5.1.md
@@ -8,49 +8,49 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.5.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.5.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## Serialization
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.5.2.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.5.2.md
@@ -8,71 +8,71 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.5.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.5.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Serialization
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.6.1.md
@@ -8,125 +8,125 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.6.2.md
@@ -8,143 +8,143 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.6.md
@@ -8,115 +8,115 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.7.1.md
@@ -8,151 +8,151 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.7.2.md
@@ -8,165 +8,165 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.5-4.7.md
@@ -8,153 +8,153 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ADO.NET
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
+[!INCLUDE[ConcurrentQueue&lt;T&gt;.TryPeek can return an erroneous null via its out parameter](~/includes/migration-guide/runtime/core/concurrentqueuelttgttrypeek-can-return-an-erroneous-null-via-its-out.md)]
 
-[!include[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
+[!INCLUDE[Deserialization of objects across appdomains can fail](~/includes/migration-guide/runtime/core/deserialization-objects-across-appdomains-can-fail.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
+[!INCLUDE[EventListener truncates strings with embedded nulls](~/includes/migration-guide/runtime/core/eventlistener-truncates-strings-with-embedded-nulls.md)]
 
-[!include[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
+[!INCLUDE[EventSource.WriteEvent impls must pass WriteEvent the same parameters that it received (plus ID)](~/includes/migration-guide/runtime/core/eventsourcewriteevent-impls-must-pass-writeevent-same-parameters-that-it.md)]
 
-[!include[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
+[!INCLUDE[Marshal.SizeOf and Marshal.PtrToStructure overloads break dynamic code](~/includes/migration-guide/runtime/core/marshalsizeof-marshalptrtostructure-overloads-break-dynamic-code.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
+[!INCLUDE[Some .NET APIs cause first chance (handled) EntryPointNotFoundExceptions](~/includes/migration-guide/runtime/core/some-net-apis-cause-first-chance-handled-entrypointnotfoundexceptions.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
+[!INCLUDE[WinRT stream adapters no long call FlushAsync automatically on close](~/includes/migration-guide/runtime/core/winrt-stream-adapters-no-long-call-flushasync-automatically-on-close.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
+[!INCLUDE[ADO.NET now attempts to automatically reconnect broken SQL connections](~/includes/migration-guide/runtime/adonet/adonet-now-attempts-automatically-reconnect-broken-sql-connections.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
-[!include[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
+[!INCLUDE[NetDataContractSerializer fails to deserialize a ConcurrentDictionary serialized with a different .NET version](~/includes/migration-guide/runtime/serialization/netdatacontractserializer-fails-deserialize-concurrentdictionary-serialized.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
+[!INCLUDE[MinFreeMemoryPercentageToActiveService is now respected](~/includes/migration-guide/runtime/wcf/minfreememorypercentagetoactiveservice-now-respected.md)]
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
+[!INCLUDE[Scrolling a WPF TreeView or grouped ListBox in a VirtualizingStackPanel can cause a hang](~/includes/migration-guide/runtime/wpf/scrolling-wpf-treeview-grouped-listbox-virtualizingstackpanel-can-cause-hang.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.5.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.5.2.md
@@ -8,35 +8,35 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.5.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.5.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Data
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.6.1.md
@@ -8,103 +8,103 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.6.2.md
@@ -8,121 +8,121 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.6.md
@@ -8,93 +8,93 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.7.1.md
@@ -8,129 +8,129 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.7.2.md
@@ -8,143 +8,143 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.1-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.5.1-4.7.md
@@ -8,131 +8,131 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.1 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.1 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
+[!INCLUDE[ASP.NET MVC now escapes spaces in strings passed in via route parameters](~/includes/migration-guide/runtime/asp/aspnet-mvc-now-escapes-spaces-strings-passed-via-route-parameters.md)]
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
-[!include[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
+[!INCLUDE[No longer able to set EnableViewStateMac to false](~/includes/migration-guide/runtime/asp/no-longer-able-set-enableviewstatemac-false.md)]
 
-[!include[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
+[!INCLUDE[Profiling ASP.Net MVC4 apps can lead to Fatal Execution Engine Error](~/includes/migration-guide/runtime/asp/profiling-aspnet-mvc4-apps-can-lead-fatal-execution-engine-error.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
-[!include[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
+[!INCLUDE[SqlConnection.Open fails on Windows 7 with non-IFS Winsock BSP or LSP present](~/includes/migration-guide/runtime/data/sqlconnectionopen-fails-on-windows-7-with-non-ifs-winsock-bsp-lsp-present.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Entity Framework
 
-[!include[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
+[!INCLUDE[EF no longer throws for QueryViews with specific characteristics](~/includes/migration-guide/runtime/ef/ef-no-longer-throws-for-queryviews-with-specific-characteristics.md)]
 
-[!include[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
+[!INCLUDE[Opt-in break to revert from different 4.5 SQL generation to simpler 4.0 SQL generation](~/includes/migration-guide/runtime/ef/opt-in-break-revert-from-different-45-sql-generation-simpler-40.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
+[!INCLUDE[Calling DataGrid.CommitEdit from a CellEditEnding handler drops focus](~/includes/migration-guide/runtime/wpf/calling-datagridcommitedit-from-celleditending-handler-drops-focus.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
+[!INCLUDE[Intermittently unable to scroll to bottom item in ItemsControls (like ListBox and DataGrid) when using custom DataTemplates](~/includes/migration-guide/runtime/wpf/intermittently-unable-scroll-bottom-item-itemscontrols-like-listbox-datagrid.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.2-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.5.2-4.6.1.md
@@ -8,87 +8,87 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.2 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.2-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.2-4.6.2.md
@@ -8,105 +8,105 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.2 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.2-4.6.md
+++ b/docs/framework/migration-guide/runtime/4.5.2-4.6.md
@@ -8,77 +8,77 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.2 to 4.6
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.6, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.2-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.5.2-4.7.1.md
@@ -8,113 +8,113 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.2 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.2-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.5.2-4.7.2.md
@@ -8,127 +8,127 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.2 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.5.2-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.5.2-4.7.md
@@ -8,115 +8,115 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.5.2 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.5.2 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## ASP.NET
 
-[!include[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
+[!INCLUDE[GridViews with AllowCustomPaging set to true may fire the PageIndexChanging event when leaving the final page of the view](~/includes/migration-guide/runtime/asp/gridviews-with-allowcustompaging-set-true-may-fire-pageindexchanging-event.md)]
 
 ## Core
 
-[!include[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
+[!INCLUDE[A ConcurrentDictionary serialized in .NET Framework 4.5 with NetDataContractSerializer cannot be deserialized by .NET Framework 4.5.1 or 4.5.2](~/includes/migration-guide/runtime/core/concurrentdictionary-serialized-net-framework-45-with.md)]
 
-[!include[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
+[!INCLUDE[AppDomainSetup.DynamicBase is no longer randomized by UseRandomizedStringHashAlgorithm](~/includes/migration-guide/runtime/core/appdomainsetupdynamicbase-no-longer-randomized-by.md)]
 
-[!include[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
+[!INCLUDE[Calling Attribute.GetCustomAttributes on an indexer property no longer throws AmbiguousMatchException if the ambiguity can be resolved by index's type](~/includes/migration-guide/runtime/core/calling-attributegetcustomattributes-on-an-indexer-property-no-longer-throws.md)]
 
-[!include[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
+[!INCLUDE[COR_PRF_GC_ROOT_HANDLEs are not being enumerated by profilers](~/includes/migration-guide/runtime/core/corprfgcroothandles-are-not-being-enumerated-by-profilers.md)]
 
-[!include[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
+[!INCLUDE[ETW EventListeners do not capture events from providers with explicit keywords (like the TPL provider)](~/includes/migration-guide/runtime/core/etw-eventlisteners-do-not-capture-events-from-providers-with-explicit.md)]
 
-[!include[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
+[!INCLUDE[Persian calendar now uses the Hijri solar algorithm](~/includes/migration-guide/runtime/core/persian-calendar-now-uses-hijri-solar-algorithm.md)]
 
-[!include[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
+[!INCLUDE[Reflection objects can no longer be passed from managed code to out-of-process DCOM clients](~/includes/migration-guide/runtime/core/reflection-objects-can-no-longer-be-passed-from-managed-code-out-of-process.md)]
 
-[!include[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
+[!INCLUDE[TargetFrameworkName for default app domain no longer defaults to null if not set](~/includes/migration-guide/runtime/core/targetframeworkname-for-default-app-domain-no-longer-defaults-null-if-not.md)]
 
-[!include[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
+[!INCLUDE[X509Certificate2.ToString(Boolean) does not throw now when .NET cannot handle the certificate](~/includes/migration-guide/runtime/core/x509certificate2tostringboolean-does-not-throw-now-when-net-cannot-handle.md)]
 
 ## Data
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Debugger
 
-[!include[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
+[!INCLUDE[Null coalescer values are not visible in debugger until one step later](~/includes/migration-guide/runtime/debugger/null-coalescer-values-are-not-visible-debugger-until-one-step-later.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Networking
 
-[!include[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
+[!INCLUDE[ContentDisposition DateTimes returns slightly different string](~/includes/migration-guide/runtime/networking/contentdisposition-datetimes-returns-slightly-different-string.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Serialization
 
-[!include[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
+[!INCLUDE[Exception message has changed for failed DataContract serialization in case of an unknown type](~/includes/migration-guide/runtime/serialization/exception-message-has-changed-for-failed-datacontract-serialization-case-an.md)]
 
 ## Setup and Deployment
 
-[!include[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
+[!INCLUDE[Product versioning changes in the .NET Framework 4.6 and later versions](~/includes/migration-guide/runtime/setup/product-versioning-changes-net-framework-46-later-versions.md)]
 
-[!include[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
+[!INCLUDE[The .NET Framework 4.6 does not use a 4.5.x.x version when registering itself in the registry](~/includes/migration-guide/runtime/setup/net-framework-46-does-not-use-45xx-version-when-registering-itself-registry.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
+[!INCLUDE[WCF services that use NETTCP with SSL security and MD5 certificate authentication](~/includes/migration-guide/runtime/wcf/wcf-services-that-use-nettcp-with-ssl-security-md5-certificate.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
+[!INCLUDE[Accessing a WPF DataGrid's selected items from a handler of the DataGrid's UnloadingRow event can cause a NullReferenceException](~/includes/migration-guide/runtime/wpf/accessing-wpf-datagrids-selected-items-from-handler-unloadingrow-event-can.md)]
 
-[!include[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
+[!INCLUDE[Calling Items.Refresh on a WPF ListBox, ListView, or DataGrid with items selected can cause duplicate items to appear in the element](~/includes/migration-guide/runtime/wpf/calling-itemsrefresh-on-wpf-listbox-listview-datagrid-with-items-selected.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
+[!INCLUDE[ListBoxItem IsSelected binding issue with ObservableCollection&lt;T&gt;.Move](~/includes/migration-guide/runtime/wpf/listboxitem-isselected-binding-issue-with-observablecollectionlttgtmove.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
+[!INCLUDE[Right clicking on a WPF DataGrid row header changes the DataGrid selection](~/includes/migration-guide/runtime/wpf/right-clicking-on-wpf-datagrid-row-header-changes-selection.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
+[!INCLUDE[WPF spawns a wisptis.exe process which can freeze the mouse](~/includes/migration-guide/runtime/wpf/wpf-spawns-wisptisexe-process-which-can-freeze-mouse.md)]
 
-[!include[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
+[!INCLUDE[WPF spell checking in text-enabled controls will not work in Windows 10 for languages not in the OS's input language list](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-text-enabled-controls-will-not-work-windows-10-for.md)]
 
-[!include[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
+[!INCLUDE[WPF windows are rendered without clipping when extending outside a single monitor](~/includes/migration-guide/runtime/wpf/wpf-windows-are-rendered-without-clipping-when-extending-outside-single.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6-4.6.1.md
+++ b/docs/framework/migration-guide/runtime/4.6-4.6.1.md
@@ -8,21 +8,21 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6 to 4.6.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.6.1, review the following topics for application compatibility issues that may affect your app:
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.6-4.6.2.md
@@ -8,51 +8,51 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.6-4.7.1.md
@@ -8,59 +8,59 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.6-4.7.2.md
@@ -8,75 +8,75 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.6-4.7.md
@@ -8,61 +8,61 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Tools
 
-[!include[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
+[!INCLUDE[Contract.Invariant or Contract.Requires<TException> do not consider String.IsNullOrEmpty to be pure](~/includes/migration-guide/runtime/tools/contractinvariant-contractrequirestexception-do-not-consider.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6.1-4.6.2.md
+++ b/docs/framework/migration-guide/runtime/4.6.1-4.6.2.md
@@ -8,49 +8,49 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6.1 to 4.6.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.6.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6.1-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.6.1-4.7.2.md
@@ -8,77 +8,77 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6.1 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6.1-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.6.1-4.7.md
@@ -8,63 +8,63 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6.1 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.1 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## Data
 
-[!include[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
+[!INCLUDE[Attempting a TCP/IP connection to a SQL Server database that resolves to `localhost` fails](~/includes/migration-guide/runtime/data/attempting-tcpip-connection-sql-server-database-that-resolves-localhost.md)]
 
-[!include[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
+[!INCLUDE[Connection pool blocking period for Azure SQL databases is removed](~/includes/migration-guide/runtime/data/connection-pool-blocking-period-for-azure-sql-databases-removed.md)]
 
 ## Globalization
 
-[!include[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
+[!INCLUDE[Unicode standard version 8.0 categories now supported](~/includes/migration-guide/runtime/globalization/unicode-standard-version-80-categories-now-supported.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
-[!include[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
+[!INCLUDE[RSACng.VerifyHash now returns False for any verification failure](~/includes/migration-guide/runtime/security/rsacngverifyhash-now-returns-false-for-any-verification-failure.md)]
 
-[!include[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
+[!INCLUDE[SignedXml and EncryptedXml Breaking Changes](~/includes/migration-guide/runtime/security/signedxml-encryptedxml-breaking-changes.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
+[!INCLUDE[Remove Ssl3 from the WCF TransportDefaults](~/includes/migration-guide/runtime/wcf/remove-ssl3-from-wcf-transportdefaults.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
+[!INCLUDE[Changing the IsEnabled property of the parent of a TextBlock control affects any child controls](~/includes/migration-guide/runtime/wpf/changing-isenabled-property-parent-textblock-control-affects-any-child.md)]
 
-[!include[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
+[!INCLUDE[CoerceIsSelectionBoxHighlighted](~/includes/migration-guide/runtime/wpf/coerceisselectionboxhighlighted.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
+[!INCLUDE[Horizontal scrolling and virtualization](~/includes/migration-guide/runtime/wpf/horizontal-scrolling-virtualization.md)]
 
-[!include[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
+[!INCLUDE[Items.Clear does not remove duplicates from SelectedItems](~/includes/migration-guide/runtime/wpf/itemsclear-does-not-remove-duplicates-from-selecteditems.md)]
 
-[!include[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
+[!INCLUDE[Item-scrolling a flat list with items of different pixel-height](~/includes/migration-guide/runtime/wpf/item-scrolling-flat-list-with-items-different-pixel-height.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
-[!include[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
+[!INCLUDE[WPF Spell Checking fails in unexpected ways](~/includes/migration-guide/runtime/wpf/wpf-spell-checking-fails-unexpected-ways.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6.2-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.6.2-4.7.1.md
@@ -8,39 +8,39 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6.2 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.2 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6.2-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.6.2-4.7.2.md
@@ -8,55 +8,55 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6.2 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.2 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.6.2-4.7.md
+++ b/docs/framework/migration-guide/runtime/4.6.2-4.7.md
@@ -8,33 +8,33 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.6.2 to 4.7
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.6.2 to 4.7, review the following topics for application compatibility issues that may affect your app:
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
+[!INCLUDE[DataGridCellsPanel.BringIndexIntoView throws ArgumentOutOfRangeException](~/includes/migration-guide/runtime/wpf/datagridcellspanelbringindexintoview-throws-argumentoutofrangeexception.md)]
 
-[!include[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
+[!INCLUDE[ObjectDisposedException thrown by WPF spellchecker](~/includes/migration-guide/runtime/wpf/objectdisposedexception-thrown-by-wpf-spellchecker.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 
-[!include[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
+[!INCLUDE[RibbonGroup background is set to transparent in localized builds](~/includes/migration-guide/runtime/wpf/ribbongroup-background-set-transparent-localized-builds.md)]
 
-[!include[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
+[!INCLUDE[WPF Printing Stack Update](~/includes/migration-guide/runtime/wpf/wpf-printing-stack-update.md)]
 
 ## Windows Workflow Foundation (WF)
 
-[!include[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
+[!INCLUDE[Workflow now throws original exception instead of NullReferenceException in some cases](~/includes/migration-guide/runtime/wf/workflow-now-throws-original-exception-instead-nullreferenceexception-some.md)]
 
-[!include[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
+[!INCLUDE[Workflow SQL persistence adds primary key clusters and disallows null values in some columns](~/includes/migration-guide/runtime/wf/workflow-sql-persistence-adds-primary-key-clusters-disallows-null-values.md)]
 

--- a/docs/framework/migration-guide/runtime/4.7-4.7.1.md
+++ b/docs/framework/migration-guide/runtime/4.7-4.7.1.md
@@ -8,33 +8,33 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.7 to 4.7.1
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.7 to 4.7.1, review the following topics for application compatibility issues that may affect your app:
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 

--- a/docs/framework/migration-guide/runtime/4.7-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.7-4.7.2.md
@@ -8,49 +8,49 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.7 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.7 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
 ## JIT
 
-[!include[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
+[!INCLUDE[Incorrect code generation when passing and comparing UInt16 values](~/includes/migration-guide/runtime/jit/incorrect-code-generation-when-passing-comparing-uint16-values.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Security
 
-[!include[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
+[!INCLUDE[RSACng and DSACng are once again usable in Partial Trust scenarios](~/includes/migration-guide/runtime/security/rsacng-dsacng-are-once-again-usable-partial-trust-scenarios.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Communication Foundation (WCF)
 
-[!include[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
+[!INCLUDE[WCF AddressHeaderCollection now throws an ArgumentException if an addressHeader element is null](~/includes/migration-guide/runtime/wcf/wcf-addressheadercollection-now-throws-an-argumentexception-if-addressheader.md)]
 
-[!include[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
+[!INCLUDE[WCF MsmqSecureHashAlgorithm default value is now SHA256](~/includes/migration-guide/runtime/wcf/wcf-msmqsecurehashalgorithm-default-value-now-sha256.md)]
 
-[!include[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
+[!INCLUDE[WCF PipeConnection.GetHashAlgorithm now uses SHA256](~/includes/migration-guide/runtime/wcf/wcf-pipeconnectiongethashalgorithm-now-uses-sha256.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
+[!INCLUDE[Chained Popups with StaysOpen=False](~/includes/migration-guide/runtime/wpf/chained-popups-with-staysopenfalse.md)]
 
-[!include[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
+[!INCLUDE[Crash in Selector when removing an item from a custom INCC collection](~/includes/migration-guide/runtime/wpf/crash-selector-when-removing-an-item-from-custom-incc-collection.md)]
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 
-[!include[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
+[!INCLUDE[Resizing a Grid can hang](~/includes/migration-guide/runtime/wpf/resizing-grid-can-hang.md)]
 

--- a/docs/framework/migration-guide/runtime/4.7.1-4.7.2.md
+++ b/docs/framework/migration-guide/runtime/4.7.1-4.7.2.md
@@ -8,27 +8,27 @@ ms.author: "ronpet"
 
 # Runtime Changes for Migration from .NET Framework 4.7.1 to 4.7.2
 
-[!include[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
+[!INCLUDE[versionselector](../../../../includes/migration-guide/runtime/versionselector.md)]
 
-[!include[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
+[!INCLUDE[introduction](../../../../includes/migration-guide/runtime/introduction.md)]
 
 If you are migrating from the .NET Framework 4.7.1 to 4.7.2, review the following topics for application compatibility issues that may affect your app:
 
 ## Core
 
-[!include[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
+[!INCLUDE[Allow Unicode in URIs that resemble UNC shares](~/includes/migration-guide/runtime/core/allow-unicode-uris-that-resemble-unc-shares.md)]
 
-[!include[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
+[!INCLUDE[Support special relative URI notation when Unicode is present](~/includes/migration-guide/runtime/core/support-special-relative-uri-notation-when-unicode-present.md)]
 
 ## Runtime
 
-[!include[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
+[!INCLUDE[Improved WCF chain trust certificate validation for Net.Tcp certificate authentication](~/includes/migration-guide/runtime/runtime/improved-wcf-chain-trust-certificate-validation-for-nettcp-authentication.md)]
 
 ## Web Applications
 
-[!include["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
+[!INCLUDE["dataAnnotations:dataTypeAttribute:disableRegEx" app setting is on by default in .NET Framework 4.7.2](~/includes/migration-guide/runtime/web/dataannotationsdatatypeattributedisableregex-app-setting-on-by-default-net.md)]
 
 ## Windows Presentation Foundation (WPF)
 
-[!include[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
+[!INCLUDE[Keytips behavior improved in WPF](~/includes/migration-guide/runtime/wpf/keytips-behavior-improved-wpf.md)]
 


### PR DESCRIPTION
This is a bulk fix to fix formatting issues that LOC is seeing because of the capitalization of "include" in include tags. All changes are to uppercase the lower case "\[!include\[" tags to "\[!INCLUDE\[". 
User Story 1292378
This is related to #6163 and #6164 