### PR TITLE
Don't use US-specific units

### DIFF
--- a/docs/csharp/quick-starts/interpolated-strings.yml
+++ b/docs/csharp/quick-starts/interpolated-strings.yml
@@ -55,7 +55,7 @@ items:
        public override string ToString() => Name;
     }
 
-    public enum Unit { item, pound, ounce, dozen };
+    public enum Unit { item, kilogram, gram, dozen };
 
     var item = new Vegetable("eggplant");
     var date = DateTime.Now;


### PR DESCRIPTION
This tutorial isn't just for people from the US, so I think it shouldn't use units that are used only in the US.

I think "ounce" is especially confusing, since it's less well known, and when I try to [look it up](https://en.wikipedia.org/wiki/Ounce), it doesn't clarify things much:

> The ounce is a unit of mass, weight, or volume