### PR TITLE
Fix typo

### DIFF
--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -168,7 +168,7 @@ public class DogHairLengthComparer : IEqualityComparer<Dog>
     public int GetHashCode(Dog d)
     {
         // default hashcode is enough here, as these are simple objects.
-        return b.GetHashCode();
+        return d.GetHashCode();
     }
 }
 


### PR DESCRIPTION
## Summary

Fixed the GetHashCode(Dog d) function at the union part. It now calls d object's function instead of b's.

Fixes #6977