### PR TITLE
Small logic error

### DIFF
--- a/docs/standard/garbage-collection/implementing-dispose.md
+++ b/docs/standard/garbage-collection/implementing-dispose.md
@@ -102,7 +102,7 @@ Here's the general pattern for implementing the dispose pattern for a base class
 
 A class derived from a class that implements the <xref:System.IDisposable> interface shouldn't implement <xref:System.IDisposable>, because the base class implementation of <xref:System.IDisposable.Dispose%2A?displayProperty=nameWithType> is inherited by its derived classes. Instead, to implement the dispose pattern for a derived class, you provide the following:  
   
-* A `protected Dispose(Boolean)` method that overrides the base class method and performs the actual work of releasing the resources of the derived class. This method should also call the `Dispose(Boolean)` method of the base class and pass it a value of `true` for the *disposing* argument.  
+* A `protected Dispose(Boolean)` method that overrides the base class method and performs the actual work of releasing the resources of the derived class. This method should also call the `Dispose(Boolean)` method of the base class and pass its disposing status for the argument.  
   
 * Either a class derived from <xref:System.Runtime.InteropServices.SafeHandle> that wraps your unmanaged resource (recommended), or an override to the <xref:System.Object.Finalize%2A?displayProperty=nameWithType> method. The <xref:System.Runtime.InteropServices.SafeHandle> class provides a finalizer that frees you from having to code one. If you do provide a finalizer, it should call the `Dispose(Boolean)` overload with a *disposing* argument of `false`.  
   


### PR DESCRIPTION
The base class should be passed the disposing state as an argument in the dispose method, otherwise it will not free managed base resources when disposing. The actual code example has the right parameter argument.
