### PR TITLE
Link to related Target Frameworks doc

### DIFF
--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -96,7 +96,9 @@ In addition to the official roadmap, there are other frameworks to be ported to 
 Some Microsoft or third-party platforms don’t support .NET Core. For example, some Azure services such as Service Fabric Stateful Reliable Services and Service Fabric Reliable Actors require .NET Framework. Some other services provide an SDK not yet available for consumption on .NET Core. This is a transitional circumstance, as all of Azure services use .NET Core. In the meantime, you can always use the equivalent REST API instead of the client SDK.
 
 ## See also
- [Choose between ASP.NET and ASP.NET Core](/aspnet/core/choose-aspnet-framework)  
+
+ [Choose between ASP.NET and ASP.NET Core](/aspnet/core/choose-aspnet-framework)
+ [Target frameworks](frameworks.md)
  [.NET Core Guide](../core/index.md)  
  [Porting from .NET Framework to .NET Core](../core/porting/index.md)  
  [.NET Framework on Docker Guide](../framework/docker/index.md)  


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/7013

Adds a link to the related Target Frameworks doc, per the suggestion of @spottedmahn.