### PR TITLE
Doc bypassonlocal incompat with scriptlocation

### DIFF
--- a/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
@@ -61,7 +61,7 @@ Defines a proxy server.
   
  The value for the `proxyaddress` attribute should be a well-formed Uniform Resource Indicator (URI).  
   
- The `scriptLocation` attribute refers to the automatic detection of proxy configuration scripts. The <xref:System.Net.WebProxy> class will attempt to locate a configuration script (usually named Wpad.dat) when the **Use automatic configuration script** option is selected in Internet Explorer. If `bypassonlocal` is set to any value, `scriptLocation` will be ignored.
+ The `scriptLocation` attribute refers to the automatic detection of proxy configuration scripts. The <xref:System.Net.WebProxy> class will attempt to locate a configuration script (usually named Wpad.dat) when the **Use automatic configuration script** option is selected in Internet Explorer. If `bypassonlocal` is set to any value, `scriptLocation` is ignored.
   
  Use the `usesystemdefault` attribute for .NET Framework version 1.1 applications that are migrating to version 2.0.  
   

--- a/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
@@ -61,7 +61,7 @@ Defines a proxy server.
   
  The value for the `proxyaddress` attribute should be a well-formed Uniform Resource Indicator (URI).  
   
- The `scriptLocation` attribute refers to the automatic detection of proxy configuration scripts. The <xref:System.Net.WebProxy> class will attempt to locate a configuration script (usually named Wpad.dat) when the **Use automatic configuration script** option is selected in Internet Explorer.  
+ The `scriptLocation` attribute refers to the automatic detection of proxy configuration scripts. The <xref:System.Net.WebProxy> class will attempt to locate a configuration script (usually named Wpad.dat) when the **Use automatic configuration script** option is selected in Internet Explorer. If `bypassonlocal` is set to any value, `scriptLocation` will be ignored; do not use the `bypassonlocal` attribute **at all** if you want to use `scriptLocation`.
   
  Use the `usesystemdefault` attribute for .NET Framework version 1.1 applications that are migrating to version 2.0.  
   

--- a/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
+++ b/docs/framework/configure-apps/file-schema/network/proxy-element-network-settings.md
@@ -42,7 +42,7 @@ Defines a proxy server.
 |`autoDetect`|Specifies whether the proxy is automatically detected. The default value is `unspecified`.|  
 |`bypassonlocal`|Specifies whether the proxy is bypassed for local resources. Local resources include the local server (`http://localhost`, `http://loopback`, or `http://127.0.0.1`) and a URI without a period (`http://webserver`). The default value is `unspecified`.|  
 |`proxyaddress`|Specifies the proxy URI to use.|  
-|`scriptLocation`|Specifies the location of the configuration script.|  
+|`scriptLocation`|Specifies the location of the configuration script. Do not use the `bypassonlocal` attribute with this attribute. |  
 |`usesystemdefault`|Specifies whether to use Internet Explorer proxy settings. If set to `true`, subsequent attributes will override Internet Explorer proxy settings. The default value is `unspecified`.|  
   
 ### Child Elements  
@@ -61,7 +61,7 @@ Defines a proxy server.
   
  The value for the `proxyaddress` attribute should be a well-formed Uniform Resource Indicator (URI).  
   
- The `scriptLocation` attribute refers to the automatic detection of proxy configuration scripts. The <xref:System.Net.WebProxy> class will attempt to locate a configuration script (usually named Wpad.dat) when the **Use automatic configuration script** option is selected in Internet Explorer. If `bypassonlocal` is set to any value, `scriptLocation` will be ignored; do not use the `bypassonlocal` attribute **at all** if you want to use `scriptLocation`.
+ The `scriptLocation` attribute refers to the automatic detection of proxy configuration scripts. The <xref:System.Net.WebProxy> class will attempt to locate a configuration script (usually named Wpad.dat) when the **Use automatic configuration script** option is selected in Internet Explorer. If `bypassonlocal` is set to any value, `scriptLocation` will be ignored.
   
  Use the `usesystemdefault` attribute for .NET Framework version 1.1 applications that are migrating to version 2.0.  
   


### PR DESCRIPTION
## Summary

Added a note about how the `bypassonlocal` attribute kills the `scriptlocation` attribute.

Fixes #6112 
