### PR TITLE
Removed incorrect documentation comment

### DIFF
--- a/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
+++ b/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md
@@ -70,7 +70,6 @@ type Type1 =
     /// This is an instance method.
     member InstanceMethod : x:int -> char
 
-    /// This is an instance property.
     nested type NestedType = 
         /// This is StaticProperty1 on NestedType.
         static member StaticProperty1 : string


### PR DESCRIPTION
`NestedType` is not an instance property and it seems the type provider code below does not add any XML comment to this type:

https://github.com/dotnet/docs/blob/9523cc5cab66431420f96f6f86de6b32846a6a19/docs/fsharp/tutorials/type-providers/creating-a-type-provider.md#L338-L359