### PR TITLE
fix typo in `Match at Least n Times: {n,}`

### DIFF
--- a/docs/standard/base-types/quantifiers-in-regular-expressions.md
+++ b/docs/standard/base-types/quantifiers-in-regular-expressions.md
@@ -109,7 +109,7 @@ Quantifiers specify how many instances of a character, group, or character class
 |`\b`|End at a word boundary.|  
   
 ### Match at Least n Times: {n,}  
- The `{`*n*`,}` quantifier matches the preceding element at least *n* times, where *n* is any integer. `{`*n*`,}` is a greedy quantifier whose lazy equivalent is `{`*n*`}?`.  
+ The `{`*n*`,}` quantifier matches the preceding element at least *n* times, where *n* is any integer. `{`*n*`,}` is a greedy quantifier whose lazy equivalent is `{`*n*`,}?`.  
   
  For example, the regular expression `\b\d{2,}\b\D+` tries to match a word boundary followed by at least two digits followed by a word boundary and a non-digit character. The following example illustrates this regular expression. The regular expression fails to match the phrase `"7 days"` because it contains just one decimal digit, but it successfully matches the phrases `"10 weeks and 300 years"`.  
   


### PR DESCRIPTION
## Summary

Fix typo in `Match at Least n Times: {n,}`
