### PR TITLE
NUnit template included in cli

### DIFF
--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -55,9 +55,9 @@ Make the *PrimeService.Tests* directory the current directory and create a new p
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
   <PackageReference Include="NUnit" Version="3.10.1" />
   <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
 </ItemGroup>
 ```
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -40,6 +40,8 @@ Change the directory back to the *unit-testing-using-nunit* directory. Run [`dot
 
 ## Creating the test project
 
+This section applies to: ✓ .NET SDK 2.1.400 and later versions.
+
 Next, create the *PrimeService.Tests* directory. The following outline shows the directory structure:
 
 ```

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -2,7 +2,7 @@
 title: Unit testing C# with NUnit and .NET Core
 description: Learn unit test concepts in C# and .NET Core through an interactive experience building a sample solution step-by-step using dotnet test and NUnit.
 author: rprouse
-ms.date: 12/01/2017
+ms.date: 08/31/2018
 ---
 # Unit testing C# with NUnit and .NET Core
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -6,9 +6,12 @@ ms.date: 08/31/2018
 ---
 # Unit testing C# with NUnit and .NET Core
 
-**This topic applies to:** ✓ .NET SDK 2.1.400 and later versions
-
 This tutorial takes you through an interactive experience building a sample solution step-by-step to learn unit testing concepts. If you prefer to follow the tutorial using a pre-built solution, [view or download the sample code](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-using-nunit/) before you begin. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#viewing-and-downloading-samples).
+
+## Prerequisites
+
+- [.NET Core SDK 2.1 SDK (v. 2.1.400)](https://www.microsoft.com/net/download) or later versions.
+- A text editor or code editor of your choice.
 
 ## Creating the source project
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -6,6 +6,8 @@ ms.date: 08/31/2018
 ---
 # Unit testing C# with NUnit and .NET Core
 
+**This topic applies to:** ✓ .NET SDK 2.1.400 and later versions
+
 This tutorial takes you through an interactive experience building a sample solution step-by-step to learn unit testing concepts. If you prefer to follow the tutorial using a pre-built solution, [view or download the sample code](https://github.com/dotnet/samples/blob/master/core/getting-started/unit-testing-using-nunit/) before you begin. For download instructions, see [Samples and Tutorials](../../samples-and-tutorials/index.md#viewing-and-downloading-samples).
 
 ## Creating the source project
@@ -39,8 +41,6 @@ namespace Prime.Services
 Change the directory back to the *unit-testing-using-nunit* directory. Run [`dotnet sln add PrimeService/PrimeService.csproj`](../tools/dotnet-sln.md) to add the class library project to the solution.
 
 ## Creating the test project
-
-This section applies to: ✓ .NET SDK 2.1.400 and later versions.
 
 Next, create the *PrimeService.Tests* directory. The following outline shows the directory structure:
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -12,8 +12,14 @@ This tutorial takes you through an interactive experience building a sample solu
 
 ## Creating the source project
 
-Open a shell window. Create a directory called *unit-testing-using-nunit* to hold the solution. Inside this new directory, run [`dotnet new sln`](../tools/dotnet-new.md) to create
-a new solution file for the class library and the test project. Next, create a *PrimeService* directory. The following outline shows the directory and file structure thus far:
+Open a shell window. Create a directory called *unit-testing-using-nunit* to hold the solution. Inside this new directory, run the following command to create
+a new solution file for the class library and the test project:
+
+```console
+dotnet new sln
+```
+ 
+Next, create a *PrimeService* directory. The following outline shows the directory and file structure thus far:
 
 ```
 /unit-testing-using-nunit
@@ -21,7 +27,13 @@ a new solution file for the class library and the test project. Next, create a *
     /PrimeService
 ```
 
-Make *PrimeService* the current directory and run [`dotnet new classlib`](../tools/dotnet-new.md) to create the source project. Rename *Class1.cs* to *PrimeService.cs*. To use test-driven development (TDD), you create a failing implementation of the `PrimeService` class:
+Make *PrimeService* the current directory and run the following command to create the source project:
+
+```console
+dotnet new classlib
+```
+
+Rename *Class1.cs* to *PrimeService.cs*. To use test-driven development (TDD), you create a failing implementation of the `PrimeService` class:
 
 ```csharp
 using System;
@@ -38,7 +50,11 @@ namespace Prime.Services
 }
 ```
 
-Change the directory back to the *unit-testing-using-nunit* directory. Run [`dotnet sln add PrimeService/PrimeService.csproj`](../tools/dotnet-sln.md) to add the class library project to the solution.
+Change the directory back to the *unit-testing-using-nunit* directory. Run the following command to add the class library project to the solution:
+
+```
+dotnet sln add PrimeService/PrimeService.csproj
+```
 
 ## Creating the test project
 
@@ -53,15 +69,15 @@ Next, create the *PrimeService.Tests* directory. The following outline shows the
     /PrimeService.Tests
 ```
 
-Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new nunit`](../tools/dotnet-new.md). The dotnet new command creates a test project that uses NUnit as the test library. The generated template configures the test runner in the *PrimeService.Tests.csproj* file:
+Make the *PrimeService.Tests* directory the current directory and create a new project using the following command:
 
-```xml
-<ItemGroup>
-  <PackageReference Include="NUnit" Version="3.10.1" />
-  <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-</ItemGroup>
 ```
+dotnet new nunit
+```
+
+The [dotnet new](../tools/dotnet-new.md) command creates a test project that uses NUnit as the test library. The generated template configures the test runner in the *PrimeService.Tests.csproj* file:
+
+[!code-xml[Packages](~/samples/core/getting-started/unit-testing-using-nunit/PrimeService.Tests/PrimeService.Tests.csproj#Packages)]
 
 The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added the Microsoft test SDK, the NUnit test framework, and the NUnit test adapter. Now, add the `PrimeService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
 
@@ -84,11 +100,15 @@ The following outline shows the final solution layout:
         PrimeService.Tests.csproj
 ```
 
-Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj`](../tools/dotnet-sln.md) in the *unit-testing-using-dotnet-test* directory.
+Execute the following command in the *unit-testing-using-dotnet-test* directory:
+
+```
+dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj
+```
 
 ## Creating the first test
 
-The TDD approach calls for writing one failing test, making it pass, then repeating the process. Remove *UnitTest1.cs* from the *PrimeService.Tests* directory and create a new C# file named *PrimeService_IsPrimeShould.cs* with the following content:
+The TDD approach calls for writing one failing test, making it pass, then repeating the process. In the the *PrimeService.Tests* directory, rename the *UnitTest1.cs* file to *PrimeService_IsPrimeShould.cs* and replace its entire contents with the following code:
 
 ```csharp
 using NUnit.Framework;
@@ -144,7 +164,7 @@ Instead of creating new tests, apply this attribute to create a single data driv
 
 [!code-csharp[Sample_TestCode](../../../samples/core/getting-started/unit-testing-using-nunit/PrimeService.Tests/PrimeService_IsPrimeShould.cs?name=Sample_TestCode)]
 
-Run `dotnet test`, and two of these tests fail. To make all of the tests pass, change the `if` clause at the beginning of the method:
+Run `dotnet test`, and two of these tests fail. To make all of the tests pass, change the `if` clause at the beginning of the `Main` method in the *PrimeService.cs* file:
 
 ```csharp
 if (candidate < 2)

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -54,7 +54,7 @@ namespace Prime.Services
 
 Change the directory back to the *unit-testing-using-nunit* directory. Run the following command to add the class library project to the solution:
 
-```
+```console
 dotnet sln add PrimeService/PrimeService.csproj
 ```
 
@@ -73,7 +73,7 @@ Next, create the *PrimeService.Tests* directory. The following outline shows the
 
 Make the *PrimeService.Tests* directory the current directory and create a new project using the following command:
 
-```
+```console
 dotnet new nunit
 ```
 
@@ -83,7 +83,7 @@ The [dotnet new](../tools/dotnet-new.md) command creates a test project that use
 
 The test project requires other packages to create and run unit tests. `dotnet new` in the previous step added the Microsoft test SDK, the NUnit test framework, and the NUnit test adapter. Now, add the `PrimeService` class library as another dependency to the project. Use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
 
-```
+```console
 dotnet add reference ../PrimeService/PrimeService.csproj
 ```
 
@@ -104,7 +104,7 @@ The following outline shows the final solution layout:
 
 Execute the following command in the *unit-testing-using-dotnet-test* directory:
 
-```
+```console
 dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj
 ```
 

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -10,7 +10,7 @@ This tutorial takes you through an interactive experience building a sample solu
 
 ## Prerequisites
 
-- [.NET Core SDK 2.1 SDK (v. 2.1.400)](https://www.microsoft.com/net/download) or later versions.
+- [.NET Core SDK 2.1 (v. 2.1.400)](https://www.microsoft.com/net/download) or later versions.
 - A text editor or code editor of your choice.
 
 ## Creating the source project

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -38,15 +38,7 @@ namespace Prime.Services
 
 Change the directory back to the *unit-testing-using-nunit* directory. Run [`dotnet sln add PrimeService/PrimeService.csproj`](../tools/dotnet-sln.md) to add the class library project to the solution.
 
-## Install the NUnit project template
-
-The NUnit test project templates need to be installed before creating a test project. This only needs to be done once on each developer machine where you'll create new NUnit projects. Run [`dotnet new -i NUnit3.DotNetNew.Template`](../tools/dotnet-new.md) to install the NUnit templates.
-
-```
-dotnet new -i NUnit3.DotNetNew.Template
-```
-
-### Creating the test project
+## Creating the test project
 
 Next, create the *PrimeService.Tests* directory. The following outline shows the directory structure:
 
@@ -59,13 +51,13 @@ Next, create the *PrimeService.Tests* directory. The following outline shows the
     /PrimeService.Tests
 ```
 
-Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new nunit`](../tools/dotnet-new.md). The dotnet new command creates a test project that uses NUnit as the test library. The generated template configures the test runner in the *PrimeServiceTests.csproj* file:
+Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new nunit`](../tools/dotnet-new.md). The dotnet new command creates a test project that uses NUnit as the test library. The generated template configures the test runner in the *PrimeService.Tests.csproj* file:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-  <PackageReference Include="NUnit" Version="3.9.0" />
-  <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+  <PackageReference Include="NUnit" Version="3.10.1" />
+  <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
 </ItemGroup>
 ```
 
@@ -87,7 +79,7 @@ The following outline shows the final solution layout:
         PrimeService.csproj
     /PrimeService.Tests
         Test Source Files
-        PrimeServiceTests.csproj
+        PrimeService.Tests.csproj
 ```
 
 Execute [`dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj`](../tools/dotnet-sln.md) in the *unit-testing-using-dotnet-test* directory.

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -15,14 +15,13 @@ This tutorial takes you through an interactive experience building a sample solu
 
 ## Creating the source project
 
-Open a shell window. Create a directory called *unit-testing-using-nunit* to hold the solution. Inside this new directory, run the following command to create
-a new solution file for the class library and the test project:
+Open a shell window. Create a directory called *unit-testing-using-nunit* to hold the solution. Inside this new directory, run the following command to create a new solution file for the class library and the test project:
 
 ```console
 dotnet new sln
 ```
  
-Next, create a *PrimeService* directory. The following outline shows the directory and file structure thus far:
+Next, create a *PrimeService* directory. The following outline shows the directory and file structure so far:
 
 ```
 /unit-testing-using-nunit
@@ -111,7 +110,7 @@ dotnet sln add .\PrimeService.Tests\PrimeService.Tests.csproj
 
 ## Creating the first test
 
-The TDD approach calls for writing one failing test, making it pass, then repeating the process. In the the *PrimeService.Tests* directory, rename the *UnitTest1.cs* file to *PrimeService_IsPrimeShould.cs* and replace its entire contents with the following code:
+The TDD approach calls for writing one failing test, making it pass, then repeating the process. In the *PrimeService.Tests* directory, rename the *UnitTest1.cs* file to *PrimeService_IsPrimeShould.cs* and replace its entire contents with the following code:
 
 ```csharp
 using NUnit.Framework;


### PR DESCRIPTION
## Summary
NUnit template is now in dotnet CLI. 
Adding the package `dotnet new -i NUnit3.DotNetNew.Template` is no longer required since the template is pre-installed.

I also updated the version numbers and tweaked a few places the csproj names lost a period.

Contributes to https://github.com/dotnet/docs/issues/7204 
