### PR TITLE
Fix "whitespace" words - docs/visual-basic

### DIFF
--- a/docs/visual-basic/misc/run-time-messages.md
+++ b/docs/visual-basic/misc/run-time-messages.md
@@ -447,7 +447,7 @@ This section contains the Visual Basic error messages that occur at run time.
   
  [TargetFilePath specifies an existing folder](../../visual-basic/misc/targetfilepath-specifies-an-existing-folder.md)  
   
- [TextFieldParser does not support comment tokens that contain whitespace](../../visual-basic/misc/textfieldparser-does-not-support-comment-tokens-that-contain-whitespace.md)  
+ [TextFieldParser does not support comment tokens that contain white space](../../visual-basic/misc/textfieldparser-does-not-support-comment-tokens-that-contain-whitespace.md)  
   
  [TextFieldParser does not support delimiters that contain endline characters](../../visual-basic/misc/textfieldparser-does-not-support-delimiters-that-contain-endline-characters.md)  
   

--- a/docs/visual-basic/misc/textfieldparser-does-not-support-comment-tokens-that-contain-whitespace.md
+++ b/docs/visual-basic/misc/textfieldparser-does-not-support-comment-tokens-that-contain-whitespace.md
@@ -1,11 +1,11 @@
 ---
-title: "TextFieldParser does not support comment tokens that contain whitespace"
+title: "TextFieldParser does not support comment tokens that contain white space"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vbrTextFieldParser_WhitespaceInToken"
 ms.assetid: 55107656-270e-4bbb-841a-478904df8e07
 ---
-# TextFieldParser does not support comment tokens that contain whitespace
+# TextFieldParser does not support comment tokens that contain white space
 A comment token that contains white space has been supplied. The `TextFieldParser` does not support comment tokens that contain white space unless the white space occurs at the beginning of the token. White space occurring at the beginning of a token is ignored.  
   
 ## To correct this error  

--- a/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md
+++ b/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md
@@ -32,7 +32,7 @@ where:
 - *format-string* is a format string appropriate for the type of object being formatted. For example, for a <xref:System.DateTime> value, it could be a [standard date and time format string](~/docs/standard/base-types/standard-date-and-time-format-strings.md) such as "D" or "d".
 
 > [!IMPORTANT]
-> You cannot have any whitespace between the `$` and the `"` that starts the string. Doing so causes a compiler error.
+> You cannot have any white space between the `$` and the `"` that starts the string. Doing so causes a compiler error.
 
  You can use an interpolated string anywhere you can use a string literal.  The interpolated string is evaluated each time the code with the interpolated string executes. This allows you to separate the definition and evaluation of an interpolated string.  
   


### PR DESCRIPTION
## Fix "whitespace" words - docs/visual-basic

This PR came out from this [issue](https://github.com/dotnet/docs/issues/4439). It's all about docs/visual-basic.

## Brief explanation
We should use **white-space** for adjectives and **white space** for nouns.

## Suggested Reviewers
@mairaw @rpetrusha @wstaelens 