### PR TITLE
Fix "whitespace" words - docs/fsharp

### DIFF
--- a/docs/fsharp/language-reference/strings.md
+++ b/docs/fsharp/language-reference/strings.md
@@ -36,7 +36,7 @@ let xmlFragment1 = @"<book author=""Milton, John"" title=""Paradise Lost"">"
 let xmlFragment2 = """<book author="Milton, John" title="Paradise Lost">"""
 ```
 
-In code, strings that have line breaks are accepted and the line breaks are interpreted literally as newlines, unless a backslash character is the last character before the line break. Leading whitespace on the next line is ignored when the backslash character is used. The following code produces a string `str1` that has value `"abc\ndef"` and a string `str2` that has value `"abcdef"`.
+In code, strings that have line breaks are accepted and the line breaks are interpreted literally as newlines, unless a backslash character is the last character before the line break. Leading white space on the next line is ignored when the backslash character is used. The following code produces a string `str1` that has value `"abc\ndef"` and a string `str2` that has value `"abcdef"`.
 
 [!code-fsharp[Main](../../../samples/snippets/fsharp/lang-ref-1/snippet1001.fs)]
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -15,7 +15,7 @@ These guidelines are based on [A comprehensive guide to F# Formatting Convention
 
 ## General rules for indentation
 
-F# uses significant whitespace by default. The following guidelines are intended to provide guidance as to how to juggle some challenges this can impose.
+F# uses significant white space by default. The following guidelines are intended to provide guidance as to how to juggle some challenges this can impose.
 
 ### Using spaces
 
@@ -547,9 +547,9 @@ let comparer =
               reversed.CompareTo (rev s2) }
 ```
 
-### Formatting whitespace in expressions
+### Formatting white space in expressions
 
-Avoid extraneous whitespace in F# expressions.
+Avoid extraneous white space in F# expressions.
 
 ```fsharp
 // OK


### PR DESCRIPTION
## Fix "whitespace" words - docs/fsharp

This PR came out from this [issue](https://github.com/dotnet/docs/issues/4439). It's all about docs/fsharp.

## Brief explanation
We should use **white-space** for adjectives and **white space** for nouns.

## Suggested Reviewers
@mairaw @rpetrusha @wstaelens 