### PR TITLE
markdig fixes.

### DIFF
--- a/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
+++ b/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
@@ -1070,7 +1070,7 @@ Providers must often cache access to schema information. The cached data should 
 
 When you compile a `.dll` or `.exe` file, the backing .dll file for generated types is statically linked into the resulting assembly. This link is created by copying the Intermediate Language (IL) type definitions and any managed resources from the backing assembly into the final assembly. When you use F# Interactive, the backing .dll file isn't copied and is instead loaded directly into the F# Interactive process.
 
-### Exceptions and Diagnostics from Type Providers
+### Exceptions and Diagnostics from Type Providers
 
 All uses of all members from provided types may throw exceptions. In all cases, if a type provider throws an exception, the host compiler attributes the error to a specific type provider.
 
@@ -1098,11 +1098,9 @@ The ProvidedTypes-0.2 helper code that is part of the F# 3.0 release has only li
 
 - The provider must have an assembly that has an actual backing .NET .dll file with a matching .dll file on disk.
 
-
 ## Rules and Limitations
 
 When you write type providers, keep the following rules and limitations in mind.
-
 
 ### Provided types must be reachable
 


### PR DESCRIPTION
Wow, an invalid whitespace char.

This change updates for markdown compliance as enforced by the markdig processor.

