### PR TITLE
Fixing typos on /docs/docs/framework/wcf/feature-details/bindings.md …

### DIFF
--- a/docs/framework/wcf/feature-details/bindings.md
+++ b/docs/framework/wcf/feature-details/bindings.md
@@ -7,7 +7,7 @@ helpviewer_keywords:
   - "bindings [WCF]"
 ms.assetid: 83639133-89f7-43f0-b4ef-8d9e57c08d25
 ---
-# Windows Communcation Foundation Bindings
+# Windows Communication Foundation Bindings
 Windows Communication Foundation (WCF) separates how the software for an application is written from how it communicates with other software. Bindings are used to specify the transport, encoding, and protocol details required for clients and services to communicate with each other. WCF uses bindings to generate the underlying wire representation of the endpoint, so most of the binding details must be agreed upon by the parties that are communicating. The easiest way to achieve this is for clients of a service to use the same binding that the endpoint for the service uses. For more information about how to do this, see [Using Bindings to Configure Windows Communication Foundation Services and Clients](http://msdn.microsoft.com/library/bd8b277b-932f-472f-a42a-b02bb5257dfb).  
   
  A binding is made up of a collection of binding elements. Each element describes some aspect of how the endpoint communicates with clients. A binding must include at least one transport binding element, at least one message-encoding binding element (which the transport binding element can provide by default), and any number of other protocol binding elements. The process that builds a runtime out of this description allows each binding element to contribute code to that runtime.  


### PR DESCRIPTION
/docs/docs/framework/wcf/feature-details/bindings.md

## Summary

There was a typo on the binding file. Changed word from Communcation to Communication
