### PR TITLE
 C32904: Line 34 is not rendering well in loc pages. #7050

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataassemblyimport-findassembliesbyname-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataassemblyimport-findassembliesbyname-method.md
@@ -46,7 +46,7 @@ HRESULT FindAssembliesByName (
   
  `ppIUnk`  
  [in] An array of type [IUnknown](/cpp/atl/iunknown) in which to put the `IMetadataAssemblyImport` interface pointers.  
-  
+  <!-- Link at previous line is wrong displayed in localizate versions -->
  `cMax`  
  [out] The maximum number of interface pointers that can be placed in `ppIUnk`.  
   


### PR DESCRIPTION
Hello, @mairaw, and @rpetrusha 
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
This issue is related to the previous PR: https://github.com/dotnet/docs/pull/7050
It seems the IUnknow link is interpreted as a [xref link](https://review.docs.microsoft.com/en-us/help/contribute/markdown-reference?branch=master#xref-cross-reference-links). It was converted to < IUnknown> and therefore it broken the translated content.
Do you know if there is a known workaround for it?
Thanks in advance.