### PR TITLE
add missing space and language identifier

### DIFF
--- a/docs/framework/wcf/feature-details/interoperability-with-pox-applications.md
+++ b/docs/framework/wcf/feature-details/interoperability-with-pox-applications.md
@@ -1,67 +1,69 @@
 ---
-title: "Interoperability with POX Applications"
+title: "Interoperability with POX applications"
 ms.date: "03/30/2017"
 ms.assetid: 449276b8-4633-46f0-85c9-81f01d127636
 ---
-# Interoperability with POX Applications
+# Interoperability with POX applications
+
 "Plain Old XML" (POX) applications communicate by exchanging raw HTTP messages that contain only XML application data that is not enclosed within a SOAP envelope. Windows Communication Foundation (WCF) can provide both services and clients that use POX messages. On the service, WCF can be used to implement services that expose endpoints to clients such as Web browsers and scripting languages that send and receive POX messages. On the client, the WCF programming model can be used to implement clients that communicate with POX-based services.  
   
 > [!NOTE]
->  This document was originally written for the [!INCLUDE[dnprdnshort](../../../../includes/dnprdnshort-md.md)] 3.0.  [!INCLUDE[dnprdnshort](../../../../includes/dnprdnshort-md.md)] 3.5 has built-in support for working with POX applications. For more information about see [WCF Web HTTP Programming Model](../../../../docs/framework/wcf/feature-details/wcf-web-http-programming-model.md)  
+> This document was originally written for the [!INCLUDE[dnprdnshort](../../../../includes/dnprdnshort-md.md)] 3.0.  [!INCLUDE[dnprdnshort](../../../../includes/dnprdnshort-md.md)] 3.5 has built-in support for working with POX applications. For more information about see [WCF Web HTTP Programming Model](../../../../docs/framework/wcf/feature-details/wcf-web-http-programming-model.md).
   
-## POX Programming with WCF  
- WCF services that communicate over HTTP using POX messages use a [\<customBinding>](../../../../docs/framework/configure-apps/file-schema/wcf/custombinding.md).  
+## POX programming with WCF
+
+WCF services that communicate over HTTP using POX messages use a [\<customBinding>](../../../../docs/framework/configure-apps/file-schema/wcf/custombinding.md).
+
+```xml
+<customBinding>
+   <binding name="poxServerBinding">
+       <textMessageEncoding messageVersion="None" />
+       <httpTransport />
+   </binding>
+</customBinding>
+```
+
+This custom binding contains two elements:
+
+- [\<httpTransport>](../../../../docs/framework/configure-apps/file-schema/wcf/httptransport.md)
+
+- [\<textMessageEncoding>](../../../../docs/framework/configure-apps/file-schema/wcf/textmessageencoding.md)
+
+The standard WCF Text Message Encoder is specially configured to use the <xref:System.ServiceModel.Channels.MessageVersion.None%2A> value, which allows it to process XML message payloads that do not arrive wrapped in a SOAP envelope.
+
+WCF clients that communicate over HTTP using POX messages use a similar binding (shown in the following imperative code).
+
+```csharp
+private static Binding CreatePoxBinding()
+{
+    TextMessageEncodingBindingElement encoder =
+        new TextMessageEncodingBindingElement( MessageVersion.None, Encoding.UTF8 );
+    HttpTransportBindingElement transport = new HttpTransportBindingElement();
+    transport.ManualAddressing = true;
+    return new CustomBinding( new BindingElement[] { encoder, transport } );
+}
+```
+
+Because POX clients must explicitly specify the URIs to which they send messages, they usually must configure the <xref:System.ServiceModel.Channels.HttpTransportBindingElement> to a manual addressing mode by setting the <xref:System.ServiceModel.Channels.TransportBindingElement.ManualAddressing%2A> property to `true` on the element. This allows messages to be addressed explicitly by application code and it is not necessary to create a new <xref:System.ServiceModel.ChannelFactory> every time an application sends a message to a different HTTP URI.
+
+Because POX messages do not use SOAP headers to convey important protocol information, POX clients and services often must manipulate pieces of the underlying HTTP request used to send or receive a message. HTTP-specific protocol information such as the HTTP headers and status codes are surfaced in the WCF programming model through two classes:
+
+- <xref:System.ServiceModel.Channels.HttpRequestMessageProperty>, which contains information about the HTTP request, such as the HTTP method and request headers.
+
+- <xref:System.ServiceModel.Channels.HttpResponseMessageProperty>, which contains information about the HTTP response, such as the HTTP status code and status description, as well as any HTTP response headers.
   
-```xml  
-<customBinding>  
-   <binding name="poxServerBinding">  
-       <textMessageEncoding messageVersion="None" />  
-       <httpTransport />  
-   </binding>  
-</customBinding>  
-```  
-  
- This custom binding contains two elements:  
-  
--   The [\<httpTransport>](../../../../docs/framework/configure-apps/file-schema/wcf/httptransport.md) and  
-  
--   The [\<textMessageEncoding>](../../../../docs/framework/configure-apps/file-schema/wcf/textmessageencoding.md).  
-  
- The standard WCF Text Message Encoder is specially configured to use the <xref:System.ServiceModel.Channels.MessageVersion.None%2A> value, which allows it to process XML message payloads that do not arrive wrapped in a SOAP envelope.  
-  
- WCF clients that communicate over HTTP using POX messages use a similar binding (shown in the following imperative code).  
-  
-```  
-private static Binding CreatePoxBinding()  
-{  
-    TextMessageEncodingBindingElement encoder =   
-    new TextMessageEncodingBindingElement( MessageVersion.None, Encoding.UTF8 );  
-    HttpTransportBindingElement transport = new HttpTransportBindingElement();  
-    transport.ManualAddressing = true;  
-    return new CustomBinding( new BindingElement[] { encoder, transport } );  
-}   
-```  
-  
- Because POX clients must explicitly specify the URIs to which they send messages, they usually must configure the <xref:System.ServiceModel.Channels.HttpTransportBindingElement> to a manual addressing mode by setting the <xref:System.ServiceModel.Channels.TransportBindingElement.ManualAddressing%2A> property to `true` on the element. This allows messages to be addressed explicitly by application code and it is not necessary to create a new <xref:System.ServiceModel.ChannelFactory> every time an application sends a message to a different HTTP URI.  
-  
- Because POX messages do not use SOAP headers to convey important protocol information, POX clients and services often must manipulate pieces of the underlying HTTP request used to send or receive a message. HTTP-specific protocol information such as the HTTP headers and status codes are surfaced in the WCF programming model through two classes:  
-  
--   <xref:System.ServiceModel.Channels.HttpRequestMessageProperty>, which contains information about the HTTP request, such as the HTTP method and request headers.  
-  
--   <xref:System.ServiceModel.Channels.HttpResponseMessageProperty>, which contains information about the HTTP response, such as the HTTP status code and status description, as well as any HTTP response headers.  
-  
- The following code example shows how to create an HTTP GET request message that is addressed to`http://localhost:8100/customers`.  
-  
-```  
-Message request = Message.CreateMessage( MessageVersion.None, String.Empty );  
-request.Headers.To = "http://localhost:8100/customers";  
-  
-HttpRequestMessageProperty property = new HttpRequestMessageProperty();  
-property.Method = "GET";  
-property.SuppressEntityBody = true;  
-request.Properties.Add( HttpRequestMessageProperty.Name, property );  
-```  
-  
- First, an empty request <xref:System.ServiceModel.Channels.Message> is created by calling <xref:System.ServiceModel.Channels.Message.CreateMessage%28System.ServiceModel.Channels.MessageVersion%2CSystem.String%29>. The <xref:System.ServiceModel.Channels.MessageVersion.None%2A> parameter is used to indicate that a SOAP envelope is not required and <xref:System.String.Empty> parameter is passed as the Action. The request message is then addressed by setting <xref:System.ServiceModel.Channels.MessageHeaders.To%2A> header to the desired URI. Next, an <xref:System.ServiceModel.Channels.HttpRequestMessageProperty> is created and the <xref:System.ServiceModel.Channels.HttpRequestMessageProperty.Method%2A> is set to the HTTP verb GET method and the <xref:System.ServiceModel.Channels.HttpRequestMessageProperty.SuppressEntityBody%2A> is set to `true` to indicate that no data should be sent in the body of the outgoing HTTP request message. Finally, the request property is added to the <xref:System.ServiceModel.Channels.Message.Properties%2A> collection of the request message so it can influence how the HTTP Transport sends the request. The message is then ready to be sent over an appropriate instance of the <xref:System.ServiceModel.Channels.IRequestChannel>.  
-  
- Similar techniques can be used on the service to extract the <xref:System.ServiceModel.Channels.HttpRequestMessageProperty> from an incoming message and construct a response.
+The following code example shows how to create an HTTP GET request message that is addressed to `http://localhost:8100/customers`.
+
+```csharp
+Message request = Message.CreateMessage( MessageVersion.None, String.Empty );
+request.Headers.To = "http://localhost:8100/customers";
+
+HttpRequestMessageProperty property = new HttpRequestMessageProperty();
+property.Method = "GET";
+property.SuppressEntityBody = true;
+request.Properties.Add( HttpRequestMessageProperty.Name, property );
+```
+
+First, an empty request <xref:System.ServiceModel.Channels.Message> is created by calling <xref:System.ServiceModel.Channels.Message.CreateMessage%28System.ServiceModel.Channels.MessageVersion%2CSystem.String%29>. The <xref:System.ServiceModel.Channels.MessageVersion.None%2A> parameter is used to indicate that a SOAP envelope is not required and <xref:System.String.Empty> parameter is passed as the Action. The request message is then addressed by setting <xref:System.ServiceModel.Channels.MessageHeaders.To%2A> header to the desired URI. Next, an <xref:System.ServiceModel.Channels.HttpRequestMessageProperty> is created and the <xref:System.ServiceModel.Channels.HttpRequestMessageProperty.Method%2A> is set to the HTTP verb GET method and the <xref:System.ServiceModel.Channels.HttpRequestMessageProperty.SuppressEntityBody%2A> is set to `true` to indicate that no data should be sent in the body of the outgoing HTTP request message. Finally, the request property is added to the <xref:System.ServiceModel.Channels.Message.Properties%2A> collection of the request message so it can influence how the HTTP Transport sends the request. The message is then ready to be sent over an appropriate instance of the <xref:System.ServiceModel.Channels.IRequestChannel>.
+
+Similar techniques can be used on the service to extract the <xref:System.ServiceModel.Channels.HttpRequestMessageProperty> from an incoming message and construct a response.


### PR DESCRIPTION
I've noticed with PR #7963, that the fix removed a space from the sentence. 
Hide whitespace changes for easier diff.