### PR TITLE
Clarified when `foreach` can be used with `ref`

### DIFF
--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -1,6 +1,6 @@
 ---
 title: "foreach, in (C# Reference)"
-ms.date: 06/28/2018
+ms.date: 06/29/2018
 f1_keywords: 
   - "foreach"
   - "foreach_CSharpKeyword"
@@ -29,11 +29,11 @@ The following example shows usage of the `foreach` statement with an instance of
 
 The next example uses the `foreach` statement with an instance of the <xref:System.Span%601?displayProperty=nameWithType> type, which doesn't implement any interfaces:
 
-[!code-csharp-interactive[span example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#2)]
+[!code-csharp[span example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#2)]
 
-Beginning with C# 7.3, when the collection type supports `ref` access to its elements, you can declare the iteration variable with the `ref` or `ref readonly` modifier. The following example uses a `ref` iteration variable to set the value of each item in a stackalloc array. The `ref readonly` version iterates the collection to print all the values. The `readonly` declaration uses an implicit local variable declaration. Implicit variable declarations can be used with either `ref` or `ref readonly` declarations, as can explicitly typed variable declarations.
+Beginning with C# 7.3, if the enumerator's `Current` property returns a [reference return value](../../programming-guide/classes-and-structs/ref-returns.md) (`ref T` where `T` is the type of the collection element), you can declare the iteration variable with the `ref` or `ref readonly` modifier. The following example uses a `ref` iteration variable to set the value of each item in a stackalloc array. The `ref readonly` version iterates the collection to print all the values. The `readonly` declaration uses an implicit local variable declaration. Implicit variable declarations can be used with either `ref` or `ref readonly` declarations, as can explicitly typed variable declarations.
 
-[!code-csharp-interactive[ref span example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#RefSpan)]
+[!code-csharp[ref span example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#RefSpan)]
 
 ## C# language specification
 


### PR DESCRIPTION
This PR is the result of [this comment](https://github.com/dotnet/docs/pull/6202#discussion_r199004502)

I've disabled interactivity of two snippets, because the one with a span reports the following error:
>(2,24): error CS1579: foreach statement cannot operate on variables of type 'Span<int>' because 'Span<int>' does not contain a public definition for 'GetEnumerator'

And the one with `ref` modifiers reports:
>(1,21): error CS1525: Invalid expression term 'stackalloc'
(3,26): error CS1579: foreach statement cannot operate on variables of type 'Span<int>' because 'Span<int>' does not contain a public definition for 'GetEnumerator'
(3,10): error CS1073: Unexpected token 'ref'
(4,5): error CS1656: Cannot assign to 'item' because it is a 'foreach iteration variable'
(6,35): error CS1579: foreach statement cannot operate on variables of type 'Span<int>' because 'Span<int>' does not contain a public definition for 'GetEnumerator'
(6,10): error CS1073: Unexpected token 'ref'
(6,23): error CS0825: The contextual keyword 'var' may only appear within a local variable declaration or in script code

Use rich diff for review.
