### PR TITLE
Update old VS refs

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0151.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0151.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS0151"
-ms.date: 07/20/2015
+ms.date: 08/14/2018
 f1_keywords:
   - "CS0151"
 helpviewer_keywords:

--- a/docs/csharp/language-reference/compiler-messages/cs0151.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0151.md
@@ -1,68 +1,69 @@
 ---
 title: "Compiler Error CS0151"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0151"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0151"
 ms.assetid: 1adda08b-6be5-46c8-96f9-5ac7c7bfe48c
 ---
 # Compiler Error CS0151
-A value of an integral type expected  
-  
- A variable was used in a situation where an integral data type was required. For more information, see [Types](../../../csharp/programming-guide/types/index.md).  
-  
-## Example  
- This error can occur when there is no conversion or if the available implicit conversions result in an ambiguous situation. The following sample generates CS0151.  
-  
-```csharp  
-// CS0151.cs  
-public class MyClass  
-{  
-   public static implicit operator int (MyClass aa)  
-   {  
-      return 0;  
-   }  
-  
-   public static implicit operator long (MyClass aa)  
-   {  
-      return 0;  
-   }  
-  
-   public static void Main()  
-   {  
-      MyClass a = new MyClass();  
-  
-      // Compiler cannot choose between int and long  
-      switch (a)   // CS0151  
-      // try the following line instead  
-      // switch ((int)a)  
-      {  
-         case 1:  
-            break;  
-      }  
-   }  
-}  
-```  
-  
-## Example  
- In Visual Studio 2008 and later, a [void](../../../csharp/language-reference/keywords/void.md) method invocation generates CS0151. You can fix the error by calling a method that returns an integral type such as [int](../../../csharp/language-reference/keywords/int.md) or [long](../../../csharp/language-reference/keywords/long.md).  
-  
-```csharp  
-class C  
-{  
-    static void Main()  
-    {  
-  
-        switch (M()) // CS0151  
-        {  
-            default:  
-                break;  
-        }  
-    }  
-  
-    static void M()  
-    {  
-    }  
-}  
+
+A value of an integral type expected
+
+A variable was used in a situation where an integral data type was required. For more information, see [Types](../../../csharp/programming-guide/types/index.md).
+
+## Example of ambiguous conversion
+
+This error can occur when there is no conversion or if the available implicit conversions result in an ambiguous situation. The following example generates CS0151:
+
+```csharp
+public class MyClass
+{
+   public static implicit operator int (MyClass aa)
+   {
+      return 0;
+   }
+
+   public static implicit operator long (MyClass aa)
+   {
+      return 0;
+   }
+
+   public static void Main()
+   {
+      MyClass a = new MyClass();
+
+      // Compiler cannot choose between int and long.
+      switch (a)   // CS0151
+      // try the following line instead
+      // switch ((int)a)
+      {
+         case 1:
+            break;
+      }
+   }
+}
+```
+
+## Example of void method
+
+A [void](../../../csharp/language-reference/keywords/void.md) method invocation in a [switch](../keywords/switch.md) match expression generates CS0151. You can fix the error by calling a method that returns an integral type such as [int](../../../csharp/language-reference/keywords/int.md) or [long](../../../csharp/language-reference/keywords/long.md) instead.
+
+```csharp
+class C
+{
+    static void Main()
+    {
+        switch (M()) // CS0151
+        {
+            default:
+                break;
+        }
+    }
+
+    static void M()
+    {
+    }
+}
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs0173.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0173.md
@@ -1,76 +1,73 @@
 ---
 title: "Compiler Error CS0173"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0173"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0173"
 ms.assetid: eb1797ad-bf62-4e2b-8922-bef4aff36954
 ---
 # Compiler Error CS0173
-Type of conditional expression cannot be determined because there is no implicit conversion between 'class1' and 'class2'  
-  
- Conversions between classes are useful when you want objects of different classes to work with the same code. However, two classes that work together cannot have mutual and redundant conversions, or no implicit conversions. The types of `class1` and `class2` are determined independently, and the more general type is selected as the type of the conditional expression. For more information about how types are determined, see [Conditional operator cannot cast implicitly](https://stackoverflow.com/questions/2215745/conditional-operator-cannot-cast-implicitly/2215959#2215959).  
-  
- To resolve CS0173, verify that there is one and only one implicit conversion between `class1` and `class2`, regardless of which direction the conversion is in and regardless of which class the conversion is in. For more information, see [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md) and [Conversion Operators](../../../csharp/programming-guide/statements-expressions-operators/conversion-operators.md).  
-  
-## Example  
- The following sample generates CS0173:  
-  
-```csharp  
-// CS0173.cs  
-public class C {}  
-  
-public class A   
-{  
-    //// The following code defines an implicit conversion operator from    
-    //// type C to type A.  
-    //public static implicit operator A(C c)  
-    //{  
-    //    A a = new A();  
-    //    a = c;  
-    //    return a;  
-    //}  
-}  
-  
-public class MyClass  
-{  
-    public static void F(bool b)  
-    {  
-        A a = new A();  
-        C c = new C();  
-  
-        // The following line causes CS0173 because there is no implicit  
-        // conversion from a to c or from c to a.  
-        object o = b ? a : c;  
-  
-        // To resolve the error, you can cast a and c.  
-        //object o = b ? (object)a : (object)c;  
-  
-        // Alternatively, you can add a conversion operator from class C to  
-        // class A, or from class A to class C, but not both.  
-    }  
-  
-   public static void Main()  
-   {  
-      F(true);  
-   }  
-}  
-```  
-  
-## Example  
- The following code does not produce CS0173 in Visual Studio 2005, but does in later versions.  
-  
-```csharp  
-//cs0173_2.cs  
-class M  
-{  
-    static int Main ()  
-    {  
-        int X = 1;  
-        // The following line causes CS0173 in Visual Studio 2005.  
-        object o = (X == 0) ? null : null;  
-        return -1;  
-    }  
-}  
+
+Type of conditional expression cannot be determined because there is no implicit conversion between 'class1' and 'class2'
+
+Conversions between classes are useful when you want objects of different classes to work with the same code. However, two classes that work together cannot have mutual and redundant conversions, or no implicit conversions. The types of `class1` and `class2` are determined independently, and the more general type is selected as the type of the conditional expression. For more information about how types are determined, see [Conditional operator cannot cast implicitly](https://stackoverflow.com/questions/2215745/conditional-operator-cannot-cast-implicitly/2215959#2215959).
+
+To resolve CS0173, verify that there is one and only one implicit conversion between `class1` and `class2`, regardless of which direction the conversion is in and regardless of which class the conversion is in. For more information, see [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md) and [Conversion Operators](../../../csharp/programming-guide/statements-expressions-operators/conversion-operators.md).
+
+## Example
+
+The following examples generate compiler error CS0173:
+
+```csharp
+public class C {}
+
+public class A
+{
+    // The following code defines an implicit conversion operator from
+    // type C to type A.
+    //public static implicit operator A(C c)
+    //{
+    //    A a = new A();
+    //    a = c;
+    //    return a;
+    //}
+}
+
+public class MyClass
+{
+    public static void F(bool b)
+    {
+        A a = new A();
+        C c = new C();
+
+        // The following line causes CS0173 because there is no implicit
+        // conversion from a to c or from c to a.
+        object o = b ? a : c;
+
+        // To resolve the error, you can cast a and c.
+        // object o = b ? (object)a : (object)c;
+
+        // Alternatively, you can add a conversion operator from class C to
+        // class A, or from class A to class C, but not both.
+    }
+
+   public static void Main()
+   {
+      F(true);
+   }
+}
+```
+
+```csharp
+class M
+{
+    static int Main ()
+    {
+        int X = 1;
+        // The following line causes CS0173.
+        object o = (X == 0) ? null : null;
+        return -1;
+    }
+}
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs0173.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0173.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS0173"
-ms.date: 07/20/2015
+ms.date: 08/14/2018
 f1_keywords:
   - "CS0173"
 helpviewer_keywords:

--- a/docs/csharp/language-reference/keywords/for.md
+++ b/docs/csharp/language-reference/keywords/for.md
@@ -1,5 +1,5 @@
 ---
-title: "for (C# Reference)"
+title: C# for statement
 ms.date: 06/13/2018
 f1_keywords:
   - "for"
@@ -103,10 +103,10 @@ The following example defines the infinite `for` loop:
 
 ## See also
 
-[The for statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-for-statement)
-[C# Reference](../index.md)
-[C# Programming Guide](../../programming-guide/index.md)
-[C# Keywords](index.md)
-[foreach, in](foreach-in.md)
-[for Statement (C++)](/cpp/cpp/for-statement-cpp)
-[Iteration Statements](iteration-statements.md)
+- [The for statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-for-statement)
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [foreach, in](foreach-in.md)
+- [for Statement (C++)](/cpp/cpp/for-statement-cpp)
+- [Iteration Statements](iteration-statements.md)

--- a/docs/csharp/language-reference/keywords/for.md
+++ b/docs/csharp/language-reference/keywords/for.md
@@ -1,10 +1,10 @@
 ---
 title: "for (C# Reference)"
 ms.date: 06/13/2018
-f1_keywords: 
+f1_keywords:
   - "for"
   - "for_CSharpKeyword"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "for keyword [C#]"
 ms.assetid: 34041a40-2c87-467a-9ffb-a0417d8f67a8
 ---
@@ -13,14 +13,14 @@ ms.assetid: 34041a40-2c87-467a-9ffb-a0417d8f67a8
 The `for` statement executes a statement or a block of statements while a specified boolean expression evaluates to `true`.
 
 At any point within the `for` statement block, you can break out of the loop by using the [break](break.md) statement, or step to the next iteration in the loop by using the [continue](continue.md) statement. You also can exit a `for` loop by the [goto](goto.md), [return](return.md), or [throw](throw.md) statements.
-  
+
 ## Structure of the `for` statement
 
 The `for` statement defines *initializer*, *condition*, and *iterator* sections:
-  
+
 ```csharp
-for (initializer; condition; iterator)  
-    body  
+for (initializer; condition; iterator)
+    body
 ```
 
 All three sections are optional. The body of the loop is either a statement or a block of statements.
@@ -39,11 +39,11 @@ The statements in the *initializer* section are executed only once, before enter
 
   - [assignment](../operators/assignment-operator.md) statement
 
-  - invocation of a method  
+  - invocation of a method
 
-  - prefix or postfix [increment](../operators/increment-operator.md) expression, such as `++i` or `i++`  
+  - prefix or postfix [increment](../operators/increment-operator.md) expression, such as `++i` or `i++`
 
-  - prefix or postfix [decrement](../operators/decrement-operator.md) expression, such as `--i` or `i--`  
+  - prefix or postfix [decrement](../operators/decrement-operator.md) expression, such as `--i` or `i--`
 
   - creation of an object by using [new](new-operator.md) keyword
 
@@ -67,15 +67,15 @@ i < 5
 
 ### The *iterator* section
 
-The *iterator* section defines what happens after each iteration of the body of the loop. The *iterator* section contains zero or more of the following statement expressions, separated by commas:  
+The *iterator* section defines what happens after each iteration of the body of the loop. The *iterator* section contains zero or more of the following statement expressions, separated by commas:
 
 - [assignment](../operators/assignment-operator.md) statement
 
-- invocation of a method  
+- invocation of a method
 
-- prefix or postfix [increment](../operators/increment-operator.md) expression, such as `++i` or `i++`  
+- prefix or postfix [increment](../operators/increment-operator.md) expression, such as `++i` or `i++`
 
-- prefix or postfix [decrement](../operators/decrement-operator.md) expression, such as `--i` or `i--`  
+- prefix or postfix [decrement](../operators/decrement-operator.md) expression, such as `--i` or `i--`
 
 - creation of an object by using [new](new-operator.md) keyword
 
@@ -90,23 +90,23 @@ i++
 ## Examples
 
 The following example illustrates several less common usages of the `for` statement sections: assigning a value to an external loop variable in the *initializer* section, invoking a method in both the *initializer* and the *iterator* sections, and changing the values of two variables in the *iterator* section. Select **Run** to run the example code. After that you can modify the code and run it again.
-  
+
 [!code-csharp-interactive[not typical for loop example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#6)]
-  
+
 The following example defines the infinite `for` loop:
-  
+
 [!code-csharp[infinite for loop example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#7)]
-  
-## C# language specification  
+
+## C# language specification
 
 [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
-  
+
 ## See also
 
-[The for statement (C# language specification)](../language-specification/index.md)  
-[C# Reference](../index.md)  
-[C# Programming Guide](../../programming-guide/index.md)  
-[C# Keywords](index.md)  
-[foreach, in](foreach-in.md)  
-[for Statement (C++)](/cpp/cpp/for-statement-cpp)  
+[The for statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-for-statement)
+[C# Reference](../index.md)
+[C# Programming Guide](../../programming-guide/index.md)
+[C# Keywords](index.md)
+[foreach, in](foreach-in.md)
+[for Statement (C++)](/cpp/cpp/for-statement-cpp)
 [Iteration Statements](iteration-statements.md)

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -1,5 +1,5 @@
 ---
-title: "foreach, in (C# Reference)"
+title: C# foreach statement
 ms.date: 06/29/2018
 f1_keywords:
   - "foreach"
@@ -10,7 +10,7 @@ helpviewer_keywords:
   - "in keyword [C#]"
 ms.assetid: 5a9c5ddc-5fd3-457a-9bb6-9abffcd874ec
 ---
-# foreach, in (C# Reference)
+# foreach, in (C# reference)
 
 The `foreach` statement executes a statement or a block of statements for each element in an instance of the type that implements the <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> interface. The `foreach` statement is not limited to those types and can be applied to an instance of any type that satisfies the following conditions:
 
@@ -41,10 +41,10 @@ Beginning with C# 7.3, if the enumerator's `Current` property returns a [referen
 
 ## See also
 
-[The foreach statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-foreach-statement)
-[Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)
-[for](for.md)
-[Iteration Statements](iteration-statements.md)
-[C# Keywords](index.md)
-[C# Reference](../index.md)
-[C# Programming Guide](../../programming-guide/index.md)
+- [The foreach statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-foreach-statement)
+- [Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)
+- [for](for.md)
+- [Iteration Statements](iteration-statements.md)
+- [C# Keywords](index.md)
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -1,10 +1,10 @@
 ---
 title: "foreach, in (C# Reference)"
 ms.date: 06/29/2018
-f1_keywords: 
+f1_keywords:
   - "foreach"
   - "foreach_CSharpKeyword"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "foreach keyword [C#]"
   - "foreach statement [C#]"
   - "in keyword [C#]"
@@ -41,10 +41,10 @@ Beginning with C# 7.3, if the enumerator's `Current` property returns a [referen
 
 ## See also
 
-[The foreach statement (C# language specification)](../language-specification/index.md)  
-[Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)  
-[for](for.md)  
-[Iteration Statements](iteration-statements.md)  
-[C# Keywords](index.md)  
-[C# Reference](../index.md)  
-[C# Programming Guide](../../programming-guide/index.md)  
+[The foreach statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-foreach-statement)
+[Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)
+[for](for.md)
+[Iteration Statements](iteration-statements.md)
+[C# Keywords](index.md)
+[C# Reference](../index.md)
+[C# Programming Guide](../../programming-guide/index.md)

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -1,12 +1,12 @@
 ---
 title: "switch keyword (C# Reference)"
 ms.date: 03/07/2017
-f1_keywords: 
+f1_keywords:
   - "switch_CSharpKeyword"
   - "switch"
   - "case"
   - "case_CSharpKeyword"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "switch statement [C#]"
   - "switch keyword [C#]"
   - "case statement [C#]"
@@ -14,17 +14,18 @@ helpviewer_keywords:
 ms.assetid: 44bae8b8-8841-4d85-826b-8a94277daecb
 ---
 # switch (C# Reference)
-`switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *match expression*. 
-  
- [!code-csharp[switch#1](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch1.cs#1)]  
 
-The `switch` statement is often used as an alternative to an [if-else](if-else.md) construct if a single expression is tested against three or more conditions. For example, the following `switch` statement determines whether a variable of type `Color` has one of three values: 
+`switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *match expression*.
 
-[!code-csharp[switch#3](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch3.cs#1)] 
+[!code-csharp[switch#1](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch1.cs#1)]
 
-It is equivalent to the following example that uses an `if`-`else` construct. 
+The `switch` statement is often used as an alternative to an [if-else](if-else.md) construct if a single expression is tested against three or more conditions. For example, the following `switch` statement determines whether a variable of type `Color` has one of three values:
 
-[!code-csharp[switch#3a](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch3a.cs#1)] 
+[!code-csharp[switch#3](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch3.cs#1)]
+
+It is equivalent to the following example that uses an `if`-`else` construct.
+
+[!code-csharp[switch#3a](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch3a.cs#1)]
 
 ## The match expression
 
@@ -38,38 +39,38 @@ In C# 6, the match expression must be an expression that returns a value of the 
 
 - a [char](char.md).
 - a [string](string.md).
-- a [bool](bool.md). 
+- a [bool](bool.md).
 - an integral value, such as an [int](int.md) or a [long](long.md).
 - an [enum](enum.md) value.
 
 Starting with C# 7.0, the match expression can be any non-null expression.
- 
+
 ## The switch section
- 
+
  A `switch` statement includes one or more switch sections. Each switch section contains one or more *case labels* (either a case or default label) followed by one or more statements. The `switch` statement may include at most one default label placed in any switch section. The following example shows a simple `switch` statement that has three switch sections, each containing two statements. The second switch section contains the `case 2:` and `case 3:` labels.
- 
-  A `switch` statement can include any number of switch sections, and each section can have one or more case labels, as shown in the following example. However, no two case labels may contain the same expression.  
 
- [!code-csharp[switch#2](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch2.cs#1)]  
+  A `switch` statement can include any number of switch sections, and each section can have one or more case labels, as shown in the following example. However, no two case labels may contain the same expression.
 
- Only one switch section in a switch statement executes. C# does not allow execution to continue from one switch section to the next. Because of this, the following code generates a compiler error, CS0163: "Control cannot fall through from one case label (<case label>) to another."  
+ [!code-csharp[switch#2](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch2.cs#1)]
 
-```csharp  
-switch (caseSwitch)  
-{  
-    // The following switch section causes an error.  
-    case 1:  
-        Console.WriteLine("Case 1...");  
-        // Add a break or other jump statement here.  
-    case 2:  
-        Console.WriteLine("... and/or Case 2");  
-        break;  
-}  
-```  
+ Only one switch section in a switch statement executes. C# does not allow execution to continue from one switch section to the next. Because of this, the following code generates a compiler error, CS0163: "Control cannot fall through from one case label (<case label>) to another."
+
+```csharp
+switch (caseSwitch)
+{
+    // The following switch section causes an error.
+    case 1:
+        Console.WriteLine("Case 1...");
+        // Add a break or other jump statement here.
+    case 2:
+        Console.WriteLine("... and/or Case 2");
+        break;
+}
+```
 This requirement is usually met by explicitly exiting the switch section by using a [break](break.md), [goto](goto.md), or [return](return.md) statement. However, the following code is also valid, because it ensures that program control cannot fall through to the `default` switch section.
-  
- [!code-csharp[switch#4](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch4.cs#1)]    
-  
+
+ [!code-csharp[switch#4](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch4.cs#1)]
+
  Execution of the statement list in the switch section with a case label that matches the match expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `goto label`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label. A `goto` statement, if it is used, must transfer control to a constant label. This restriction is necessary, since attempting to transfer control to a non-constant label can have undesirable side-effects, such transferring control to an unintended location in code or creating an endless loop.
 
 ## Case labels
@@ -80,18 +81,18 @@ This requirement is usually met by explicitly exiting the switch section by usin
 
  Because C# 6 supports only the constant pattern and does not allow the repetition of constant values, case labels define mutually exclusive values, and only one pattern can match the match expression. As a result, the order in which `case` statements appear is unimportant.
 
- In C# 7.0, however, because other patterns are supported, case labels need not define mutually exclusive values, and multiple patterns can match the match expression. Because only the statements in the switch section that contains the first matching pattern are executed, the order in which `case` statements appear is now important. If C# detects a switch section whose case statement or statements are equivalent to or are subsets of previous statements, it generates a compiler error, CS8120, "The switch case has already been handled by a previous case." 
+ In C# 7.0, however, because other patterns are supported, case labels need not define mutually exclusive values, and multiple patterns can match the match expression. Because only the statements in the switch section that contains the first matching pattern are executed, the order in which `case` statements appear is now important. If C# detects a switch section whose case statement or statements are equivalent to or are subsets of previous statements, it generates a compiler error, CS8120, "The switch case has already been handled by a previous case."
 
  The following example illustrates a `switch` statement that uses a variety of non-mutually exclusive patterns. If you move the `case 0:` switch section so that it is no longer the first section in the `switch` statement, C# generates a compiler error because an integer whose value is zero is a subset of all integers, which is the pattern defined by the `case int val` statement.
 
- [!code-csharp[switch#5](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch5.cs#1)]    
+ [!code-csharp[switch#5](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch5.cs#1)]
 
 You can correct this issue and eliminate the compiler warning in one of two ways:
 
-- By changing the order of the switch sections. 
- 
+- By changing the order of the switch sections.
+
 - By using a </a name="when">when clause</a> in the `case` label.
- 
+
 ## The `default` case
 
 The `default` case specifies the switch section to execute if the match expression does not match any other `case` label. If a `default` case is not present and the match expression does not match any other `case` label, program flow falls through the `switch` statement.
@@ -99,10 +100,10 @@ The `default` case specifies the switch section to execute if the match expressi
 The `default` case can appear in any order in the `switch` statement. Regardless of its order in the source code, it is always evaluated last, after all `case` labels have been evaluated.
 
 ## <a name="pattern" /> Pattern matching with the `switch` statement
-  
-Each `case` statement defines a pattern that, if it matches the match expression, causes its  containing switch section to be executed. All versions of C# support the constant pattern. The remaining patterns are supported beginning with C# 7.0. 
-  
-### Constant pattern 
+
+Each `case` statement defines a pattern that, if it matches the match expression, causes its  containing switch section to be executed. All versions of C# support the constant pattern. The remaining patterns are supported beginning with C# 7.0.
+
+### Constant pattern
 
 The constant pattern tests whether the match expression equals a specified constant. Its syntax is:
 
@@ -110,10 +111,10 @@ The constant pattern tests whether the match expression equals a specified const
    case constant:
 ```
 
-where *constant* is the value to test for. *constant* can be any of the following constant expressions: 
+where *constant* is the value to test for. *constant* can be any of the following constant expressions:
 
 - A [bool](bool.md) literal, either `true` or `false`.
-- Any integral constant, such as an [int](int.md), a [long](long.md), or a [byte](byte.md). 
+- Any integral constant, such as an [int](int.md), a [long](long.md), or a [byte](byte.md).
 - The name of a declared `const` variable.
 - An enumeration constant.
 - A [char](char.md) literal.
@@ -123,24 +124,24 @@ The constant expression is evaluated as follows:
 
 - If *expr* and *constant* are integral types, the C# equality operator determines whether the expression returns `true` (that is, whether `expr == constant`).
 
-- Otherwise, the value of the expression is determined by a call to the static [Object.Equals(expr, constant)](xref:System.Object.Equals(System.Object,System.Object)) method.  
+- Otherwise, the value of the expression is determined by a call to the static [Object.Equals(expr, constant)](xref:System.Object.Equals(System.Object,System.Object)) method.
 
-The following example uses the constant pattern to determine whether a particular date is a weekend, the first day of the work week, the last day of the work week, or the middle of the work week. It evaluates the <xref:System.DateTime.DayOfWeek?displayProperty=nameWithType> property of the current day against the members of the <xref:System.DayOfWeek> enumeration. 
+The following example uses the constant pattern to determine whether a particular date is a weekend, the first day of the work week, the last day of the work week, or the middle of the work week. It evaluates the <xref:System.DateTime.DayOfWeek?displayProperty=nameWithType> property of the current day against the members of the <xref:System.DayOfWeek> enumeration.
 
 [!code-csharp[switch#7](../../../../samples/snippets/csharp/language-reference/keywords/switch/const-pattern.cs#1)]
 
 The following example uses the constant pattern to handle user input in a console application that simulates an automatic coffee machine.
-  
- [!code-csharp[switch#6](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch6.cs)]  
+
+ [!code-csharp[switch#6](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch6.cs)]
 
 ### Type pattern
 
 The type pattern enables concise type evaluation and conversion. When used with the `switch` statement to perform pattern matching, it tests whether an expression can be converted to a specified type and, if it can be, casts it to a variable of that type. Its syntax is:
 
 ```csharp
-   case type varname 
+   case type varname
 ```
-where *type* is the name of the type to which the result of *expr* is to be converted, and *varname* is the object to which the result of *expr* is converted if the match succeeds. 
+where *type* is the name of the type to which the result of *expr* is to be converted, and *varname* is the object to which the result of *expr* is converted if the match succeeds.
 
 The `case` expression is `true` if any of the following is true:
 
@@ -159,35 +160,33 @@ Note that `null` does not match a type. To match a `null`, you use the following
 ```csharp
 case null:
 ```
- 
+
 The following example uses the type pattern to provide information about various kinds of collection types.
 
 [!code-csharp[switch#5](../../../../samples/snippets/csharp/language-reference/keywords/switch/type-pattern.cs#1)]
 
-Without pattern matching, this code might be written as follows. The use of type pattern matching produces more compact, readable code by eliminating the need to test whether the result of a conversion is a `null` or to perform repeated casts.  
+Without pattern matching, this code might be written as follows. The use of type pattern matching produces more compact, readable code by eliminating the need to test whether the result of a conversion is a `null` or to perform repeated casts.
 
 [!code-csharp[switch#6](../../../../samples/snippets/csharp/language-reference/keywords/switch/type-pattern2.cs#1)]
 
 ## <a name="when" /> The `case` statement and the `when` clause
 
-Starting with C# 7.0, because case statements need not be mutually exclusive, you can add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value. One of the more common uses for the `when` clause is used to prevent a switch section from executing when the value of a match expression is `null`. 
+Starting with C# 7.0, because case statements need not be mutually exclusive, you can add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value. One of the more common uses for the `when` clause is used to prevent a switch section from executing when the value of a match expression is `null`.
 
- The following example defines a base `Shape` class, a `Rectangle` class that derives from `Shape`, and a `Square` class that derives from `Rectangle`. It uses the `when` clause to ensure that the `ShowShapeInfo` treats a `Rectangle` object that has been assigned equal lengths and widths as a `Square` even if it has not been instantiated as a `Square` object. The method does not attempt to display information either about an object that is `null` or a shape whose area is zero. 
+ The following example defines a base `Shape` class, a `Rectangle` class that derives from `Shape`, and a `Square` class that derives from `Rectangle`. It uses the `when` clause to ensure that the `ShowShapeInfo` treats a `Rectangle` object that has been assigned equal lengths and widths as a `Square` even if it has not been instantiated as a `Square` object. The method does not attempt to display information either about an object that is `null` or a shape whose area is zero.
 
 [!code-csharp[switch#8](../../../../samples/snippets/csharp/language-reference/keywords/switch/when-clause.cs#1)]
-  
+
 Note that the `when` clause in the example that attempts to test whether a `Shape` object is `null` does not execute. The correct type pattern to test for a `null` is `case null:`.
 
-## C# Language Specification  
- [!INCLUDE[CSharplangspec](../../../../includes/csharplangspec-md.md)]  
-  
-## See Also  
+## C# Language Specification
 
- [C# Reference](../index.md)  
- [C# Programming Guide](../../programming-guide/index.md)  
- [C# Keywords](index.md)  
- [if-else](if-else.md)  
- [Pattern Matching](../../pattern-matching.md)  
- 
+For more information, see [The switch statement](../language-specification/statements.md#the-switch-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
- 
+## See Also
+
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [if-else](if-else.md)
+- [Pattern Matching](../../pattern-matching.md)

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -47,13 +47,13 @@ Starting with C# 7.0, the match expression can be any non-null expression.
 
 ## The switch section
 
- A `switch` statement includes one or more switch sections. Each switch section contains one or more *case labels* (either a case or default label) followed by one or more statements. The `switch` statement may include at most one default label placed in any switch section. The following example shows a simple `switch` statement that has three switch sections, each containing two statements. The second switch section contains the `case 2:` and `case 3:` labels.
+A `switch` statement includes one or more switch sections. Each switch section contains one or more *case labels* (either a case or default label) followed by one or more statements. The `switch` statement may include at most one default label placed in any switch section. The following example shows a simple `switch` statement that has three switch sections, each containing two statements. The second switch section contains the `case 2:` and `case 3:` labels.
 
-  A `switch` statement can include any number of switch sections, and each section can have one or more case labels, as shown in the following example. However, no two case labels may contain the same expression.
+A `switch` statement can include any number of switch sections, and each section can have one or more case labels, as shown in the following example. However, no two case labels may contain the same expression.
 
- [!code-csharp[switch#2](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch2.cs#1)]
+[!code-csharp[switch#2](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch2.cs#1)]
 
- Only one switch section in a switch statement executes. C# does not allow execution to continue from one switch section to the next. Because of this, the following code generates a compiler error, CS0163: "Control cannot fall through from one case label (<case label>) to another."
+Only one switch section in a switch statement executes. C# does not allow execution to continue from one switch section to the next. Because of this, the following code generates a compiler error, CS0163: "Control cannot fall through from one case label (<case label>) to another."
 
 ```csharp
 switch (caseSwitch)
@@ -67,25 +67,26 @@ switch (caseSwitch)
         break;
 }
 ```
+
 This requirement is usually met by explicitly exiting the switch section by using a [break](break.md), [goto](goto.md), or [return](return.md) statement. However, the following code is also valid, because it ensures that program control cannot fall through to the `default` switch section.
 
- [!code-csharp[switch#4](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch4.cs#1)]
+[!code-csharp[switch#4](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch4.cs#1)]
 
- Execution of the statement list in the switch section with a case label that matches the match expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `goto label`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label. A `goto` statement, if it is used, must transfer control to a constant label. This restriction is necessary, since attempting to transfer control to a non-constant label can have undesirable side-effects, such transferring control to an unintended location in code or creating an endless loop.
+Execution of the statement list in the switch section with a case label that matches the match expression begins with the first statement and proceeds through the statement list, typically until a jump statement, such as a `break`, `goto case`, `goto label`, `return`, or `throw`, is reached. At that point, control is transferred outside the `switch` statement or to another case label. A `goto` statement, if it is used, must transfer control to a constant label. This restriction is necessary, since attempting to transfer control to a non-constant label can have undesirable side-effects, such transferring control to an unintended location in code or creating an endless loop.
 
 ## Case labels
 
- Each case label specifies a pattern to compare to the match expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the match expression, control is transferred to the section with the `default` case label, if there is one. If there is no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
+Each case label specifies a pattern to compare to the match expression (the `caseSwitch` variable in the previous examples). If they match, control is transferred to the switch section that contains the **first** matching case label. If no case label pattern matches the match expression, control is transferred to the section with the `default` case label, if there is one. If there is no `default` case, no statements in any switch section are executed, and control is transferred outside the `switch` statement.
 
- For information on the `switch` statement and pattern matching, see the [Pattern matching with the `switch` statement](#pattern) section.
+For information on the `switch` statement and pattern matching, see the [Pattern matching with the `switch` statement](#pattern) section.
 
- Because C# 6 supports only the constant pattern and does not allow the repetition of constant values, case labels define mutually exclusive values, and only one pattern can match the match expression. As a result, the order in which `case` statements appear is unimportant.
+Because C# 6 supports only the constant pattern and does not allow the repetition of constant values, case labels define mutually exclusive values, and only one pattern can match the match expression. As a result, the order in which `case` statements appear is unimportant.
 
- In C# 7.0, however, because other patterns are supported, case labels need not define mutually exclusive values, and multiple patterns can match the match expression. Because only the statements in the switch section that contains the first matching pattern are executed, the order in which `case` statements appear is now important. If C# detects a switch section whose case statement or statements are equivalent to or are subsets of previous statements, it generates a compiler error, CS8120, "The switch case has already been handled by a previous case."
+In C# 7.0, however, because other patterns are supported, case labels need not define mutually exclusive values, and multiple patterns can match the match expression. Because only the statements in the switch section that contains the first matching pattern are executed, the order in which `case` statements appear is now important. If C# detects a switch section whose case statement or statements are equivalent to or are subsets of previous statements, it generates a compiler error, CS8120, "The switch case has already been handled by a previous case."
 
- The following example illustrates a `switch` statement that uses a variety of non-mutually exclusive patterns. If you move the `case 0:` switch section so that it is no longer the first section in the `switch` statement, C# generates a compiler error because an integer whose value is zero is a subset of all integers, which is the pattern defined by the `case int val` statement.
+The following example illustrates a `switch` statement that uses a variety of non-mutually exclusive patterns. If you move the `case 0:` switch section so that it is no longer the first section in the `switch` statement, C# generates a compiler error because an integer whose value is zero is a subset of all integers, which is the pattern defined by the `case int val` statement.
 
- [!code-csharp[switch#5](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch5.cs#1)]
+[!code-csharp[switch#5](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch5.cs#1)]
 
 You can correct this issue and eliminate the compiler warning in one of two ways:
 
@@ -132,7 +133,7 @@ The following example uses the constant pattern to determine whether a particula
 
 The following example uses the constant pattern to handle user input in a console application that simulates an automatic coffee machine.
 
- [!code-csharp[switch#6](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch6.cs)]
+[!code-csharp[switch#6](../../../../samples/snippets/csharp/language-reference/keywords/switch/switch6.cs)]
 
 ### Type pattern
 
@@ -141,6 +142,7 @@ The type pattern enables concise type evaluation and conversion. When used with 
 ```csharp
    case type varname
 ```
+
 where *type* is the name of the type to which the result of *expr* is to be converted, and *varname* is the object to which the result of *expr* is converted if the match succeeds.
 
 The `case` expression is `true` if any of the following is true:
@@ -171,9 +173,9 @@ Without pattern matching, this code might be written as follows. The use of type
 
 ## <a name="when" /> The `case` statement and the `when` clause
 
-Starting with C# 7.0, because case statements need not be mutually exclusive, you can add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value. One of the more common uses for the `when` clause is used to prevent a switch section from executing when the value of a match expression is `null`.
+Starting with C# 7.0, because case statements need not be mutually exclusive, you can add a `when` clause to specify an additional condition that must be satisfied for the case statement to evaluate to true. The `when` clause can be any expression that returns a Boolean value.
 
- The following example defines a base `Shape` class, a `Rectangle` class that derives from `Shape`, and a `Square` class that derives from `Rectangle`. It uses the `when` clause to ensure that the `ShowShapeInfo` treats a `Rectangle` object that has been assigned equal lengths and widths as a `Square` even if it has not been instantiated as a `Square` object. The method does not attempt to display information either about an object that is `null` or a shape whose area is zero.
+The following example defines a base `Shape` class, a `Rectangle` class that derives from `Shape`, and a `Square` class that derives from `Rectangle`. It uses the `when` clause to ensure that the `ShowShapeInfo` treats a `Rectangle` object that has been assigned equal lengths and widths as a `Square` even if it has not been instantiated as a `Square` object. The method does not attempt to display information either about an object that is `null` or a shape whose area is zero.
 
 [!code-csharp[switch#8](../../../../samples/snippets/csharp/language-reference/keywords/switch/when-clause.cs#1)]
 

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -183,7 +183,7 @@ Note that the `when` clause in the example that attempts to test whether a `Shap
 
 ## C# Language Specification
 
-For more information, see [The switch statement](../language-specification/statements.md#the-switch-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [The switch statement](/dotnet/csharp/language-reference/language-specification/statements#the-switch-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -1,6 +1,6 @@
 ---
-title: "switch keyword (C# Reference)"
-ms.date: 03/07/2017
+title: C# switch statement
+ms.date: 08/14/2018
 f1_keywords:
   - "switch_CSharpKeyword"
   - "switch"
@@ -13,7 +13,7 @@ helpviewer_keywords:
   - "default keyword [C#]"
 ms.assetid: 44bae8b8-8841-4d85-826b-8a94277daecb
 ---
-# switch (C# Reference)
+# switch (C# reference)
 
 `switch` is a selection statement that chooses a single *switch section* to execute from a list of candidates based on a pattern match with the *match expression*.
 
@@ -181,11 +181,11 @@ The following example defines a base `Shape` class, a `Rectangle` class that der
 
 Note that the `when` clause in the example that attempts to test whether a `Shape` object is `null` does not execute. The correct type pattern to test for a `null` is `case null:`.
 
-## C# Language Specification
+## C# language specification
 
 For more information, see [The switch statement](/dotnet/csharp/language-reference/language-specification/statements#the-switch-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
-## See Also
+## See also
 
 - [C# Reference](../index.md)
 - [C# Programming Guide](../../programming-guide/index.md)

--- a/docs/csharp/misc/cs0121.md
+++ b/docs/csharp/misc/cs0121.md
@@ -1,83 +1,80 @@
 ---
 title: "Compiler Error CS0121"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0121"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0121"
 ms.assetid: 316cb77e-a500-4129-ae1b-e68b9188fd3e
 ---
-# Compiler Error CS0121
-The call is ambiguous between the following methods or properties: 'method1' and 'method2'  
-  
- Due to implicit conversion, the compiler was not able to call one form of an overloaded method. You can resolve this error in the following ways:  
-  
--   Specify the method parameters in such a way that implicit conversion does not take place.  
-  
--   Remove all overloads for the method.  
-  
--   Cast to proper type before calling method.  
-  
-## Example  
- The following sample generates CS0121:  
-  
-```csharp  
-// CS0121.cs  
-public class C  
-{  
-   void f(int i, double d)   
-   {  
-   }  
-  
-   void f(double d, int i)  
-   {  
-   }  
-  
-   public static void Main()  
-   {  
-      C c = new C();  
-  
-      c.f(1, 1);   // CS0121  
-      // try the following line instead  
-      // c.f(1, 1.0);  
-      // or  
-      // c.f(1.0, 1);  
-      // or  
-      // c.f(1, (double)1);   // cast and specify which method to call  
-   }  
-}  
-```  
-  
-## Example  
- The following example produces CS0121 in the current version of Visual Studio, but not in Visual Studio 2005:  
-  
-```csharp  
-//CS0121_2.cs  
-class Program2  
-{  
-  
-    static int ol_invoked = 0;  
-  
-    delegate int D1(int x);  
-    delegate T D1<T>(T x);  
-    delegate T D1<T, U>(U u);  
-  
-    static void F(D1 d1) { ol_invoked = 1; }  
-    static void F<T>(D1<T> d1t) { ol_invoked = 2; }  
-    static void F<T, U>(D1<T, U> d1t) { ol_invoked = 3; }  
-  
-    static int Test001()  
-    {  
-        F(delegate(int x) { return 1; }); //CS0121  
-        if (ol_invoked == 1)  
-            return 0;  
-        else  
-            return 1;  
-    }  
-  
-    static int Main()  
-    {  
-        return Test001();  
-    }  
-}  
+# Compiler error CS0121
+
+The call is ambiguous between the following methods or properties: 'method1' and 'method2'
+
+Due to implicit conversion, the compiler was not able to call one form of an overloaded method. You can resolve this error in the following ways:
+
+- Specify the method parameters in such a way that implicit conversion does not take place.
+
+- Remove all overloads for the method.
+
+- Cast to proper type before calling the method.
+
+## Examples
+
+The following examples generate compiler error CS0121:
+
+```csharp
+public class C
+{
+   void f(int i, double d)
+   {
+   }
+
+   void f(double d, int i)
+   {
+   }
+
+   public static void Main()
+   {
+      C c = new C();
+
+      c.f(1, 1);   // CS0121
+
+      // Try the following code instead:
+      // c.f(1, 1.0);
+      // or
+      // c.f(1.0, 1);
+      // or
+      // c.f(1, (double)1);   // Cast and specify which method to call.
+   }
+}
+```
+
+```csharp
+class Program2
+{
+    static int ol_invoked = 0;
+
+    delegate int D1(int x);
+    delegate T D1<T>(T x);
+    delegate T D1<T, U>(U u);
+
+    static void F(D1 d1) { ol_invoked = 1; }
+    static void F<T>(D1<T> d1t) { ol_invoked = 2; }
+    static void F<T, U>(D1<T, U> d1t) { ol_invoked = 3; }
+
+    static int Test001()
+    {
+        F(delegate(int x) { return 1; }); // CS0121
+        if (ol_invoked == 1)
+            return 0;
+        else
+            return 1;
+    }
+
+    static int Main()
+    {
+        return Test001();
+    }
+}
 ```

--- a/docs/csharp/misc/cs0121.md
+++ b/docs/csharp/misc/cs0121.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS0121"
-ms.date: 07/20/2015
+ms.date: 08/14/2018
 f1_keywords:
   - "CS0121"
 helpviewer_keywords:

--- a/docs/csharp/misc/cs0473.md
+++ b/docs/csharp/misc/cs0473.md
@@ -1,65 +1,64 @@
 ---
 title: "Compiler Error CS0473"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0473"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0473"
 ms.assetid: 58eb141e-7da0-41c8-b868-7cd2a15f07f9
 ---
 # Compiler Error CS0473
-Explicit interface implementation 'method name' matches more than one interface member. Which interface member is actually chosen is implementation-dependent. Consider using a non-explicit implementation instead.  
-  
- In some cases a generic method might acquire the same signature as a non-generic method. The problem is that there is no way in the common language infrastructure (CLI) metadata system to unambiguously state which method binds to which slot. It is up to the CLI to make that determination.  
-  
-> [!NOTE]
->  This error is raised in Visual Studio 2008 in places where it was not raised in Visual Studio 2005.  
-  
-## To correct this error  
-  
-1.  Eliminate the explicit implementation and just have the implicit implementation `public int TestMethod(int)` implement both of the interface methods.  
-  
-## Example  
- The following code generates CS0473:  
-  
-```csharp  
-// cs0473.cs  
-public interface ITest<T>  
-{  
-    int TestMethod(int i);  
-    int TestMethod(T i);  
-}  
-  
-public class ImplementingClass : ITest<int>  
-{  
-    int ITest<int>.TestMethod(int i) // CS0473  
-    {  
-        return i + 1;  
-    }  
-  
-    public int TestMethod(int i)  
-    {  
-        return i - 1;  
-    }  
-}  
-  
-class T  
-{  
-    static int Main()  
-    {  
-        ImplementingClass a = new ImplementingClass();  
-        if (a.TestMethod(0) != -1)  
-            return -1;  
-  
-        ITest<int> i_a = a;  
-        System.Console.WriteLine(i_a.TestMethod(0).ToString());  
-        if (i_a.TestMethod(0) != 1)  
-            return -1;  
-  
-        return 0;  
-    }  
-}  
-```  
-  
-## See Also  
- [Fabulous Adventures in Coding](http://blogs.msdn.com/ericlippert/archive/2006/04/06/570126.aspx)
+
+Explicit interface implementation 'method name' matches more than one interface member. Which interface member is actually chosen is implementation-dependent. Consider using a non-explicit implementation instead.
+
+In some cases a generic method might acquire the same signature as a non-generic method. The problem is that there is no way in the common language infrastructure (CLI) metadata system to unambiguously state which method binds to which slot. It is up to the CLI to make that determination.
+
+## To correct this error
+
+To correct the error, eliminate the explicit implementation and implement both of the interface methods in the implicit implementation `public int TestMethod(int)`.
+
+## Example
+
+The following code generates CS0473:
+
+```csharp
+public interface ITest<T>
+{
+    int TestMethod(int i);
+    int TestMethod(T i);
+}
+
+public class ImplementingClass : ITest<int>
+{
+    int ITest<int>.TestMethod(int i) // CS0473
+    {
+        return i + 1;
+    }
+
+    public int TestMethod(int i)
+    {
+        return i - 1;
+    }
+}
+
+class T
+{
+    static int Main()
+    {
+        ImplementingClass a = new ImplementingClass();
+        if (a.TestMethod(0) != -1)
+            return -1;
+
+        ITest<int> i_a = a;
+        System.Console.WriteLine(i_a.TestMethod(0).ToString());
+        if (i_a.TestMethod(0) != 1)
+            return -1;
+
+        return 0;
+    }
+}
+```
+
+## See also
+
+[Fabulous Adventures in Coding](http://blogs.msdn.com/ericlippert/archive/2006/04/06/570126.aspx)

--- a/docs/csharp/misc/cs0473.md
+++ b/docs/csharp/misc/cs0473.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS0473"
-ms.date: 07/20/2015
+ms.date: 08/14/2018
 f1_keywords:
   - "CS0473"
 helpviewer_keywords:

--- a/docs/csharp/programming-guide/concepts/iterators.md
+++ b/docs/csharp/programming-guide/concepts/iterators.md
@@ -11,7 +11,7 @@ An iterator method or `get` accessor performs a custom iteration over a collecti
 
 You consume an iterator from client code by using a [foreach](../../../csharp/language-reference/keywords/foreach-in.md) statement or by using a LINQ query.
 
-In the following example, the first iteration of the `foreach` loop causes execution to proceed  in the `SomeNumbers` iterator method until the first `yield return` statement is reached. This iteration returns a value of 3, and the current location in the iterator method is retained. On the next iteration of the loop, execution in the iterator method continues from where it left off, again stopping when it reaches a `yield return` statement. This iteration returns a value of 5, and the current location in the iterator method is again retained. The loop completes when the end of the iterator method is reached.
+In the following example, the first iteration of the `foreach` loop causes execution to proceed in the `SomeNumbers` iterator method until the first `yield return` statement is reached. This iteration returns a value of 3, and the current location in the iterator method is retained. On the next iteration of the loop, execution in the iterator method continues from where it left off, again stopping when it reaches a `yield return` statement. This iteration returns a value of 5, and the current location in the iterator method is again retained. The loop completes when the end of the iterator method is reached.
 
 ```csharp
 static void Main()
@@ -318,7 +318,7 @@ public class Stack<T> : IEnumerable<T>
 
 An iterator can occur as a method or `get` accessor. An iterator cannot occur in an event, instance constructor, static constructor, or static finalizer.
 
-An implicit conversion must exist from the expression type in the `yield return` statement to the return type of the iterator.
+An implicit conversion must exist from the expression type in the `yield return` statement to the type argument for the IEnumerable<T> returned by the iterator.
 
 In C#, an iterator method cannot have any `in`, `ref`, or `out` parameters.
 
@@ -328,13 +328,13 @@ In C#, "yield" is not a reserved word and has special meaning only when it is us
 
 Although you write an iterator as a method, the compiler translates it into a nested class that is, in effect, a state machine. This class keeps track of the position of the iterator as long the `foreach` loop in the client code continues.
 
-To see what the compiler does, you can use the Ildasm.exe tool to view the Microsoft intermediate language code that is generated for an iterator method.
+To see what the compiler does, you can use the Ildasm.exe tool to view the Microsoft intermediate language code that's generated for an iterator method.
 
 When you create an iterator for a [class](../../../csharp/language-reference/keywords/class.md) or [struct](../../../csharp/language-reference/keywords/struct.md), you don't have to implement the whole <xref:System.Collections.IEnumerator> interface. When the compiler detects the iterator, it automatically generates the `Current`, `MoveNext`, and `Dispose` methods of the <xref:System.Collections.IEnumerator> or <xref:System.Collections.Generic.IEnumerator%601> interface.
 
 On each successive iteration of the `foreach` loop (or the direct call to `IEnumerator.MoveNext`), the next iterator code body resumes after the previous `yield return` statement. It then continues to the next `yield return` statement until the end of the iterator body is reached, or until a `yield break` statement is encountered.
 
-Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To re-iterate from the start, you must obtain a new iterator.
+Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To reiterate from the start, you must obtain a new iterator. Calling <xref:System.Collections.IEnumerator.Reset%2A> on the iterator returned by an iterator method throws a <xref:System.NotSupportedException>.
 
 For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).
 

--- a/docs/csharp/programming-guide/concepts/iterators.md
+++ b/docs/csharp/programming-guide/concepts/iterators.md
@@ -4,365 +4,355 @@ ms.date: 07/20/2015
 ms.assetid: c93f6dd4-e72a-4a06-be1c-a98b3255b734
 ---
 # Iterators (C#)
-An *iterator* can be used to step through collections such as lists and arrays.  
-  
- An iterator method or `get` accessor performs a custom iteration over a collection. An iterator method uses the [yield return](../../../csharp/language-reference/keywords/yield.md) statement to return each element one at a time. When a `yield return` statement is reached, the current location in code is remembered. Execution is restarted from that location the next time the iterator function is called.  
-  
- You consume an iterator from client code by using a [foreach](../../../csharp/language-reference/keywords/foreach-in.md) statement or by using a LINQ query.  
-  
- In the following example, the first iteration of the `foreach` loop causes execution to proceed  in the `SomeNumbers` iterator method until the first `yield return` statement is reached. This iteration returns a value of 3, and the current location in the iterator method is retained. On the next iteration of the loop, execution in the iterator method continues from where it left off, again stopping when it reaches a `yield return` statement. This iteration returns a value of 5, and the current location in the iterator method is again retained. The loop completes when the end of the iterator method is reached.  
-  
-```csharp  
-static void Main()  
-{  
-    foreach (int number in SomeNumbers())  
-    {  
-        Console.Write(number.ToString() + " ");  
-    }  
-    // Output: 3 5 8  
-    Console.ReadKey();  
-}  
-  
-public static System.Collections.IEnumerable SomeNumbers()  
-{  
-    yield return 3;  
-    yield return 5;  
-    yield return 8;  
-}  
-```  
-  
- The return type of an iterator method or `get` accessor can be <xref:System.Collections.IEnumerable>, <xref:System.Collections.Generic.IEnumerable%601>, <xref:System.Collections.IEnumerator>, or <xref:System.Collections.Generic.IEnumerator%601>.  
-  
- You can use a `yield break` statement to end the iteration.  
-  
- Iterators were introduced in C# in Visual Studio 2005.  
-  
- **In this topic**  
-  
--   [Simple Iterator](#BKMK_SimpleIterator)  
-  
--   [Creating a Collection Class](#BKMK_CollectionClass)  
-  
--   [Using Iterators with a Generic List](#BKMK_GenericList)  
-  
--   [Syntax Information](#BKMK_SyntaxInformation)  
-  
--   [Technical Implementation](#BKMK_Technical)  
-  
--   [Use of Iterators](#BKMK_UseOfIterators)  
-  
+
+An *iterator* can be used to step through collections such as lists and arrays.
+
+An iterator method or `get` accessor performs a custom iteration over a collection. An iterator method uses the [yield return](../../../csharp/language-reference/keywords/yield.md) statement to return each element one at a time. When a `yield return` statement is reached, the current location in code is remembered. Execution is restarted from that location the next time the iterator function is called.
+
+You consume an iterator from client code by using a [foreach](../../../csharp/language-reference/keywords/foreach-in.md) statement or by using a LINQ query.
+
+In the following example, the first iteration of the `foreach` loop causes execution to proceed  in the `SomeNumbers` iterator method until the first `yield return` statement is reached. This iteration returns a value of 3, and the current location in the iterator method is retained. On the next iteration of the loop, execution in the iterator method continues from where it left off, again stopping when it reaches a `yield return` statement. This iteration returns a value of 5, and the current location in the iterator method is again retained. The loop completes when the end of the iterator method is reached.
+
+```csharp
+static void Main()
+{
+    foreach (int number in SomeNumbers())
+    {
+        Console.Write(number.ToString() + " ");
+    }
+    // Output: 3 5 8
+    Console.ReadKey();
+}
+
+public static System.Collections.IEnumerable SomeNumbers()
+{
+    yield return 3;
+    yield return 5;
+    yield return 8;
+}
+```
+
+The return type of an iterator method or `get` accessor can be <xref:System.Collections.IEnumerable>, <xref:System.Collections.Generic.IEnumerable%601>, <xref:System.Collections.IEnumerator>, or <xref:System.Collections.Generic.IEnumerator%601>.
+
+You can use a `yield break` statement to end the iteration.
+
 > [!NOTE]
->  For all examples in this topic except the Simple Iterator example, include [using](../../../csharp/language-reference/keywords/using-directive.md) directives for the `System.Collections` and `System.Collections.Generic` namespaces.  
-  
-##  <a name="BKMK_SimpleIterator"></a> Simple Iterator  
- The following example has a single `yield return` statement that is inside a [for](../../../csharp/language-reference/keywords/for.md) loop. In `Main`, each iteration of the `foreach` statement body creates a call to the iterator function, which proceeds to the next `yield return` statement.  
-  
-```csharp  
-static void Main()  
-{  
-    foreach (int number in EvenSequence(5, 18))  
-    {  
-        Console.Write(number.ToString() + " ");  
-    }  
-    // Output: 6 8 10 12 14 16 18  
-    Console.ReadKey();  
-}  
-  
-public static System.Collections.Generic.IEnumerable<int>  
-    EvenSequence(int firstNumber, int lastNumber)  
-{  
-    // Yield even numbers in the range.  
-    for (int number = firstNumber; number <= lastNumber; number++)  
-    {  
-        if (number % 2 == 0)  
-        {  
-            yield return number;  
-        }  
-    }  
-}  
-```  
-  
-##  <a name="BKMK_CollectionClass"></a> Creating a Collection Class  
- In the following example, the `DaysOfTheWeek` class implements the <xref:System.Collections.IEnumerable> interface, which requires a <xref:System.Collections.IEnumerable.GetEnumerator%2A> method. The compiler implicitly calls the `GetEnumerator` method, which returns an <xref:System.Collections.IEnumerator>.  
-  
- The `GetEnumerator` method returns each string one at a time by using the `yield return` statement.  
-  
-```csharp  
-static void Main()  
-{  
-    DaysOfTheWeek days = new DaysOfTheWeek();  
-  
-    foreach (string day in days)  
-    {  
-        Console.Write(day + " ");  
-    }  
-    // Output: Sun Mon Tue Wed Thu Fri Sat  
-    Console.ReadKey();  
-}  
-  
-public class DaysOfTheWeek : IEnumerable  
-{  
-    private string[] days = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };  
-  
-    public IEnumerator GetEnumerator()  
-    {  
-        for (int index = 0; index < days.Length; index++)  
-        {  
-            // Yield each day of the week.  
-            yield return days[index];  
-        }  
-    }  
-}  
-```  
-  
- The following example creates a `Zoo` class that contains a collection of animals.  
-  
- The `foreach` statement that refers to the class instance (`theZoo`) implicitly calls the `GetEnumerator` method. The `foreach` statements that refer to the `Birds` and `Mammals` properties use the `AnimalsForType` named iterator method.  
-  
-```csharp  
-static void Main()  
-{  
-    Zoo theZoo = new Zoo();  
-  
-    theZoo.AddMammal("Whale");  
-    theZoo.AddMammal("Rhinoceros");  
-    theZoo.AddBird("Penguin");  
-    theZoo.AddBird("Warbler");  
-  
-    foreach (string name in theZoo)  
-    {  
-        Console.Write(name + " ");  
-    }  
-    Console.WriteLine();  
-    // Output: Whale Rhinoceros Penguin Warbler  
-  
-    foreach (string name in theZoo.Birds)  
-    {  
-        Console.Write(name + " ");  
-    }  
-    Console.WriteLine();  
-    // Output: Penguin Warbler  
-  
-    foreach (string name in theZoo.Mammals)  
-    {  
-        Console.Write(name + " ");  
-    }  
-    Console.WriteLine();  
-    // Output: Whale Rhinoceros  
-  
-    Console.ReadKey();  
-}  
-  
-public class Zoo : IEnumerable  
-{  
-    // Private members.  
-    private List<Animal> animals = new List<Animal>();  
-  
-    // Public methods.  
-    public void AddMammal(string name)  
-    {  
-        animals.Add(new Animal { Name = name, Type = Animal.TypeEnum.Mammal });  
-    }  
-  
-    public void AddBird(string name)  
-    {  
-        animals.Add(new Animal { Name = name, Type = Animal.TypeEnum.Bird });  
-    }  
-  
-    public IEnumerator GetEnumerator()  
-    {  
-        foreach (Animal theAnimal in animals)  
-        {  
-            yield return theAnimal.Name;  
-        }  
-    }  
-  
-    // Public members.  
-    public IEnumerable Mammals  
-    {  
-        get { return AnimalsForType(Animal.TypeEnum.Mammal); }  
-    }  
-  
-    public IEnumerable Birds  
-    {  
-        get { return AnimalsForType(Animal.TypeEnum.Bird); }  
-    }  
-  
-    // Private methods.  
-    private IEnumerable AnimalsForType(Animal.TypeEnum type)  
-    {  
-        foreach (Animal theAnimal in animals)  
-        {  
-            if (theAnimal.Type == type)  
-            {  
-                yield return theAnimal.Name;  
-            }  
-        }  
-    }  
-  
-    // Private class.  
-    private class Animal  
-    {  
-        public enum TypeEnum { Bird, Mammal }  
-  
-        public string Name { get; set; }  
-        public TypeEnum Type { get; set; }  
-    }  
-}  
-```  
-  
-##  <a name="BKMK_GenericList"></a> Using Iterators with a Generic List  
- In the following example, the <xref:System.Collections.Generic.Stack%601> generic class implements the <xref:System.Collections.Generic.IEnumerable%601> generic interface. The <xref:System.Collections.Generic.Stack%601.Push%2A> method assigns values to an array of type `T`. The <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> method returns the array values by using the `yield return` statement.  
-  
- In addition to the generic <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> method, the non-generic <xref:System.Collections.IEnumerable.GetEnumerator%2A> method must also be implemented. This is because <xref:System.Collections.Generic.IEnumerable%601> inherits from <xref:System.Collections.IEnumerable>. The non-generic implementation defers to the generic implementation.  
-  
- The example uses named iterators to support various ways of iterating through the same collection of data. These named iterators are the `TopToBottom` and `BottomToTop` properties, and the `TopN` method.  
-  
- The `BottomToTop` property uses an iterator in a `get` accessor.  
-  
-```csharp  
-static void Main()  
-{  
-    Stack<int> theStack = new Stack<int>();  
-  
-    //  Add items to the stack.  
-    for (int number = 0; number <= 9; number++)  
-    {  
-        theStack.Push(number);  
-    }  
-  
-    // Retrieve items from the stack.  
-    // foreach is allowed because theStack implements  
-    // IEnumerable<int>.  
-    foreach (int number in theStack)  
-    {  
-        Console.Write("{0} ", number);  
-    }  
-    Console.WriteLine();  
-    // Output: 9 8 7 6 5 4 3 2 1 0  
-  
-    // foreach is allowed, because theStack.TopToBottom  
-    // returns IEnumerable(Of Integer).  
-    foreach (int number in theStack.TopToBottom)  
-    {  
-        Console.Write("{0} ", number);  
-    }  
-    Console.WriteLine();  
-    // Output: 9 8 7 6 5 4 3 2 1 0  
-  
-    foreach (int number in theStack.BottomToTop)  
-    {  
-        Console.Write("{0} ", number);  
-    }  
-    Console.WriteLine();  
-    // Output: 0 1 2 3 4 5 6 7 8 9  
-  
-    foreach (int number in theStack.TopN(7))  
-    {  
-        Console.Write("{0} ", number);  
-    }  
-    Console.WriteLine();  
-    // Output: 9 8 7 6 5 4 3  
-  
-    Console.ReadKey();  
-}  
-  
-public class Stack<T> : IEnumerable<T>  
-{  
-    private T[] values = new T[100];  
-    private int top = 0;  
-  
-    public void Push(T t)  
-    {  
-        values[top] = t;  
-        top++;  
-    }  
-    public T Pop()  
-    {  
-        top--;  
-        return values[top];  
-    }  
-  
-    // This method implements the GetEnumerator method. It allows  
-    // an instance of the class to be used in a foreach statement.  
-    public IEnumerator<T> GetEnumerator()  
-    {  
-        for (int index = top - 1; index >= 0; index--)  
-        {  
-            yield return values[index];  
-        }  
-    }  
-  
-    IEnumerator IEnumerable.GetEnumerator()  
-    {  
-        return GetEnumerator();  
-    }  
-  
-    public IEnumerable<T> TopToBottom  
-    {  
-        get { return this; }  
-    }  
-  
-    public IEnumerable<T> BottomToTop  
-    {  
-        get  
-        {  
-            for (int index = 0; index <= top - 1; index++)  
-            {  
-                yield return values[index];  
-            }  
-        }  
-    }  
-  
-    public IEnumerable<T> TopN(int itemsFromTop)  
-    {  
-        // Return less than itemsFromTop if necessary.  
-        int startIndex = itemsFromTop >= top ? 0 : top - itemsFromTop;  
-  
-        for (int index = top - 1; index >= startIndex; index--)  
-        {  
-            yield return values[index];  
-        }  
-    }  
-  
-}  
-```  
-  
-##  <a name="BKMK_SyntaxInformation"></a> Syntax Information  
- An iterator can occur as a method or `get` accessor. An iterator cannot occur in an event, instance constructor, static constructor, or static finalizer.  
-  
- An implicit conversion must exist from the expression type in the `yield return` statement to the return type of the iterator.  
-  
- In C#, an iterator method cannot have any `in`, `ref`, or `out` parameters.  
-  
- In C#, "yield" is not a reserved word and has special meaning only when it is used before a `return` or `break` keyword.  
-  
-##  <a name="BKMK_Technical"></a> Technical Implementation  
- Although you write an iterator as a method, the compiler translates it into a nested class that is, in effect, a state machine. This class keeps track of the position of the iterator as long the `foreach` loop in the client code continues.  
-  
- To see what the compiler does, you can use the Ildasm.exe tool to view the Microsoft intermediate language code that is generated for an iterator method.  
-  
- When you create an iterator for a [class](../../../csharp/language-reference/keywords/class.md) or [struct](../../../csharp/language-reference/keywords/struct.md), you don't have to implement the whole <xref:System.Collections.IEnumerator> interface. When the compiler detects the iterator, it automatically generates the `Current`, `MoveNext`, and `Dispose` methods of the <xref:System.Collections.IEnumerator> or <xref:System.Collections.Generic.IEnumerator%601> interface.  
-  
- On each successive iteration of the `foreach` loop (or the direct call to `IEnumerator.MoveNext`), the next iterator code body resumes after the previous `yield return` statement. It then continues to the next `yield return` statement until the end of the iterator body is reached, or until a `yield break` statement is encountered.  
-  
- Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To re-iterate from the start, you must obtain a new iterator.  
-  
- For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).  
-  
-##  <a name="BKMK_UseOfIterators"></a> Use of Iterators  
- Iterators enable you to maintain the simplicity of a `foreach` loop when you need to use complex code to populate a list sequence. This can be useful when you want to do the following:  
-  
--   Modify the list sequence after the first `foreach` loop iteration.  
-  
--   Avoid fully loading a large list before the first iteration of a `foreach` loop. An example is a paged fetch to load a batch of table rows. Another example is the <xref:System.IO.DirectoryInfo.EnumerateFiles%2A> method, which implements iterators within the .NET Framework.  
-  
--   Encapsulate building the list in the iterator. In the iterator method, you can build the list and then yield each result in a loop.  
-  
-## See Also  
- <xref:System.Collections.Generic>  
- <xref:System.Collections.Generic.IEnumerable%601>  
- [foreach, in](../../../csharp/language-reference/keywords/foreach-in.md)  
- [yield](../../../csharp/language-reference/keywords/yield.md)  
- [Using foreach with Arrays](../../../csharp/programming-guide/arrays/using-foreach-with-arrays.md)  
- [Generics](../../../csharp/programming-guide/generics/index.md)
+> For all examples in this topic except the Simple Iterator example, include [using](../../../csharp/language-reference/keywords/using-directive.md) directives for the `System.Collections` and `System.Collections.Generic` namespaces.
+
+##  <a name="BKMK_SimpleIterator"></a> Simple Iterator
+
+The following example has a single `yield return` statement that is inside a [for](../../../csharp/language-reference/keywords/for.md) loop. In `Main`, each iteration of the `foreach` statement body creates a call to the iterator function, which proceeds to the next `yield return` statement.
+
+```csharp
+static void Main()
+{
+    foreach (int number in EvenSequence(5, 18))
+    {
+        Console.Write(number.ToString() + " ");
+    }
+    // Output: 6 8 10 12 14 16 18
+    Console.ReadKey();
+}
+
+public static System.Collections.Generic.IEnumerable<int>
+    EvenSequence(int firstNumber, int lastNumber)
+{
+    // Yield even numbers in the range.
+    for (int number = firstNumber; number <= lastNumber; number++)
+    {
+        if (number % 2 == 0)
+        {
+            yield return number;
+        }
+    }
+}
+```
+
+##  <a name="BKMK_CollectionClass"></a> Creating a Collection Class
+
+In the following example, the `DaysOfTheWeek` class implements the <xref:System.Collections.IEnumerable> interface, which requires a <xref:System.Collections.IEnumerable.GetEnumerator%2A> method. The compiler implicitly calls the `GetEnumerator` method, which returns an <xref:System.Collections.IEnumerator>.
+
+The `GetEnumerator` method returns each string one at a time by using the `yield return` statement.
+
+```csharp
+static void Main()
+{
+    DaysOfTheWeek days = new DaysOfTheWeek();
+
+    foreach (string day in days)
+    {
+        Console.Write(day + " ");
+    }
+    // Output: Sun Mon Tue Wed Thu Fri Sat
+    Console.ReadKey();
+}
+
+public class DaysOfTheWeek : IEnumerable
+{
+    private string[] days = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+
+    public IEnumerator GetEnumerator()
+    {
+        for (int index = 0; index < days.Length; index++)
+        {
+            // Yield each day of the week.
+            yield return days[index];
+        }
+    }
+}
+```
+
+The following example creates a `Zoo` class that contains a collection of animals.
+
+The `foreach` statement that refers to the class instance (`theZoo`) implicitly calls the `GetEnumerator` method. The `foreach` statements that refer to the `Birds` and `Mammals` properties use the `AnimalsForType` named iterator method.
+
+```csharp
+static void Main()
+{
+    Zoo theZoo = new Zoo();
+
+    theZoo.AddMammal("Whale");
+    theZoo.AddMammal("Rhinoceros");
+    theZoo.AddBird("Penguin");
+    theZoo.AddBird("Warbler");
+
+    foreach (string name in theZoo)
+    {
+        Console.Write(name + " ");
+    }
+    Console.WriteLine();
+    // Output: Whale Rhinoceros Penguin Warbler
+
+    foreach (string name in theZoo.Birds)
+    {
+        Console.Write(name + " ");
+    }
+    Console.WriteLine();
+    // Output: Penguin Warbler
+
+    foreach (string name in theZoo.Mammals)
+    {
+        Console.Write(name + " ");
+    }
+    Console.WriteLine();
+    // Output: Whale Rhinoceros
+
+    Console.ReadKey();
+}
+
+public class Zoo : IEnumerable
+{
+    // Private members.
+    private List<Animal> animals = new List<Animal>();
+
+    // Public methods.
+    public void AddMammal(string name)
+    {
+        animals.Add(new Animal { Name = name, Type = Animal.TypeEnum.Mammal });
+    }
+
+    public void AddBird(string name)
+    {
+        animals.Add(new Animal { Name = name, Type = Animal.TypeEnum.Bird });
+    }
+
+    public IEnumerator GetEnumerator()
+    {
+        foreach (Animal theAnimal in animals)
+        {
+            yield return theAnimal.Name;
+        }
+    }
+
+    // Public members.
+    public IEnumerable Mammals
+    {
+        get { return AnimalsForType(Animal.TypeEnum.Mammal); }
+    }
+
+    public IEnumerable Birds
+    {
+        get { return AnimalsForType(Animal.TypeEnum.Bird); }
+    }
+
+    // Private methods.
+    private IEnumerable AnimalsForType(Animal.TypeEnum type)
+    {
+        foreach (Animal theAnimal in animals)
+        {
+            if (theAnimal.Type == type)
+            {
+                yield return theAnimal.Name;
+            }
+        }
+    }
+
+    // Private class.
+    private class Animal
+    {
+        public enum TypeEnum { Bird, Mammal }
+
+        public string Name { get; set; }
+        public TypeEnum Type { get; set; }
+    }
+}
+```
+
+##  <a name="BKMK_GenericList"></a> Using Iterators with a Generic List
+
+In the following example, the <xref:System.Collections.Generic.Stack%601> generic class implements the <xref:System.Collections.Generic.IEnumerable%601> generic interface. The <xref:System.Collections.Generic.Stack%601.Push%2A> method assigns values to an array of type `T`. The <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> method returns the array values by using the `yield return` statement.
+
+In addition to the generic <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> method, the non-generic <xref:System.Collections.IEnumerable.GetEnumerator%2A> method must also be implemented. This is because <xref:System.Collections.Generic.IEnumerable%601> inherits from <xref:System.Collections.IEnumerable>. The non-generic implementation defers to the generic implementation.
+
+The example uses named iterators to support various ways of iterating through the same collection of data. These named iterators are the `TopToBottom` and `BottomToTop` properties, and the `TopN` method.
+
+The `BottomToTop` property uses an iterator in a `get` accessor.
+
+```csharp
+static void Main()
+{
+    Stack<int> theStack = new Stack<int>();
+
+    //  Add items to the stack.
+    for (int number = 0; number <= 9; number++)
+    {
+        theStack.Push(number);
+    }
+
+    // Retrieve items from the stack.
+    // foreach is allowed because theStack implements IEnumerable<int>.
+    foreach (int number in theStack)
+    {
+        Console.Write("{0} ", number);
+    }
+    Console.WriteLine();
+    // Output: 9 8 7 6 5 4 3 2 1 0
+
+    // foreach is allowed, because theStack.TopToBottom returns IEnumerable(Of Integer).
+    foreach (int number in theStack.TopToBottom)
+    {
+        Console.Write("{0} ", number);
+    }
+    Console.WriteLine();
+    // Output: 9 8 7 6 5 4 3 2 1 0
+
+    foreach (int number in theStack.BottomToTop)
+    {
+        Console.Write("{0} ", number);
+    }
+    Console.WriteLine();
+    // Output: 0 1 2 3 4 5 6 7 8 9
+
+    foreach (int number in theStack.TopN(7))
+    {
+        Console.Write("{0} ", number);
+    }
+    Console.WriteLine();
+    // Output: 9 8 7 6 5 4 3
+
+    Console.ReadKey();
+}
+
+public class Stack<T> : IEnumerable<T>
+{
+    private T[] values = new T[100];
+    private int top = 0;
+
+    public void Push(T t)
+    {
+        values[top] = t;
+        top++;
+    }
+    public T Pop()
+    {
+        top--;
+        return values[top];
+    }
+
+    // This method implements the GetEnumerator method. It allows
+    // an instance of the class to be used in a foreach statement.
+    public IEnumerator<T> GetEnumerator()
+    {
+        for (int index = top - 1; index >= 0; index--)
+        {
+            yield return values[index];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public IEnumerable<T> TopToBottom
+    {
+        get { return this; }
+    }
+
+    public IEnumerable<T> BottomToTop
+    {
+        get
+        {
+            for (int index = 0; index <= top - 1; index++)
+            {
+                yield return values[index];
+            }
+        }
+    }
+
+    public IEnumerable<T> TopN(int itemsFromTop)
+    {
+        // Return less than itemsFromTop if necessary.
+        int startIndex = itemsFromTop >= top ? 0 : top - itemsFromTop;
+
+        for (int index = top - 1; index >= startIndex; index--)
+        {
+            yield return values[index];
+        }
+    }
+
+}
+```
+
+##  <a name="BKMK_SyntaxInformation"></a> Syntax Information
+
+An iterator can occur as a method or `get` accessor. An iterator cannot occur in an event, instance constructor, static constructor, or static finalizer.
+
+An implicit conversion must exist from the expression type in the `yield return` statement to the return type of the iterator.
+
+In C#, an iterator method cannot have any `in`, `ref`, or `out` parameters.
+
+In C#, "yield" is not a reserved word and has special meaning only when it is used before a `return` or `break` keyword.
+
+##  <a name="BKMK_Technical"></a> Technical Implementation
+
+Although you write an iterator as a method, the compiler translates it into a nested class that is, in effect, a state machine. This class keeps track of the position of the iterator as long the `foreach` loop in the client code continues.
+
+To see what the compiler does, you can use the Ildasm.exe tool to view the Microsoft intermediate language code that is generated for an iterator method.
+
+When you create an iterator for a [class](../../../csharp/language-reference/keywords/class.md) or [struct](../../../csharp/language-reference/keywords/struct.md), you don't have to implement the whole <xref:System.Collections.IEnumerator> interface. When the compiler detects the iterator, it automatically generates the `Current`, `MoveNext`, and `Dispose` methods of the <xref:System.Collections.IEnumerator> or <xref:System.Collections.Generic.IEnumerator%601> interface.
+
+On each successive iteration of the `foreach` loop (or the direct call to `IEnumerator.MoveNext`), the next iterator code body resumes after the previous `yield return` statement. It then continues to the next `yield return` statement until the end of the iterator body is reached, or until a `yield break` statement is encountered.
+
+Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To re-iterate from the start, you must obtain a new iterator.
+
+For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).
+
+##  <a name="BKMK_UseOfIterators"></a> Use of Iterators
+
+Iterators enable you to maintain the simplicity of a `foreach` loop when you need to use complex code to populate a list sequence. This can be useful when you want to do the following:
+
+- Modify the list sequence after the first `foreach` loop iteration.
+
+- Avoid fully loading a large list before the first iteration of a `foreach` loop. An example is a paged fetch to load a batch of table rows. Another example is the <xref:System.IO.DirectoryInfo.EnumerateFiles%2A> method, which implements iterators within the .NET Framework.
+
+- Encapsulate building the list in the iterator. In the iterator method, you can build the list and then yield each result in a loop.
+
+## See also
+
+- <xref:System.Collections.Generic>
+- <xref:System.Collections.Generic.IEnumerable%601>
+- [foreach, in](../../../csharp/language-reference/keywords/foreach-in.md)
+- [yield](../../../csharp/language-reference/keywords/yield.md)
+- [Using foreach with Arrays](../../../csharp/programming-guide/arrays/using-foreach-with-arrays.md)
+- [Generics](../../../csharp/programming-guide/generics/index.md)

--- a/docs/csharp/programming-guide/concepts/iterators.md
+++ b/docs/csharp/programming-guide/concepts/iterators.md
@@ -1,6 +1,6 @@
 ---
-title: "Iterators (C#)"
-ms.date: 07/20/2015
+title: Iterate through collections in C#
+ms.date: 08/14/2018
 ms.assetid: c93f6dd4-e72a-4a06-be1c-a98b3255b734
 ---
 # Iterators (C#)
@@ -39,7 +39,7 @@ You can use a `yield break` statement to end the iteration.
 > [!NOTE]
 > For all examples in this topic except the Simple Iterator example, include [using](../../../csharp/language-reference/keywords/using-directive.md) directives for the `System.Collections` and `System.Collections.Generic` namespaces.
 
-##  <a name="BKMK_SimpleIterator"></a> Simple Iterator
+## Simple Iterator
 
 The following example has a single `yield return` statement that is inside a [for](../../../csharp/language-reference/keywords/for.md) loop. In `Main`, each iteration of the `foreach` statement body creates a call to the iterator function, which proceeds to the next `yield return` statement.
 
@@ -68,7 +68,7 @@ public static System.Collections.Generic.IEnumerable<int>
 }
 ```
 
-##  <a name="BKMK_CollectionClass"></a> Creating a Collection Class
+## Creating a Collection Class
 
 In the following example, the `DaysOfTheWeek` class implements the <xref:System.Collections.IEnumerable> interface, which requires a <xref:System.Collections.IEnumerable.GetEnumerator%2A> method. The compiler implicitly calls the `GetEnumerator` method, which returns an <xref:System.Collections.IEnumerator>.
 
@@ -198,7 +198,7 @@ public class Zoo : IEnumerable
 }
 ```
 
-##  <a name="BKMK_GenericList"></a> Using Iterators with a Generic List
+## Using Iterators with a Generic List
 
 In the following example, the <xref:System.Collections.Generic.Stack%601> generic class implements the <xref:System.Collections.Generic.IEnumerable%601> generic interface. The <xref:System.Collections.Generic.Stack%601.Push%2A> method assigns values to an array of type `T`. The <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> method returns the array values by using the `yield return` statement.
 
@@ -314,7 +314,7 @@ public class Stack<T> : IEnumerable<T>
 }
 ```
 
-##  <a name="BKMK_SyntaxInformation"></a> Syntax Information
+## Syntax Information
 
 An iterator can occur as a method or `get` accessor. An iterator cannot occur in an event, instance constructor, static constructor, or static finalizer.
 
@@ -324,7 +324,7 @@ In C#, an iterator method cannot have any `in`, `ref`, or `out` parameters.
 
 In C#, "yield" is not a reserved word and has special meaning only when it is used before a `return` or `break` keyword.
 
-##  <a name="BKMK_Technical"></a> Technical Implementation
+## Technical Implementation
 
 Although you write an iterator as a method, the compiler translates it into a nested class that is, in effect, a state machine. This class keeps track of the position of the iterator as long the `foreach` loop in the client code continues.
 
@@ -338,7 +338,7 @@ Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displa
 
 For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).
 
-##  <a name="BKMK_UseOfIterators"></a> Use of Iterators
+## Use of Iterators
 
 Iterators enable you to maintain the simplicity of a `foreach` loop when you need to use complex code to populate a list sequence. This can be useful when you want to do the following:
 
@@ -348,7 +348,7 @@ Iterators enable you to maintain the simplicity of a `foreach` loop when you nee
 
 - Encapsulate building the list in the iterator. In the iterator method, you can build the list and then yield each result in a loop.
 
-## See also
+## See Also
 
 - <xref:System.Collections.Generic>
 - <xref:System.Collections.Generic.IEnumerable%601>

--- a/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
@@ -1,6 +1,6 @@
 ---
 title: "&lt;compiler&gt; Element"
-ms.date: "03/30/2017"
+ms.date: 08/14/2018
 f1_keywords:
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#compiler"
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#configuration/system.codedom/compilers/compiler"

--- a/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
@@ -1,10 +1,10 @@
 ---
 title: "&lt;compiler&gt; Element"
 ms.date: "03/30/2017"
-f1_keywords: 
+f1_keywords:
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#compiler"
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#configuration/system.codedom/compilers/compiler"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "compiler configuration elements, <compiler> element"
   - "<compiler> element"
   - "compiler configuration attributes"
@@ -15,87 +15,93 @@ ms.author: "markl"
 manager: "markl"
 ---
 # &lt;compiler&gt; Element
-Specifies the compiler configuration attributes for a language provider.  
-  
- \<configuration Element>  
-\<system.codedom Element>  
-\<compilers Element>  
-\<compiler> Element  
-  
-## Syntax  
-  
-```xml  
-<compiler  
-  language="languageName[;...;...]"  
-  extension="fileExtension[;...;...]"  
-  type="typeName, assemblyName"  
-  warningLevel="number"  
-  compilerOptions="option1 option2"  
-/>  
-```  
-  
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
-  
-### Attributes  
-  
-|Attribute|Description|  
-|---------------|-----------------|  
-|`compilerOptions`|Optional attribute.<br /><br /> Specifies additional compiler-specific arguments for compilation. The values for the `compilerOptions` attribute are typically listed in a compiler options topic for the compiler. In the Visual Studio 2005 documentation, you can locate the options for the compiler by looking for "compiler options" in the index.|  
-|`extension`|Required attribute.<br /><br /> Provides a semicolon-separated list of file name extensions used by source files for the language provider. For example, ".cs".|  
-|`language`|Required attribute.<br /><br /> Provides a semicolon-separated list of language names supported by the language provider. For example, "c#;cs;csharp".|  
-|`type`|Required attribute.<br /><br /> Specifies the type name of the language provider, including the name of the assembly containing the provider implementation. The type name must meet the requirements defined in [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md).|  
-|`warningLevel`|Optional attribute.<br /><br /> Specifies the default compiler warning level; determines the level at which the language provider treats compilation warnings as errors.|  
-  
-### Child Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<providerOption> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/provideroption-element.md)|Specifies compiler version attributes for a language provider.|  
-  
-### Parent Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<configuration> Element](../../../../../docs/framework/configure-apps/file-schema/configuration-element.md)|The root element in every configuration file used by the common language runtime and .NET Framework applications.|  
-|[\<system.codedom> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/system-codedom-element.md)|Specifies compiler configuration settings for available language providers.|  
-|[\<compilers> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/compilers-element.md)|Container for compiler configuration elements; contains zero or more `<compiler>` elements.|  
-  
-## Remarks  
- Each `<compiler>` element specifies the compiler configuration attributes for a specific language provider. The provider extends the <xref:System.CodeDom.Compiler.CodeDomProvider?displayProperty=nameWithType> class for a specific language; the `<compiler>` element defines the compiler and code generator settings for the language provider.  
-  
- The .NET Framework defines the initial compiler settings in the machine configuration file (Machine.config). Developers and compiler vendors can add configuration settings for a new <xref:System.CodeDom.Compiler.CodeDomProvider> implementation. Use the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo%2A?displayProperty=nameWithType> method to programmatically enumerate language provider and compiler configuration settings on a computer.  
-  
- Compiler elements in the application or Web configuration file can supplement or override the settings in the machine configuration file. If more than one provider implementation is configured for the same language name or the same file extension, the last matching configuration overrides any previous configured providers for that language name or file extension.  
-  
-## Configuration File  
- This element can be used in the machine configuration file and the application configuration file.  
-  
-## Example  
- The following example illustrates a typical compiler configuration element.  
-  
-```xml  
-<configuration>  
-  <system.codedom>  
-    <compilers>  
-      <!-- zero or more compiler elements -->  
-      <compiler  
-        language="c#;cs;csharp"  
-        extension=".cs"  
-        type="Microsoft.CSharp.CSharpCodeProvider, System,   
-          Version=2.0.3600.0, Culture=neutral,   
-          PublicKeyToken=b77a5c561934e089"  
-        compilerOptions="/optimize"  
-        warningLevel="1" />  
-    </compilers>  
-  </system.codedom>  
-</configuration>  
-```  
-  
-## See Also  
- <xref:System.CodeDom.Compiler.CompilerInfo>  
- <xref:System.CodeDom.Compiler.CodeDomProvider>  
- [Configuration File Schema](../../../../../docs/framework/configure-apps/file-schema/index.md)  
- [\<compilers> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/compilers-element.md)  
- [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md)  
- [compiler Element for compilers for compilation (ASP.NET Settings Schema)](https://msdn.microsoft.com/library/f7d6b078-5d42-4134-b3f7-62e1aba1df1e(v=vs.100))
+
+Specifies the compiler configuration attributes for a language provider.
+
+\<configuration Element>
+\<system.codedom Element>
+\<compilers Element>
+\<compiler> Element
+
+## Syntax
+
+```xml
+<compiler
+  language="languageName[;...;...]"
+  extension="fileExtension[;...;...]"
+  type="typeName, assemblyName"
+  warningLevel="number"
+  compilerOptions="option1 option2"
+/>
+```
+
+## Attributes and Elements
+
+The following sections describe attributes, child elements, and parent elements.
+
+### Attributes
+
+|Attribute|Description|
+|---------------|-----------------|
+|`compilerOptions`|Optional attribute.<br /><br /> Specifies additional compiler-specific arguments for compilation. The values for the `compilerOptions` attribute are typically listed in a compiler options topic for the compiler.|
+|`extension`|Required attribute.<br /><br /> Provides a semicolon-separated list of file name extensions used by source files for the language provider. For example, ".cs".|
+|`language`|Required attribute.<br /><br /> Provides a semicolon-separated list of language names supported by the language provider. For example, "c#;cs;csharp".|
+|`type`|Required attribute.<br /><br /> Specifies the type name of the language provider, including the name of the assembly containing the provider implementation. The type name must meet the requirements defined in [Specifying Fully Qualified Type Names](../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md).|
+|`warningLevel`|Optional attribute.<br /><br /> Specifies the default compiler warning level; determines the level at which the language provider treats compilation warnings as errors.|
+
+### Child Elements
+
+|Element|Description|
+|-------------|-----------------|
+|[\<providerOption> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/provideroption-element.md)|Specifies compiler version attributes for a language provider.|
+
+### Parent Elements
+
+|Element|Description|
+|-------------|-----------------|
+|[\<configuration> Element](../../../../../docs/framework/configure-apps/file-schema/configuration-element.md)|The root element in every configuration file used by the common language runtime and .NET Framework applications.|
+|[\<system.codedom> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/system-codedom-element.md)|Specifies compiler configuration settings for available language providers.|
+|[\<compilers> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/compilers-element.md)|Container for compiler configuration elements; contains zero or more `<compiler>` elements.|
+
+## Remarks
+
+Each `<compiler>` element specifies the compiler configuration attributes for a specific language provider. The provider extends the <xref:System.CodeDom.Compiler.CodeDomProvider?displayProperty=nameWithType> class for a specific language; the `<compiler>` element defines the compiler and code generator settings for the language provider.
+
+The .NET Framework defines the initial compiler settings in the machine configuration file (Machine.config). Developers and compiler vendors can add configuration settings for a new <xref:System.CodeDom.Compiler.CodeDomProvider> implementation. Use the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo%2A?displayProperty=nameWithType> method to programmatically enumerate language provider and compiler configuration settings on a computer.
+
+Compiler elements in the application or Web configuration file can supplement or override the settings in the machine configuration file. If more than one provider implementation is configured for the same language name or the same file extension, the last matching configuration overrides any previous configured providers for that language name or file extension.
+
+## Configuration File
+
+This element can be used in the machine configuration file and the application configuration file.
+
+## Example
+
+The following example illustrates a typical compiler configuration element:
+
+```xml
+<configuration>
+  <system.codedom>
+    <compilers>
+      <!-- zero or more compiler elements -->
+      <compiler
+        language="c#;cs;csharp"
+        extension=".cs"
+        type="Microsoft.CSharp.CSharpCodeProvider, System,
+          Version=2.0.3600.0, Culture=neutral,
+          PublicKeyToken=b77a5c561934e089"
+        compilerOptions="/optimize"
+        warningLevel="1" />
+    </compilers>
+  </system.codedom>
+</configuration>
+```
+
+## See Also
+
+- <xref:System.CodeDom.Compiler.CompilerInfo>
+- <xref:System.CodeDom.Compiler.CodeDomProvider>
+- [Configuration File Schema](../../../../../docs/framework/configure-apps/file-schema/index.md)
+- [\<compilers> Element](../../../../../docs/framework/configure-apps/file-schema/compiler/compilers-element.md)
+- [Specifying Fully Qualified Type Names]-(../../../../../docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md)
+- [compiler Element for compilers for compilation (ASP.NET Settings Schema)](https://msdn.microsoft.com/library/f7d6b078-5d42-4134-b3f7-62e1aba1df1e(v=vs.100))

--- a/docs/framework/debug-trace-profile/diagnosing-errors-with-managed-debugging-assistants.md
+++ b/docs/framework/debug-trace-profile/diagnosing-errors-with-managed-debugging-assistants.md
@@ -1,6 +1,6 @@
 ---
 title: "Diagnosing Errors with Managed Debugging Assistants"
-ms.date: "03/30/2017"
+ms.date: 08/14/2018
 f1_keywords:
   - "EHMDA"
 helpviewer_keywords:

--- a/docs/framework/debug-trace-profile/diagnosing-errors-with-managed-debugging-assistants.md
+++ b/docs/framework/debug-trace-profile/diagnosing-errors-with-managed-debugging-assistants.md
@@ -1,9 +1,9 @@
 ---
 title: "Diagnosing Errors with Managed Debugging Assistants"
 ms.date: "03/30/2017"
-f1_keywords: 
+f1_keywords:
   - "EHMDA"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "run-time error debugging"
   - "managed code, run-time debugging"
   - "resource debugging"
@@ -33,147 +33,152 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # Diagnosing Errors with Managed Debugging Assistants
-Managed debugging assistants (MDAs) are debugging aids that work in conjunction with the common language runtime (CLR) to provide information on runtime state. The assistants generate informational messages about runtime events that you cannot otherwise trap. You can use MDAs to isolate hard-to-find application bugs that occur when transitioning between managed and unmanaged code. You can enable or disable all MDAs by adding a key to the Windows registry or by setting an environment variable. You can enable specific MDAs by using application configuration settings. You can set additional configuration settings for some individual MDAs in the application's configuration file. Because these configuration files are parsed when the runtime is loaded, you must enable the MDA before the managed application starts. You cannot enable it for applications that have already started.  
-  
+
+Managed debugging assistants (MDAs) are debugging aids that work in conjunction with the common language runtime (CLR) to provide information on runtime state. The assistants generate informational messages about runtime events that you cannot otherwise trap. You can use MDAs to isolate hard-to-find application bugs that occur when transitioning between managed and unmanaged code. You can enable or disable all MDAs by adding a key to the Windows registry or by setting an environment variable. You can enable specific MDAs by using application configuration settings. You can set additional configuration settings for some individual MDAs in the application's configuration file. Because these configuration files are parsed when the runtime is loaded, you must enable the MDA before the managed application starts. You cannot enable it for applications that have already started.
+
 > [!NOTE]
->  When an MDA is enabled, it is active even when your code is not executing under a debugger. If an MDA event is raised when a debugger is not present, the event message is presented in an unhandled exception dialog box, although it is not an unhandled exception. To avoid the dialog box, remove the MDA-enabling settings when your code is not executing in a debugging environment.  
-  
+> When an MDA is enabled, it is active even when your code is not executing under a debugger. If an MDA event is raised when a debugger is not present, the event message is presented in an unhandled exception dialog box, although it is not an unhandled exception. To avoid the dialog box, remove the MDA-enabling settings when your code is not executing in a debugging environment.
+
 > [!NOTE]
->  When your code is executing in the Visual Studio integrated development environment (IDE), you can avoid the exception dialog box that appears for specific MDA events. To do that, on the **Debug** menu, click **Exceptions**. (If the **Debug** menu does not contain an **Exceptions** command, click **Customize** on the **Tools** menu to add it.) In the **Exceptions** dialog box, expand the **Managed Debugging Assistants** list, and then clear the **Thrown** check box for the individual MDA. For example, to avoid the exception dialog box for a [contextSwitchDeadlock](../../../docs/framework/debug-trace-profile/contextswitchdeadlock-mda.md) clear the **Thrown** check box next to its name in the **Managed Debugging Assistants** list. You can also use this dialog box to enable the display of MDA exception dialog boxes.  
-  
- The following table lists the MDAs that ship with the .NET Framework.  
-  
-|||  
-|-|-|  
-|[asynchronousThreadAbort](../../../docs/framework/debug-trace-profile/asynchronousthreadabort-mda.md)|[bindingFailure](../../../docs/framework/debug-trace-profile/bindingfailure-mda.md)|  
-|[callbackOnCollectedDelegate](../../../docs/framework/debug-trace-profile/callbackoncollecteddelegate-mda.md)|[contextSwitchDeadlock](../../../docs/framework/debug-trace-profile/contextswitchdeadlock-mda.md)|  
-|[dangerousThreadingAPI](../../../docs/framework/debug-trace-profile/dangerousthreadingapi-mda.md)|[dateTimeInvalidLocalFormat](../../../docs/framework/debug-trace-profile/datetimeinvalidlocalformat-mda.md)|  
-|[dirtyCastAndCallOnInterface](../../../docs/framework/debug-trace-profile/dirtycastandcalloninterface-mda.md)|[disconnectedContext](../../../docs/framework/debug-trace-profile/disconnectedcontext-mda.md)|  
-|[dllMainReturnsFalse](../../../docs/framework/debug-trace-profile/dllmainreturnsfalse-mda.md)|[exceptionSwallowedOnCallFromCom](../../../docs/framework/debug-trace-profile/exceptionswallowedoncallfromcom-mda.md)|  
-|[failedQI](../../../docs/framework/debug-trace-profile/failedqi-mda.md)|[fatalExecutionEngineError](../../../docs/framework/debug-trace-profile/fatalexecutionengineerror-mda.md)|  
-|[gcManagedToUnmanaged](../../../docs/framework/debug-trace-profile/gcmanagedtounmanaged-mda.md)|[gcUnmanagedToManaged](../../../docs/framework/debug-trace-profile/gcunmanagedtomanaged-mda.md)|  
-|[illegalPrepareConstrainedRegion](../../../docs/framework/debug-trace-profile/illegalprepareconstrainedregion-mda.md)|[invalidApartmentStateChange](../../../docs/framework/debug-trace-profile/invalidapartmentstatechange-mda.md)|  
-|[invalidCERCall](../../../docs/framework/debug-trace-profile/invalidcercall-mda.md)|[invalidFunctionPointerInDelegate](../../../docs/framework/debug-trace-profile/invalidfunctionpointerindelegate-mda.md)|  
-|[invalidGCHandleCookie](../../../docs/framework/debug-trace-profile/invalidgchandlecookie-mda.md)|[invalidIUnknown](../../../docs/framework/debug-trace-profile/invalidiunknown-mda.md)|  
-|[invalidMemberDeclaration](../../../docs/framework/debug-trace-profile/invalidmemberdeclaration-mda.md)|[invalidOverlappedToPinvoke](../../../docs/framework/debug-trace-profile/invalidoverlappedtopinvoke-mda.md)|  
-|[invalidVariant](../../../docs/framework/debug-trace-profile/invalidvariant-mda.md)|[jitCompilationStart](../../../docs/framework/debug-trace-profile/jitcompilationstart-mda.md)|  
-|[loaderLock](../../../docs/framework/debug-trace-profile/loaderlock-mda.md)|[loadFromContext](../../../docs/framework/debug-trace-profile/loadfromcontext-mda.md)|  
-|[marshalCleanupError](../../../docs/framework/debug-trace-profile/marshalcleanuperror-mda.md)|[marshaling](../../../docs/framework/debug-trace-profile/marshaling-mda.md)|  
-|[memberInfoCacheCreation](../../../docs/framework/debug-trace-profile/memberinfocachecreation-mda.md)|[moduloObjectHashcode](../../../docs/framework/debug-trace-profile/moduloobjecthashcode-mda.md)|  
-|[nonComVisibleBaseClass](../../../docs/framework/debug-trace-profile/noncomvisiblebaseclass-mda.md)|[notMarshalable](../../../docs/framework/debug-trace-profile/notmarshalable-mda.md)|  
-|[openGenericCERCall](../../../docs/framework/debug-trace-profile/opengenericcercall-mda.md)|[overlappedFreeError](../../../docs/framework/debug-trace-profile/overlappedfreeerror-mda.md)|  
-|[pInvokeLog](../../../docs/framework/debug-trace-profile/pinvokelog-mda.md)|[pInvokeStackImbalance](../../../docs/framework/debug-trace-profile/pinvokestackimbalance-mda.md)|  
-|[raceOnRCWCleanup](../../../docs/framework/debug-trace-profile/raceonrcwcleanup-mda.md)|[reentrancy](../../../docs/framework/debug-trace-profile/reentrancy-mda.md)|  
-|[releaseHandleFailed](../../../docs/framework/debug-trace-profile/releasehandlefailed-mda.md)|[reportAvOnComRelease](../../../docs/framework/debug-trace-profile/reportavoncomrelease-mda.md)|  
-|[streamWriterBufferedDataLost](../../../docs/framework/debug-trace-profile/streamwriterbuffereddatalost-mda.md)|[virtualCERCall](../../../docs/framework/debug-trace-profile/virtualcercall-mda.md)|  
-  
- By default, the .NET Framework activates a subset of MDAs for all managed debuggers. You can view the default set in Visual Studio by clicking **Exceptions** on the **Debug** menu and expanding the **Managed Debugging Assistants** list.  
-  
-## Enabling and Disabling MDAs  
- You can enable and disable MDAs by using a registry key, an environment variable, and application configuration settings. You must enable either the registry key or the environment variable to use the application configuration settings.  
-  
- In Visual Studio 2005 and later versions, when the hosting process is enabled, you cannot disable MDAs that are in the default set or enable MDAs that are not in the default set. The hosting process is enabled by default, so it must be explicitly disabled.  
-  
- To disable the hosting process in Visual Studio, do the following:  
-  
-1.  In **Solution Explorer**, select a project.  
-  
-2.  On the **Project** menu, click **Properties**.  
-  
-     The **Project Designer** window appears.  
-  
-3.  Click the **Debug** tab.  
-  
-4.  In the **Enable Debuggers** section, clear the **Enable the Visual Studio hosting process** check box.  
-  
- However, disabling the hosting process can affect performance. You can avoid the need to disable MDAs by preventing Visual Studio from displaying the MDA dialog box whenever an MDA notification is received. To do that, click **Exceptions** on the **Debug** menu, expand the **Managed Debugging Assistants** list, and then select or clear the **Thrown** check box for the individual MDA.  
-  
-### Enabling and Disabling MDAs by Using a Registry Key  
- You can enable MDAs by adding the HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\MDA subkey (type REG_SZ, value 1) in the Windows registry. Copy the following example into a text file named MDAEnable.reg. Open the Windows Registry Editor (RegEdit.exe) and from the **File** menu choose **Import**. Select the MDAEnable.reg  file to enable MDAs on that computer. Setting the subkey to string value of 1 (not DWORD value of 1) enables the reading of MDA settings from the *ApplicationName.suffix*.mda.config file. (For example the MDA configuration file for Notepad would be named notepad.exe.mda.config)  
-  
-```  
-Windows Registry Editor Version 5.00  
-  
-[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework]  
-"MDA"="1"  
-```  
-  
- If the computer is running a 32-bit application on a 64-bit operating system, then the MDA key should be set like the following:  
-  
-```  
-      Windows Registry Editor Version 5.00   
-  
-[HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework]  
-"MDA"="1"  
-```  
-  
- See [Enabling and Disabling MDAs by Using Application-Specific Configuration Settings](#appConfig) for more information. The registry setting can be overridden by the COMPLUS_MDA environment variable. See [Enabling and Disabling MDAs by Using an Environment Variable](#envVariable) for more information.  
-  
- To disable MDAs, set the MDA subkey to 0 (zero) using the Windows Registry Editor.  
-  
- By default, some MDAs are enabled when you run an application that is attached to a debugger, even without adding the registry key. Examples of such assistants are [pInvokeStackImbalance](../../../docs/framework/debug-trace-profile/pinvokestackimbalance-mda.md) and [invalidApartmentStateChange](../../../docs/framework/debug-trace-profile/invalidapartmentstatechange-mda.md). You can disable these assistants by running the MDADisable.reg file as described earlier in this section.  
-  
-<a name="envVariable"></a>   
-### Enabling and Disabling MDAs by Using an Environment Variable  
- MDA activation can also controlled by the environment variable COMPLUS_MDA, which overrides the registry key. The COMPLUS_MDA string is a case-insensitive, semicolon-delimited list of MDA names or other special control strings. Starting under a managed or unmanaged debugger enables a set of MDAs by default. This is done by implicitly prepending the semicolon-delimited list of MDAs enabled by default under debuggers to the value of the environment variable or registry key. The special control strings are the following:  
-  
--   `0` - Deactivates all MDAs.  
-  
--   `1` - Reads MDA settings from *ApplicationName*.mda.config.  
-  
--   `managedDebugger` - Explicitly activates all MDAs that are implicitly activated when a managed executable is started under a debugger.  
-  
--   `unmanagedDebugger` - Explicitly activates all MDAs that are implicitly activated when an unmanaged executable is started under a debugger.  
-  
- If there are conflicting settings, the most recent settings override previous settings:  
-  
--   `COMPLUS_MDA=0` disables all MDAs, including those implicitly enabled under a debugger.  
-  
--   `COMPLUS_MDA=gcUnmanagedToManaged` enables `gcUnmanagedToManaged` in addition to any MDAs that are implicitly enabled under a debugger.  
-  
--   `COMPLUS_MDA=0;gcUnmanagedToManaged` enables `gcUnmanagedToManaged` but disables MDAs that would otherwise be implicitly enabled under a debugger.  
-  
-<a name="appConfig"></a>   
-### Enabling and Disabling MDAs by Using Application-Specific Configuration Settings  
- You can enable, disable, and configure some assistants individually in the MDA configuration file for the application. To enable the use of an application configuration file for configuring MDAs, either the MDA registry key or the COMPLUS_MDA environment variable must be set. The application configuration file is typically located in the same directory as the application's executable (.exe) file. The file name takes the form *ApplicationName*.mda.config; for example, notepad.exe.mda.config. Assistants that are enabled in the application configuration file may have attributes or elements specifically designed to control that assistant's behavior. The following example shows how to enable and configure the [marshaling](../../../docs/framework/debug-trace-profile/marshaling-mda.md).  
-  
-```xml  
-<mdaConfig>  
-  <assistants>  
-    <marshaling>  
-      <methodFilter>  
-        <match name="*"/>  
-      </methodFilter>  
-      <fieldFilter>  
-        <match name="*"/>  
-      </fieldFilter>  
-    </marshaling>  
-  </assistants>  
-</mdaConfig>  
-```  
-  
- The `Marshaling` MDA emits information about the managed type that is being marshaled to an unmanaged type for each managed-to-unmanaged transition in the application. The `Marshaling` MDA can also filter the names of the method and structure fields supplied in the `<methodFilter>` and `<fieldFilter>` child elements, respectively.  
-  
- The following example shows how to enable multiple MDAs by using their default settings.  
-  
-```xml  
-<mdaConfig>  
-  <assistants>  
-    <illegalPrepareConstrainedRegion />  
-    <invalidCERCall />  
-    <openGenericCERCall />  
-    <virtualCERCall />  
-  </assistants>  
-</mdaConfig>  
-```  
-  
+> When your code is executing in the Visual Studio integrated development environment (IDE), you can avoid the exception dialog box that appears for specific MDA events. To do that, on the **Debug** menu, click **Exceptions**. (If the **Debug** menu does not contain an **Exceptions** command, click **Customize** on the **Tools** menu to add it.) In the **Exceptions** dialog box, expand the **Managed Debugging Assistants** list, and then clear the **Thrown** check box for the individual MDA. For example, to avoid the exception dialog box for a [contextSwitchDeadlock](../../../docs/framework/debug-trace-profile/contextswitchdeadlock-mda.md) clear the **Thrown** check box next to its name in the **Managed Debugging Assistants** list. You can also use this dialog box to enable the display of MDA exception dialog boxes.
+
+The following table lists the MDAs that ship with the .NET Framework.
+
+|||
+|-|-|
+|[asynchronousThreadAbort](../../../docs/framework/debug-trace-profile/asynchronousthreadabort-mda.md)|[bindingFailure](../../../docs/framework/debug-trace-profile/bindingfailure-mda.md)|
+|[callbackOnCollectedDelegate](../../../docs/framework/debug-trace-profile/callbackoncollecteddelegate-mda.md)|[contextSwitchDeadlock](../../../docs/framework/debug-trace-profile/contextswitchdeadlock-mda.md)|
+|[dangerousThreadingAPI](../../../docs/framework/debug-trace-profile/dangerousthreadingapi-mda.md)|[dateTimeInvalidLocalFormat](../../../docs/framework/debug-trace-profile/datetimeinvalidlocalformat-mda.md)|
+|[dirtyCastAndCallOnInterface](../../../docs/framework/debug-trace-profile/dirtycastandcalloninterface-mda.md)|[disconnectedContext](../../../docs/framework/debug-trace-profile/disconnectedcontext-mda.md)|
+|[dllMainReturnsFalse](../../../docs/framework/debug-trace-profile/dllmainreturnsfalse-mda.md)|[exceptionSwallowedOnCallFromCom](../../../docs/framework/debug-trace-profile/exceptionswallowedoncallfromcom-mda.md)|
+|[failedQI](../../../docs/framework/debug-trace-profile/failedqi-mda.md)|[fatalExecutionEngineError](../../../docs/framework/debug-trace-profile/fatalexecutionengineerror-mda.md)|
+|[gcManagedToUnmanaged](../../../docs/framework/debug-trace-profile/gcmanagedtounmanaged-mda.md)|[gcUnmanagedToManaged](../../../docs/framework/debug-trace-profile/gcunmanagedtomanaged-mda.md)|
+|[illegalPrepareConstrainedRegion](../../../docs/framework/debug-trace-profile/illegalprepareconstrainedregion-mda.md)|[invalidApartmentStateChange](../../../docs/framework/debug-trace-profile/invalidapartmentstatechange-mda.md)|
+|[invalidCERCall](../../../docs/framework/debug-trace-profile/invalidcercall-mda.md)|[invalidFunctionPointerInDelegate](../../../docs/framework/debug-trace-profile/invalidfunctionpointerindelegate-mda.md)|
+|[invalidGCHandleCookie](../../../docs/framework/debug-trace-profile/invalidgchandlecookie-mda.md)|[invalidIUnknown](../../../docs/framework/debug-trace-profile/invalidiunknown-mda.md)|
+|[invalidMemberDeclaration](../../../docs/framework/debug-trace-profile/invalidmemberdeclaration-mda.md)|[invalidOverlappedToPinvoke](../../../docs/framework/debug-trace-profile/invalidoverlappedtopinvoke-mda.md)|
+|[invalidVariant](../../../docs/framework/debug-trace-profile/invalidvariant-mda.md)|[jitCompilationStart](../../../docs/framework/debug-trace-profile/jitcompilationstart-mda.md)|
+|[loaderLock](../../../docs/framework/debug-trace-profile/loaderlock-mda.md)|[loadFromContext](../../../docs/framework/debug-trace-profile/loadfromcontext-mda.md)|
+|[marshalCleanupError](../../../docs/framework/debug-trace-profile/marshalcleanuperror-mda.md)|[marshaling](../../../docs/framework/debug-trace-profile/marshaling-mda.md)|
+|[memberInfoCacheCreation](../../../docs/framework/debug-trace-profile/memberinfocachecreation-mda.md)|[moduloObjectHashcode](../../../docs/framework/debug-trace-profile/moduloobjecthashcode-mda.md)|
+|[nonComVisibleBaseClass](../../../docs/framework/debug-trace-profile/noncomvisiblebaseclass-mda.md)|[notMarshalable](../../../docs/framework/debug-trace-profile/notmarshalable-mda.md)|
+|[openGenericCERCall](../../../docs/framework/debug-trace-profile/opengenericcercall-mda.md)|[overlappedFreeError](../../../docs/framework/debug-trace-profile/overlappedfreeerror-mda.md)|
+|[pInvokeLog](../../../docs/framework/debug-trace-profile/pinvokelog-mda.md)|[pInvokeStackImbalance](../../../docs/framework/debug-trace-profile/pinvokestackimbalance-mda.md)|
+|[raceOnRCWCleanup](../../../docs/framework/debug-trace-profile/raceonrcwcleanup-mda.md)|[reentrancy](../../../docs/framework/debug-trace-profile/reentrancy-mda.md)|
+|[releaseHandleFailed](../../../docs/framework/debug-trace-profile/releasehandlefailed-mda.md)|[reportAvOnComRelease](../../../docs/framework/debug-trace-profile/reportavoncomrelease-mda.md)|
+|[streamWriterBufferedDataLost](../../../docs/framework/debug-trace-profile/streamwriterbuffereddatalost-mda.md)|[virtualCERCall](../../../docs/framework/debug-trace-profile/virtualcercall-mda.md)|
+
+By default, the .NET Framework activates a subset of MDAs for all managed debuggers. You can view the default set in Visual Studio by clicking **Exceptions** on the **Debug** menu and expanding the **Managed Debugging Assistants** list.
+
+## Enabling and Disabling MDAs
+
+You can enable and disable MDAs by using a registry key, an environment variable, and application configuration settings. You must enable either the registry key or the environment variable to use the application configuration settings.
+
+When the hosting process is enabled, you can't disable MDAs that are in the default set or enable MDAs that are not in the default set. The hosting process is enabled by default, so it must be explicitly disabled.
+
+To disable the hosting process in Visual Studio, do the following:
+
+1.  In **Solution Explorer**, select a project.
+
+2.  On the **Project** menu, click **Properties**.
+
+     The **Project Designer** window appears.
+
+3.  Click the **Debug** tab.
+
+4.  In the **Enable Debuggers** section, clear the **Enable the Visual Studio hosting process** check box.
+
+However, disabling the hosting process can affect performance. You can avoid the need to disable MDAs by preventing Visual Studio from displaying the MDA dialog box whenever an MDA notification is received. To do that, click **Exceptions** on the **Debug** menu, expand the **Managed Debugging Assistants** list, and then select or clear the **Thrown** check box for the individual MDA.
+
+### Enabling and Disabling MDAs by Using a Registry Key
+
+You can enable MDAs by adding the **HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework\MDA** subkey (type REG_SZ, value 1) in the Windows registry. Copy the following example into a text file named *MDAEnable.reg*. Open the Windows Registry Editor (RegEdit.exe), and from the **File** menu choose **Import**. Select the *MDAEnable.reg* file to enable MDAs on that computer. Setting the subkey to string value of **1** (not DWORD value of **1**) enables the reading of MDA settings from the *ApplicationName.suffix*.mda.config file. For example, the MDA configuration file for Notepad would be named notepad.exe.mda.config.
+
+```text
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework]
+"MDA"="1"
+```
+
+If the computer is running a 32-bit application on a 64-bit operating system, then the MDA key should be set like the following:
+
+```text
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework]
+"MDA"="1"
+```
+
+See [Enabling and Disabling MDAs by Using Application-Specific Configuration Settings](#appConfig) for more information. The registry setting can be overridden by the COMPLUS_MDA environment variable. See [Enabling and Disabling MDAs by Using an Environment Variable](#envVariable) for more information.
+
+To disable MDAs, set the MDA subkey to 0 (zero) using the Windows Registry Editor.
+
+By default, some MDAs are enabled when you run an application that is attached to a debugger, even without adding the registry key. Examples of such assistants are [pInvokeStackImbalance](../../../docs/framework/debug-trace-profile/pinvokestackimbalance-mda.md) and [invalidApartmentStateChange](../../../docs/framework/debug-trace-profile/invalidapartmentstatechange-mda.md). You can disable these assistants by running the MDADisable.reg file as described earlier in this section.
+
+### Enabling and Disabling MDAs by Using an Environment Variable <a name="envVariable"></a>
+
+MDA activation can also controlled by the environment variable COMPLUS_MDA, which overrides the registry key. The COMPLUS_MDA string is a case-insensitive, semicolon-delimited list of MDA names or other special control strings. Starting under a managed or unmanaged debugger enables a set of MDAs by default. This is done by implicitly prepending the semicolon-delimited list of MDAs enabled by default under debuggers to the value of the environment variable or registry key. The special control strings are the following:
+
+-   `0` - Deactivates all MDAs.
+
+-   `1` - Reads MDA settings from *ApplicationName*.mda.config.
+
+-   `managedDebugger` - Explicitly activates all MDAs that are implicitly activated when a managed executable is started under a debugger.
+
+-   `unmanagedDebugger` - Explicitly activates all MDAs that are implicitly activated when an unmanaged executable is started under a debugger.
+
+If there are conflicting settings, the most recent settings override previous settings:
+
+-   `COMPLUS_MDA=0` disables all MDAs, including those implicitly enabled under a debugger.
+
+-   `COMPLUS_MDA=gcUnmanagedToManaged` enables `gcUnmanagedToManaged` in addition to any MDAs that are implicitly enabled under a debugger.
+
+-   `COMPLUS_MDA=0;gcUnmanagedToManaged` enables `gcUnmanagedToManaged` but disables MDAs that would otherwise be implicitly enabled under a debugger.
+
+### Enabling and Disabling MDAs by Using Application-Specific Configuration Settings <a name="appConfig"></a>
+
+You can enable, disable, and configure some assistants individually in the MDA configuration file for the application. To enable the use of an application configuration file for configuring MDAs, either the MDA registry key or the COMPLUS_MDA environment variable must be set. The application configuration file is typically located in the same directory as the application's executable (.exe) file. The file name takes the form *ApplicationName*.mda.config; for example, notepad.exe.mda.config. Assistants that are enabled in the application configuration file may have attributes or elements specifically designed to control that assistant's behavior. The following example shows how to enable and configure the [marshaling](../../../docs/framework/debug-trace-profile/marshaling-mda.md).
+
+```xml
+<mdaConfig>
+  <assistants>
+    <marshaling>
+      <methodFilter>
+        <match name="*"/>
+      </methodFilter>
+      <fieldFilter>
+        <match name="*"/>
+      </fieldFilter>
+    </marshaling>
+  </assistants>
+</mdaConfig>
+```
+
+The `Marshaling` MDA emits information about the managed type that is being marshaled to an unmanaged type for each managed-to-unmanaged transition in the application. The `Marshaling` MDA can also filter the names of the method and structure fields supplied in the `<methodFilter>` and `<fieldFilter>` child elements, respectively.
+
+The following example shows how to enable multiple MDAs by using their default settings.
+
+```xml
+<mdaConfig>
+  <assistants>
+    <illegalPrepareConstrainedRegion />
+    <invalidCERCall />
+    <openGenericCERCall />
+    <virtualCERCall />
+  </assistants>
+</mdaConfig>
+```
+
 > [!IMPORTANT]
->  When you specify more than one assistant in a configuration file, you must list them in alphabetical order. For example, if you want to enable both the `virtualCERCall` and the `invalidCERCall` MDAs, you must add the `<invalidCERCall />` entry before the `<virtualCERCall />` entry. If the entries are not in alphabetical order, an unhandled invalid configuration file exception message is displayed.  
-  
-### MDA Output  
- MDA output is similar to the following example, which shows the output from the `pInvokeStackImbalance` MDA.  
-  
- `A call to PInvoke function 'MDATest!MDATest.Program::StdCall' has unbalanced the stack. This is likely because the managed PInvoke signature does not match the unmanaged target signature. Check that the calling convention and parameters of the PInvoke signature match the target unmanaged signature.`  
-  
-## See Also  
- [Debugging, Tracing, and Profiling](../../../docs/framework/debug-trace-profile/index.md)
+> When you specify more than one assistant in a configuration file, you must list them in alphabetical order. For example, if you want to enable both the `virtualCERCall` and the `invalidCERCall` MDAs, you must add the `<invalidCERCall />` entry before the `<virtualCERCall />` entry. If the entries are not in alphabetical order, an unhandled invalid configuration file exception message is displayed.
+
+### MDA Output
+
+MDA output is similar to the following example, which shows the output from the `pInvokeStackImbalance` MDA.
+
+`A call to PInvoke function 'MDATest!MDATest.Program::StdCall' has unbalanced the stack. This is likely because the managed PInvoke signature does not match the unmanaged target signature. Check that the calling convention and parameters of the PInvoke signature match the target unmanaged signature.`
+
+## See also
+
+[Debugging, Tracing, and Profiling](../../../docs/framework/debug-trace-profile/index.md)


### PR DESCRIPTION
- remove refs to Visual Studio 2005
- remove leading/trailing whitespace (if this creates too much noise, let me know - hopefully it diffs better in CodeFlow)

Contributes to  #6923 and #7172 