### PR TITLE
Removed remark about object initializers with nullable structs

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
+++ b/docs/csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md
@@ -38,9 +38,6 @@ foreach(var p in productInfos){...}
 select new {p.ProductName, Price = p.UnitPrice};  
 ```  
   
-## Object initializers with nullable types  
- It is a compile-time error to use an object initializer with a nullable struct.  
-  
 ## Collection initializers  
  Collection initializers let you specify one or more element initializers when you initialize a collection type that implements <xref:System.Collections.IEnumerable> and has `Add` with the appropriate signature as an instance method or an extension method. The element initializers can be a simple value, an expression or an object initializer. By using a collection initializer you do not have to specify multiple calls to the `Add` method of the class in your source code; the compiler adds the calls.  
   


### PR DESCRIPTION
First, I've checked the [language specification](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf) and haven't found anything specific about using object initializers with a nullable struct.

Second, if such a compile-time error exists, I think its message explains the issue better than the text being deleted by this PR. This text is not actionable and might set more limits than intended. For example, the example in the referenced issue compiles.

Fixes #5497
