### PR TITLE
C37856: Replacing single quotes syntax to avoid extra content in link

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/xml-namespace-uri-uri-can-be-bound-only-to-xmlns.md
+++ b/docs/visual-basic/language-reference/error-messages/xml-namespace-uri-uri-can-be-bound-only-to-xmlns.md
@@ -8,8 +8,8 @@ helpviewer_keywords:
   - "BC31183"
 ms.assetid: 0ab1dbce-8397-4959-b2cd-f58798b051a0
 ---
-# XML namespace URI 'http://www.w3.org/XML/1998/namespace'; can be bound only to &#39;xmlns&#39;
-The URI http://www.w3.org/XML/1998/namespace is used in an XML namespace declaration. This URI is a reserved namespace and cannot be included in an XML namespace declaration.  
+# XML namespace URI `http://www.w3.org/XML/1998/namespace`; can be bound only to &#39;xmlns&#39;
+The URI `http://www.w3.org/XML/1998/namespace` is used in an XML namespace declaration. This URI is a reserved namespace and cannot be included in an XML namespace declaration.  
   
  **Error ID:** BC31183  
   

--- a/docs/visual-basic/language-reference/error-messages/xml-namespace-uri-uri-can-be-bound-only-to-xmlns.md
+++ b/docs/visual-basic/language-reference/error-messages/xml-namespace-uri-uri-can-be-bound-only-to-xmlns.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
   - "BC31183"
 ms.assetid: 0ab1dbce-8397-4959-b2cd-f58798b051a0
 ---
-# XML namespace URI &#39;http://www.w3.org/XML/1998/namespace&#39; can be bound only to &#39;xmlns&#39;
+# XML namespace URI 'http://www.w3.org/XML/1998/namespace'; can be bound only to &#39;xmlns&#39;
 The URI http://www.w3.org/XML/1998/namespace is used in an XML namespace declaration. This URI is a reserved namespace and cannot be included in an XML namespace declaration.  
   
  **Error ID:** BC31183  


### PR DESCRIPTION
Hello, @mairaw ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Missing space after the URL is causing the entity to be linked. Please use the single quotation mark.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.