### PR TITLE
C32907: Line 34 is not rendering well in loc pages.

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataemit-applyeditandcontinue-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataemit-applyeditandcontinue-method.md
@@ -31,7 +31,7 @@ HRESULT ApplyEditAndContinue (
   
 #### Parameters  
  `pImport`  
- [in] Pointer to an [IUnknown](/cpp/atl/iunknown) object that represents the delta metadata from the portable executable (PE) file.  
+ \[in\] Pointer to an [IUnknown](/cpp/atl/iunknown) object that represents the delta metadata from the portable executable (PE) file.
   
  The delta metadata is the block of metadata that includes the changes that were made to the copy of the module's actual metadata.  
   


### PR DESCRIPTION
Hello, @mairaw,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
"It seems link at line 34 is not rendering well on localized pages [Italian example](https://docs.microsoft.com/it-IT/dotnet/framework/unmanaged-api/metadata/imetadataemit-applyeditandcontinue-method#parameters) I suppose it is due the unescaped \[\]". 

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.