### PR TITLE
Corrected exception handling

### DIFF
--- a/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/using-exceptions_3.cs
+++ b/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/using-exceptions_3.cs
@@ -1,32 +1,32 @@
-        using System;
-        using System.IO;
+using System;
+using System.IO;
 
-        public class ExceptionExample
+public class ExceptionExample
+{
+    static void Main()
+    {
+        try
         {
-            static void Main()
+            using (var sw = new StreamWriter(@"C:\test\test.txt"))
             {
-                try
-                {
-                    using(var sw = new StreamWriter(@"C:\test\test.txt"))
-                    {
-                       sw.WriteLine("Hello");
-                    }   
-                }
-                // Put the more specific exceptions first.
-                catch (DirectoryNotFoundException ex)
-                {
-                    System.Console.WriteLine(ex.ToString());  
-                }
-                catch (FileNotFoundException ex)
-                {
-                    System.Console.WriteLine(ex.ToString());  
-                }
-                // Put the least specific exception last.
-                catch (IOException ex)
-                {
-                    System.Console.WriteLine(ex.ToString());  
-                }
-
-                Console.WriteLine("Done"); 
-            }
+                sw.WriteLine("Hello");
+            }   
         }
+        // Put the more specific exceptions first.
+        catch (DirectoryNotFoundException ex)
+        {
+            Console.WriteLine(ex);  
+        }
+        catch (FileNotFoundException ex)
+        {
+            Console.WriteLine(ex);  
+        }
+        // Put the least specific exception last.
+        catch (IOException ex)
+        {
+            Console.WriteLine(ex);  
+        }
+
+        Console.WriteLine("Done"); 
+    }
+}

--- a/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/using-exceptions_3.cs
+++ b/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/using-exceptions_3.cs
@@ -1,27 +1,32 @@
-        static void TestCatch2()
+        using System;
+        using System.IO;
+
+        public class ExceptionExample
         {
-            System.IO.StreamWriter sw = null;
-            try
+            static void Main()
             {
-                sw = new System.IO.StreamWriter(@"C:\test\test.txt");
-                sw.WriteLine("Hello");
-            }
+                try
+                {
+                    using(var sw = new StreamWriter(@"C:\test\test.txt"))
+                    {
+                    sw.WriteLine("Hello");
+                    }   
+                }
+                // Put the more specific exceptions first.
+                catch (DirectoryNotFoundException ex)
+                {
+                    System.Console.WriteLine(ex.ToString());  
+                }
+                catch (FileNotFoundException ex)
+                {
+                    System.Console.WriteLine(ex.ToString());  
+                }
+                // Put the least specific exception last.
+                catch (IOException ex)
+                {
+                    System.Console.WriteLine(ex.ToString());  
+                }
 
-            catch (System.IO.FileNotFoundException ex)
-            {
-                // Put the more specific exception first.
-                System.Console.WriteLine(ex.ToString());  
+                Console.WriteLine("Done"); 
             }
-
-            catch (System.IO.IOException ex)
-            {
-                // Put the less specific exception last.
-                System.Console.WriteLine(ex.ToString());  
-            }
-            finally 
-            {
-                sw.Close();
-            }
-
-            System.Console.WriteLine("Done"); 
         }

--- a/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/using-exceptions_3.cs
+++ b/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/using-exceptions_3.cs
@@ -9,7 +9,7 @@
                 {
                     using(var sw = new StreamWriter(@"C:\test\test.txt"))
                     {
-                    sw.WriteLine("Hello");
+                       sw.WriteLine("Hello");
                     }   
                 }
                 // Put the more specific exceptions first.


### PR DESCRIPTION
## Corrected exception handling

There are two problems with the original code:
- It throws a NullReferenceException if the StreamWriter cannot be instantiated because the file c://test/test.txt does not exist.
- It handles a FileNotFoundException but not a DirectoryNotFoundException. Either can be thrown.

I've wrapped the StreamWriter in a `using` statement and handled DirectoryNotFoundException.

Fixes #6442
