### PR TITLE
Corrected this typo: "a exception"

### DIFF
--- a/docs/csharp/language-reference/keywords/try-catch.md
+++ b/docs/csharp/language-reference/keywords/try-catch.md
@@ -37,7 +37,7 @@ catch (InvalidCastException e)
   
  It is possible to use more than one specific `catch` clause in the same try-catch statement. In this case, the order of the `catch` clauses is important because the `catch` clauses are examined in order. Catch the more specific exceptions before the less specific ones. The compiler produces an error if you order your catch blocks so that a later block can never be reached.  
   
- Using `catch` arguments is one way to filter for the exceptions you want to handle.  You can also use a exception filter that further examines the exception to decide whether to handle it.  If the exception filter returns false, then the search for a handler continues.  
+ Using `catch` arguments is one way to filter for the exceptions you want to handle.  You can also use an exception filter that further examines the exception to decide whether to handle it.  If the exception filter returns false, then the search for a handler continues.  
   
 ```csharp  
 catch (ArgumentException e) when (e.ParamName == "…")  


### PR DESCRIPTION
Corrected a typo. This text: "You can also use a exception filter ...", should be "You can also use an exception filter ...".

Fixes #7876 