### PR TITLE
Fix missing behaviorConfiguration attribute in 'how-to-inspect-or-modify-messages-on-the-client' example.

### DIFF
--- a/docs/framework/wcf/extending/how-to-inspect-or-modify-messages-on-the-client.md
+++ b/docs/framework/wcf/extending/how-to-inspect-or-modify-messages-on-the-client.md
@@ -96,7 +96,8 @@ public class SimpleBehaviorExtensionElement : BehaviorExtensionElement
     <system.serviceModel>  
         <client>  
             <endpoint address="http://localhost:8080/SimpleService/"   
-                      binding="wsHttpBinding"  
+                      binding="wsHttpBinding"
+                      behaviorConfiguration="clientInspectorsAdded"
                       contract="ServiceReference1.IService1"  
                       name="WSHttpBinding_IService1"/>  
         </client>  


### PR DESCRIPTION
## Summary

Fix missing behaviorConfiguration attribute on the endpoint in how-to-inspect-or-modify-messages-on-the-client.md.

Fixes #8006
