### PR TITLE
Patch 3

### DIFF
--- a/docs/framework/data/adonet/connection-strings.md
+++ b/docs/framework/data/adonet/connection-strings.md
@@ -5,7 +5,7 @@ ms.assetid: 745c5f95-2f02-4674-b378-6d51a7ec2490
 ---
 # Connection Strings in ADO.NET
 
-A connection string contains initialization information that is passed as a parameter from a data provider to a data source. The data provider accepts the connection string via <xref:System.String> the <xref:System.Data.Common.DbConnection.ConnectionString?displayProperty=nameWithType> property, whose setter parses it and ensures the syntax is correct and the keywords are supported.
+A connection string contains initialization information that is passed as a parameter from a data provider to a data source. The data provider accepts the connection string via the <xref:System.Data.Common.DbConnection.ConnectionString?displayProperty=nameWithType> property, whose setter parses it and ensures the syntax is correct and the keywords are supported.
 The <xref:System.Data.Common.DbConnection.Open?displayProperty=nameWithType> method passes the parsed connection parameters to the data source, which performs further validation and establishes a connection.
 
 A connection string is a semicolon-delimited list of key/value parameter pairs:

--- a/docs/framework/data/adonet/connection-strings.md
+++ b/docs/framework/data/adonet/connection-strings.md
@@ -4,11 +4,11 @@ ms.date: "03/30/2017"
 ms.assetid: 745c5f95-2f02-4674-b378-6d51a7ec2490
 ---
 # Connection Strings in ADO.NET
-The .NET Framework 2.0 introduced new capabilities for working with connection strings, including the introduction of new keywords to the connection string builder classes, which facilitate creating valid connection strings at run time.  
-  
-A connection string contains initialization information that is passed as a parameter from a data provider to a data source. The syntax depends on the data provider, and the connection string is parsed during the attempt to open a connection. Syntax errors generate a run-time exception, but other errors occur only after the data source receives connection information. Once validated, the data source applies the options specified in the connection string and opens the connection.
-  
-The format of a connection string is a semicolon-delimited list of key/value parameter pairs:
+
+A connection string contains initialization information that is passed as a parameter from a data provider to a data source. The data provider accepts the connection string via the xref:DbConnection.ConnectionString?displayProperty=nameWithType property, whose setter parses it and ensures the syntax is correct and the keywords are supported.
+The xref:DbConnection.ConnectionString?displayProperty=nameWithType method passes the parsed connection parameters to the data source, which performs further validation and establishes a connection.
+
+A connection string is a semicolon-delimited list of key/value parameter pairs:
   
 	keyword1=value; keyword2=value;
   
@@ -31,10 +31,10 @@ The quotation marks themselves, as well as the equals sign, do not require escap
 
 Since each value is read till the next semicolon or the end of string, the value in the latter example is `a=b=c`, and the final semicolon is optional.
 
-Valid connection string syntax depends on the provider, and has evolved over the years from earlier APIs like ODBC. The .NET Framework Data Provider for SQL Server (SqlClient) incorporates many elements from older syntax and is generally more flexible with common connection string syntax. There are frequently equally valid synonyms for connection string syntax elements, but some syntax and spelling errors can cause problems. For example, "`Integrated Security=true`" is valid, whereas "`IntegratedSecurity=true`" causes an error. In addition, connection strings constructed at run time from unvalidated user input can lead to string injection attacks, jeopardizing security at the data source.
-  
-To address these problems, ADO.NET 2.0 introduced new connection string builders for each .NET Framework data provider. Keywords are exposed as properties, enabling connection string syntax to be validated before submission to the data source.
-  
+Although all connection strings share the same syntax described above, the set of recognised keywords depends on the provider and has evolved over the years from earlier APIs such as *ODBC*. The *.NET Framework* data provider for *SQL Server* (`SqlClient`) supports many keywords from older APIs but is generally more flexible and accepts synonyms for many of the common connection-string keywords.
+
+Spelling errors can cause problems. For example, `Integrated Security=true` is valid, whereas `IntegratedSecurity=true` causes an error. In addition, connection strings manually constructed at run-time from unvalidated user input are vulnerable to string-injection attacks, jeopardizing security at the data source. To address these problems, *ADO.NET* 2.0 introduced new [connection-string builders](../../../../docs/framework/data/adonet/connection-string-builders.md) for each *.NET Framework* data provider. They expose parameters as strongly-typed properties, enabling connection strings to be validated before submission to the data source.
+
 ## In This Section  
  [Connection String Builders](../../../../docs/framework/data/adonet/connection-string-builders.md)  
  Demonstrates how to use the `ConnectionStringBuilder` classes to construct valid connection strings at run time.

--- a/docs/framework/data/adonet/connection-strings.md
+++ b/docs/framework/data/adonet/connection-strings.md
@@ -5,8 +5,8 @@ ms.assetid: 745c5f95-2f02-4674-b378-6d51a7ec2490
 ---
 # Connection Strings in ADO.NET
 
-A connection string contains initialization information that is passed as a parameter from a data provider to a data source. The data provider accepts the connection string via the xref:DbConnection.ConnectionString?displayProperty=nameWithType property, whose setter parses it and ensures the syntax is correct and the keywords are supported.
-The xref:DbConnection.ConnectionString?displayProperty=nameWithType method passes the parsed connection parameters to the data source, which performs further validation and establishes a connection.
+A connection string contains initialization information that is passed as a parameter from a data provider to a data source. The data provider accepts the connection string via <xref:System.String> the <xref:System.Data.Common.DbConnection.ConnectionString?displayProperty=nameWithType> property, whose setter parses it and ensures the syntax is correct and the keywords are supported.
+The <xref:System.Data.Common.DbConnection.Open?displayProperty=nameWithType> method passes the parsed connection parameters to the data source, which performs further validation and establishes a connection.
 
 A connection string is a semicolon-delimited list of key/value parameter pairs:
   


### PR DESCRIPTION
## Summary

1. Remove the mention of the term `format` and use the term `syntax` for the general structure of connection strings, because only parameter names (keywords) differ from provider to provider. Where`syntax` was used to mean the set of supported keywords, say so explicitly.

2. Correct the wrong statement that the connection string is parsed and analysed for errors during the opening of the connection, and supply instead a more detailed description of what is checked when.

3. Remove explicit reference to exceptions wrt. syntax checking because exceptions are the standard and default way of error handling throughout .NET.

4. Remove the duplicate statement about new features in ADO.NET 2.0 (per-provider connection-string builders) from the beginning of the document. It is still present at the end.

Fixes #7770 .
