### PR TITLE
Update casting-and-type-conversions.md

### DIFF
--- a/docs/csharp/programming-guide/types/casting-and-type-conversions.md
+++ b/docs/csharp/programming-guide/types/casting-and-type-conversions.md
@@ -11,11 +11,12 @@ helpviewer_keywords:
 ms.assetid: 568df58a-d292-4b55-93ba-601578722878
 ---
 # Casting and Type Conversions (C# Programming Guide)
-Because C# is statically-typed at compile time, after a variable is declared, it cannot be declared again or used to store values of another type unless that type is convertible to the variable's type. For example, there is no conversion from an integer to any arbitrary string. Therefore, after you declare `i` as an integer, you cannot assign the string "Hello" to it, as is shown in the following code.  
+
+Because C# is statically-typed at compile time, after a variable is declared, it cannot be declared again or assigned a value of another type unless that type is implicitly convertible to the variable's type. For example, the `string` cannot be implicitly converted to `int`. Therefore, after you declare `i` as an `int`, you cannot assign the string "Hello" to it, as the following code shows:
   
 ```csharp  
 int i;  
-i = "Hello"; // Error: "Cannot implicitly convert type 'string' to 'int'"  
+i = "Hello"; // error CS0029: Cannot implicitly convert type 'string' to 'int'
 ```  
   
  However, you might sometimes need to copy a value into a variable or method parameter of another type. For example, you might have an integer variable that you need to pass to a method whose parameter is typed as `double`. Or you might need to assign a class variable to a variable of an interface type. These kinds of operations are called *type conversions*. In C#, you can perform the following kinds of conversions:  


### PR DESCRIPTION
Made PR based on the [comment](https://github.com/dotnet/docs/pull/6963#issuecomment-412987775) in #6963 

I use "implicitly convertible", because I assume that if cast is used then a variable is assigned a value of the expression of its type (and not a value of another type).
