### PR TITLE
Simplify Core entry page

### DIFF
--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -26,22 +26,16 @@ C#, Visual Basic, and F# languages can be used to write applications and librari
 .NET Core exposes APIs for many scenarios, a few of which follow:
 
 - Primitive types, such as [string][string] and [int][int].
-- Collections, such as [List<T>][list] and [Dictionary<K,V>][dictionary].
-- Utility types, such as [HttpClient][httpclient], and [FileStream][filestream].
-- Data types, such as [DataSet][dataset], and [DbSet][dbset].
-- High performance types, such as [Vector][vector] and [Pipelines][pipelines].
+- Collections, such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType> and <xref:System.Collections.Generic.Dictionary%601?displayProperty=nameWithType>.
+- Utility types, such as <xref:System.Net.Http.HttpClient?displayProperty=nameWithType>, and <xref:System.IO.FileStream?displayProperty=nameWithType>.
+- Data types, such as <xref:System.Data.DataSet?displayProperty=nameWithType>, and [DbSet][dbset].
+- High performance types, such as <xref:System.Numerics.Vector?displayProperty=nameWithType> and [Pipelines][pipelines].
 
 .NET Core provides compatibility with .NET Framework and Mono APIs by implementing the [.NET Standard](../standard/net-standard.md) specification.
 
-[string]: https://docs.microsoft.com/dotnet/api/system.string?view=netcore-2.1
-[int]: https://docs.microsoft.com/dotnet/api/system.int32?view=netcore-2.1
-[dictionary]: https://docs.microsoft.com/dotnet/api/system.collections.generic.dictionary-2?view=netcore-2.1
-[list]: https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1?view=netcore-2.1
-[httpclient]: https://docs.microsoft.com/dotnet/api/system.net.http.httpclient?view=netcore-2.1
-[filestream]: https://docs.microsoft.com/dotnet/api/system.io.filestream?view=netcore-2.1
+[string]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/string
+[int]: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/int
 [pipelines]: https://blogs.msdn.microsoft.com/dotnet/2018/07/09/system-io-pipelines-high-performance-io-in-net/
-[vector]: https://docs.microsoft.com/dotnet/api/system.numerics.vector?view=netcore-2.1
-[dataset]: https://docs.microsoft.com/dotnet/api/system.data.dataset?view=netcore-2.1
 [dbset]: https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/
 
 ## Frameworks
@@ -69,7 +63,7 @@ These components are distributed in the following ways:
 
 ### Open Source
 
-[.NET Core](https://github.com/dotnet/core) is open source (MIT license) and was contributed to the [.NET Foundation](https://dotnetfoundation.org) by Microsoft in 2014. It is now one of the most active .NET Foundation projects. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET Core as part of apps, tools, new platforms and hosting services. Some of these companies make significant contributions to .NET Core on GitHub and provide guidance on the product direction as part of the [.NET Foundation Technical Steering Group](https://dotnetfoundation.org/blog/tsg-welcome).
+[.NET Core](https://github.com/dotnet/core) is open source ([MIT license](https://github.com/dotnet/core/blob/master/LICENSE.TXT)) and was contributed to the [.NET Foundation](https://dotnetfoundation.org) by Microsoft in 2014. It is now one of the most active .NET Foundation projects. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET Core as part of apps, tools, new platforms and hosting services. Some of these companies make significant contributions to .NET Core on GitHub and provide guidance on the product direction as part of the [.NET Foundation Technical Steering Group](https://dotnetfoundation.org/blog/tsg-welcome).
 
 ### Designed for Adaptability
 
@@ -87,8 +81,8 @@ Windows and Unix implementations are similar in size. Windows has a larger imple
 
 There are a mix of platform-specific and platform-neutral libraries in .NET Core. You can see the pattern in a few examples:
 
-- [CoreCLR](https://github.com/dotnet/coreclr) is platform-specific. It's built in C/C++, so is platform-specific by construction.
-- [System.IO](https://github.com/dotnet/corefx/tree/master/src/System.IO) and [System.Security.Cryptography.Algorithms](https://github.com/dotnet/corefx/tree/master/src/System.Security.Cryptography.Algorithms) are platform-specific, given that the storage and cryptography APIs differ significantly on each OS.
+- [CoreCLR](https://github.com/dotnet/coreclr) is platform-specific. It builds on top of OS subsystems, like the memory manager and thread scheduler.
+- [System.IO](https://github.com/dotnet/corefx/tree/master/src/System.IO) and [System.Security.Cryptography.Algorithms](https://github.com/dotnet/corefx/tree/master/src/System.Security.Cryptography.Algorithms) are platform-specific, given that storage and cryptography APIs are different on each OS.
 - [System.Collections](https://github.com/dotnet/corefx/tree/master/src/System.Collections) and [System.Linq](https://github.com/dotnet/corefx/tree/master/src/System.Linq) are platform-neutral, given that they create and operate over data structures.
 
 ## Comparisons to other .NET implementations
@@ -101,8 +95,8 @@ It is perhaps easiest to understand the size and shape of .NET Core by comparing
 
 The major differences between .NET Core and the .NET Framework:
 
-- **App-models** -- .NET Core does not support all the .NET Framework app-models. In particular, it doesn't ASP.NET Web Forms and MVC. It was announced that [.NET Core 3 will support WPF and Windows Forms](https://blogs.msdn.microsoft.com/dotnet/2018/05/07/net-core-3-and-support-for-windows-desktop-applications/).
-- **APIs** -- .NET Core contains a large subset of .NET Framework Base Class Library, with a different factoring (assembly names are different; type shape differs in key cases). These differences require changes to port source to .NET Core in some cases (see [microsoft/dotnet-apiport[(https://github.com/microsoft/dotnet-apiport)). .NET Core implements the [.NET Standard](../standard/net-standard.md) API specification.
+- **App-models** -- .NET Core does not support all the .NET Framework app-models. In particular, it doesn't support ASP.NET Web Forms and MVC. It was announced that [.NET Core 3 will support WPF and Windows Forms](https://blogs.msdn.microsoft.com/dotnet/2018/05/07/net-core-3-and-support-for-windows-desktop-applications/).
+- **APIs** -- .NET Core contains a large subset of .NET Framework Base Class Library, with a different factoring (assembly names are different; members exposed on types differ in key cases). These differences require changes to port source to .NET Core in some cases (see [microsoft/dotnet-apiport[(https://github.com/microsoft/dotnet-apiport)). .NET Core implements the [.NET Standard](../standard/net-standard.md) API specification.
 - **Subsystems** -- .NET Core implements a subset of the subsystems in the .NET Framework, with the goal of a simpler implementation and programming model. For example, Code Access Security (CAS) is not supported, while reflection is supported.
 - **Platforms** -- The .NET Framework supports Windows and Windows Server while .NET Core also supports macOS and Linux.
 - **Open Source** -- .NET Core is open source, while a [read-only subset of the .NET Framework](https://github.com/microsoft/referencesource) is open source.

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -1,6 +1,6 @@
 ---
 title: About .NET Core
-description: .NET Core is a modular, high-performance implementation of .NET for creating Windows, Linux, and Mac apps. Learn about .NET Core to get started.
+description: Learn about .NET Core.
 author: richlander
 ms.author: mairaw
 ms.date: 08/01/2018

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -19,15 +19,7 @@ ms.date: 08/01/2018
 
 ## Languages
 
-The C#, Visual Basic, and F# languages can be used to write applications and libraries for .NET Core. These languages are or can be integrated into your favorite text editors and IDEs, including [Visual Studio](https://visualstudio.microsoft.com/vs/), [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp), Sublime Text and Vim. This integration is provided, in part, by the good folks from the [OmniSharp](http://www.omnisharp.net/) and [Ionide](http://ionide.io) projects.
-
-## Frameworks
-
-Multiple frameworks have been built on top of .NET Core:
-
-- [ASP.NET Core](/aspnet/core/)
-- [Windows 10 Universal Windows Platform (UWP)](https://developer.microsoft.com/windows)
-- [Tizen](https://developer.tizen.org/development/training/.net-application)
+C#, Visual Basic, and F# languages can be used to write applications and libraries for .NET Core. These languages are or can be integrated into your favorite text editors and IDEs, including [Visual Studio](https://visualstudio.microsoft.com/vs/), [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp), Sublime Text and Vim. This integration is provided, in part, by the good folks from the [OmniSharp](http://www.omnisharp.net/) and [Ionide](http://ionide.io) projects.
 
 ## APIs
 
@@ -52,6 +44,14 @@ Multiple frameworks have been built on top of .NET Core:
 [dataset]: https://docs.microsoft.com/dotnet/api/system.data.dataset?view=netcore-2.1
 [dbset]: https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/
 
+## Frameworks
+
+Multiple frameworks have been built on top of .NET Core:
+
+- [ASP.NET Core](/aspnet/core/)
+- [Windows 10 Universal Windows Platform (UWP)](https://developer.microsoft.com/windows)
+- [Tizen](https://developer.tizen.org/development/training/.net-application)
+
 ## Composition
 
 .NET Core is composed of the following parts:
@@ -63,9 +63,9 @@ Multiple frameworks have been built on top of .NET Core:
 
 These components are distributed in the following ways:
 
-- [.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes .NET Core runtime and framework libraries.
+- [.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes the .NET Core runtime and framework libraries.
 - ASP.NET Core Runtime -- includes ASP.NET Core and .NET Core runtime and framework libraries.
-- [.NET Core SDK](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes .NET CLI Tools, ASP.NET Core runtime, and .NET Core runtime and framework.
+- [.NET Core SDK](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes the .NET CLI Tools, ASP.NET Core runtime, and .NET Core runtime and framework.
 
 ### Open Source
 
@@ -73,9 +73,9 @@ These components are distributed in the following ways:
 
 ### Designed for Adaptability
 
-.NET Core has been built as a very similar but unique product relative to other .NET products. It has been designed to enable broad adaptability to new platforms, for new workloads and with new compiler toolchains. It has several OS and CPU ports in progress and may be ported to many more. An example is the [LLILC](https://github.com/dotnet/llilc) project, which is an early prototype of native compilation for .NET Core via the [LLVM](http://llvm.org/) compiler.
+.NET Core has been built as a very similar but unique product relative to other .NET products. It has been designed to enable broad adaptability to new platforms and workloads. It has several OS and CPU ports available and may be ported to many more.
 
-The product is broken into several pieces, enabling the various parts to be adapted to new platforms on different schedules. The runtime and platform-specific foundational libraries must be ported as a unit. Platform-agnostic libraries should work as-is on all platforms, by construction. There is a project bias to reducing platform-specific implementations to increase developer efficiency, preferring platform-neutral C# code whenever an algorithm or API can be implemented in-full or in-part that way.
+The product is broken into several pieces, enabling the various parts to be adapted to new platforms at different times. The runtime and platform-specific foundational libraries must be ported as a unit. Platform-agnostic libraries should work as-is on all platforms, by construction. There is a project bias to reducing platform-specific implementations to increase developer efficiency, preferring platform-neutral C# code whenever an algorithm or API can be implemented in-full or in-part that way.
 
 People commonly ask how .NET Core is implemented in order to support multiple operating systems. They typically ask if there are separate implementations or if [conditional compilation](https://en.wikipedia.org/wiki/Conditional_compilation) is used. It's both, with a strong bias towards conditional compilation.
 
@@ -83,32 +83,31 @@ You can see in the chart below that the vast majority of [CoreFX](https://github
 
 ![CoreFX: Lines of Code per Platform](../images/corefx-platforms-loc.png)
 
-Windows and Unix implementations are similar in size. Windows has a larger implementation since CoreFX implements some Windows-only features, such as [Microsoft.Win32.Registry](https://github.com/dotnet/corefx/tree/master/src/Microsoft.Win32.Registry) but does not yet implement any Unix-only concepts. You will also see that the majority of the Linux and macOS implementations are shared across a Unix implementation, while the Linux- and macOS-specific implementations are roughly similar in size.
-
+Windows and Unix implementations are similar in size. Windows has a larger implementation since CoreFX implements some Windows-only features, such as [Microsoft.Win32.Registry](https://github.com/dotnet/corefx/tree/master/src/Microsoft.Win32.Registry) but does not yet implement many Unix-only concepts. You will also see that the majority of the Linux and macOS implementations are shared across a Unix implementation, while the Linux- and macOS-specific implementations are roughly similar in size.
 
 There are a mix of platform-specific and platform-neutral libraries in .NET Core. You can see the pattern in a few examples:
 
 - [CoreCLR](https://github.com/dotnet/coreclr) is platform-specific. It's built in C/C++, so is platform-specific by construction.
-- [System.IO](https://github.com/dotnet/corefx/tree/master/src/System.IO) and [System.Security.Cryptography.Algorithms](https://github.com/dotnet/corefx/tree/master/src/System.Security.Cryptography.Algorithms) are platform-specific, given that the storage and cryptography APIs differ significantly on each OS. 
+- [System.IO](https://github.com/dotnet/corefx/tree/master/src/System.IO) and [System.Security.Cryptography.Algorithms](https://github.com/dotnet/corefx/tree/master/src/System.Security.Cryptography.Algorithms) are platform-specific, given that the storage and cryptography APIs differ significantly on each OS.
 - [System.Collections](https://github.com/dotnet/corefx/tree/master/src/System.Collections) and [System.Linq](https://github.com/dotnet/corefx/tree/master/src/System.Linq) are platform-neutral, given that they create and operate over data structures.
 
 ## Comparisons to other .NET implementations
 
-It is perhaps easiest to understand the size and shape of .NET Core by comparing it to existing .NET implementations. 
+It is perhaps easiest to understand the size and shape of .NET Core by comparing it to existing .NET implementations.
 
 ### Comparison with .NET Framework
 
-.NET was first announced by Microsoft in 2000 and then evolved from there. The .NET Framework has been the primary .NET implementation produced by Microsoft during that 15+ year span. 
+.NET was first announced by Microsoft in 2000 and then evolved from there. The .NET Framework has been the primary .NET implementation produced by Microsoft during that nearly two decade period.
 
-The major differences between .NET Core and the .NET Framework: 
+The major differences between .NET Core and the .NET Framework:
 
-- **App-models** -- .NET Core does not support all the .NET Framework app-models, in part because many of them are built on Windows technologies, such as WPF (built on top of DirectX). The console and ASP.NET Core app-models are supported by both .NET Core and .NET Framework. 
-- **APIs** -- .NET Core contains many of the same, but fewer, APIs as the .NET Framework, and with a different factoring (assembly names are different; type shape differs in key cases). These differences currently typically require changes to port source to .NET Core. .NET Core implements the [.NET Standard](../standard/net-standard.md) API, which will grow to include more of the .NET Framework BCL API over time.
+- **App-models** -- .NET Core does not support all the .NET Framework app-models. In particular, it doesn't ASP.NET Web Forms and MVC. It was announced that [.NET Core 3 will support WPF and Windows Forms](https://blogs.msdn.microsoft.com/dotnet/2018/05/07/net-core-3-and-support-for-windows-desktop-applications/).
+- **APIs** -- .NET Core contains a large subset of .NET Framework Base Class Library, with a different factoring (assembly names are different; type shape differs in key cases). These differences require changes to port source to .NET Core in some cases (see [microsoft/dotnet-apiport[(https://github.com/microsoft/dotnet-apiport)). .NET Core implements the [.NET Standard](../standard/net-standard.md) API specification.
 - **Subsystems** -- .NET Core implements a subset of the subsystems in the .NET Framework, with the goal of a simpler implementation and programming model. For example, Code Access Security (CAS) is not supported, while reflection is supported.
 - **Platforms** -- The .NET Framework supports Windows and Windows Server while .NET Core also supports macOS and Linux.
 - **Open Source** -- .NET Core is open source, while a [read-only subset of the .NET Framework](https://github.com/microsoft/referencesource) is open source.
 
-While .NET Core is unique and has significant differences to the .NET Framework and other .NET implementations, it is straightforward to share code, using either source or binary sharing techniques. 
+While .NET Core is unique and has significant differences to the .NET Framework and other .NET implementations, it is straightforward to share code between these implementations, using either source or binary sharing techniques.
 
 ### Comparison with Mono
 
@@ -120,4 +119,4 @@ The major differences between .NET Core and Mono:
 - **APIs** -- Mono supports a [large subset](http://docs.go-mono.com/?link=root%3a%2fclasslib) of the .NET Framework APIs, using the same assembly names and factoring.
 - **Platforms** -- Mono supports many platforms and CPUs.
 - **Open Source** -- Mono and .NET Core both use the MIT license and are .NET Foundation projects.
-- **Focus** -- The primary focus of Mono in recent years is mobile platforms, while .NET Core is focused on cloud workloads.
+- **Focus** -- The primary focus of Mono in recent years is mobile platforms, while .NET Core is focused on cloud and desktop workloads.

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -26,7 +26,7 @@ C#, Visual Basic, and F# languages can be used to write applications and librari
 .NET Core exposes APIs for many scenarios, a few of which follow:
 
 - Primitive types, such as [string][string] and [int][int].
-- Collections, such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType> and <xref:System.Collections.Generic.Dictionary%601?displayProperty=nameWithType>.
+- Collections, such as <xref:System.Collections.Generic.List%601?displayProperty=nameWithType> and <xref:System.Collections.Generic.Dictionary%602?displayProperty=nameWithType>.
 - Utility types, such as <xref:System.Net.Http.HttpClient?displayProperty=nameWithType>, and <xref:System.IO.FileStream?displayProperty=nameWithType>.
 - Data types, such as <xref:System.Data.DataSet?displayProperty=nameWithType>, and [DbSet][dbset].
 - High performance types, such as <xref:System.Numerics.Vector?displayProperty=nameWithType> and [Pipelines][pipelines].

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -58,7 +58,7 @@ Multiple frameworks have been built on top of .NET Core:
 These components are distributed in the following ways:
 
 - [.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes the .NET Core runtime and framework libraries.
-- ASP.NET Core Runtime -- includes ASP.NET Core and .NET Core runtime and framework libraries.
+- [ASP.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes ASP.NET Core and .NET Core runtime and framework libraries.
 - [.NET Core SDK](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes the .NET CLI Tools, ASP.NET Core runtime, and .NET Core runtime and framework.
 
 ### Open Source

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -1,0 +1,123 @@
+---
+title: About .NET Core
+description: .NET Core is a modular, high-performance implementation of .NET for creating Windows, Linux, and Mac apps. Learn about .NET Core to get started.
+author: richlander
+ms.author: mairaw
+ms.date: 08/01/2018
+---
+# About .NET Core
+
+.NET Core has the following characteristics:
+
+- **Cross-platform:** Runs on Windows, macOS and Linux [operating systems](https://github.com/dotnet/core/blob/master/os-lifecycle-policy.md).
+- **Consistent across architecures:** Runs your code with the same behavior on multiple architectures, including x64, x86, and ARM.
+- **Command-line tools:**  Includes easy-to-use command-line tools that be used for local development and in continuous-integration scenarios.
+- **Flexible deployment:** Can be included in your app or installed side-by-side user- or machine-wide. Can be used with [Docker containers](docker/index.md).
+- **Compatible:** .NET Core is compatible with .NET Framework, Xamarin and Mono, via [.NET Standard](../standard/net-standard.md).
+- **Open source:** The .NET Core platform is open source, using MIT and Apache 2 licenses. .NET Core is a [.NET Foundation](https://dotnetfoundation.org/) project.
+- **Supported by Microsoft:** .NET Core is supported by Microsoft, per [.NET Core Support](https://www.microsoft.com/net/core/support/).
+
+## Languages
+
+The C#, Visual Basic, and F# languages can be used to write applications and libraries for .NET Core. These languages are or can be integrated into your favorite text editors and IDEs, including [Visual Studio](https://visualstudio.microsoft.com/vs/), [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp), Sublime Text and Vim. This integration is provided, in part, by the good folks from the [OmniSharp](http://www.omnisharp.net/) and [Ionide](http://ionide.io) projects.
+
+## Frameworks
+
+Multiple frameworks have been built on top of .NET Core:
+
+- [ASP.NET Core](/aspnet/core/)
+- [Windows 10 Universal Windows Platform (UWP)](https://developer.microsoft.com/windows)
+- [Tizen](https://developer.tizen.org/development/training/.net-application)
+
+## APIs
+
+.NET Core exposes APIs for many scenarios, a few of which follow:
+
+- Primitive types, such as [string][string] and [int][int].
+- Collections, such as [List<T>][list] and [Dictionary<K,V>][dictionary].
+- Utility types, such as [HttpClient][httpclient], and [FileStream][filestream].
+- Data types, such as [DataSet][dataset], and [DbSet][dbset].
+- High performance types, such as [Vector][vector] and [Pipelines][pipelines].
+
+.NET Core provides compatibility with .NET Framework and Mono APIs by implementing the [.NET Standard](../standard/net-standard.md) specification.
+
+[string]: https://docs.microsoft.com/dotnet/api/system.string?view=netcore-2.1
+[int]: https://docs.microsoft.com/dotnet/api/system.int32?view=netcore-2.1
+[dictionary]: https://docs.microsoft.com/dotnet/api/system.collections.generic.dictionary-2?view=netcore-2.1
+[list]: https://docs.microsoft.com/dotnet/api/system.collections.generic.list-1?view=netcore-2.1
+[httpclient]: https://docs.microsoft.com/dotnet/api/system.net.http.httpclient?view=netcore-2.1
+[filestream]: https://docs.microsoft.com/dotnet/api/system.io.filestream?view=netcore-2.1
+[pipelines]: https://blogs.msdn.microsoft.com/dotnet/2018/07/09/system-io-pipelines-high-performance-io-in-net/
+[vector]: https://docs.microsoft.com/dotnet/api/system.numerics.vector?view=netcore-2.1
+[dataset]: https://docs.microsoft.com/dotnet/api/system.data.dataset?view=netcore-2.1
+[dbset]: https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/
+
+## Composition
+
+.NET Core is composed of the following parts:
+
+- The [.NET Core runtime](https://github.com/dotnet/coreclr), which provides a type system, assembly loading, a garbage collector, native interop and other basic services. [.NET Core framework libraries](https://github.com/dotnet/corefx) provide primitive data types, app composition types and fundamental utilities.
+- The [ASP.NET runtime](https://github.com/aspnet/home), which provides a framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends.
+- The [.NET Core CLI tools](https://github.com/dotnet/cli) and language compilers ([Roslyn](https://github.com/dotnet/roslyn) and [F#](https://github.com/microsoft/visualfsharp)) that enable the .NET Core developer experience.
+- The [dotnet tool](https://github.com/dotnet/core-setup), which is used to launch .NET Core apps and CLI tools. It selects the runtime and hosts the runtime, provides an assembly loading policy and launches apps and tools.
+
+These components are distributed in the following ways:
+
+- [.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes .NET Core runtime and framework libraries.
+- ASP.NET Core Runtime -- includes ASP.NET Core and .NET Core runtime and framework libraries.
+- [.NET Core SDK](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes .NET CLI Tools, ASP.NET Core runtime, and .NET Core runtime and framework.
+
+### Open Source
+
+[.NET Core](https://github.com/dotnet/core) is open source (MIT license) and was contributed to the [.NET Foundation](https://dotnetfoundation.org) by Microsoft in 2014. It is now one of the most active .NET Foundation projects. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET Core as part of apps, tools, new platforms and hosting services. Some of these companies make significant contributions to .NET Core on GitHub and provide guidance on the product direction as part of the [.NET Foundation Technical Steering Group](https://dotnetfoundation.org/blog/tsg-welcome).
+
+### Designed for Adaptability
+
+.NET Core has been built as a very similar but unique product relative to other .NET products. It has been designed to enable broad adaptability to new platforms, for new workloads and with new compiler toolchains. It has several OS and CPU ports in progress and may be ported to many more. An example is the [LLILC](https://github.com/dotnet/llilc) project, which is an early prototype of native compilation for .NET Core via the [LLVM](http://llvm.org/) compiler.
+
+The product is broken into several pieces, enabling the various parts to be adapted to new platforms on different schedules. The runtime and platform-specific foundational libraries must be ported as a unit. Platform-agnostic libraries should work as-is on all platforms, by construction. There is a project bias to reducing platform-specific implementations to increase developer efficiency, preferring platform-neutral C# code whenever an algorithm or API can be implemented in-full or in-part that way.
+
+People commonly ask how .NET Core is implemented in order to support multiple operating systems. They typically ask if there are separate implementations or if [conditional compilation](https://en.wikipedia.org/wiki/Conditional_compilation) is used. It's both, with a strong bias towards conditional compilation.
+
+You can see in the chart below that the vast majority of [CoreFX](https://github.com/dotnet/corefx) is platform-neutral code that is shared across all platforms. Platform-neutral code can be implemented as a single portable assembly that is used on all platforms.
+
+![CoreFX: Lines of Code per Platform](../images/corefx-platforms-loc.png)
+
+Windows and Unix implementations are similar in size. Windows has a larger implementation since CoreFX implements some Windows-only features, such as [Microsoft.Win32.Registry](https://github.com/dotnet/corefx/tree/master/src/Microsoft.Win32.Registry) but does not yet implement any Unix-only concepts. You will also see that the majority of the Linux and macOS implementations are shared across a Unix implementation, while the Linux- and macOS-specific implementations are roughly similar in size.
+
+
+There are a mix of platform-specific and platform-neutral libraries in .NET Core. You can see the pattern in a few examples:
+
+- [CoreCLR](https://github.com/dotnet/coreclr) is platform-specific. It's built in C/C++, so is platform-specific by construction.
+- [System.IO](https://github.com/dotnet/corefx/tree/master/src/System.IO) and [System.Security.Cryptography.Algorithms](https://github.com/dotnet/corefx/tree/master/src/System.Security.Cryptography.Algorithms) are platform-specific, given that the storage and cryptography APIs differ significantly on each OS. 
+- [System.Collections](https://github.com/dotnet/corefx/tree/master/src/System.Collections) and [System.Linq](https://github.com/dotnet/corefx/tree/master/src/System.Linq) are platform-neutral, given that they create and operate over data structures.
+
+## Comparisons to other .NET implementations
+
+It is perhaps easiest to understand the size and shape of .NET Core by comparing it to existing .NET implementations. 
+
+### Comparison with .NET Framework
+
+.NET was first announced by Microsoft in 2000 and then evolved from there. The .NET Framework has been the primary .NET implementation produced by Microsoft during that 15+ year span. 
+
+The major differences between .NET Core and the .NET Framework: 
+
+- **App-models** -- .NET Core does not support all the .NET Framework app-models, in part because many of them are built on Windows technologies, such as WPF (built on top of DirectX). The console and ASP.NET Core app-models are supported by both .NET Core and .NET Framework. 
+- **APIs** -- .NET Core contains many of the same, but fewer, APIs as the .NET Framework, and with a different factoring (assembly names are different; type shape differs in key cases). These differences currently typically require changes to port source to .NET Core. .NET Core implements the [.NET Standard](../standard/net-standard.md) API, which will grow to include more of the .NET Framework BCL API over time.
+- **Subsystems** -- .NET Core implements a subset of the subsystems in the .NET Framework, with the goal of a simpler implementation and programming model. For example, Code Access Security (CAS) is not supported, while reflection is supported.
+- **Platforms** -- The .NET Framework supports Windows and Windows Server while .NET Core also supports macOS and Linux.
+- **Open Source** -- .NET Core is open source, while a [read-only subset of the .NET Framework](https://github.com/microsoft/referencesource) is open source.
+
+While .NET Core is unique and has significant differences to the .NET Framework and other .NET implementations, it is straightforward to share code, using either source or binary sharing techniques. 
+
+### Comparison with Mono
+
+[Mono](http://www.mono-project.com/) is the original cross-platform and [open source](https://github.com/mono/mono) .NET implementation, first shipping in 2004. It can be thought of as a community clone of the .NET Framework. The Mono project team relied on the open [.NET standards](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/dotnet-standards.md) (notably ECMA 335) published by Microsoft in order to provide a compatible implementation.
+
+The major differences between .NET Core and Mono:
+
+- **App-models** -- Mono supports a subset of the .NET Framework app-models (for example, Windows Forms) and some additional ones (for example, [Xamarin.iOS](https://www.xamarin.com/platform)) through the Xamarin product. .NET Core doesn't support these.
+- **APIs** -- Mono supports a [large subset](http://docs.go-mono.com/?link=root%3a%2fclasslib) of the .NET Framework APIs, using the same assembly names and factoring.
+- **Platforms** -- Mono supports many platforms and CPUs.
+- **Open Source** -- Mono and .NET Core both use the MIT license and are .NET Foundation projects.
+- **Focus** -- The primary focus of Mono in recent years is mobile platforms, while .NET Core is focused on cloud workloads.

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -7,137 +7,39 @@ ms.date: 06/20/2016
 ---
 # .NET Core Guide
 
-> Check out the ["Getting Started" tutorials](get-started.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
+[.NET Core](about.md) is an [open source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
 
-.NET Core is a general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios. 
+See [About .NET Core](about.md) to learn more about .NET Core.
 
-The following characteristics best define .NET Core:
+Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
 
-- **Flexible deployment:** Can be included in your app or installed side-by-side user- or machine-wide.
-- **Cross-platform:** Runs on Windows, macOS and Linux; can be ported to other operating systems. The [supported Operating Systems (OS)](https://github.com/dotnet/core/blob/master/roadmap.md), CPUs and application scenarios will grow over time, provided by Microsoft, other companies, and individuals.
-- **Command-line tools:**  All product scenarios can be exercised at the command-line. 
-- **Compatible:** .NET Core is compatible with .NET Framework, Xamarin and Mono, via the [.NET Standard](../standard/net-standard.md).
-- **Open source:** The .NET Core platform is open source, using MIT and Apache 2 licenses. Documentation is licensed under [CC-BY](https://creativecommons.org/licenses/by/4.0/). .NET Core is a [.NET Foundation](https://dotnetfoundation.org/) project.
-- **Supported by Microsoft:** .NET Core is supported by Microsoft, per [.NET Core Support](https://www.microsoft.com/net/core/support/)
+Try .NET Core in your browser:
 
-## Composition
+* [Hello C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/hello-world)
+* [Numbers in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/numbers-in-csharp)
+* [Collections in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/list-collection)
 
-.NET Core is composed of the following parts:
+## .NET Core 2.1
 
-- A [.NET runtime](https://github.com/dotnet/coreclr), which provides a type system, assembly loading, a garbage collector, native interop and other basic services. 
-- A set of [framework libraries](https://github.com/dotnet/corefx), which provide primitive data types, app composition types and fundamental utilities. 
-- A [set of SDK tools](https://github.com/dotnet/cli) and language compilers ([Roslyn](https://github.com/dotnet/roslyn) and [F#](https://github.com/microsoft/visualfsharp)) that enable the base developer experience, available in the [.NET Core SDK](sdk.md).
-- The 'dotnet' app host, which is used to launch .NET Core apps. It selects the runtime and hosts the runtime, provides an assembly loading policy and launches the app. The same host is also used to launch SDK tools in much the same way.
+The latest version is [.NET Core 2.1](whats-new.md). New features include: global tools, high-performance APIs (such as <xref:System.Span%601?displayProperty=nameWithType>), tiered JIT compilation, [build](https://blogs.msdn.microsoft.com/dotnet/2018/05/30/announcing-net-core-2-1/) and [runtime performance improvements](https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/), and  support for Alpine and ARM32.
 
-### Languages
+## Download .NET Core 2.1
 
-The C#, Visual Basic, and F# languages can be used to write applications and libraries for .NET Core. The compilers run on .NET Core, enabling you to develop for .NET Core anywhere it runs. In general, you will not use the compilers directly, but indirectly using the SDK tools.
+Download the [.NET Core  2.1 SDK](https://www.microsoft.com/net/download) to try .NET Core on your Windows, macOS or Linux machine. Visit [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) if you prefer to use Docker containers.
 
-The C#, Visual Basic, and F# compilers and the .NET Core tools are or can be integrated into several text editors and IDEs, including Visual Studio, [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp), Sublime Text and Vim, making .NET Core development an option in your favorite coding environment and OS. This integration is provided, in part, by the good folks of the [OmniSharp project](http://www.omnisharp.net/) and [Ionide](http://ionide.io).
+All .NET Core versions are available at [.NET Core Downloads](https://www.microsoft.com/net/download/archives) if you are looking for another .NET Core version.
 
-### .NET APIs and Compatibility
+## Create your first application
 
-.NET Core can be thought of as a cross-platform version of the .NET Framework, at the layer of the .NET Framework Base Class Libraries (BCL). It implements the [.NET Standard](../standard/net-standard.md) specification. .NET Core provides a subset of the APIs that are available in the .NET Framework or Mono/Xamarin. In some cases, types are not fully implemented (some members are not available or have been moved).
+After installing the .NET Core SDK, open a command prompt. Type the following `dotnet` commands to create and run a C# application.
 
-Look at the [.NET Core roadmap](https://github.com/dotnet/core/blob/master/roadmap.md) to learn more about the .NET Core API roadmap.
+```console
+dotnet new console
+dotnet run
+```
 
-### Relationship to .NET Standard
+You should see the following output:
 
-The [.NET Standard](../standard/net-standard.md) is an API spec that describes the consistent set of .NET APIs that developers can expect in each .NET implementation. .NET implementations need to implement this spec in order to be considered .NET Standard-compliant and to support libraries that target .NET Standard. 
-
-.NET Core implements .NET Standard, and therefore supports .NET Standard libraries.
-
-### Workloads
-
-By itself, .NET Core includes a single application model -- console apps -- which is useful for tools, local services and text-based games. Additional application models have been built on top of .NET Core to extend its functionality, such as:
-
-- [ASP.NET Core](/aspnet/core/)
-- [Windows 10 Universal Windows Platform (UWP)](https://developer.microsoft.com/windows)
-- [Xamarin.Forms when targeting UWP](https://www.xamarin.com/forms)
-
-### Open Source
-
-[.NET Core](https://github.com/dotnet/core) is open source (MIT license) and was contributed to the [.NET Foundation](https://dotnetfoundation.org) by Microsoft in 2014. It is now one of the most active .NET Foundation projects. It can be freely adopted by individuals and companies, including for personal, academic or commercial purposes. Multiple companies use .NET Core as part of apps, tools, new platforms and hosting services. Some of these companies make significant contributions to .NET Core on GitHub and provide guidance on the product direction as part of the [.NET Foundation Technical Steering Group](https://dotnetfoundation.org/blog/tsg-welcome).
-
-## Acquisition
-
-.NET Core is distributed in two main ways, as packages on NuGet.org and as standalone distributions.
-
-### Distributions
-
-You can download .NET Core at the [.NET Core Getting Started](https://www.microsoft.com/net/core) page.
-
-- The *Microsoft .NET Core* distribution includes the CoreCLR runtime, associated libraries, a console application host and the `dotnet` app launcher. It is described by the [`Microsoft.NETCore.App`](https://www.nuget.org/packages/Microsoft.NETCore.App) metapackage.
-- The *Microsoft .NET Core SDK* distribution includes .NET Core and a set of tools for restoring NuGet packages and compiling and building apps. 
-
-Typically, you will first install the .NET Core SDK to get started with .NET Core development. You may choose to install additional .NET Core (perhaps pre-release) builds.
-
-### Packages
-
-- [.NET Core Packages](packages.md) contain the .NET Core runtime and libraries (reference assemblies and implementations). For example, [System.Net.Http](https://www.nuget.org/packages/System.Net.Http/).
-- [.NET Core Metapackages](packages.md) describe various layers and app-models by referencing the appropriate set of versioned library packages.
-
-## Architecture
-
-.NET Core is a cross-platform .NET implementation. The primary architectural concerns unique to .NET Core are related to providing platform-specific implementations for supported platforms.
-
-### Environments
-
-.NET Core is supported by Microsoft on Windows, macOS and Linux. On Linux, Microsoft primarily supports .NET Core running on Red Hat Enterprise Linux (RHEL) and Debian distribution families.
-
-.NET Core currently supports X64 CPUs. On Windows, X86 is also supported. ARM64 and ARM32 are in progress.
-
-The [.NET Core Roadmap](https://github.com/dotnet/core/blob/master/roadmap.md) provides more detailed information on workload and OS and CPU environment support and plans.
-
-Other companies or groups may support .NET Core for other app types and environment.
-
-### Designed for Adaptability
-
-.NET Core has been built as a very similar but unique product relative to other .NET products. It has been designed to enable broad adaptability to new platforms, for new workloads and with new compiler toolchains. It has several OS and CPU ports in progress and may be ported to many more. An example is the [LLILC](https://github.com/dotnet/llilc) project, which is an early prototype of native compilation for .NET Core via the [LLVM](http://llvm.org/) compiler.
-
-The product is broken into several pieces, enabling the various parts to be adapted to new platforms on different schedules. The runtime and platform-specific foundational libraries must be ported as a unit. Platform-agnostic libraries should work as-is on all platforms, by construction. There is a project bias to reducing platform-specific implementations to increase developer efficiency, preferring platform-neutral C# code whenever an algorithm or API can be implemented in-full or in-part that way.
-
-People commonly ask how .NET Core is implemented in order to support multiple operating systems. They typically ask if there are separate implementations or if [conditional compilation](https://en.wikipedia.org/wiki/Conditional_compilation) is used. It's both, with a strong bias towards conditional compilation.
-
-You can see in the chart below that the vast majority of [CoreFX](https://github.com/dotnet/corefx) is platform-neutral code that is shared across all platforms. Platform-neutral code can be implemented as a single portable assembly that is used on all platforms.
-
-![CoreFX: Lines of Code per Platform](../images/corefx-platforms-loc.png)
-
-Windows and Unix implementations are similar in size. Windows has a larger implementation since CoreFX implements some Windows-only features, such as [Microsoft.Win32.Registry](https://github.com/dotnet/corefx/tree/master/src/Microsoft.Win32.Registry) but does not yet implement any Unix-only concepts. You will also see that the majority of the Linux and macOS implementations are shared across a Unix implementation, while the Linux- and macOS-specific implementations are roughly similar in size.
-
-
-There are a mix of platform-specific and platform-neutral libraries in .NET Core. You can see the pattern in a few examples:
-
-- [CoreCLR](https://github.com/dotnet/coreclr) is platform-specific. It's built in C/C++, so is platform-specific by construction.
-- [System.IO](https://github.com/dotnet/corefx/tree/master/src/System.IO) and [System.Security.Cryptography.Algorithms](https://github.com/dotnet/corefx/tree/master/src/System.Security.Cryptography.Algorithms) are platform-specific, given that the storage and cryptography APIs differ significantly on each OS. 
-- [System.Collections](https://github.com/dotnet/corefx/tree/master/src/System.Collections) and [System.Linq](https://github.com/dotnet/corefx/tree/master/src/System.Linq) are platform-neutral, given that they create and operate over data structures.
-
-## Comparisons to other .NET implementations
-
-It is perhaps easiest to understand the size and shape of .NET Core by comparing it to existing .NET implementations. 
-
-### Comparison with .NET Framework
-
-.NET was first announced by Microsoft in 2000 and then evolved from there. The .NET Framework has been the primary .NET implementation produced by Microsoft during that 15+ year span. 
-
-The major differences between .NET Core and the .NET Framework: 
-
-- **App-models** -- .NET Core does not support all the .NET Framework app-models, in part because many of them are built on Windows technologies, such as WPF (built on top of DirectX). The console and ASP.NET Core app-models are supported by both .NET Core and .NET Framework. 
-- **APIs** -- .NET Core contains many of the same, but fewer, APIs as the .NET Framework, and with a different factoring (assembly names are different; type shape differs in key cases). These differences currently typically require changes to port source to .NET Core. .NET Core implements the [.NET Standard](../standard/net-standard.md) API, which will grow to include more of the .NET Framework BCL API over time.
-- **Subsystems** -- .NET Core implements a subset of the subsystems in the .NET Framework, with the goal of a simpler implementation and programming model. For example, Code Access Security (CAS) is not supported, while reflection is supported.
-- **Platforms** -- The .NET Framework supports Windows and Windows Server while .NET Core also supports macOS and Linux.
-- **Open Source** -- .NET Core is open source, while a [read-only subset of the .NET Framework](https://github.com/microsoft/referencesource) is open source.
-
-While .NET Core is unique and has significant differences to the .NET Framework and other .NET implementations, it is straightforward to share code, using either source or binary sharing techniques. 
-
-### Comparison with Mono
-
-[Mono](http://www.mono-project.com/) is the original cross-platform and [open source](https://github.com/mono/mono) .NET implementation, first shipping in 2004. It can be thought of as a community clone of the .NET Framework. The Mono project team relied on the open [.NET standards](https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/dotnet-standards.md) (notably ECMA 335) published by Microsoft in order to provide a compatible implementation.
-
-The major differences between .NET Core and Mono:
-
-- **App-models** -- Mono supports a subset of the .NET Framework app-models (for example, Windows Forms) and some additional ones (for example, [Xamarin.iOS](https://www.xamarin.com/platform)) through the Xamarin product. .NET Core doesn't support these.
-- **APIs** -- Mono supports a [large subset](http://docs.go-mono.com/?link=root%3a%2fclasslib) of the .NET Framework APIs, using the same assembly names and factoring.
-- **Platforms** -- Mono supports many platforms and CPUs.
-- **Open Source** -- Mono and .NET Core both use the MIT license and are .NET Foundation projects.
-- **Focus** -- The primary focus of Mono in recent years is mobile platforms, while .NET Core is focused on cloud workloads.
+```console
+Hello World!
+```

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -3,25 +3,26 @@ title: .NET Core Guide
 description: .NET Core is a modular, high-performance implementation of .NET for creating Windows, Linux, and Mac apps. Learn about .NET Core to get started.
 author: richlander
 ms.author: mairaw
-ms.date: 06/20/2016
+ms.date: 08/01/2018
+ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and IoT applications.
+[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and IoT applications.
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 
-Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running. If you want to try something really quick, you can [try .NET Core in your browser](https://docs.microsoft.com/dotnet/csharp/quick-starts/hello-world).
+Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running. If you want to try .NET Core in you browser, look at the [Numbers in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/hello-world) quickstart.
 
 ## Download .NET Core 2.1
 
-Download the [.NET Core  2.1 SDK](https://www.microsoft.com/net/download) to try .NET Core on your Windows, macOS or Linux machine. Visit [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) if you prefer to use Docker containers.
+Download the [.NET Core  2.1 SDK](https://www.microsoft.com/net/download) to try .NET Core on your Windows, macOS, or Linux machine. Visit [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) if you prefer to use Docker containers.
 
-All .NET Core versions are available at [.NET Core Downloads](https://www.microsoft.com/net/download/archives) if you are looking for another .NET Core version.
+All .NET Core versions are available at [.NET Core Downloads](https://www.microsoft.com/net/download/archives) if you're looking for another .NET Core version.
 
 ## .NET Core 2.1
 
-The latest version is [.NET Core 2.1](whats-new/index.md). New features include: global tools, high-performance APIs (such as <xref:System.Span%601?displayProperty=nameWithType>), tiered JIT compilation, [build](https://blogs.msdn.microsoft.com/dotnet/2018/05/30/announcing-net-core-2-1/) and [runtime performance improvements](https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/), and  support for Alpine and ARM32.
+The latest version is [.NET Core 2.1](whats-new/dotnet-core-2-1.md). New features include: global tools, high-performance APIs (such as <xref:System.Span%601?displayProperty=nameWithType>), tiered JIT compilation, [build](https://blogs.msdn.microsoft.com/dotnet/2018/05/30/announcing-net-core-2-1/) and [runtime performance improvements](https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/), and support for Alpine and ARM32.
 
 ## Create your first application
 
@@ -40,7 +41,7 @@ Hello World!
 
 ## Support
 
-.NET Core is [supported by Microsoft](https://www.microsoft.com/net/support/policy), on Windows, macOS and Linux. It is updated for security and quality multiple times a year, typically monthly.
+.NET Core is [supported by Microsoft](https://www.microsoft.com/net/support/policy), on Windows, macOS and Linux. It's updated for security and quality several times a year, typically monthly.
 
 .NET Core binary distributions are built and tested on Microsoft-maintained servers in Azure and supported just like any Microsoft product.
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -7,27 +7,21 @@ ms.date: 06/20/2016
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
+[.NET Core](about.md) is an [open source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and IoT applications.
 
-See [About .NET Core](about.md) to learn more about .NET Core.
+See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 
-Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running.
-
-Try .NET Core in your browser:
-
-* [Hello C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/hello-world)
-* [Numbers in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/numbers-in-csharp)
-* [Collections in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/list-collection)
-
-## .NET Core 2.1
-
-The latest version is [.NET Core 2.1](whats-new.md). New features include: global tools, high-performance APIs (such as <xref:System.Span%601?displayProperty=nameWithType>), tiered JIT compilation, [build](https://blogs.msdn.microsoft.com/dotnet/2018/05/30/announcing-net-core-2-1/) and [runtime performance improvements](https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/), and  support for Alpine and ARM32.
+Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running. If you want to try something really quick, you can [try .NET Core in your browser](https://docs.microsoft.com/dotnet/csharp/quick-starts/hello-world).
 
 ## Download .NET Core 2.1
 
 Download the [.NET Core  2.1 SDK](https://www.microsoft.com/net/download) to try .NET Core on your Windows, macOS or Linux machine. Visit [microsoft/dotnet](https://hub.docker.com/r/microsoft/dotnet/) if you prefer to use Docker containers.
 
 All .NET Core versions are available at [.NET Core Downloads](https://www.microsoft.com/net/download/archives) if you are looking for another .NET Core version.
+
+## .NET Core 2.1
+
+The latest version is [.NET Core 2.1](whats-new/index.md). New features include: global tools, high-performance APIs (such as <xref:System.Span%601?displayProperty=nameWithType>), tiered JIT compilation, [build](https://blogs.msdn.microsoft.com/dotnet/2018/05/30/announcing-net-core-2-1/) and [runtime performance improvements](https://blogs.msdn.microsoft.com/dotnet/2018/04/18/performance-improvements-in-net-core-2-1/), and  support for Alpine and ARM32.
 
 ## Create your first application
 
@@ -43,3 +37,11 @@ You should see the following output:
 ```console
 Hello World!
 ```
+
+## Support
+
+.NET Core is [supported by Microsoft](https://www.microsoft.com/net/support/policy), on Windows, macOS and Linux. It is updated for security and quality multiple times a year, typically monthly.
+
+.NET Core binary distributions are built and tested on Microsoft-maintained servers in Azure and supported just like any Microsoft product.
+
+[Red Hat supports .NET Core](http://redhatloves.net/) on Red Hat Enterprise Linux (RHEL). Red Hat builds .NET Core from source and makes it available in the [Red Hat Software Collections](https://developers.redhat.com/products/softwarecollections/overview/). Red Hat and Microsoft collaborate to ensure that .NET Core works well on RHEL.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -63,6 +63,7 @@
 
 <!-- .NET Core Content -->
 # [.NET Core Guide](core/index.md)
+## [About .NET Core](core/about.md)
 ## [Get started](core/get-started.md)
 ### [Get started with C# and Visual Studio Code](core/tutorials/with-visual-studio-code.md)
 ### [Build a C# Hello World app with .NET Core in Visual Studio 2017](core/tutorials/with-visual-studio.md)


### PR DESCRIPTION
The .NET Core entry page is busy. Let's simplify it and also include more actionable information.

I didn't even read most of the existing content on the about page. We can deal with that as a second PR.
