### PR TITLE
Updated Default values table

### DIFF
--- a/docs/csharp/language-reference/keywords/default-values-table.md
+++ b/docs/csharp/language-reference/keywords/default-values-table.md
@@ -36,7 +36,7 @@ The following table shows the default values of [value types](value-types.md).
 
 ## Remarks
 
-C# doesn't allow uninitialized variables. You can initialize a variable with the default value of its type. You also can use the default value of a type to specify the default value of a method's [optional argument](../../programming-guide/classes-and-structs/named-and-optional-arguments.md#optional-arguments).
+You cannot use uninitialized variables in C#. You can initialize a variable with the default value of its type. You also can use the default value of a type to specify the default value of a method's [optional argument](../../programming-guide/classes-and-structs/named-and-optional-arguments.md#optional-arguments).
 
 Use [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type as the following example shows:
 

--- a/docs/csharp/language-reference/keywords/default-values-table.md
+++ b/docs/csharp/language-reference/keywords/default-values-table.md
@@ -38,7 +38,7 @@ The following table shows the default values of [value types](value-types.md).
 
 You cannot use uninitialized variables in C#. You can initialize a variable with the default value of its type. You also can use the default value of a type to specify the default value of a method's [optional argument](../../programming-guide/classes-and-structs/named-and-optional-arguments.md#optional-arguments).
 
-Use [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type as the following example shows:
+Use the [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type, as the following example shows:
 
 ```csharp
 int a = default(int);

--- a/docs/csharp/language-reference/keywords/default-values-table.md
+++ b/docs/csharp/language-reference/keywords/default-values-table.md
@@ -1,7 +1,7 @@
 ---
 title: "Default values table (C# Reference)"
 description: Learn what are the default values of C# value types.
-ms.date: 08/22/2018
+ms.date: 08/23/2018
 helpviewer_keywords: 
   - "constructors [C#], return values"
   - "keywords [C#], new"
@@ -36,6 +36,8 @@ The following table shows the default values of [value types](value-types.md).
 
 ## Remarks
 
+C# doesn't allow uninitialized variables. You can initialize a variable with the default value of its type. You also can use the default value of a type to specify the default value of a method's [optional argument](../../programming-guide/classes-and-structs/named-and-optional-arguments.md#optional-arguments).
+
 Use [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type as the following example shows:
 
 ```csharp
@@ -48,7 +50,7 @@ Beginning with C# 7.1, you can use the [`default` literal](../../programming-gui
 int a = default;
 ```
 
-You also can use the default constructor to produce the default value of a value type:
+You also can use the default constructor or the implicit default constructor to produce the default value of a value type, as the following example shows. For more information about constructors, see the [Constructors](../../programming-guide/classes-and-structs/constructors.md) article.
 
 ```csharp
 int a = new int();

--- a/docs/csharp/language-reference/keywords/default-values-table.md
+++ b/docs/csharp/language-reference/keywords/default-values-table.md
@@ -1,7 +1,7 @@
 ---
 title: "Default values table (C# Reference)"
-description: Learn what are the default values of value types returned by the default constructors.
-ms.date: 07/20/2015
+description: Learn what are the default values of C# value types.
+ms.date: 08/22/2018
 helpviewer_keywords: 
   - "constructors [C#], return values"
   - "keywords [C#], new"
@@ -14,19 +14,7 @@ helpviewer_keywords:
 ---
 # Default values table (C# Reference)
 
-The following table shows the default values of value types returned by the default constructors. Default constructors are invoked by using the `new` operator, as follows:
-
-```csharp
-int myInt = new int();
-```
-
-The preceding statement has the same effect as the following statement:
-
-```csharp
-int myInt = 0;
-```
-
-Remember that using uninitialized variables in C# is not allowed.
+The following table shows the default values of [value types](value-types.md).
 
 |Value type|Default value|
 |----------------|-------------------|
@@ -35,7 +23,7 @@ Remember that using uninitialized variables in C# is not allowed.
 |[char](char.md)|'\0'|
 |[decimal](decimal.md)|0M|
 |[double](double.md)|0.0D|
-|[enum](enum.md)|The value produced by the expression (E)0, where E is the enum identifier.|
+|[enum](enum.md)|The value produced by the expression `(E)0`, where `E` is the enum identifier.|
 |[float](float.md)|0.0F|
 |[int](int.md)|0|
 |[long](long.md)|0L|
@@ -46,10 +34,34 @@ Remember that using uninitialized variables in C# is not allowed.
 |[ulong](ulong.md)|0|
 |[ushort](ushort.md)|0|
 
+## Remarks
+
+Use [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type as the following example shows:
+
+```csharp
+int a = default(int);
+```
+
+Beginning with C# 7.1, you can use the [`default` literal](../../programming-guide/statements-expressions-operators/default-value-expressions.md#default-literal-and-type-inference) to initialize a variable with the default value of its type:
+
+```csharp
+int a = default;
+```
+
+You also can use the default constructor to produce the default value of a value type:
+
+```csharp
+int a = new int();
+```
+
+The default value of any [reference type](reference-types.md) is `null`. The default value of a [nullable type](../../programming-guide/nullable-types/index.md) is an instance for which the <xref:System.Nullable%601.HasValue%2A> property is `false` and the <xref:System.Nullable%601.Value%2A> property is undefined.
+
 ## See also
- [C# Reference](../index.md)  
- [C# Programming Guide](../../programming-guide/index.md)  
- [Value Types Table](value-types-table.md)  
- [Value Types](value-types.md)  
- [Built-In Types Table](built-in-types-table.md)  
- [Reference Tables for Types](reference-tables-for-types.md)
+
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [Reference tables for types](reference-tables-for-types.md)
+- [Value types](value-types.md)
+- [Value types table](value-types-table.md)
+- [Built-in types table](built-in-types-table.md)


### PR DESCRIPTION
This PR updates the [Default values table](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/default-values-table) article in the following way:
- Move the table to the top of the article, all other content - to the **Remarks** section. To be consistent with other table articles.
- Focus the **Remarks** section on *how* to produce the default value: which is either the default value expression or the default constructor of a value type.
- Mention default values of reference and nullable types for completeness. 

I didn't touch the `helpviewer_keywords` section in metadata. Please let me know if it should be updated as well.
