### PR TITLE
C26874: replacing Markdown Italics by HTML Italics tags

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/best-practices-for-implementing-the-event-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/best-practices-for-implementing-the-event-based-asynchronous-pattern.md
@@ -29,9 +29,9 @@ The Event-based Asynchronous Pattern provides you with an effective way to expos
   
 -   Define a <em>MethodName</em>**Completed** event on the same class as the method.  
   
--   Define an <xref:System.EventArgs> class and accompanying delegate for the <em>MethodName</em>**Completed** event that derives from the <xref:System.ComponentModel.AsyncCompletedEventArgs> class. The default class name should be of the form *MethodName***CompletedEventArgs**.  
+-   Define an <xref:System.EventArgs> class and accompanying delegate for the <em>MethodName</em>**Completed** event that derives from the <xref:System.ComponentModel.AsyncCompletedEventArgs> class. The default class name should be of the form <em>MethodName</em>**CompletedEventArgs**.  
   
--   Ensure that the <xref:System.EventArgs> class is specific to the return values of the *MethodName* method. When you use the <xref:System.EventArgs> class, you should never require developers to cast the result.  
+-   Ensure that the <xref:System.EventArgs> class is specific to the return values of the <em>MethodName</em> method. When you use the <xref:System.EventArgs> class, you should never require developers to cast the result.  
   
      The following code example shows good and bad implementation of this design requirement respectively.  
   
@@ -51,27 +51,27 @@ private void Form1_MethodNameCompleted(object sender, MethodNameCompletedEventAr
   
 -   Do not define an <xref:System.EventArgs> class for returning methods that return `void`. Instead, use an instance of the <xref:System.ComponentModel.AsyncCompletedEventArgs> class.  
   
--   Ensure that you always raise the *MethodName***Completed** event. This event should be raised on successful completion, on an error, or on cancellation. Applications should never encounter a situation where they remain idle and completion never occurs.  
+-   Ensure that you always raise the <em>MethodName</em>**Completed** event. This event should be raised on successful completion, on an error, or on cancellation. Applications should never encounter a situation where they remain idle and completion never occurs.  
   
 -   Ensure that you catch any exceptions that occur in the asynchronous operation and assign the caught exception to the <xref:System.ComponentModel.AsyncCompletedEventArgs.Error%2A> property.  
   
 -   If there was an error completing the task, the results should not be accessible. When the <xref:System.ComponentModel.AsyncCompletedEventArgs.Error%2A> property is not `null`, ensure that accessing any property in the <xref:System.EventArgs> structure raises an exception. Use the <xref:System.ComponentModel.AsyncCompletedEventArgs.RaiseExceptionIfNecessary%2A> method to perform this verification.  
   
--   Model a time out as an error. When a time out occurs, raise the *MethodName***Completed** event and assign a <xref:System.TimeoutException> to the <xref:System.ComponentModel.AsyncCompletedEventArgs.Error%2A> property.  
+-   Model a time out as an error. When a time out occurs, raise the <em>MethodName</em>**Completed** event and assign a <xref:System.TimeoutException> to the <xref:System.ComponentModel.AsyncCompletedEventArgs.Error%2A> property.  
   
--   If your class supports multiple concurrent invocations, ensure that the *MethodName***Completed** event contains the appropriate `userSuppliedState` object.  
+-   If your class supports multiple concurrent invocations, ensure that the <em>MethodName</em>**Completed** event contains the appropriate `userSuppliedState` object.  
   
--   Ensure that the *MethodName***Completed** event is raised on the appropriate thread and at the appropriate time in the application lifecycle. For more information, see the Threading and Contexts section.  
+-   Ensure that the <em>MethodName</em>**Completed** event is raised on the appropriate thread and at the appropriate time in the application lifecycle. For more information, see the Threading and Contexts section.  
   
 ### Simultaneously Executing Operations  
   
--   If your class supports multiple concurrent invocations, enable the developer to track each invocation separately by defining the *MethodName***Async** overload that takes an object-valued state parameter, or task ID, called `userSuppliedState`. This parameter should always be the last parameter in the *MethodName***Async** method's signature.  
+-   If your class supports multiple concurrent invocations, enable the developer to track each invocation separately by defining the <em>MethodName</em>**Async** overload that takes an object-valued state parameter, or task ID, called `userSuppliedState`. This parameter should always be the last parameter in the <em>MethodName</em>**Async** method's signature.  
   
--   If your class defines the *MethodName***Async** overload that takes an object-valued state parameter, or task ID, be sure to track the lifetime of the operation with that task ID, and be sure to provide it back into the completion handler. There are helper classes available to assist. For more information on concurrency management, see [How to: Implement a Component That Supports the Event-based Asynchronous Pattern](../../../docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md).  
+-   If your class defines the <em>MethodName</em>**Async** overload that takes an object-valued state parameter, or task ID, be sure to track the lifetime of the operation with that task ID, and be sure to provide it back into the completion handler. There are helper classes available to assist. For more information on concurrency management, see [How to: Implement a Component That Supports the Event-based Asynchronous Pattern](../../../docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md).  
   
--   If your class defines the *MethodName***Async** method without the state parameter, and it does not support multiple concurrent invocations, ensure that any attempt to invoke *MethodName***Async** before the prior *MethodName***Async** invocation has completed raises an <xref:System.InvalidOperationException>.  
+-   If your class defines the <em>MethodName</em>**Async** method without the state parameter, and it does not support multiple concurrent invocations, ensure that any attempt to invoke <em>MethodName</em>**Async** before the prior <em>MethodName</em>**Async** invocation has completed raises an <xref:System.InvalidOperationException>.  
   
--   In general, do not raise an exception if the *MethodName***Async** method without the `userSuppliedState` parameter is invoked multiple times so that there are multiple outstanding operations. You can raise an exception when your class explicitly cannot handle that situation, but assume that developers can handle these multiple indistinguishable callbacks  
+-   In general, do not raise an exception if the <em>MethodName</em>**Async** method without the `userSuppliedState` parameter is invoked multiple times so that there are multiple outstanding operations. You can raise an exception when your class explicitly cannot handle that situation, but assume that developers can handle these multiple indistinguishable callbacks  
   
 ### Accessing Results  
   
@@ -83,7 +83,7 @@ private void Form1_MethodNameCompleted(object sender, MethodNameCompletedEventAr
   
 -   Support progress reporting, if possible. This enables developers to provide a better application user experience when they use your class.  
   
--   If you implement a **ProgressChanged** or *MethodName***ProgressChanged** event, ensure that there are no such events raised for a particular asynchronous operation after that operation's *MethodName***Completed** event has been raised.  
+-   If you implement a **ProgressChanged** or <em>MethodName</em>**ProgressChanged** event, ensure that there are no such events raised for a particular asynchronous operation after that operation's <em>MethodName</em>**Completed** event has been raised.  
   
 -   If the standard <xref:System.ComponentModel.ProgressChangedEventArgs> is being populated, ensure that the <xref:System.ComponentModel.ProgressChangedEventArgs.ProgressPercentage%2A> can always be interpreted as a percentage. The percentage does not need to be accurate, but it should represent a percentage. If your progress reporting metric must be something other than a percentage, derive a class from the <xref:System.ComponentModel.ProgressChangedEventArgs> class and leave <xref:System.ComponentModel.ProgressChangedEventArgs.ProgressPercentage%2A> at 0. Avoid using a reporting metric other than a percentage.  
   
@@ -93,7 +93,7 @@ private void Form1_MethodNameCompleted(object sender, MethodNameCompletedEventAr
   
 -   Do not expose an `IsBusy` property if your class supports multiple concurrent invocations. For example, XML Web service proxies do not expose an `IsBusy` property because they support multiple concurrent invocations of asynchronous methods.  
   
--   The `IsBusy` property should return `true` after the *MethodName***Async** method has been called and before the *MethodName***Completed** event has been raised. Otherwise it should return `false`. The <xref:System.ComponentModel.BackgroundWorker> and <xref:System.Net.WebClient> components are examples of classes that expose an `IsBusy` property.  
+-   The `IsBusy` property should return `true` after the <em>MethodName</em>**Async** method has been called and before the <em>MethodName</em>**Completed** event has been raised. Otherwise it should return `false`. The <xref:System.ComponentModel.BackgroundWorker> and <xref:System.Net.WebClient> components are examples of classes that expose an `IsBusy` property.  
   
 ### Cancellation  
   
@@ -105,7 +105,7 @@ private void Form1_MethodNameCompleted(object sender, MethodNameCompletedEventAr
   
 -   Ensure that calls to a cancellation method always return successfully, and never raise an exception. In general, a client is not notified as to whether an operation is truly cancelable at any given time, and is not notified as to whether a previously issued cancellation has succeeded. However, the application will always be given notification when a cancellation succeeded, because the application takes part in the completion status.  
   
--   Raise the *MethodName***Completed** event when the operation is canceled.  
+-   Raise the <em>MethodName</em>**Completed** event when the operation is canceled.  
   
 ### Errors and Exceptions  
   
@@ -114,7 +114,7 @@ private void Form1_MethodNameCompleted(object sender, MethodNameCompletedEventAr
 ### Threading and Contexts  
  For correct operation of your class, it is critical that the client's event handlers are invoked on the proper thread or context for the given application model, including [!INCLUDE[vstecasp](../../../includes/vstecasp-md.md)] and Windows Forms applications. Two important helper classes are provided to ensure that your asynchronous class behaves correctly under any application model: <xref:System.ComponentModel.AsyncOperation> and <xref:System.ComponentModel.AsyncOperationManager>.  
   
- <xref:System.ComponentModel.AsyncOperationManager> provides one method, <xref:System.ComponentModel.AsyncOperationManager.CreateOperation%2A>, which returns an <xref:System.ComponentModel.AsyncOperation>. Your *MethodName***Async** method calls <xref:System.ComponentModel.AsyncOperationManager.CreateOperation%2A> and your class uses the returned <xref:System.ComponentModel.AsyncOperation> to track the lifetime of the asynchronous task.  
+ <xref:System.ComponentModel.AsyncOperationManager> provides one method, <xref:System.ComponentModel.AsyncOperationManager.CreateOperation%2A>, which returns an <xref:System.ComponentModel.AsyncOperation>. Your <em>MethodName</em>**Async** method calls <xref:System.ComponentModel.AsyncOperationManager.CreateOperation%2A> and your class uses the returned <xref:System.ComponentModel.AsyncOperation> to track the lifetime of the asynchronous task.  
   
  To report progress, incremental results, and completion to the client, call the <xref:System.ComponentModel.AsyncOperation.Post%2A> and <xref:System.ComponentModel.AsyncOperation.OperationCompleted%2A> methods on the <xref:System.ComponentModel.AsyncOperation>. <xref:System.ComponentModel.AsyncOperation> is responsible for marshaling calls to the client's event handlers to the proper thread or context.  
   


### PR DESCRIPTION
Hello, @mairaw ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
"Italics should be replaced with HTML tags to avoid broken content on localization"

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR then share your PR number so we can confirm and close this PR.

Many thanks in advance.