### PR TITLE
Suggest F# record declaration guideline

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -200,11 +200,13 @@ For all other types, use the prefix form.
 
 A tuple instantiation should be parenthesized, and the delimiting commas within should be followed by a single space, for example: `(1, 2)`, `(x, y, z)`.
 
-A commonly accepted exception is to omit parentheses in pattern matching of tuples:
+It is commonly accepted to omit parentheses in pattern matching of tuples:
 
 ```fsharp
 let (x, y) = z // Destructuring
+let x, y = z // OK
 
+// OK
 match x, y with
 | 1, _ -> 0
 | x, 1 -> 0
@@ -278,7 +280,7 @@ type PostalAddress =
     }
 ```
 
-Placing the opening token on the same line and the closing token on a new line is also fine, but be aware that you need to use the verbose syntax to define members (the `with` keyword):
+Placing the opening token on the same line and the closing token on a new line is also fine, but be aware that you need to use the [verbose syntax](../language-reference/verbose-syntax.md) to define members (the `with` keyword):
 
 ```fsharp
 //  OK, but verbose syntax required

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -196,6 +196,21 @@ F# inherits both the postfix ML style of naming generic types (for example, `int
 
 For all other types, use the prefix form.
 
+## Formatting tuples
+
+A tuple instantiation should be parenthesized, and the delimiting commas within should be followed by a single space, for example: `(1, 2)`, `(x, y, z)`.
+
+A commonly accepted exception is to omit parentheses in pattern matching of tuples:
+
+```fsharp
+let (x, y) = z // Destructuring
+
+match x, y with
+| 1, _ -> 0
+| x, 1 -> 0
+| x, y -> 1
+```
+
 ## Formatting discriminated union declarations
 
 Indent `|` in type definition by 4 spaces:
@@ -213,6 +228,8 @@ type Volume =
 | USPint of float
 | ImperialPint of float
 ```
+
+## Formatting discriminated unions
 
 Instantiated Discriminated Unions that split across multiple lines should give contained data a new scope with indentation:
 
@@ -233,19 +250,44 @@ let tree1 =
     )
 ```
 
-## Formatting tuples
+## Formatting record declarations
 
-A tuple instantiation should be parenthesized, and the delimiting commas within should be followed by a single space, for example: `(1, 2)`, `(x, y, z)`.
-
-A commonly accepted exception is to omit parentheses in pattern matching of tuples:
+Indent `{` in type definition by 4 spaces and start the field list on the same line:
 
 ```fsharp
-let (x, y) = z // Destructuring
+// OK
+type PostalAddress =
+    { Address : string
+      City : string
+      Zip : string }
+    member x.ZipAndCity = sprintf "%s %s" x.Zip x.City
 
-match x, y with
-| 1, _ -> 0
-| x, 1 -> 0
-| x, y -> 1
+// Not OK
+type PostalAddress =
+  { Address : string
+    City : string
+    Zip : string }
+    member x.ZipAndCity = sprintf "%s %s" x.Zip x.City
+    
+// Unusual in F#
+type PostalAddress =
+    { 
+        Address : string
+        City : string
+        Zip : string
+    }
+```
+
+Placing the opening token on the same line and the closing token on a new line is also fine, but be aware that you need to use the verbose syntax to define members (the `with` keyword):
+
+```fsharp
+//  OK, but verbose syntax required
+type PostalAddress = { 
+    Address : string
+    City : string
+    Zip : string
+} with
+    member x.ZipAndCity = sprintf "%s %s" x.Zip x.City
 ```
 
 ## Formatting records


### PR DESCRIPTION
split the section about discriminated unions into declaration and usage and add a section regarding record declarations.

## Summary

Added a section regarding record declarations and split discriminated unions to match the two sections for records.

Fixes #6775 

/cc @cartermp 
