### PR TITLE
C42959: Missing hyperlink

### DIFF
--- a/docs/framework/wcf/feature-details/interoperability-with-pox-applications.md
+++ b/docs/framework/wcf/feature-details/interoperability-with-pox-applications.md
@@ -50,7 +50,7 @@ private static Binding CreatePoxBinding()
   
 -   <xref:System.ServiceModel.Channels.HttpResponseMessageProperty>, which contains information about the HTTP response, such as the HTTP status code and status description, as well as any HTTP response headers.  
   
- The following code example shows how to create an HTTP GET request message that is addressed to http://localhost:8100/customers.  
+ The following code example shows how to create an HTTP GET request message that is addressed to`http://localhost:8100/customers`.  
   
 ```  
 Message request = Message.CreateMessage( MessageVersion.None, String.Empty );  


### PR DESCRIPTION
Hello, @mairaw, @yishengjin1413, @Mikejo5000,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue:   Example URL should be escaped in order to avoid creating a link. 
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
