### PR TITLE
Add details on which member can be used when using CallerMemberName in an attribute constructor

### DIFF
--- a/docs/csharp/programming-guide/concepts/caller-information.md
+++ b/docs/csharp/programming-guide/concepts/caller-information.md
@@ -70,7 +70,7 @@ The following chart shows the member names that are returned when you use the `C
 |Static constructor|The string ".cctor"|
 |Destructor|The string "Finalize"|
 |User-defined operators or conversions|The generated name for the member, for example, "op_Addition".|
-|Attribute constructor|The name of the member to which the attribute is applied. If the attribute is any element within a member (such as a parameter, a return value, or a generic type parameter), this result is the name of the member that's associated with that element.|
+|Attribute constructor|The name of the method or property to which the attribute is applied. If the attribute is any element within a member (such as a parameter, a return value, or a generic type parameter), this result is the name of the member that's associated with that element.|
 |No containing member (for example, assembly-level or attributes that are applied to types)|The default value of the optional parameter.|
 
 ## See also


### PR DESCRIPTION
## Summary

Add details on which member can be used when using CallerMemberName in an attribute constructor.

Fixes #6586
