### PR TITLE
Visual Studio refresh - parallel programming, regasm, auto binding

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -4,224 +4,228 @@ ms.date: 07/20/2015
 ms.assetid: 25331850-35a7-43b3-ab76-3908e4346b9d
 ---
 # Start Multiple Async Tasks and Process Them As They Complete (C#)
-By using <xref:System.Threading.Tasks.Task.WhenAny%2A?displayProperty=nameWithType>, you can start multiple tasks at the same time and process them one by one as they’re completed rather than process them in the order in which they're started.  
-  
- The following example uses a query to create a collection of tasks. Each task downloads the contents of a specified website. In each iteration of a while loop, an awaited call to `WhenAny` returns the task in the collection of tasks that finishes its download first. That task is removed from the collection and processed. The loop repeats until the collection contains no more tasks.  
-  
-> [!NOTE]
->  To run the examples, you must have Visual Studio 2012 or newer and  the .NET Framework 4.5 or newer installed on your computer.  
-  
-## Downloading the Example  
- You can download the complete Windows Presentation Foundation (WPF) project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea) and then follow these steps.  
-  
-1.  Decompress the file that you downloaded, and then start Visual Studio.  
-  
-2.  On the menu bar, choose **File**, **Open**, **Project/Solution**.  
-  
-3.  In the **Open Project** dialog box, open the folder that holds the sample code that you decompressed, and then open the solution (.sln) file for AsyncFineTuningCS.  
-  
-4.  In **Solution Explorer**, open the shortcut menu for the **ProcessTasksAsTheyFinish** project, and then choose **Set as StartUp Project**.  
-  
-5.  Choose the F5 key to run the project.  
-  
-     Choose the Ctrl+F5 keys to run the project without debugging it.  
-  
-6.  Run the project several times to verify that the downloaded lengths don't always appear in the same order.  
-  
- If you don't want to download the project, you can review the MainWindow.xaml.cs file at the end of this topic.  
-  
-## Building the Example  
- This example adds to the code that’s developed in [Cancel Remaining Async Tasks after One Is Complete (C#)](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md)[Cancel Remaining Async Tasks after One Is Complete](https://msdn.microsoft.com/library/8e800b58-235a-44b7-a02c-fa4375591d76) and uses the same UI.  
-  
- To build the example yourself, step by step, follow the instructions in the "Downloading the Example" section, but choose **CancelAfterOneTask** as the **StartUp Project**. Add the changes in this topic to the `AccessTheWebAsync` method in that project. The changes are marked with asterisks.  
-  
- The **CancelAfterOneTask** project already includes a query that, when executed, creates a collection of tasks. Each call to `ProcessURLAsync` in the following code returns a <xref:System.Threading.Tasks.Task%601> where `TResult` is an integer.  
-  
-```csharp  
-IEnumerable<Task<int>> downloadTasksQuery =  
-    from url in urlList select ProcessURL(url, client, ct);  
-```  
-  
- In the MainWindow.xaml.cs file of the  project, make the following changes to the `AccessTheWebAsync` method.  
-  
--   Execute the query by applying <xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType> instead of <xref:System.Linq.Enumerable.ToArray%2A>.  
-  
-    ```csharp  
-    List<Task<int>> downloadTasks = downloadTasksQuery.ToList();  
-    ```  
-  
--   Add a while loop that performs the following steps for each task in the collection.  
-  
-    1.  Awaits a call to `WhenAny` to identify the first task in the collection to finish its download.  
-  
-        ```csharp  
-        Task<int> firstFinishedTask = await Task.WhenAny(downloadTasks);  
-        ```  
-  
-    2.  Removes that task from the collection.  
-  
-        ```csharp  
-        downloadTasks.Remove(firstFinishedTask);  
-        ```  
-  
-    3.  Awaits `firstFinishedTask`, which is returned by a call to `ProcessURLAsync`. The `firstFinishedTask` variable is a <xref:System.Threading.Tasks.Task%601> where `TReturn` is an integer. The task is already complete, but you await it to retrieve the length of the downloaded website, as the following example shows.  
-  
-        ```csharp  
-        int length = await firstFinishedTask;  
-        resultsTextBox.Text += String.Format("\r\nLength of the download:  {0}", length);  
-        ```  
-  
- You should run the project several times to verify that the downloaded lengths don't always appear in the same order.  
-  
-> [!CAUTION]
->  You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing tasks as they complete](https://blogs.msdn.microsoft.com/pfxteam/2012/08/02/processing-tasks-as-they-complete/).  
-  
-## Complete Example  
- The following code is the complete text of the MainWindow.xaml.cs file for the example. Asterisks mark the elements that were added for this example.  
-  
- Notice that you must add a reference for <xref:System.Net.Http>.  
-  
- You can download the project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea).  
-  
-```csharp  
-using System;  
-using System.Collections.Generic;  
-using System.Linq;  
-using System.Text;  
-using System.Threading.Tasks;  
-using System.Windows;  
-using System.Windows.Controls;  
-using System.Windows.Data;  
-using System.Windows.Documents;  
-using System.Windows.Input;  
-using System.Windows.Media;  
-using System.Windows.Media.Imaging;  
-using System.Windows.Navigation;  
-using System.Windows.Shapes;  
-  
-// Add a using directive and a reference for System.Net.Http.  
-using System.Net.Http;  
-  
-// Add the following using directive.  
-using System.Threading;  
-  
-namespace ProcessTasksAsTheyFinish  
-{  
-    public partial class MainWindow : Window  
-    {  
-        // Declare a System.Threading.CancellationTokenSource.  
-        CancellationTokenSource cts;  
-  
-        public MainWindow()  
-        {  
-            InitializeComponent();  
-        }  
-  
-        private async void startButton_Click(object sender, RoutedEventArgs e)  
-        {  
-            resultsTextBox.Clear();  
-  
-            // Instantiate the CancellationTokenSource.  
-            cts = new CancellationTokenSource();  
-  
-            try  
-            {  
-                await AccessTheWebAsync(cts.Token);  
-                resultsTextBox.Text += "\r\nDownloads complete.";  
-            }  
-            catch (OperationCanceledException)  
-            {  
-                resultsTextBox.Text += "\r\nDownloads canceled.\r\n";  
-            }  
-            catch (Exception)  
-            {  
-                resultsTextBox.Text += "\r\nDownloads failed.\r\n";  
-            }  
-  
-            cts = null;  
-        }  
-  
-        private void cancelButton_Click(object sender, RoutedEventArgs e)  
-        {  
-            if (cts != null)  
-            {  
-                cts.Cancel();  
-            }  
-        }  
-  
-        async Task AccessTheWebAsync(CancellationToken ct)  
-        {  
-            HttpClient client = new HttpClient();  
-  
-            // Make a list of web addresses.  
-            List<string> urlList = SetUpURLList();  
-  
-            // ***Create a query that, when executed, returns a collection of tasks.  
-            IEnumerable<Task<int>> downloadTasksQuery =  
-                from url in urlList select ProcessURL(url, client, ct);  
-  
-            // ***Use ToList to execute the query and start the tasks.   
-            List<Task<int>> downloadTasks = downloadTasksQuery.ToList();  
-  
-            // ***Add a loop to process the tasks one at a time until none remain.  
-            while (downloadTasks.Count > 0)  
-            {  
-                    // Identify the first task that completes.  
-                    Task<int> firstFinishedTask = await Task.WhenAny(downloadTasks);  
-  
-                    // ***Remove the selected task from the list so that you don't  
-                    // process it more than once.  
-                    downloadTasks.Remove(firstFinishedTask);  
-  
-                    // Await the completed task.  
-                    int length = await firstFinishedTask;  
-                    resultsTextBox.Text += String.Format("\r\nLength of the download:  {0}", length);  
-            }  
-        }  
-  
-        private List<string> SetUpURLList()  
-        {  
-            List<string> urls = new List<string>   
-            {   
-                "http://msdn.microsoft.com",  
-                "http://msdn.microsoft.com/library/windows/apps/br211380.aspx",  
-                "http://msdn.microsoft.com/library/hh290136.aspx",  
-                "http://msdn.microsoft.com/library/dd470362.aspx",  
-                "http://msdn.microsoft.com/library/aa578028.aspx",  
-                "http://msdn.microsoft.com/library/ms404677.aspx",  
-                "http://msdn.microsoft.com/library/ff730837.aspx"  
-            };  
-            return urls;  
-        }  
-  
-        async Task<int> ProcessURL(string url, HttpClient client, CancellationToken ct)  
-        {  
-            // GetAsync returns a Task<HttpResponseMessage>.   
-            HttpResponseMessage response = await client.GetAsync(url, ct);  
-  
-            // Retrieve the website contents from the HttpResponseMessage.  
-            byte[] urlContents = await response.Content.ReadAsByteArrayAsync();  
-  
-            return urlContents.Length;  
-        }  
-    }  
-}  
-  
-// Sample Output:  
-  
-// Length of the download:  226093  
-// Length of the download:  412588  
-// Length of the download:  175490  
-// Length of the download:  204890  
-// Length of the download:  158855  
-// Length of the download:  145790  
-// Length of the download:  44908  
-// Downloads complete.  
-```  
-  
-## See Also
 
-- <xref:System.Threading.Tasks.Task.WhenAny%2A>  
-- [Fine-Tuning Your Async Application (C#)](../../../../csharp/programming-guide/concepts/async/fine-tuning-your-async-application.md)  
-- [Asynchronous Programming with async and await (C#)](../../../../csharp/programming-guide/concepts/async/index.md)  
+By using <xref:System.Threading.Tasks.Task.WhenAny%2A?displayProperty=nameWithType>, you can start multiple tasks at the same time and process them one by one as they’re completed rather than process them in the order in which they're started.
+
+The following example uses a query to create a collection of tasks. Each task downloads the contents of a specified website. In each iteration of a while loop, an awaited call to `WhenAny` returns the task in the collection of tasks that finishes its download first. That task is removed from the collection and processed. The loop repeats until the collection contains no more tasks.
+
+> [!NOTE]
+> To run the examples, you must have Visual Studio (2012 or newer) and the .NET Framework 4.5 or newer installed on your computer.
+
+## Download the example
+
+You can download the complete Windows Presentation Foundation (WPF) project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea) and then follow these steps.
+
+1.  Decompress the file that you downloaded, and then start Visual Studio.
+
+2.  On the menu bar, choose **File** > **Open** > **Project/Solution**.
+
+3.  In the **Open Project** dialog box, open the folder that holds the sample code that you decompressed, and then open the solution (.sln) file for AsyncFineTuningCS.
+
+4.  In **Solution Explorer**, open the shortcut menu for the **ProcessTasksAsTheyFinish** project, and then choose **Set as StartUp Project**.
+
+5.  Choose the **F5** key to run the project.
+
+    Or, choose the **Ctrl**+**F5** keys to run the project without debugging it.
+
+6.  Run the project several times to verify that the downloaded lengths don't always appear in the same order.
+
+If you don't want to download the project, you can review the MainWindow.xaml.cs file at the end of this topic.
+
+## Build the example
+
+This example adds to the code that’s developed in [Cancel Remaining Async Tasks after One Is Complete (C#)](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md) and [Cancel Remaining Async Tasks after One Is Complete (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md) and uses the same UI.
+
+To build the example yourself, step by step, follow the instructions in the [Downloading the Example](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md#downloading-the-example) section, but choose **CancelAfterOneTask** as the **StartUp Project**. Add the changes in this topic to the `AccessTheWebAsync` method in that project. The changes are marked with asterisks.
+
+The **CancelAfterOneTask** project already includes a query that, when executed, creates a collection of tasks. Each call to `ProcessURLAsync` in the following code returns a <xref:System.Threading.Tasks.Task%601> where `TResult` is an integer.
+
+```csharp
+IEnumerable<Task<int>> downloadTasksQuery =
+    from url in urlList select ProcessURL(url, client, ct);
+```
+
+In the MainWindow.xaml.cs file of the project, make the following changes to the `AccessTheWebAsync` method.
+
+-   Execute the query by applying <xref:System.Linq.Enumerable.ToList%2A?displayProperty=nameWithType> instead of <xref:System.Linq.Enumerable.ToArray%2A>.
+
+    ```csharp
+    List<Task<int>> downloadTasks = downloadTasksQuery.ToList();
+    ```
+
+-   Add a `while` loop that performs the following steps for each task in the collection:
+
+    1.  Awaits a call to `WhenAny` to identify the first task in the collection to finish its download.
+
+        ```csharp
+        Task<int> firstFinishedTask = await Task.WhenAny(downloadTasks);
+        ```
+
+    2.  Removes that task from the collection.
+
+        ```csharp
+        downloadTasks.Remove(firstFinishedTask);
+        ```
+
+    3.  Awaits `firstFinishedTask`, which is returned by a call to `ProcessURLAsync`. The `firstFinishedTask` variable is a <xref:System.Threading.Tasks.Task%601> where `TReturn` is an integer. The task is already complete, but you await it to retrieve the length of the downloaded website, as the following example shows.
+
+        ```csharp
+        int length = await firstFinishedTask;
+        resultsTextBox.Text += String.Format("\r\nLength of the download:  {0}", length);
+        ```
+
+Run the project several times to verify that the downloaded lengths don't always appear in the same order.
+
+> [!CAUTION]
+> You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing tasks as they complete](https://blogs.msdn.microsoft.com/pfxteam/2012/08/02/processing-tasks-as-they-complete/).
+
+## Complete example
+
+The following code is the complete text of the MainWindow.xaml.cs file for the example. Asterisks mark the elements that were added for this example.
+
+Notice that you must add a reference for <xref:System.Net.Http>.
+
+You can download the project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea).
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+// Add a using directive and a reference for System.Net.Http.
+using System.Net.Http;
+
+// Add the following using directive.
+using System.Threading;
+
+namespace ProcessTasksAsTheyFinish
+{
+    public partial class MainWindow : Window
+    {
+        // Declare a System.Threading.CancellationTokenSource.
+        CancellationTokenSource cts;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private async void startButton_Click(object sender, RoutedEventArgs e)
+        {
+            resultsTextBox.Clear();
+
+            // Instantiate the CancellationTokenSource.
+            cts = new CancellationTokenSource();
+
+            try
+            {
+                await AccessTheWebAsync(cts.Token);
+                resultsTextBox.Text += "\r\nDownloads complete.";
+            }
+            catch (OperationCanceledException)
+            {
+                resultsTextBox.Text += "\r\nDownloads canceled.\r\n";
+            }
+            catch (Exception)
+            {
+                resultsTextBox.Text += "\r\nDownloads failed.\r\n";
+            }
+
+            cts = null;
+        }
+
+        private void cancelButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (cts != null)
+            {
+                cts.Cancel();
+            }
+        }
+
+        async Task AccessTheWebAsync(CancellationToken ct)
+        {
+            HttpClient client = new HttpClient();
+
+            // Make a list of web addresses.
+            List<string> urlList = SetUpURLList();
+
+            // ***Create a query that, when executed, returns a collection of tasks.
+            IEnumerable<Task<int>> downloadTasksQuery =
+                from url in urlList select ProcessURL(url, client, ct);
+
+            // ***Use ToList to execute the query and start the tasks.
+            List<Task<int>> downloadTasks = downloadTasksQuery.ToList();
+
+            // ***Add a loop to process the tasks one at a time until none remain.
+            while (downloadTasks.Count > 0)
+            {
+                    // Identify the first task that completes.
+                    Task<int> firstFinishedTask = await Task.WhenAny(downloadTasks);
+
+                    // ***Remove the selected task from the list so that you don't
+                    // process it more than once.
+                    downloadTasks.Remove(firstFinishedTask);
+
+                    // Await the completed task.
+                    int length = await firstFinishedTask;
+                    resultsTextBox.Text += String.Format("\r\nLength of the download:  {0}", length);
+            }
+        }
+
+        private List<string> SetUpURLList()
+        {
+            List<string> urls = new List<string>
+            {
+                "http://msdn.microsoft.com",
+                "http://msdn.microsoft.com/library/windows/apps/br211380.aspx",
+                "http://msdn.microsoft.com/library/hh290136.aspx",
+                "http://msdn.microsoft.com/library/dd470362.aspx",
+                "http://msdn.microsoft.com/library/aa578028.aspx",
+                "http://msdn.microsoft.com/library/ms404677.aspx",
+                "http://msdn.microsoft.com/library/ff730837.aspx"
+            };
+            return urls;
+        }
+
+        async Task<int> ProcessURL(string url, HttpClient client, CancellationToken ct)
+        {
+            // GetAsync returns a Task<HttpResponseMessage>.
+            HttpResponseMessage response = await client.GetAsync(url, ct);
+
+            // Retrieve the website contents from the HttpResponseMessage.
+            byte[] urlContents = await response.Content.ReadAsByteArrayAsync();
+
+            return urlContents.Length;
+        }
+    }
+}
+
+// Sample Output:
+
+// Length of the download:  226093
+// Length of the download:  412588
+// Length of the download:  175490
+// Length of the download:  204890
+// Length of the download:  158855
+// Length of the download:  145790
+// Length of the download:  44908
+// Downloads complete.
+```
+
+## See also
+
+- <xref:System.Threading.Tasks.Task.WhenAny%2A>
+- [Fine-Tuning Your Async Application (C#)](../../../../csharp/programming-guide/concepts/async/fine-tuning-your-async-application.md)
+- [Asynchronous Programming with async and await (C#)](../../../../csharp/programming-guide/concepts/async/index.md)
 - [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea)

--- a/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -1,6 +1,6 @@
 ---
-title: "Start Multiple Async Tasks and Process Them As They Complete (C#)"
-ms.date: 07/20/2015
+title: Process asynchronous tasks as they complete
+ms.date: 09/12/2018
 ms.assetid: 25331850-35a7-43b3-ab76-3908e4346b9d
 ---
 # Start Multiple Async Tasks and Process Them As They Complete (C#)
@@ -12,37 +12,35 @@ The following example uses a query to create a collection of tasks. Each task do
 > [!NOTE]
 > To run the examples, you must have Visual Studio (2012 or newer) and the .NET Framework 4.5 or newer installed on your computer.
 
-## Download the example
+## Download an example solution
 
 You can download the complete Windows Presentation Foundation (WPF) project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea) and then follow these steps.
 
-1.  Decompress the file that you downloaded, and then start Visual Studio.
+> [!TIP]
+> If you don't want to download the project, you can review the MainWindow.xaml.cs file at the end of this topic instead.
+
+1.  Extract the files that you downloaded from the .zip file, and then start Visual Studio.
 
 2.  On the menu bar, choose **File** > **Open** > **Project/Solution**.
 
-3.  In the **Open Project** dialog box, open the folder that holds the sample code that you decompressed, and then open the solution (.sln) file for AsyncFineTuningCS.
+3.  In the **Open Project** dialog box, open the folder that holds the sample code you downloaded, and then open the solution (.sln) file for AsyncFineTuningCS.
 
 4.  In **Solution Explorer**, open the shortcut menu for the **ProcessTasksAsTheyFinish** project, and then choose **Set as StartUp Project**.
 
-5.  Choose the **F5** key to run the project.
-
-    Or, choose the **Ctrl**+**F5** keys to run the project without debugging it.
+5.  Choose the **F5** key to run the program (or, press **Ctrl**+**F5** keys to run the program without debugging it).
 
 6.  Run the project several times to verify that the downloaded lengths don't always appear in the same order.
 
-If you don't want to download the project, you can review the MainWindow.xaml.cs file at the end of this topic.
+## Create the program yourself
 
-## Build the example
+This example adds to the code that’s developed in [Cancel Remaining Async Tasks after One Is Complete (C#)](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md), and it uses the same UI.
 
-This example adds to the code that’s developed in [Cancel Remaining Async Tasks after One Is Complete (C#)](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md) and [Cancel Remaining Async Tasks after One Is Complete (Visual Basic)](../../../../visual-basic/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md) and uses the same UI.
+To build the example yourself, step by step, follow the instructions in the [Downloading the Example](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md#downloading-the-example) section, but set **CancelAfterOneTask** as the startup project. Add the changes in this topic to the `AccessTheWebAsync` method in that project. The changes are marked with asterisks.
 
-To build the example yourself, step by step, follow the instructions in the [Downloading the Example](../../../../csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md#downloading-the-example) section, but choose **CancelAfterOneTask** as the **StartUp Project**. Add the changes in this topic to the `AccessTheWebAsync` method in that project. The changes are marked with asterisks.
-
-The **CancelAfterOneTask** project already includes a query that, when executed, creates a collection of tasks. Each call to `ProcessURLAsync` in the following code returns a <xref:System.Threading.Tasks.Task%601> where `TResult` is an integer.
+The **CancelAfterOneTask** project already includes a query that, when executed, creates a collection of tasks. Each call to `ProcessURLAsync` in the following code returns a <xref:System.Threading.Tasks.Task%601>, where `TResult` is an integer:
 
 ```csharp
-IEnumerable<Task<int>> downloadTasksQuery =
-    from url in urlList select ProcessURL(url, client, ct);
+IEnumerable<Task<int>> downloadTasksQuery = from url in urlList select ProcessURL(url, client, ct);
 ```
 
 In the MainWindow.xaml.cs file of the project, make the following changes to the `AccessTheWebAsync` method.
@@ -74,16 +72,14 @@ In the MainWindow.xaml.cs file of the project, make the following changes to the
         resultsTextBox.Text += String.Format("\r\nLength of the download:  {0}", length);
         ```
 
-Run the project several times to verify that the downloaded lengths don't always appear in the same order.
+Run the program several times to verify that the downloaded lengths don't always appear in the same order.
 
 > [!CAUTION]
 > You can use `WhenAny` in a loop, as described in the example, to solve problems that involve a small number of tasks. However, other approaches are more efficient if you have a large number of tasks to process. For more information and examples, see [Processing tasks as they complete](https://blogs.msdn.microsoft.com/pfxteam/2012/08/02/processing-tasks-as-they-complete/).
 
 ## Complete example
 
-The following code is the complete text of the MainWindow.xaml.cs file for the example. Asterisks mark the elements that were added for this example.
-
-Notice that you must add a reference for <xref:System.Net.Http>.
+The following code is the complete text of the MainWindow.xaml.cs file for the example. Asterisks mark the elements that were added for this example. Also, take note that you must add a reference for <xref:System.Net.Http>.
 
 You can download the project from [Async Sample: Fine Tuning Your Application](https://code.msdn.microsoft.com/Async-Fine-Tuning-Your-a676abea).
 

--- a/docs/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection.md
+++ b/docs/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection.md
@@ -28,7 +28,7 @@ Automatic binding redirects are enabled by default for traditional desktop apps 
    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
    ```
 
-3. Change **true** to **false**:
+3. Change `true` to `false`:
 
    ```xml
    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>

--- a/docs/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection.md
+++ b/docs/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection.md
@@ -49,24 +49,24 @@ You can enable automatic binding redirects in existing apps that target older ve
    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
    ```
 
-The following shows an example project file with the element inserted:
+   The following shows an example project file with the element inserted:
 
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-      <Configuration Condition=" '$(Configuration)' == ''     ">Debug</Configuration>
-      <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-      <ProjectGuid>{123334}</ProjectGuid>
-      ...
-      <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    </PropertyGroup>
-  ...
-</Project>
-```
+   ```xml
+   <?xml version="1.0" encoding="utf-8"?>
+   <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+       <PropertyGroup>
+         <Configuration Condition=" '$(Configuration)' == ''     ">Debug</Configuration>
+         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+         <ProjectGuid>{123334}</ProjectGuid>
+         ...
+         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+       </PropertyGroup>
+     ...
+   </Project>
+   ```
 
-4. Compile your app.
+3. Compile your app.
 
 ## Enable automatic binding redirects in web apps
 

--- a/docs/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection.md
+++ b/docs/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Enable and Disable Automatic Binding Redirection"
-ms.date: "03/30/2017"
-helpviewer_keywords: 
+ms.date: 09/12/2018
+helpviewer_keywords:
   - "side-by-side execution, assembly binding redirection"
   - "assemblies [.NET Framework], binding redirection"
 ms.assetid: 5fca42f3-bdce-4b81-a704-61e42c89d3ba
@@ -10,72 +10,81 @@ ms.author: "markl"
 manager: "markl"
 ---
 # How to: Enable and Disable Automatic Binding Redirection
-Starting with [!INCLUDE[vs_dev12](../../../includes/vs-dev12-md.md)], when you compile apps that target the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)], binding redirects may be automatically added to the app configuration file to override assembly unification. Binding redirects are added if your app or its components reference more than one version of the same assembly, even if you manually specify binding redirects in the configuration file for your app. The automatic binding redirection feature affects traditional desktop apps and web apps that target the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)], although the behavior is slightly different for a web app. You can enable automatic binding redirection if you have existing apps that target previous versions of the .NET Framework, or you can disable this feature if you want to keep manually authored binding redirects.  
-  
-## Disabling automatic binding redirects in desktop apps  
- Automatic binding redirects are enabled by default for traditional desktop apps that target the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)] and later versions. The binding redirects are added to the output configuration (app.config) file when the app is compiled and overrides the assembly unification that might otherwise take place. The source app.config file is not modified. You can disable this feature by modifying the project file for the app.  
-  
-#### To disable automatic binding redirects  
-  
-1.  In Visual Studio, select the project in **Solution Explorer**, and then choose **Open Folder in File Explorer** from the shortcut menu.  
-  
-2.  In File Explorer, find the project (.csproj or .vbproj) file, and open it in Notepad.  
-  
-3.  In the project file, find the following property entry:  
-  
-     `<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>`  
-  
-4.  Change `true` to `false`:  
-  
-     `<AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>`  
-  
-## Enabling automatic binding redirects manually  
- You can enable automatic binding redirects in existing apps that target older versions of the .NET Framework, or in cases where you are not automatically prompted to add a redirect. If you are targeting a newer version of the framework but do not get automatically prompted to add a redirect, you will likely get   build output that suggests you remap assemblies.  
-  
-#### To manually add an automatic binding redirect property  
-  
-1.  In Visual Studio, select the project in **Solution Explorer**, and then choose **Open Folder in File Explorer** from the shortcut menu.  
-  
-2.  In File Explorer, find the project (.csproj or .vbproj) file, and open it in Notepad.  
-  
-3.  Add the following element to the first configuration property group (under the \<PropertyGroup> tag):  
-  
-     `<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>`  
-  
-     The following shows an example project file with the element inserted.  
-  
-    ```xml  
-    <?xml version="1.0" encoding="utf-8"?>  
-    <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
-      <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />  
-      <PropertyGroup>  
-        <Configuration Condition=" '$(Configuration)' == ''     ">Debug</Configuration>  
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>  
-        <ProjectGuid>{123334}</ProjectGuid>  
-        ...  
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>  
-      </PropertyGroup>  
-    ...  
-    </Project>  
-    ```  
-  
-4.  Compile your app.  
-  
-## Enabling automatic binding redirects in web apps  
- Automatic binding redirects are implemented differently for web apps. Because the source configuration (web.config) file must be modified for web apps, binding redirects are not automatically added to the configuration file. However, Visual Studio notifies you of binding conflicts, and you can add binding redirects to resolve the conflicts. Because you are always prompted to add binding redirects, you do not need to explicitly disable this feature for a web app.  
-  
-#### To add binding redirects to a web.config file  
-  
-1.  In Visual Studio, compile the app, and check for build warnings.  
-  
-     ![Build warning for assembly reference conflicts](../../../docs/framework/configure-apps/media/clr-assemblyrefwarning.png "CLR_AssemblyRefWarning")  
-  
-2.  If there are assembly binding conflicts, a warning appears. Double-click the warning. (Keyboard: Select the warning and press **Enter**.)  
-  
-     A dialog box that enables you to automatically add the necessary binding redirects to the source web.config file appears.  
-  
-     ![Binding redirect permission dialog](../../../docs/framework/configure-apps/media/clr-addbindingredirect.png "CLR_AddBindingRedirect")  
-  
-## See Also  
- [\<bindingRedirect> Element](../../../docs/framework/configure-apps/file-schema/runtime/bindingredirect-element.md)  
- [Redirecting Assembly Versions](../../../docs/framework/configure-apps/redirect-assembly-versions.md)
+
+When you compile apps in Visual Studio that target the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)] and later versions, binding redirects may be automatically added to the app configuration file to override assembly unification. Binding redirects are added if your app or its components reference more than one version of the same assembly, even if you manually specify binding redirects in the configuration file for your app. The automatic binding redirection feature affects traditional desktop apps and web apps that target the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)] or a later version, although the behavior is slightly different for a web app. You can enable automatic binding redirection if you have existing apps that target previous versions of the .NET Framework, or you can disable this feature if you want to keep manually authored binding redirects.
+
+## Disable automatic binding redirects in desktop apps
+
+Automatic binding redirects are enabled by default for traditional desktop apps that target the [!INCLUDE[net_v451](../../../includes/net-v451-md.md)] and later versions. The binding redirects are added to the output configuration (app.config) file when the app is compiled and overrides the assembly unification that might otherwise take place. The source app.config file is not modified. You can disable this feature by modifying the project file for the app.
+
+1. Open the project file for editing using one of the following methods:
+
+   - In Visual Studio, select the project in **Solution Explorer**, and then choose **Open Folder in File Explorer** from the shortcut menu. In File Explorer, find the project (.csproj or .vbproj) file and open it in Notepad.
+   - In Visual Studio, in **Solution Explorer**, right-click the project and choose **Unload Project**. Right-click the unloaded project again, and then choose **Edit [projectname.csproj]**.
+
+2. In the project file, find the following property entry:
+
+   ```xml
+   <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+   ```
+
+3. Change **true** to **false**:
+
+   ```xml
+   <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+   ```
+
+## Enable automatic binding redirects manually
+
+You can enable automatic binding redirects in existing apps that target older versions of the .NET Framework, or in cases where you're not automatically prompted to add a redirect. If you're targeting a newer version of the framework but do not get automatically prompted to add a redirect, you'll likely get build output that suggests you remap assemblies.
+
+1. Open the project file for editing using one of the following methods:
+
+   - In Visual Studio, select the project in **Solution Explorer**, and then choose **Open Folder in File Explorer** from the shortcut menu. In File Explorer, find the project (.csproj or .vbproj) file and open it in Notepad.
+   - In Visual Studio, in **Solution Explorer**, right-click the project and choose **Unload Project**. Right-click the unloaded project again, and then choose **Edit [projectname.csproj]**.
+
+2. Add the following element to the first configuration property group (under the \<PropertyGroup> tag):
+
+   ```xml
+   <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+   ```
+
+The following shows an example project file with the element inserted:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+      <Configuration Condition=" '$(Configuration)' == ''     ">Debug</Configuration>
+      <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+      <ProjectGuid>{123334}</ProjectGuid>
+      ...
+      <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    </PropertyGroup>
+  ...
+</Project>
+```
+
+4. Compile your app.
+
+## Enable automatic binding redirects in web apps
+
+Automatic binding redirects are implemented differently for web apps. Because the source configuration (web.config) file must be modified for web apps, binding redirects are not automatically added to the configuration file. However, Visual Studio notifies you of binding conflicts, and you can add binding redirects to resolve the conflicts. Because you're always prompted to add binding redirects, you don't need to explicitly disable this feature for a web app.
+
+To add binding redirects to a web.config file:
+
+1. In Visual Studio, compile the app, and check for build warnings.
+
+   ![Build warning for assembly reference conflicts](../../../docs/framework/configure-apps/media/clr-assemblyrefwarning.png "CLR_AssemblyRefWarning")
+
+2. If there are assembly binding conflicts, a warning appears. Double-click the warning, or select the warning and press **Enter**.
+
+   A dialog box that enables you to automatically add the necessary binding redirects to the source web.config file appears.
+
+   ![Binding redirect permission dialog](../../../docs/framework/configure-apps/media/clr-addbindingredirect.png "CLR_AddBindingRedirect")
+
+## See also
+
+- [\<bindingRedirect> Element](../../../docs/framework/configure-apps/file-schema/runtime/bindingredirect-element.md)
+- [Redirecting Assembly Versions](../../../docs/framework/configure-apps/redirect-assembly-versions.md)

--- a/docs/framework/tools/regasm-exe-assembly-registration-tool.md
+++ b/docs/framework/tools/regasm-exe-assembly-registration-tool.md
@@ -1,7 +1,7 @@
 ---
 title: "Regasm.exe (Assembly Registration Tool)"
 ms.date: "03/30/2017"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Assembly Registration tool"
   - "assemblies [.NET Framework], registering"
   - "Regasm.exe"
@@ -11,73 +11,77 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # Regasm.exe (Assembly Registration Tool)
-The Assembly Registration tool reads the metadata within an assembly and adds the necessary entries to the registry, which allows COM clients to create .NET Framework classes transparently. Once a class is registered, any COM client can use it as though the class were a COM class. The class is registered only once, when the assembly is installed. Instances of classes within the assembly cannot be created from COM until they are actually registered.  
-  
- To run the tool, use the Developer Command Prompt (or the Visual Studio Command Prompt in Windows 7). For more information, see [Command Prompts](../../../docs/framework/tools/developer-command-prompt-for-vs.md).  
-  
- At the command prompt, type the following:  
-  
-## Syntax  
-  
-```  
-regasm assemblyFile [options]  
-```  
-  
-#### Parameters  
-  
-|Parameter|Description|  
-|---------------|-----------------|  
-|*assemblyFile*|The assembly to be registered with COM.|  
-  
-|Option|Description|  
-|------------|-----------------|  
-|**/codebase**|Creates a Codebase entry in the registry. The Codebase entry specifies the file path for an assembly that is not installed in the global assembly cache. You should not specify this option if you will subsequently install the assembly that you are registering into the global assembly cache. The *assemblyFile* argument that you specify with the **/codebase** option must be a [strong-named assembly](../../../docs/framework/app-domains/strong-named-assemblies.md).|  
-|**/registered**|Specifies that this tool will only refer to type libraries that have already been registered.|  
-|**/asmpath:directory**|Specifies a directory containing assembly references. Must be used with the **/regfile** option.|  
-|**/nologo**|Suppresses the Microsoft startup banner display.|  
-|**/regfile** [**:** *regFile*]|Generates the specified .reg file for the assembly, which contains the needed registry entries. Specifying this option does not change the registry. You cannot use this option with the **/u** or **/tlb** options.|  
-|**/silent** or **/s**|Suppresses the display of success messages.|  
-|**/tlb** [**:** *typeLibFile*]|Generates a type library from the specified assembly containing definitions of the accessible types defined within the assembly.|  
-|**/unregister** or **/u**|Unregisters the creatable classes found in *assemblyFile*. Omitting this option causes Regasm.exe to register the creatable classes in the assembly.|  
-|**/verbose**|Specifies verbose mode; displays a list of any referenced assemblies for which a type library needs to be generated, when specified with the **/tlb** option.|  
-|**/?** or **/help**|Displays command syntax and options for the tool.|  
-  
+
+The Assembly Registration tool reads the metadata within an assembly and adds the necessary entries to the registry, which allows COM clients to create .NET Framework classes transparently. Once a class is registered, any COM client can use it as though the class were a COM class. The class is registered only once, when the assembly is installed. Instances of classes within the assembly cannot be created from COM until they are actually registered.
+
+To run the tool, use the Developer Command Prompt for Visual Studio. For more information, see [Command Prompts](../../../docs/framework/tools/developer-command-prompt-for-vs.md).
+
+At the command prompt, type the following:
+
+## Syntax
+
+```
+regasm assemblyFile [options]
+```
+
+#### Parameters
+
+|Parameter|Description|
+|---------------|-----------------|
+|*assemblyFile*|The assembly to be registered with COM.|
+
+|Option|Description|
+|------------|-----------------|
+|**/codebase**|Creates a Codebase entry in the registry. The Codebase entry specifies the file path for an assembly that is not installed in the global assembly cache. You should not specify this option if you will subsequently install the assembly that you are registering into the global assembly cache. The *assemblyFile* argument that you specify with the **/codebase** option must be a [strong-named assembly](../../../docs/framework/app-domains/strong-named-assemblies.md).|
+|**/registered**|Specifies that this tool will only refer to type libraries that have already been registered.|
+|**/asmpath:directory**|Specifies a directory containing assembly references. Must be used with the **/regfile** option.|
+|**/nologo**|Suppresses the Microsoft startup banner display.|
+|**/regfile** [**:** *regFile*]|Generates the specified .reg file for the assembly, which contains the needed registry entries. Specifying this option does not change the registry. You cannot use this option with the **/u** or **/tlb** options.|
+|**/silent** or **/s**|Suppresses the display of success messages.|
+|**/tlb** [**:** *typeLibFile*]|Generates a type library from the specified assembly containing definitions of the accessible types defined within the assembly.|
+|**/unregister** or **/u**|Unregisters the creatable classes found in *assemblyFile*. Omitting this option causes Regasm.exe to register the creatable classes in the assembly.|
+|**/verbose**|Specifies verbose mode; displays a list of any referenced assemblies for which a type library needs to be generated, when specified with the **/tlb** option.|
+|**/?** or **/help**|Displays command syntax and options for the tool.|
+
 > [!NOTE]
->  The Regasm.exe command-line options are case insensitive. You only need to provide enough of the option to uniquely identify it. For example, **/n** is equivalent to **/nologo** and **/t:** *outfile.tlb* is equivalent to **/tlb:** *outfile.tlb*.  
-  
-## Remarks  
- You can use the **/regfile** option to generate a .reg file that contains the registry entries instead of making the changes directly to the registry. You can update the registry on a computer by importing the .reg file with the Registry Editor tool (Regedit.exe). Note that the .reg file does not contain any registry updates that can be made by user-defined register functions.  Note that the **/regfile** option only emits registry entries for managed classes.  This option does not emit entries for `TypeLibID`s or `InterfaceID`s.  
-  
- When you specify the **/tlb** option, Regasm.exe generates and registers a type library describing the types found in the assembly. Regasm.exe places the generated type libraries in the current working directory or the directory specified for the output file. Generating a type library for an assembly that references other assemblies may cause several type libraries to be generated at once. You can use the type library to provide type information to development tools like [!INCLUDE[vsprvslong](../../../includes/vsprvslong-md.md)]. You should not use the **/tlb** option if the assembly you are registering was produced by the Type Library Importer ([Tlbimp.exe](../../../docs/framework/tools/tlbimp-exe-type-library-importer.md)). You cannot export a type library from an assembly that was imported from a type library. Using the **/tlb** option has the same effect as using the Type Library Exporter ([Tlbexp.exe](../../../docs/framework/tools/tlbexp-exe-type-library-exporter.md)) and Regasm.exe, with the exception that Tlbexp.exe does not register the type library it produces.  If you use the **/tlb** option to registered a type library, you can use **/tlb** option with the **/unregister** option to unregistered the type library. Using the two options together will unregister the type library and interface entries, which can clean the registry considerably.  
-  
- When you register an assembly for use by COM, Regasm.exe adds entries to the registry on the local computer. More specifically, it creates version-dependent registry keys that allow multiple versions of the same assembly to run side by side on a computer. The first time an assembly is registered, one top-level key is created for the assembly and a unique subkey is created for the specific version. Each time you register a new version of the assembly, Regasm.exe creates a subkey for the new version.  
-  
- For example, consider a scenario where you register the managed component, myComp.dll, version 1.0.0.0 for use by COM. Later, you register myComp.dll, version 2.0.0.0. You determine that all COM client applications on the computer are using myComp.dll version 2.0.0.0 and you decide to unregister myComponent.dll version 1.0.0.0. This registry scheme allows you to unregister myComp.dll version 1.0.0.0 because only the version 1.0.0.0 subkey is removed.  
-  
- After registering an assembly using Regasm.exe, you can install it in the [global assembly cache](../../../docs/framework/app-domains/gac.md) so that it can be activated from any COM client. If the assembly is only going to be activated by a single application, you can place it in that application's directory.  
-  
-## Examples  
- The following command registers all public classes contained in `myTest.dll`.  
-  
-```  
-regasm myTest.dll  
-```  
-  
- The following command generates the file `myTest.reg`, which contains all the necessary registry entries. This command does not update the registry.  
-  
-```  
-regasm myTest.dll /regfile:myTest.reg  
-```  
-  
- The following command registers all public classes contained in `myTest.dll`, and generates and registers the type library `myTest.tlb`, which contains definitions of all the public types defined in `myTest.dll`.  
-  
-```  
-regasm myTest.dll /tlb:myTest.tlb  
-```  
-  
-## See Also  
- [Tools](../../../docs/framework/tools/index.md)  
- [Tlbexp.exe (Type Library Exporter)](../../../docs/framework/tools/tlbexp-exe-type-library-exporter.md)  
- [Tlbimp.exe (Type Library Importer)](../../../docs/framework/tools/tlbimp-exe-type-library-importer.md)  
- [Registering Assemblies with COM](../../../docs/framework/interop/registering-assemblies-with-com.md)  
- [Command Prompts](../../../docs/framework/tools/developer-command-prompt-for-vs.md)
+> The Regasm.exe command-line options are case insensitive. You only need to provide enough of the option to uniquely identify it. For example, **/n** is equivalent to **/nologo** and **/t:** *outfile.tlb* is equivalent to **/tlb:** *outfile.tlb*.
+
+## Remarks
+
+You can use the **/regfile** option to generate a .reg file that contains the registry entries instead of making the changes directly to the registry. You can update the registry on a computer by importing the .reg file with the Registry Editor tool (Regedit.exe). Note that the .reg file does not contain any registry updates that can be made by user-defined register functions.  Note that the **/regfile** option only emits registry entries for managed classes.  This option does not emit entries for `TypeLibID`s or `InterfaceID`s.
+
+When you specify the **/tlb** option, Regasm.exe generates and registers a type library describing the types found in the assembly. Regasm.exe places the generated type libraries in the current working directory or the directory specified for the output file. Generating a type library for an assembly that references other assemblies may cause several type libraries to be generated at once. You can use the type library to provide type information to development tools like Visual Studio. You should not use the **/tlb** option if the assembly you are registering was produced by the Type Library Importer ([Tlbimp.exe](../../../docs/framework/tools/tlbimp-exe-type-library-importer.md)). You cannot export a type library from an assembly that was imported from a type library. Using the **/tlb** option has the same effect as using the Type Library Exporter ([Tlbexp.exe](../../../docs/framework/tools/tlbexp-exe-type-library-exporter.md)) and Regasm.exe, with the exception that Tlbexp.exe does not register the type library it produces.  If you use the **/tlb** option to registered a type library, you can use **/tlb** option with the **/unregister** option to unregistered the type library. Using the two options together will unregister the type library and interface entries, which can clean the registry considerably.
+
+When you register an assembly for use by COM, Regasm.exe adds entries to the registry on the local computer. More specifically, it creates version-dependent registry keys that allow multiple versions of the same assembly to run side by side on a computer. The first time an assembly is registered, one top-level key is created for the assembly and a unique subkey is created for the specific version. Each time you register a new version of the assembly, Regasm.exe creates a subkey for the new version.
+
+For example, consider a scenario where you register the managed component, myComp.dll, version 1.0.0.0 for use by COM. Later, you register myComp.dll, version 2.0.0.0. You determine that all COM client applications on the computer are using myComp.dll version 2.0.0.0 and you decide to unregister myComponent.dll version 1.0.0.0. This registry scheme allows you to unregister myComp.dll version 1.0.0.0 because only the version 1.0.0.0 subkey is removed.
+
+After registering an assembly using Regasm.exe, you can install it in the [global assembly cache](../../../docs/framework/app-domains/gac.md) so that it can be activated from any COM client. If the assembly is only going to be activated by a single application, you can place it in that application's directory.
+
+## Examples
+
+The following command registers all public classes contained in `myTest.dll`.
+
+```
+regasm myTest.dll
+```
+
+The following command generates the file `myTest.reg`, which contains all the necessary registry entries. This command does not update the registry.
+
+```
+regasm myTest.dll /regfile:myTest.reg
+```
+
+The following command registers all public classes contained in `myTest.dll`, and generates and registers the type library `myTest.tlb`, which contains definitions of all the public types defined in `myTest.dll`.
+
+```
+regasm myTest.dll /tlb:myTest.tlb
+```
+
+## See also
+
+- [Tools](../../../docs/framework/tools/index.md)
+- [Tlbexp.exe (Type Library Exporter)](../../../docs/framework/tools/tlbexp-exe-type-library-exporter.md)
+- [Tlbimp.exe (Type Library Importer)](../../../docs/framework/tools/tlbimp-exe-type-library-importer.md)
+- [Registering Assemblies with COM](../../../docs/framework/interop/registering-assemblies-with-com.md)
+- [Command Prompts](../../../docs/framework/tools/developer-command-prompt-for-vs.md)

--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -1,11 +1,11 @@
 ---
-title: "How to: Write a Simple Parallel.ForEach Loop"
-ms.date: "03/30/2017"
+title: Write a simple parallel program
+ms.date: 09/12/2018
 ms.technology: dotnet-standard
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "foreach, parallel version"
   - "parallel programming, foreach"
 ms.assetid: cb5fab92-1c19-499e-ae91-8b7525dd875f
@@ -13,36 +13,38 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # How to: Write a Simple Parallel.ForEach Loop
-This example shows how to use a <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType> loop to enable data parallelism over any <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> data source.  
-  
+
+This example shows how to use a <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType> loop to enable data parallelism over any <xref:System.Collections.IEnumerable?displayProperty=nameWithType> or <xref:System.Collections.Generic.IEnumerable%601?displayProperty=nameWithType> data source.
+
 > [!NOTE]
->  This documentation uses lambda expressions to define delegates in PLINQ. If you are not familiar with lambda expressions in C# or Visual Basic, see [Lambda Expressions in PLINQ and TPL](../../../docs/standard/parallel-programming/lambda-expressions-in-plinq-and-tpl.md).  
-  
-## Example  
- [!code-csharp[TPL_Parallel#03](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.cs#03)]
- [!code-vb[TPL_Parallel#03](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb#03)]  
-  
- A <xref:System.Threading.Tasks.Parallel.ForEach%2A> loop works like a <xref:System.Threading.Tasks.Parallel.For%2A> loop. The source collection is partitioned and the work is scheduled on multiple threads based on the system environment. The more processors on the system, the faster the parallel method runs. For some source collections, a sequential loop may be faster, depending on the size of the source, and the kind of work being performed. For more information about performance, see [Potential Pitfalls in Data and Task Parallelism](../../../docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md)  
-  
- For more information about parallel loops, see [How to: Write a Simple Parallel.For Loop](../../../docs/standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md).  
-  
- To use <xref:System.Threading.Tasks.Parallel.ForEach%2A> with a non-generic collection, you can use the <xref:System.Linq.Enumerable.Cast%2A> extension method to convert the collection to a generic collection, as shown in the following example:  
-  
- [!code-csharp[TPL_Parallel#07](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/nongeneric.cs#07)]
- [!code-vb[TPL_Parallel#07](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/nongeneric.vb#07)]  
-  
- You can also use Parallel LINQ (PLINQ) to parallelize processing of <xref:System.Collections.Generic.IEnumerable%601> data sources. PLINQ enables you to use declarative query syntax to express the loop behavior. For more information, see [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md).  
-  
-## Compiling the Code  
-  
--   Copy and paste this code into a Visual Studio 2010 Console Application project.  
-  
--   Add a reference to System.Drawing.dll  
-  
--   Press F5  
-  
+> This documentation uses lambda expressions to define delegates in PLINQ. If you are not familiar with lambda expressions in C# or Visual Basic, see [Lambda Expressions in PLINQ and TPL](../../../docs/standard/parallel-programming/lambda-expressions-in-plinq-and-tpl.md).
+
+## Example
+
+[!code-csharp[TPL_Parallel#03](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/simpleforeach.cs#03)]
+[!code-vb[TPL_Parallel#03](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/simpleforeach.vb#03)]
+
+A <xref:System.Threading.Tasks.Parallel.ForEach%2A> loop works like a <xref:System.Threading.Tasks.Parallel.For%2A> loop. The source collection is partitioned and the work is scheduled on multiple threads based on the system environment. The more processors on the system, the faster the parallel method runs. For some source collections, a sequential loop may be faster, depending on the size of the source, and the kind of work being performed. For more information about performance, see [Potential Pitfalls in Data and Task Parallelism](../../../docs/standard/parallel-programming/potential-pitfalls-in-data-and-task-parallelism.md)
+
+For more information about parallel loops, see [How to: Write a Simple Parallel.For Loop](../../../docs/standard/parallel-programming/how-to-write-a-simple-parallel-for-loop.md).
+
+To use <xref:System.Threading.Tasks.Parallel.ForEach%2A> with a non-generic collection, you can use the <xref:System.Linq.Enumerable.Cast%2A> extension method to convert the collection to a generic collection, as shown in the following example:
+
+[!code-csharp[TPL_Parallel#07](../../../samples/snippets/csharp/VS_Snippets_Misc/tpl_parallel/cs/nongeneric.cs#07)]
+[!code-vb[TPL_Parallel#07](../../../samples/snippets/visualbasic/VS_Snippets_Misc/tpl_parallel/vb/nongeneric.vb#07)]
+
+You can also use Parallel LINQ (PLINQ) to parallelize processing of <xref:System.Collections.Generic.IEnumerable%601> data sources. PLINQ enables you to use declarative query syntax to express the loop behavior. For more information, see [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md).
+
+## Compile the code
+
+- Copy and paste this code into a Visual Studio **Console App** project.
+
+- Add a reference to System.Drawing.dll
+
+- Press **F5**
+
 ## See also
 
-- [Data Parallelism](../../../docs/standard/parallel-programming/data-parallelism-task-parallel-library.md)  
-- [Parallel Programming](../../../docs/standard/parallel-programming/index.md)  
+- [Data Parallelism](../../../docs/standard/parallel-programming/data-parallelism-task-parallel-library.md)
+- [Parallel Programming](../../../docs/standard/parallel-programming/index.md)
 - [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md)

--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -35,7 +35,7 @@ To use <xref:System.Threading.Tasks.Parallel.ForEach%2A> with a non-generic coll
 
 You can also use Parallel LINQ (PLINQ) to parallelize processing of <xref:System.Collections.Generic.IEnumerable%601> data sources. PLINQ enables you to use declarative query syntax to express the loop behavior. For more information, see [Parallel LINQ (PLINQ)](../../../docs/standard/parallel-programming/parallel-linq-plinq.md).
 
-## Compile the code
+## Compile and run the code
 
 - Copy and paste this code into a Visual Studio **Console App** project.
 

--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -1,5 +1,5 @@
 ---
-title: Write a simple parallel program
+title: Write a simple parallel program using ForEach
 ms.date: 09/12/2018
 ms.technology: dotnet-standard
 dev_langs:

--- a/docs/standard/parallel-programming/index.md
+++ b/docs/standard/parallel-programming/index.md
@@ -12,7 +12,7 @@ ms.author: "ronpet"
 
 Many personal computers and workstations have multiple CPU cores that enable multiple threads to be executed simultaneously. To take advantage of the hardware, you can parallelize your code to distribute work across multiple processors.
 
-In the past, parallelization required low-level manipulation of threads and locks. Visual Studio and the .NET Framework enhance support for parallel programming by providing a runtime, class library types, and diagnostic tools. These features simplify parallel development so that you can write efficient, fine-grained, and scalable parallel code in a natural idiom without having to work directly with threads or the thread pool. Parallel programming features were introduced with the .NET Framework 4.
+In the past, parallelization required low-level manipulation of threads and locks. Visual Studio and the .NET Framework enhance support for parallel programming by providing a runtime, class library types, and diagnostic tools. These features, which were introduced with the .NET Framework 4, simplify parallel development. You can write efficient, fine-grained, and scalable parallel code in a natural idiom without having to work directly with threads or the thread pool.
 
 The following illustration provides a high-level overview of the parallel programming architecture in the .NET Framework:
 

--- a/docs/standard/parallel-programming/index.md
+++ b/docs/standard/parallel-programming/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Parallel Programming in .NET"
-ms.date: "03/30/2017"
+ms.date: 09/12/2018
 ms.technology: dotnet-standard
 helpviewer_keywords:
   - "parallel programming"
@@ -10,9 +10,13 @@ ms.author: "ronpet"
 ---
 # Parallel Programming in .NET
 
-Many personal computers and workstations have several CPU cores that enable multiple threads to be executed simultaneously. Computers in the near future are expected to have significantly more cores. To take advantage of the hardware of today and tomorrow, you can parallelize your code to distribute work across multiple processors. In the past, parallelization required low-level manipulation of threads and locks. Visual Studio 2010 and the .NET Framework 4 enhance support for parallel programming by providing a new runtime, new class library types, and new diagnostic tools. These features simplify parallel development so that you can write efficient, fine-grained, and scalable parallel code in a natural idiom without having to work directly with threads or the thread pool. The following illustration provides a high-level overview of the parallel programming architecture in the .NET Framework 4.
+Many personal computers and workstations have multiple CPU cores that enable multiple threads to be executed simultaneously. To take advantage of the hardware, you can parallelize your code to distribute work across multiple processors.
 
- ![.NET Parallel Programming Architecture](./media/tpl-architecture.png "TPL_Architecture")
+In the past, parallelization required low-level manipulation of threads and locks. Visual Studio and the .NET Framework enhance support for parallel programming by providing a runtime, class library types, and diagnostic tools. These features simplify parallel development so that you can write efficient, fine-grained, and scalable parallel code in a natural idiom without having to work directly with threads or the thread pool. Parallel programming features were introduced with the .NET Framework 4.
+
+The following illustration provides a high-level overview of the parallel programming architecture in the .NET Framework:
+
+![.NET Parallel Programming Architecture](./media/tpl-architecture.png)
 
 ## Related Topics
 


### PR DESCRIPTION
Minor refreshes, e.g. adding "or later" or removing specific VS/.NET Framework version. Also, lots of whitespace removal. Also added another way of editing a project file.

Part of the fix for #7172.