### PR TITLE
Renamed variable to avoid confusion

### DIFF
--- a/docs/csharp/programming-guide/nullable-types/index.md
+++ b/docs/csharp/programming-guide/nullable-types/index.md
@@ -32,7 +32,7 @@ Nullable types have the following characteristics:
   
 - You can also use the `==` and `!=` operators with a nullable type, as shown in the following example: `if (x != null) y = x.Value;`. If `a` and `b` are both null, `a == b` evaluates to `true`.  
 
-- Beginning with C# 7.0, you can use pattern matching to both examine and get a value of a nullable type: `if (x is int xValue) y = xValue;`.
+- Beginning with C# 7.0, you can use [pattern matching](../../pattern-matching.md#the-is-type-pattern-expression) to both examine and get a value of a nullable type: `if (x is int valueOfX) y = valueOfX;`.
   
 - The default value of `T?` is an instance whose <xref:System.Nullable%601.HasValue%2A> property returns `false`.  
 


### PR DESCRIPTION
Also referenced the corresponding section of the "Pattern matching" article.

Fixes #7030
