### PR TITLE
Standardize See Also section using bulleted lists

### DIFF
--- a/docs/csharp/getting-started/introduction-to-the-csharp-language-and-the-net-framework.md
+++ b/docs/csharp/getting-started/introduction-to-the-csharp-language-and-the-net-framework.md
@@ -8,27 +8,29 @@ helpviewer_keywords:
 ms.assetid: 0a2dff4e-cd84-42ff-8141-e89889b24081
 ---
 # Introduction to the C# Language and the .NET Framework
+
 C# is an elegant and type-safe object-oriented language that enables developers to build a variety of secure and robust applications that run on the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)]. You can use C# to create Windows client applications, XML Web services, distributed components, client-server applications, database applications, and much, much more. Visual C# provides an advanced code editor, convenient user interface designers, integrated debugger, and many other tools to make it easier to develop applications based on the C# language and the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)].  
   
 > [!NOTE]
 > The Visual C# documentation assumes that you have an understanding of basic programming concepts. If you are a complete beginner, you might want to explore Visual C# Express, which is available on the Web. You can also take advantage of books and Web resources about C# to learn practical programming skills.  
   
-## C# Language  
+## C# Language
+
  C# syntax is highly expressive, yet it is also simple and easy to learn. The curly-brace syntax of C# will be instantly recognizable to anyone familiar with C, C++ or Java. Developers who know any of these languages are typically able to begin to work productively in C# within a very short time. C# syntax simplifies many of the complexities of C++ and provides powerful features such as nullable value types, enumerations, delegates, lambda expressions and direct memory access, which are not found in Java. C# supports generic methods and types, which provide increased type safety and performance, and iterators, which enable implementers of collection classes to define custom iteration behaviors that are simple to use by client code. [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)] expressions make the strongly-typed query a first-class language construct.  
   
  As an object-oriented language, C# supports the concepts of encapsulation, inheritance, and polymorphism. All variables and methods, including the `Main` method, the application's entry point, are encapsulated within class definitions. A class may inherit directly from one parent class, but it may implement any number of interfaces. Methods that override virtual methods in a parent class require the `override` keyword as a way to avoid accidental redefinition. In C#, a struct is like a lightweight class; it is a stack-allocated type that can implement interfaces but does not support inheritance.  
   
  In addition to these basic object-oriented principles, C# makes it easy to develop software components through several innovative language constructs, including the following:  
   
--   Encapsulated method signatures called *delegates*, which enable type-safe event notifications.  
+- Encapsulated method signatures called *delegates*, which enable type-safe event notifications.  
   
--   Properties, which serve as accessors for private member variables.  
+- Properties, which serve as accessors for private member variables.  
   
--   Attributes, which provide declarative metadata about types at run time.  
+- Attributes, which provide declarative metadata about types at run time.  
   
--   Inline XML documentation comments.  
+- Inline XML documentation comments.  
   
--   [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)] which provides built-in query capabilities across a variety of data sources.  
+- [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)] which provides built-in query capabilities across a variety of data sources.  
   
  If you have to interact with other Windows software such as COM objects or native Win32 DLLs, you can do this in C# through a process called "Interop." Interop enables C# programs to do almost anything that a native C++ application can do. C# even supports pointers and the concept of "unsafe" code for those cases in which direct memory access is absolutely critical.  
   
@@ -36,13 +38,14 @@ C# is an elegant and type-safe object-oriented language that enables developers 
   
  The following are additional C# resources:  
   
--   For a good general introduction to the language, see Chapter 1 of the [C# Language Specification](../../csharp/language-reference/language-specification/index.md).  
+- For a good general introduction to the language, see Chapter 1 of the [C# Language Specification](../../csharp/language-reference/language-specification/index.md).  
   
--   For detailed information about specific aspects of the C# language, see the [C# Reference](../../csharp/language-reference/index.md).  
+- For detailed information about specific aspects of the C# language, see the [C# Reference](../../csharp/language-reference/index.md).  
   
--   For more information about [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)], see [LINQ (Language-Integrated Query)](../programming-guide/concepts/linq/index.md).  
+- For more information about [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)], see [LINQ (Language-Integrated Query)](../programming-guide/concepts/linq/index.md).  
 
-## .NET Framework Platform Architecture  
+## .NET Framework Platform Architecture
+
  C# programs run on the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)], an integral component of Windows that includes a virtual execution system called the common language runtime (CLR) and a unified set of class libraries. The CLR is the commercial implementation by Microsoft of the common language infrastructure (CLI), an international standard that is the basis for creating execution and development environments in which languages and libraries work together seamlessly.  
   
  Source code written in C# is compiled into an intermediate language (IL) that conforms to the CLI specification. The IL code and resources, such as bitmaps and strings, are stored on disk in an executable file called an assembly, typically with an extension of .exe or .dll. An assembly contains a manifest that provides information about the assembly's types, version, culture, and security requirements.  
@@ -58,5 +61,6 @@ C# is an elegant and type-safe object-oriented language that enables developers 
  For more information about the .NET Framework, see [Overview of the Microsoft .NET Framework](../../framework/get-started/overview.md).  
   
 ## See Also  
- [C#](../../csharp/index.md)
- [Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic)
+
+- [C#](../../csharp/index.md)
+- [Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic)

--- a/docs/csharp/language-reference/language-specification/index.md
+++ b/docs/csharp/language-reference/language-specification/index.md
@@ -21,8 +21,9 @@ Issues on the draft specification should be created in the [dotnet/csharplang](h
 in fixing any errors you find, you may submit a [Pull Request](https://github.com/dotnet/csharplang/pulls) to the same repository.
 
 ## See also
- [C# Reference](../index.md)  
- [C# Programming Guide](../../programming-guide/index.md)
+
+- [C# Reference](../index.md)  
+- [C# Programming Guide](../../programming-guide/index.md)
 
 >[!div class="step-by-step"]
 [Next](../../../../_csharplang/spec/introduction.md)

--- a/docs/csharp/language-reference/operators/addition-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/addition-assignment-operator.md
@@ -33,7 +33,8 @@ x = x + y
 ## Example  
  [!code-csharp[csRefOperators#35](../../../csharp/language-reference/operators/codesnippet/CSharp/addition-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/addition-operator.md
+++ b/docs/csharp/language-reference/operators/addition-operator.md
@@ -27,8 +27,9 @@ The `+` operator can function as either a unary or a binary operator.
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [operator (C# Reference)](../../../csharp/language-reference/keywords/operator.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [operator (C# Reference)](../../../csharp/language-reference/keywords/operator.md)

--- a/docs/csharp/language-reference/operators/and-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/and-assignment-operator.md
@@ -31,7 +31,8 @@ x = x & y
 ## Example  
  [!code-csharp[csRefOperators#34](../../../csharp/language-reference/operators/codesnippet/CSharp/and-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/and-operator.md
+++ b/docs/csharp/language-reference/operators/and-operator.md
@@ -27,7 +27,8 @@ The `&` operator can function as either a unary or a binary operator.
 ## Example  
  [!code-csharp[csRefOperators#38](../../../csharp/language-reference/operators/codesnippet/CSharp/and-operator_2.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -16,7 +16,8 @@ The assignment operator (`=`) stores the value of its right-hand operand in the 
 ## Example  
  [!code-csharp[csRefOperators#49](../../../csharp/language-reference/operators/codesnippet/CSharp/assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/bitwise-complement-operator.md
+++ b/docs/csharp/language-reference/operators/bitwise-complement-operator.md
@@ -22,8 +22,9 @@ The `~` operator performs a bitwise complement operation on its operand, which h
 ## Example  
  [!code-csharp[csRefOperators#25](../../../csharp/language-reference/operators/codesnippet/CSharp/bitwise-complement-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [Finalizers](../../../csharp/programming-guide/classes-and-structs/destructors.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [Finalizers](../../../csharp/programming-guide/classes-and-structs/destructors.md)

--- a/docs/csharp/language-reference/operators/conditional-and-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-and-operator.md
@@ -36,7 +36,8 @@ x & y
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -45,10 +45,11 @@ classify = (input > 0) ? "positive" : "negative";
 ## Example  
  [!code-csharp[csRefOperators#41](../../../csharp/language-reference/operators/codesnippet/CSharp/conditional-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [if-else](../../../csharp/language-reference/keywords/if-else.md)  
- [?. and ?[] Operators](../../../csharp/language-reference/operators/null-conditional-operators.md)  
- [?? Operator](../../../csharp/language-reference/operators/null-coalescing-operator.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [if-else](../../../csharp/language-reference/keywords/if-else.md)  
+- [?. and ?[] Operators](../../../csharp/language-reference/operators/null-conditional-operators.md)  
+- [?? Operator](../../../csharp/language-reference/operators/null-coalescing-operator.md)

--- a/docs/csharp/language-reference/operators/conditional-or-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-or-operator.md
@@ -34,7 +34,8 @@ x | y
   
  [!code-csharp[csRefOperators#52](../../../csharp/language-reference/operators/codesnippet/CSharp/conditional-or-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/decrement-operator.md
+++ b/docs/csharp/language-reference/operators/decrement-operator.md
@@ -19,7 +19,8 @@ The decrement operator (`--`) decrements its operand by 1. The decrement operato
 ## Example  
  [!code-csharp[csRefOperators#8](../../../csharp/language-reference/operators/codesnippet/CSharp/decrement-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/dereference-operator.md
+++ b/docs/csharp/language-reference/operators/dereference-operator.md
@@ -31,7 +31,8 @@ x->y
 ## Example  
  [!code-csharp[csRefOperators#15](../../../csharp/language-reference/operators/codesnippet/CSharp/dereference-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/division-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/division-assignment-operator.md
@@ -31,7 +31,8 @@ x = x / y
 ## Example  
  [!code-csharp[csRefOperators#5](codesnippet/CSharp/division-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/division-operator.md
+++ b/docs/csharp/language-reference/operators/division-operator.md
@@ -23,7 +23,8 @@ The division operator (`/`) divides its first operand by its second operand. All
 ## Example  
  [!code-csharp[csRefOperators#42](../../../csharp/language-reference/operators/codesnippet/CSharp/division-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/equality-comparison-operator.md
+++ b/docs/csharp/language-reference/operators/equality-comparison-operator.md
@@ -17,7 +17,8 @@ For predefined value types, the equality operator (`==`) returns true if the val
 ## Example  
  [!code-csharp[csRefOperators#36](../../../csharp/language-reference/operators/codesnippet/CSharp/equality-comparison-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/greater-than-equal-operator.md
+++ b/docs/csharp/language-reference/operators/greater-than-equal-operator.md
@@ -17,7 +17,8 @@ All numeric and enumeration types define a "greater than or equal" relational op
 ## Example  
  [!code-csharp[csRefOperators#39](../../../csharp/language-reference/operators/codesnippet/CSharp/greater-than-equal-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/greater-than-operator.md
+++ b/docs/csharp/language-reference/operators/greater-than-operator.md
@@ -17,8 +17,9 @@ All numeric and enumeration types define a "greater than" relational operator (`
 ## Example  
  [!code-csharp[csRefOperators#29](../../../csharp/language-reference/operators/codesnippet/CSharp/greater-than-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [explicit](../../../csharp/language-reference/keywords/explicit.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [explicit](../../../csharp/language-reference/keywords/explicit.md)

--- a/docs/csharp/language-reference/operators/increment-operator.md
+++ b/docs/csharp/language-reference/operators/increment-operator.md
@@ -21,7 +21,8 @@ The increment operator (`++`) increments its operand by 1. The increment operato
 ## Example  
  [!code-csharp[csRefOperators#3](../../../csharp/language-reference/operators/codesnippet/CSharp/increment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/index-operator.md
+++ b/docs/csharp/language-reference/operators/index-operator.md
@@ -43,11 +43,12 @@ Square brackets (`[]`) are used for arrays, indexers, and attributes. They can a
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [Arrays](../../../csharp/programming-guide/arrays/index.md)  
- [Indexers](../../../csharp/programming-guide/indexers/index.md)  
- [unsafe](../../../csharp/language-reference/keywords/unsafe.md)  
- [fixed Statement](../../../csharp/language-reference/keywords/fixed-statement.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [Arrays](../../../csharp/programming-guide/arrays/index.md)  
+- [Indexers](../../../csharp/programming-guide/indexers/index.md)  
+- [unsafe](../../../csharp/language-reference/keywords/unsafe.md)  
+- [fixed Statement](../../../csharp/language-reference/keywords/fixed-statement.md)

--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -201,11 +201,11 @@ C# provides many operators, which are symbols that specify which operations (mat
 -   Floating-point arithmetic overflow or division by zero never throws an exception, because floating-point types are based on IEEE 754 and so have provisions for representing infinity and NaN (Not a Number).  
   
 -   [Decimal](../../../csharp/language-reference/keywords/decimal.md) arithmetic overflow always throws an <xref:System.OverflowException>. Decimal division by zero always throws a <xref:System.DivideByZeroException>.  
-  
-  
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C#](../../../csharp/index.md)
- [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md)  
- [C# Keywords](../../../csharp/language-reference/keywords/index.md)
+
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C#](../../../csharp/index.md)
+- [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md)  
+- [C# Keywords](../../../csharp/language-reference/keywords/index.md)

--- a/docs/csharp/language-reference/operators/invocation-operator.md
+++ b/docs/csharp/language-reference/operators/invocation-operator.md
@@ -32,7 +32,8 @@ In addition to being used to specify the order of operations in an expression, p
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -104,8 +104,9 @@ public override string ToString()
 ```
 For more detailed information on expression body definitions, see [Expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md).
 
-## See Also  
-[C# Reference](../../../csharp/language-reference/index.md)   
-[C# Programming Guide](../../../csharp/programming-guide/index.md)   
-[Lambda Expressions](../../../csharp/programming-guide/statements-expressions-operators/lambda-expressions.md)   
-[Expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md).
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)   
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)   
+- [Lambda Expressions](../../../csharp/programming-guide/statements-expressions-operators/lambda-expressions.md)   
+- [Expression-bodied members](../../programming-guide/statements-expressions-operators/expression-bodied-members.md).

--- a/docs/csharp/language-reference/operators/left-shift-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/left-shift-assignment-operator.md
@@ -31,7 +31,8 @@ x = x << y
 ## Example  
  [!code-csharp[csRefOperators#12](../../../csharp/language-reference/operators/codesnippet/CSharp/left-shift-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/left-shift-operator.md
+++ b/docs/csharp/language-reference/operators/left-shift-operator.md
@@ -26,7 +26,8 @@ The left-shift operator (`<<`) shifts its first operand left by the number of bi
 ## Comments  
  Note that `i<<1` and `i<<33` give the same result, because 1 and 33 have the same low-order five bits.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/less-than-equal-operator.md
+++ b/docs/csharp/language-reference/operators/less-than-equal-operator.md
@@ -17,8 +17,9 @@ All numeric and enumeration types define a "less than or equal" relational opera
 ## Example  
  [!code-csharp[csRefOperators#32](../../../csharp/language-reference/operators/codesnippet/CSharp/less-than-equal-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [explicit](../../../csharp/language-reference/keywords/explicit.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [explicit](../../../csharp/language-reference/keywords/explicit.md)

--- a/docs/csharp/language-reference/operators/less-than-operator.md
+++ b/docs/csharp/language-reference/operators/less-than-operator.md
@@ -17,7 +17,8 @@ All numeric and enumeration types define a "less than" relational operator (`<`)
 ## Example  
  [!code-csharp[csRefOperators#24](../../../csharp/language-reference/operators/codesnippet/CSharp/less-than-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/logical-negation-operator.md
+++ b/docs/csharp/language-reference/operators/logical-negation-operator.md
@@ -18,7 +18,8 @@ The logical negation operator (`!`) is a unary operator that negates its operand
 ## Example  
  [!code-csharp[csRefOperators#7](../../../csharp/language-reference/operators/codesnippet/CSharp/logical-negation-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/member-access-operator.md
+++ b/docs/csharp/language-reference/operators/member-access-operator.md
@@ -39,7 +39,8 @@ The dot operator (`.`) is used for member access. The dot operator specifies a m
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/multiplication-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/multiplication-assignment-operator.md
@@ -31,7 +31,8 @@ x = x * y
 ## Example  
  [!code-csharp[csRefOperators#13](../../../csharp/language-reference/operators/codesnippet/CSharp/multiplication-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/multiplication-operator.md
+++ b/docs/csharp/language-reference/operators/multiplication-operator.md
@@ -24,8 +24,9 @@ The multiplication operator (`*`) computes the product of its operands. All nume
 ## Example  
  [!code-csharp[csRefOperators#51](../../../csharp/language-reference/operators/codesnippet/CSharp/multiplication-operator_2.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [Unsafe Code and Pointers](../../../csharp/programming-guide/unsafe-code-pointers/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [Unsafe Code and Pointers](../../../csharp/programming-guide/unsafe-code-pointers/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/namespace-alias-qualifer.md
+++ b/docs/csharp/language-reference/operators/namespace-alias-qualifer.md
@@ -25,10 +25,11 @@ The namespace alias qualifier (`::`) is used to look up identifiers. It is alway
 ## C# Language Specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [Namespace Keywords](../../../csharp/language-reference/keywords/namespace-keywords.md)  
- [. Operator](../../../csharp/language-reference/operators/member-access-operator.md)  
- [extern alias](../../../csharp/language-reference/keywords/extern-alias.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [Namespace Keywords](../../../csharp/language-reference/keywords/namespace-keywords.md)  
+- [. Operator](../../../csharp/language-reference/operators/member-access-operator.md)  
+- [extern alias](../../../csharp/language-reference/keywords/extern-alias.md)

--- a/docs/csharp/language-reference/operators/not-equal-operator.md
+++ b/docs/csharp/language-reference/operators/not-equal-operator.md
@@ -20,7 +20,8 @@ The inequality operator (`!=`) returns false if its operands are equal, true oth
 ## Example  
  [!code-csharp[csRefOperators#33](../../../csharp/language-reference/operators/codesnippet/CSharp/not-equal-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/null-coalescing-operator.md
+++ b/docs/csharp/language-reference/operators/null-coalescing-operator.md
@@ -22,9 +22,10 @@ The `??` operator is called the null-coalescing operator.  It returns the left-h
 ## Example  
  [!code-csharp[csRefOperators#53](../../../csharp/language-reference/operators/codesnippet/CSharp/null-conditional-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)  
- [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md)  
- [What Exactly Does 'Lifted' mean?](https://blogs.msdn.microsoft.com/ericlippert/2007/06/27/what-exactly-does-lifted-mean/)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)  
+- [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md)  
+- [What Exactly Does 'Lifted' mean?](https://blogs.msdn.microsoft.com/ericlippert/2007/06/27/what-exactly-does-lifted-mean/)

--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -73,8 +73,9 @@ PropertyChanged?.Invoke(…)
   
  For more information, see the [Visual Basic Language Reference](../../../visual-basic/language-reference/index.md).  
   
-## See Also  
- [?? (null-coalescing operator)](null-coalescing-operator.md)  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [Visual Basic Programming Guide](../../../visual-basic/programming-guide/index.md)
+## See Also
+
+- [?? (null-coalescing operator)](null-coalescing-operator.md)  
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [Visual Basic Programming Guide](../../../visual-basic/programming-guide/index.md)

--- a/docs/csharp/language-reference/operators/or-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/or-assignment-operator.md
@@ -31,7 +31,8 @@ x = x | y
 ## Example  
  [!code-csharp[csRefOperators#10](../../../csharp/language-reference/operators/codesnippet/CSharp/or-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/or-operator.md
+++ b/docs/csharp/language-reference/operators/or-operator.md
@@ -20,7 +20,8 @@ Binary `|` operators are predefined for the integral types and `bool`. For integ
 ## Example  
  [!code-csharp[csRefOperators#31](../../../csharp/language-reference/operators/codesnippet/CSharp/or-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/remainder-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/remainder-assignment-operator.md
@@ -31,7 +31,8 @@ x = x % y
 ## Example  
  [!code-csharp[csRefOperators#4](../../../csharp/language-reference/operators/codesnippet/CSharp/modulus-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/remainder-operator.md
+++ b/docs/csharp/language-reference/operators/remainder-operator.md
@@ -24,7 +24,8 @@ The remainder operator (`%`) computes the remainder after dividing its first ope
 ## Comments  
  Note the round-off errors associated with the double type.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/right-shift-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/right-shift-assignment-operator.md
@@ -31,7 +31,8 @@ x = x >> y
 ## Example  
  [!code-csharp[csRefOperators#11](../../../csharp/language-reference/operators/codesnippet/CSharp/right-shift-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/right-shift-operator.md
+++ b/docs/csharp/language-reference/operators/right-shift-operator.md
@@ -23,7 +23,8 @@ The right-shift operator (`>>`) shifts its first operand right by the number of 
 ## Example  
  [!code-csharp[csRefOperators#26](../../../csharp/language-reference/operators/codesnippet/CSharp/right-shift-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/subtraction-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/subtraction-assignment-operator.md
@@ -33,7 +33,8 @@ x = x - y
 ## Example  
  [!code-csharp[csRefOperators#6](codesnippet/CSharp/subtraction-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/subtraction-operator.md
+++ b/docs/csharp/language-reference/operators/subtraction-operator.md
@@ -23,7 +23,8 @@ The `-` operator can function as either a unary or a binary operator.
 ## Example  
  [!code-csharp[csRefOperators#40](../../../csharp/language-reference/operators/codesnippet/CSharp/subtraction-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/xor-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/xor-assignment-operator.md
@@ -30,7 +30,8 @@ x = x ^ y
 ## Example  
  [!code-csharp[csRefOperators#23](../../../csharp/language-reference/operators/codesnippet/CSharp/xor-assignment-operator_1.cs)]  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/operators/xor-operator.md
+++ b/docs/csharp/language-reference/operators/xor-operator.md
@@ -25,7 +25,8 @@ Binary `^` operators are predefined for the integral types and `bool`. For integ
   
  The result of the exclusive-OR is `1100 0111`, which is C7 in hexadecimal.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Operators](../../../csharp/language-reference/operators/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Operators](../../../csharp/language-reference/operators/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/index.md
+++ b/docs/csharp/language-reference/preprocessor-directives/index.md
@@ -33,5 +33,6 @@ Although the compiler doesn't have a separate preprocessor, the directives descr
 A preprocessor directive must be the only instruction on a line.
 
 ## See also
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-define.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-define.md
@@ -57,11 +57,12 @@ public class TestDefine
   
  For an example of how to undefine a symbol, see [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md).  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)  
- [const](../../../csharp/language-reference/keywords/const.md)  
- [How to: Compile Conditionally with Trace and Debug](../../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug.md)  
- [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md)  
- [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)  
+- [const](../../../csharp/language-reference/keywords/const.md)  
+- [How to: Compile Conditionally with Trace and Debug](../../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug.md)  
+- [#undef](../../../csharp/language-reference/preprocessor-directives/preprocessor-undef.md)  
+- [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-elif.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-elif.md
@@ -34,7 +34,8 @@ ms.assetid: 731d78df-08e0-4d51-b8c8-f193c27de13f
   
  See [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md) for an example of how to use `#elif`.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-else.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-else.md
@@ -13,7 +13,8 @@ ms.assetid: 6a347322-cfa2-4a86-98f8-ddfa2cb7d4db
 ## Remarks  
  [#endif](../../../csharp/language-reference/preprocessor-directives/preprocessor-endif.md) must be the next preprocessor directive after `#else`. See [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md) for an example of how to use `#else`.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-endif.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-endif.md
@@ -21,7 +21,8 @@ ms.assetid: 6a5fca55-5aee-441f-86f6-1c99fbe9ec05
 ## Remarks  
  A conditional directive, beginning with a `#if` directive, must explicitly be terminated with a `#endif` directive. See [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md) for an example of how to use `#endif`.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-endregion.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-endregion.md
@@ -21,7 +21,8 @@ class MyClass
 #endregion  
 ```  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-error.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-error.md
@@ -36,7 +36,8 @@ class MainClass
 }  
 ```  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-if.md
@@ -82,7 +82,7 @@ public class MyClass
 
 ## See also
 
-[C# Reference](../../../csharp/language-reference/index.md)  
-[C# Programming Guide](../../../csharp/programming-guide/index.md)  
-[C# Preprocessor Directives](index.md)  
-[How to: Compile Conditionally with Trace and Debug](../../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug.md).
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](index.md)  
+- [How to: Compile Conditionally with Trace and Debug](../../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug.md).

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
@@ -70,7 +70,8 @@ class MainClass
 }  
 ```  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md
@@ -47,7 +47,8 @@ class TestClass
 }  
 ```  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md
@@ -52,8 +52,9 @@ public class D
 }  
 ```  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)  
- [C# Compiler Errors](../../../csharp/language-reference/compiler-messages/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)  
+- [C# Compiler Errors](../../../csharp/language-reference/compiler-messages/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-pragma.md
@@ -27,9 +27,10 @@ ms.assetid: 5b7944cd-d402-46a1-ad8f-feffb2d83673
  `pragma-arguments`  
  Pragma-specific arguments.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)  
- [#pragma warning](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md)  
- [#pragma checksum](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)  
+- [#pragma warning](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning.md)  
+- [#pragma checksum](../../../csharp/language-reference/preprocessor-directives/preprocessor-pragma-checksum.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-region.md
@@ -26,7 +26,8 @@ public class MyClass
   
  A `#region` block cannot overlap with a [#if](../../../csharp/language-reference/preprocessor-directives/preprocessor-if.md) block. However, a `#region` block can be nested in a `#if` block, and a `#if` block can be nested in a `#region` block.  
   
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-undef.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-undef.md
@@ -13,15 +13,15 @@ ms.assetid: 686c92d2-7194-4be4-b2f4-80091712d513
  A symbol can be defined either with the [#define](../../../csharp/language-reference/preprocessor-directives/preprocessor-define.md) directive or the [-define](../../../csharp/language-reference/compiler-options/define-compiler-option.md) compiler option. The `#undef` directive must appear in the file before you use any statements that are not also directives.  
   
 ## Example  
-  
+
 ```csharp
 // preprocessor_undef.cs  
 // compile with: /d:DEBUG  
 #undef DEBUG  
 using System;  
-class MyClass   
+class MyClass
 {  
-    static void Main()   
+    static void Main()
     {  
 #if DEBUG  
         Console.WriteLine("DEBUG is defined");  
@@ -30,10 +30,12 @@ class MyClass
 #endif  
     }  
 }  
-```  
-  
- **DEBUG is not defined**  
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+```
+
+**DEBUG is not defined**
+
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-warning.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-warning.md
@@ -14,18 +14,18 @@ ms.assetid: e6fb496d-bb8b-4018-baf6-5b60a0c8902b
 #warning Deprecated code in this method.  
 ```  
   
-## Remarks  
+## Remarks
  A common use of `#warning` is in a conditional directive. It is also possible to generate a user-defined error with [#error](../../../csharp/language-reference/preprocessor-directives/preprocessor-error.md).  
   
 ## Example  
-  
+
 ```csharp
 // preprocessor_warning.cs  
 // CS1030 expected  
 #define DEBUG  
-class MainClass   
+class MainClass
 {  
-    static void Main()   
+    static void Main()
     {  
 #if DEBUG  
 #warning DEBUG is defined  
@@ -33,8 +33,9 @@ class MainClass
     }  
 }  
 ```  
-  
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)
+
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Preprocessor Directives](../../../csharp/language-reference/preprocessor-directives/index.md)

--- a/docs/csharp/language-reference/tokens/index.md
+++ b/docs/csharp/language-reference/tokens/index.md
@@ -22,7 +22,7 @@ Special characters are predefined, contextual characters that modify the program
 
 - [$](../../../csharp/language-reference/tokens/interpolated.md), the interpolated string character.
 
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)
+## See Also
 
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -82,12 +82,13 @@ The following example uses implicit conversion to <xref:System.FormattableString
 
 If you are new to string interpolation, see the [String interpolation in C#](../../quick-starts/interpolated-strings.yml) quickstart. For more examples, see the [String interpolation in C#](../../tutorials/string-interpolation.md) tutorial.
 
-## See also  
- <xref:System.String.Format%2A?displayProperty=nameWithType>  
- <xref:System.FormattableString?displayProperty=nameWithType>  
- <xref:System.IFormattable?displayProperty=nameWithType>  
- [Composite formatting](../../../standard/base-types/composite-formatting.md)  
- [Strings](../../programming-guide/strings/index.md)  
- [C# Programming Guide](../../programming-guide/index.md)  
- [C# Special Characters](index.md)  
- [C# Reference](../index.md)  
+## See also
+
+- <xref:System.String.Format%2A?displayProperty=nameWithType>
+- <xref:System.FormattableString?displayProperty=nameWithType>
+- <xref:System.IFormattable?displayProperty=nameWithType>
+- [Composite formatting](../../../standard/base-types/composite-formatting.md)
+- [Strings](../../programming-guide/strings/index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Special Characters](index.md)
+- [C# Reference](../index.md)

--- a/docs/csharp/language-reference/tokens/verbatim.md
+++ b/docs/csharp/language-reference/tokens/verbatim.md
@@ -68,7 +68,8 @@ The `@` special character serves as a verbatim identifier. It can be used in the
 
    [!code-csharp[verbatim4](../../../../samples/snippets/csharp/language-reference/keywords/verbatim4.cs#1)]
 
-## See Also  
- [C# Reference](../../../csharp/language-reference/index.md)  
- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
- [C# Special Characters](../../../csharp/language-reference/tokens/index.md)
+## See Also
+
+- [C# Reference](../../../csharp/language-reference/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Special Characters](../../../csharp/language-reference/tokens/index.md)

--- a/docs/csharp/linq/create-a-nested-group.md
+++ b/docs/csharp/linq/create-a-nested-group.md
@@ -19,4 +19,4 @@ Note that three nested `foreach` loops are required to iterate over the inner el
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)
+- [Language Integrated Query (LINQ)](index.md)

--- a/docs/csharp/linq/dynamically-specify-predicate-filters-at-runtime.md
+++ b/docs/csharp/linq/dynamically-specify-predicate-filters-at-runtime.md
@@ -64,5 +64,5 @@ In some cases, you don't know until run time how many predicates you have to app
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)  
-[where clause](../language-reference/keywords/where-clause.md)  
+- [Language Integrated Query (LINQ)](index.md)
+- [where clause](../language-reference/keywords/where-clause.md)

--- a/docs/csharp/linq/group-query-results.md
+++ b/docs/csharp/linq/group-query-results.md
@@ -70,11 +70,11 @@ Paste the following method into the `StudentClass` class. Change the calling sta
 
 ## See also
 
-<xref:System.Linq.Enumerable.GroupBy%2A>  
-<xref:System.Linq.IGrouping%602>  
-[Language Integrated Query (LINQ)](index.md)  
-[group clause](../language-reference/keywords/group-clause.md)  
-[Anonymous Types](../programming-guide/classes-and-structs/anonymous-types.md)  
-[Perform a Subquery on a Grouping Operation](perform-a-subquery-on-a-grouping-operation.md)  
-[Create a Nested Group](create-a-nested-group.md)  
-[Grouping Data](../programming-guide/concepts/linq/grouping-data.md)  
+- <xref:System.Linq.Enumerable.GroupBy%2A>  
+- <xref:System.Linq.IGrouping%602>  
+- [Language Integrated Query (LINQ)](index.md)  
+- [group clause](../language-reference/keywords/group-clause.md)  
+- [Anonymous Types](../programming-guide/classes-and-structs/anonymous-types.md)  
+- [Perform a Subquery on a Grouping Operation](perform-a-subquery-on-a-grouping-operation.md)  
+- [Create a Nested Group](create-a-nested-group.md)  
+- [Grouping Data](../programming-guide/concepts/linq/grouping-data.md)  

--- a/docs/csharp/linq/group-results-by-contiguous-keys.md
+++ b/docs/csharp/linq/group-results-by-contiguous-keys.md
@@ -45,4 +45,4 @@ To use the extension method in your project, copy the `MyExtensions` static clas
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)
+- [Language Integrated Query (LINQ)](index.md)

--- a/docs/csharp/linq/handle-exceptions-in-query-expressions.md
+++ b/docs/csharp/linq/handle-exceptions-in-query-expressions.md
@@ -26,4 +26,4 @@ Note that the `try` block encloses the `foreach` loop, and not the query itself.
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)  
+- [Language Integrated Query (LINQ)](index.md)  

--- a/docs/csharp/linq/handle-null-values-in-query-expressions.md
+++ b/docs/csharp/linq/handle-null-values-in-query-expressions.md
@@ -24,6 +24,6 @@ In a join clause, if only one of the comparison keys is a nullable value type, y
 
 ## See also
 
-<xref:System.Nullable%601>  
-[Language Integrated Query (LINQ)](index.md)  
-[Nullable types](../programming-guide/nullable-types/index.md)  
+- <xref:System.Nullable%601>  
+- [Language Integrated Query (LINQ)](index.md)  
+- [Nullable types](../programming-guide/nullable-types/index.md)  

--- a/docs/csharp/linq/join-by-using-composite-keys.md
+++ b/docs/csharp/linq/join-by-using-composite-keys.md
@@ -32,6 +32,6 @@ Composite keys can be also used in a `group` clause.
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)  
-[join clause](../language-reference/keywords/join-clause.md)  
-[group clause](../language-reference/keywords/group-clause.md)  
+- [Language Integrated Query (LINQ)](index.md)  
+- [join clause](../language-reference/keywords/join-clause.md)  
+- [group clause](../language-reference/keywords/group-clause.md)  

--- a/docs/csharp/linq/order-the-results-of-a-join-clause.md
+++ b/docs/csharp/linq/order-the-results-of-a-join-clause.md
@@ -16,6 +16,6 @@ This query creates a group join, and then sorts the groups based on the category
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)  
-[orderby clause](../language-reference/keywords/orderby-clause.md)  
-[join clause](../language-reference/keywords/join-clause.md)  
+- [Language Integrated Query (LINQ)](index.md)  
+- [orderby clause](../language-reference/keywords/orderby-clause.md)  
+- [join clause](../language-reference/keywords/join-clause.md)  

--- a/docs/csharp/linq/perform-a-subquery-on-a-grouping-operation.md
+++ b/docs/csharp/linq/perform-a-subquery-on-a-grouping-operation.md
@@ -21,4 +21,4 @@ For more information about continuations, see [into](../language-reference/keywo
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)
+- [Language Integrated Query (LINQ)](index.md)

--- a/docs/csharp/linq/perform-custom-join-operations.md
+++ b/docs/csharp/linq/perform-custom-join-operations.md
@@ -37,6 +37,6 @@ In the following example, the query must join two sequences based on matching ke
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)  
-[join clause](../language-reference/keywords/join-clause.md)  
-[Order the results of a join clause](order-the-results-of-a-join-clause.md)  
+- [Language Integrated Query (LINQ)](index.md)  
+- [join clause](../language-reference/keywords/join-clause.md)  
+- [Order the results of a join clause](order-the-results-of-a-join-clause.md)  

--- a/docs/csharp/linq/perform-grouped-joins.md
+++ b/docs/csharp/linq/perform-grouped-joins.md
@@ -29,8 +29,8 @@ Group joins are ideal for creating XML by using LINQ to XML. The following examp
 
 ## See also
 
-<xref:System.Linq.Enumerable.Join%2A>  
-<xref:System.Linq.Enumerable.GroupJoin%2A>  
-[Perform inner joins](perform-inner-joins.md)  
-[Perform left outer joins](perform-left-outer-joins.md)  
-[Anonymous types](../programming-guide/classes-and-structs/anonymous-types.md)  
+- <xref:System.Linq.Enumerable.Join%2A>  
+- <xref:System.Linq.Enumerable.GroupJoin%2A>  
+- [Perform inner joins](perform-inner-joins.md)  
+- [Perform left outer joins](perform-left-outer-joins.md)  
+- [Anonymous types](../programming-guide/classes-and-structs/anonymous-types.md)  

--- a/docs/csharp/linq/perform-inner-joins.md
+++ b/docs/csharp/linq/perform-inner-joins.md
@@ -60,8 +60,8 @@ The result of `query1` is equivalent to the result set that would have been obta
 
 ## See also
 
-<xref:System.Linq.Enumerable.Join%2A>  
-<xref:System.Linq.Enumerable.GroupJoin%2A>  
-[Perform grouped joins](perform-grouped-joins.md)  
-[Perform left outer joins](perform-left-outer-joins.md)  
-[Anonymous types](../programming-guide/classes-and-structs/anonymous-types.md)  
+- <xref:System.Linq.Enumerable.Join%2A>  
+- <xref:System.Linq.Enumerable.GroupJoin%2A>  
+- [Perform grouped joins](perform-grouped-joins.md)  
+- [Perform left outer joins](perform-left-outer-joins.md)  
+- [Anonymous types](../programming-guide/classes-and-structs/anonymous-types.md)  

--- a/docs/csharp/linq/perform-left-outer-joins.md
+++ b/docs/csharp/linq/perform-left-outer-joins.md
@@ -23,8 +23,8 @@ The second step is to include each element of the first (left) collection in the
 
 ## See also
 
-<xref:System.Linq.Enumerable.Join%2A>  
-<xref:System.Linq.Enumerable.GroupJoin%2A>  
-[Perform inner joins](perform-inner-joins.md)  
-[Perform grouped joins](perform-grouped-joins.md)  
-[Anonymous types](../programming-guide/classes-and-structs/anonymous-types.md)  
+- <xref:System.Linq.Enumerable.Join%2A>  
+- <xref:System.Linq.Enumerable.GroupJoin%2A>  
+- [Perform inner joins](perform-inner-joins.md)  
+- [Perform grouped joins](perform-grouped-joins.md)  
+- [Anonymous types](../programming-guide/classes-and-structs/anonymous-types.md)  

--- a/docs/csharp/linq/query-a-collection-of-objects.md
+++ b/docs/csharp/linq/query-a-collection-of-objects.md
@@ -20,5 +20,5 @@ This query is intentionally simple to enable you to experiment. For example, you
   
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)  
-[String interpolation](../language-reference/tokens/interpolated.md)
+- [Language Integrated Query (LINQ)](index.md)  
+- [String interpolation](../language-reference/tokens/interpolated.md)

--- a/docs/csharp/linq/query-expression-basics.md
+++ b/docs/csharp/linq/query-expression-basics.md
@@ -168,7 +168,7 @@ For more information, see [How to: perform a subquery on a grouping operation](p
 
 ## See also
 
-[C# programming guide](../programming-guide/index.md)  
-[Language Integrated Query (LINQ)](index.md)  
-[Query keywords (LINQ)](../language-reference/keywords/query-keywords.md)  
-[Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md)  
+- [C# programming guide](../programming-guide/index.md)  
+- [Language Integrated Query (LINQ)](index.md)  
+- [Query keywords (LINQ)](../language-reference/keywords/query-keywords.md)  
+- [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md)  

--- a/docs/csharp/linq/return-a-query-from-a-method.md
+++ b/docs/csharp/linq/return-a-query-from-a-method.md
@@ -14,5 +14,6 @@ This example shows how to return a query from a method as the return value and a
   
  [!code-csharp[csProgGuideLINQ#80](~/samples/snippets/csharp/concepts/linq/how-to-return-a-query-from-a-method_1.cs)]  
 
-## See Also  
- [Language Integrated Query (LINQ)](index.md)
+## See Also
+
+- [Language Integrated Query (LINQ)](index.md)

--- a/docs/csharp/linq/store-the-results-of-a-query-in-memory.md
+++ b/docs/csharp/linq/store-the-results-of-a-query-in-memory.md
@@ -24,4 +24,4 @@ A query is basically a set of instructions for how to retrieve and organize data
 
 ## See also
 
-[Language Integrated Query (LINQ)](index.md)
+- [Language Integrated Query (LINQ)](index.md)

--- a/docs/csharp/linq/write-linq-queries.md
+++ b/docs/csharp/linq/write-linq-queries.md
@@ -75,6 +75,6 @@ int numCount = numbers.Where(n => n < 3 || n > 7).Count();
 
 ## See also
 
-[Walkthrough: Writing Queries in C#](../programming-guide/concepts/linq/walkthrough-writing-queries-linq.md)
-[Language Integrated Query (LINQ)](index.md)
-[where clause](../language-reference/keywords/where-clause.md)
+- [Walkthrough: Writing Queries in C#](../programming-guide/concepts/linq/walkthrough-writing-queries-linq.md)
+- [Language Integrated Query (LINQ)](index.md)
+- [where clause](../language-reference/keywords/where-clause.md)

--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -290,12 +290,12 @@ For more information, see [Iterators](programming-guide/concepts/iterators.md).
 
 ## See also ##
 
-[Access Modifiers](language-reference/keywords/access-modifiers.md)   
-[Static Classes and Static Class Members](programming-guide/classes-and-structs/static-classes-and-static-class-members.md)   
-[Inheritance](programming-guide/classes-and-structs/inheritance.md)   
-[Abstract and Sealed Classes and Class Members](programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md)   
-[params](language-reference/keywords/params.md)   
-[out](language-reference/keywords/out-parameter-modifier.md)   
-[ref](language-reference/keywords/ref.md)   
-[in](language-reference/keywords/in-parameter-modifier.md)   
-[Passing Parameters](programming-guide/classes-and-structs/passing-parameters.md)
+- [Access Modifiers](language-reference/keywords/access-modifiers.md)   
+- [Static Classes and Static Class Members](programming-guide/classes-and-structs/static-classes-and-static-class-members.md)   
+- [Inheritance](programming-guide/classes-and-structs/inheritance.md)   
+- [Abstract and Sealed Classes and Class Members](programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md)   
+- [params](language-reference/keywords/params.md)   
+- [out](language-reference/keywords/out-parameter-modifier.md)   
+- [ref](language-reference/keywords/ref.md)   
+- [in](language-reference/keywords/in-parameter-modifier.md)   
+- [Passing Parameters](programming-guide/classes-and-structs/passing-parameters.md)


### PR DESCRIPTION
Use bulleted list in `See Also` section of docs\csharp\language-reference\keywords\ files

Contributes to #6923 
