### PR TITLE
Fix missing <T> in sub header on async-in-depth.md

### DIFF
--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -108,7 +108,7 @@ More importantly, because I/O-bound work spends virtually no time on the CPU, de
 
 Additionally, dispatching work to the UI thread (such as updating a UI) is very simple with `async` methods, and does not require extra work (such as calling a thread-safe delegate).
 
-## Deeper Dive into Task and Task<T> for a CPU-Bound Operation
+## Deeper Dive into Task and Task&lt;T&gt; for a CPU-Bound Operation
 
 CPU-bound `async` code is a bit different than I/O-bound `async` code.  Because the work is done on the CPU, there's no way to get around dedicating a thread to the computation.  The use of `async` and `await` provides you with a clean way to interact with a background thread and keep the caller of the async method responsive.  Note that this does not provide any protection for shared data.  If you are using shared data, you will still need to apply an appropriate synchronization strategy.
 


### PR DESCRIPTION
## Summary

Describe your changes here.
Change <T> to html escaped syntax to avoid having it removed during build.

Fixes #Issue_Number (if available)
