### PR TITLE
Corrected file extension for tlbimp.exe

### DIFF
--- a/docs/framework/interop/how-to-generate-interop-assemblies-from-type-libraries.md
+++ b/docs/framework/interop/how-to-generate-interop-assemblies-from-type-libraries.md
@@ -26,13 +26,13 @@ The [Type Library Importer (Tlbimp.exe)](../../../docs/framework/tools/tlbimp-ex
  The following command produces the Loanlib.dll assembly in the `Loanlib` namespace.  
   
 ```  
-tlbimp Loanlib.dll  
+tlbimp Loanlib.tlb  
 ```  
   
  The following command produces an interop assembly with an altered name (LOANLib.dll).  
   
 ```  
-tlbimp LoanLib.dll /out: LOANLib.dll  
+tlbimp LoanLib.tlb /out: LOANLib.dll  
 ```  
   
 ## See Also  


### PR DESCRIPTION
## Corrected file extension for tlbimp.exe

tlbimp.exe writes type information from a COM type library to a managed assembly, not vice versa.

Fixes #6289 

//cc @bilbothebaggins
