### PR TITLE
added Visual Basic to title metadata

### DIFF
--- a/docs/visual-basic/language-reference/data-types/object-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/object-data-type.md
@@ -1,5 +1,5 @@
 ---
-title: "Object Data Type"
+title: "Object Data Type (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Object"

--- a/docs/visual-basic/language-reference/data-types/uinteger-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/uinteger-data-type.md
@@ -1,5 +1,5 @@
 ---
-title: "UInteger Data Type"
+title: "UInteger Data Type (Visual Basic)"
 ms.date: 01/31/2018
 f1_keywords: 
   - "vb.uinteger"

--- a/docs/visual-basic/language-reference/data-types/user-defined-data-type.md
+++ b/docs/visual-basic/language-reference/data-types/user-defined-data-type.md
@@ -1,5 +1,5 @@
 ---
-title: "User-Defined Data Type"
+title: "User-Defined Data Type (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "UserDefined"

--- a/docs/visual-basic/language-reference/directives/const-directive.md
+++ b/docs/visual-basic/language-reference/directives/const-directive.md
@@ -1,5 +1,5 @@
 ---
-title: "#Const Directive"
+title: "#Const Directive (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.#Const"

--- a/docs/visual-basic/language-reference/directives/externalsource-directive.md
+++ b/docs/visual-basic/language-reference/directives/externalsource-directive.md
@@ -1,5 +1,5 @@
 ---
-title: "#ExternalSource Directive"
+title: "#ExternalSource Directive (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "#Externalsource"

--- a/docs/visual-basic/language-reference/directives/if-then-else-directives.md
+++ b/docs/visual-basic/language-reference/directives/if-then-else-directives.md
@@ -1,5 +1,5 @@
 ---
-title: "#If...Then...#Else Directives"
+title: "#If...Then...#Else Directives (Visual Basic)"
 ms.date: 04/11/2018
 f1_keywords: 
   - "vb.#EndIf"

--- a/docs/visual-basic/language-reference/directives/region-directive.md
+++ b/docs/visual-basic/language-reference/directives/region-directive.md
@@ -1,5 +1,5 @@
 ---
-title: "#Region Directive"
+title: "#Region Directive (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Region"

--- a/docs/visual-basic/language-reference/objects/my-application-info-object.md
+++ b/docs/visual-basic/language-reference/objects/my-application-info-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Application.Info Object"
+title: "My.Application.Info Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Application.Info object"

--- a/docs/visual-basic/language-reference/objects/my-application-log-object.md
+++ b/docs/visual-basic/language-reference/objects/my-application-log-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Application.Log Object"
+title: "My.Application.Log Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Application.Log object"

--- a/docs/visual-basic/language-reference/objects/my-application-object.md
+++ b/docs/visual-basic/language-reference/objects/my-application-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Application Object"
+title: "My.Application Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Application object"

--- a/docs/visual-basic/language-reference/objects/my-computer-audio-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-audio-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Audio Object"
+title: "My.Computer.Audio Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "Audio object"

--- a/docs/visual-basic/language-reference/objects/my-computer-clipboard-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-clipboard-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Clipboard Object"
+title: "My.Computer.Clipboard Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "Clipboard"

--- a/docs/visual-basic/language-reference/objects/my-computer-clock-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-clock-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Clock Object"
+title: "My.Computer.Clock Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.Clock object"

--- a/docs/visual-basic/language-reference/objects/my-computer-filesystem-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-filesystem-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.FileSystem Object"
+title: "My.Computer.FileSystem Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "FileSystem module"

--- a/docs/visual-basic/language-reference/objects/my-computer-filesystem-specialdirectories-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-filesystem-specialdirectories-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.FileSystem.SpecialDirectories Object"
+title: "My.Computer.FileSystem.SpecialDirectories Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.FileSystem.SpecialDirectories object"

--- a/docs/visual-basic/language-reference/objects/my-computer-info-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-info-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Info Object"
+title: "My.Computer.Info Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.Info object"

--- a/docs/visual-basic/language-reference/objects/my-computer-keyboard-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-keyboard-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Keyboard Object"
+title: "My.Computer.Keyboard Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.Keyboard object"

--- a/docs/visual-basic/language-reference/objects/my-computer-mouse-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-mouse-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Mouse Object"
+title: "My.Computer.Mouse Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.Mouse object"

--- a/docs/visual-basic/language-reference/objects/my-computer-network-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-network-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Network Object"
+title: "My.Computer.Network Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.Network object"

--- a/docs/visual-basic/language-reference/objects/my-computer-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer Object"
+title: "My.Computer Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer object"

--- a/docs/visual-basic/language-reference/objects/my-computer-ports-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-ports-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Ports Object"
+title: "My.Computer.Ports Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Computer.Ports object"

--- a/docs/visual-basic/language-reference/objects/my-computer-registry-object.md
+++ b/docs/visual-basic/language-reference/objects/my-computer-registry-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Computer.Registry Object"
+title: "My.Computer.Registry Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "DeleteSetting function [Visual Basic], increasing performance"

--- a/docs/visual-basic/language-reference/objects/my-forms-object.md
+++ b/docs/visual-basic/language-reference/objects/my-forms-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Forms Object"
+title: "My.Forms Object (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "My.Forms"

--- a/docs/visual-basic/language-reference/objects/my-log-object.md
+++ b/docs/visual-basic/language-reference/objects/my-log-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Log Object"
+title: "My.Log Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.Log object"

--- a/docs/visual-basic/language-reference/objects/my-request-object.md
+++ b/docs/visual-basic/language-reference/objects/my-request-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Request Object"
+title: "My.Request Object (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "My.MyWebExtension.Request"

--- a/docs/visual-basic/language-reference/objects/my-resources-object.md
+++ b/docs/visual-basic/language-reference/objects/my-resources-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Resources Object"
+title: "My.Resources Object (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "My.Resources"

--- a/docs/visual-basic/language-reference/objects/my-response-object.md
+++ b/docs/visual-basic/language-reference/objects/my-response-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Response Object"
+title: "My.Response Object (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "My.MyWebExtension.Response"

--- a/docs/visual-basic/language-reference/objects/my-settings-object.md
+++ b/docs/visual-basic/language-reference/objects/my-settings-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.Settings Object"
+title: "My.Settings Object (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "My.MySettingsProperty.Settings"

--- a/docs/visual-basic/language-reference/objects/my-user-object.md
+++ b/docs/visual-basic/language-reference/objects/my-user-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.User Object"
+title: "My.User Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "My.User property"

--- a/docs/visual-basic/language-reference/objects/my-webservices-object.md
+++ b/docs/visual-basic/language-reference/objects/my-webservices-object.md
@@ -1,5 +1,5 @@
 ---
-title: "My.WebServices Object"
+title: "My.WebServices Object (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "My.WebServices"

--- a/docs/visual-basic/language-reference/objects/textfieldparser-object.md
+++ b/docs/visual-basic/language-reference/objects/textfieldparser-object.md
@@ -1,5 +1,5 @@
 ---
-title: "TextFieldParser Object"
+title: "TextFieldParser Object (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "TextFieldParser object"

--- a/docs/visual-basic/language-reference/operators/integer-division-assignment-operator.md
+++ b/docs/visual-basic/language-reference/operators/integer-division-assignment-operator.md
@@ -1,5 +1,5 @@
 ---
-title: "\\= Operator"
+title: "\\= Operator (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "\\="

--- a/docs/visual-basic/language-reference/statements/a-e-statements.md
+++ b/docs/visual-basic/language-reference/statements/a-e-statements.md
@@ -1,5 +1,5 @@
 ---
-title: "A-E Statements"
+title: "A-E Statements (Visual Basic)"
 ms.date: 07/20/2015
 ms.assetid: af97c2bf-dddb-48a8-8eb6-798cd219430b
 ---

--- a/docs/visual-basic/language-reference/statements/addhandler-statement.md
+++ b/docs/visual-basic/language-reference/statements/addhandler-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "AddHandler Statement"
+title: "AddHandler Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.AddHandlerMethod"

--- a/docs/visual-basic/language-reference/statements/declare-statement.md
+++ b/docs/visual-basic/language-reference/statements/declare-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Declare Statement"
+title: "Declare Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Declare"

--- a/docs/visual-basic/language-reference/statements/delegate-statement.md
+++ b/docs/visual-basic/language-reference/statements/delegate-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Delegate Statement"
+title: "Delegate Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Delegate"

--- a/docs/visual-basic/language-reference/statements/end-statement.md
+++ b/docs/visual-basic/language-reference/statements/end-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "End Statement"
+title: "End Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.End"

--- a/docs/visual-basic/language-reference/statements/error-statement.md
+++ b/docs/visual-basic/language-reference/statements/error-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Error Statement"
+title: "Error Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.error"

--- a/docs/visual-basic/language-reference/statements/event-statement.md
+++ b/docs/visual-basic/language-reference/statements/event-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Event Statement"
+title: "Event Statement (Visual Basic)"
 ms.date: 05/12/2018
 f1_keywords: 
   - "vb.Event"

--- a/docs/visual-basic/language-reference/statements/f-p-statements.md
+++ b/docs/visual-basic/language-reference/statements/f-p-statements.md
@@ -1,5 +1,5 @@
 ---
-title: "F-P Statements"
+title: "F-P Statements (Visual Basic)"
 ms.date: 07/20/2015
 ms.assetid: cdce7ab0-c52e-4d33-a29b-bf32cdacc79f
 ---

--- a/docs/visual-basic/language-reference/statements/get-statement.md
+++ b/docs/visual-basic/language-reference/statements/get-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Get Statement"
+title: "Get Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Get"

--- a/docs/visual-basic/language-reference/statements/goto-statement.md
+++ b/docs/visual-basic/language-reference/statements/goto-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "GoTo Statement"
+title: "GoTo Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.GoTo"

--- a/docs/visual-basic/language-reference/statements/implements-statement.md
+++ b/docs/visual-basic/language-reference/statements/implements-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Implements Statement"
+title: "Implements Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Implements"

--- a/docs/visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md
+++ b/docs/visual-basic/language-reference/statements/imports-statement-net-namespace-and-type.md
@@ -1,5 +1,5 @@
 ---
-title: "Imports Statement (.NET Namespace and Type)"
+title: "Imports Statement - .NET Namespace and Type (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Imports"

--- a/docs/visual-basic/language-reference/statements/imports-statement-xml-namespace.md
+++ b/docs/visual-basic/language-reference/statements/imports-statement-xml-namespace.md
@@ -1,5 +1,5 @@
 ---
-title: "Imports Statement (XML Namespace)"
+title: "Imports Statement - XML Namespace (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.ImportsXmlns"

--- a/docs/visual-basic/language-reference/statements/inherits-statement.md
+++ b/docs/visual-basic/language-reference/statements/inherits-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Inherits Statement"
+title: "Inherits Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Inherits"

--- a/docs/visual-basic/language-reference/statements/mid-statement.md
+++ b/docs/visual-basic/language-reference/statements/mid-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Mid Statement"
+title: "Mid Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.MidB"

--- a/docs/visual-basic/language-reference/statements/module-statement.md
+++ b/docs/visual-basic/language-reference/statements/module-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Module Statement"
+title: "Module Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "Module"

--- a/docs/visual-basic/language-reference/statements/namespace-statement.md
+++ b/docs/visual-basic/language-reference/statements/namespace-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Namespace Statement"
+title: "Namespace Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Namespace"

--- a/docs/visual-basic/language-reference/statements/operator-statement.md
+++ b/docs/visual-basic/language-reference/statements/operator-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Operator Statement"
+title: "Operator Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.operator"

--- a/docs/visual-basic/language-reference/statements/option-compare-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-compare-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Option Compare Statement"
+title: "Option Compare Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Compare"

--- a/docs/visual-basic/language-reference/statements/option-infer-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-infer-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Option Infer Statement"
+title: "Option Infer Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.OptionInfer"

--- a/docs/visual-basic/language-reference/statements/option-keyword-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-keyword-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Option &lt;keyword&gt; Statement"
+title: "Option &lt;keyword&gt; Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.option"

--- a/docs/visual-basic/language-reference/statements/option-strict-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-strict-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Option Strict Statement"
+title: "Option Strict Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Strict"

--- a/docs/visual-basic/language-reference/statements/property-statement.md
+++ b/docs/visual-basic/language-reference/statements/property-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Property Statement"
+title: "Property Statement (Visual Basic)"
 ms.date: 05/12/2018
 f1_keywords: 
   - "vb.PropertySet"

--- a/docs/visual-basic/language-reference/statements/q-z-statements.md
+++ b/docs/visual-basic/language-reference/statements/q-z-statements.md
@@ -1,5 +1,5 @@
 ---
-title: "Q-Z Statements"
+title: "Q-Z Statements (Visual Basic)"
 ms.date: 07/20/2015
 ms.assetid: 32a9e547-c1b7-40f2-8118-7eef1d19649e
 ---

--- a/docs/visual-basic/language-reference/statements/raiseevent-statement.md
+++ b/docs/visual-basic/language-reference/statements/raiseevent-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "RaiseEvent Statement"
+title: "RaiseEvent Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.RaiseEventMethod"

--- a/docs/visual-basic/language-reference/statements/removehandler-statement.md
+++ b/docs/visual-basic/language-reference/statements/removehandler-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "RemoveHandler Statement"
+title: "RemoveHandler Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.RemoveHandlerMethod"

--- a/docs/visual-basic/language-reference/statements/resume-statement.md
+++ b/docs/visual-basic/language-reference/statements/resume-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Resume Statement"
+title: "Resume Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.Resume"

--- a/docs/visual-basic/language-reference/statements/structure-statement.md
+++ b/docs/visual-basic/language-reference/statements/structure-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Structure Statement"
+title: "Structure Statement (Visual Basic)"
 ms.date: 05/12/2018
 f1_keywords: 
   - "vb.Structure"

--- a/docs/visual-basic/language-reference/statements/synclock-statement.md
+++ b/docs/visual-basic/language-reference/statements/synclock-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "SyncLock Statement"
+title: "SyncLock Statement (Visual Basic)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "vb.SyncLock"

--- a/docs/visual-basic/language-reference/statements/then-statement.md
+++ b/docs/visual-basic/language-reference/statements/then-statement.md
@@ -1,5 +1,5 @@
 ---
-title: "Then Statement"
+title: "Then Statement (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "Then keyword [Visual Basic]"


### PR DESCRIPTION
The VBA issue this week reminded me that I've been wanting to complement the title metadata of this VB section of the docs. 

The [GoTo statement](https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/goto-statement) topic gets tons of page views but top keywords from Google and Bing indicate that people were actually looking for the VBA topic. I've already added VBA to the [GoTo statement topic of the VBA reference](https://msdn.microsoft.com/en-us/vba/language-reference-vba/articles/goto-statement) and that article is now ranked better, but we also needed to better indicate that these docs are for Visual Basic.