### PR TITLE
Added the code owner for .NET threading docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,3 +63,5 @@
 /docs/standard/io/** @mairaw
 # .NET base types - Formatting
 /docs/standard/base-types/formatting-types/** @rpetrusha
+# .NET threading
+/docs/standard/threading/** @rpetrusha


### PR DESCRIPTION
I've noticed that mostly @rpetrusha reviews PRs related to .NET threading topics. Also he has authored a lot of articles (if not all) from the corresponding folder.

@rpetrusha if you disagree with the proposed update, feel free to close this PR.
