### PR TITLE
Fix command to add XUnit package

### DIFF
--- a/docs/core/tutorials/testing-with-cli.md
+++ b/docs/core/tutorials/testing-with-cli.md
@@ -97,7 +97,7 @@ Optional exercise: You can add a new pet type, such as a `Bird`, by extending th
 
 The `NewTypes` project is in place, and you've organized it by keeping the pets-related types in a folder. Next, create your test project and start writing tests with the [xUnit](https://xunit.github.io/) test framework. Unit testing allows you to automatically check the bevahior of your pet types to confirm that they're operating properly.
 
-Create a *test* folder with a *NewTypesTests* folder within it. At a command prompt from the *NewTypesTests* folder, execute `dotnet new xunit`. This produces two files: *NewTypesTests.csproj* and *UnitTest1.cs*.
+Create a *test* folder with a *NewTypesTests* folder within it. At a command prompt from the *NewTypesTests* folder, execute `dotnet add package xunit`. This produces two files: *NewTypesTests.csproj* and *UnitTest1.cs*.
 
 The test project cannot currently test the types in `NewTypes` and requires a project reference to the `NewTypes` project. To add a project reference, use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
 


### PR DESCRIPTION
# Title

Fix command to add the XUnit package when testing with CLI

## Summary

The current command to add a package reference to a project in the documentation is incorrect. It's not the proper way to add a package when working with .NET Core.

Fixes #6317 

## Suggested Reviewers

@BillWagner
