### PR TITLE
Removed reference to dracula transform.

### DIFF
--- a/docs/machine-learning/resources/transforms.md
+++ b/docs/machine-learning/resources/transforms.md
@@ -54,7 +54,7 @@ The following tables contain information about all of the data transforms suppor
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.HashConverter> | Converts column values into hashes. This transform accepts both numeric and text inputs, both single and vector-valued columns. This is a part of the Dracula transform. |
+| <xref:Microsoft.ML.Transforms.HashConverter> | Converts column values into hashes. This transform accepts both numeric and text inputs, both single and vector-valued columns. |
 | <xref:Microsoft.ML.Transforms.TreeLeafFeaturizer> | Trains a tree ensemble, or loads it from a file, then maps a numeric feature vector to three outputs: 1. A vector containing the individual tree outputs of the tree ensemble. 2. A vector indicating the leaves that the feature vector falls on in the tree ensemble. 3. A vector indicating the paths that the feature vector falls on in the tree ensemble. If both a model file and a trainer are specified, the vector will use the model file. If neither are specified, the vector will train a default FastTree model. This can handle key labels by training a regression model towards their optionally permuted indices. |
 
 ## Label parsing


### PR DESCRIPTION
Removed reference to Dracula transform as it is not supported.

[Internet Review URL](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/resources/transforms?branch=pr-en-us-6860)

Fixes [dotnet/machinelearning/#609](https://github.com/dotnet/machinelearning/issues/609).