### PR TITLE
Refresh topic about installing to GAC

### DIFF
--- a/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
+++ b/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
@@ -1,40 +1,33 @@
 ---
-title: "How to: Install an Assembly into the Global Assembly Cache"
-ms.date: 09/18/2018
+title: Install an assembly into the GAC
+ms.date: 09/20/2018
 helpviewer_keywords:
   - "assemblies [.NET Framework], global assembly cache"
   - "Gacutil.exe"
   - "strong-named assemblies, global assembly cache"
   - "global assembly cache, installing assemblies"
   - "Global Assembly Cache tool"
+  - "windows installer, global assembly cache"
 ms.assetid: a7e6f091-d02c-49ba-b736-7295cb0eb743
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# How to: Install an Assembly into the Global Assembly Cache
+# How to: Install an assembly into the global assembly cache
 
-There are two ways to install a strong-named assembly into the global assembly cache (GAC):
+There are two ways to install a strong-named assembly into the global assembly cache (GAC).
 
-> [!IMPORTANT]
-> Only strong-named assemblies can be installed into the GAC. For information about how to create a strong-named assembly, see [How to: Sign an Assembly with a Strong Name](../../../docs/framework/app-domains/how-to-sign-an-assembly-with-a-strong-name.md).
+## Windows Installer
 
-- Use [Windows Installer](/windows/desktop/Msi/installation-of-assemblies-to-the-global-assembly-cache).
+[Windows Installer](/windows/desktop/Msi/installation-of-assemblies-to-the-global-assembly-cache), the Windows installation engine, is the recommended and most common way to add assemblies to the global assembly cache. Windows Installer provides reference counting of assemblies in the global assembly cache, plus other benefits. You can use the [WiX Toolset extension for Visual Studio 2017](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension) to create an installer package for Windows Installer.
 
-   This is the recommended and most common way to add assemblies to the global assembly cache. The installer provides reference counting of assemblies in the global assembly cache, plus other benefits.
+## Global assembly cache tool
 
-- Use the [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md).
-
-   You can use Gacutil.exe to add strong-named assemblies to the global assembly cache and to view the contents of the global assembly cache.
+You can use [Global assembly cache tool (gacutil.exe)](../tools/gacutil-exe-gac-tool.md) to add strong-named assemblies to the global assembly cache and to view the contents of the global assembly cache.
 
    > [!NOTE]
    > Gacutil.exe is only for development purposes and should not be used to install production assemblies into the global assembly cache.
 
-> [!NOTE]
-> In earlier versions of the .NET Framework, the Shfusion.dll Windows shell extension enabled you to install assemblies by dragging them in **File Explorer**. Beginning with the .NET Framework 4, Shfusion.dll is obsolete.
-
-## Use the Global Assembly Cache tool (Gacutil.exe)
-
-At the command prompt, type the following command:
+The syntax for gacutil is as follows:
 
 ```shell
 gacutil -i <assembly name>
@@ -48,34 +41,15 @@ The following example installs an assembly with the file name `hello.dll` into t
 gacutil -i hello.dll
 ```
 
-For more information, see [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md).
+> [!IMPORTANT]
+> Only strong-named assemblies can be installed into the GAC. For information about how to create a strong-named assembly, see [How to: Sign an Assembly with a Strong Name](how-to-sign-an-assembly-with-a-strong-name.md).
 
-## Use an InstallShield Limited Edition Project
-
-1. Add a setup and deployment package to your solution by opening the shortcut menu for your solution, and then choosing **Add**, **New Project**.
-
-2. In the **Add New Project** dialog box, in the **Installed** folder, choose **Other Project Types**,  **Setup and Deployment**, **InstallShield Limited Edition**, and give your project a name. (If prompted, download, install, and activate InstallShield.)
-
-3. Perform the general configuration of your setup and deployment project either by using the Project Assistant in **Solution Explorer**, or by choosing the substeps of the numbered steps in the **Solution Explorer**.Configure your setup as you would if you were not adding assemblies to the GAC.
-
-4. To begin the process of adding an assembly to the GAC, choose **Files**, which is under the **Specify Application Data** step in **Solution Explorer**.
-
-5. In the **Destination computer's folders** pane, open the shortcut menu for **Destination Computer**, and then choose **Show Predefined Folder**, **[GlobalAssemblyCache]**.
-
-6. For each project in the solution that contains an assembly that you want to install in the global assembly cache:
-
-    1. In the **Source computer's folders** pane, choose the project.
-
-    2. In the **Destination computer's folders** pane, choose **[GlobalAssemblyCache]**.
-
-    3. In the **Source computer's files** pane, choose **Primary output from** *<project_name>*.
-
-    4. Drag the file to the **Destination computer's files** pane (or use the **Copy** and **Paste** commands from the file's shortcut menu).
+> [!NOTE]
+> In earlier versions of the .NET Framework, the Shfusion.dll Windows shell extension enabled you to install assemblies by dragging them in **File Explorer**. Beginning with the .NET Framework 4, Shfusion.dll is obsolete.
 
 ## See also
 
-- [Working with Assemblies and the Global Assembly Cache](../../../docs/framework/app-domains/working-with-assemblies-and-the-gac.md)
-- [How to: Remove an Assembly from the Global Assembly Cache](../../../docs/framework/app-domains/how-to-remove-an-assembly-from-the-gac.md)
-- [Gacutil.exe (Global Assembly Cache Tool)](../../../docs/framework/tools/gacutil-exe-gac-tool.md)
-- [How to: Sign an Assembly with a Strong Name](../../../docs/framework/app-domains/how-to-sign-an-assembly-with-a-strong-name.md)
-- [Windows Installer Deployment](https://msdn.microsoft.com/library/121be21b-b916-43e2-8f10-8b080516d2a0)
+- [Working with Assemblies and the Global Assembly Cache](working-with-assemblies-and-the-gac.md)
+- [How to: Remove an Assembly from the Global Assembly Cache](how-to-remove-an-assembly-from-the-gac.md)
+- [Gacutil.exe (Global Assembly Cache Tool)](../tools/gacutil-exe-gac-tool.md)
+- [How to: Sign an Assembly with a Strong Name](how-to-sign-an-assembly-with-a-strong-name.md)

--- a/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
+++ b/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
@@ -16,9 +16,12 @@ ms.author: "ronpet"
 
 There are two ways to install a strong-named assembly into the global assembly cache (GAC).
 
+> [!IMPORTANT]
+> Only strong-named assemblies can be installed into the GAC. For information about how to create a strong-named assembly, see [How to: Sign an Assembly with a Strong Name](how-to-sign-an-assembly-with-a-strong-name.md).
+
 ## Windows Installer
 
-[Windows Installer](/windows/desktop/Msi/installation-of-assemblies-to-the-global-assembly-cache), the Windows installation engine, is the recommended and most common way to add assemblies to the global assembly cache. Windows Installer provides reference counting of assemblies in the global assembly cache, plus other benefits. You can use the [WiX Toolset extension for Visual Studio 2017](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension) to create an installer package for Windows Installer.
+[Windows Installer](/windows/desktop/Msi/installation-of-assemblies-to-the-global-assembly-cache), the Windows installation engine, is the recommended way to add assemblies to the global assembly cache. Windows Installer provides reference counting of assemblies in the global assembly cache and other benefits. You can use the [WiX Toolset extension for Visual Studio 2017](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension) to create an installer package for Windows Installer.
 
 ## Global assembly cache tool
 
@@ -40,9 +43,6 @@ The following example installs an assembly with the file name `hello.dll` into t
 ```shell
 gacutil -i hello.dll
 ```
-
-> [!IMPORTANT]
-> Only strong-named assemblies can be installed into the GAC. For information about how to create a strong-named assembly, see [How to: Sign an Assembly with a Strong Name](how-to-sign-an-assembly-with-a-strong-name.md).
 
 > [!NOTE]
 > In earlier versions of the .NET Framework, the Shfusion.dll Windows shell extension enabled you to install assemblies by dragging them in **File Explorer**. Beginning with the .NET Framework 4, Shfusion.dll is obsolete.

--- a/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
+++ b/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: Install an Assembly into the Global Assembly Cache"
-ms.date: "03/30/2017"
-helpviewer_keywords: 
+ms.date: 09/18/2018
+helpviewer_keywords:
   - "assemblies [.NET Framework], global assembly cache"
   - "Gacutil.exe"
   - "strong-named assemblies, global assembly cache"
@@ -12,68 +12,70 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # How to: Install an Assembly into the Global Assembly Cache
-There are two ways to install a strong-named assembly into the global assembly cache (GAC):  
-  
+
+There are two ways to install a strong-named assembly into the global assembly cache (GAC):
+
 > [!IMPORTANT]
->  Only strong-named assemblies can be installed into the GAC. For information about how to create a strong-named assembly, see [How to: Sign an Assembly with a Strong Name](../../../docs/framework/app-domains/how-to-sign-an-assembly-with-a-strong-name.md).  
-  
--   Using [Windows Installer](/windows/desktop/Msi/windows-installer-portal).  
-  
-     You do this in Visual Studio 2012 and Visual Studio 2013 by creating an InstallShield Limited Edition Project.  
-  
-     This is the recommended and most common way to add assemblies to the global assembly cache. The installer provides reference counting of assemblies in the global assembly cache, plus other benefits.  
-  
--   Using the [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md).  
-  
-     You can use Gacutil.exe to add strong-named assemblies to the global assembly cache and to view the contents of the global assembly cache.  
-  
-    > [!NOTE]
-    >  Gacutil.exe is only for development purposes and should not be used to install production assemblies into the global assembly cache.  
-  
+> Only strong-named assemblies can be installed into the GAC. For information about how to create a strong-named assembly, see [How to: Sign an Assembly with a Strong Name](../../../docs/framework/app-domains/how-to-sign-an-assembly-with-a-strong-name.md).
+
+- Use [Windows Installer](/windows/desktop/Msi/installation-of-assemblies-to-the-global-assembly-cache).
+
+   This is the recommended and most common way to add assemblies to the global assembly cache. The installer provides reference counting of assemblies in the global assembly cache, plus other benefits.
+
+- Use the [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md).
+
+   You can use Gacutil.exe to add strong-named assemblies to the global assembly cache and to view the contents of the global assembly cache.
+
+   > [!NOTE]
+   > Gacutil.exe is only for development purposes and should not be used to install production assemblies into the global assembly cache.
+
 > [!NOTE]
->  In earlier versions of the .NET Framework, the Shfusion.dll Windows shell extension enabled you to install assemblies by dragging them in File Explorer. Beginning with the [!INCLUDE[net_v40_long](../../../includes/net-v40-long-md.md)], Shfusion.dll is obsolete.  
-  
-### To use the Global Assembly Cache tool (Gacutil.exe)  
-  
-1.  At the command prompt, type the following command:  
-  
-     **gacutil -i** \<*assembly name*>  
-  
-     In this command, *assembly name* is the name of the assembly to install in the global assembly cache.  
-  
- The following example installs an assembly with the file name `hello.dll` into the global assembly cache.  
-  
-```  
-gacutil -i hello.dll  
-```  
-  
- For more information, see [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md).  
-  
-### To use an InstallShield Limited Edition Project  
-  
-1.  Add a setup and deployment package to your solution by opening the shortcut menu for your solution, and then choosing **Add**, **New Project**.  
-  
-2.  In the **Add New Project** dialog box, in the **Installed** folder, choose **Other Project Types**,  **Setup and Deployment**, **InstallShield Limited Edition**, and give your project a name. (If prompted, download, install, and activate InstallShield.)  
-  
-3.  Perform the general configuration of your setup and deployment project either by using the Project Assistant in **Solution Explorer**, or by choosing the substeps of the numbered steps in the **Solution Explorer**.Configure your setup as you would if you were not adding assemblies to the GAC.  
-  
-4.  To begin the process of adding an assembly to the GAC, choose **Files**, which is under the **Specify Application Data** step in **Solution Explorer**.  
-  
-5.  In the **Destination computer's folders** pane, open the shortcut menu for **Destination Computer**, and then choose **Show Predefined Folder**, **[GlobalAssemblyCache]**.  
-  
-6.  For each project in the solution that contains an assembly that you want to install in the global assembly cache:  
-  
-    1.  In the **Source computer's folders** pane, choose the project.  
-  
-    2.  In the **Destination computer's folders** pane, choose **[GlobalAssemblyCache]**.  
-  
-    3.  In the **Source computer's files** pane, choose **Primary output from** *<project_name>*.  
-  
-    4.  Drag the file in step c to the **Destination computer's files** pane (or use the **Copy** and **Paste** commands from the file's shortcut menu).  
-  
-## See Also  
- [Working with Assemblies and the Global Assembly Cache](../../../docs/framework/app-domains/working-with-assemblies-and-the-gac.md)  
- [How to: Remove an Assembly from the Global Assembly Cache](../../../docs/framework/app-domains/how-to-remove-an-assembly-from-the-gac.md)  
- [Gacutil.exe (Global Assembly Cache Tool)](../../../docs/framework/tools/gacutil-exe-gac-tool.md)  
- [How to: Sign an Assembly with a Strong Name](../../../docs/framework/app-domains/how-to-sign-an-assembly-with-a-strong-name.md)  
- [Windows Installer Deployment](https://msdn.microsoft.com/library/121be21b-b916-43e2-8f10-8b080516d2a0)
+> In earlier versions of the .NET Framework, the Shfusion.dll Windows shell extension enabled you to install assemblies by dragging them in **File Explorer**. Beginning with the .NET Framework 4, Shfusion.dll is obsolete.
+
+## Use the Global Assembly Cache tool (Gacutil.exe)
+
+At the command prompt, type the following command:
+
+```shell
+gacutil -i <assembly name>
+```
+
+In this command, *assembly name* is the name of the assembly to install in the global assembly cache.
+
+The following example installs an assembly with the file name `hello.dll` into the global assembly cache.
+
+```shell
+gacutil -i hello.dll
+```
+
+For more information, see [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md).
+
+## Use an InstallShield Limited Edition Project
+
+1. Add a setup and deployment package to your solution by opening the shortcut menu for your solution, and then choosing **Add**, **New Project**.
+
+2. In the **Add New Project** dialog box, in the **Installed** folder, choose **Other Project Types**,  **Setup and Deployment**, **InstallShield Limited Edition**, and give your project a name. (If prompted, download, install, and activate InstallShield.)
+
+3. Perform the general configuration of your setup and deployment project either by using the Project Assistant in **Solution Explorer**, or by choosing the substeps of the numbered steps in the **Solution Explorer**.Configure your setup as you would if you were not adding assemblies to the GAC.
+
+4. To begin the process of adding an assembly to the GAC, choose **Files**, which is under the **Specify Application Data** step in **Solution Explorer**.
+
+5. In the **Destination computer's folders** pane, open the shortcut menu for **Destination Computer**, and then choose **Show Predefined Folder**, **[GlobalAssemblyCache]**.
+
+6. For each project in the solution that contains an assembly that you want to install in the global assembly cache:
+
+    1. In the **Source computer's folders** pane, choose the project.
+
+    2. In the **Destination computer's folders** pane, choose **[GlobalAssemblyCache]**.
+
+    3. In the **Source computer's files** pane, choose **Primary output from** *<project_name>*.
+
+    4. Drag the file to the **Destination computer's files** pane (or use the **Copy** and **Paste** commands from the file's shortcut menu).
+
+## See also
+
+- [Working with Assemblies and the Global Assembly Cache](../../../docs/framework/app-domains/working-with-assemblies-and-the-gac.md)
+- [How to: Remove an Assembly from the Global Assembly Cache](../../../docs/framework/app-domains/how-to-remove-an-assembly-from-the-gac.md)
+- [Gacutil.exe (Global Assembly Cache Tool)](../../../docs/framework/tools/gacutil-exe-gac-tool.md)
+- [How to: Sign an Assembly with a Strong Name](../../../docs/framework/app-domains/how-to-sign-an-assembly-with-a-strong-name.md)
+- [Windows Installer Deployment](https://msdn.microsoft.com/library/121be21b-b916-43e2-8f10-8b080516d2a0)

--- a/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
+++ b/docs/framework/app-domains/how-to-install-an-assembly-into-the-gac.md
@@ -25,7 +25,7 @@ There are two ways to install a strong-named assembly into the global assembly c
 
 ## Global assembly cache tool
 
-You can use [Global assembly cache tool (gacutil.exe)](../tools/gacutil-exe-gac-tool.md) to add strong-named assemblies to the global assembly cache and to view the contents of the global assembly cache.
+You can use the [Global assembly cache tool (gacutil.exe)](../tools/gacutil-exe-gac-tool.md) to add strong-named assemblies to the global assembly cache and to view the contents of the global assembly cache.
 
    > [!NOTE]
    > Gacutil.exe is only for development purposes and should not be used to install production assemblies into the global assembly cache.

--- a/docs/framework/app-domains/how-to-view-the-contents-of-the-gac.md
+++ b/docs/framework/app-domains/how-to-view-the-contents-of-the-gac.md
@@ -16,11 +16,11 @@ ms.author: "ronpet"
 ---
 # How to: View the contents of the global assembly cache
 
-Use the [global assembly cache tool (gacutil.exe)](../tools/gacutil-exe-gac-tool.md) to view the contents of the global assembly cache.
+Use the [global assembly cache tool (gacutil.exe)](../tools/gacutil-exe-gac-tool.md) to view the contents of the global assembly cache (GAC).
 
-## To view a list of the assemblies in the global assembly cache
+## View the assemblies in the GAC
 
-At the [Visual Studio command prompt](../tools/developer-command-prompt-for-vs.md), type the following command:
+To view a list of the assemblies in the global assembly cache, open [Developer Command Prompt for Visual Studio](../tools/developer-command-prompt-for-vs.md), and then enter the following command:
 
 ```shell
 gacutil -l

--- a/docs/framework/app-domains/how-to-view-the-contents-of-the-gac.md
+++ b/docs/framework/app-domains/how-to-view-the-contents-of-the-gac.md
@@ -1,7 +1,7 @@
 ---
 title: "How to: View the Contents of the Global Assembly Cache"
 ms.date: "03/30/2017"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "assemblies [.NET Framework], global assembly cache"
   - "global assembly cache, viewing contents"
   - "viewing assemblies in global assembly cache"
@@ -14,19 +14,28 @@ ms.assetid: c5f786a0-969b-4f14-9f02-e77c3384d9af
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# How to: View the Contents of the Global Assembly Cache
-Use the [Global Assembly Cache tool (Gacutil.exe)](../../../docs/framework/tools/gacutil-exe-gac-tool.md) to view the contents of the global assembly cache.  
-  
-### To view a list of the assemblies in the global assembly cache  
-  
-1.  At the [Visual Studio command prompt](../../../docs/framework/tools/developer-command-prompt-for-vs.md), type the following command:  
-  
-     **gacutil -l**   
-     -or-  
-    **gacutil /l**  
-  
- In earlier versions of the .NET Framework, the [Shfusion.dll](https://msdn.microsoft.com/library/0d9464cf-ddba-4ca9-bbec-f678fb58f380) Windows shell extension enabled you to view the global assembly cache in File Explorer. Beginning with the [!INCLUDE[net_v40_long](../../../includes/net-v40-long-md.md)], Shfusion.dll is obsolete.  
-  
-## See Also  
- [Working with Assemblies and the Global Assembly Cache](../../../docs/framework/app-domains/working-with-assemblies-and-the-gac.md)  
- [Gacutil.exe (Global Assembly Cache Tool)](../../../docs/framework/tools/gacutil-exe-gac-tool.md)
+# How to: View the contents of the global assembly cache
+
+Use the [global assembly cache tool (gacutil.exe)](../tools/gacutil-exe-gac-tool.md) to view the contents of the global assembly cache.
+
+## To view a list of the assemblies in the global assembly cache
+
+At the [Visual Studio command prompt](../tools/developer-command-prompt-for-vs.md), type the following command:
+
+```shell
+gacutil -l
+```
+
+-or-
+
+```shell
+gacutil /l
+```
+
+> [!NOTE]
+> In earlier versions of the .NET Framework, the [Shfusion.dll](/previous-versions/dotnet/netframework-4.0/34149zk3(v=vs.100)) Windows shell extension enabled you to view the global assembly cache in File Explorer. Beginning with the [!INCLUDE[net_v40_long](../../../includes/net-v40-long-md.md)], Shfusion.dll is obsolete.
+
+## See also
+
+- [Working with Assemblies and the Global Assembly Cache](working-with-assemblies-and-the-gac.md)
+- [Gacutil.exe (Global Assembly Cache Tool)](../tools/gacutil-exe-gac-tool.md)


### PR DESCRIPTION
Removes references to VS 2012 and 2013. Also removes InstallShield section since it's not included with VS 2017. Adds info about the WiX Toolset extension for VS 2017.

Part of the fix for #7172.