### PR TITLE
Fixed link formatting

### DIFF
--- a/docs/visual-basic/language-reference/operators/mod-operator.md
+++ b/docs/visual-basic/language-reference/operators/mod-operator.md
@@ -39,7 +39,7 @@ number1 Mod number2
 The result is the remainder after `number1` is divided by `number2`. For example, the expression `14 Mod 4` evaluates to 2.  
 
 > [!NOTE]
-> There is a difference between *remainder* and *modulus* in mathematics, with different results for negative numbers. The `Mod` operator in Visual Basic, the .NET Framework `op_Modulus` operator, and the underlying [rem]<xref:System.Reflection.Emit.OpCodes.Rem> IL instruction all perform a remainder operation.
+> There is a difference between *remainder* and *modulus* in mathematics, with different results for negative numbers. The `Mod` operator in Visual Basic, the .NET Framework `op_Modulus` operator, and the underlying [rem](<xref:System.Reflection.Emit.OpCodes.Rem>) IL instruction all perform a remainder operation.
 
 The result of a `Mod` operation retains the sign of the dividend, `number1`, and so it may be positive or negative. The result is always in the range (-`number2`, `number2`), exclusive. For example:
 


### PR DESCRIPTION
Without parentheses, it renders as
> [rem][Rem](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.rem?view=netframework-4.7.2)