### PR TITLE
update link to asp.net core docs tutorials

### DIFF
--- a/docs/core/tutorials/aspnet-core.md
+++ b/docs/core/tutorials/aspnet-core.md
@@ -7,4 +7,4 @@ ms.date: 06/20/2016
 ---
 # Getting started with ASP.NET Core
 
-For tutorials about developing ASP.NET Core web applications, we suggest you head over to [ASP.NET Core documentation](/aspnet/core/).
+For tutorials about developing ASP.NET Core web applications, we suggest you head over to [ASP.NET Core documentation](https://docs.microsoft.com/en-us/aspnet/core/tutorials).

--- a/docs/core/tutorials/aspnet-core.md
+++ b/docs/core/tutorials/aspnet-core.md
@@ -7,4 +7,4 @@ ms.date: 06/20/2016
 ---
 # Getting started with ASP.NET Core
 
-For tutorials about developing ASP.NET Core web applications, we suggest you head over to [ASP.NET Core documentation](https://docs.microsoft.com/en-us/aspnet/core/tutorials).
+For tutorials about developing ASP.NET Core web applications, tions, see [ASP.NET Core documentation](aspnet/core/tutorials).

--- a/docs/core/tutorials/aspnet-core.md
+++ b/docs/core/tutorials/aspnet-core.md
@@ -7,4 +7,4 @@ ms.date: 06/20/2016
 ---
 # Getting started with ASP.NET Core
 
-For tutorials about developing ASP.NET Core web applications, tions, see [ASP.NET Core documentation](aspnet/core/tutorials).
+For tutorials about developing ASP.NET Core web applications, see [ASP.NET Core Tutorials](aspnet/core/tutorials).


### PR DESCRIPTION
## Summary

Link no longer exists in gh and it seems like it was intended to go to primary doc site for asp.net core

