### PR TITLE
The -main compiler switch accepts a fully qualified class name as a parameter

### DIFF
--- a/docs/csharp/language-reference/compiler-options/main-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/main-compiler-option.md
@@ -21,6 +21,7 @@ This option specifies the class that contains the entry point to the program, if
 ## Arguments  
  `class`  
  The type that contains the **Main** method.  
+ The provided class name must be fully qualified : it must include the full namespace containing the class, followed by the class name. For example, when the `Main` method is located inside the `Program` class in the `MyApplication.Core` namespace, the compiler option has to be `-main:MyApplication.Core.Program`.
   
 ## Remarks  
  If your compilation includes more than one type with a [Main](../../../csharp/programming-guide/main-and-command-args/index.md) method, you can specify which type contains the **Main** method that you want to use as the entry point into the program.  

--- a/docs/csharp/language-reference/compiler-options/main-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/main-compiler-option.md
@@ -21,7 +21,7 @@ This option specifies the class that contains the entry point to the program, if
 ## Arguments  
  `class`  
  The type that contains the **Main** method.  
- The provided class name must be fully qualified : it must include the full namespace containing the class, followed by the class name. For example, when the `Main` method is located inside the `Program` class in the `MyApplication.Core` namespace, the compiler option has to be `-main:MyApplication.Core.Program`.
+ The provided class name must be fully qualified; it must include the full namespace containing the class, followed by the class name. For example, when the `Main` method is located inside the `Program` class in the `MyApplication.Core` namespace, the compiler option has to be `-main:MyApplication.Core.Program`.
   
 ## Remarks  
  If your compilation includes more than one type with a [Main](../../../csharp/programming-guide/main-and-command-args/index.md) method, you can specify which type contains the **Main** method that you want to use as the entry point into the program.  


### PR DESCRIPTION
This PR adds a little explanation regarding the `class` parameter of the `-main` C# compiler switch

Fixes #5691
