### PR TITLE
Synchronize custom event accessor sample with larger sample

### DIFF
--- a/docs/csharp/programming-guide/events/codesnippet/CSharp/how-to-implement-interface-events_1.cs
+++ b/docs/csharp/programming-guide/events/codesnippet/CSharp/how-to-implement-interface-events_1.cs
@@ -1,3 +1,4 @@
+#region everything
 namespace WrapTwoInterfaceEvents
 {
     using System;
@@ -29,6 +30,7 @@ namespace WrapTwoInterfaceEvents
         // Explicit interface implementation required.
         // Associate IDrawingObject's event with
         // PreDrawEvent
+        #region IDrawingObjectOnDraw
         event EventHandler IDrawingObject.OnDraw
         {
             add
@@ -46,6 +48,8 @@ namespace WrapTwoInterfaceEvents
                 }
             }
         }
+        #endregion
+
         // Explicit interface implementation required.
         // Associate IShape's event with
         // PostDrawEvent
@@ -133,3 +137,4 @@ namespace WrapTwoInterfaceEvents
     Drawing a shape.
     Sub2 receives the IShape event.
 */
+#endregion

--- a/docs/csharp/programming-guide/events/how-to-implement-custom-event-accessors.md
+++ b/docs/csharp/programming-guide/events/how-to-implement-custom-event-accessors.md
@@ -15,25 +15,7 @@ An event is a special kind of multicast delegate that can only be invoked from w
 ## Example  
  The following example shows how to implement custom add and remove event accessors. Although you can substitute any code inside the accessors, we recommend that you lock the event before you add or remove a new event handler method.  
   
-```csharp
-event EventHandler IDrawingObject.OnDraw  
-{  
-    add  
-    {  
-        lock (PreDrawEvent)  
-        {  
-            PreDrawEvent += value;  
-        }  
-    }  
-    remove  
-    {  
-        lock (PreDrawEvent)  
-        {  
-            PreDrawEvent -= value;  
-        }  
-    }  
-}  
-```  
+[!code-csharp[IDrawingObject.OnDraw](codesnippet/CSharp/how-to-implement-interface-events_1.cs#IDrawingObjectOnDraw)]  
   
 ## See Also  
  [Events](../../../csharp/programming-guide/events/index.md)  

--- a/docs/csharp/programming-guide/events/how-to-implement-interface-events.md
+++ b/docs/csharp/programming-guide/events/how-to-implement-interface-events.md
@@ -9,47 +9,47 @@ ms.assetid: 63527447-9535-4880-8e95-35e2075827df
 # How to: Implement Interface Events (C# Programming Guide)
 An [interface](../../../csharp/language-reference/keywords/interface.md) can declare an [event](../../../csharp/language-reference/keywords/event.md). The following example shows how to implement interface events in a class. Basically the rules are the same as when you implement any interface method or property.  
   
-### To implement interface events in a class  
+## To implement interface events in a class  
   
--   Declare the event in your class and then invoke it in the appropriate areas.  
+Declare the event in your class and then invoke it in the appropriate areas.  
   
-    ```csharp
-    namespace ImplementInterfaceEvents  
+```csharp
+namespace ImplementInterfaceEvents  
+{  
+    public interface IDrawingObject  
     {  
-        public interface IDrawingObject  
-        {  
-            event EventHandler ShapeChanged;  
-        }  
-        public class MyEventArgs : EventArgs   
-        {  
-            // class members  
-        }  
-        public class Shape : IDrawingObject  
-        {  
-            public event EventHandler ShapeChanged;  
-            void ChangeShape()  
-            {  
-                // Do something here before the event…  
-  
-                OnShapeChanged(new MyEventArgs(/*arguments*/));  
-  
-                // or do something here after the event.   
-            }  
-            protected virtual void OnShapeChanged(MyEventArgs e)  
-            {  
-                ShapeChanged?.Invoke(this, e);  
-            }  
-        }  
-  
+        event EventHandler ShapeChanged;  
     }  
-    ```  
+    public class MyEventArgs : EventArgs   
+    {  
+        // class members  
+    }  
+    public class Shape : IDrawingObject  
+    {  
+        public event EventHandler ShapeChanged;  
+        void ChangeShape()  
+        {  
+            // Do something here before the event…  
+
+            OnShapeChanged(new MyEventArgs(/*arguments*/));  
+
+            // or do something here after the event.   
+        }  
+        protected virtual void OnShapeChanged(MyEventArgs e)  
+        {  
+            ShapeChanged?.Invoke(this, e);  
+        }  
+    }  
+
+}  
+```  
   
 ## Example  
 The following example shows how to handle the less-common situation in which your class inherits from two or more interfaces and each interface has an event with the same name. In this situation, you must provide an explicit interface implementation for at least one of the events. When you write an explicit interface implementation for an event, you must also write the `add` and `remove` event accessors. Normally these are provided by the compiler, but in this case the compiler cannot provide them.  
   
 By providing your own accessors, you can specify whether the two events are represented by the same event in your class, or by different events. For example, if the events should be raised at different times according to the interface specifications, you can associate each event with a separate implementation in your class. In the following example, subscribers determine which `OnDraw` event they will receive by casting the shape reference to either an `IShape` or an `IDrawingObject`.  
   
- [!code-csharp[csProgGuideEvents#10](../../../csharp/programming-guide/events/codesnippet/CSharp/how-to-implement-interface-events_1.cs)]  
+ [!code-csharp[WrapTwoInterfaceEvents](../../../csharp/programming-guide/events/codesnippet/CSharp/how-to-implement-interface-events_1.cs#everything)]
   
 ## See Also  
  [C# Programming Guide](../../../csharp/programming-guide/index.md)  


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/6188.

Also made small formatting changes to the article with the larger sample.

The code in `how-to-implement-custom-event-accessors.md` seems to come from the larger sample in `how-to-implement-interface-events.md`, but probably wasn't updated when the larger sample was fixed. This way, it's ensured that both articles stay in sync from now on.