### PR TITLE
Simplified PublicInstancePropertiesEqual in LINQ examples

### DIFF
--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -200,22 +200,19 @@ var results = DirectionsProcessor.GetDirections(start, end)
 ```csharp
 public static bool PublicInstancePropertiesEqual<T>(this T self, T to, params string[] ignore) where T : class
 {
-    if (self != null && to != null)
+    if (self == null || to == null)
     {
-        var type = typeof(T);
-        var ignoreList = new List<string>(ignore);
-
-        // Selects the properties which have unequal values into a sequence of those properties.
-        var unequalProperties = from pi in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                where !ignoreList.Contains(pi.Name)
-                                let selfValue = type.GetProperty(pi.Name).GetValue(self, null)
-                                let toValue = type.GetProperty(pi.Name).GetValue(to, null)
-                                where selfValue != toValue && (selfValue == null || !selfValue.Equals(toValue))
-                                select new { Prop = pi.Name, selfValue, toValue };
-        return !unequalProperties.Any();
+        return self == to;
     }
-
-    return self == to;
+    
+    // Selects the properties which have unequal values into a sequence of those properties.
+    var unequalProperties = from property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                            where !ignore.Contains(property.Name)
+                            let selfValue = property.GetValue(self, null)
+                            let toValue = property.GetValue(to, null)
+                            where !Equals(selfValue, toValue)
+                            select new { property, selfValue, toValue };
+    return !unequalProperties.Any();
 }
 ```
 

--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -211,7 +211,7 @@ public static bool PublicInstancePropertiesEqual<T>(this T self, T to, params st
                             let selfValue = property.GetValue(self, null)
                             let toValue = property.GetValue(to, null)
                             where !Equals(selfValue, toValue)
-                            select new { property, selfValue, toValue };
+                            select property;
     return !unequalProperties.Any();
 }
 ```


### PR DESCRIPTION
The changes I did:

* Inverted `if` to put all `null`-related code in the same place and to decrease indentation.
* Removed unnecessary locals.
* Renamed `pi` to more clear `property`.
* Removed unnecessary calls to `GetProperty()`.
* Simplified comparing equality by using the `static` overload of `object.Equals`.
* Avoided unnecessary allocation of anonymous object for the result.