### PR TITLE
Update camelCase capitalization for username

### DIFF
--- a/docs/standard/design-guidelines/capitalization-conventions.md
+++ b/docs/standard/design-guidelines/capitalization-conventions.md
@@ -86,7 +86,7 @@ The guidelines in this chapter lay out a simple method for using case that, when
 |`Placeholder`|`placeholder`|`PlaceHolder`|  
 |`SignIn`|`signIn`|`SignOn`|  
 |`SignOut`|`signOut`|`SignOff`|  
-|`UserName`|`userName`|`Username`|  
+|`UserName`|`username`|`UserName`|  
 |`WhiteSpace`|`whiteSpace`|`Whitespace`|  
 |`Writable`|`writable`|`Writeable`|  
   


### PR DESCRIPTION
## Summary

Guidelines suggest not capitalizing each part of a closed-form compound word, and "username" has become a closed-form compound in modern usage.

Fixes #6523.