### PR TITLE
Fixed link to the section

### DIFF
--- a/docs/csharp/misc/cs1021.md
+++ b/docs/csharp/misc/cs1021.md
@@ -39,5 +39,5 @@ class Program
     }
 }
 ```
-
-For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the [System.Numerics.BigInteger](https://docs.microsoft.com/dotnet/api/System.Numerics.BigInteger#instantiating-a-biginteger-object) reference page.
+ 
+For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the [Instantiating a BigInteger Object](https://docs.microsoft.com/dotnet/api/System.Numerics.BigInteger#instantiating-a-biginteger-object) section of the  <xref:System.Numerics.BigInteger> reference page.

--- a/docs/csharp/misc/cs1021.md
+++ b/docs/csharp/misc/cs1021.md
@@ -40,4 +40,4 @@ class Program
 }
 ```
 
-For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the <xref:System.Numerics.BigInteger#instantiating-a-biginteger-object?displayProperty=nameWithType> reference page.
+For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the <xref:System.Numerics.BigInteger#instantiating-a-biginteger-object> reference page.

--- a/docs/csharp/misc/cs1021.md
+++ b/docs/csharp/misc/cs1021.md
@@ -40,4 +40,4 @@ class Program
 }
 ```
 
-For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the <xref:System.Numerics.BigInteger#instantiating-a-biginteger-object> reference page.
+For information about how to instantiate a <xref:System.Numerics.BigInteger?displayProperty=nameWithType> instance whose value exceeds the range of the built-in numeric types, see the [System.Numerics.BigInteger](https://docs.microsoft.com/dotnet/api/System.Numerics.BigInteger#instantiating-a-biginteger-object) reference page.


### PR DESCRIPTION
In the [current version](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1021) generated link doesn't bring to the section needed.
