### PR TITLE
Clarify that path is relative to source in XML Doc

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/include.md
+++ b/docs/csharp/programming-guide/xmldoc/include.md
@@ -18,7 +18,7 @@ ms.assetid: a8a70302-6196-4643-bd09-ef33f411f18f
   
 #### Parameters  
  `filename`  
- The name of the XML file containing the documentation. The file name can be qualified with a path. Enclose `filename` in single quotation marks (' ').  
+ The name of the XML file containing the documentation. The file name can be qualified with a path relative to the source code file. Enclose `filename` in single quotation marks (' ').  
   
  `tagpath`  
  The path of the tags in `filename` that leads to the tag `name`. Enclose the path in single quotation marks (' ').  


### PR DESCRIPTION
## Summary

Clarify that path is relative to source in XML documentation

**Description**

The current documentation about including an XML documentation file for code in a separate file is unclear about the path to the documentation file. According to the language spec, the documentation file is relative to the source code file. This PR makes it clear to clear any ambiguity.

Fixes #6337 
