### PR TITLE
Clarified VS version support

### DIFF
--- a/docs/csharp/language-reference/compiler-options/nostdlib-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/nostdlib-compiler-option.md
@@ -23,7 +23,7 @@ ms.assetid: ec197989-fa49-4725-a455-e06b551eb65f
   
  If you do not specify **-nostdlib**, mscorlib.dll will be imported into your program (same as specifying **-nostdlib-**). Specifying **-nostdlib** is the same as specifying **-nostdlib+**.  
   
-### To set this compiler option in the Visual Studio development environment  
+### To set this compiler option in the Visual Studio development environment (**Visual Studio 2015 and earlier versions only**) 
   
 1.  Open the **Properties** page for the project.  
   


### PR DESCRIPTION
This compiler option can only be set within Visual Studio 2015 and earlier, so I added some clarifying language.

Fixes #6500 

[Internal Review URL](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/nostdlib-compiler-option?branch=pr-en-us-6514)