### PR TITLE
C37836: Changing asterisk style to avoid broken content on localization

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/component-that-supports-the-event-based-asynchronous-pattern.md
@@ -52,7 +52,7 @@ If you are writing a class with some operations that may incur noticeable delays
 -   Create a class called `PrimeNumberCalculator` that inherits from <xref:System.ComponentModel.Component>.  
   
 ## Defining Public Asynchronous Events and Delegates  
- Your component communicates to clients using events. The *MethodName***Completed** event alerts clients to the completion of an asynchronous task, and the *MethodName***ProgressChanged** event informs clients of the progress of an asynchronous task.  
+ Your component communicates to clients using events. The _MethodName_**Completed** event alerts clients to the completion of an asynchronous task, and the _MethodName_**ProgressChanged** event informs clients of the progress of an asynchronous task.  
   
 #### To define asynchronous events for clients of your component:  
   


### PR DESCRIPTION
Hi @mairaw , @rpetrusha 
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Three asterisks in a row are not rendered properly.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
