### PR TITLE
Exception handling for I/O operations

### DIFF
--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -14,14 +14,14 @@ ms.workload:
 ---
 # Handling I/O errors in .NET
 
-In addition to the exceptions that can be thrown in any method call (such as an <xref:System.OutOfMemoryException> when a system is stressed or an <xref:System.NullReferernceException> due to programmer error), .NET file system methods can throw the following exceptions:
+In addition to the exceptions that can be thrown in any method call (such as an <xref:System.OutOfMemoryException> when a system is stressed or an <xref:System.NullReferenceException> due to programmer error), .NET file system methods can throw the following exceptions:
 
 - <xref:System.IO.IOException?displayProperty=nameWithType>, the base class of all <xref:System.IO> exception types. It is thrown for errors whose return codes from the operating system don't directly map to any other exception type.
 - <xref:System.IO.FileNotFoundException?displayProperty=nameWithType>.
 - <xref:System.IO.DirectoryNotFoundException?displayProperty=nameWithType>.
 - <xref:System.IO.DriveNotFoundException??displayProperty=nameWithType>.
 - <xref:System.IO.PathTooLongException?displayProperty=nameWithType>.
-- <xref:System.OperationCancelledException?displayProperty=nameWithType>.
+- <xref:System.OperationCanceledException?displayProperty=nameWithType>.
 - <xref:System.UnauthorizedAccessException?displayProperty=nameWithType>.
 - <xref:System.ArgumentException?displayProperty=nameWithType>, which is thrown for invalid path characters on .NET Framework and on .NET Core 2.0 and previous versions.
 - <xref:System.NotSupportedException?displayProperty=nameWithType>, which is thrown for invalid colons in .NET Framework.
@@ -33,7 +33,7 @@ Because the file system is an operating system resource, I/O methods in both .NE
 
 For example, on the Windows operating system, a method call that returns an error code of `ERROR_FILE_NOT_FOUND` (or 0x02) maps to a <xref:System.IO.FileNotFoundException>, and an error code of `ERROR_PATH_NOT_FOUND` (or 0x03) maps to a <xref:System.IO.DirectoryNotFoundException>.
 
-However, the precise conditions under which the operating system returns particular error codes is often undocumented or poorly documented. As a result, unexpected exceptions can occur. For example, because you are working with a directory rather than a file, you would expect that providing an invalid directory path to the <xref:System.IO.DirectoryInfo.#ctor%6A?displayProperty=nameWithType> constructor throws a <xref:System.IO.DirectoryNotFoundException>. However, it may also throw a <xref:System.IO.FileNotFoundException>.
+However, the precise conditions under which the operating system returns particular error codes is often undocumented or poorly documented. As a result, unexpected exceptions can occur. For example, because you are working with a directory rather than a file, you would expect that providing an invalid directory path to the <xref:System.IO.DirectoryInfo.%23ctor%2A?displayProperty=nameWithType> constructor throws a <xref:System.IO.DirectoryNotFoundException>. However, it may also throw a <xref:System.IO.FileNotFoundException>.
 
 ## Exception handling in I/O operations
 
@@ -46,7 +46,7 @@ Because of this reliance on the operating system, identical exception conditions
 | <xref:System.IO.DirectoryNotFoundException> | Yes | Yes |
 | <xref:System.IO.DriveNotFoundException?> | Yes | Yes |
 | <xref:System.IO.PathTooLongException> | Yes | Yes |
-| <xref:System.OperationCancelledException> | Yes | Yes |
+| <xref:System.OperationCanceledException> | Yes | Yes |
 | <xref:System.UnauthorizedAccessException> | Yes | Yes |
 | <xref:System.ArgumentException> | .NET Core 2.0 and earlier| Yes |
 | <xref:System.NotSupportedException> | No | Yes |
@@ -63,7 +63,7 @@ In addition, starting with .NET Core 2.1, validation checks for path correctness
 
 Note that, in your exception handling code, you should always handle the <xref:System.IO.IOException> last. Otherwise, because it is the base class of all other IO exceptions, the catch blocks of derived classes will not be evaluated.
 
-In the case of an <xref:System.IO.IOException>, you can get additional error information from the [IOException.HResult](xref:System.Exception.HResult) property. To convert the HResult value to a Win32 error code, you strip out the upper 16 bits of the 32-bit value. The following table lists error codes that may be wrapped in an <xref:System.IOException>.
+In the case of an <xref:System.IO.IOException>, you can get additional error information from the [IOException.HResult](xref:System.Exception.HResult) property. To convert the HResult value to a Win32 error code, you strip out the upper 16 bits of the 32-bit value. The following table lists error codes that may be wrapped in an <xref:System.IO.IOException>.
 
 | HResult | Constant | Description |
 | --- | --- | --- |

--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -14,7 +14,7 @@ ms.workload:
 ---
 # Handling I/O errors in .NET
 
-.NET file system methods can throw the following exceptions:
+In addition to the exceptions that can be thrown in any method call (such as an <xref:System.OutOfMemoryException> when a system is stressed or an <xref:System.NullReferernceException> due to programmer error), .NET file system methods can throw the following exceptions:
 
 - <xref:System.IO.IOException?displayProperty=nameWithType>, the base class of all <xref:System.IO> exception types. It is thrown for errors whose return codes from the operating system don't directly map to any other exception type.
 - <xref:System.IO.FileNotFoundException?displayProperty=nameWithType>.
@@ -31,13 +31,13 @@ ms.workload:
 
 Because the file system is an operating system resource, I/O methods in both .NET Core and .NET Framework wrap calls to the underlying operating system. When an I/O error occurs in code executed by the operating system, the operating system returns error information to the .NET I/O method. The method then translates the error information, typically in the form of an error code, into a .NET exception type. In most cases, it does this by directly translating the error code into its corresponding exception type; it does not perform any special mapping of the error based on the context of the method call.
 
-For example, on the Windows operating system, a method call that returns an error code of `ERROR_FILE_NOT_FOUND` (or 0x2) maps to a <xref:System.IO.FileNotFoundException>, and an error code of `ERROR_PATH_NOT_FOUND` (or 0x03) maps to a <xref:System.IO.DirectoryNotFoundException>.
+For example, on the Windows operating system, a method call that returns an error code of `ERROR_FILE_NOT_FOUND` (or 0x02) maps to a <xref:System.IO.FileNotFoundException>, and an error code of `ERROR_PATH_NOT_FOUND` (or 0x03) maps to a <xref:System.IO.DirectoryNotFoundException>.
 
 However, the precise conditions under which the operating system returns particular error codes is often undocumented or poorly documented. As a result, unexpected exceptions can occur. For example, because you are working with a directory rather than a file, you would expect that providing an invalid directory path to the <xref:System.IO.DirectoryInfo.#ctor%6A?displayProperty=nameWithType> constructor throws a <xref:System.IO.DirectoryNotFoundException>. However, it may also throw a <xref:System.IO.FileNotFoundException>.
 
 ## Exception handling in I/O operations
 
-Because of this reliance on the operating system, identical exception conditions (such as the directory not found error in our example) can result in an I/O method throwing any one of the entire class of I/O exceptions. This means that, when calling I/O APIs, your code should be prepared to most or all of these exceptions, as shown in the following table:
+Because of this reliance on the operating system, identical exception conditions (such as the directory not found error in our example) can result in an I/O method throwing any one of the entire class of I/O exceptions. This means that, when calling I/O APIs, your code should be prepared to handle most or all of these exceptions, as shown in the following table:
 
 | Exception type | .NET Core | .NET Framework |
 |---|---|---|
@@ -60,6 +60,22 @@ As the base class for exceptions in the <xref:System.IO> namespace, <xref:System
 > Because <xref:System.IO.IOException> is the base class of the other exception types in the <xref:System.IO> namespace, you should handle in a `catch` block after you've handled the other I/O-related exceptions.
 
 In addition, starting with .NET Core 2.1, validation checks for path correctness (for example, to ensure that invalid characters are not present in a path) have been removed, and the runtime throws an exception mapped from an operating system error code rather than from its own validation code. The most likely exception to be thrown in this case is an <xref:System.IO.IOException>, although any other exception type could also be thrown.
+
+Note that, in your exception handling code, you should always handle the <xref:System.IO.IOException> last. Otherwise, because it is the base class of all other IO exceptions, the catch blocks of derived classes will not be evaluated.
+
+In the case of an <xref:System.IO.IOException>, you can get additional error information from the [IOException.HResult](xref:System.Exception.HResult) property. To convert the HResult value to a Win32 error code, you strip out the upper 16 bits of the 32-bit value. The following table lists error codes that may be wrapped in an <xref:System.IOException>.
+
+| HResult | Constant | Description |
+| --- | --- | --- |
+| ERROR_SHARING_VIOLATION | 32 | The file name is missing, or the file or directory is in use. |
+| ERROR_FILE_EXISTS | 80 | The file already exists. |
+| ERROR_INVALID_PARAMETER | 87 | An argument supplied to the method is invalid. |
+| ERROR_ALREADY_EXISTS | 183 | The file or directory already exists. |
+
+You can handle these using a `When` clause in a catch statement, as the following example shows.
+
+[!code-csharp[io-exception-handling](~/samples/snippets/standard/io/io-exceptions/cs/io-exceptions.cs)]
+[!code-vb[io-exception-handling](~/samples/snippets/standard/io/io-exceptions/vb/io-exceptions.vb)]
 
 ## See also
 

--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -14,7 +14,7 @@ ms.workload:
 ---
 # Handling I/O errors in .NET
 
-In both .NET Core and .NET Framework, I/O methods wrap calls to the underlying operating system. When an I/O error occurs in code executed by the operating system, operating system returns an error code to the .NET I/O method. The method then translates the error information, typically in the form of an error code, into a .NET exception type. In most cases, it does this by directly translating the error code into its corresponding exception type; it does not perform any special mapping of the error based on the context of the method call. 
+Because the file system is an operating system resource, I/O methods in both .NET Core and .NET Framework wrap calls to the underlying operating system. When an I/O error occurs in code executed by the operating system, the operating system returns an error information to the .NET I/O method. The method then translates the error information, typically in the form of an error code, into a .NET exception type. In most cases, it does this by directly translating the error code into its corresponding exception type; it does not perform any special mapping of the error based on the context of the method call. 
 
 For example, on the Windows operating system, a call to a <xref:System.IO.Directory?displayProperty=nameWithType> method such as <xref:System.IO.Directory.SetLastWriteTime%2A> with a directory path that does not exist can return either of two error codes to the method:
 

--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -56,6 +56,9 @@ Because of this reliance on the operating system, identical exception conditions
 
 As the base class for exceptions in the <xref:System.IO> namespace, <xref:System.IO.IOException> is also thrown for any error code that does not map to a predefined exception type. This means that it can be thrown by any I/O operation.
 
+> [!IMPORTANT]
+> Because <xref:System.IO.IOException> is the base class of the other exception types in the <xref:System.IO> namespace, you should handle in a `catch` block after you've handled the other I/O-related exceptions.
+
 In addition, starting with .NET Core 2.1, validation checks for path correctness (for example, to ensure that invalid characters are not present in a path) have been removed, and the runtime throws an exception mapped from an operating system error code rather than from its own validation code. The most likely exception to be thrown in this case is an <xref:System.IO.IOException>, although any other exception type could also be thrown.
 
 ## See also

--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -27,7 +27,9 @@ The method in turn translates `ERROR_FILE_NOT_FOUND` to a <xref:System.IO.FileNo
 
 Because of this reliance on the operating system, identical exception conditions (such as the directory not found error in our example) can result in an I/O method throwing one of a class of exceptions. In this case, exception handling code should be prepared to handle each exception in the class. This applies particularly to <xref:System.IO.DirectoryNotFoundException> and <xref:System.IO.FileNotFoundException>.
 
-For example, the following `GetTextContents` method returns a block of memory that contains the contents of a text file. 
+For example, the following `IOLibrary.CountSubdirectories` method returns the number of subdirectories in a particular directory. Note that even though the method works with a directory, it handles both a <xref:System.IO.DirectoryNotFoundException> and a <xref:System.IO.FileNotFoundException>, since the runtime can throw either exception if a directory does not exist.
+
+
 
 
 

--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -14,22 +14,53 @@ ms.workload:
 ---
 # Handling I/O errors in .NET
 
-Because the file system is an operating system resource, I/O methods in both .NET Core and .NET Framework wrap calls to the underlying operating system. When an I/O error occurs in code executed by the operating system, the operating system returns an error information to the .NET I/O method. The method then translates the error information, typically in the form of an error code, into a .NET exception type. In most cases, it does this by directly translating the error code into its corresponding exception type; it does not perform any special mapping of the error based on the context of the method call. 
+.NET file system methods can throw the following exceptions:
 
-For example, on the Windows operating system, a call to a <xref:System.IO.Directory?displayProperty=nameWithType> method such as <xref:System.IO.Directory.SetLastWriteTime%2A> with a directory path that does not exist can return either of two error codes to the method:
+- <xref:System.IO.IOException?displayProperty=nameWithType>, the base class of all <xref:System.IO> exception types. It is thrown for errors whose return codes from the operating system don't directly map to any other exception type.
+- <xref:System.IO.FileNotFoundException?displayProperty=nameWithType>.
+- <xref:System.IO.DirectoryNotFoundException?displayProperty=nameWithType>.
+- <xref:System.IO.DriveNotFoundException??displayProperty=nameWithType>.
+- <xref:System.IO.PathTooLongException?displayProperty=nameWithType>.
+- <xref:System.OperationCancelledException?displayProperty=nameWithType>.
+- <xref:System.UnauthorizedAccessException?displayProperty=nameWithType>.
+- <xref:System.ArgumentException?displayProperty=nameWithType>, which is thrown for invalid path characters on .NET Framework and on .NET Core 2.0 and previous versions.
+- <xref:System.NotSupportedException?displayProperty=nameWithType>, which is thrown for invalid colons in .NET Framework.
+- <xref:System.Security.SecurityException?displayProperty=nameWithType>, which is thrown for applications running in limited trust that lack the necessary permissions on .NET Framework only. (Full trust is the default on .NET Framework.)
 
-```cpp
-ERROR_FILE_NOT_FOUND = 0x2;
-ERROR_PATH_NOT_FOUND = 0x3;
-```
+## Mapping error codes to exceptions
 
-The method in turn translates `ERROR_FILE_NOT_FOUND` to a <xref:System.IO.FileNotFoundException> and `ERROR_PATH_NOT_FOUND` to <xref:System.IO.DirectoryNotFoundException>. It does not perform any special mapping of `ERROR_FILE_NOT_FOUND` to <xref:System.IO.DirectoryNotFoundException> because the error relates to a bad directory path rather than a bad file path.
+Because the file system is an operating system resource, I/O methods in both .NET Core and .NET Framework wrap calls to the underlying operating system. When an I/O error occurs in code executed by the operating system, the operating system returns error information to the .NET I/O method. The method then translates the error information, typically in the form of an error code, into a .NET exception type. In most cases, it does this by directly translating the error code into its corresponding exception type; it does not perform any special mapping of the error based on the context of the method call.
 
-Because of this reliance on the operating system, identical exception conditions (such as the directory not found error in our example) can result in an I/O method throwing one of a class of exceptions. In this case, exception handling code should be prepared to handle each exception in the class. This applies particularly to <xref:System.IO.DirectoryNotFoundException> and <xref:System.IO.FileNotFoundException>.
+For example, on the Windows operating system, a method call that returns an error code of `ERROR_FILE_NOT_FOUND` (or 0x2) maps to a <xref:System.IO.FileNotFoundException>, and an error code of `ERROR_PATH_NOT_FOUND` (or 0x03) maps to a <xref:System.IO.DirectoryNotFoundException>.
 
-For example, the following `IOLibrary.CountSubdirectories` method returns the number of subdirectories in a particular directory. Note that even though the method works with a directory, it handles both a <xref:System.IO.DirectoryNotFoundException> and a <xref:System.IO.FileNotFoundException>, since the runtime can throw either exception if a directory does not exist.
+However, the precise conditions under which the operating system returns particular error codes is often undocumented or poorly documented. As a result, unexpected exceptions can occur. For example, because you are working with a directory rather than a file, you would expect that providing an invalid directory path to the <xref:System.IO.DirectoryInfo.#ctor%6A?displayProperty=nameWithType> constructor throws a <xref:System.IO.DirectoryNotFoundException>. However, it may also throw a <xref:System.IO.FileNotFoundException>.
 
+## Exception handling in I/O operations
 
+Because of this reliance on the operating system, identical exception conditions (such as the directory not found error in our example) can result in an I/O method throwing any one of the entire class of I/O exceptions. This means that, when calling I/O APIs, your code should be prepared to most or all of these exceptions, as shown in the following table:
 
+| Exception type | .NET Core | .NET Framework |
+|---|---|---|
+| <xref:System.IO.IOException> | Yes | Yes |
+| <xref:System.IO.FileNotFoundException> | Yes | Yes |
+| <xref:System.IO.DirectoryNotFoundException> | Yes | Yes |
+| <xref:System.IO.DriveNotFoundException?> | Yes | Yes |
+| <xref:System.IO.PathTooLongException> | Yes | Yes |
+| <xref:System.OperationCancelledException> | Yes | Yes |
+| <xref:System.UnauthorizedAccessException> | Yes | Yes |
+| <xref:System.ArgumentException> | .NET Core 2.0 and earlier| Yes |
+| <xref:System.NotSupportedException> | No | Yes |
+| <xref:System.Security.SecurityException> | No | Limited trust only |
 
+## Handling IOException
 
+As the base class for exceptions in the <xref:System.IO> namespace, <xref:System.IO.IOException> is also thrown for any error code that does not map to a predefined exception type. This means that it can be thrown by any I/O operation.
+
+In addition, starting with .NET Core 2.1, validation checks for path correctness (for example, to ensure that invalid characters are not present in a path) have been removed, and the runtime throws an exception mapped from an operating system error code rather than from its own validation code. The most likely exception to be thrown in this case is an <xref:System.IO.IOException>, although any other exception type could also be thrown.
+
+## See also
+
+- [Handling and throwing exceptions in .NET](../exceptions/index.md)
+- [Exception handling (Task Parallel Library)](../parallel-programming/exception-handling-task-parallel-library.md)
+- [Best practices for exceptions](../exceptions/best-practices-for-exceptions.md)
+- [How to use specific exceptions in a catch block](../exceptions/how-to-use-specific-exceptions-in-a-catch-block.md)

--- a/docs/standard/io/handling-io-errors.md
+++ b/docs/standard/io/handling-io-errors.md
@@ -1,0 +1,33 @@
+---
+title: "Handling I/O errors in .NET"
+ms.date: "08/27/2018"
+ms.technology: dotnet-standard
+ms.topic: "article"
+helpviewer_keywords: 
+  - "I/O, exception handling"
+  - "I/O, errors"
+author: "rpetrusha"
+ms.author: "ronpet"
+ms.workload: 
+  - "dotnet"
+  - "dotnetcore"
+---
+# Handling I/O errors in .NET
+
+In both .NET Core and .NET Framework, I/O methods wrap calls to the underlying operating system. When an I/O error occurs in code executed by the operating system, operating system returns an error code to the .NET I/O method. The method then translates the error information, typically in the form of an error code, into a .NET exception type. In most cases, it does this by directly translating the error code into its corresponding exception type; it does not perform any special mapping of the error based on the context of the method call. 
+
+For example, on the Windows operating system, a call to a <xref:System.IO.Directory?displayProperty=nameWithType> method such as <xref:System.IO.Directory.SetLastWriteTime%2A> with a directory path that does not exist can return either of two error codes to the method:
+
+```cpp
+ERROR_FILE_NOT_FOUND = 0x2;
+ERROR_PATH_NOT_FOUND = 0x3;
+```
+
+The method in turn translates `ERROR_FILE_NOT_FOUND` to a <xref:System.IO.FileNotFoundException> and `ERROR_PATH_NOT_FOUND` to <xref:System.IO.DirectoryNotFoundException>. It does not perform any special mapping of `ERROR_FILE_NOT_FOUND` to <xref:System.IO.DirectoryNotFoundException> because the error relates to a bad directory path rather than a bad file path.
+
+Because of this reliance on the operating system, identical exception conditions (such as the directory not found error in our example) can result in an I/O method throwing one of a class of exceptions. In this case, exception handling code should be prepared to handle each exception in the class. This applies particularly to <xref:System.IO.DirectoryNotFoundException> and <xref:System.IO.FileNotFoundException>.
+
+For example, the following `GetTextContents` method returns a block of memory that contains the contents of a text file. 
+
+
+

--- a/docs/standard/io/index.md
+++ b/docs/standard/io/index.md
@@ -35,6 +35,8 @@ For path naming conventions and the ways to express a file path for Windows syst
   
 -   <xref:System.IO.Path> - provides methods and properties for processing directory strings in a cross-platform manner.  
   
+ You should always provide robust exception handling when calling filesystem methods. For more information, see [Handling I/O errors](handling-io-errors.md).
+ 
  In addition to using these classes, Visual Basic users can use the methods and properties provided by the <xref:Microsoft.VisualBasic.FileIO.FileSystem?displayProperty=nameWithType> class for file I/O.  
   
  See [How to: Copy Directories](../../../docs/standard/io/how-to-copy-directories.md), [How to: Create a Directory Listing](https://msdn.microsoft.com/library/4d2772b1-b991-4532-a8a6-6ef733277e69), and [How to: Enumerate Directories and Files](../../../docs/standard/io/how-to-enumerate-directories-and-files.md).  

--- a/docs/standard/io/toc.md
+++ b/docs/standard/io/toc.md
@@ -14,6 +14,7 @@
 ### [Composing Streams](composing-streams.md)
 ### [How to: Convert Between .NET Framework Streams and Windows Runtime Streams](how-to-convert-between-dotnet-streams-and-winrt-streams.md)
 ## [Asynchronous File I/O](asynchronous-file-i-o.md)
+## [Handling I/O errors](handling-io-errors.md)
 ## [Isolated Storage](isolated-storage.md)
 ### [Types of Isolation](types-of-isolation.md)
 ### [How to: Obtain Stores for Isolated Storage](how-to-obtain-stores-for-isolated-storage.md)


### PR DESCRIPTION
## Exception handling for I/O operations

Fixes #6431 

See also #336

[internal review link](https://review.docs.microsoft.com/en-us/dotnet/standard/io/handling-io-errors?branch=pr-en-us-7385)

//cc @JeremyKuhne @jpreese 