### PR TITLE
Add suggestion to also target .NET Standard 2.0

### DIFF
--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -44,7 +44,7 @@ In general, we recommend you to target the *lowest* version of .NET Standard pos
 1. Target the next lower version of .NET Standard and build your project.
 2. If your project builds successfully, repeat step 1. Otherwise, retarget to the next higher version and that's the version you should use.
 
-However, since targeting lower .NET Standard versions introduces a number of support dependencies, if your project targets .NET Standard 1.x, [we recomment that you *also* target .NET Standard 2.0](library-guidance/cross-platform-targeting.md). This simplifies the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks, and it reduces the number of packages they need to download.
+However, targeting lower .NET Standard versions introduces a number of support dependencies. If your project targets .NET Standard 1.x, [we recommend that you *also* target .NET Standard 2.0](library-guidance/cross-platform-targeting.md). This simplifies the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks, and it reduces the number of packages they need to download.
 
 ### .NET Standard versioning rules
 

--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -44,7 +44,7 @@ In general, we recommend you to target the *lowest* version of .NET Standard pos
 1. Target the next lower version of .NET Standard and build your project.
 2. If your project builds successfully, repeat step 1. Otherwise, retarget to the next higher version and that's the version you should use.
 
-However, since targeting lower .NET Standard versions introduces a number of support dependencies, if your project targets .NET Standard 1.x, it is [suggested to *also* target .NET Standard 2.0](https://github.com/dotnet/standard/blob/master/docs/versions.md#how-do-i-know-which-net-standard-version-i-should-target). This will simplify the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks and it will reduce the number of packages they will need to download.
+However, since targeting lower .NET Standard versions introduces a number of support dependencies, if your project targets .NET Standard 1.x, [we recomment that you *also* target .NET Standard 2.0](library-guidance/cross-platform-targeting.md). This simplifies the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks, and it reduces the number of packages they need to download.
 
 ### .NET Standard versioning rules
 

--- a/docs/standard/net-standard.md
+++ b/docs/standard/net-standard.md
@@ -44,6 +44,8 @@ In general, we recommend you to target the *lowest* version of .NET Standard pos
 1. Target the next lower version of .NET Standard and build your project.
 2. If your project builds successfully, repeat step 1. Otherwise, retarget to the next higher version and that's the version you should use.
 
+However, since targeting lower .NET Standard versions introduces a number of support dependencies, if your project targets .NET Standard 1.x, it is [suggested to *also* target .NET Standard 2.0](https://github.com/dotnet/standard/blob/master/docs/versions.md#how-do-i-know-which-net-standard-version-i-should-target). This will simplify the dependency graph for users of your library that run on .NET Standard 2.0 compatible frameworks and it will reduce the number of packages they will need to download.
+
 ### .NET Standard versioning rules
 
 There are two primary versioning rules:


### PR DESCRIPTION
Short addition to the .NET Standard targeting guide.
Based on [.NET Standard targeting suggestions](https://github.com/dotnet/standard/blob/master/docs/versions.md#how-do-i-know-which-net-standard-version-i-should-target) on dotnet/standard and [tweet by David Fowler](https://twitter.com/davidfowl/status/1008453902058917888).