### PR TITLE
Removing Space From Links for LOC Bulk Fix

### DIFF
--- a/docs/standard/containerized-lifecycle-architecture/Docker-application-lifecycle/containers-foundation-for-devops-collaboration.md
+++ b/docs/standard/containerized-lifecycle-architecture/Docker-application-lifecycle/containers-foundation-for-devops-collaboration.md
@@ -62,5 +62,5 @@ Here are some of the most important benefits provided by a solid DevOps workflow
 -   Plug and play well with many of your existing DevOps investments, including investments in open source
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (../Microsoft-platform-tools-containerized-apps/index.md)
+[Previous](index.md)
+[Next](../Microsoft-platform-tools-containerized-apps/index.md)

--- a/docs/standard/containerized-lifecycle-architecture/Docker-application-lifecycle/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/Docker-application-lifecycle/index.md
@@ -10,5 +10,5 @@ ms.date: 09/22/2017
 The life cycle of containerized applications is a journey that begins with the developer. The developer chooses to implement containers and Docker because it eliminates frictions in deployments and IT operations, which ultimately helps everyone to be more agile, more productive end-to-end, and faster.
 
 >[!div class="step-by-step"]
-[Previous] (../docker-containers-images-and-registries.md)
-[Next] (containers-foundation-for-devops-collaboration.md)
+[Previous](../docker-containers-images-and-registries.md)
+[Next](containers-foundation-for-devops-collaboration.md)

--- a/docs/standard/containerized-lifecycle-architecture/Microsoft-platform-tools-containerized-apps/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/Microsoft-platform-tools-containerized-apps/index.md
@@ -53,5 +53,5 @@ With VSTS, developers can create container-focused DevOps for a fast, iterative 
 Thus, Microsoft offers a complete foundation for an end-to-end containerized Docker application life cycle. However, it is *a collection of products and technologies that allow you to optionally select and integrate with existing tools and processes*. The flexibility in a broad approach along with the strength in the depth of capabilities place Microsoft in a strong position for containerized Docker application development.
 
 >[!div class="step-by-step"]
-[Previous] (../Docker-application-lifecycle/containers-foundation-for-devops-collaboration.md)
-[Next] (../design-develop-containerized-apps/index.md)
+[Previous](../Docker-application-lifecycle/containers-foundation-for-devops-collaboration.md)
+[Next](../design-develop-containerized-apps/index.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/design-docker-applications.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/design-docker-applications.md
@@ -13,5 +13,5 @@ However, before we get into the application life cycle and DevOps, it is importa
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (common-container-design-principles.md)
+[Previous](index.md)
+[Next](common-container-design-principles.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/docker-apps-development-environment.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/docker-apps-development-environment.md
@@ -42,5 +42,5 @@ Basically, you can use any modern language supported by Docker in Linux or Windo
 
 
 >[!div class="step-by-step"]
-[Previous] (orchestrate-high-scalability-availability.md)
-[Next] (docker-apps-inner-loop-workflow.md)
+[Previous](orchestrate-high-scalability-availability.md)
+[Next](docker-apps-inner-loop-workflow.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/docker-apps-inner-loop-workflow.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/docker-apps-inner-loop-workflow.md
@@ -255,5 +255,5 @@ user\_ed/2016/02/27/visual-studio-code-new-features-13-big-debugging-updates-ric
 
 
 >[!div class="step-by-step"]
-[Previous] (docker-apps-development-environment.md)
-[Next] (visual-studio-tools-for-docker.md)
+[Previous](docker-apps-development-environment.md)
+[Next](visual-studio-tools-for-docker.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/index.md
@@ -14,5 +14,5 @@ There are many great-fit use cases for containers, not just for microservices-or
 
 
 >[!div class="step-by-step"]
-[Prev] (../Microsoft-platform-tools-containerized-apps/index.md)
-[Next] (design-docker-applications.md)
+[Prev](../Microsoft-platform-tools-containerized-apps/index.md)
+[Next](design-docker-applications.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/monolithic-applications.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/monolithic-applications.md
@@ -65,5 +65,5 @@ Figure 4-4 also shows that the publish flow pushes an image through a Container 
 
 
 >[!div class="step-by-step"]
-[Previous] (common-container-design-principles.md)
-[Next] (state-and-data-in-docker-applications.md)
+[Previous](common-container-design-principles.md)
+[Next](state-and-data-in-docker-applications.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/orchestrate-high-scalability-availability.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/orchestrate-high-scalability-availability.md
@@ -175,5 +175,5 @@ Note that Docker containers are themselves stateless. If you want to implement a
 
 
 >[!div class="step-by-step"]
-[Previous] (soa-applications.md)
-[Next] (docker-apps-development-environment.md)
+[Previous](soa-applications.md)
+[Next](docker-apps-development-environment.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/set-up-windows-containers-with-powershell.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/set-up-windows-containers-with-powershell.md
@@ -27,5 +27,5 @@ RUN powershell add-windowsfeature web-asp-net45
 ```
 
 >[!div class="step-by-step"]
-[Previous] (visual-studio-tools-for-docker.md)
-[Next] (../docker-devops-workflow/index.md)
+[Previous](visual-studio-tools-for-docker.md)
+[Next](../docker-devops-workflow/index.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/soa-applications.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/soa-applications.md
@@ -15,5 +15,5 @@ At the end of the day, the container clustering solutions are useful for both a 
 
 
 >[!div class="step-by-step"]
-[Previous] (state-and-data-in-docker-applications.md)
-[Next] (orchestrate-high-scalability-availability.md)
+[Previous](state-and-data-in-docker-applications.md)
+[Next](orchestrate-high-scalability-availability.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/state-and-data-in-docker-applications.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/state-and-data-in-docker-applications.md
@@ -45,5 +45,5 @@ Remote data sources and caches like SQL Database, DocumentDB, or a remote cache 
 
 
 >[!div class="step-by-step"]
-[Previous] (monolithic-applications.md)
-[Next] (soa-applications.md)
+[Previous](monolithic-applications.md)
+[Next](soa-applications.md)

--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/visual-studio-tools-for-docker.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/visual-studio-tools-for-docker.md
@@ -66,5 +66,5 @@ Deploy an ASP.NET container to a remote Docker host: [https://docs.microsoft.com
 
 
 >[!div class="step-by-step"]
-[Previous] (docker-apps-inner-loop-workflow.md)
-[Next] (set-up-windows-containers-with-powershell.md)
+[Previous](docker-apps-inner-loop-workflow.md)
+[Next](set-up-windows-containers-with-powershell.md)

--- a/docs/standard/containerized-lifecycle-architecture/docker-containers-images-and-registries.md
+++ b/docs/standard/containerized-lifecycle-architecture/docker-containers-images-and-registries.md
@@ -28,5 +28,5 @@ Private image registries, either hosted on-premises or in the cloud, are recomme
 -   You want to have minimum network latency between your images and your chosen deployment environment. For example, if your production environment is Azure, you probably want to store your images in Azure Container Registry so that network latency will be minimal. In a similar way, if your production environment is on-premises, you might want to have an on-premises Docker Trusted Registry available within the same local network.
 
 >[!div class="step-by-step"]
-[Previous] (docker-terminology.md)
-[Next] (Docker-application-lifecycle/index.md)
+[Previous](docker-terminology.md)
+[Next](Docker-application-lifecycle/index.md)

--- a/docs/standard/containerized-lifecycle-architecture/docker-devops-workflow/docker-application-outer-loop-devops-workflow.md
+++ b/docs/standard/containerized-lifecycle-architecture/docker-devops-workflow/docker-application-outer-loop-devops-workflow.md
@@ -230,5 +230,5 @@ This topic also is covered in the next chapter as part of the tasks that IT oper
 Only when monitoring and diagnostics are 100 percent within the realm of DevOps are the monitoring processes and analytics performed by the development team against testing or beta environments. This is done either by performing load testing or simply by monitoring beta or QA environments, where beta testers are trying the new versions.
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (../run-manage-monitor-docker-environments/index.md)
+[Previous](index.md)
+[Next](../run-manage-monitor-docker-environments/index.md)

--- a/docs/standard/containerized-lifecycle-architecture/docker-devops-workflow/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/docker-devops-workflow/index.md
@@ -30,5 +30,5 @@ The complexity of containerized application development increases steadily depen
 
 
 >[!div class="step-by-step"]
-[Previous] (../design-develop-containerized-apps/set-up-windows-containers-with-powershell.md)
-[Next] (docker-application-outer-loop-devops-workflow.md)
+[Previous](../design-develop-containerized-apps/set-up-windows-containers-with-powershell.md)
+[Next](docker-application-outer-loop-devops-workflow.md)

--- a/docs/standard/containerized-lifecycle-architecture/docker-terminology.md
+++ b/docs/standard/containerized-lifecycle-architecture/docker-terminology.md
@@ -41,5 +41,5 @@ This section lists terms and definitions with which you should become familiar w
 
 
 >[!div class="step-by-step"]
-[Previous] (what-is-docker.md)
-[Next] (docker-containers-images-and-registries.md)
+[Previous](what-is-docker.md)
+[Next](docker-containers-images-and-registries.md)

--- a/docs/standard/containerized-lifecycle-architecture/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/index.md
@@ -27,4 +27,4 @@ In short, containers offer the benefits of isolation, portability, agility, scal
 
 
 >[!div class="step-by-step"]
-[Next] (what-is-docker.md)
+[Next](what-is-docker.md)

--- a/docs/standard/containerized-lifecycle-architecture/key-takeaways/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/key-takeaways/index.md
@@ -20,4 +20,4 @@ ms.date: 09/22/2017
 Visual Studio Team Services greatly simplifies your DevOps environment designated to Docker environments from your Continuous Deployment pipelines, including simple Docker environments or more advanced microservice and container orchestrators based on Azure.
 
 >[!div class="step-by-step"]
-[Previous] (../run-manage-monitor-docker-environments/monitor-containerized-application-services.md)
+[Previous](../run-manage-monitor-docker-environments/monitor-containerized-application-services.md)

--- a/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/index.md
+++ b/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/index.md
@@ -16,5 +16,5 @@ How you run your containerized applications in production (infrastructure archit
 
 
 >[!div class="step-by-step"]
-[Previous] (../docker-devops-workflow/docker-application-outer-loop-devops-workflow.md)
-[Next] (run-microservices-based-applications-in-production.md)
+[Previous](../docker-devops-workflow/docker-application-outer-loop-devops-workflow.md)
+[Next](run-microservices-based-applications-in-production.md)

--- a/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/manage-production-docker-environments.md
+++ b/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/manage-production-docker-environments.md
@@ -40,5 +40,5 @@ Following are Service Fabric management tools:
 
 
 >[!div class="step-by-step"]
-[Previous] (run-microservices-based-applications-in-production.md)
-[Next] (monitor-containerized-application-services.md)
+[Previous](run-microservices-based-applications-in-production.md)
+[Next](monitor-containerized-application-services.md)

--- a/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/monitor-containerized-application-services.md
+++ b/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/monitor-containerized-application-services.md
@@ -91,5 +91,5 @@ Saving queries is also a standard feature in Operations Management Suite and can
 **More info** To find information on installing and configuring the Docker container solution in [Operations Management Suite](http://microsoft.com/oms), go to <https://docs.microsoft.com/azure/log-analytics/log-analytics-containers>.
 
 >[!div class="step-by-step"]
-[Previous] (manage-production-docker-environments.md)
-[Next] (../key-takeaways/index.md)
+[Previous](manage-production-docker-environments.md)
+[Next](../key-takeaways/index.md)

--- a/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/run-microservices-based-applications-in-production.md
+++ b/docs/standard/containerized-lifecycle-architecture/run-manage-monitor-docker-environments/run-microservices-based-applications-in-production.md
@@ -29,5 +29,5 @@ The capabilities provided by orchestrators and schedulers are very complex to de
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (manage-production-docker-environments.md)
+[Previous](index.md)
+[Next](manage-production-docker-environments.md)

--- a/docs/standard/containerized-lifecycle-architecture/what-is-docker.md
+++ b/docs/standard/containerized-lifecycle-architecture/what-is-docker.md
@@ -47,5 +47,5 @@ Figure 1-3: Comparison of traditional VMs to Docker containers
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (docker-terminology.md)
+[Previous](index.md)
+[Next](docker-terminology.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/asynchronous-message-based-communication.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/asynchronous-message-based-communication.md
@@ -102,5 +102,5 @@ Additional topics to consider when using asynchronous communication are message 
 
 
 >[!div class="step-by-step"]
-[Previous] (communication-in-microservice-architecture.md)
-[Next] (maintain-microservice-apis.md)
+[Previous](communication-in-microservice-architecture.md)
+[Next](maintain-microservice-apis.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/communication-in-microservice-architecture.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/communication-in-microservice-architecture.md
@@ -103,5 +103,5 @@ Since communication is in real time, client apps show the changes almost instant
 
 
 >[!div class="step-by-step"]
-[Previous] (direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md)
-[Next] (asynchronous-message-based-communication.md)
+[Previous](direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md)
+[Next](asynchronous-message-based-communication.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/containerize-monolithic-applications.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/containerize-monolithic-applications.md
@@ -67,5 +67,5 @@ As also shown in Figure 4-4, the publish flow pushes an image through a containe
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (docker-application-state-data.md)
+[Previous](index.md)
+[Next](docker-application-state-data.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/data-sovereignty-per-microservice.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/data-sovereignty-per-microservice.md
@@ -57,5 +57,5 @@ DDD benefits from microservices by getting real boundaries in the form of distri
 
 
 >[!div class="step-by-step"]
-[Previous] (microservices-architecture.md)
-[Next] (logical-versus-physical-architecture.md)
+[Previous](microservices-architecture.md)
+[Next](logical-versus-physical-architecture.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-API-Gateway-pattern.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/direct-client-to-microservice-communication-versus-the-API-Gateway-pattern.md
@@ -177,5 +177,5 @@ After the initial architecture and patterns explanation sections, the next secti
     [*https://www.youtube.com/watch?v=rXi5CLjIQ9k*](https://www.youtube.com/watch?v=rXi5CLjIQ9k)
 
 >[!div class="step-by-step"]
-[Previous] (identify-microservice-domain-model-boundaries.md)
-[Next] (communication-in-microservice-architecture.md)
+[Previous](identify-microservice-domain-model-boundaries.md)
+[Next](communication-in-microservice-architecture.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/distributed-data-management.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/distributed-data-management.md
@@ -103,5 +103,5 @@ The use of asynchronous communication is explained with additional details later
 
 
 >[!div class="step-by-step"]
-[Previous] (logical-versus-physical-architecture.md)
-[Next] (identify-microservice-domain-model-boundaries.md)
+[Previous](logical-versus-physical-architecture.md)
+[Next](identify-microservice-domain-model-boundaries.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/docker-application-state-data.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/docker-application-state-data.md
@@ -53,5 +53,5 @@ In addition, when Docker containers are managed by an orchestrator, containers m
 
 
 >[!div class="step-by-step"]
-[Previous] (containerize-monolithic-applications.md)
-[Next] (service-oriented-architecture.md)
+[Previous](containerize-monolithic-applications.md)
+[Next](service-oriented-architecture.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/identify-microservice-domain-model-boundaries.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/identify-microservice-domain-model-boundaries.md
@@ -47,5 +47,5 @@ There are several benefits to not sharing the same user entity with the same num
 
 
 >[!div class="step-by-step"]
-[Previous] (distributed-data-management.md)
-[Next] (direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md)
+[Previous](distributed-data-management.md)
+[Next](direct-client-to-microservice-communication-versus-the-api-gateway-pattern.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/index.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/index.md
@@ -25,5 +25,5 @@ You might find a scenario where you want multiple processes running in a single 
 
 
 >[!div class="step-by-step"]
-[Previous] (../net-core-net-framework-containers/official-net-docker-images.md)
-[Next] (containerize-monolithic-applications.md)
+[Previous](../net-core-net-framework-containers/official-net-docker-images.md)
+[Next](containerize-monolithic-applications.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/logical-versus-physical-architecture.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/logical-versus-physical-architecture.md
@@ -31,5 +31,5 @@ In short, the logical architecture of microservices does not always have to coin
 
 
 >[!div class="step-by-step"]
-[Previous] (data-sovereignty-per-microservice.md)
-[Next] (distributed-data-management.md)
+[Previous](data-sovereignty-per-microservice.md)
+[Next](distributed-data-management.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/maintain-microservice-apis.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/maintain-microservice-apis.md
@@ -32,5 +32,5 @@ Finally, if you are using a REST architecture, [Hypermedia](https://www.infoq.co
 
 
 >[!div class="step-by-step"]
-[Previous] (asynchronous-message-based-communication.md)
-[Next] (microservices-addressability-service-registry.md)
+[Previous](asynchronous-message-based-communication.md)
+[Next](microservices-addressability-service-registry.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/microservice-based-composite-ui-shape-layout.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/microservice-based-composite-ui-shape-layout.md
@@ -52,5 +52,5 @@ However, we encourage you to use the following references to learn more about co
 
 
 >[!div class="step-by-step"]
-[Previous] (microservices-addressability-service-registry.md)
-[Next] (resilient-high-availability-microservices.md)
+[Previous](microservices-addressability-service-registry.md)
+[Next](resilient-high-availability-microservices.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/microservices-addressability-service-registry.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/microservices-addressability-service-registry.md
@@ -28,5 +28,5 @@ Note that there is certain overlap between the service registry and the API gate
 
 
 >[!div class="step-by-step"]
-[Previous] (maintain-microservice-apis.md)
-[Next] (microservice-based-composite-ui-shape-layout.md)
+[Previous](maintain-microservice-apis.md)
+[Next](microservice-based-composite-ui-shape-layout.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/microservices-architecture.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/microservices-architecture.md
@@ -58,5 +58,5 @@ Of these, only the first three are covered or introduced in this guide. The last
 
 
 >[!div class="step-by-step"]
-[Previous] (service-oriented-architecture.md)
-[Next] (data-sovereignty-per-microservice.md)
+[Previous](service-oriented-architecture.md)
+[Next](data-sovereignty-per-microservice.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/resilient-high-availability-microservices.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/resilient-high-availability-microservices.md
@@ -73,5 +73,5 @@ Different orchestrators might sound similar, but the diagnostics and health chec
 
 
 >[!div class="step-by-step"]
-[Previous] (microservice-based-composite-ui-shape-layout.md)
-[Next] (scalable-available-multi-container-microservice-applications.md)
+[Previous](microservice-based-composite-ui-shape-layout.md)
+[Next](scalable-available-multi-container-microservice-applications.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/scalable-available-multi-container-microservice-applications.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/scalable-available-multi-container-microservice-applications.md
@@ -129,5 +129,5 @@ ACS is currently available for Standard A, D, DS, G, and GS series Linux virtual
 
 
 >[!div class="step-by-step"]
-[Previous] (resilient-high-availability-microservices.md)
-[Next] (using-azure-service-fabric.md)
+[Previous](resilient-high-availability-microservices.md)
+[Next](using-azure-service-fabric.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/service-oriented-architecture.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/service-oriented-architecture.md
@@ -21,5 +21,5 @@ This guide focuses on microservices, because a SOA approach is less prescriptive
 
 
 >[!div class="step-by-step"]
-[Previous] (docker-application-state-data.md)
-[Next] (microservices-architecture.md)
+[Previous](docker-application-state-data.md)
+[Next](microservices-architecture.md)

--- a/docs/standard/microservices-architecture/architect-microservice-container-applications/using-azure-service-fabric.md
+++ b/docs/standard/microservices-architecture/architect-microservice-container-applications/using-azure-service-fabric.md
@@ -83,5 +83,5 @@ Other microservice frameworks that allow stateful services, that support the Act
 Note that Docker containers are themselves stateless. If you want to implement a stateful service, you need one of the additional prescriptive and higher-level frameworks noted earlier. 
 
 >[!div class="step-by-step"]
-[Previous] (scalable-available-multi-container-microservice-applications.md)
-[Next] (../docker-application-development-process/index.md)
+[Previous](scalable-available-multi-container-microservice-applications.md)
+[Next](../docker-application-development-process/index.md)

--- a/docs/standard/microservices-architecture/container-docker-introduction/docker-containers-images-registries.md
+++ b/docs/standard/microservices-architecture/container-docker-introduction/docker-containers-images-registries.md
@@ -28,5 +28,5 @@ Private image registries, either hosted on-premises or in the cloud, are recomme
 -   You want to have minimum network latency between your images and your chosen deployment environment. For example, if your production environment is Azure cloud, you probably want to store your images in Azure Container Registry so that network latency will be minimal. In a similar way, if your production environment is on-premises, you might want to have an on-premises Docker Trusted Registry available within the same local network.
 
 >[!div class="step-by-step"]
-[Previous] (docker-terminology.md)
-[Next] (../net-core-net-framework-containers/index.md)
+[Previous](docker-terminology.md)
+[Next](../net-core-net-framework-containers/index.md)

--- a/docs/standard/microservices-architecture/container-docker-introduction/docker-defined.md
+++ b/docs/standard/microservices-architecture/container-docker-introduction/docker-defined.md
@@ -52,5 +52,5 @@ A container image is a way to package an app or service and deploy it in a relia
 Docker developers don't say, "It works on my machine, why not in production?" They say, "It runs on Docker". Docker-packaged apps can be executed on any supported Docker environment. Docker packaged apps run consistently on all deployment targets (Dev, QA, staging, production).
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (docker-terminology.md)
+[Previous](index.md)
+[Next](docker-terminology.md)

--- a/docs/standard/microservices-architecture/container-docker-introduction/docker-terminology.md
+++ b/docs/standard/microservices-architecture/container-docker-introduction/docker-terminology.md
@@ -41,5 +41,5 @@ This section lists terms and definitions you should be familiar with before gett
 
 
 >[!div class="step-by-step"]
-[Previous] (docker-defined.md)
-[Next] (docker-containers-images-registries.md)
+[Previous](docker-defined.md)
+[Next](docker-containers-images-registries.md)

--- a/docs/standard/microservices-architecture/container-docker-introduction/index.md
+++ b/docs/standard/microservices-architecture/container-docker-introduction/index.md
@@ -25,5 +25,5 @@ In short, containers offer the benefits of isolation, portability, agility, scal
 
 
 >[!div class="step-by-step"]
-[Previous] (../index.md)
-[Next] (docker-defined.md)
+[Previous](../index.md)
+[Next](docker-defined.md)

--- a/docs/standard/microservices-architecture/containerize-net-framework-applications/index.md
+++ b/docs/standard/microservices-architecture/containerize-net-framework-applications/index.md
@@ -180,5 +180,5 @@ There are a couple of differences between the development configuration and a pr
 In the development environment, you must run all the containers in the same OS. Docker CE for Windows does not support running Windows- and Linux-based containers at the same time. In production, you can decide if you want to run the catalog microservice in a Windows container in a single Docker host (or cluster), or have the Web Forms application communicate with an instance of the catalog microservice running in a Linux container on a different Docker host. It depends on how you want to optimize for network latency. In most cases, you want the microservices that your applications depend on running in the same Docker host (or swarm) for ease of deployment and lower communication latency. In those configurations, the only costly communications is between the microservice instances and the high-availability servers for the persistent data storage.
 
 >[!div class="step-by-step"]
-[Previous] (../net-core-single-containers-linux-windows-server-hosts/index.md)
-[Next] (../multi-container-microservice-net-applications/index.md)
+[Previous](../net-core-single-containers-linux-windows-server-hosts/index.md)
+[Next](../multi-container-microservice-net-applications/index.md)

--- a/docs/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow.md
+++ b/docs/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow.md
@@ -415,5 +415,5 @@ RUN powershell add-windowsfeature web-asp-net45
     [*https://github.com/Microsoft/aspnet-docker/blob/master/4.6.2/Dockerfile*](https://github.com/Microsoft/aspnet-docker/blob/master/4.6.2/Dockerfile)
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (../net-core-single-containers-linux-windows-server-hosts/index.md)
+[Previous](index.md)
+[Next](../net-core-single-containers-linux-windows-server-hosts/index.md)

--- a/docs/standard/microservices-architecture/docker-application-development-process/index.md
+++ b/docs/standard/microservices-architecture/docker-application-development-process/index.md
@@ -40,5 +40,5 @@ As mentioned in earlier sections of this guide, you can use .NET Framework, .NET
 
 
 >[!div class="step-by-step"]
-[Previous] (../architect-microservice-container-applications/using-azure-service-fabric.md)
-[Next] (docker-app-development-workflow.md)
+[Previous](../architect-microservice-container-applications/using-azure-service-fabric.md)
+[Next](docker-app-development-workflow.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/handle-partial-failure.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/handle-partial-failure.md
@@ -35,5 +35,5 @@ In addition, it is essential that you design your microservices and client appli
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (partial-failure-strategies.md)
+[Previous](index.md)
+[Next](partial-failure-strategies.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/implement-circuit-breaker-pattern.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/implement-circuit-breaker-pattern.md
@@ -240,5 +240,5 @@ Policy.Handle<HttpResponseException>() // etc
 
 
 >[!div class="step-by-step"]
-[Previous] (implement-http-call-retries-exponential-backoff-polly.md)
-[Next] (monitor-app-health.md)
+[Previous](implement-http-call-retries-exponential-backoff-polly.md)
+[Next](monitor-app-health.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/implement-custom-http-call-retries-exponential-backoff.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/implement-custom-http-call-retries-exponential-backoff.md
@@ -111,5 +111,5 @@ However, this code is suitable only as a proof of concept. The next topic explai
 
 
 >[!div class="step-by-step"]
-[Previous] (implement-resilient-entity-framework-core-sql-connections.md)
-[Next] (implement-http-call-retries-exponential-backoff-polly.md)
+[Previous](implement-resilient-entity-framework-core-sql-connections.md)
+[Next](implement-http-call-retries-exponential-backoff-polly.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
@@ -165,5 +165,5 @@ private Policy[] CreatePolicies()
 
 
 >[!div class="step-by-step"]
-[Previous] (implement-custom-http-call-retries-exponential-backoff.md)
-[Next] (implement-circuit-breaker-pattern.md)
+[Previous](implement-custom-http-call-retries-exponential-backoff.md)
+[Next](implement-circuit-breaker-pattern.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/implement-resilient-entity-framework-core-sql-connections.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/implement-resilient-entity-framework-core-sql-connections.md
@@ -87,5 +87,5 @@ The first DbContext is \_catalogContext and the second DbContext is within the \
 
 
 >[!div class="step-by-step"]
-[Previous] (implement-retries-exponential-backoff.md)
-[Next] (implement-custom-http-call-retries-exponential-backoff.md)
+[Previous](implement-retries-exponential-backoff.md)
+[Next](implement-custom-http-call-retries-exponential-backoff.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/implement-retries-exponential-backoff.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/implement-retries-exponential-backoff.md
@@ -13,5 +13,5 @@ There are many approaches to implement retries logic with exponential backoff.
 
 
 >[!div class="step-by-step"]
-[Previous] (partial-failure-strategies.md)
-[Next] (implement-resilient-entity-framework-core-sql-connections.md)
+[Previous](partial-failure-strategies.md)
+[Next](implement-resilient-entity-framework-core-sql-connections.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/index.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/index.md
@@ -17,5 +17,5 @@ The many individual components of your application should also incorporate healt
 
 
 >[!div class="step-by-step"]
-[Previous] (../microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md)
-[Next] (handle-partial-failure.md)
+[Previous](../microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md)
+[Next](handle-partial-failure.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/monitor-app-health.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/monitor-app-health.md
@@ -191,5 +191,5 @@ Finally, if you were storing all the event streams, you can use Microsoft Power 
     [*https://www.microsoft.com/en-us/cloud-platform/operations-management-suite*](https://www.microsoft.com/en-us/cloud-platform/operations-management-suite)
 
 >[!div class="step-by-step"]
-[Previous] (implement-circuit-breaker-pattern.md)
-[Next] (../secure-net-microservices-web-applications/index.md)
+[Previous](implement-circuit-breaker-pattern.md)
+[Next](../secure-net-microservices-web-applications/index.md)

--- a/docs/standard/microservices-architecture/implement-resilient-applications/partial-failure-strategies.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/partial-failure-strategies.md
@@ -40,5 +40,5 @@ Strategies for dealing with partial failures include the following.
 
 
 >[!div class="step-by-step"]
-[Previous] (handle-partial-failure.md)
-[Next] (implement-retries-exponential-backoff.md)
+[Previous](handle-partial-failure.md)
+[Next](implement-retries-exponential-backoff.md)

--- a/docs/standard/microservices-architecture/index.md
+++ b/docs/standard/microservices-architecture/index.md
@@ -148,4 +148,4 @@ We wrote this guide to help you understand the architecture of containerized app
 [dotnet-architecture-ebooks-feedback@service.microsoft.com](mailto:dotnet-architecture-ebooks-feedback@service.microsoft.com)
 
 >[!div class="step-by-step"]
-[Next] (container-docker-introduction/index.md)
+[Next](container-docker-introduction/index.md)

--- a/docs/standard/microservices-architecture/key-takeaways.md
+++ b/docs/standard/microservices-architecture/key-takeaways.md
@@ -32,4 +32,4 @@ As a summary and key takeaways, the following are the most important conclusions
 **Orchestrators.** Container-based orchestrators like the ones provided in Azure Container Service (Kubernetes, Mesos DC/OS, and Docker Swarm) and Azure Service Fabric are indispensable for any production-ready microservice-based application and for any multi-container application with significant complexity, scalability needs, and constant evolution. This guide has introduced orchestrators and their role in microservice-based and container-based solutions. If your application needs are moving you toward complex containerized apps, you will find it useful to seek out additional resources for learning more about orchestrators
 
 >[!div class="step-by-step"]
-[Previous] (secure-net-microservices-web-applications/azure-key-vault-protects-secrets.md)
+[Previous](secure-net-microservices-web-applications/azure-key-vault-protects-secrets.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/apply-simplified-microservice-cqrs-ddd-patterns.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/apply-simplified-microservice-cqrs-ddd-patterns.md
@@ -31,5 +31,5 @@ The application layer can be the Web API itself. The important design aspect her
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (eshoponcontainers-cqrs-ddd-microservice.md)
+[Previous](index.md)
+[Next](eshoponcontainers-cqrs-ddd-microservice.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/client-side-validation.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/client-side-validation.md
@@ -59,5 +59,5 @@ In summary, these are the most important concepts in regards to validation:
 
 
 >[!div class="step-by-step"]
-[Previous] (domain-model-layer-validations.md)
-[Next] (domain-events-design-implementation.md)
+[Previous](domain-model-layer-validations.md)
+[Next](domain-events-design-implementation.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/cqrs-microservice-reads.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/cqrs-microservice-reads.md
@@ -193,5 +193,5 @@ You can see in the image above some example values based on the ViewModel types 
     *https://docs.microsoft.com/aspnet/core/tutorials/web-api-help-pages-using-swagger?tabs=visual-studio*
 
 >[!div class="step-by-step"]
-[Previous] (eshoponcontainers-cqrs-ddd-microservice.md)
-[Next] (ddd-oriented-microservice.md)
+[Previous](eshoponcontainers-cqrs-ddd-microservice.md)
+[Next](ddd-oriented-microservice.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/ddd-oriented-microservice.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/ddd-oriented-microservice.md
@@ -100,5 +100,5 @@ This layer design should be independent for each microservice. As noted earlier,
 
 
 >[!div class="step-by-step"]
-[Previous] (cqrs-microservice-reads.md)
-[Next] (microservice-domain-model.md)
+[Previous](cqrs-microservice-reads.md)
+[Next](microservice-domain-model.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
@@ -360,5 +360,5 @@ As stated, use domain events to explicitly implement side effects of changes wit
 
 
 >[!div class="step-by-step"]
-[Previous] (client-side-validation.md)
-[Next] (infrastructure-persistence-layer-design.md)
+[Previous](client-side-validation.md)
+[Next](infrastructure-persistence-layer-design.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-model-layer-validations.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-model-layer-validations.md
@@ -126,5 +126,5 @@ Using field validation with data annotations, for example, you do not duplicate 
 
 
 >[!div class="step-by-step"]
-[Previous] (enumeration-classes-over-enum-types.md)
-[Next] (client-side-validation.md)
+[Previous](enumeration-classes-over-enum-types.md)
+[Next](client-side-validation.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -122,5 +122,5 @@ public class CardType : Enumeration
 
 
 >[!div class="step-by-step"]
-[Previous] (implement-value-objects.md)
-[Next] (domain-model-layer-validations.md)
+[Previous](implement-value-objects.md)
+[Next](domain-model-layer-validations.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/eshoponcontainers-cqrs-ddd-microservice.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/eshoponcontainers-cqrs-ddd-microservice.md
@@ -58,5 +58,5 @@ There is only one application architecture: the architecture of the system or en
 
 
 >[!div class="step-by-step"]
-[Previous] (apply-simplified-microservice-cqrs-ddd-patterns.md)
-[Next] (cqrs-microservice-reads.md)
+[Previous](apply-simplified-microservice-cqrs-ddd-patterns.md)
+[Next](cqrs-microservice-reads.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/implement-value-objects.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/implement-value-objects.md
@@ -323,5 +323,5 @@ public class Address
 
 
 >[!div class="step-by-step"]
-[Previous] (seedwork-domain-model-base-classes-interfaces.md)
-[Next] (enumeration-classes-over-enum-types.md)
+[Previous](seedwork-domain-model-base-classes-interfaces.md)
+[Next](enumeration-classes-over-enum-types.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/index.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/index.md
@@ -64,5 +64,5 @@ DDD training
 
 
 >[!div class="step-by-step"]
-[Previous] (../multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md)
-[Next] (apply-simplified-microservice-cqrs-ddd-patterns.md)
+[Previous](../multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md)
+[Next](apply-simplified-microservice-cqrs-ddd-patterns.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-design.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-design.md
@@ -159,5 +159,5 @@ In the upcoming sections, it is explained how to implement the Specification pat
     [*https://www.martinfowler.com/apsupp/spec.pdf/*](https://www.martinfowler.com/apsupp/spec.pdf)
 
 >[!div class="step-by-step"]
-[Previous] (domain-events-design-implementation.md)
-[Next] (infrastructure-persistence-layer-implemenation-entity-framework-core.md)
+[Previous](domain-events-design-implementation.md)
+[Next](infrastructure-persistence-layer-implemenation-entity-framework-core.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-implemenation-entity-framework-core.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-implemenation-entity-framework-core.md
@@ -465,5 +465,5 @@ Although we don't recommended to return IQueryable from a repository, it’s per
     
 
 >[!div class="step-by-step"]
-[Previous] (infrastructure-persistence-layer-design.md)
-[Next] (nosql-database-persistence-infrastructure.md)
+[Previous](infrastructure-persistence-layer-design.md)
+[Next](nosql-database-persistence-infrastructure.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-implementation-web-api.md
@@ -861,5 +861,5 @@ In a similar way, you could implement other behaviors for additional aspects or 
     [*https://github.com/JeremySkinner/FluentValidation*](https://github.com/JeremySkinner/FluentValidation)
 
 >[!div class="step-by-step"]
-[Previous] (microservice-application-layer-web-api-design.md)
-[Next] (../implement-resilient-applications/index.md)
+[Previous](microservice-application-layer-web-api-design.md)
+[Next](../implement-resilient-applications/index.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-web-api-design.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-application-layer-web-api-design.md
@@ -42,5 +42,5 @@ It would take another guide to cover SOLID in detail. Therefore, this guide requ
 
 
 >[!div class="step-by-step"]
-[Previous] (nosql-database-persistence-infrastructure.md)
-[Next] (microservice-application-layer-implementation-web-api.md)
+[Previous](nosql-database-persistence-infrastructure.md)
+[Next](microservice-application-layer-implementation-web-api.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-domain-model.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/microservice-domain-model.md
@@ -148,5 +148,5 @@ Identifying and working with aggregates requires research and experience. For mo
 
 
 >[!div class="step-by-step"]
-[Previous] (ddd-oriented-microservice.md)
-[Next] (net-core-microservice-domain-model.md)
+[Previous](ddd-oriented-microservice.md)
+[Next](net-core-microservice-domain-model.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/net-core-microservice-domain-model.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/net-core-microservice-domain-model.md
@@ -174,5 +174,5 @@ For example, in the preceding OrderAggregate code example, there are several pri
 
 
 >[!div class="step-by-step"]
-[Previous] (microservice-domain-model.md)
-[Next] (seedwork-domain-model-base-classes-interfaces.md)
+[Previous](microservice-domain-model.md)
+[Next](seedwork-domain-model-base-classes-interfaces.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/nosql-database-persistence-infrastructure.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/nosql-database-persistence-infrastructure.md
@@ -328,5 +328,5 @@ If the `ESHOP_AZURE_COSMOSDB` global variable is empty, meaning that it is comme
 
 
 >[!div class="step-by-step"]
-[Previous] (infrastructure-persistence-layer-implemenation-entity-framework-core.md)
-[Next] (microservice-application-layer-web-api-design.md)
+[Previous](infrastructure-persistence-layer-implemenation-entity-framework-core.md)
+[Next](microservice-application-layer-web-api-design.md)

--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
@@ -138,5 +138,5 @@ public interface IRepository<T> where T : IAggregateRoot
 
 
 >[!div class="step-by-step"]
-[Previous] (net-core-microservice-domain-model.md)
-[Next] (implement-value-objects.md)
+[Previous](net-core-microservice-domain-model.md)
+[Next](implement-value-objects.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
@@ -255,5 +255,5 @@ The `IHostedService` interface provides a convenient way to start background tas
 
 
 >[!div class="step-by-step"]
-[Previous] (test-aspnet-core-services-web-apps.md)
-[Next] (../microservice-ddd-cqrs-patterns/index.md)
+[Previous](test-aspnet-core-services-web-apps.md)
+[Next](../microservice-ddd-cqrs-patterns/index.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/data-driven-crud-microservice.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/data-driven-crud-microservice.md
@@ -410,5 +410,5 @@ It is that simple. And because it is automatically generated, the Swagger metada
 
 
 >[!div class="step-by-step"]
-[Previous] (microservice-application-design.md)
-[Next] (multi-container-applications-docker-compose.md)
+[Previous](microservice-application-design.md)
+[Next](multi-container-applications-docker-compose.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/database-server-container.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/database-server-container.md
@@ -195,5 +195,5 @@ Finally, in the docker-compose.override.yml file, the basket.api microservice fo
 
 
 >[!div class="step-by-step"]
-[Previous] (multi-container-applications-docker-compose.md)
-[Next] (integration-event-based-microservice-communications.md)
+[Previous](multi-container-applications-docker-compose.md)
+[Next](integration-event-based-microservice-communications.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/index.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/index.md
@@ -15,5 +15,5 @@ However, if you know how to design and develop a microservices-based application
 
 
 >[!div class="step-by-step"]
-[Previous] (../containerize-net-framework-applications/index.md)
-[Next] (microservice-application-design.md)
+[Previous](../containerize-net-framework-applications/index.md)
+[Next](microservice-application-design.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/integration-event-based-microservice-communications.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/integration-event-based-microservice-communications.md
@@ -123,5 +123,5 @@ The `Subscribe` methods (you can have several implementations depending on the a
 
 
 >[!div class="step-by-step"]
-[Previous] (database-server-container.md)
-[Next] (rabbitmq-event-bus-development-test-environment.md)
+[Previous](database-server-container.md)
+[Next](rabbitmq-event-bus-development-test-environment.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/microservice-application-design.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/microservice-application-design.md
@@ -189,5 +189,5 @@ There is no silver bullet or a right architecture pattern for every given case. 
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (data-driven-crud-microservice.md)
+[Previous](index.md)
+[Next](data-driven-crud-microservice.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/multi-container-applications-docker-compose.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/multi-container-applications-docker-compose.md
@@ -548,5 +548,5 @@ The overall takeway here is that you are able to build your application the same
 
 
 >[!div class="step-by-step"]
-[Previous] (data-driven-crud-microservice.md)
-[Next] (database-server-container.md)
+[Previous](data-driven-crud-microservice.md)
+[Next](database-server-container.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/rabbitmq-event-bus-development-test-environment.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/rabbitmq-event-bus-development-test-environment.md
@@ -105,5 +105,5 @@ The Subscribe method accepts an IIntegrationEventHandler object, which is like a
 
 
 >[!div class="step-by-step"]
-[Previous] (integration-event-based-microservice-communications.md)
-[Next] (subscribe-events.md)
+[Previous](integration-event-based-microservice-communications.md)
+[Next](subscribe-events.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/subscribe-events.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/subscribe-events.md
@@ -375,5 +375,5 @@ If the “redelivered” flag is set, the receiver must take that into account, 
 
 
 >[!div class="step-by-step"]
-[Previous] (rabbitmq-event-bus-development-test-environment.md)
-[Next] (test-aspnet-core-services-web-apps.md)
+[Previous](rabbitmq-event-bus-development-test-environment.md)
+[Next](test-aspnet-core-services-web-apps.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/test-aspnet-core-services-web-apps.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/test-aspnet-core-services-web-apps.md
@@ -120,5 +120,5 @@ There are a few approaches you can use. In the docker-compose.yml file that you 
 Once the compose application is up and running, you can take advantage of breakpoints and exceptions if you are running Visual Studio. Or you can run the integration tests automatically in your CI pipeline in Visual Studio Team Services or any other CI/CD system that supports Docker containers.
 
 >[!div class="step-by-step"]
-[Previous] (subscribe-events.md)
-[Next] (../microservice-ddd-cqrs-patterns/index.md)
+[Previous](subscribe-events.md)
+[Next](../microservice-ddd-cqrs-patterns/index.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/container-framework-choice-factors.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/container-framework-choice-factors.md
@@ -52,5 +52,5 @@ There are several features of your application that affect your decision. You sh
     - If you use client APIs available for *.NET Core*, you can also choose between *Linux containers and Windows containers*.
 
 >[!div class="step-by-step"]
-[Previous] (net-framework-container-scenarios.md)
-[Next] (net-container-os-targets.md)
+[Previous](net-framework-container-scenarios.md)
+[Next](net-container-os-targets.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/general-guidance.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/general-guidance.md
@@ -41,5 +41,5 @@ Using .NET Framework on Docker can improve your deployment experiences by minimi
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (net-core-container-scenarios.md)
+[Previous](index.md)
+[Next](net-core-container-scenarios.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/index.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/index.md
@@ -11,5 +11,5 @@ There are two supported implementations for building server-side containerized D
 
 
 >[!div class="step-by-step"]
-[Previous] (../container-docker-introduction/docker-containers-images-registries.md)
-[Next] (general-guidance.md)
+[Previous](../container-docker-introduction/docker-containers-images-registries.md)
+[Next](general-guidance.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/net-container-os-targets.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/net-container-os-targets.md
@@ -44,5 +44,5 @@ When you add the image name to your Dockerfile file, you can select the operatin
 
 
 >[!div class="step-by-step"]
-[Previous] (container-framework-choice-factors.md)
-[Next] (official-net-docker-images.md)
+[Previous](container-framework-choice-factors.md)
+[Next](official-net-docker-images.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/net-core-container-scenarios.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/net-core-container-scenarios.md
@@ -47,5 +47,5 @@ This is especially relevant for microservices architectures, where you could hav
 
 
 >[!div class="step-by-step"]
-[Previous] (general-guidance.md)
-[Next] (net-framework-container-scenarios.md)
+[Previous](general-guidance.md)
+[Next](net-framework-container-scenarios.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/net-framework-container-scenarios.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/net-framework-container-scenarios.md
@@ -59,5 +59,5 @@ In the meantime, if any platform or service in Azure still doesn’t support .NE
 
 
 >[!div class="step-by-step"]
-[Previous] (net-core-container-scenarios.md)
-[Next] (container-framework-choice-factors.md)
+[Previous](net-core-container-scenarios.md)
+[Next](container-framework-choice-factors.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/official-net-docker-images.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/official-net-docker-images.md
@@ -50,5 +50,5 @@ When you explore the .NET image repositories at Docker Hub, you will find multip
 
 
 >[!div class="step-by-step"]
-[Previous] (net-container-os-targets.md)
-[Next] (../architect-microservice-container-applications/index.md)
+[Previous](net-container-os-targets.md)
+[Next](../architect-microservice-container-applications/index.md)

--- a/docs/standard/microservices-architecture/net-core-single-containers-linux-windows-server-hosts/index.md
+++ b/docs/standard/microservices-architecture/net-core-single-containers-linux-windows-server-hosts/index.md
@@ -136,5 +136,5 @@ You might need to stop running processes when you switch between different confi
 The wizard that adds Docker support communicates with the running Docker process. The wizard will not run correctly if Docker is not running when you start the wizard. In addition, the wizard examines your current container choice to add the correct Docker support. If you want to add support for Windows Containers, you need to run the wizard while you have Docker running with Windows Containers configured. If you want to add support for Linux containers, run the wizard while you have Docker running with Linux containers configured.
 
 >[!div class="step-by-step"]
-[Previous] (../docker-application-development-process/docker-app-development-workflow.md)
-[Next] (../containerize-net-framework-applications/index.md)
+[Previous](../docker-application-development-process/docker-app-development-workflow.md)
+[Next](../containerize-net-framework-applications/index.md)

--- a/docs/standard/microservices-architecture/secure-net-microservices-web-applications/authorization-net-microservices-web-applications.md
+++ b/docs/standard/microservices-architecture/secure-net-microservices-web-applications/authorization-net-microservices-web-applications.md
@@ -123,5 +123,5 @@ An example of a custom authorization requirement and handler for checking a user
 
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (developer-app-secrets-storage.md)
+[Previous](index.md)
+[Next](developer-app-secrets-storage.md)

--- a/docs/standard/microservices-architecture/secure-net-microservices-web-applications/azure-key-vault-protects-secrets.md
+++ b/docs/standard/microservices-architecture/secure-net-microservices-web-applications/azure-key-vault-protects-secrets.md
@@ -69,5 +69,5 @@ In this example, the call to AddAzureKeyVault comes at the end of configuration 
     [*https://github.com/aspnet/Configuration/tree/dev/src/Microsoft.Extensions.Configuration.DockerSecrets*](https://github.com/aspnet/Configuration/tree/dev/src/Microsoft.Extensions.Configuration.DockerSecrets)
 
 >[!div class="step-by-step"]
-[Previous] (developer-app-secrets-storage.md)
-[Next] (../key-takeaways.md)
+[Previous](developer-app-secrets-storage.md)
+[Next](../key-takeaways.md)

--- a/docs/standard/microservices-architecture/secure-net-microservices-web-applications/developer-app-secrets-storage.md
+++ b/docs/standard/microservices-architecture/secure-net-microservices-web-applications/developer-app-secrets-storage.md
@@ -47,5 +47,5 @@ Using secrets stored with Secret Manager in an application is accomplished by ca
 
 
 >[!div class="step-by-step"]
-[Previous] (authorization-net-microservices-web-applications.md)
-[Next] (azure-key-vault-protects-secrets.md)
+[Previous](authorization-net-microservices-web-applications.md)
+[Next](azure-key-vault-protects-secrets.md)

--- a/docs/standard/microservices-architecture/secure-net-microservices-web-applications/index.md
+++ b/docs/standard/microservices-architecture/secure-net-microservices-web-applications/index.md
@@ -244,5 +244,5 @@ The JWT bearer authentication middleware can also support more advanced scenario
 
 
 >[!div class="step-by-step"]
-[Previous] (../implement-resilient-applications/monitor-app-health.md)
-[Next] (authorization-net-microservices-web-applications.md)
+[Previous](../implement-resilient-applications/monitor-app-health.md)
+[Next](authorization-net-microservices-web-applications.md)

--- a/docs/standard/modern-web-apps-azure-architecture/architectural-principles.md
+++ b/docs/standard/modern-web-apps-azure-architecture/architectural-principles.md
@@ -111,5 +111,5 @@ At a minimum, individual web applications should strive to be their own bounded 
 > <https://martinfowler.com/bliki/BoundedContext.html>
 
 > [!div class="step-by-step"]
-[Previous] (choose-between-traditional-web-and-single-page-apps.md)
-[Next] (common-web-application-architectures.md)
+[Previous](choose-between-traditional-web-and-single-page-apps.md)
+[Next](common-web-application-architectures.md)

--- a/docs/standard/modern-web-apps-azure-architecture/azure-hosting-recommendations-for-asp-net-web-apps.md
+++ b/docs/standard/modern-web-apps-azure-architecture/azure-hosting-recommendations-for-asp-net-web-apps.md
@@ -121,4 +121,4 @@ Figure 11-2 shows an example reference architecture. This diagram describes a re
     <https://docs.microsoft.com/azure/app-service-web/choose-web-site-cloud-service-vm>
 
 >[!div class="step-by-step"]
-[Previous] (development-process-for-azure.md)
+[Previous](development-process-for-azure.md)

--- a/docs/standard/modern-web-apps-azure-architecture/choose-between-traditional-web-and-single-page-apps.md
+++ b/docs/standard/modern-web-apps-azure-architecture/choose-between-traditional-web-and-single-page-apps.md
@@ -86,5 +86,5 @@ The following decision table summarizes some of the basic factors to consider wh
   | Rich, Complex User Interface Requirements | **Limited** | **Well-Suited** |
 
 >[!div class="step-by-step"]
-[Previous] (modern-web-applications-characteristics.md)
+[Previous](modern-web-applications-characteristics.md)
 [Next](architectural-principles.md)

--- a/docs/standard/modern-web-apps-azure-architecture/common-client-side-web-technologies.md
+++ b/docs/standard/modern-web-apps-azure-architecture/common-client-side-web-technologies.md
@@ -161,5 +161,5 @@ JavaScript frameworks continue to evolve with breakneck speed. Use the considera
 > <https://hackernoon.com/5-best-javascript-frameworks-in-2017-7a63b3870282>
 
 >[!div class="step-by-step"]
-[Previous] (common-web-application-architectures.md)
-[Next] (develop-asp-net-core-mvc-apps.md)
+[Previous](common-web-application-architectures.md)
+[Next](develop-asp-net-core-mvc-apps.md)

--- a/docs/standard/modern-web-apps-azure-architecture/common-web-application-architectures.md
+++ b/docs/standard/modern-web-apps-azure-architecture/common-web-application-architectures.md
@@ -219,5 +219,5 @@ While monolithic apps can benefit from Docker, breaking up the monolithic applic
 > - **Architecting Microservices e-book** <http://aka.ms/MicroservicesEbook>
 
 >[!div class="step-by-step"]
-[Previous] (architectural-principles.md)
-[Next] (common-client-side-web-technologies.md)
+[Previous](architectural-principles.md)
+[Next](common-client-side-web-technologies.md)

--- a/docs/standard/modern-web-apps-azure-architecture/develop-asp-net-core-mvc-apps.md
+++ b/docs/standard/modern-web-apps-azure-architecture/develop-asp-net-core-mvc-apps.md
@@ -549,5 +549,5 @@ If you're hosting your application on Azure, you can use Microsoft Azure Applica
 > <https://docs.microsoft.com/azure/application-gateway/application-gateway-introduction>
 
 >[!div class="step-by-step"]
-[Previous] (common-client-side-web-technologies.md)
-[Next] (work-with-data-in-asp-net-core-apps.md)
+[Previous](common-client-side-web-technologies.md)
+[Next](work-with-data-in-asp-net-core-apps.md)

--- a/docs/standard/modern-web-apps-azure-architecture/development-process-for-azure.md
+++ b/docs/standard/modern-web-apps-azure-architecture/development-process-for-azure.md
@@ -107,5 +107,5 @@ While the Web App is running, you can monitor the health of the application and 
 
 
 >[!div class="step-by-step"]
-[Previous] (test-asp-net-core-mvc-apps.md)
-[Next] (azure-hosting-recommendations-for-asp-net-web-apps.md)
+[Previous](test-asp-net-core-mvc-apps.md)
+[Next](azure-hosting-recommendations-for-asp-net-web-apps.md)

--- a/docs/standard/modern-web-apps-azure-architecture/index.md
+++ b/docs/standard/modern-web-apps-azure-architecture/index.md
@@ -67,4 +67,4 @@ Feel free to forward this guide to your team to help ensure a common understandi
 <https://docs.microsoft.com/dotnet/standard/choosing-core-framework-server>
 
 >[!div class="step-by-step"]
-[Next] (modern-web-applications-characteristics.md)
+[Next](modern-web-applications-characteristics.md)

--- a/docs/standard/modern-web-apps-azure-architecture/modern-web-applications-characteristics.md
+++ b/docs/standard/modern-web-apps-azure-architecture/modern-web-applications-characteristics.md
@@ -71,5 +71,5 @@ In addition to ASP.NET Core, traditional ASP.NET 4.x continues to be a robust an
 > <https://docs.microsoft.com/aspnet/core/testing/>
 
 >[!div class="step-by-step"]
-[Previous] (index.md)
-[Next] (choose-between-traditional-web-and-single-page-apps.md)
+[Previous](index.md)
+[Next](choose-between-traditional-web-and-single-page-apps.md)

--- a/docs/standard/modern-web-apps-azure-architecture/test-asp-net-core-mvc-apps.md
+++ b/docs/standard/modern-web-apps-azure-architecture/test-asp-net-core-mvc-apps.md
@@ -267,5 +267,5 @@ public class CatalogControllerGetImage : BaseWebTest
 This functional test exercises the full ASP.NET Core MVC application stack, including all middleware, filters, binders, etc. that may be in place. It verifies that a given route ("/catalog/pic/1") returns the expected byte array for a file in a known location. It does so without setting up a real web server, and so avoids much of the brittleness that using a real web server for testing can experience (for example, problems with firewall settings). Functional tests that run against TestServer are usually slower than integration and unit tests, but are much faster than tests that would run over the network to a test web server.
 
 >[!div class="step-by-step"]
-[Previous] (work-with-data-in-asp-net-core-apps.md)
-[Next] (development-process-for-azure.md)
+[Previous](work-with-data-in-asp-net-core-apps.md)
+[Next](development-process-for-azure.md)

--- a/docs/standard/modern-web-apps-azure-architecture/work-with-data-in-asp-net-core-apps.md
+++ b/docs/standard/modern-web-apps-azure-architecture/work-with-data-in-asp-net-core-apps.md
@@ -431,5 +431,5 @@ _cache.Get<CancellationTokenSource>("cts").Cancel();
 ```
 
 >[!div class="step-by-step"]
-[Previous] (develop-asp-net-core-mvc-apps.md)
-[Next] (test-asp-net-core-mvc-apps.md)
+[Previous](develop-asp-net-core-mvc-apps.md)
+[Next](test-asp-net-core-mvc-apps.md)


### PR DESCRIPTION
This is a bulk fix removing spaces between the description and address portions of markdown links that are breaking rendering for LOC. User Story 1292440
This is related to #6169 
This supersedes pull request #6178

