### PR TITLE
false is not a function

### DIFF
--- a/docs/standard/security/security-and-race-conditions.md
+++ b/docs/standard/security/security-and-race-conditions.md
@@ -32,7 +32,7 @@ End Sub
 ```csharp  
 void Dispose()   
 {  
-    if( myObj != null )   
+    if (myObj != null)   
     {  
         Cleanup(myObj);  
         myObj = null;  
@@ -53,7 +53,7 @@ Sub SomeSecureFunction()
     If SomeDemandPasses() Then  
         fCallersOk = True  
         DoOtherWork()  
-        fCallersOk = False()  
+        fCallersOk = False  
     End If  
 End Sub  
   
@@ -70,16 +70,16 @@ End Sub
 ```csharp  
 void SomeSecureFunction()   
 {  
-    if(SomeDemandPasses())   
+    if (SomeDemandPasses())   
     {  
         fCallersOk = true;  
         DoOtherWork();  
-        fCallersOk = false();  
+        fCallersOk = false;  
     }  
 }  
 void DoOtherWork()   
 {  
-    if( fCallersOK )   
+    if (fCallersOK)   
     {  
         DoSomethingTrusted();  
     }  


### PR DESCRIPTION
false is not a function - so removed the brackets `()` after it. Also corrected the spacing around if condition clauses.
