### PR TITLE
Add logger example

### DIFF
--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -246,7 +246,7 @@ Run the tests in the `test1` project:
 
 `dotnet test ~/projects/test1/test1.csproj`
 
-Run the tests in the project in the current directory and generate test results file in the trx format:
+Run the tests in the project in the current directory and generate a test results file in the trx format:
 
 `dotnet test --logger:trx`
 

--- a/docs/core/tools/dotnet-test.md
+++ b/docs/core/tools/dotnet-test.md
@@ -246,6 +246,10 @@ Run the tests in the `test1` project:
 
 `dotnet test ~/projects/test1/test1.csproj`
 
+Run the tests in the project in the current directory and generate test results file in the trx format:
+
+`dotnet test --logger:trx`
+
 ## Filter option details
 
 `--filter <EXPRESSION>`


### PR DESCRIPTION
## Summary
Some confusion came up on how to use the `dotnet test` logger option.

Adding logger example to examples section.
