### PR TITLE
Removed Sentence

### DIFF
--- a/docs/csharp/language-reference/keywords/group-clause.md
+++ b/docs/csharp/language-reference/keywords/group-clause.md
@@ -47,7 +47,7 @@ The following example shows the use of a bool value for a key to divide the resu
 
 ### Grouping by numeric range
 
-The next example uses an expression to create numeric group keys that represent a percentile range. Note the use of [let](let-clause.md) as a convenient location to store a method call result, so that you don't have to call the method two times in the `group` clause. Note also in the `group` clause that to avoid a "divide by zero" exception the code checks to make sure that the student doesn't have an average of zero. For more information about how to safely use methods in query expressions, see [How to: Handle Exceptions in Query Expressions](../../programming-guide/linq-query-expressions/how-to-handle-exceptions-in-query-expressions.md).
+The next example uses an expression to create numeric group keys that represent a percentile range. Note the use of [let](let-clause.md) as a convenient location to store a method call result, so that you don't have to call the method two times in the `group` clause. For more information about how to safely use methods in query expressions, see [How to: Handle Exceptions in Query Expressions](../../programming-guide/linq-query-expressions/how-to-handle-exceptions-in-query-expressions.md).
 
 [!code-csharp[cscsrefQueryKeywords#15](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsCsrefQueryKeywords/CS/Group.cs#15)]
 


### PR DESCRIPTION


## Summary
Removed sentence 'Note also in the group clause that to avoid a "divide by zero" exception the code checks to make sure that the student doesn't have an average of zero' as logged in #7487

Fixes #7487
