### PR TITLE
C42938: Missing hyperlink

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-create-a-service-endpoint-in-configuration.md
+++ b/docs/framework/wcf/feature-details/how-to-create-a-service-endpoint-in-configuration.md
@@ -77,7 +77,7 @@ Endpoints provide clients with access to the functionality a Windows Communicati
 ```  
   
 ## Example  
- The first endpoint definition shown in the following sample specifies a relative address, which means the endpoint address is a combination of the base address and the relative address following the rules of Uniform Resource Identifier (URI) composition. The relative address is empty (""), so the endpoint address is the same as the base address. The actual endpoint address is `http://localhost:8000/servicemodelsamples/service.`  
+ The first endpoint definition shown in the following sample specifies a relative address, which means the endpoint address is a combination of the base address and the relative address following the rules of Uniform Resource Identifier (URI) composition. The relative address is empty (""), so the endpoint address is the same as the base address. The actual endpoint address is `http://localhost:8000/servicemodelsamples/service`.  
   
 ```xml  
 <endpoint address=""   
@@ -86,7 +86,7 @@ Endpoints provide clients with access to the functionality a Windows Communicati
 ```  
   
 ## Example  
- The second endpoint definition also specifies a relative address, as shown in the following sample configuration. The relative address, "test", is appended to the base address. The actual endpoint address is `http://localhost:8000/servicemodelsamples/service/test.`  
+ The second endpoint definition also specifies a relative address, as shown in the following sample configuration. The relative address, "test", is appended to the base address. The actual endpoint address is `http://localhost:8000/servicemodelsamples/service/test`.  
   
 ```xml  
 <endpoint address="/test"  
@@ -95,7 +95,7 @@ Endpoints provide clients with access to the functionality a Windows Communicati
 ```  
   
 ## Example  
- The third endpoint definition specifies an absolute address, as shown in the following sample configuration. The base address plays no role in the address. The actual endpoint address is `http://localhost:8001/hello/servicemodelsamples.`  
+ The third endpoint definition specifies an absolute address, as shown in the following sample configuration. The base address plays no role in the address. The actual endpoint address is `http://localhost:8001/hello/servicemodelsamples`.  
   
 ```xml  
 <endpoint address="http://localhost:8001/hello/servicemodelsamples"  

--- a/docs/framework/wcf/feature-details/how-to-create-a-service-endpoint-in-configuration.md
+++ b/docs/framework/wcf/feature-details/how-to-create-a-service-endpoint-in-configuration.md
@@ -77,7 +77,7 @@ Endpoints provide clients with access to the functionality a Windows Communicati
 ```  
   
 ## Example  
- The first endpoint definition shown in the following sample specifies a relative address, which means the endpoint address is a combination of the base address and the relative address following the rules of Uniform Resource Identifier (URI) composition. The relative address is empty (""), so the endpoint address is the same as the base address. The actual endpoint address is http://localhost:8000/servicemodelsamples/service.  
+ The first endpoint definition shown in the following sample specifies a relative address, which means the endpoint address is a combination of the base address and the relative address following the rules of Uniform Resource Identifier (URI) composition. The relative address is empty (""), so the endpoint address is the same as the base address. The actual endpoint address is `http://localhost:8000/servicemodelsamples/service.`  
   
 ```xml  
 <endpoint address=""   
@@ -86,7 +86,7 @@ Endpoints provide clients with access to the functionality a Windows Communicati
 ```  
   
 ## Example  
- The second endpoint definition also specifies a relative address, as shown in the following sample configuration. The relative address, "test", is appended to the base address. The actual endpoint address is http://localhost:8000/servicemodelsamples/service/test.  
+ The second endpoint definition also specifies a relative address, as shown in the following sample configuration. The relative address, "test", is appended to the base address. The actual endpoint address is `http://localhost:8000/servicemodelsamples/service/test.`  
   
 ```xml  
 <endpoint address="/test"  
@@ -95,7 +95,7 @@ Endpoints provide clients with access to the functionality a Windows Communicati
 ```  
   
 ## Example  
- The third endpoint definition specifies an absolute address, as shown in the following sample configuration. The base address plays no role in the address. The actual endpoint address is http://localhost:8001/hello/servicemodelsamples.  
+ The third endpoint definition specifies an absolute address, as shown in the following sample configuration. The base address plays no role in the address. The actual endpoint address is `http://localhost:8001/hello/servicemodelsamples.`  
   
 ```xml  
 <endpoint address="http://localhost:8001/hello/servicemodelsamples"  


### PR DESCRIPTION
Hello, @mairaw, @yishengjin1413, @yishengjin1413,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description of the source issue: Example URLs should be escaped in order to avoid creating a link
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
