### PR TITLE
Categories in "Accessibility" are incorrect

### DIFF
--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -60,9 +60,9 @@ Each member of a class has an associated accessibility, which controls the regio
 * `protected internal`
 	- Access limited to the containing class or classes derived from the containing class, or classes within the same assembly
 * `private`
-	- Access limited to this class    	
+	- Access limited to this class
 * `private protected`
-	- Access limited to classes derived from the containing class within the same assembly.
+	- Access limited to the containing class or classes derived from the containing type within the same assembly
 
 ## Type parameters
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -49,7 +49,7 @@ The following provides an overview of the kinds of members a class can contain.
 
 ## Accessibility
 
-Each member of a class has an associated accessibility, which controls the regions of program text that are able to access the member. There are five possible forms of accessibility. These are summarized below.
+Each member of a class has an associated accessibility, which controls the regions of program text that are able to access the member. There are six possible forms of accessibility. These are summarized below.
 
 * `public`
 	- Access not limited

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -58,9 +58,11 @@ Each member of a class has an associated accessibility, which controls the regio
 * `internal`
 	- Access limited to the current assembly (.exe, .dll, etc.)
 * `protected internal`
-	- Access limited to the containing class or classes derived from the containing type within the same assembly
+	- Access limited to the containing class or classes derived from the containing class, or classes within the same assembly
 * `private`
 	- Access limited to this class    	
+* `private protected`
+	- Access limited to classes derived from the containing class within the same assembly.
 
 ## Type parameters
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -58,11 +58,9 @@ Each member of a class has an associated accessibility, which controls the regio
 * `internal`
 	- Access limited to the current assembly (.exe, .dll, etc.)
 * `protected internal`
-	- Access limited to the containing class or classes derived from the containing class
+	- Access limited to the containing class or classes derived from the containing type within the same assembly
 * `private`
-	- Access limited to this class
-* `private protected`
-    - Access limited to the containing class or classes derived from the containing type within the same assembly
+	- Access limited to this class    	
 
 ## Type parameters
 

--- a/docs/csharp/tour-of-csharp/classes-and-objects.md
+++ b/docs/csharp/tour-of-csharp/classes-and-objects.md
@@ -58,7 +58,7 @@ Each member of a class has an associated accessibility, which controls the regio
 * `internal`
 	- Access limited to the current assembly (.exe, .dll, etc.)
 * `protected internal`
-	- Access limited to the containing class or classes derived from the containing class, or classes within the same assembly
+	- Access limited to the containing class, classes derived from the containing class, or classes within the same assembly
 * `private`
 	- Access limited to this class
 * `private protected`


### PR DESCRIPTION
## Summary

-The brief provided for "private protected" should be the brief for "protected internal". 
-Removed "private protected" from the category.

Fixes #6206 