### PR TITLE
Revised links to Overloadable operators article

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0019.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0019.md
@@ -13,7 +13,7 @@ Operator 'operator' cannot be applied to operands of type 'type' and 'type'
   
  A binary operator is applied to data types that do not support it. For example, you cannot use the [&#124;&#124;](../../../csharp/language-reference/operators/conditional-or-operator.md) operator on strings, you cannot use [+](../../../csharp/language-reference/operators/addition-operator.md) , [-](../../../csharp/language-reference/operators/subtraction-operator.md) , [\<](../../../csharp/language-reference/operators/less-than-operator.md) , or [>](../../../csharp/language-reference/operators/greater-than-operator.md) operators on [bool](../../../csharp/language-reference/keywords/bool.md) variables, and you cannot use the [==](../../../csharp/language-reference/operators/equality-comparison-operator.md) operator with a `struct` type unless the type explicitly overloads that operator.  
   
- If you encounter this error with a class type, it is because the class does not overload the operator. For more information, see [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).  
+ If you encounter this error with a class type, it is because the class does not overload the operator. For more information, see the [`operator` keyword](../../../csharp/language-reference/keywords/operator.md) article and [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).  
   
 ## Example
 

--- a/docs/csharp/language-reference/compiler-messages/cs0019.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0019.md
@@ -13,7 +13,7 @@ Operator 'operator' cannot be applied to operands of type 'type' and 'type'
   
  A binary operator is applied to data types that do not support it. For example, you cannot use the [&#124;&#124;](../../../csharp/language-reference/operators/conditional-or-operator.md) operator on strings, you cannot use [+](../../../csharp/language-reference/operators/addition-operator.md) , [-](../../../csharp/language-reference/operators/subtraction-operator.md) , [\<](../../../csharp/language-reference/operators/less-than-operator.md) , or [>](../../../csharp/language-reference/operators/greater-than-operator.md) operators on [bool](../../../csharp/language-reference/keywords/bool.md) variables, and you cannot use the [==](../../../csharp/language-reference/operators/equality-comparison-operator.md) operator with a `struct` type unless the type explicitly overloads that operator.  
   
- If you encounter this error with a class type, it is because the class does not overload the operator. For more information, see the [`operator` keyword](../../../csharp/language-reference/keywords/operator.md) article and [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).  
+ If you encounter this error with a class type, it is because the class does not overload the operator. For more information, see the [operator](../../../csharp/language-reference/keywords/operator.md) keyword article and [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).  
   
 ## Example
 

--- a/docs/csharp/language-reference/compiler-messages/cs0563.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0563.md
@@ -10,7 +10,7 @@ ms.assetid: c1561e4e-7f00-41ff-abff-b8228aee66a4
 # Compiler Error CS0563
 One of the parameters of a binary operator must be the containing type  
   
- The method declaration for an [operator overload](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) must follow certain guidelines.  
+The method declaration for an [operator overload](../keywords/operator.md) must follow certain guidelines.  
   
 ## Example  
  The following sample generates CS0563:  

--- a/docs/csharp/misc/cs0215.md
+++ b/docs/csharp/misc/cs0215.md
@@ -10,7 +10,7 @@ ms.assetid: 2060440d-be22-4c10-8b26-43b08b615447
 # Compiler Error CS0215
 The return type of operator True or False must be bool  
   
- User-defined [true](../../csharp/language-reference/keywords/true.md) and [false](../../csharp/language-reference/keywords/false.md) operators must have a return type of [bool](../../csharp/language-reference/keywords/bool.md). For more information, see [Overloadable Operators](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).  
+ User-defined [true](../../csharp/language-reference/keywords/true-operator.md) and [false](../../csharp/language-reference/keywords/false-operator.md) operators must have a return type of [bool](../../csharp/language-reference/keywords/bool.md). For more information, see [Overloadable Operators](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) and the [operator](../../csharp/language-reference/keywords/operator.md) keyword article.  
   
  The following sample generates CS0215:  
   

--- a/docs/csharp/misc/cs0217.md
+++ b/docs/csharp/misc/cs0217.md
@@ -49,7 +49,8 @@ public class MyClass
    }  
 }  
 ```  
-  
-## See Also
+
+## See also
 
 - [Overloadable Operators](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md)
+- [`operator` keyword](../../csharp/language-reference/keywords/operator.md)

--- a/docs/csharp/misc/cs0562.md
+++ b/docs/csharp/misc/cs0562.md
@@ -10,7 +10,7 @@ ms.assetid: dceecce5-90ce-4554-820c-f4c06b2b8258
 # Compiler Error CS0562
 The parameter of a unary operator must be the containing type  
   
-The method declaration for an operator overload must follow certain guidelines. For more information, see the [`operator` keyword](../../csharp/language-reference/keywords/operator.md) article and [Operator Overloading Sample](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2008/57198473(v=vs.90)).
+The method declaration for an operator overload must follow certain guidelines. For more information, see the [operator](../../csharp/language-reference/keywords/operator.md) keyword article and [Operator Overloading Sample](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2008/57198473(v=vs.90)).
   
 ## Example  
  The following sample generates CS0562:  

--- a/docs/csharp/misc/cs0562.md
+++ b/docs/csharp/misc/cs0562.md
@@ -10,7 +10,7 @@ ms.assetid: dceecce5-90ce-4554-820c-f4c06b2b8258
 # Compiler Error CS0562
 The parameter of a unary operator must be the containing type  
   
- The method declaration for an operator overload must follow certain guidelines. For more information, see [Overloadable Operators](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) and [Operator Overloading Sample](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2008/57198473(v=vs.90)).
+The method declaration for an operator overload must follow certain guidelines. For more information, see the [`operator` keyword](../../csharp/language-reference/keywords/operator.md) article and [Operator Overloading Sample](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2008/57198473(v=vs.90)).
   
 ## Example  
  The following sample generates CS0562:  

--- a/docs/csharp/misc/cs1020.md
+++ b/docs/csharp/misc/cs1020.md
@@ -10,7 +10,7 @@ ms.assetid: e8860769-a847-4248-a37b-77a59863467c
 # Compiler Error CS1020
 Overloadable binary operator expected  
   
- An attempt was made to define an [operator overload](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md), but the operator was not a binary operator, which takes two parameters.  
+ An attempt was made to define an [operator overload](../../csharp/language-reference/keywords/operator.md), but the operator was not an overloadable binary operator, which takes two parameters. For the list of overloadable operators, see [Overloadable operators](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).
   
  The following sample generates CS1020:  
   

--- a/docs/csharp/misc/cs1534.md
+++ b/docs/csharp/misc/cs1534.md
@@ -10,7 +10,7 @@ ms.assetid: afb28c3a-a74c-4e47-b016-9e3245a5a1b1
 # Compiler Error CS1534
 Overloaded binary operator 'operator' takes two parameters  
   
- The definition of a binary [overloadable operator](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) must take two parameters.  
+ The definition of a binary [operator](../../csharp/language-reference/keywords/operator.md) must take two parameters.  
   
  The following sample generates CS1534:  
   

--- a/docs/csharp/misc/cs1535.md
+++ b/docs/csharp/misc/cs1535.md
@@ -10,7 +10,7 @@ ms.assetid: 19f41e78-9aea-4575-abd0-60ddb927276f
 # Compiler Error CS1535
 Overloaded unary operator 'operator' takes one parameter  
   
- The definition of a unary [overloadable operator](../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) must take one parameter.  
+ The definition of a unary [operator](../../csharp/language-reference/keywords/operator.md) must take one parameter.  
   
 ## Example  
  The following sample generates CS1535:  

--- a/docs/csharp/programming-guide/statements-expressions-operators/operators.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/operators.md
@@ -157,7 +157,7 @@ a = (b = c);
 |`a = (b + c) * (d - e)`|a, b, c, +, d, e, -, *, =|  
   
 ## Operator Overloading  
- You can change the behavior of operators for custom classes and structs. This process is referred to as *operator overloading*. For more information, see [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) and the [`operator` keyword](../../../csharp/language-reference/keywords/operator.md) article.  
+ You can change the behavior of operators for custom classes and structs. This process is referred to as *operator overloading*. For more information, see [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) and the [operator](../../../csharp/language-reference/keywords/operator.md) keyword article.  
   
 ## Related Sections  
  For more information, see [Operator Keywords](../../../csharp/language-reference/keywords/operator-keywords.md) and [C# Operators](../../../csharp/language-reference/operators/index.md).  

--- a/docs/csharp/programming-guide/statements-expressions-operators/operators.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/operators.md
@@ -157,7 +157,7 @@ a = (b = c);
 |`a = (b + c) * (d - e)`|a, b, c, +, d, e, -, *, =|  
   
 ## Operator Overloading  
- You can change the behavior of operators for custom classes and structs. This process is referred to as *operator overloading*. For more information, see [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md).  
+ You can change the behavior of operators for custom classes and structs. This process is referred to as *operator overloading*. For more information, see [Overloadable Operators](../../../csharp/programming-guide/statements-expressions-operators/overloadable-operators.md) and the [`operator` keyword](../../../csharp/language-reference/keywords/operator.md) article.  
   
 ## Related Sections  
  For more information, see [Operator Keywords](../../../csharp/language-reference/keywords/operator-keywords.md) and [C# Operators](../../../csharp/language-reference/operators/index.md).  


### PR DESCRIPTION
PR #7283 moved guidelines for operator overloading from the [Overloadable operators](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/overloadable-operators) article to the [operator](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/operator) keyword article. However, it didn't revised existing links to the "Overloadable operators" article. This PR fixes that.
