### PR TITLE
Improved article about non-CLS exceptions

### DIFF
--- a/docs/csharp/programming-guide/exceptions/how-to-catch-a-non-cls-exception.md
+++ b/docs/csharp/programming-guide/exceptions/how-to-catch-a-non-cls-exception.md
@@ -6,52 +6,41 @@ helpviewer_keywords:
 ms.assetid: db4630b3-5240-471a-b3a7-c7ff6ab31e8d
 ---
 # How to: Catch a non-CLS Exception
-Some .NET languages, including C++/CLI, allow objects to throw exceptions that do not derive from <xref:System.Exception>. Such exceptions are called *non-CLS exceptions* or *non-Exceptions*. In Visual C# you cannot throw non-CLS exceptions, but you can catch them in two ways:  
+Some .NET languages, including C++/CLI, allow objects to throw exceptions that do not derive from <xref:System.Exception>. Such exceptions are called *non-CLS exceptions* or *non-Exceptions*. In C# you cannot throw non-CLS exceptions, but you can catch them in two ways:  
   
--   Within a `catch (Exception e)` block as a <xref:System.Runtime.CompilerServices.RuntimeWrappedException>.  
+-   Within a `catch (RuntimeWrappedException e)` block.
   
      By default, a Visual C# assembly catches non-CLS exceptions as wrapped exceptions. Use this method if you need access to the original exception, which can be accessed through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property. The procedure later in this topic explains how to catch exceptions in this manner.  
   
--   Within a general catch block (a catch block without an exception type specified) that is put after a `catch (Exception)` or `catch (Exception e)` block.  
+-   Within a general catch block (a catch block without an exception type specified) that is put after all other `catch` blocks.
   
      Use this method when you want to perform some action (such as writing to a log file) in response to non-CLS exceptions, and you do not need access to the exception information. By default the common language runtime wraps all exceptions. To disable this behavior, add this assembly-level attribute to your code, typically in the AssemblyInfo.cs file: `[assembly: RuntimeCompatibilityAttribute(WrapNonExceptionThrows = false)]`.  
   
 ### To catch a non-CLS exception  
   
-1.  Within a `catch(Exception e) block`, use the `as` keyword to test whether `e` can be cast to a <xref:System.Runtime.CompilerServices.RuntimeWrappedException>.  
-  
-2.  Access the original exception through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property.  
+Within a `catch(RuntimeWrappedException e)` block, access the original exception through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property.  
   
 ## Example  
- The following example shows how to catch a non-CLS exception that was thrown from a class library written in C++/CLR. Note that in this example, the Visual C# client code knows in advance that the exception type being thrown is a <xref:System.String?displayProperty=nameWithType>. You can cast the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property back its original type as long as that type is accessible from your code.  
+ The following example shows how to catch a non-CLS exception that was thrown from a class library written in C++/CLI. Note that in this example, the C# client code knows in advance that the exception type being thrown is a <xref:System.String?displayProperty=nameWithType>. You can cast the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property back its original type as long as that type is accessible from your code.  
   
-```  
-// Class library written in C++/CLR.  
-   ThrowNonCLS.Class1 myClass = new ThrowNonCLS.Class1();  
-  
-   try  
-   {  
+```csharp
+// Class library written in C++/CLI.
+var myClass = new ThrowNonCLS.Class1();
+
+try
+{
     // throws gcnew System::String(  
     // "I do not derive from System.Exception!");  
-    myClass.TestThrow();   
-   }  
-  
-   catch (Exception e)  
-   {  
-    RuntimeWrappedException rwe = e as RuntimeWrappedException;  
-    if (rwe != null)      
-    {  
-      String s = rwe.WrappedException as String;  
-      if (s != null)  
-      {  
-        Console.WriteLine(s);  
-      }  
-    }  
-    else  
-    {  
-       // Handle other System.Exception types.  
-    }  
-   }             
+    myClass.TestThrow();
+}
+catch (RuntimeWrappedException e)
+{
+    String s = e.WrappedException as String;
+    if (s != null)
+    {
+        Console.WriteLine(s);
+    }
+}
 ```  
   
 ## See Also  

--- a/docs/csharp/programming-guide/exceptions/how-to-catch-a-non-cls-exception.md
+++ b/docs/csharp/programming-guide/exceptions/how-to-catch-a-non-cls-exception.md
@@ -10,7 +10,7 @@ Some .NET languages, including C++/CLI, allow objects to throw exceptions that d
   
 -   Within a `catch (RuntimeWrappedException e)` block.
   
-     By default, a Visual C# assembly catches non-CLS exceptions as wrapped exceptions. Use this method if you need access to the original exception, which can be accessed through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property. The procedure later in this topic explains how to catch exceptions in this manner.  
+     By default, a Visual C# assembly catches non-CLS exceptions as wrapped exceptions. Use this method if you need access to the original exception, which can be accessed through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A?displayProperty=nameWithType> property. The procedure later in this topic explains how to catch exceptions in this manner.  
   
 -   Within a general catch block (a catch block without an exception type specified) that is put after all other `catch` blocks.
   
@@ -18,10 +18,10 @@ Some .NET languages, including C++/CLI, allow objects to throw exceptions that d
   
 ### To catch a non-CLS exception  
   
-Within a `catch(RuntimeWrappedException e)` block, access the original exception through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property.  
+Within a `catch(RuntimeWrappedException e)` block, access the original exception through the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A?displayProperty=nameWithType> property.  
   
 ## Example  
- The following example shows how to catch a non-CLS exception that was thrown from a class library written in C++/CLI. Note that in this example, the C# client code knows in advance that the exception type being thrown is a <xref:System.String?displayProperty=nameWithType>. You can cast the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A> property back its original type as long as that type is accessible from your code.  
+ The following example shows how to catch a non-CLS exception that was thrown from a class library written in C++/CLI. Note that in this example, the C# client code knows in advance that the exception type being thrown is a <xref:System.String?displayProperty=nameWithType>. You can cast the <xref:System.Runtime.CompilerServices.RuntimeWrappedException.WrappedException%2A?displayProperty=nameWithType> property back its original type as long as that type is accessible from your code.  
   
 ```csharp
 // Class library written in C++/CLI.


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/6446.

Changes I made:

* Instead of using `catch (Exception ex)` and then testing for `RuntimeWrappedException`, just use `catch (RuntimeWrappedException e)`. It's simpler and I don't see any reason not to do it this way.
* Visual C# → C#.
* C++/CLR → C++/CLI.
* Improved formatting and enabled syntax highlighting.