### PR TITLE
add obsolete error message

### DIFF
--- a/docs/core/migration/20-21.md
+++ b/docs/core/migration/20-21.md
@@ -36,7 +36,7 @@ For an overview of the new features in .NET Core 2.1, see [What's new in .NET Co
   
   `The tool 'Microsoft.EntityFrameworkCore.Tools.DotNet' is now included in the .NET Core SDK. Here is information on resolving this warning.`
   
-  Removing the `<DotNetCliToolReference>` reference from your project file fixes this issue.
+  Removing the `<DotNetCliToolReference>` references for those tools from your project file fixes this issue.
 
 ## See also
 

--- a/docs/core/migration/20-21.md
+++ b/docs/core/migration/20-21.md
@@ -3,7 +3,7 @@ title: Migrate from .NET Core 2.0 to 2.1
 description: Learn how to upgrade your .NET Core 2.0 app to 2.1.
 author: mairaw
 ms.author: mairaw
-ms.date: 06/18/2018
+ms.date: 08/06/2018
 ---
 # Migrate from .NET Core 2.0 to 2.1
 
@@ -25,6 +25,18 @@ For an overview of the new features in .NET Core 2.1, see [What's new in .NET Co
   * [dotnet-user-secrets](https://github.com/aspnet/DotNetTools/blob/dev/src/dotnet-user-secrets/README.md) (Microsoft.Extensions.SecretManager.Tools)
   * [dotnet-sql-cache](https://github.com/aspnet/DotNetTools/blob/dev/src/dotnet-sql-cache/README.md) (Microsoft.Extensions.Caching.SqlConfig.Tools)
   * [dotnet-ef](/ef/core/miscellaneous/cli/dotnet) (Microsoft.EntityFrameworkCore.Tools.DotNet)
+  
+  In previous .NET Core SDK versions, the reference to one of these tools in your project file looks similar to the following example:
+
+  ```xml
+  <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
+  ```
+
+  Since this entry isn't used by the the .NET Core SDK any longer, you'll a warning similar to the following if you still have references to one of these bundled tools from your project:
+  
+  `The tool 'Microsoft.EntityFrameworkCore.Tools.DotNet' is now included in the .NET Core SDK. Here is information on resolving this warning.`
+  
+  Removing the `<DotNetCliToolReference>` reference from your project file fixes this issue.
 
 ## See also
 

--- a/docs/core/migration/20-21.md
+++ b/docs/core/migration/20-21.md
@@ -32,7 +32,7 @@ For an overview of the new features in .NET Core 2.1, see [What's new in .NET Co
   <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
   ```
 
-  Since this entry isn't used by the the .NET Core SDK any longer, you'll a warning similar to the following if you still have references to one of these bundled tools from your project:
+  Since this entry isn't used by the the .NET Core SDK any longer, you'll see a warning similar to the following if you still have references to one of these bundled tools in your project:
   
   `The tool 'Microsoft.EntityFrameworkCore.Tools.DotNet' is now included in the .NET Core SDK. Here is information on resolving this warning.`
   


### PR DESCRIPTION
Contributes to #6802 

I didn't think that the exact text from https://github.com/dotnet/cli/issues/9119#issuecomment-384825724 fitted into this topic, so please let me know what you think. 
The [What's new](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-2-1#new-cli-commands) topic already covers the introduction of these tools in 2.1.
And the [global.json](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json#troubleshooting-build-warnings) topic covers the error you get if you're trying to reference one of the old dotnet-ef versions with SDK 2.1 and what you need to do.