### PR TITLE
C26886: Misuse of ` character to create codeboxes

### DIFF
--- a/docs/framework/wcf/samples/transport-udp.md
+++ b/docs/framework/wcf/samples/transport-udp.md
@@ -68,7 +68,7 @@ The UDP Transport sample demonstrates how to implement UDP unicast and multicast
 
 -   The``<xref:System.ServiceModel.Channels.ChannelManagerBase> class implements <xref:System.ServiceModel.Channels.CommunicationObject> and provides a unified base class for <xref:System.ServiceModel.Channels.ChannelFactoryBase> and <xref:System.ServiceModel.Channels.ChannelListenerBase>. The <xref:System.ServiceModel.Channels.ChannelManagerBase> class works in conjunction with <xref:System.ServiceModel.Channels.ChannelBase>, which is a base class that implements <xref:System.ServiceModel.Channels.IChannel>.  
   
--   The``<xref:System.ServiceModel.Channels.ChannelFactoryBase> class implements <xref:System.ServiceModel.Channels.ChannelManagerBase> and <xref:System.ServiceModel.Channels.IChannelFactory> and consolidates the `CreateChannel` overloads into one `OnCreateChannel` abstract method.  
+-   The `<xref:System.ServiceModel.Channels.ChannelFactoryBase>` class implements `<xref:System.ServiceModel.Channels.ChannelManagerBase>` and `<xref:System.ServiceModel.Channels.IChannelFactory>` and consolidates the `CreateChannel` overloads into one `OnCreateChannel` abstract method.  
   
 -   The <xref:System.ServiceModel.Channels.ChannelListenerBase> class implements <xref:System.ServiceModel.Channels.IChannelListener>. It takes care of basic state management.  
   
@@ -103,13 +103,13 @@ this.socket.SendTo(messageBuffer.Array, messageBuffer.Offset, messageBuffer.Coun
 ```  
   
 ### The UdpChannelListener  
- The``UdpChannelListener that the sample implements derives from the <xref:System.ServiceModel.Channels.ChannelListenerBase> class. It uses a single UDP socket to receive datagrams. The `OnOpen` method receives data using the UDP socket in an asynchronous loop. The data are then converted into messages using the Message Encoding Framework.  
+ The `UdpChannelListener` that the sample implements derives from the `<xref:System.ServiceModel.Channels.ChannelListenerBase>` class. It uses a single UDP socket to receive datagrams. The `OnOpen` method receives data using the UDP socket in an asynchronous loop. The data are then converted into messages using the Message Encoding Framework.  
   
 ```csharp
 message = MessageEncoderFactory.Encoder.ReadMessage(new ArraySegment<byte>(buffer, 0, count), bufferManager);  
 ```  
   
- Because the same datagram channel represents messages that arrive from a number of sources, the `UdpChannelListener` is a singleton listener. There is, at most, one active <xref:System.ServiceModel.Channels.IChannel>``associated with this listener at a time. The sample generates another one only if a channel that is returned by the `AcceptChannel` method is subsequently disposed. When a message is received, it is enqueued into this singleton channel.  
+ Because the same datagram channel represents messages that arrive from a number of sources, the `UdpChannelListener` is a singleton listener. There is, at most, one active `<xref:System.ServiceModel.Channels.IChannel>` associated with this listener at a time. The sample generates another one only if a channel that is returned by the `AcceptChannel` method is subsequently disposed. When a message is received, it is enqueued into this singleton channel.  
   
 #### UdpInputChannel  
  The `UdpInputChannel` class implements `IInputChannel`. It consists of a queue of incoming messages that is populated by the `UdpChannelListener`'s socket. These messages are dequeued by the `IInputChannel.Receive` method.  

--- a/docs/framework/wcf/samples/transport-udp.md
+++ b/docs/framework/wcf/samples/transport-udp.md
@@ -66,9 +66,9 @@ The UDP Transport sample demonstrates how to implement UDP unicast and multicast
   
 -   The <xref:System.ServiceModel.Channels.CommunicationObject> class implements <xref:System.ServiceModel.ICommunicationObject> and enforces the state machine previously described in Step 2. 
 
--   The``<xref:System.ServiceModel.Channels.ChannelManagerBase> class implements <xref:System.ServiceModel.Channels.CommunicationObject> and provides a unified base class for <xref:System.ServiceModel.Channels.ChannelFactoryBase> and <xref:System.ServiceModel.Channels.ChannelListenerBase>. The <xref:System.ServiceModel.Channels.ChannelManagerBase> class works in conjunction with <xref:System.ServiceModel.Channels.ChannelBase>, which is a base class that implements <xref:System.ServiceModel.Channels.IChannel>.  
+-   The <xref:System.ServiceModel.Channels.ChannelManagerBase> class implements <xref:System.ServiceModel.Channels.CommunicationObject> and provides a unified base class for <xref:System.ServiceModel.Channels.ChannelFactoryBase> and <xref:System.ServiceModel.Channels.ChannelListenerBase>. The <xref:System.ServiceModel.Channels.ChannelManagerBase> class works in conjunction with <xref:System.ServiceModel.Channels.ChannelBase>, which is a base class that implements <xref:System.ServiceModel.Channels.IChannel>.  
   
--   The `<xref:System.ServiceModel.Channels.ChannelFactoryBase>` class implements `<xref:System.ServiceModel.Channels.ChannelManagerBase>` and `<xref:System.ServiceModel.Channels.IChannelFactory>` and consolidates the `CreateChannel` overloads into one `OnCreateChannel` abstract method.  
+-   The <xref:System.ServiceModel.Channels.ChannelFactoryBase> class implements <xref:System.ServiceModel.Channels.ChannelManagerBase> and <xref:System.ServiceModel.Channels.IChannelFactory> and consolidates the `CreateChannel` overloads into one `OnCreateChannel` abstract method.  
   
 -   The <xref:System.ServiceModel.Channels.ChannelListenerBase> class implements <xref:System.ServiceModel.Channels.IChannelListener>. It takes care of basic state management.  
   
@@ -103,13 +103,13 @@ this.socket.SendTo(messageBuffer.Array, messageBuffer.Offset, messageBuffer.Coun
 ```  
   
 ### The UdpChannelListener  
- The `UdpChannelListener` that the sample implements derives from the `<xref:System.ServiceModel.Channels.ChannelListenerBase>` class. It uses a single UDP socket to receive datagrams. The `OnOpen` method receives data using the UDP socket in an asynchronous loop. The data are then converted into messages using the Message Encoding Framework.  
+ The `UdpChannelListener` that the sample implements derives from the <xref:System.ServiceModel.Channels.ChannelListenerBase> class. It uses a single UDP socket to receive datagrams. The `OnOpen` method receives data using the UDP socket in an asynchronous loop. The data are then converted into messages using the Message Encoding Framework.  
   
 ```csharp
 message = MessageEncoderFactory.Encoder.ReadMessage(new ArraySegment<byte>(buffer, 0, count), bufferManager);  
 ```  
   
- Because the same datagram channel represents messages that arrive from a number of sources, the `UdpChannelListener` is a singleton listener. There is, at most, one active `<xref:System.ServiceModel.Channels.IChannel>` associated with this listener at a time. The sample generates another one only if a channel that is returned by the `AcceptChannel` method is subsequently disposed. When a message is received, it is enqueued into this singleton channel.  
+ Because the same datagram channel represents messages that arrive from a number of sources, the `UdpChannelListener` is a singleton listener. There is, at most, one active <xref:System.ServiceModel.Channels.IChannel> associated with this listener at a time. The sample generates another one only if a channel that is returned by the `AcceptChannel` method is subsequently disposed. When a message is received, it is enqueued into this singleton channel.  
   
 #### UdpInputChannel  
  The `UdpInputChannel` class implements `IInputChannel`. It consists of a queue of incoming messages that is populated by the `UdpChannelListener`'s socket. These messages are dequeued by the `IInputChannel.Receive` method.  


### PR DESCRIPTION
Hello, @mairaw ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"this bug is affected by a source issue by the ´ character used to create codeboxes"
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.