### PR TITLE
C42947: Extra hyperlink

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-use-a-service-moniker-with-wsdl-contracts.md
+++ b/docs/framework/wcf/feature-details/how-to-use-a-service-moniker-with-wsdl-contracts.md
@@ -10,7 +10,7 @@ There are situations when you may want to have a completely self-contained COM I
   
 1.  Open and build the GettingStarted sample solution.  
   
-2.  Open Internet Explorer and browse to http://localhost/ServiceModelSamples/Service.svc to make sure that the service is working.  
+2.  Open Internet Explorer and browse to `http://localhost/ServiceModelSamples/Service.svc` to make sure that the service is working.  
   
 3.  In the Service.cs file, add the following attribute on the CalculatorService class:  
   
@@ -20,7 +20,7 @@ There are situations when you may want to have a completely self-contained COM I
   
   
   
-5.  Create a WSDL file for the application to read. Because the namespaces were added in steps 3 and 4, you can use IE to query for the entire WSDL description of the service by browsing to http://localhost/ServiceModelSamples/Service.svc?wsdl. You can then save the file from Internet Explorer as serviceWSDL.xml. If you do not specify the namespaces in steps 3 and 4, the WSDL document returned from querying the above URL will not be the complete WSDL. The WSDL document returned will include several import statements that import other WSDL documents. You will have to go through each import statement and build the complete WSDL document, combining the WSDL returned from the service with the WSDL imported.  
+5.  Create a WSDL file for the application to read. Because the namespaces were added in steps 3 and 4, you can use IE to query for the entire WSDL description of the service by browsing to `http://localhost/ServiceModelSamples/Service.svc?wsdl`. You can then save the file from Internet Explorer as serviceWSDL.xml. If you do not specify the namespaces in steps 3 and 4, the WSDL document returned from querying the above URL will not be the complete WSDL. The WSDL document returned will include several import statements that import other WSDL documents. You will have to go through each import statement and build the complete WSDL document, combining the WSDL returned from the service with the WSDL imported.  
   
 6.  Open Visual Basic 6.0 and create a new Standard .exe file. Add a button to the form and double-click the button to add the following code to the Click handler:  
   


### PR DESCRIPTION
Hello @mairaw, @yishengjin1413, @Mikejo5000,
Localization team has reported source content issue that causes issue for localization.
Description of the source issue: Example URL should be escaped in order to avoid creating a link
Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
