### PR TITLE
The lock keyword uses try...finally

### DIFF
--- a/docs/standard/threading/overview-of-synchronization-primitives.md
+++ b/docs/standard/threading/overview-of-synchronization-primitives.md
@@ -34,7 +34,7 @@ ms.author: "ronpet"
  Locks give control of a resource to one thread at a time, or to a specified number of threads. A thread that requests an exclusive lock when the lock is in use blocks until the lock becomes available.  
   
 ### Exclusive Locks  
- The simplest form of locking is the `lock` statement in C# and the `SyncLock` statement in Visual Basic, which controls access to a block of code. Such a block is frequently referred to as a critical section. The `lock` statement is implemented by using the <xref:System.Threading.Monitor.Enter%2A?displayProperty=nameWithType> and <xref:System.Threading.Monitor.Exit%2A?displayProperty=nameWithType> methods, and it uses `try…catch…finally` block to ensure that the lock is released.  
+ The simplest form of locking is the `lock` statement in C# and the `SyncLock` statement in Visual Basic, which controls access to a block of code. Such a block is frequently referred to as a critical section. The `lock` statement is implemented by using the <xref:System.Threading.Monitor.Enter%2A?displayProperty=nameWithType> and <xref:System.Threading.Monitor.Exit%2A?displayProperty=nameWithType> methods, and it uses `try…finally` block to ensure that the lock is released.  
   
  In general, using the `lock` or `SyncLock` statement to protect small blocks of code, never spanning more than a single method, is the best way to use the <xref:System.Threading.Monitor> class. Although powerful, the <xref:System.Threading.Monitor> class is prone to orphan locks and deadlocks.  
   

--- a/docs/standard/threading/overview-of-synchronization-primitives.md
+++ b/docs/standard/threading/overview-of-synchronization-primitives.md
@@ -34,7 +34,7 @@ ms.author: "ronpet"
  Locks give control of a resource to one thread at a time, or to a specified number of threads. A thread that requests an exclusive lock when the lock is in use blocks until the lock becomes available.  
   
 ### Exclusive Locks  
- The simplest form of locking is the `lock` statement in C# and the `SyncLock` statement in Visual Basic, which controls access to a block of code. Such a block is frequently referred to as a critical section. The `lock` statement is implemented by using the <xref:System.Threading.Monitor.Enter%2A?displayProperty=nameWithType> and <xref:System.Threading.Monitor.Exit%2A?displayProperty=nameWithType> methods, and it uses `try…finally` block to ensure that the lock is released.  
+ The simplest form of locking is the `lock` statement in C# and the `SyncLock` statement in Visual Basic, which controls access to a block of code. Such a block is frequently referred to as a critical section. The `lock` statement is implemented by using the <xref:System.Threading.Monitor.Enter%2A?displayProperty=nameWithType> and <xref:System.Threading.Monitor.Exit%2A?displayProperty=nameWithType> methods, and it uses a `try…finally` block to ensure that the lock is released.  
   
  In general, using the `lock` or `SyncLock` statement to protect small blocks of code, never spanning more than a single method, is the best way to use the <xref:System.Threading.Monitor> class. Although powerful, the <xref:System.Threading.Monitor> class is prone to orphan locks and deadlocks.  
   


### PR DESCRIPTION
nit: according to the [specification](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/statements#the-lock-statement) the `lock` keyword is implemented with the `try...finally` block.
