### PR TITLE
Missing dash in the `dotnet build-server` command

### DIFF
--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -49,7 +49,7 @@ Starting with .NET Core 2.0, `dotnet restore` is run implicitly if necessary whe
 
 - [`dotnet new`](dotnet-new.md)
 - [`dotnet build`](dotnet-build.md)
-- [`dotnet build server`](dotnet-build-server.md)
+- [`dotnet build-server`](dotnet-build-server.md)
 - [`dotnet run`](dotnet-run.md)
 - [`dotnet test`](dotnet-test.md)
 - [`dotnet publish`](dotnet-publish.md)


### PR DESCRIPTION
I know it is not a big deal but it can cause confusion.

## Summary

Corrected `dotnet build-server` command by adding a dash.
