### PR TITLE
ML tutorials: reference overview of new ML.NET API

### DIFF
--- a/docs/machine-learning/tutorials/index.md
+++ b/docs/machine-learning/tutorials/index.md
@@ -12,6 +12,6 @@ The following tutorials enable you to understand how to use [ML.NET](../index.md
 - [Iris clustering](iris-clustering.md): demonstrates how to apply a **clustering** task using ML.NET.
 
 > [!NOTE]
-> The tutorials demonstrate how to use the ML.NET API introduced in ML.NET 0.1. For information about new API introduced in ML.NET 0.6, see [ML.NET high-level concepts](https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetHighLevelConcepts.md) and [ML.NET Cookbook](https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetCookBook.md).
+> The tutorials demonstrate how to use the ML.NET `LearningPipeline` API introduced in ML.NET 0.1. For information about the new API introduced in ML.NET 0.6, see [ML.NET high-level concepts](https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetHighLevelConcepts.md) and [ML.NET Cookbook](https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetCookBook.md).
 
 For more examples that use ML.NET, check the [dotnet/machinelearning-samples](https://github.com/dotnet/machinelearning-samples) GitHub repository.

--- a/docs/machine-learning/tutorials/index.md
+++ b/docs/machine-learning/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 title: ML.NET tutorials
 description: Explore the ML.NET tutorials to learn how to build custom AI solutions and integrate them into your .NET applications.
-ms.date: 07/02/2018
+ms.date: 10/03/2018
 ---
 # ML.NET tutorials
 
@@ -10,5 +10,8 @@ The following tutorials enable you to understand how to use [ML.NET](../index.md
 - [Sentiment analysis](sentiment-analysis.md): demonstrates how to apply a **binary classification** task using ML.NET.
 - [Taxi fare predictor](taxi-fare.md): demonstrates how to apply a **regression** task using ML.NET.
 - [Iris clustering](iris-clustering.md): demonstrates how to apply a **clustering** task using ML.NET.
+
+> [!NOTE]
+> The tutorials demonstrate how to use the ML.NET API introduced in ML.NET 0.1. For information about new API introduced in ML.NET 0.6, see [ML.NET high-level concepts](https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetHighLevelConcepts.md) and [ML.NET Cookbook](https://github.com/dotnet/machinelearning/blob/master/docs/code/MlNetCookBook.md).
 
 For more examples that use ML.NET, check the [dotnet/machinelearning-samples](https://github.com/dotnet/machinelearning-samples) GitHub repository.


### PR DESCRIPTION
As the [new API released with 0.6 version](https://github.com/dotnet/machinelearning/blob/master/docs/release-notes/0.6/release-0.6.md) and while tutorials are not updated, would be useful to give the links to the overview of new API.

/cc: @JRAlexander 
