### PR TITLE
Reviewed tables of built-in numeric types

### DIFF
--- a/docs/csharp/language-reference/keywords/decimal.md
+++ b/docs/csharp/language-reference/keywords/decimal.md
@@ -14,7 +14,7 @@ The `decimal` keyword indicates a 128-bit data type. Compared to other floating-
 
 |Type|Approximate Range|Precision|.NET type|
 |----------|-----------------------|---------------|-------------------------|
-|`decimal`|(-7.9 x 10<sup>28</sup> to 7.9 x 10<sup>28</sup>) / (10<sup>0</sup> to 10<sup>28</sup>)|28-29 significant digits|<xref:System.Decimal?displayProperty=nameWithType>|
+|`decimal`|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 significant digits|<xref:System.Decimal?displayProperty=nameWithType>|
 
 The default value of a `decimal` is 0m.
 

--- a/docs/csharp/language-reference/keywords/float.md
+++ b/docs/csharp/language-reference/keywords/float.md
@@ -15,7 +15,7 @@ The `float` keyword signifies a simple type that stores 32-bit floating-point va
 
 |Type|Approximate range|Precision|.NET type|  
 |----------|-----------------------|---------------|-------------------------|  
-|`float`|-3.4 × 10<sup>38</sup> to +3.4 × 10<sup>38</sup>|7 digits|<xref:System.Single?displayProperty=nameWithType>|  
+|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|7 digits|<xref:System.Single?displayProperty=nameWithType>|  
 
 ## Literals
 

--- a/docs/csharp/language-reference/keywords/floating-point-types-table.md
+++ b/docs/csharp/language-reference/keywords/floating-point-types-table.md
@@ -14,9 +14,9 @@ The following table shows the precision and approximate ranges for the floating-
   
 |Type|Approximate range|Precision|  
 |----------|-----------------------|---------------|  
-|[float](float.md)|±1.5e−45 to ±3.4e38|7 digits|  
-|[double](double.md)|±5.0e−324 to ±1.7e308|15-16 digits|  
-|[decimal](decimal.md)|(-7.9 x 10<sup>28</sup> to 7.9 x 10<sup>28</sup>) / (10<sup>0</sup> to 10<sup>28</sup>)|28-29 digits|  
+|[float](float.md)|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|7 digits|  
+|[double](double.md)|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|  
+|[decimal](decimal.md)|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
 ## See also
 

--- a/docs/csharp/language-reference/keywords/floating-point-types-table.md
+++ b/docs/csharp/language-reference/keywords/floating-point-types-table.md
@@ -1,26 +1,30 @@
 ---
-title: "Floating-Point Types Table (C# Reference)"
-ms.date: 07/20/2015
+title: "Floating-point types table (C# Reference)"
+description: "Overview of the built-in C# floating-point types"
+ms.date: 08/20/2018
 helpviewer_keywords: 
   - "floating-point numbers [C#]"
   - "ranges of floating-point types [C#]"
   - "types [C#], floating-point types"
 ms.assetid: da886cc5-e01e-4f62-b3ec-6428c8f7a102
 ---
-# Floating-Point Types Table (C# Reference)
+# Floating-point types table (C# Reference)
+
 The following table shows the precision and approximate ranges for the floating-point types.  
   
 |Type|Approximate range|Precision|  
 |----------|-----------------------|---------------|  
 |[float](float.md)|±1.5e−45 to ±3.4e38|7 digits|  
 |[double](double.md)|±5.0e−324 to ±1.7e308|15-16 digits|  
+|[decimal](decimal.md)|(-7.9 x 10<sup>28</sup> to 7.9 x 10<sup>28</sup>) / (10<sup>0</sup> to 10<sup>28</sup>)|28-29 digits|  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [Default Values Table](default-values-table.md)  
- [Built-In Types Table](built-in-types-table.md)  
- [Integral Types Table](integral-types-table.md)  
- [Formatting Numeric Results Table](formatting-numeric-results-table.md)  
- [Reference Tables for Types](reference-tables-for-types.md)  
- [decimal](decimal.md)
+## See also
+
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [Reference tables for types](reference-tables-for-types.md)
+- [Integral types table](integral-types-table.md)
+- [Default values table](default-values-table.md)
+- [Formatting numeric results table](formatting-numeric-results-table.md)
+- [Built-in types table](built-in-types-table.md)

--- a/docs/csharp/language-reference/keywords/integral-types-table.md
+++ b/docs/csharp/language-reference/keywords/integral-types-table.md
@@ -1,6 +1,7 @@
 ---
-title: "Integral Types Table (C# Reference)"
-ms.date: 07/20/2015
+title: "Integral types table (C# Reference)"
+description: "Overview of the built-in C# integral types"
+ms.date: 08/20/2018
 helpviewer_keywords: 
   - "integral types, C#"
   - "Visual C#, integral types"
@@ -8,29 +9,32 @@ helpviewer_keywords:
   - "ranges of integral types [C#]"
 ms.assetid: 62e86126-46ff-40b0-9028-e61d7558268c
 ---
-# Integral Types Table (C# Reference)
+# Integral types table (C# Reference)
+
 The following table shows the sizes and ranges of the integral types, which constitute a subset of simple types.  
   
 |Type|Range|Size|  
 |----------|-----------|----------|  
-|[sbyte](../../../csharp/language-reference/keywords/sbyte.md)|-128 to 127|Signed 8-bit integer|  
-|[byte](../../../csharp/language-reference/keywords/byte.md)|0 to 255|Unsigned 8-bit integer|  
-|[char](../../../csharp/language-reference/keywords/char.md)|U+0000 to U+ffff|Unicode 16-bit character|  
-|[short](../../../csharp/language-reference/keywords/short.md)|-32,768 to 32,767|Signed 16-bit integer|  
-|[ushort](../../../csharp/language-reference/keywords/ushort.md)|0 to 65,535|Unsigned 16-bit integer|  
-|[int](../../../csharp/language-reference/keywords/int.md)|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|  
-|[uint](../../../csharp/language-reference/keywords/uint.md)|0 to 4,294,967,295|Unsigned 32-bit integer|  
-|[long](../../../csharp/language-reference/keywords/long.md)|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|  
-|[ulong](../../../csharp/language-reference/keywords/ulong.md)|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|  
+|[sbyte](sbyte.md)|-128 to 127|Signed 8-bit integer|  
+|[byte](byte.md)|0 to 255|Unsigned 8-bit integer|  
+|[char](char.md)|U+0000 to U+ffff|Unicode 16-bit character|  
+|[short](short.md)|-32,768 to 32,767|Signed 16-bit integer|  
+|[ushort](ushort.md)|0 to 65,535|Unsigned 16-bit integer|  
+|[int](int.md)|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|  
+|[uint](uint.md)|0 to 4,294,967,295|Unsigned 32-bit integer|  
+|[long](long.md)|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|  
+|[ulong](ulong.md)|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|  
   
- If the value represented by an integer literal exceeds the range of `ulong`, a compilation error will occur.  
+ If the value represented by an integer literal exceeds <xref:System.UInt64.MaxValue?displayProperty=nameWithType>, a compile error [CS1021](../../misc/cs1021.md) occurs.
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Keywords](../../../csharp/language-reference/keywords/index.md)  
- [Built-In Types Table](../../../csharp/language-reference/keywords/built-in-types-table.md)  
- [Floating-Point Types Table](../../../csharp/language-reference/keywords/floating-point-types-table.md)  
- [Default Values Table](../../../csharp/language-reference/keywords/default-values-table.md)  
- [Formatting Numeric Results Table](../../../csharp/language-reference/keywords/formatting-numeric-results-table.md)  
- [Reference Tables for Types](../../../csharp/language-reference/keywords/reference-tables-for-types.md)
+## See also
+
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [Reference tables for types](reference-tables-for-types.md)
+- [Floating-point types table](floating-point-types-table.md)
+- [Default values table](default-values-table.md)
+- [Formatting numeric results table](formatting-numeric-results-table.md)
+- [Built-in types table](built-in-types-table.md)
+- <xref:System.Numerics.BigInteger?displayProperty=nameWithType>

--- a/docs/csharp/language-reference/keywords/integral-types-table.md
+++ b/docs/csharp/language-reference/keywords/integral-types-table.md
@@ -24,8 +24,12 @@ The following table shows the sizes and ranges of the integral types, which cons
 |[uint](uint.md)|0 to 4,294,967,295|Unsigned 32-bit integer|  
 |[long](long.md)|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|  
 |[ulong](ulong.md)|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|  
+
+## Remarks
   
- If the value represented by an integer literal exceeds <xref:System.UInt64.MaxValue?displayProperty=nameWithType>, a compile error [CS1021](../../misc/cs1021.md) occurs.
+If the value represented by an integer literal exceeds <xref:System.UInt64.MaxValue?displayProperty=nameWithType>, a compiler error [CS1021](../../misc/cs1021.md) occurs.
+
+Use the <xref:System.Numerics.BigInteger?displayProperty=nameWithType> class to represent an arbitrarily large signed integer.
   
 ## See also
 
@@ -37,4 +41,3 @@ The following table shows the sizes and ranges of the integral types, which cons
 - [Default values table](default-values-table.md)
 - [Formatting numeric results table](formatting-numeric-results-table.md)
 - [Built-in types table](built-in-types-table.md)
-- <xref:System.Numerics.BigInteger?displayProperty=nameWithType>

--- a/docs/csharp/misc/cs1021.md
+++ b/docs/csharp/misc/cs1021.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS1021"
-ms.date: 07/20/2015
+ms.date: 08/20/2018
 f1_keywords: 
   - "CS1021"
 helpviewer_keywords: 
@@ -8,23 +8,36 @@ helpviewer_keywords:
 ms.assetid: 0346ba58-d7cd-40bd-bcad-b90117fdc9b5
 ---
 # Compiler Error CS1021
+
 Integral constant is too large  
   
- A value assigned to an [integral type](../../csharp/language-reference/keywords/integral-types-table.md) is larger than the largest possible unsigned integer value.  
+A value represented by an integer literal is greater than <xref:System.UInt64.MaxValue?displayProperty=nameWithType>.  
   
- The following sample generates CS1021:  
-  
-```csharp  
+The following sample generates CS1021:  
+
+```csharp
 // CS1021.cs  
-enum F : int  
-{  
-   a=(int)2590000000000000000000   // CS1021  
-}  
-  
-public class clx  
-{  
-   public static void Main()  
-   {  
-   }  
+class Program
+{
+    static void Main(string[] args)
+    {
+        int a = 18_446_744_073_709_552_000;
+    }
 }  
 ```
+
+Note that the following code also generates CS1021:
+
+```csharp
+using System.Numerics;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var a = new BigInteger(18_446_744_073_709_552_000);
+    }
+}
+```
+
+For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the <xref:System.Numerics.BigInteger?displayProperty=nameWithType> reference page.

--- a/docs/csharp/misc/cs1021.md
+++ b/docs/csharp/misc/cs1021.md
@@ -26,7 +26,7 @@ class Program
 }  
 ```
 
-Note that the following code also generates CS1021:
+The following code also generates CS1021:
 
 ```csharp
 using System.Numerics;
@@ -40,4 +40,4 @@ class Program
 }
 ```
 
-For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the <xref:System.Numerics.BigInteger?displayProperty=nameWithType> reference page.
+For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the <xref:System.Numerics.BigInteger#instantiating-a-biginteger-object?displayProperty=nameWithType> reference page.


### PR DESCRIPTION
Along with the formatting updates, this PR:
- adds the reference to `BigInteger` API page to the [Integral Types Table](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/integral-types-table) article
- corrects (error occurs not in the assignment) and updates the [CS1021](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1021) article
- adds the `decimal` row to the [Floating-point types table](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/floating-point-types-table)
