### PR TITLE
Preprocessor directives: Change `/define` to `-define`

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-define.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-define.md
@@ -1,6 +1,6 @@
 ---
 title: "#define (C# Reference)"
-ms.date: 07/20/2015
+ms.date: 06/30/2018
 f1_keywords: 
   - "#define"
 helpviewer_keywords: 
@@ -23,9 +23,9 @@ You use `#define` to define a symbol. When you use the symbol as the expression 
   
  You can define a symbol, but you cannot assign a value to a symbol. The `#define` directive must appear in the file before you use any instructions that aren't also preprocessor directives.  
   
- You can also define a symbol with the [/define](../../../csharp/language-reference/compiler-options/define-compiler-option.md) compiler option. You can undefine a symbol with [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md).  
+ You can also define a symbol with the [-define](../../../csharp/language-reference/compiler-options/define-compiler-option.md) compiler option. You can undefine a symbol with [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md).  
   
- A symbol that you define with `/define` or with `#define` does not conflict with a variable of the same name. That is, a variable name should not be passed to a preprocessor directive and a symbol can only be evaluated by a preprocessor directive.  
+ A symbol that you define with `-define` or with `#define` does not conflict with a variable of the same name. That is, a variable name should not be passed to a preprocessor directive and a symbol can only be evaluated by a preprocessor directive.  
   
  The scope of a symbol that was created by using `#define` is the file in which the symbol was defined.  
   

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
@@ -1,6 +1,6 @@
 ---
 title: "#if preprocessor directive (C# Reference)"
-ms.date: "02/13/2017"
+ms.date: 06/30/2018
 f1_keywords: 
   - "#if"
 helpviewer_keywords: 
@@ -27,9 +27,9 @@ A conditional directive beginning with a `#if` directive must explicitly be term
 
 `#define` lets you define a symbol. By then using the symbol as the expression passed to the `#if` directive, the expression evaluates to `true`.
 
-You can also define a symbol with the [/define](../compiler-options/define-compiler-option.md) compiler option. You can undefine a symbol with [#undef](preprocessor-undef.md).
+You can also define a symbol with the [-define](../compiler-options/define-compiler-option.md) compiler option. You can undefine a symbol with [#undef](preprocessor-undef.md).
 
-A symbol that you define with `/define` or with `#define` doesn't conflict with a variable of the same name. That is, a variable name should not be passed to a preprocessor directive, and a symbol can only be evaluated by a preprocessor directive.
+A symbol that you define with `-define` or with `#define` doesn't conflict with a variable of the same name. That is, a variable name should not be passed to a preprocessor directive, and a symbol can only be evaluated by a preprocessor directive.
 
 The scope of a symbol created with `#define` is the file in which it was defined.
 

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-undef.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-undef.md
@@ -1,6 +1,6 @@
 ---
 title: "#undef (C# Reference)"
-ms.date: 07/20/2015
+ms.date: 06/30/2018
 f1_keywords: 
   - "#undef"
 helpviewer_keywords: 
@@ -10,7 +10,7 @@ ms.assetid: 686c92d2-7194-4be4-b2f4-80091712d513
 # #undef (C# Reference)
 `#undef` lets you undefine a symbol, such that, by using the symbol as the expression in a [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md) directive, the expression will evaluate to `false`.  
   
- A symbol can be defined either with the [#define](../../../csharp/language-reference/preprocessor-directives/preprocessor-define.md) directive or the [/define](../../../csharp/language-reference/compiler-options/define-compiler-option.md) compiler option. The `#undef` directive must appear in the file before you use any statements that are not also directives.  
+ A symbol can be defined either with the [#define](../../../csharp/language-reference/preprocessor-directives/preprocessor-define.md) directive or the [-define](../../../csharp/language-reference/compiler-options/define-compiler-option.md) compiler option. The `#undef` directive must appear in the file before you use any statements that are not also directives.  
   
 ## Example  
   


### PR DESCRIPTION
In line with https://github.com/dotnet/docs/pull/4138 and https://github.com/dotnet/docs/blob/master/docs/csharp/language-reference/compiler-options/define-compiler-option.md

Part of solving https://github.com/dotnet/docs/issues/4072
