### PR TITLE
Add Value Options to the TOC

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -346,6 +346,7 @@
 ### [F# Collection Types](fsharp/language-reference/fsharp-collection-types.md)
 ### [Lists](fsharp/language-reference/lists.md)
 ### [Options](fsharp/language-reference/options.md)
+### [Value Options](fsharp/language-reference/value-options.md)
 ### [Results](fsharp/language-reference/results.md)
 ### [Sequences](fsharp/language-reference/sequences.md)
 ### [Arrays](fsharp/language-reference/arrays.md)


### PR DESCRIPTION
They were missing. Fixes #5885