### PR TITLE
Event wait handles: shorten related section info

### DIFF
--- a/docs/standard/threading/eventwaithandle-autoresetevent-countdownevent-manualresetevent.md
+++ b/docs/standard/threading/eventwaithandle-autoresetevent-countdownevent-manualresetevent.md
@@ -1,6 +1,6 @@
 ---
 title: "EventWaitHandle, AutoResetEvent, CountdownEvent, ManualResetEvent"
-ms.date: "03/30/2017"
+ms.date: "09/14/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "wait handles"
@@ -11,32 +11,28 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # EventWaitHandle, AutoResetEvent, CountdownEvent, ManualResetEvent
-Event wait handles allow threads to synchronize activities by signaling each other and by waiting on each other's signals. These synchronization events are based on Win32 wait handles and can be divided into two types: those that reset automatically when signaled and those that are reset manually.  
+
+Event wait handles allow threads to synchronize activities by signaling each other and by waiting on each other's signals. These synchronization events are based on operating system wait handles and can be divided into two types: those that reset automatically when signaled and those that are reset manually.  
   
- Event wait handles are useful in many of the same synchronization scenarios as the <xref:System.Threading.Monitor> class. Event wait handles are often easier to use than the <xref:System.Threading.Monitor.Wait%2A?displayProperty=nameWithType> and <xref:System.Threading.Monitor.Pulse%2A?displayProperty=nameWithType> methods, and they offer more control over signaling. Named event wait handles can also be used to synchronize activities across application domains and processes, whereas monitors are local to an application domain.  
+Event wait handles are useful in many of the same synchronization scenarios as the <xref:System.Threading.Monitor> class. Event wait handles are often easier to use than the <xref:System.Threading.Monitor.Wait%2A?displayProperty=nameWithType> and <xref:System.Threading.Monitor.Pulse%2A?displayProperty=nameWithType> methods, and they offer more control over signaling. Named event wait handles can also be used to synchronize activities across application domains and processes, whereas monitors are local to an application domain.  
   
-## In This Section  
- [EventWaitHandle](../../../docs/standard/threading/eventwaithandle.md)  
- The <xref:System.Threading.EventWaitHandle> class can represent either automatic or manual reset events and either local events or named system events.  
+## In this section
+
+ [EventWaitHandle](eventwaithandle.md)  
+ The <xref:System.Threading.EventWaitHandle?displayProperty=nameWithType> class can represent either automatic or manual reset events and either local events or named system events.  
   
- [AutoResetEvent](../../../docs/standard/threading/autoresetevent.md)  
- The <xref:System.Threading.AutoResetEvent> class derives from <xref:System.Threading.EventWaitHandle> and represents a local event that resets automatically.  
+ [AutoResetEvent](autoresetevent.md)  
+ The <xref:System.Threading.AutoResetEvent?displayProperty=nameWithType> class derives from <xref:System.Threading.EventWaitHandle> and represents a local event that resets automatically.  
   
- [ManualResetEvent and ManualResetEventSlim](../../../docs/standard/threading/manualresetevent-and-manualreseteventslim.md)  
- The <xref:System.Threading.ManualResetEvent> class derives from <xref:System.Threading.EventWaitHandle> and represents a local event that must be reset manually. The <xref:System.Threading.ManualResetEventSlim> class is a lightweight, faster version that can be used for events within the same process.  
+ [ManualResetEvent and ManualResetEventSlim](manualresetevent-and-manualreseteventslim.md)  
+ The <xref:System.Threading.ManualResetEvent?displayProperty=nameWithType> class derives from <xref:System.Threading.EventWaitHandle> and represents a local event that must be reset manually. The <xref:System.Threading.ManualResetEventSlim?displayProperty=nameWithType> class is a lightweight, faster version that can be used for events within the same process.  
   
- [CountdownEvent](../../../docs/standard/threading/countdownevent.md)  
- The <xref:System.Threading.CountdownEvent> class provides a simplified way to implement fork/join parallelism patterns in code that uses wait handles.  
-  
-## Related Sections  
- [Wait Handles](https://msdn.microsoft.com/library/48d10b6f-5fd7-407c-86ab-0179aef72489)  
- The <xref:System.Threading.WaitHandle> class is the base class for the <xref:System.Threading.EventWaitHandle>, <xref:System.Threading.Semaphore>, and <xref:System.Threading.Mutex> classes. It contains static methods such as <xref:System.Threading.WaitHandle.SignalAndWait%2A> and <xref:System.Threading.WaitHandle.WaitAll%2A> that are useful when working with all types of wait handles.  
-  
+ [CountdownEvent](countdownevent.md)  
+ The <xref:System.Threading.CountdownEvent?displayProperty=nameWithType> class provides a simplified way to implement fork/join parallelism patterns in code that uses wait handles.  
+
 ## See also
 
-- <xref:System.Threading.EventWaitHandle>  
-- <xref:System.Threading.WaitHandle>  
-- <xref:System.Threading.AutoResetEvent>  
-- <xref:System.Threading.ManualResetEvent>  
-- [Threading Objects and Features](../../../docs/standard/threading/threading-objects-and-features.md)  
-- [Managed Threading Basics](../../../docs/standard/threading/managed-threading-basics.md)
+- <xref:System.Threading.WaitHandle?displayProperty=nameWithType>
+- <xref:System.Threading.Barrier?displayProperty=nameWithType>
+- [Threading objects and features](threading-objects-and-features.md)
+- [Managed threading basics](managed-threading-basics.md)


### PR DESCRIPTION
Updated the [EventWaitHandle, AutoResetEvent, CountdownEvent, ManualResetEvent](https://docs.microsoft.com/en-us/dotnet/standard/threading/eventwaithandle-autoresetevent-countdownevent-manualresetevent) article: merged the **Related sections** and **See also** sections. Removed the paragraph about the `WaitHandle` class as it doesn't fit the topic, as far as I concern: the link in the **See also** to `WaitHandle` is enough. Please correct me if I deleted too much.

Also, replaced "...events are based on Win32 wait handles..." with "...events are based on operating system wait handles..."

@rpetrusha please review.