### PR TITLE
C37769: Fixing link removing the extra space

### DIFF
--- a/docs/csharp/language-reference/operators/or-operator.md
+++ b/docs/csharp/language-reference/operators/or-operator.md
@@ -13,7 +13,7 @@ ms.assetid: 82d6bb78-54c8-40bf-b679-531180ddaf70
 Binary `|` operators are predefined for the integral types and `bool`. For integral types, `|` computes the bitwise OR of its operands. For `bool` operands, `|` computes the logical OR of its operands; that is, the result is `false` if and only if both its operands are `false`.  
   
 ## Remarks  
- The binary `|` operator evaluates both operands regardless of the first one's value, in contrast to the [conditional-OR operator]     (conditional-or-operator.md) `||`.
+ The binary `|` operator evaluates both operands regardless of the first one's value, in contrast to the [conditional-OR operator](conditional-or-operator.md) `||`.
  
  User-defined types can overload the `|` operator (see [operator](../../../csharp/language-reference/keywords/operator.md)).  
   


### PR DESCRIPTION
Hello, @mairaw , @mikeblome 
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description:  Broken Link in source due spaces between ] and ( 

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
