### PR TITLE
Added sample code to read attributes for C# tour

### DIFF
--- a/docs/csharp/tour-of-csharp/attributes.md
+++ b/docs/csharp/tour-of-csharp/attributes.md
@@ -19,7 +19,11 @@ All attribute classes derive from the <xref:System.Attribute> base class provide
 
 This example attaches a `HelpAttribute` to the `Widget` class. It adds another `HelpAttribute` to the `Display` method in the class. The public constructors of an attribute class control the information that must be provided when the attribute is attached to a program entity. Additional information can be provided by referencing public read-write properties of the attribute class (such as the reference to the `Topic` property previously).
 
-When a particular attribute is requested through reflection, the constructor for the attribute class is invoked with the information provided in the program source, and the resulting attribute instance is returned. If additional information was provided through properties, those properties are set to the given values before the attribute instance is returned.
+The metadata defined by attributes can be read and manipulated at runtime using reflection. When a particular attribute is requested using this technique, the constructor for the attribute class is invoked with the information provided in the program source, and the resulting attribute instance is returned. If additional information was provided through properties, those properties are set to the given values before the attribute instance is returned.
+
+The following code sample demonstrates how to get the `HelpAttribute` instances associated to the `Widget` class and its `Display` method.
+
+[!code-csharp[AttributeRead](../../../samples/snippets/csharp/tour/attributes/Program.cs#L34-L54)]
 
 >[!div class="step-by-step"]
 [Previous](delegates.md)

--- a/docs/csharp/tour-of-csharp/attributes.md
+++ b/docs/csharp/tour-of-csharp/attributes.md
@@ -23,7 +23,7 @@ The metadata defined by attributes can be read and manipulated at runtime using 
 
 The following code sample demonstrates how to get the `HelpAttribute` instances associated to the `Widget` class and its `Display` method.
 
-[!code-csharp[AttributeRead](../../../samples/snippets/csharp/tour/attributes/Program.cs#L34-L54)]
+[!code-csharp[AttributeRead](../../../samples/snippets/csharp/tour/attributes/Program.cs#ReadAttributes)]
 
 >[!div class="step-by-step"]
 [Previous](delegates.md)


### PR DESCRIPTION
This PR adds a snippet to demonstrate how to read attributes with C# at [C# Attributes - A tour of the C# language](https://docs.microsoft.com/en-us/dotnet/csharp/tour-of-csharp/attributes)

Fixes #5424 

Related PR in dotnet/samples : dotnet/samples#186

