### PR TITLE
Fixing the typo on tag

### DIFF
--- a/docs/framework/wcf/how-to-set-the-security-mode.md
+++ b/docs/framework/wcf/how-to-set-the-security-mode.md
@@ -82,7 +82,7 @@ Windows Communication Foundation (WCF) security has three common security modes 
     ```xml  
     <wsHttpBinding>  
     <binding name="TransportSecurity">  
-        <security mode="Transport" />  
+        <security mode="Transport" >  
            <transport clientCredentialType = "Windows" />  
         </security>  
     </binding>  
@@ -94,7 +94,7 @@ Windows Communication Foundation (WCF) security has three common security modes 
     ```xml  
     <wsHttpBinding>  
     <binding name="MessageSecurity">  
-        <security mode="Message" />  
+        <security mode="Message" >  
            <message clientCredentialType = "Certificate" />  
         </security>  
     </binding>  


### PR DESCRIPTION
Removing extra slash 

## Summary

Removing the forward slash from the tag as it is not self closing

Fixes #8066 
