### PR TITLE
Interlocked operations: updated the definition of the atomic operation

### DIFF
--- a/docs/standard/threading/interlocked-operations.md
+++ b/docs/standard/threading/interlocked-operations.md
@@ -14,7 +14,7 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # Interlocked Operations
-The <xref:System.Threading.Interlocked> class provides methods that synchronize access to a variable that is shared by multiple threads. The threads of different processes can use this mechanism if the variable is in shared memory. Interlocked operations are atomic — that is, the entire operation is a unit that cannot be interrupted by another interlocked operation on the same variable. This is important in operating systems with preemptive multithreading, where a thread can be suspended after loading a value from a memory address, but before having the chance to alter it and store it.  
+The <xref:System.Threading.Interlocked> class provides methods that synchronize access to a variable that is shared by multiple threads. The threads of different processes can use this mechanism if the variable is in shared memory. Interlocked operations are atomic — that is, the entire operation is a unit that cannot be interrupted by another operation on the same variable. This is important in operating systems with preemptive multithreading, where a thread can be suspended after loading a value from a memory address, but before having the chance to alter it and store it.  
   
  The <xref:System.Threading.Interlocked> class provides the following operations:  
   


### PR DESCRIPTION
Current text (emphasis mine):
>Interlocked operations are atomic — that is, the entire operation is a unit that cannot be interrupted by **another interlocked operation** on the same variable. 

Atomic operation cannot be interrupted by another interlocked operation, true. Even more, it cannot be interrupted by any other operation.