### PR TITLE
Barrier: removed .NET Framework mention + updated xrefs

### DIFF
--- a/docs/standard/threading/barrier.md
+++ b/docs/standard/threading/barrier.md
@@ -1,6 +1,6 @@
 ---
-title: "Barrier (.NET Framework)"
-ms.date: "03/30/2017"
+title: "Barrier"
+ms.date: "09/14/2018"
 ms.technology: dotnet-standard
 dev_langs: 
   - "csharp"
@@ -11,39 +11,44 @@ ms.assetid: 613a8bc7-6a28-4795-bd6c-1abd9050478f
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Barrier (.NET Framework)
-A *barrier* is a user-defined synchronization primitive that enables multiple threads (known as *participants*) to work concurrently on an algorithm in phases. Each participant executes until it reaches the barrier point in the code. The barrier represents the end of one phase of work. When a participant reaches the barrier, it blocks until all participants have reached the same barrier. After all participants have reached the barrier, you can optionally invoke a post-phase action. This post-phase action can be used to perform actions by a single thread while all other threads are still blocked. After the action has been executed, the participants are all unblocked.  
+# Barrier
+
+A <xref:System.Threading.Barrier?displayProperty=nameWithType> is a synchronization primitive that enables multiple threads (known as *participants*) to work concurrently on an algorithm in phases. Each participant executes until it reaches the barrier point in the code. The barrier represents the end of one phase of work. When a participant reaches the barrier, it blocks until all participants have reached the same barrier. After all participants have reached the barrier, you can optionally invoke a post-phase action. This post-phase action can be used to perform actions by a single thread while all other threads are still blocked. After the action has been executed, the participants are all unblocked.  
   
  The following code snippet shows a basic barrier pattern.  
   
  [!code-csharp[CDS_Barrier#02](../../../samples/snippets/csharp/VS_Snippets_Misc/cds_barrier/cs/barrier.cs#02)]
  [!code-vb[CDS_Barrier#02](../../../samples/snippets/visualbasic/VS_Snippets_Misc/cds_barrier/vb/barrier_vb.vb#02)]  
   
- For a complete example, see [How to: Synchronize Concurrent Operations with a Barrier](../../../docs/standard/threading/how-to-synchronize-concurrent-operations-with-a-barrier.md).  
+ For a complete example, see [How to: synchronize concurrent operations with a Barrier](how-to-synchronize-concurrent-operations-with-a-barrier.md).  
   
-## Adding and Removing Participants  
- When you create a <xref:System.Threading.Barrier>, specify the number of participants. You can also add or remove participants dynamically at any time. For example, if one participant solves its part of the problem, you can store the result, stop execution on that thread, and call <xref:System.Threading.Barrier.RemoveParticipant%2A> to decrement the number of participants in the barrier. When you add a participant by calling <xref:System.Threading.Barrier.AddParticipant%2A>, the return value specifies the current phase number, which may be useful in order to initialize the work of the new participant.  
+## Adding and removing participants
+
+ When you create a <xref:System.Threading.Barrier> instance, specify the number of participants. You can also add or remove participants dynamically at any time. For example, if one participant solves its part of the problem, you can store the result, stop execution on that thread, and call <xref:System.Threading.Barrier.RemoveParticipant%2A?displayProperty=nameWithType> to decrement the number of participants in the barrier. When you add a participant by calling <xref:System.Threading.Barrier.AddParticipant%2A?displayProperty=nameWithType>, the return value specifies the current phase number, which may be useful in order to initialize the work of the new participant.  
   
-## Broken Barriers  
- Deadlocks can occur if one participant fails to reach the barrier. To avoid these deadlocks, use the overloads of the <xref:System.Threading.Barrier.SignalAndWait%2A> method to specify a time-out period and a cancellation token. These overloads return a Boolean value that every participant can check before it continues to the next phase.  
+## Broken barriers
+
+ Deadlocks can occur if one participant fails to reach the barrier. To avoid these deadlocks, use the overloads of the <xref:System.Threading.Barrier.SignalAndWait%2A?displayProperty=nameWithType> method to specify a time-out period and a cancellation token. These overloads return a Boolean value that every participant can check before it continues to the next phase.  
   
-## Post-Phase Exceptions  
+## Post-phase exceptions
+
  If the post-phase delegate throws an exception, it is wrapped in a <xref:System.Threading.BarrierPostPhaseException> object which is then propagated to all participants.  
   
-## Barrier Versus ContinueWhenAll  
+## Barrier versus ContinueWhenAll
+
  Barriers are especially useful when the threads are performing multiple phases in loops. If your code requires only one or two phases of work, consider whether to use <xref:System.Threading.Tasks.Task?displayProperty=nameWithType> objects with any kind of implicit join, including:  
   
--   <xref:System.Threading.Tasks.TaskFactory.ContinueWhenAll%2A>  
+-   <xref:System.Threading.Tasks.TaskFactory.ContinueWhenAll%2A?displayProperty=nameWithType>  
   
--   <xref:System.Threading.Tasks.Parallel.Invoke%2A>  
+-   <xref:System.Threading.Tasks.Parallel.Invoke%2A?displayProperty=nameWithType>  
   
--   <xref:System.Threading.Tasks.Parallel.ForEach%2A>  
+-   <xref:System.Threading.Tasks.Parallel.ForEach%2A?displayProperty=nameWithType>  
   
--   <xref:System.Threading.Tasks.Parallel.For%2A>  
+-   <xref:System.Threading.Tasks.Parallel.For%2A?displayProperty=nameWithType>  
   
- For more information, see [Chaining Tasks by Using Continuation Tasks](../../../docs/standard/parallel-programming/chaining-tasks-by-using-continuation-tasks.md).  
+ For more information, see [Chaining Tasks by Using Continuation Tasks](../parallel-programming/chaining-tasks-by-using-continuation-tasks.md).  
   
 ## See also
 
-- [Threading Objects and Features](../../../docs/standard/threading/threading-objects-and-features.md)  
-- [How to: Synchronize Concurrent Operations with a Barrier](../../../docs/standard/threading/how-to-synchronize-concurrent-operations-with-a-barrier.md)
+- [Threading objects and features](threading-objects-and-features.md)  
+- [How to: synchronize concurrent operations with a Barrier](how-to-synchronize-concurrent-operations-with-a-barrier.md)


### PR DESCRIPTION
Also the first sentence was confusing:
>A *barrier* is a user-defined synchronization primitive ...

Sounds like the article is about a pattern, not about the certain .NET type. So, I've changed it to
>A <xref:System.Threading.Barrier?displayProperty=nameWithType> is a synchronization primitive
