### PR TITLE
C42961. Extra hyperlink

### DIFF
--- a/docs/framework/wcf/endpoint-creation-overview.md
+++ b/docs/framework/wcf/endpoint-creation-overview.md
@@ -32,7 +32,7 @@ All communication with a Windows Communication Foundation (WCF) service occurs t
   
 -   Implement an `Echo` service of the type defined by the `IEcho` contract.  
   
--   Specify an endpoint address of http://localhost:8000/Echo for the service.  
+-   Specify an endpoint address of `http://localhost:8000/Echo` for the service.  
   
 -   Configure the `Echo` service using a <xref:System.ServiceModel.WSHttpBinding> binding.  
   


### PR DESCRIPTION
Hello @mairaw, @yishengjin1413, @Mikejo5000,
Localization team has reported source content issue that causes issue for localization.
Description of the source issue: Example URL should be escaped in order to avoid creating a link
Please review the comment tag added and reply with explanation if fix is needed or not. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
