### PR TITLE
Improve throw new exception with inner exception example

### DIFF
--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -163,7 +163,12 @@ This example illustrates the use of `throw` to re-throw the original exception, 
 catch (Exception ex)
 {
     from.RollbackTransaction(withdrawalTrxID);
-    throw new Exception("Withdrawal failed", ex);
+    throw new TransferFundsException("Withdrawal failed", ex)
+    {
+    	From = from,
+	To = to,
+	Amount = amount
+    };
 }
 ```
 

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -163,7 +163,7 @@ This example illustrates the use of `throw` to re-throw the original exception, 
 catch (Exception ex)
 {
     from.RollbackTransaction(withdrawalTrxID);
-    throw new TransferFundsException("Withdrawal failed", ex)
+    throw new TransferFundsException("Withdrawal failed", innerException: ex)
     {
     	From = from,
 	To = to,


### PR DESCRIPTION
## Summary

As per suggestion from @BillWagner throw a more descriptive exception type (no need to show full definition of the class in the article).

Fixes #6881 
