### PR TITLE
Introduce net-standard-table more accurately

### DIFF
--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -21,7 +21,7 @@ The various .NET implementations target specific versions of .NET Standard. Each
 
 ## .NET implementation support
 
-The following table lists all versions of .NET Standard and the platforms supported:
+The following table lists the minimum platform versions that support each .NET Standard version.
 
 [!INCLUDE [net-standard-table](~/includes/net-standard-table.md)]
 


### PR DESCRIPTION
## Summary

It was realised that some people not only miss the bullet points below the net-standard-table, but that the table was inaccurately introduced. Making the introduction to the table more verbose by pre-emptively projecting the purpose of the table to the reader and anticipating their confusion with missing data will help align their thoughts more clearly and free them to interpret the table using their own method or the guides below the table.

Fixes #6022
