### PR TITLE
Correction of example output text

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-implement-user-defined-conversions-between-structs_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-implement-user-defined-conversions-between-structs_1.cs
@@ -79,5 +79,5 @@
         }
         /* Output:
             10
-            Conversion not yet implemented
+            Conversion to string is not implemented
         */


### PR DESCRIPTION
## Summary

The example string output text for the implicit cast did not match the return text in the code
