### PR TITLE
fix wrong link

### DIFF
--- a/docs/standard/design-guidelines/usage-guidelines.md
+++ b/docs/standard/design-guidelines/usage-guidelines.md
@@ -1,5 +1,5 @@
 ---
-title: "Usage Guidelines"
+title: "Usage guidelines"
 ms.date: "03/30/2017"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
@@ -8,24 +8,28 @@ ms.assetid: 42215ffa-a099-4a26-b14e-fb2bdb6f95b7
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Usage Guidelines
-This section contains guidelines for using common types in publicly accessible APIs. It deals with direct usage of built-in Framework types (e.g., serialization attributes) and overloading common operators.  
+# Usage guidelines
+
+This section contains guidelines for using common types in publicly accessible APIs. It deals with direct usage of built-in Framework types (e.g., serialization attributes) and overloading common operators.
   
- The <xref:System.IDisposable?displayProperty=nameWithType> interface is not covered in this section, but is discussed in the [Dispose Pattern](../../../docs/standard/design-guidelines/dispose-pattern.md) section.  
-  
+The <xref:System.IDisposable?displayProperty=nameWithType> interface is not covered in this section, but is discussed in the [Dispose Pattern](../../../docs/standard/design-guidelines/dispose-pattern.md) section.
+
 > [!NOTE]
->  For guidelines and additional information about about other common, built-in .NET Framework types, see the reference topics for the following: <xref:System.DateTime?displayProperty=nameWithType>, <xref:System.DateTimeOffset?displayProperty=nameWithType>, <xref:System.ICloneable?displayProperty=nameWithType>, <xref:System.IComparable%601?displayProperty=nameWithType>, <xref:System.IEquatable%601?displayProperty=nameWithType>, <xref:System.Nullable%601?displayProperty=nameWithType>, <xref:System.Object?displayProperty=nameWithType>, <xref:System.Uri?displayProperty=nameWithType>.  
+> For guidelines and additional information about about other common, built-in .NET Framework types, see the reference topics for the following: <xref:System.DateTime?displayProperty=nameWithType>, <xref:System.DateTimeOffset?displayProperty=nameWithType>, <xref:System.ICloneable?displayProperty=nameWithType>, <xref:System.IComparable%601?displayProperty=nameWithType>, <xref:System.IEquatable%601?displayProperty=nameWithType>, <xref:System.Nullable%601?displayProperty=nameWithType>, <xref:System.Object?displayProperty=nameWithType>, <xref:System.Uri?displayProperty=nameWithType>.
+
+## In this section
+
+[Arrays](arrays.md)  
+[Attributes](attributes.md)  
+[Collections](collections.md)  
+[Serialization](serialization.md)  
+[System.Xml Usage](system-xml-usage.md)  
+[Equality Operators](equality-operators.md)  
+
+*Portions © 2005, 2009 Microsoft Corporation. All rights reserved.*
+
+*Reprinted by permission of Pearson Education, Inc. from [Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries, 2nd Edition](https://www.informit.com/store/framework-design-guidelines-conventions-idioms-and-9780321545619) by Krzysztof Cwalina and Brad Abrams, published Oct 22, 2008 by Addison-Wesley Professional as part of the Microsoft Windows Development Series.*
   
-## In This Section  
- [Arrays](../../../docs/standard/design-guidelines/arrays.md)  
- [Attributes](../../../docs/standard/design-guidelines/attributes.md)  
- [Collections](/cpp/mfc/collections)  
- [Serialization](../../../docs/standard/design-guidelines/serialization.md)  
- [System.Xml Usage](../../../docs/standard/design-guidelines/system-xml-usage.md)  
- [Equality Operators](../../../docs/standard/design-guidelines/equality-operators.md)  
- *Portions © 2005, 2009 Microsoft Corporation. All rights reserved.*  
-  
- *Reprinted by permission of Pearson Education, Inc. from [Framework Design Guidelines: Conventions, Idioms, and Patterns for Reusable .NET Libraries, 2nd Edition](https://www.informit.com/store/framework-design-guidelines-conventions-idioms-and-9780321545619) by Krzysztof Cwalina and Brad Abrams, published Oct 22, 2008 by Addison-Wesley Professional as part of the Microsoft Windows Development Series.*  
-  
-## See Also  
- [Framework Design Guidelines](../../../docs/standard/design-guidelines/index.md)
+## See also
+
+[Framework Design Guidelines](../../../docs/standard/design-guidelines/index.md)

--- a/docs/standard/design-guidelines/usage-guidelines.md
+++ b/docs/standard/design-guidelines/usage-guidelines.md
@@ -21,7 +21,7 @@ The <xref:System.IDisposable?displayProperty=nameWithType> interface is not cove
 
 [Arrays](arrays.md)  
 [Attributes](attributes.md)  
-[Collections](collections.md)  
+[Collections](guidelines-for-collections.md)  
 [Serialization](serialization.md)  
 [System.Xml Usage](system-xml-usage.md)  
 [Equality Operators](equality-operators.md)  


### PR DESCRIPTION
Fixes #6400 

[Hide whitespace changes](https://github.com/dotnet/docs/pull/6433/files?utf8=%E2%9C%93&diff=split&w=1) for easier diff