### PR TITLE
Removed not necessary line

### DIFF
--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -24,8 +24,6 @@ The value types consist of two main categories:
   
     -   [Floating-point types](../../../csharp/language-reference/keywords/floating-point-types-table.md)  
   
-    -   [decimal](../../../csharp/language-reference/keywords/decimal.md)  
-  
 -   [bool](../../../csharp/language-reference/keywords/bool.md)  
   
 -   User defined structs.  


### PR DESCRIPTION
As PR #7131 included `decimal` into the floating-point types table, it's not necessary anymore to mention `decimal` separately in the list of numerical types.
