### PR TITLE
fix office xref links

### DIFF
--- a/_zip/missingapi.yml
+++ b/_zip/missingapi.yml
@@ -1,4 +1,4 @@
-### YamlMime:XRefMap
+﻿### YamlMime:XRefMap
 hrefUpdated: true
 references:
 - uid: System.Xml.Linq.XElement.Elements*
@@ -583,3 +583,21 @@ references:
   name.vb: Microsoft.Office.Interop.Excel
   fullName: Microsoft.Office.Interop.Excel
   fullName.vb: Microsoft.Office.Interop.Excel
+- uid: Microsoft.Office.Interop.Excel.Range.Range*
+  href: https://docs.microsoft.com/dotnet/api/microsoft.office.interop.excel.range.range
+  name: Range
+  name.vb: Range
+  fullName: Microsoft.Office.Interop.Excel.Range.Range
+  fullName.vb: Microsoft.Office.Interop.Excel.Range.Range
+- uid: Microsoft.Office.Interop.Excel.Range.AutoFormat*
+  href: https://docs.microsoft.com/dotnet/api/microsoft.office.interop.excel.range.autoformat
+  name: AutoFormat
+  name.vb: AutoFormat
+  fullName: Microsoft.Office.Interop.Excel.Range.AutoFormat
+  fullName.vb: Microsoft.Office.Interop.Excel.Range.AutoFormat
+- uid: Microsoft.Office.Interop.Excel.XlRangeAutoFormat
+  href: https://docs.microsoft.com/dotnet/api/microsoft.office.interop.excel.xlrangeautoformat
+  name: XlRangeAutoFormat
+  name.vb: XlRangeAutoFormat
+  fullName: Microsoft.Office.Interop.Excel.XlRangeAutoFormat
+  fullName.vb: Microsoft.Office.Interop.Excel.XlRangeAutoFormat

--- a/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
+++ b/docs/csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md
@@ -95,7 +95,7 @@ Optional parameters in ExampleMethod
 ## COM Interfaces  
  Named and optional arguments, along with support for dynamic objects and other enhancements, greatly improve interoperability with COM APIs, such as Office Automation APIs.  
   
- For example, the [AutoFormat](<xref:Microsoft.Office.Interop.Excel.Range.AutoFormat%2A>) method in the Microsoft Office Excel [Range](<xref:Microsoft.Office.Interop.Excel.Range>) interface has seven parameters, all of which are optional. These parameters are shown in the following illustration.  
+ For example, the <xref:Microsoft.Office.Interop.Excel.Range.AutoFormat%2A> method in the Microsoft Office Excel <xref:Microsoft.Office.Interop.Excel.Range> interface has seven parameters, all of which are optional. These parameters are shown in the following illustration.  
   
  ![IntelliSense Quick Info for the AutoFormat method.](../../../csharp/programming-guide/classes-and-structs/media/autoformat_parameters.png "AutoFormat_Parameters")  
 AutoFormat parameters  

--- a/docs/csharp/programming-guide/interop/how-to-access-office-onterop-objects.md
+++ b/docs/csharp/programming-guide/interop/how-to-access-office-onterop-objects.md
@@ -21,7 +21,7 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
 [!INCLUDE[note_settings_general](~/includes/note-settings-general-md.md)]  
   
-### To create a new console application  
+## To create a new console application  
   
 1.  Start Visual Studio.  
   
@@ -39,7 +39,7 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
      The new project appears in **Solution Explorer**.  
   
-### To add references  
+## To add references  
   
 1.  In **Solution Explorer**, right-click your project's name and then click **Add Reference**. The **Add Reference** dialog box appears.  
   
@@ -47,7 +47,7 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
 3.  Click **OK**.  
   
-### To add necessary using directives  
+## To add necessary using directives  
   
 1.  In **Solution Explorer**, right-click the **Program.cs** file and then click **View Code**.  
   
@@ -55,7 +55,7 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
      [!code-csharp[csProgGuideOfficeHowTo#1](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_1.cs)]  
   
-### To create a list of bank accounts  
+## To create a list of bank accounts  
   
 1.  Paste the following class definition into **Program.cs**, under the `Program` class.  
   
@@ -65,11 +65,11 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
      [!code-csharp[csProgGuideOfficeHowTo#3](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_3.cs)]  
   
-### To declare a method that exports account information to Excel  
+## To declare a method that exports account information to Excel  
   
 1.  Add the following method to the `Program` class to set up an Excel worksheet.  
   
-     Method [Add](<xref:Microsoft.Office.Interop.Excel.Workbooks.Add%2A>) has an optional parameter for specifying a particular template. Optional parameters, new in [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)], enable you to omit the argument for that parameter if you want to use the parameter's default value. Because no argument is sent in the following code, `Add` uses the default template and creates a new workbook. The equivalent statement in earlier versions of C# requires a placeholder argument: `ExcelApp.Workbooks.Add(Type.Missing)`.  
+     Method <xref:Microsoft.Office.Interop.Excel.Workbooks.Add%2A> has an optional parameter for specifying a particular template. Optional parameters, new in [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)], enable you to omit the argument for that parameter if you want to use the parameter's default value. Because no argument is sent in the following code, `Add` uses the default template and creates a new workbook. The equivalent statement in earlier versions of C# requires a placeholder argument: `ExcelApp.Workbooks.Add(Type.Missing)`.  
   
      [!code-csharp[csProgGuideOfficeHowTo#4](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_4.cs)]  
   
@@ -85,13 +85,13 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
      [!code-csharp[csProgGuideOfficeHowTo#13](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_7.cs)]  
   
-     Earlier versions of C# require explicit casting for these operations because `ExcelApp.Columns[1]` returns an `Object`, and `AutoFit` is an Excel [Range](<xref:Microsoft.Office.Interop.Excel.Range>) method. The following lines show the casting.  
+     Earlier versions of C# require explicit casting for these operations because `ExcelApp.Columns[1]` returns an `Object`, and `AutoFit` is an Excel <xref:Microsoft.Office.Interop.Excel.Range> method. The following lines show the casting.  
   
      [!code-csharp[csProgGuideOfficeHowTo#14](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_8.cs)]  
   
      [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)], and later versions, converts the returned `Object` to `dynamic` automatically if the assembly is referenced by the [/link](../../../csharp/language-reference/compiler-options/link-compiler-option.md) compiler option or, equivalently, if the Excel **Embed Interop Types** property is set to true. True is the default value for this property.  
   
-### To run the project  
+## To run the project  
   
 1.  Add the following line at the end of `Main`.  
   
@@ -101,11 +101,11 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
      An Excel worksheet appears that contains the data from the two accounts.  
   
-### To add a Word document  
+## To add a Word document  
   
 1.  To illustrate additional ways in which [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)], and later versions, enhances Office programming, the following code opens a Word application and creates an icon that links to the Excel worksheet.  
   
-     Paste method `CreateIconInWordDoc`, provided later in this step, into the `Program` class. `CreateIconInWordDoc` uses named and optional arguments to reduce the complexity of the method calls to [Add](<xref:Microsoft.Office.Interop.Word.Documents.Add%2A>) and [PasteSpecial](<xref:Microsoft.Office.Interop.Word.Selection.PasteSpecial%2A>). These calls incorporate two other new features introduced in [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)] that simplify calls to COM methods that have reference parameters. First, you can send arguments to the reference parameters as if they were value parameters. That is, you can send values directly, without creating a variable for each reference parameter. The compiler generates temporary variables to hold the argument values, and discards the variables when you return from the call. Second, you can omit the `ref` keyword in the argument list.  
+     Paste method `CreateIconInWordDoc`, provided later in this step, into the `Program` class. `CreateIconInWordDoc` uses named and optional arguments to reduce the complexity of the method calls to <xref:Microsoft.Office.Interop.Word.Documents.Add%2A> and <xref:Microsoft.Office.Interop.Word.Selection.PasteSpecial%2A>. These calls incorporate two other new features introduced in [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)] that simplify calls to COM methods that have reference parameters. First, you can send arguments to the reference parameters as if they were value parameters. That is, you can send values directly, without creating a variable for each reference parameter. The compiler generates temporary variables to hold the argument values, and discards the variables when you return from the call. Second, you can omit the `ref` keyword in the argument list.  
   
      The `Add` method has four reference parameters, all of which are optional. In [!INCLUDE[csharp_dev10_long](~/includes/csharp-dev10-long-md.md)], or later versions, you can omit arguments for any or all of the parameters if you want to use their default values. In [!INCLUDE[csharp_orcas_long](~/includes/csharp-orcas-long-md.md)] and earlier versions, an argument must be provided for each parameter, and the argument must be a variable because the parameters are reference parameters.  
   
@@ -129,7 +129,7 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
      A Word document appears that contains an icon. Double-click the icon to bring the worksheet to the foreground.  
   
-### To set the Embed Interop Types property  
+## To set the Embed Interop Types property  
   
 1.  Additional enhancements are possible when you call a COM type that does not require a primary interop assembly (PIA) at run time. Removing the dependency on PIAs results in version independence and easier deployment. For more information about the advantages of programming without PIAs, see [Walkthrough: Embedding Types from Managed Assemblies](../../../csharp/programming-guide/concepts/assemblies-gac/walkthrough-embedding-types-from-managed-assemblies-in-visual-studio.md).  
   
@@ -145,17 +145,17 @@ Visual C# has features that simplify access to Office API objects. The new featu
   
 4.  Find **Embed Interop Types** in the list of properties, and change its value to **False**. Equivalently, you can compile by using the [/reference](../../../csharp/language-reference/compiler-options/reference-compiler-option.md) compiler option instead of [/link](../../../csharp/language-reference/compiler-options/link-compiler-option.md) at a command prompt.  
   
-### To add additional formatting to the table  
+## To add additional formatting to the table  
   
 1.  Replace the two calls to `AutoFit` in `DisplayInExcel` with the following statement.  
   
      [!code-csharp[csProgGuideOfficeHowTo#15](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_14.cs)]  
   
-     The [AutoFormat](<xref:Microsoft.Office.Interop.Excel.Range.AutoFormat%2A>) method has seven value parameters, all of which are optional. Named and optional arguments enable you to provide arguments for none, some, or all of them. In the previous statement, an argument is supplied for only one of the parameters, `Format`. Because `Format` is the first parameter in the parameter list, you do not have to provide the parameter name. However, the statement might be easier to understand if the parameter name is included, as is shown in the following code.  
+     The <xref:Microsoft.Office.Interop.Excel.Range.AutoFormat%2A> method has seven value parameters, all of which are optional. Named and optional arguments enable you to provide arguments for none, some, or all of them. In the previous statement, an argument is supplied for only one of the parameters, `Format`. Because `Format` is the first parameter in the parameter list, you do not have to provide the parameter name. However, the statement might be easier to understand if the parameter name is included, as is shown in the following code.  
   
      [!code-csharp[csProgGuideOfficeHowTo#16](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-access-office-onterop-objects_15.cs)]  
   
-2.  Press CTRL+F5 to see the result. Other formats are listed in the [XlRangeAutoFormat](<xref:Microsoft.Office.Interop.Excel.XlRangeAutoFormat>) enumeration.  
+2.  Press CTRL+F5 to see the result. Other formats are listed in the <xref:Microsoft.Office.Interop.Excel.XlRangeAutoFormat> enumeration.  
   
 3.  Compare the statement in step 1 with the following code, which shows the arguments that are required in [!INCLUDE[csharp_orcas_long](~/includes/csharp-orcas-long-md.md)] or earlier versions.  
   

--- a/docs/csharp/programming-guide/interop/how-to-use-indexed-properties-in-com-interop-rogramming.md
+++ b/docs/csharp/programming-guide/interop/how-to-use-indexed-properties-in-com-interop-rogramming.md
@@ -10,7 +10,7 @@ ms.assetid: 756bfc1e-7c28-4d4d-b114-ac9288c73882
 # How to: Use Indexed Properties in COM Interop Programming (C# Programming Guide)
 *Indexed properties* improve the way in which COM properties that have parameters are consumed in C# programming. Indexed properties work together with other features in Visual C#, such as [named and optional arguments](../../../csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md), a new type ([dynamic](../../../csharp/language-reference/keywords/dynamic.md)), and [embedded type information](../../../csharp/programming-guide/concepts/assemblies-gac/walkthrough-embedding-types-from-managed-assemblies-in-visual-studio.md), to enhance Microsoft Office programming.  
   
- In earlier versions of C#, methods are accessible as properties only if the `get` method has no parameters and the `set` method has one and only one value parameter. However, not all COM properties meet those restrictions. For example, the Excel [Range](<xref:Microsoft.Office.Interop.Excel.Range.Range%2A>) property has a `get` accessor that requires a parameter for the name of the range. In the past, because you could not access the `Range` property directly, you had to use the `get_Range` method instead, as shown in the following example.  
+ In earlier versions of C#, methods are accessible as properties only if the `get` method has no parameters and the `set` method has one and only one value parameter. However, not all COM properties meet those restrictions. For example, the Excel <xref:Microsoft.Office.Interop.Excel.Range.Range%2A> property has a `get` accessor that requires a parameter for the name of the range. In the past, because you could not access the `Range` property directly, you had to use the `get_Range` method instead, as shown in the following example.  
   
  [!code-csharp[csProgGuideIndexedProperties#1](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-use-indexed-properties-in-com-interop-rogramming_1.cs)]  
   
@@ -21,7 +21,7 @@ ms.assetid: 756bfc1e-7c28-4d4d-b114-ac9288c73882
 > [!NOTE]
 >  The previous example also uses the [optional arguments](../../../csharp/programming-guide/classes-and-structs/named-and-optional-arguments.md) feature, which enables you to omit `Type.Missing`.  
   
- Similarly to set the value of the `Value` property of a [Range](<xref:Microsoft.Office.Interop.Excel.Range>) object in Visual C# 2008 and earlier, two arguments are required. One supplies an argument for an optional parameter that specifies the type of the range value. The other supplies the value for the `Value` property. The following examples illustrate these techniques. Both set the value of the A1 cell to `Name`.
+ Similarly to set the value of the `Value` property of a <xref:Microsoft.Office.Interop.Excel.Range> object in Visual C# 2008 and earlier, two arguments are required. One supplies an argument for an optional parameter that specifies the type of the range value. The other supplies the value for the `Value` property. The following examples illustrate these techniques. Both set the value of the A1 cell to `Name`.
   
  [!code-csharp[csProgGuideIndexedProperties#3](../../../csharp/programming-guide/interop/codesnippet/CSharp/how-to-use-indexed-properties-in-com-interop-rogramming_3.cs)]  
   


### PR DESCRIPTION
Fix build warnings. I'm adding the broken xref links to the office zip file and changing the xref links on the topics to the auto-generated link text. I've posted a question to the engineering team about why the office xref links don't work for us yet since they are in the .NET API browser now.