### PR TITLE
Update dotnet-svcutil-guide.md

### DIFF
--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -55,7 +55,7 @@ dotnet new console
 
 ```xml
 <ItemGroup>
-  <DotNetCliToolReference Include="dotnet-svcutil" Version="1.0.0" />
+  <DotNetCliToolReference Include="dotnet-svcutil" Version="1.0.2" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
Update instructions to point to latest version of dotnet-svcutil (1.0.2)

## Summary

Instructions are referencing version `1.0.0` of svcutil rather than `1.0.2` which is the latest version