### PR TITLE
Corrected typo/code example misalignment

### DIFF
--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -127,7 +127,7 @@ and `explicitFieldTwo`, not `localVariableOne` and `localVariableTwo`:
 For any field where an explicit name is not provided, an applicable implicit
 name is projected. There is no requirement to provide semantic names,
 either explicitly or implicitly. The following initializer has     field
-names `Item1`, whose value is `42` and `StringContent`, whose value is "The answer to everything":
+names `Item1`, whose value is `42` and `stringContent`, whose value is "The answer to everything":
 
 [!code-csharp[MixedTuple](../../samples/snippets/csharp/tuples/tuples/program.cs#MixedTuple "mixed tuple")]
 


### PR DESCRIPTION
In the code example `stringContent` uses lower case 's' so the text should also.