### PR TITLE
C26919: Escaping URL to be shown as text.

### DIFF
--- a/docs/framework/ui-automation/ui-automation-support-for-the-hyperlink-control-type.md
+++ b/docs/framework/ui-automation/ui-automation-support-for-the-hyperlink-control-type.md
@@ -54,7 +54,7 @@ manager: "markl"
 |---------------------------------------|--------------------|-----------|  
 |<xref:System.Windows.Automation.Provider.IInvokeProvider>|Yes|All hyperlink controls must support the Invoke pattern.|  
 |<xref:System.Windows.Automation.Provider.IValueProvider>|Depends|Hyperlink controls should support the Value control pattern when the link contains information that is usable and meaningful to the user.|  
-|<xref:System.Windows.Automation.Provider.IValueProvider.Value>|For example, "http://www...."|A URL for an Internet or Intranet address is an example of a hyperlink that contains information that is meaningful to the user. A programmatic link, however, is meaningful only to an application and is not recommended for the Value property.|  
+|<xref:System.Windows.Automation.Provider.IValueProvider.Value>|For example, `"http://www...."`|A URL for an Internet or Intranet address is an example of a hyperlink that contains information that is meaningful to the user. A programmatic link, however, is meaningful only to an application and is not recommended for the Value property.|  
   
 <a name="Required_UI_Automation_Events"></a>   
 ## Required UI Automation Events  


### PR DESCRIPTION
Hello, @mairaw  ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"This is an instance of source issue since links for products that have migrated to markdig should be written in the []() form. Nonetheless, this link reported as missing in the targets does not redirect to any URL, thus it should be escaped"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.