### PR TITLE
Improve C# consistency with space between class name and opening bracket

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0311.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0311.md
@@ -22,8 +22,8 @@ The type 'type1' cannot be used as type parameter 'T' in the generic type or met
   
 ```csharp  
 // cs0311.cs  
-class B{}  
-class C{}  
+class B {}  
+class C {}  
 class Test<T> where T : C  
 { }  
   

--- a/docs/csharp/misc/cs0658.md
+++ b/docs/csharp/misc/cs0658.md
@@ -17,7 +17,7 @@ ms.assetid: 0309074c-741a-492c-9370-73b4bbfd3c1a
 ```csharp  
 // CS0658.cs  
 using System;  
-public class TestAttribute : Attribute{}  
+public class TestAttribute : Attribute {}  
 [badAttributeLocation: Test]   // CS0658, badAttributeLocation is invalid  
 class ClassTest  
 {  

--- a/docs/csharp/misc/cs1527.md
+++ b/docs/csharp/misc/cs1527.md
@@ -31,8 +31,8 @@ namespace Sample
 //cs1527_2.cs  
 using System;  
   
-protected class C4{}  
-private struct S1{}  
+protected class C4 {}  
+private struct S1 {}  
 ```  
   
 ## See Also  

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-in-delegates.md
@@ -14,8 +14,8 @@ When you assign a method to a delegate, *covariance* and *contravariance* provid
 ### Code  
   
 ```csharp  
-class Mammals{}  
-class Dogs : Mammals{}  
+class Mammals {}  
+class Dogs : Mammals {}  
   
 class Program  
 {  

--- a/docs/csharp/programming-guide/concepts/object-oriented-programming.md
+++ b/docs/csharp/programming-guide/concepts/object-oriented-programming.md
@@ -301,7 +301,7 @@ var sampleObject =
  To inherit from a base class:  
   
 ```csharp  
-class DerivedClass:BaseClass{}  
+class DerivedClass:BaseClass {}  
 ```  
   
  By default all classes can be inherited. However, you can specify whether a class must not be used as a base class, or create a class that can be used as a base class only.  

--- a/docs/csharp/programming-guide/xmldoc/xml-documentation-comments.md
+++ b/docs/csharp/programming-guide/xmldoc/xml-documentation-comments.md
@@ -19,7 +19,7 @@ In Visual C# you can create documentation for your code by including XML element
 /// <summary>  
 ///  This class performs an important function.  
 /// </summary>  
-public class MyClass{}  
+public class MyClass {}  
 ```  
   
  When you compile with the [/doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md) option, the compiler will search for all XML tags in the source code and create an XML documentation file. To create the final documentation based on the compiler-generated file, you can create a custom tool or use a tool such as [Sandcastle](https://github.com/EWSoftware/SHFB).  

--- a/docs/framework/misc/securing-method-access.md
+++ b/docs/framework/misc/securing-method-access.md
@@ -104,7 +104,7 @@ End Class
 ```csharp  
 [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.InheritanceDemand, Name="FullTrust")]  
 [System.Security.Permissions.PermissionSetAttribute(System.Security.Permissions.SecurityAction.LinkDemand, Name="FullTrust")]  
-public abstract class CannotCreateInstanceOfMe_CanCastToMe{}  
+public abstract class CannotCreateInstanceOfMe_CanCastToMe {}  
 ```  
   
  For public virtual functions:  
@@ -139,7 +139,7 @@ End Class 'Base2
 ```  
   
 ```csharp  
-abstract class Base2{  
+abstract class Base2 {  
 [System.Security.Permissions.PermissionSetAttribute(  
 System.Security.Permissions.SecurityAction.InheritanceDemand, Name = "FullTrust")]  
 [System.Security.Permissions.PermissionSetAttribute(  

--- a/docs/framework/winforms/controls/how-to-develop-a-simple-windows-forms-control.md
+++ b/docs/framework/winforms/controls/how-to-develop-a-simple-windows-forms-control.md
@@ -25,7 +25,7 @@ This section walks you through the key steps for authoring a custom Windows Form
     ```  
   
     ```csharp  
-    public class FirstControl:Control{}  
+    public class FirstControl:Control {}  
     ```  
   
 2.  Define properties. (You are not required to define properties, because a control inherits many properties from the <xref:System.Windows.Forms.Control> class, but most custom controls generally do define additional properties.) The following code fragment defines a property named `TextAlignment` that `FirstControl` uses to format the display of the <xref:System.Windows.Forms.Control.Text%2A> property inherited from <xref:System.Windows.Forms.Control>. For more information about defining properties, see [Properties Overview](http://msdn.microsoft.com/library/8f1a1ff1-0f05-40e0-bfdf-80de8fff7d52).  

--- a/docs/framework/winforms/controls/overriding-the-onpaint-method.md
+++ b/docs/framework/winforms/controls/overriding-the-onpaint-method.md
@@ -39,7 +39,7 @@ End Class
 ```  
   
 ```csharp  
-public class FirstControl : Control{  
+public class FirstControl : Control {  
    public FirstControl() {}  
    protected override void OnPaint(PaintEventArgs e) {  
       // Call the OnPaint method of the base class.  

--- a/docs/standard/data/xml/xsltargumentlist-for-style-sheet-parameters-and-extension-objects.md
+++ b/docs/standard/data/xml/xsltargumentlist-for-style-sheet-parameters-and-extension-objects.md
@@ -289,7 +289,7 @@ public class Sample
   }  
   
   //Calculates the circumference of a circle given the radius.  
-  public class Calculate{  
+  public class Calculate {  
   
     private double circ = 0;  
   

--- a/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
+++ b/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
@@ -54,7 +54,7 @@ public struct Nullable<T> where T:struct { ... }
  **✓ DO** prefix descriptive type parameter names with `T`.  
   
 ```  
-public interface ISessionChannel<TSession> where TSession : ISession{  
+public interface ISessionChannel<TSession> where TSession : ISession {  
     TSession Session { get; }  
 }  
 ```  

--- a/docs/standard/serialization/controlling-xml-serialization-using-attributes.md
+++ b/docs/standard/serialization/controlling-xml-serialization-using-attributes.md
@@ -53,7 +53,7 @@ End Class
 ```  
   
 ```csharp  
-public class TaxRates{  
+public class TaxRates {  
     [XmlElement(ElementName = "TaxRate")]  
     public decimal ReturnTaxRate;  
 }  
@@ -76,10 +76,10 @@ End Class
 ```  
   
 ```csharp  
-public class Group{  
+public class Group {  
     public Employee[] Employees;  
 }  
-public class Employee{  
+public class Employee {  
     public string Name;  
 }  
 ```  
@@ -106,7 +106,7 @@ End Class
 ```  
   
 ```csharp  
-public class Group{  
+public class Group {  
     [XmlArray("TeamMembers")]  
     public Employee[] Employees;  
 }  
@@ -134,7 +134,7 @@ End Class
 ```  
   
 ```csharp  
-public class Group{  
+public class Group {  
     [XmlArrayItem("MemberName")]  
     public Employee[] Employees;  
 }  
@@ -169,15 +169,15 @@ End Class
 ```  
   
 ```csharp  
-public class Group{  
+public class Group {  
     [XmlArrayItem(Type = typeof(Employee)),  
     XmlArrayItem(Type = typeof(Manager))]  
     public Employee[] Employees;  
 }  
-public class Employee{  
+public class Employee {  
     public string Name;  
 }  
-public class Manager:Employee{  
+public class Manager:Employee {  
     public int Level;  
 }  
 ```  
@@ -209,7 +209,7 @@ End Class
 ```  
   
 ```csharp  
-public class Group{  
+public class Group {  
     [XmlElement]  
     public Employee[] Employees;  
 }  
@@ -255,7 +255,7 @@ End Class
 ```  
   
 ```csharp  
-public class Group{  
+public class Group {  
     [XmlElement(Type = typeof(Employee)),   
     XmlElement(Type = typeof(Manager))]  
     public ArrayList Info;  
@@ -280,7 +280,7 @@ End Class
 ```csharp  
 [XmlRoot("NewGroupName")]  
 [XmlType("NewTypeName")]  
-public class Group{  
+public class Group {  
     public Employee[] Employees;  
 }  
 ```  

--- a/docs/standard/serialization/examples-of-xml-serialization.md
+++ b/docs/standard/serialization/examples-of-xml-serialization.md
@@ -290,7 +290,7 @@ using System.IO;
 using System.Collections;  
 using System.Xml.Serialization;  
   
-public class Test{  
+public class Test {  
     static void Main(){  
         Test t = new Test();  
         t.SerializeCollection("coll.xml");  
@@ -308,7 +308,7 @@ public class Test{
         x.Serialize(writer, Emps);  
     }  
 }  
-public class Employees:ICollection{  
+public class Employees:ICollection {  
     public string CollectionName;  
     private ArrayList empArray = new ArrayList();   
   
@@ -337,7 +337,7 @@ public class Employees:ICollection{
     }  
 }  
   
-public class Employee{  
+public class Employee {  
     public string EmpName;  
     public string EmpID;  
     public Employee(){}  

--- a/docs/standard/serialization/xml-serialization-with-xml-web-services.md
+++ b/docs/standard/serialization/xml-serialization-with-xml-web-services.md
@@ -63,14 +63,14 @@ using System;
 using System.Web.Services;  
 using System.Web.Services.Protocols;  
 using System.Xml.Serialization;  
-public class Order{  
+public class Order {  
     // Both types of attributes can be applied. Depending on which type  
     // the method used, either one will affect the call.  
     [SoapElement(ElementName = "EncodedOrderID")]  
     [XmlElement(ElementName = "LiteralOrderID")]  
     public String OrderID;  
 }  
-public class MyService{  
+public class MyService {  
     [WebMethod][SoapDocumentMethod]  
     public Order MyLiteralMethod(){  
         Order myOrder = new Order();  
@@ -215,7 +215,7 @@ End Class
 [XmlType("BigBooksService", Namespace = "http://www.cpandl.com")]  
 [SoapType("SoapBookService")]  
 [XmlRoot("BookOrderForm")]  
-public class Order{  
+public class Order {  
     // Both types of attributes can be applied. Depending on which  
     // the method used, either one will affect the call.  
     [SoapElement(ElementName = "EncodedOrderID")]  


### PR DESCRIPTION
## Summary

When a class name and its opening bracket are on the same line, the code samples weren't all consistent with styling. A quick search through the repo found that:

- Declaring the class like: `class A{` (no space) was done `23` times in `9` files. (`8%`)
- Declaring the class like: `class A {` (space) was done `249` times in `150` files. (`92%`)
- Declaring a derived class like `:B{` or `: B{` (no space) was done `7` times in `7` files. (`5%`)
- Declaring a derived class like `:B {` or `: B {` (space) was done `124` times in `76` files. (`95%`)

So I normalized the first and third option.