### PR TITLE
Remove unsupported 2.0 from docs

### DIFF
--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -38,22 +38,6 @@ NET Core 2.1 is supported on the following Linux distributions/versions:
 
 See [.NET Core 2.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) for the complete list of .NET Core 2.1 supported operating systems, distributions and versions, out of support OS versions, and lifecycle policy links.
 
-**NET Core 2.0**
-
-NET Core 2.0 is supported on the following Linux 64-bit (`x86_64` or `amd64`) distributions/versions:
-
-* Red Hat Enterprise Linux 7, 6
-* CentOS 7
-* Oracle Linux 7
-* Fedora 27
-* Debian 9, 8.7 or later versions
-* Ubuntu 18.04, 16.04, 14.04
-* Linux Mint 18, 17
-* openSUSE 42.3 or later versions
-* SUSE Enterprise Linux (SLES) 12 Service Pack 2 or later
-
-See [.NET Core 2.0 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0-supported-os.md) for the complete list of .NET Core 2.0 supported operating systems, distributions and versions, out of support OS versions, and lifecycle policy links.
-
 # [.NET Core 1.x](#tab/netcore1x)
 
 .NET Core 1.x is supported on the following Linux 64-bit (`x86_64` or `amd64`) distributions/versions:
@@ -147,12 +131,6 @@ To install .NET Core on supported RHEL versions:
 
 2. For the latest .NET Core 2.1 on Red Hat Enterprise Linux installation information, see [the .NET Core 2.1 Getting Started Guide](https://access.redhat.com/documentation/en-us/net_core/2.1/html/getting_started_guide/)
 
-**.NET Core 2.0**
-
-1. Remove any **previous preview** versions of .NET Core from your system.
-
-2. For the latest .NET Core 2.0 on Red Hat Enterprise Linux installation information, see [the .NET Core 2.0 Getting Started Guide](https://access.redhat.com/documentation/en-us/net_core/2.0/html/getting_started_guide/) 
-
 # [.NET Core 1.x](#tab/netcore1x)
 
 **.NET Core 1.1**
@@ -178,23 +156,6 @@ For Red Hat .NET channel access registration help, see [Chapter 1 of the .NET Co
 1. Remove any **previous preview** versions of .NET Core from your system.
 
 2. Install .NET Core 2.x on supported Ubuntu and Linux Mint distributions/versions (64 bit):
-
-**.NET Core 2.0**
-
-|Runtimes / SDKs          |Ubuntu 18.04    |Ubuntu 17.10    |Ubuntu 16.04 / Linux Mint 18|Ubuntu 14.04 / Linux Mint 17|
-|-------------------------|----------------|----------------|----------------------------|----------------------------|
-|.NET Core Runtime 2.0.9  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/runtime-2.0.9)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/runtime-2.0.9)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/runtime-2.0.9)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/runtime-2.0.9)            |
-|.NET Core Runtime 2.0.8  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/runtime-2.0.8)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/runtime-2.0.8)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/runtime-2.0.8)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/runtime-2.0.8)            |
-|.NET Core Runtime 2.0.7  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/runtime-2.0.7)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/runtime-2.0.7)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/runtime-2.0.7)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/runtime-2.0.7)            |
-|.NET Core Runtime 2.0.6  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/runtime-2.0.6)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/runtime-2.0.6)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/runtime-2.0.6)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/runtime-2.0.6)            |
-|.NET Core Runtime 2.0.5  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/runtime-2.0.5)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/runtime-2.0.5)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/runtime-2.0.5)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/runtime-2.0.5)            |
-|.NET Core SDK 2.1.202    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.1.202)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.1.202)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.1.202)            |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.1.202)            |
-|.NET Core SDK 2.1.201    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.1.201)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.1.201)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.1.201)            |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.1.201)            |
-|.NET Core SDK 2.1.200    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.1.200)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.1.200)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.1.200)            |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.1.200)            |
-|.NET Core SDK 2.1.105    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.1.105)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.1.105)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.1.105)            |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.1.105)            |
-|.NET Core SDK 2.1.103    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.1.103)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.1.103)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.1.103)            |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.1.103)            |
-|.NET Core SDK 2.0.3      |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.0.3)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.0.3)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.0.3)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.0.3)            |
-|.NET Core SDK 2.0.0      |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.0.0)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu17-10/sdk-2.0.0)|[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu16-04/sdk-2.0.0)          |[Install link](https://www.microsoft.com/net/download/linux-package-manager/ubuntu14-04/sdk-2.0.0)            |
 
 **.NET Core 2.1**
 
@@ -255,29 +216,6 @@ To install .NET Core on supported Debian versions (64 bit):
 
 2. Install .NET Core 2.x on supported Debian versions (64 bit):
 
-**.NET Core 2.0**
-
-|Runtimes / SDKs          |Debian 9       |Debian 8       |
-|-------------------------|---------------|---------------|
-|.NET Core Runtime 2.0.9  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.9)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.9)   |
-|.NET Core Runtime 2.0.8  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.8)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.8)   |
-|.NET Core Runtime 2.0.7  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.7)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.7)   |
-|.NET Core Runtime 2.0.6  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.6)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.6)   |
-|.NET Core Runtime 2.0.5  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.5)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.5)   |
-|.NET Core Runtime 2.0.3  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.3)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.3)   |
-|.NET Core Runtime 2.0.0  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/runtime-2.0.0)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/runtime-2.0.0)   |
-|.NET Core SDK 2.1.202    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.202)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.202)   |
-|.NET Core SDK 2.1.201    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.201)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.201)   |
-|.NET Core SDK 2.1.200    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.200)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.200)   |
-|.NET Core SDK 2.1.105    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.105)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.105)   |
-|.NET Core SDK 2.1.105    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.105)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.105)   |
-|.NET Core SDK 2.1.104    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.104)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.104)   |
-|.NET Core SDK 2.1.103    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.103)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.103)   |
-|.NET Core SDK 2.1.102    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.102)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.102)   |
-|.NET Core SDK 2.1.101    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.1.101)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.1.101)   |
-|.NET Core SDK 2.0.3      |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.0.3)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.0.3)   |
-|.NET Core SDK 2.0.0      |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian9/sdk-2.0.0)   |[Install link](https://www.microsoft.com/net/download/linux-package-manager/debian8/sdk-2.0.0)   |
-
 **.NET Core 2.1**
 
 >[!IMPORTANT]
@@ -337,22 +275,6 @@ To install .NET Core on supported Fedora versions:
 1. Remove any **previous preview** versions of .NET Core from your system.
 
 2. Install .NET Core 2.x on supported Fedora versions (64 bit):
-
-**.NET Core 2.0**
-
-|Runtimes / SDKs          |Fedora 26 or later |Fedora 25 or previous |
-|-------------------------|-------------------|----------------------|
-|.NET Core Runtime 2.0.9  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.9)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.9)           |
-|.NET Core Runtime 2.0.8  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.8)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.8)           |
-|.NET Core Runtime 2.0.7  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.7)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.7)           |
-|.NET Core Runtime 2.0.6  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.6)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.6)           |
-|.NET Core Runtime 2.0.5  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.5)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.5)           |
-|.NET Core Runtime 2.0.3  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.3)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.3)           |
-|.NET Core Runtime 2.0.0  |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/runtime-2.0.0)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/runtime-2.0.0)           |
-|.NET Core SDK 2.1.200    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/sdk-2.1.200)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/sdk-2.1.200)           |
-|.NET Core SDK 2.1.105    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/sdk-2.1.105)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/sdk-2.1.105)           |
-|.NET Core SDK 2.1.103    |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/sdk-2.1.103)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/sdk-2.1.103)           |
-|.NET Core SDK 2.0.3      |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora26/sdk-2.0.3)       |[Install link](https://www.microsoft.com/net/download/linux-package-manager/fedora25/sdk-2.0.3)           |
 
 **.NET Core 2.1**
 
@@ -419,25 +341,6 @@ To install .NET Core for supported CentOS and Oracle Linux distributions/version
 
 2. Install .NET Core 2.x on supported CentOS and Oracle Linux distributions/versions (64 bit):
 
-**.NET Core 2.0**
-
-* .NET Core Runtime 2.0.9 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.9)
-* .NET Core Runtime 2.0.8 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.8)
-* .NET Core Runtime 2.0.7 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.7)
-* .NET Core Runtime 2.0.6 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.6)
-* .NET Core Runtime 2.0.5 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.5)
-* .NET Core Runtime 2.0.3 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.3)
-* .NET Core Runtime 2.0.0 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/runtime-2.0.0)
-* .NET Core SDK 2.1.202 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.202)
-* .NET Core SDK 2.1.201 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.201)
-* .NET Core SDK 2.1.200 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.200)
-* .NET Core SDK 2.1.105 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.105)
-* .NET Core SDK 2.1.104 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.104)
-* .NET Core SDK 2.1.103 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.103)
-* .NET Core SDK 2.1.102 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.1.102)
-* .NET Core SDK 2.0.3 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.0.3)
-* .NET Core SDK 2.0.0 [install link](https://www.microsoft.com/net/download/linux-package-manager/centos/sdk-2.0.0)
- 
 **.NET Core 2.1**
 
 >[!IMPORTANT]
@@ -493,53 +396,6 @@ To install .NET Core 2.x for supported SUSE Linux Enterprise Server and OpenSUSE
 1. Remove any **previous preview** versions of .NET Core from your system.
 
 2. Install .NET Core 2.x on supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit):
-
-**.NET Core 2.0**
-
-**SUSE Linux Enterprise Server**
-
-* .NET Core Runtime 2.0.9 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.9)
-* .NET Core Runtime 2.0.8 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.8)
-* .NET Core Runtime 2.0.7 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.7)
-* .NET Core Runtime 2.0.6 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.6)
-* .NET Core Runtime 2.0.5 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.5)
-* .NET Core Runtime 2.0.3 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.3)
-* .NET Core Runtime 2.0.0 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/runtime-2.0.0)
-* .NET Core SDK 2.1.202 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.202)
-* .NET Core SDK 2.1.201 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.201)
-* .NET Core SDK 2.1.200 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.200)
-* .NET Core SDK 2.1.105 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.105)
-* .NET Core SDK 2.1.104 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.104)
-* .NET Core SDK 2.1.103 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.103)
-* .NET Core SDK 2.1.102 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.102)
-* .NET Core SDK 2.1.101 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.101)
-* .NET Core SDK 2.1.100 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.100)
-* .NET Core SDK 2.1.4 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.4)
-* .NET Core SDK 2.1.2 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.1.2)
-* .NET Core SDK 2.0.3 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.0.3)
-* .NET Core SDK 2.0.0 [install link](https://www.microsoft.com/net/download/linux-package-manager/sles/sdk-2.0.0)
-
-**openSUSE**
-
-* .NET Core Runtime 2.0.9 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.9)
-* .NET Core Runtime 2.0.8 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.8)
-* .NET Core Runtime 2.0.7 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.7)
-* .NET Core Runtime 2.0.6 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.6)
-* .NET Core Runtime 2.0.5 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.5)
-* .NET Core Runtime 2.0.3 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.3)
-* .NET Core Runtime 2.0.0 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/runtime-2.0.0)
-* .NET Core SDK 2.1.202 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.202)
-* .NET Core SDK 2.1.201 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.201)
-* .NET Core SDK 2.1.200 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.200)
-* .NET Core SDK 2.1.105 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.105)
-* .NET Core SDK 2.1.103 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.103)
-* .NET Core SDK 2.1.102 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.102)
-* .NET Core SDK 2.1.101 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.101)
-* .NET Core SDK 2.1.100 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.100)
-* .NET Core SDK 2.1.4 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.4)
-* .NET Core SDK 2.1.2 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.1.2)
-* .NET Core SDK 2.0.3 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.0.3)
-* .NET Core SDK 2.0.0 [install link](https://www.microsoft.com/net/download/linux-package-manager/opensuse/sdk-2.0.0)
  
 **.NET Core 2.1**
 
@@ -600,6 +456,5 @@ Download and follow the .NET Core 2.1 installation instructions for supported Al
 > [!IMPORTANT]
 > If you have problems with a .NET Core installation on a supported Linux distribution/version, consult the following topics for your installed distributions/versions:
 > * [.NET Core 2.1 known issues](https://github.com/dotnet/core/tree/master/release-notes/2.1)
-> * [.NET Core 2.0 known issues](https://github.com/dotnet/core/tree/master/release-notes/2.0)
 > * [.NET Core 1.1 known issues](https://github.com/dotnet/core/blob/master/release-notes/1.1)
 > * [.NET Core 1.0 known issues](https://github.com/dotnet/core/blob/master/release-notes/1.0)

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites for .NET Core on Linux
 description: Supported Linux versions and .NET Core dependencies to develop, deploy, and run .NET Core applications on Linux machines.
 author: jralexander
 ms.author: johalex
-ms.date: 03/10/2018
+ms.date: 10/18/2018
 ---
 # Prerequisites for .NET Core on Linux
 
@@ -17,9 +17,9 @@ This article shows the dependencies needed to develop .NET Core applications on 
 
 ## Supported Linux versions
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
-.NET Core 2.x treats Linux as a single operating system. There is a single Linux build (per chip architecture) for supported Linux distributions.
+.NET Core 2.1 treats Linux as a single operating system. There is a single Linux build (per chip architecture) for supported Linux distributions.
 
 **NET Core 2.1**
 
@@ -111,7 +111,7 @@ On Linux, there are two installer package choices:
 
 The [dotnet-install scripts](./tools/dotnet-install-script.md) are used to perform a non-admin install of the CLI toolchain and the shared runtime. You can download the script from [https://dot.net/v1/dotnet-install.sh](https://dot.net/v1/dotnet-install.sh).
 
-The script defaults to installing the latest "LTS" version, which is currently .NET Core 1.1. To install .NET Core 2.x, run the script with the following switch:
+The script defaults to installing the latest "LTS" version, which is currently .NET Core 1.1. To install .NET Core 2.1, run the script with the following switch:
 
 ```console
 ./dotnet-install.sh -c Current
@@ -123,7 +123,7 @@ The installer bash script is used in automation scenarios and non-admin installa
 
 To install .NET Core on supported RHEL versions:
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
 **.NET Core 2.1**
 
@@ -151,11 +151,11 @@ For Red Hat .NET channel access registration help, see [Chapter 1 of the .NET Co
 
 ## Install .NET Core for supported Ubuntu and Linux Mint distributions/versions (64 bit)
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
-2. Install .NET Core 2.x on supported Ubuntu and Linux Mint distributions/versions (64 bit):
+2. Install .NET Core 2.1 on supported Ubuntu and Linux Mint distributions/versions (64 bit):
 
 **.NET Core 2.1**
 
@@ -210,11 +210,11 @@ To install .NET Core on supported Debian versions (64 bit):
 > [!NOTE]
 > A user-controlled directory is required for Linux system installs from tar.gz.
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore2x)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
-2. Install .NET Core 2.x on supported Debian versions (64 bit):
+2. Install .NET Core 2.1 on supported Debian versions (64 bit):
 
 **.NET Core 2.1**
 
@@ -270,11 +270,11 @@ To install .NET Core on supported Fedora versions:
 > [!NOTE]
 > A user-controlled directory is required for Linux system installs from tar.gz.
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore2x)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
-2. Install .NET Core 2.x on supported Fedora versions (64 bit):
+2. Install .NET Core 2.1 on supported Fedora versions (64 bit):
 
 **.NET Core 2.1**
 
@@ -335,11 +335,11 @@ To install .NET Core for supported CentOS and Oracle Linux distributions/version
 > [!NOTE]
 > A user-controlled directory is required for Linux system installs from tar.gz.
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore2x)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
-2. Install .NET Core 2.x on supported CentOS and Oracle Linux distributions/versions (64 bit):
+2. Install .NET Core 2.1 on supported CentOS and Oracle Linux distributions/versions (64 bit):
 
 **.NET Core 2.1**
 
@@ -389,13 +389,13 @@ To install .NET Core for supported CentOS and Oracle Linux distributions/version
 
 ## Install .NET Core for supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit)
 
-To install .NET Core 2.x for supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit):
+To install .NET Core 2.1 for supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit):
 
-# [.NET Core 2.x](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore2x)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
-2. Install .NET Core 2.x on supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit):
+2. Install .NET Core 2.1 on supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit):
  
 **.NET Core 2.1**
 

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -210,7 +210,7 @@ To install .NET Core on supported Debian versions (64 bit):
 > [!NOTE]
 > A user-controlled directory is required for Linux system installs from tar.gz.
 
-# [.NET Core 2.1](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
@@ -270,7 +270,7 @@ To install .NET Core on supported Fedora versions:
 > [!NOTE]
 > A user-controlled directory is required for Linux system installs from tar.gz.
 
-# [.NET Core 2.1](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
@@ -335,7 +335,7 @@ To install .NET Core for supported CentOS and Oracle Linux distributions/version
 > [!NOTE]
 > A user-controlled directory is required for Linux system installs from tar.gz.
 
-# [.NET Core 2.1](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 
@@ -391,7 +391,7 @@ To install .NET Core for supported CentOS and Oracle Linux distributions/version
 
 To install .NET Core 2.1 for supported SUSE Linux Enterprise Server and OpenSUSE distributions/versions (64 bit):
 
-# [.NET Core 2.1](#tab/netcore2x)
+# [.NET Core 2.1](#tab/netcore21)
 
 1. Remove any **previous preview** versions of .NET Core from your system.
 

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites for .NET Core on Linux
 description: Supported Linux versions and .NET Core dependencies to develop, deploy, and run .NET Core applications on Linux machines.
 author: jralexander
 ms.author: johalex
-ms.date: 08/20/2018
+ms.date: 03/10/2018
 ---
 # Prerequisites for .NET Core on Linux
 

--- a/docs/core/windows-prerequisites.md
+++ b/docs/core/windows-prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites for .NET Core on Windows
 description: Learn what dependencies you need on your Windows machine to develop and run .NET Core applications.
 author: mairaw
 ms.author: mairaw
-ms.date: 03/10/2018
+ms.date: 10/18/2018
 ---
 # Prerequisites for .NET Core on Windows
 

--- a/docs/core/windows-prerequisites.md
+++ b/docs/core/windows-prerequisites.md
@@ -3,7 +3,7 @@ title: Prerequisites for .NET Core on Windows
 description: Learn what dependencies you need on your Windows machine to develop and run .NET Core applications.
 author: mairaw
 ms.author: mairaw
-ms.date: 08/31/2018
+ms.date: 03/10/2018
 ---
 # Prerequisites for .NET Core on Windows
 
@@ -30,7 +30,6 @@ This article shows the dependencies needed to develop .NET Core applications on 
 The following articles have a complete list of .NET Core supported operating systems per version:
 
 * [.NET Core 2.1 - Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md)
-* [.NET Core 2.0 - Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.0/2.0-supported-os.md)
 * [.NET Core 1.x - Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0-supported-os.md)
 
 ## .NET Core dependencies
@@ -83,29 +82,6 @@ Once you have Visual Studio configured with .NET Core 2.1 SDK, you can do the fo
 * Retarget .NET Core 1.x and 2.0 projects to .NET Core 2.1, build, and run.
 * Create new .NET Core 2.1 projects.
 
-# [.NET Core 2.0](#tab/netcore20)
-
-To develop .NET Core 2.0 apps in Visual Studio 2017:
-
- 1. [Download and install Visual Studio 2017 version 15.3.0 or higher](/visualstudio/install/install-visual-studio) with the **.NET Core cross-platform development** workload (in the **Other Toolsets** section) selected.
-
-![Screenshot of Visual Studio 2017 installation with the ".NET Core cross-platform development" workload selected](./media/windows-prerequisites/vs-15-3-workloads.jpg)
-
-After the **.NET Core cross-platform development** toolset is installed, Visual Studio 2017 uses .NET Core 1.x by default. Install the .NET Core 2.0 SDK to get .NET Core 2.0 support in Visual Studio 2017.
-
- 2. Install the [.NET Core 2.0 SDK](https://www.microsoft.com/net/download/dotnet-core/2.0).
- 3. Retarget existing or new .NET Core 1.x projects to .NET Core 2.0 using the following instructions:
-    * On the **Project** menu, Choose **Properties**.
-    * In the **Target framework** selection menu, set the value to **.NET Core 2.0**.
-
-![Screenshot of Visual Studio 2017 Application Project Property with the ".NET Core 2.0" Target framework menu item selected](./media/windows-prerequisites/Targeting-dotnetCore2.png)
-
-Once the .NET Core 2.0 SDK is installed, Visual Studio 2017 uses the .NET Core SDK 2.0 by default, and supports the following actions:
-
-* Open, build, and run existing .NET Core 1.x projects.
-* Retarget .NET Core 1.x projects to .NET Core 2.0, build, and run.
-* Create new .NET Core 2.0 projects.
-
 # [.NET Core 1.x](#tab/netcore1x)
 
 To develop .NET Core 1.x apps in Visual Studio, [download and install Visual Studio 2017](/visualstudio/install/install-visual-studio) with the **".NET Core cross-platform development"** workload (in the **Other Toolsets** section) selected.
@@ -129,5 +105,4 @@ To develop .NET Core 1.x apps in Visual Studio, [download and install Visual Stu
 > * In the **About Microsoft Visual Studio** dialog, verify the version number.
 >   * For .NET Core 2.2 Preview 1 apps, Visual Studio 2017 version 15.9 (currently in Preview) or higher.
 >   * For .NET Core 2.1 apps, Visual Studio 2017 version 15.7 or higher.
->   * For .NET Core 2.0 apps, Visual Studio 2017 version 15.3 or higher.
 >   * For .NET Core 1.x apps, Visual Studio 2017 version 15.0 or higher.


### PR DESCRIPTION
.NET Core 2.0 is out of support as of 2018/10/1 - https://github.com/dotnet/core/blob/master/microsoft-support.md#out-of-support-net-core-releases