### PR TITLE
TLS guidance - fix AppContext limitation

### DIFF
--- a/docs/framework/network-programming/tls.md
+++ b/docs/framework/network-programming/tls.md
@@ -176,7 +176,7 @@ For more information about TLS protocols, see [Mitigation: TLS Protocols](../mig
 > [!WARNING]
 > Setting registry keys affects all applications on the system. Use this option only if you are in full control of the machine and can control changes to the registry.
 
-If setting one or both `AppContext` switches are not an option, you can control the security protocols that your app uses with the Windows Registry keys described in this section. You might not be able to use one or both the `AppContext` switches if your app runs on .NET Framework version earlier than 4.6, or you can't edit the configuration file. If you want to configure security with the registry, then don't specify a security protocol value in your code; doing so would override the registry.
+If setting one or both `AppContext` switches isn't an option, you can control the security protocols that your app uses with the Windows Registry keys described in this section. You might not be able to use one or both the `AppContext` switches if your app runs on .NET Framework 4.6 or earlier versions, or you can't edit the configuration file. If you want to configure security with the registry, then don't specify a security protocol value in your code; doing so would override the registry.
 
 The names of the registry keys are similar to the names of the corresponding `AppContext` switches but without a `DontEnable` prepended to the name. For example, the `AppContext` switch `DontEnableSchUseStrongCrypto` is the registry key called [SchUseStrongCrypto](#schusestrongcrypto).
 

--- a/docs/framework/network-programming/tls.md
+++ b/docs/framework/network-programming/tls.md
@@ -176,7 +176,7 @@ For more information about TLS protocols, see [Mitigation: TLS Protocols](../mig
 > [!WARNING]
 > Setting registry keys affects all applications on the system. Use this option only if you are in full control of the machine and can control changes to the registry.
 
-If setting one or both `AppContext` switches are not an option, you can control the security protocols that your app uses with the Windows Registry keys described in this section. You might not be able to use one or both the `AppContext` switches if your app targets a .NET Framework version earlier than 4.6, or you can't edit the configuration file. If you want to configure security with the registry, then don't specify a security protocol value in your code; doing so would override the registry.
+If setting one or both `AppContext` switches are not an option, you can control the security protocols that your app uses with the Windows Registry keys described in this section. You might not be able to use one or both the `AppContext` switches if your app runs on .NET Framework version earlier than 4.6, or you can't edit the configuration file. If you want to configure security with the registry, then don't specify a security protocol value in your code; doing so would override the registry.
 
 The names of the registry keys are similar to the names of the corresponding `AppContext` switches but without a `DontEnable` prepended to the name. For example, the `AppContext` switch `DontEnableSchUseStrongCrypto` is the registry key called [SchUseStrongCrypto](#schusestrongcrypto).
 

--- a/docs/framework/network-programming/tls.md
+++ b/docs/framework/network-programming/tls.md
@@ -176,7 +176,7 @@ For more information about TLS protocols, see [Mitigation: TLS Protocols](../mig
 > [!WARNING]
 > Setting registry keys affects all applications on the system. Use this option only if you are in full control of the machine and can control changes to the registry.
 
-If setting one or both `AppContext` switches isn't an option, you can control the security protocols that your app uses with the Windows Registry keys described in this section. You might not be able to use one or both the `AppContext` switches if your app runs on .NET Framework 4.6 or earlier versions, or you can't edit the configuration file. If you want to configure security with the registry, then don't specify a security protocol value in your code; doing so would override the registry.
+If setting one or both `AppContext` switches isn't an option, you can control the security protocols that your app uses with the Windows Registry keys described in this section. You might not be able to use one or both the `AppContext` switches if your app runs on .NET Framework 4.5.2 or earlier versions, or if you can't edit the configuration file. If you want to configure security with the registry, don't specify a security protocol value in your code; doing so overrides the registry setting.
 
 The names of the registry keys are similar to the names of the corresponding `AppContext` switches but without a `DontEnable` prepended to the name. For example, the `AppContext` switch `DontEnableSchUseStrongCrypto` is the registry key called [SchUseStrongCrypto](#schusestrongcrypto).
 


### PR DESCRIPTION
AppContext switches cannot be used only when the app **runs** on earlier than 4.6.
Targeting does not affect the situation.

Thanks @NikolaMilosavljevic for pointing it out!