### PR TITLE
Adding missing comma in ASM_CACHE_FLAGS

### DIFF
--- a/docs/framework/unmanaged-api/fusion/asm-cache-flags-enumeration.md
+++ b/docs/framework/unmanaged-api/fusion/asm-cache-flags-enumeration.md
@@ -27,7 +27,7 @@ typedef enum {
     ASM_CACHE_ZAP       = 0x01,  
     ASM_CACHE_GAC       = 0x02,  
     ASM_CACHE_DOWNLOAD  = 0x04,  
-    ASM_CACHE_ROOT      = 0x08  
+    ASM_CACHE_ROOT      = 0x08,  
     ASM_CACHE_ROOT_EX   = 0x80  
 } ASM_CACHE_FLAGS;  
 ```  


### PR DESCRIPTION
## Summary

Adding missing comma in ASM_CACHE_FLAGS.

Fixes #Issue_Number (if available)
