### PR TITLE
cs-interactive now reflects user culture

### DIFF
--- a/docs/standard/base-types/custom-numeric-format-strings.md
+++ b/docs/standard/base-types/custom-numeric-format-strings.md
@@ -47,7 +47,7 @@ You can create a custom numeric format string, which consists of one or more cus
   
  The following sections provide detailed information about each of the custom numeric format specifiers.  
 
-[!INCLUDE[C# interactive-note](~/includes/csharp-interactive-with-culture-note.md)] 
+[!INCLUDE[C# interactive-note](~/includes/csharp-interactive-note.md)] 
   
 <a name="Specifier0"></a>   
 ## The "0" custom specifier  

--- a/docs/standard/base-types/standard-numeric-format-strings.md
+++ b/docs/standard/base-types/standard-numeric-format-strings.md
@@ -61,7 +61,7 @@ Standard numeric format strings are supported by:
 <a name="Using"></a>   
 ## Using Standard Numeric Format Strings  
 
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-with-culture-note.md)]
+[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
 
 A standard numeric format string can be used to define the formatting of a numeric value in one of two ways:  
   
@@ -344,7 +344,7 @@ For <xref:System.Double> values, the "R" format specifier in some cases fails to
   
 ## Example  
  
-[!INCLUDE[interactive-note](~/includes/csharp-interactive-with-culture-note.md)]
+[!INCLUDE[interactive-note](~/includes/csharp-interactive-note.md)]
  
  The following example formats an integral and a floating-point numeric value using the en-US culture and all the standard numeric format specifiers. This example uses two particular numeric types (<xref:System.Double> and <xref:System.Int32>), but would yield similar results for any of the other numeric base types (<xref:System.Byte>, <xref:System.SByte>, <xref:System.Int16>, <xref:System.Int32>, <xref:System.Int64>, <xref:System.UInt16>, <xref:System.UInt32>, <xref:System.UInt64>, <xref:System.Numerics.BigInteger>, <xref:System.Decimal>, and <xref:System.Single>).  
   

--- a/includes/csharp-interactive-with-culture-note.md
+++ b/includes/csharp-interactive-with-culture-note.md
@@ -1,9 +1,0 @@
-
-> [!NOTE]
-> The C# examples in this article run in the [Try.NET](https://try.dot.net) inline code runner and playground. Select the **Run** button to run an example in an interactive window. Once you execute the code, you can modify it and run the modified code by selecting **Run** again. The modified code either runs in the interactive window or, if compilation fails, the interactive window displays all C# compiler error messages. 
->  
-> The [current culture](xref:System.Globalization.CultureInfo.CurrentCulture) of the [Try.NET](https://try.dot.net) inline code runner and playground is the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture). As a result, the output produced by the inline code runner differs from the output displayed by examples that use a default culture as the current culture. 
->
-> You can work around this limitation by adding a line of code like the following to set the culture: `System.Globalization.CultureInfo.CurrentCulture = new System.Globalization.CultureInfo("en-US");` Just replace `en-US` with the name of the culture that you'd like to be the current culture.
-
-


### PR DESCRIPTION
## cs-interactive now reflects user culture

This PR:

- Modifies topics that use the C# interactive REPL and that noted the REPL uses the invariant culture to modify the note.
- Deleted the include file containing the note about the REPL using the invariant culture. (I've confirmed that the file isn't included in any API docs.)

