### PR TITLE
Remove unnecessary casts

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-members-of-two-interfaces_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-members-of-two-interfaces_1.cs
@@ -19,33 +19,21 @@
         float lengthInches;
         float widthInches;
 
-        public Box(float length, float width)
+        public Box(float lengthInches, float widthInches)
         {
-            lengthInches = length;
-            widthInches = width;
+            this.lengthInches = lengthInches;
+            this.widthInches = widthInches;
         }
 
         // Explicitly implement the members of IEnglishDimensions:
-        float IEnglishDimensions.Length()
-        {
-            return lengthInches;
-        }
+        float IEnglishDimensions.Length() => lengthInches;
 
-        float IEnglishDimensions.Width()
-        {
-            return widthInches;
-        }
+        float IEnglishDimensions.Width() => widthInches;
 
         // Explicitly implement the members of IMetricDimensions:
-        float IMetricDimensions.Length()
-        {
-            return lengthInches * 2.54f;
-        }
+        float IMetricDimensions.Length() => lengthInches * 2.54f;
 
-        float IMetricDimensions.Width()
-        {
-            return widthInches * 2.54f;
-        }
+        float IMetricDimensions.Width() => widthInches * 2.54f;
 
         static void Main()
         {
@@ -53,10 +41,10 @@
             Box box1 = new Box(30.0f, 20.0f);
 
             // Declare an instance of the English units interface:
-            IEnglishDimensions eDimensions = (IEnglishDimensions)box1;
+            IEnglishDimensions eDimensions = box1;
 
             // Declare an instance of the metric units interface:
-            IMetricDimensions mDimensions = (IMetricDimensions)box1;
+            IMetricDimensions mDimensions = box1;
 
             // Print dimensions in English units:
             System.Console.WriteLine("Length(in): {0}", eDimensions.Length());

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-members-of-two-interfaces_2.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-members-of-two-interfaces_2.cs
@@ -1,19 +1,7 @@
         // Normal implementation:
-        public float Length()
-        {
-            return lengthInches;
-        }
-        public float Width()
-        {
-            return widthInches;
-        }
+        public float Length() => lengthInches;
+        public float Width() => widthInches;
 
         // Explicit implementation:
-        float IMetricDimensions.Length()
-        {
-            return lengthInches * 2.54f;
-        }
-        float IMetricDimensions.Width()
-        {
-            return widthInches * 2.54f;
-        }
+        float IMetricDimensions.Length() => lengthInches * 2.54f;
+        float IMetricDimensions.Width() => widthInches * 2.54f;

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-members-of-two-interfaces_3.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-members-of-two-interfaces_3.cs
@@ -1,7 +1,7 @@
         public static void Test()
         {
             Box box1 = new Box(30.0f, 20.0f);
-            IMetricDimensions mDimensions = (IMetricDimensions)box1;
+            IMetricDimensions mDimensions = box1;
 
             System.Console.WriteLine("Length(in): {0}", box1.Length());
             System.Console.WriteLine("Width (in): {0}", box1.Width());


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/6507.

Also uses expression-bodied methods and changes constructor parameter names to make it clear which unit they use.