### PR TITLE
Fixed .Net Standard compatibility shim link

### DIFF
--- a/docs/standard/whats-new/whats-new-in-dotnet-standard.md
+++ b/docs/standard/whats-new/whats-new-in-dotnet-standard.md
@@ -49,7 +49,7 @@ Some of the additions to the <xref:System> namespace in .NET Standard 2.0 includ
 
 ### Support for .NET Framework libraries
 
-The overwhelming majority of libraries target the .NET Framework rather than .NET Standard. However, most of the calls in those libraries are to APIs that are included in the .NET Standard 2.0. Starting with the .NET Standard 2.0, you can access .NET Framework libraries from a .NET Standard library by using a [compatibility shim](https://github.com/dotnet/standard/blob/master/docs/netstandard-20/README.md#assembly-unification). This compatibility layer is transparent to developers; you don't have to do anything to take advantage of .NET Framework libraries.
+The overwhelming majority of libraries target the .NET Framework rather than .NET Standard. However, most of the calls in those libraries are to APIs that are included in the .NET Standard 2.0. Starting with the .NET Standard 2.0, you can access .NET Framework libraries from a .NET Standard library by using a [compatibility shim](https://github.com/dotnet/standard/blob/master/docs/planning/netstandard-20/README.md#assembly-unification). This compatibility layer is transparent to developers; you don't have to do anything to take advantage of .NET Framework libraries.
 
 The single requirement is that the APIs called by the .NET Framework class library must be included in the .NET Standard 2.0.
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/7147.

The document was moved by https://github.com/dotnet/standard/pull/765/.