### PR TITLE
Mention how to achieve two-way binding

### DIFF
--- a/docs/framework/wpf/advanced/templatebinding-markup-extension.md
+++ b/docs/framework/wpf/advanced/templatebinding-markup-extension.md
@@ -32,7 +32,8 @@ Links the value of a property in a control template to be the value of another p
 |`sourceProperty`|Another dependency property that exists on the type being templated, specified by its <xref:System.Windows.DependencyProperty.Name%2A?displayProperty=nameWithType>.<br /><br /> - or -<br /><br /> A "dotted-down" property name that is defined by a different type than the target type being templated. This is actually a <xref:System.Windows.PropertyPath>. See [PropertyPath XAML Syntax](../../../../docs/framework/wpf/advanced/propertypath-xaml-syntax.md).|  
   
 ## Remarks  
- A `TemplateBinding` is an optimized form of a [Binding](../../../../docs/framework/wpf/advanced/binding-markup-extension.md) for template scenarios, analogous to a `Binding` constructed with `{Binding RelativeSource={RelativeSource TemplatedParent}}`. A `TemplateBinding` is always a one-way binding, even if properties involved default to two-way binding. Both properties involved must be dependency properties.  
+ A `TemplateBinding` is an optimized form of a [Binding](../../../../docs/framework/wpf/advanced/binding-markup-extension.md) for template scenarios, analogous to a `Binding` constructed with `{Binding RelativeSource={RelativeSource TemplatedParent}}`. A `TemplateBinding` is always a one-way binding, even if properties involved default to two-way binding. Both properties involved must be dependency properties. In order to achieve two-way binding to a templated parent use the following binding statement instead 
+`{Binding RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Path=MyDependencyProperty}`. 
   
  [RelativeSource](../../../../docs/framework/wpf/advanced/relativesource-markupextension.md) is another markup extension that is sometimes used in conjunction with or instead of `TemplateBinding` in order to perform relative property binding within a template.  
   


### PR DESCRIPTION
After reading [this question on StackOverflow](https://stackoverflow.com/questions/5913176/in-wpf-why-doesnt-templatebinding-work-where-binding-does) I think it should be noted in the Remarks section what is necessary to get two-way binding to work with a template binding. Right now the Remarks section only tell us that "A TemplateBinding is always a one-way binding..." which suggest that it is not possible to make a two-way binding to a templated parent.

## Summary

I have added en example of how to achieve two-way binding to a templated-parent in the Remarks section.