### PR TITLE
Update cs5001.md

### DIFF
--- a/docs/csharp/misc/cs5001.md
+++ b/docs/csharp/misc/cs5001.md
@@ -11,7 +11,7 @@ ms.assetid: e1e26e75-84e0-47c7-be8a-3c4fd0d6f497
 
 Program 'program' does not contain a static 'Main' method suitable for an entry point  
   
-This error occurs when no static `Main` method with a correct signature is found in the code that produces an executable file. This error also occurs if the entry point function, `Main`, is defined with the wrong case, such as lower-case `main`. For the information about the rules that apply to the `Main` method, see [Main() and Command-Line Arguments](../programming-guide/main-and-command-args/index.md).
+This error occurs when no static `Main` method with a correct signature is found in the code that produces an executable file. This error also occurs if the entry point function, `Main`, is defined with the wrong case, such as lower-case `main`. For information about the rules that apply to the `Main` method, see [Main() and Command-Line Arguments](../programming-guide/main-and-command-args/index.md).
 
 If the `Main` method has an `async` modifier, make sure that the [selected C# language version](../language-reference/configure-language-version.md) is 7.1 or higher.
 

--- a/docs/csharp/misc/cs5001.md
+++ b/docs/csharp/misc/cs5001.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS5001"
-ms.date: 07/20/2015
+ms.date: 08/27/2018
 f1_keywords: 
   - "CS5001"
 helpviewer_keywords: 
@@ -8,12 +8,13 @@ helpviewer_keywords:
 ms.assetid: e1e26e75-84e0-47c7-be8a-3c4fd0d6f497
 ---
 # Compiler Error CS5001
+
 Program 'program' does not contain a static 'Main' method suitable for an entry point  
   
- This error occurs when no static [Main](../../csharp/programming-guide/main-and-command-args/index.md) method with a correct signature is found in the code that produces an executable file. This error also occurs if the entry point function, `Main`, is defined with the wrong case, such as lower-case `main`.  
-  
--   `Main` must be declared as static and it must return [void](../../csharp/language-reference/keywords/void.md) or [int](../../csharp/language-reference/keywords/int.md), and it must have either no parameters or else one parameter of type `string[]`.  
-  
+This error occurs when no static `Main` method with a correct signature is found in the code that produces an executable file. This error also occurs if the entry point function, `Main`, is defined with the wrong case, such as lower-case `main`. For the information about the rules that apply to the `Main` method, see [Main() and Command-Line Arguments](../programming-guide/main-and-command-args/index.md).
+
+If the `Main` method has an `async` modifier, make sure that the [selected C# language version](../language-reference/configure-language-version.md) is 7.1 or higher.
+
 ## Example  
  The following example generates CS5001:  
   
@@ -26,7 +27,3 @@ public class a
    // static void Main() {}  
 }  
 ```  
-  
-## See Also
-
-- [Main() and Command-Line Arguments](../../csharp/programming-guide/main-and-command-args/index.md)


### PR DESCRIPTION
Reference to [Main() and command-line arguments](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/main-and-command-args/) for the rules that apply to the `Main` method and do not duplicate them in the compiler error topic.
