### PR TITLE
Use datetimeprovider interface in conditional

### DIFF
--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -326,7 +326,7 @@ public interface IDateTimeProvider
 
 public bool GetDiscountedPrice(int price, IDateTimeProvider dateTimeProvider)
 {
-    if(DateTime.Now == DayOfWeek.Tuesday) 
+    if(dateTimeProvider.DayOfWeek() == DayOfWeek.Tuesday) 
     {
         return price / 2;
     }


### PR DESCRIPTION
## Summary

Use the method on the `dateTimeProvider` interface rather than `DateTime.Now`

Fixes #7044
