### PR TITLE
Issue #6988 Call Info Attributes URL Link

### DIFF
--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -100,7 +100,11 @@ Dynamic binding gives you the potential for errors but also great power within t
 C# version 5.0 was a focused version of the language. Nearly all of the effort for that version went into another groundbreaking language concept: the `async` and `await` model for asynchronous programming .  Here is the major features list:
 
 - [Asynchronous members](../async.md)
-- [Caller info attributes](https://www.codeproject.com/Tips/606379/Caller-Info-Attributes-in-Csharp)
+- [Caller info attributes](../programming-guide/concepts/caller-information.md)
+
+### See Also
+
+* [Code Project: Caller Info Attributes in C# 5.0](https://www.codeproject.com/Tips/606379/Caller-Info-Attributes-in-Csharp)
 
 The caller info attribute lets you easily retrieve information about the context in which you're running without resorting to a ton of boilerplate reflection code. It has many uses in diagnostics and logging tasks.
 


### PR DESCRIPTION
## Summary

@BillWagner 

Per my prior issue submittal on docs.microsoft.com, issue #6988.

I replaced the main URL link to the Call Information page on docs.microsoft.com. We should keep references to internal docs.microsoft.com pages as much as possible.

I added a See Also section and kept the old Code Project link. It is useful, but an external link, thus I placed it under See Also.

Fixes #6988  (if available)
