### PR TITLE
Escaped article title

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf-directive/servicehost.md
+++ b/docs/framework/configure-apps/file-schema/wcf-directive/servicehost.md
@@ -3,7 +3,7 @@ title: "@ServiceHost"
 ms.date: "03/30/2017"
 ms.assetid: 96ba6967-00f2-422f-9aa7-15de4d33ebf3
 ---
-# @ServiceHost
+# \@ServiceHost
 Associates the factory used to produce the service host with the service to be hosted and other programming aspects required to access or compile the hosting code provided in the .svc file.  
   
 ## Syntax  


### PR DESCRIPTION
## Escaped article title

The title of the [@ServiceHost](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/wcf-directive/servicehost) topic was dropped from the build, possibly because it needs to be escaped.


