### PR TITLE
Corrected regular expression for bypass list

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/defaultproxy-element-network-settings.md
@@ -76,7 +76,7 @@ Configures the Hypertext Transfer Protocol (HTTP) proxy server.
         bypassonlocal="true"  
       />  
       <bypasslist>  
-        <add address="[a-z]+\.contoso\.com" />  
+        <add address="[a-z]+\.contoso\.com$" />  
       </bypasslist>  
     </defaultProxy>  
   </system.net>  


### PR DESCRIPTION
## Corrected regular expression for bypass list

The regular expression doesn't conform to the guidance in the documentation of the [\<bypasslist> element](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/network/bypasslist-element-network-settings). This PR corrects the error.
