### PR TITLE
Update index.md

### DIFF
--- a/docs/framework/wpf/controls/popup-placement-behavior.md
+++ b/docs/framework/wpf/controls/popup-placement-behavior.md
@@ -222,4 +222,4 @@ Placement is Mouse and the popup encounters the bottom edge of the screen
  You can customize the target origin and popup alignment point by setting the <xref:System.Windows.Controls.Primitives.Popup.Placement%2A> property to <xref:System.Windows.Controls.Primitives.PlacementMode.Custom>. Then define a <xref:System.Windows.Controls.Primitives.CustomPopupPlacementCallback> delegate that returns a set of possible placement points and primary axes (in order of preference) for the <xref:System.Windows.Controls.Primitives.Popup>. The point that shows the largest portion of the <xref:System.Windows.Controls.Primitives.Popup> is selected.  The position of the <xref:System.Windows.Controls.Primitives.Popup> is automatically adjusted if the <xref:System.Windows.Controls.Primitives.Popup> is hidden by the edge of the screen. For an example, see [Specify a Custom Popup Position](../../../../docs/framework/wpf/controls/how-to-specify-a-custom-popup-position.md).  
   
 ## See Also  
- [Popup Placement Sample](https://go.microsoft.com/fwlink/?LinkID=160032)
+ [Popup Placement Sample](https://github.com/Microsoft/WPF-Samples)

--- a/docs/framework/wpf/controls/popup-placement-behavior.md
+++ b/docs/framework/wpf/controls/popup-placement-behavior.md
@@ -222,4 +222,4 @@ Placement is Mouse and the popup encounters the bottom edge of the screen
  You can customize the target origin and popup alignment point by setting the <xref:System.Windows.Controls.Primitives.Popup.Placement%2A> property to <xref:System.Windows.Controls.Primitives.PlacementMode.Custom>. Then define a <xref:System.Windows.Controls.Primitives.CustomPopupPlacementCallback> delegate that returns a set of possible placement points and primary axes (in order of preference) for the <xref:System.Windows.Controls.Primitives.Popup>. The point that shows the largest portion of the <xref:System.Windows.Controls.Primitives.Popup> is selected.  The position of the <xref:System.Windows.Controls.Primitives.Popup> is automatically adjusted if the <xref:System.Windows.Controls.Primitives.Popup> is hidden by the edge of the screen. For an example, see [Specify a Custom Popup Position](../../../../docs/framework/wpf/controls/how-to-specify-a-custom-popup-position.md).  
   
 ## See Also  
- [Popup Placement Sample](https://go.microsoft.com/fwlink/?LinkID=160032)
+[Popup Placement Sample](https://go.microsoft.com/fwlink/?LinkID=160032)

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
@@ -72,7 +72,7 @@ Shared Sub Test()
 End Sub  
 ```  
   
- In .NET Framework 4 or later Visual Basic support covariance and contravariance in generic interfaces and delegates and allow for implicit conversion of generic type parameters. For more information, see [Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
+ In .NET Framework 4 or later Visual Basic supports covariance and contravariance in generic interfaces and delegates and allows for implicit conversion of generic type parameters. For more information, see [Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
   
  The following code example shows implicit reference conversion for generic interfaces.  
   

--- a/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
+++ b/docs/visual-basic/programming-guide/concepts/covariance-contravariance/index.md
@@ -72,7 +72,7 @@ Shared Sub Test()
 End Sub  
 ```  
   
- In .NET Framework 4 or later Visual Basic supports covariance and contravariance in generic interfaces and delegates and allows for implicit conversion of generic type parameters. For more information, see [Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
+ In .NET Framework 4 or later, Visual Basic supports covariance and contravariance in generic interfaces and delegates and allows for implicit conversion of generic type parameters. For more information, see [Variance in Generic Interfaces (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md) and [Variance in Delegates (Visual Basic)](../../../../visual-basic/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md).  
   
  The following code example shows implicit reference conversion for generic interfaces.  
   


### PR DESCRIPTION
## Summary
Fixing some minor grammar error 

Towards the end of Covariance and Contravariance (Visual Basic) we have this sentence:

> In .NET Framework 4 or later Visual Basic support covariance and contravariance in generic interfaces and delegates and allow for implicit conversion of generic type parameters.

I believe the words in bold above, should appear in their plural form so the sentence reads as follows (corrected words in ALL CAPS):

> In .NET Framework 4 or later Visual Basic SUPPORTS covariance and contravariance in generic interfaces and delegates and ALLOWS for implicit conversion of generic type parameters.

Fixes #Issue_Number [7955](https://github.com/dotnet/docs/issues/7955)
