### PR TITLE
Fix display speed functionality in Console app tutorial

### DIFF
--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -383,10 +383,10 @@ use the `config` object for the delay:
 private static async Task ShowTeleprompter(TelePrompterConfig config)
 {
     var words = ReadFrom("sampleQuotes.txt");
-    foreach (var line in words)
+    foreach (var word in words)
     {
-        Console.Write(line);
-        if (!string.IsNullOrWhiteSpace(line))
+        Console.Write(word);
+        if (!string.IsNullOrWhiteSpace(word))
         {
             await Task.Delay(config.DelayInMilliseconds);
         }
@@ -400,9 +400,9 @@ private static async Task GetInput(TelePrompterConfig config)
     {
         do {
             var key = Console.ReadKey(true);
-            if (key.KeyChar == '>')
+            if (key.Key.ToString() == "LeftArrow")
                 config.UpdateDelay(-10);
-            else if (key.KeyChar == '<')
+            else if (key.Key.ToString() == "RightArrow")
                 config.UpdateDelay(10);
         } while (!config.Done);
     };

--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -17,7 +17,7 @@ This tutorial teaches you a number of features in .NET Core and the C# language.
 
 You’ll build an application that reads a text file, and echoes the
 contents of that text file to the console. The output to the console is paced to match reading it aloud. You can speed up or slow down the pace
-by pressing the ‘<’ or ‘>’ keys.
+by pressing the ‘<’ (less than) or ‘>’ (greater than) keys.
 
 There are a lot of features in this tutorial. Let’s build them one by one.
 
@@ -273,7 +273,7 @@ have completed.
 > If you use C# 7.1 or later, you can create console applications with [`async` `Main` method](../whats-new/csharp-7-1.md#async-main).
 
 Next, you need to write the second asynchronous method to read from the
-Console and watch for the ‘<’ and ‘>’ keys. Here’s the method you add for
+Console and watch for the ‘<’ (less than) and ‘>’ (greater than) keys. Here’s the method you add for
 that task:
 
 ```csharp
@@ -300,7 +300,7 @@ private static async Task GetInput()
 
 This creates a lambda expression to represent an <xref:System.Action> delegate that reads a key
 from the Console and modifies a local variable representing the delay when
-the user presses the ‘<’ or ‘>’ keys. This method uses <xref:System.Console.ReadKey>
+the user presses the ‘<’ (less than) or ‘>’ (greater than) keys. This method uses <xref:System.Console.ReadKey>
 to block and wait for the user to press a key.
 
 To finish this feature, you need to create a new `async Task` returning
@@ -400,9 +400,9 @@ private static async Task GetInput(TelePrompterConfig config)
     {
         do {
             var key = Console.ReadKey(true);
-            if (key.Key.ToString() == "LeftArrow")
+            if (key.KeyChar == '>')
                 config.UpdateDelay(-10);
-            else if (key.Key.ToString() == "RightArrow")
+            else if (key.KeyChar == '<')
                 config.UpdateDelay(10);
         } while (!config.Done);
     };


### PR DESCRIPTION
## Summary

1. Update variable name "line" to "word" to match previous **ShowTeleprompter()** code block.
2. Revise **ReadKey** code. 

    **Explanation:** I created the app per instructions (```dotnet new console -o myApp```) and opened it in Visual Studio 2017. Project properties shows that the **Target framework** is *.NET Core 2.1*. Arrow keys did not affect output speed.

    The topic [ConsoleKeyInfo.KeyChar Property](https://docs.microsoft.com/en-us/dotnet/api/system.consolekeyinfo.keychar?view=netcore-2.1#System_ConsoleKeyInfo_KeyChar) doesn't list keys that can or cannot be captured, but it *does* say that it applies to .NET Framework 4.7.2.

    The **KeyChar** topic in .NET Framework 4.7.2 documents **KeyChar** as part of the Windows.Forms namespace, but I'm assuming it will likely behave the same as **KeyChar** in the Console namespace.  According to the **Remarks** in the .NET Framework 4.7.2 [KeyPressEventArge.KeyChar Property](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.keypresseventargs.keychar?view=netframework-4.7.2) topic, you cannot use the **KeyChar** property to get the arrow keys.

    Proposed code change causes left and right arrow keys to function as intended.