### PR TITLE
Corrected casing of config attribute values

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/mailsettings-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/mailsettings-element-network-settings.md
@@ -52,7 +52,7 @@ Configures mail sending options.
 <configuration>  
   <system.net>  
     <mailSettings>  
-      <smtp deliveryMethod="network">  
+      <smtp deliveryMethod="Network">  
         <network  
           host="localhost"  
           port="25"  

--- a/docs/framework/configure-apps/file-schema/network/network-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/network-element-network-settings.md
@@ -92,7 +92,7 @@ Configures the network options for an external Simple Mail Transport Protocol (S
 <configuration>  
   <system.net>  
     <mailSettings>  
-      <smtp deliveryMethod="network">  
+      <smtp deliveryMethod="Network">  
         <network  
           clientDomain="www.contoso.com"  
           defaultCredentials="true"  

--- a/docs/framework/configure-apps/file-schema/network/smtp-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/smtp-element-network-settings.md
@@ -40,7 +40,7 @@ Configures the delivery format, delivery method, and from address for sending em
 |Attribute|Description|  
 |---------------|-----------------|  
 |`deliveryFormat`|Specifies the delivery format for outgoing emails. Acceptable values are SevenBit and International.|  
-|`deliveryMethod`|Specifies the delivery method for emails. Acceptable values are network, pickupDirectoryFromIis, and specifiedPickupDirectory.|  
+|`deliveryMethod`|Specifies the delivery method for emails. Acceptable values are Network, PickupDirectoryFromIis, and SpecifiedPickupDirectory.|  
 |`from`|Specifies the from address for outgoing emails.|  
   
 ### Child Elements  
@@ -63,7 +63,7 @@ Configures the delivery format, delivery method, and from address for sending em
 <configuration>  
   <system.net>  
     <mailSettings>  
-      <smtp deliveryMethod="network" deliveryFormat="SevenBit"  from="ben@contoso.com">  
+      <smtp deliveryMethod="Network" deliveryFormat="SevenBit"  from="ben@contoso.com">  
         <network  
           host="localhost"  
           port="25"  

--- a/docs/framework/configure-apps/file-schema/network/specifiedpickupdirectory-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/specifiedpickupdirectory-element-network-settings.md
@@ -57,7 +57,7 @@ Configures the local directory for a Simple Mail Transport Protocol (SMTP) serve
 <configuration>  
   <system.net>  
     <mailSettings>  
-      <smtp deliveryMethod="specifiedPickupDirectory">  
+      <smtp deliveryMethod="SpecifiedPickupDirectory">  
         <specifiedPickupDirectory  
           pickupDirectoryLocation="c:\maildrop"  
         />  


### PR DESCRIPTION
## Corrected casing of config attribute values

Fixes #6286 

//cc @davidsh @ite-klass

