### PR TITLE
C28837: Escaping link that should be shown as text to avoid broken content on localization.

### DIFF
--- a/docs/standard/serialization/web-services-generics-serialization-technology-sample.md
+++ b/docs/standard/serialization/web-services-generics-serialization-technology-sample.md
@@ -52,7 +52,7 @@ ms.assetid: cdc15ea4-f678-4729-8ebe-188ae720bef7
   
 1.  Open a browser window and select its address bar.  
   
-2.  Type **http://localhost/[virtual directory]/Service.asmx**, where [virtual directory] represents the virtual directory you created when you built the sample.  
+2.  Type `http://localhost/[virtual directory]/Service.asmx`, where `[virtual directory]` represents the virtual directory you created when you built the sample.  
   
 ## Remarks  
  The sample displays a default ASP.NET page that contains links to the definition of the Web Service. You can customize the display in addition to modifying the source code for the Web service. For more information, see [Building XML Web Service Clients](https://msdn.microsoft.com/library/c606f3cb-4111-45b4-ae42-9300420fa16c).  


### PR DESCRIPTION
Hello, @mairaw ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"URL and virtual directory at line 55 should be converted to code box to avoid being localized"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.

Many thanks in advance.