### PR TITLE
CC65340: Escaping "\D" at line 165

### DIFF
--- a/docs/standard/base-types/grouping-constructs-in-regular-expressions.md
+++ b/docs/standard/base-types/grouping-constructs-in-regular-expressions.md
@@ -162,7 +162,7 @@ Grouping constructs delineate the subexpressions of a regular expression and cap
 |-------------|-----------------|  
 |`\D+`|Match one or more non-decimal digit characters.|  
 |`(?<digit>\d+)`|Match one or more decimal digit characters. Assign the match to the `digit` named group.|  
-|\D+|Match one or more non-decimal digit characters.|  
+|`\D+`|Match one or more non-decimal digit characters.|  
 |`(?<digit>\d+)?`|Match zero or one occurrence of one or more decimal digit characters. Assign the match to the `digit` named group.|  
   
 <a name="balancing_group_definition"></a>   


### PR DESCRIPTION
Hello, @rpetrusha ,
This proposed file change comes from https://github.com/dotnet/docs.zh-tw/pull/181.
Could you review this contribution and help to merge if agreed?
Many thanks in advance.