### PR TITLE
Yield definition - Adding contextual keyword

### DIFF
--- a/docs/csharp/language-reference/keywords/yield.md
+++ b/docs/csharp/language-reference/keywords/yield.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
 ms.assetid: 1089194f-9e53-46a2-8642-53ccbe9d414d
 ---
 # yield (C# Reference)
-When you use the `yield` keyword in a statement, you indicate that the method, operator, or `get` accessor in which it appears is an iterator. Using `yield` to define an iterator removes the need for an explicit extra class (the class that holds the state for an enumeration, see <xref:System.Collections.Generic.IEnumerator%601> for an example) when you implement the <xref:System.Collections.IEnumerable> and <xref:System.Collections.IEnumerator> pattern for a custom collection type.  
+When you use the `yield` [contextual keyword](../../../csharp/language-reference/keywords/index.md#contextual-keywords) in a statement, you indicate that the method, operator, or `get` accessor in which it appears is an iterator. Using `yield` to define an iterator removes the need for an explicit extra class (the class that holds the state for an enumeration, see <xref:System.Collections.Generic.IEnumerator%601> for an example) when you implement the <xref:System.Collections.IEnumerable> and <xref:System.Collections.IEnumerator> pattern for a custom collection type.  
   
  The following example shows the two forms of the `yield` statement.  
   


### PR DESCRIPTION
## Summary

Added `contextual` to `keyword`.
I have tried to link to the definition of contextual keyword to explain it, but I am not sure of the resulting link once generated.

Fixes #7378
