### PR TITLE
Revised the "How to: Identify a nullable type" topic

### DIFF
--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -99,4 +99,5 @@ Point p = new Point(); // Invoke default constructor for the struct.
  [C# Keywords](../../../csharp/language-reference/keywords/index.md)  
  [Types](../../../csharp/language-reference/keywords/types.md)  
  [Reference Tables for Types](../../../csharp/language-reference/keywords/reference-tables-for-types.md)  
- [Reference Types](../../../csharp/language-reference/keywords/reference-types.md)
+ [Reference Types](../../../csharp/language-reference/keywords/reference-types.md)  
+ [Nullable types](../../programming-guide/nullable-types/index.md)  

--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -13,7 +13,7 @@ Constraints inform the compiler about the capabilities a type argument must have
 
 |Constraint|Description|
 |----------------|-----------------|
-|`where T : struct`|The type argument must be a value type. Any value type except <xref:System.Nullable> can be specified. For more information, see [Using Nullable Types](../nullable-types/using-nullable-types.md).|
+|`where T : struct`|The type argument must be a value type. Any value type except <xref:System.Nullable%601> can be specified. For more information about nullable types, see [Nullable types](../nullable-types/index.md).|
 |`where T : class`|The type argument must be a reference type. This constraint applies also to any class, interface, delegate, or array type.|
 |`where T : unmanaged`|The type argument must not be a reference type and must not contain any reference type members at any level of nesting.|
 |`where T : new()`|The type argument must have a public parameterless constructor. When used together with other constraints, the `new()` constraint must be specified last.|

--- a/docs/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type.md
+++ b/docs/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type.md
@@ -1,6 +1,6 @@
 ---
 title: "How to: Identify a nullable type (C# Programming Guide)"
-description: "Learn how to determine whether an instance of a nullable type"
+description: "Learn how to determine whether a type is a nullable type or an instance is of a nullable type"
 ms.date: 08/06/2018
 helpviewer_keywords: 
   - "nullable types [C#], identifying"

--- a/docs/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type.md
+++ b/docs/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type.md
@@ -1,44 +1,32 @@
 ---
-title: "How to: Identify a Nullable Type (C# Programming Guide)"
-ms.date: 07/20/2015
+title: "How to: Identify a nullable type (C# Programming Guide)"
+description: "Learn how to determine whether an instance of a nullable type"
+ms.date: 08/06/2018
 helpviewer_keywords: 
   - "nullable types [C#], identifying"
 ms.assetid: d4b67ee2-66e8-40c1-ae9d-545d32c71387
 ---
-# How to: Identify a Nullable Type (C# Programming Guide)
-You can use the C# [typeof](../../../csharp/language-reference/keywords/typeof.md) operator to create a <xref:System.Type> object that represents a Nullable type:  
+# How to: Identify a nullable type (C# Programming Guide)
+
+The following example shows how to determine whether a <xref:System.Type?displayProperty=nameWithType> instance represents a nullable type:
+
+[!code-csharp-interactive[whether Type is nullable](../../../../samples/snippets/csharp/programming-guide/nullable-types/IdentifyNullableType.cs#1)]
+
+As the example shows, you use the [typeof](../../language-reference/keywords/typeof.md) operator to create a <xref:System.Type?displayProperty=nameWithType> object.  
   
-```  
-System.Type type = typeof(int?);  
-```  
+If you want to determine whether an instance is of a nullable type, don't use the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method to get a <xref:System.Type> instance to be tested with the preceding code. When you call the <xref:System.Object.GetType%2A?displayProperty=nameWithType> method on an instance of a nullable type, the instance is [boxed](using-nullable-types.md#boxing-and-unboxing) to <xref:System.Object>. As boxing of a non-null instance of a nullable type is equivalent to boxing of a value of the underlying type, <xref:System.Object.GetType%2A> returns a <xref:System.Type> object that represents the underlying type of a nullable type:
+
+[!code-csharp-interactive[GetType example](../../../../samples/snippets/csharp/programming-guide/nullable-types/IdentifyNullableType.cs#2)]
+
+Don't use the [is](../../language-reference/keywords/is.md) operator to determine whether an instance is of a nullable type. As the following example shows, you cannot distinguish types of instances of a nullable type and its underlying type with using the `is` operator:
+
+[!code-csharp-interactive[is operator example](../../../../samples/snippets/csharp/programming-guide/nullable-types/IdentifyNullableType.cs#3)]
+
+You can use the code presented in the following example to determine whether an instance is of a nullable type:
+
+[!code-csharp-interactive[whether an instance is of a nullable type](../../../../samples/snippets/csharp/programming-guide/nullable-types/IdentifyNullableType.cs#4)]
   
- You can also use the classes and methods of the <xref:System.Reflection> namespace to generate <xref:System.Type> objects that represent Nullable types. However, if you try to obtain type information from Nullable variables at runtime by using the <xref:System.Object.GetType%2A> method or the `is` operator, the result is a <xref:System.Type> object that represents the underlying type, not the Nullable type itself.  
-  
- Calling `GetType` on a Nullable type causes a boxing operation to be performed when the type is implicitly converted to <xref:System.Object>. Therefore <xref:System.Object.GetType%2A> always returns a <xref:System.Type> object that represents the underlying type, not the Nullable type.  
-  
-```  
-int? i = 5;  
-Type t = i.GetType();  
-Console.WriteLine(t.FullName); //"System.Int32"  
-```  
-  
- The C# [is](../../../csharp/language-reference/keywords/is.md) operator also operates on a Nullable's underlying type. Therefore you cannot use `is` to determine whether a variable is a Nullable type. The following example shows that the `is` operator treats a Nullable\<int> variable as an int.  
-  
-```  
-static void Main(string[] args)  
-{  
-  int? i = 5;  
-  if (i is int) // true  
-    //…  
-}  
-```  
-  
-## Example  
- Use the following code to determine whether a <xref:System.Type> object represents a Nullable type. Remember that this code always returns false if the `Type` object was returned from a call to <xref:System.Object.GetType%2A>, as explained earlier in this topic.  
-  
-```  
-if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)) {…}  
-```  
-  
-## See Also  
- [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md)  
+## See also
+
+[Nullable types](index.md)  
+[Using nullable types](using-nullable-types.md)  

--- a/docs/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type.md
+++ b/docs/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type.md
@@ -30,3 +30,4 @@ You can use the code presented in the following example to determine whether an 
 
 [Nullable types](index.md)  
 [Using nullable types](using-nullable-types.md)  
+<sref:System.Nullable.GetUnderlyingType%2A>  

--- a/docs/csharp/programming-guide/nullable-types/index.md
+++ b/docs/csharp/programming-guide/nullable-types/index.md
@@ -46,7 +46,7 @@ Nullable types have the following characteristics:
   
 - Nested nullable types are not allowed. The following line doesn't compile: `Nullable<Nullable<int>> n;`  
 
-For more information, see the [Using nullable types](using-nullable-types.md) topic.
+For more information, see the [Using nullable types](using-nullable-types.md) and [How to: Identify a nullable type](how-to-identify-a-nullable-type.md) topics.
   
 ## See also
 


### PR DESCRIPTION
To complete the revision of the nullable type topics, this PR revises the [How to: Identify a nullable type](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type) topic:
- Moved and updated code to the samples repo.
- Added the example that shows how to determine whether an instance is of a nullable type. The current version only says how not to do it.

Also updated several cross-reference links within the docs.

Supported by dotnet/samples#224
