### PR TITLE
Update in-parameter-modifier.md

### DIFF
--- a/docs/csharp/language-reference/keywords/in-parameter-modifier.md
+++ b/docs/csharp/language-reference/keywords/in-parameter-modifier.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
 
 # in parameter modifier (C# Reference)
 
-The `in` keyword causes arguments to be passed by reference. It is like the [ref](ref.md) or [out](out-parameter-modifier.md) keywords, except that `in` arguments cannot be modified by the called method. Whereas `ref` arguments may be modified,  `out` arguments must be modified by the caller, and those modifications are observable in the calling context.
+The `in` keyword causes arguments to be passed by reference. It is like the [ref](ref.md) or [out](out-parameter-modifier.md) keywords, except that `in` arguments cannot be modified by the called method. Whereas `ref` arguments may be modified,  `out` arguments must be modified by the called method, and those modifications are observable in the calling context.
 
 [!code-csharp-interactive[cs-in-keyword](../../../../samples/snippets/csharp/language-reference/keywords/in-ref-out-modifier/InParameterModifier.cs#1)]  
 


### PR DESCRIPTION
## Summary
though we know that an argument passed using out keyword, can be passed without any value assigned to it, surprisingly I saw that in the documentation it is told that 

> `out` arguments must be modified by the caller

I fixed this mistake.


Fixes #Issue_Number (if available)
