### PR TITLE
Use <schemaImporterExtensions> instead of <xmlSchemaImporterExtensions>

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -952,6 +952,10 @@
             "redirect_document_id": true
         },
         {
+            "source_path":"docs/standard/serialization/add-element-for-xmlschemaimporterextensions.md",
+            "redirect_url":"/dotnet/standard/serialization/add-element-for-schemaimporterextensions"
+        },
+        {
             "source_path": "docs/standard/serialization/marshal-by-value.md",
             "redirect_url": "/dotnet/standard/serialization-concepts"
         },

--- a/docs/standard/serialization/add-element-for-schemaimporterextensions.md
+++ b/docs/standard/serialization/add-element-for-schemaimporterextensions.md
@@ -1,17 +1,17 @@
 ---
-title: "&lt;add&gt; Element for &lt;xmlSchemaImporterExtensions&gt;"
+title: "&lt;add&gt; Element for &lt;schemaImporterExtensions&gt;"
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "XML serialization, configuration"
-  - "<add> element for <xmlSchemaImporterExtensions> element"
+  - "<add> element for <schemaImporterExtensions> element"
 ms.assetid: c828a558-094b-441e-9065-790b87315fa0
 ---
-# &lt;add&gt; Element for &lt;xmlSchemaImporterExtensions&gt;
+# &lt;add&gt; Element for &lt;schemaImporterExtensions&gt;
 Adds types used by the <xref:System.Xml.Serialization.XmlSchemaImporter> for mapping XSD types to .NET Framework types. For more information about configuration files, see [Configuration File Schema](../../../docs/framework/configure-apps/file-schema/index.md).  
   
  \<configuration>  
 \<system.xml.serialization>  
-\<XmlSchemaImporterExtensions>  
+\<schemaImporterExtensions>  
 \<add>  
   
 ## Syntax  
@@ -37,7 +37,7 @@ Adds types used by the <xref:System.Xml.Serialization.XmlSchemaImporter> for map
   
 |Element|Description|  
 |-------------|-----------------|  
-|\<xmlSchemaImporterExtensions>|Contains the types that are used by the <xref:System.Xml.Serialization.XmlSchemaImporter>.|  
+|\<schemaImporterExtensions>|Contains the types that are used by the <xref:System.Xml.Serialization.XmlSchemaImporter>.|  
   
 ## Example  
  The following code example adds an extension type that the XmlSchemaImporter can use when mapping types.  
@@ -45,11 +45,11 @@ Adds types used by the <xref:System.Xml.Serialization.XmlSchemaImporter> for map
 ```xml  
 <configuration>  
   <system.xml.serialization>  
-    <xmlSchemaImporterExtensions>  
+    <schemaImporterExtensions>  
        <add name="contoso" type="System.Web.Mobile.MobileCapabilities,   
        System.Web.Mobile, Version=2.0.0.0, Culture=neutral,   
        PublicKeyToken=b03f5f7f11d50a3a" />   
-    </xmlSchemaImporterExtensions>  
+    </schemaImporterExtensions>  
   </system.xml.serialization>  
 </configuration>  
 ```  

--- a/docs/standard/serialization/datetimeserialization-element.md
+++ b/docs/standard/serialization/datetimeserialization-element.md
@@ -50,5 +50,5 @@ Determines the serialization mode of <xref:System.DateTime> objects.
  <xref:System.Xml.Serialization.Configuration.DateTimeSerializationSection.DateTimeSerializationMode>  
  [Configuration File Schema](../../../docs/framework/configure-apps/file-schema/index.md)  
  [\<schemaImporterExtensions> Element](../../../docs/standard/serialization/schemaimporterextensions-element.md)  
- [\<add> Element for \<xmlSchemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-xmlschemaimporterextensions.md)  
+ [\<add> Element for \<schemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-schemaimporterextensions.md)  
  [\<system.xml.serialization> Element](../../../docs/standard/serialization/system-xml-serialization-element.md)

--- a/docs/standard/serialization/schemaimporterextensions-element.md
+++ b/docs/standard/serialization/schemaimporterextensions-element.md
@@ -22,7 +22,7 @@ Contains types that are used by the <xref:System.Xml.Serialization.XmlSchemaImpo
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<add> Element for \<xmlSchemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-xmlschemaimporterextensions.md)|Adds types that are used by the <xref:System.Xml.Serialization.XmlSchemaImporter> to create mappings.|  
+|[\<add> Element for \<schemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-schemaimporterextensions.md)|Adds types that are used by the <xref:System.Xml.Serialization.XmlSchemaImporter> to create mappings.|  
   
 ## Parent Elements  
   
@@ -49,5 +49,5 @@ Contains types that are used by the <xref:System.Xml.Serialization.XmlSchemaImpo
  <xref:System.Xml.Serialization.Configuration.DateTimeSerializationSection.DateTimeSerializationMode>  
  [Configuration File Schema](../../../docs/framework/configure-apps/file-schema/index.md)  
  [\<dateTimeSerialization> Element](../../../docs/standard/serialization/datetimeserialization-element.md)  
- [\<add> Element for \<xmlSchemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-xmlschemaimporterextensions.md)  
+ [\<add> Element for \<schemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-schemaimporterextensions.md)  
  [\<system.xml.serialization> Element](../../../docs/standard/serialization/system-xml-serialization-element.md)

--- a/docs/standard/serialization/system-xml-serialization-element.md
+++ b/docs/standard/serialization/system-xml-serialization-element.md
@@ -62,4 +62,4 @@ The top-level element for controlling XML serialization. For more information ab
  [Configuration File Schema](../../../docs/framework/configure-apps/file-schema/index.md)  
  [\<dateTimeSerialization> Element](../../../docs/standard/serialization/datetimeserialization-element.md)  
  [\<schemaImporterExtensions> Element](../../../docs/standard/serialization/schemaimporterextensions-element.md)  
- [\<add> Element for \<xmlSchemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-xmlschemaimporterextensions.md)
+ [\<add> Element for \<schemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-schemaimporterextensions.md)

--- a/docs/standard/serialization/toc.md
+++ b/docs/standard/serialization/toc.md
@@ -29,7 +29,7 @@
 ### [<system.xml.serialization> Element](system-xml-serialization-element.md)
 ### [<dateTimeSerialization> Element](datetimeserialization-element.md)
 ### [<schemaImporterExtensions> Element](schemaimporterextensions-element.md)
-### [<add> Element for <xmlSchemaImporterExtensions>](add-element-for-xmlschemaimporterextensions.md)
+### [<add> Element for <schemaImporterExtensions>](add-element-for-schemaimporterextensions.md)
 ### [<xmlSerializer> Element](xmlserializer-element.md)
 ## [Serialization Tools](serialization-tools.md)
 ### [XML Serializer Generator Tool (Sgen.exe)](xml-serializer-generator-tool-sgen-exe.md)

--- a/docs/standard/serialization/xml-and-soap-serialization.md
+++ b/docs/standard/serialization/xml-and-soap-serialization.md
@@ -71,7 +71,7 @@ XML serialization converts (serializes) the public fields and properties of an o
  [\<schemaImporterExtensions> Element](../../../docs/standard/serialization/schemaimporterextensions-element.md)  
  Contains types that are used by the <xref:System.Xml.Serialization.XmlSchemaImporter> class.  
   
- [\<add> Element for \<xmlSchemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-xmlschemaimporterextensions.md)  
+ [\<add> Element for \<schemaImporterExtensions>](../../../docs/standard/serialization/add-element-for-schemaimporterextensions.md)  
  Adds types that are used by the <xref:System.Xml.Serialization.XmlSchemaImporter> class.  
   
 ## Related Sections  


### PR DESCRIPTION
Both are supported but the usage inconsistency was brought up by @rpetrusha in #6596, and suggested we standardize one variant in the docs.