### PR TITLE
Fix syntax block of multiple pages in WCF configuration Schema

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/activityscheduledqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activityscheduledqueries-of-wcf.md
@@ -17,7 +17,16 @@ Represents a collection of queries that are used to track an activity scheduled 
 ## Syntax  
   
 ```xml  
-<tracking>     <trackingProfile name="Name">       <workflow>          <activityScheduledQueries>             <activityScheduledQuery activityName="String"                 childActivityName="String"/>          </activityScheduledQueries>       </workflow>     </trackingProfile></tracking>  
+<tracking>
+  <trackingProfile name="Name">
+    <workflow>
+      <activityScheduledQueries>
+        <activityScheduledQuery activityName="String"   
+                                childActivityName="String"/>
+      </activityScheduledQueries>
+    </workflow>
+  </trackingProfile>
+</tracking>
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/wcf/activityscheduledquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activityscheduledquery-of-wcf.md
@@ -18,7 +18,16 @@ Represents a collection of queries that are used to track an activity scheduled 
 ## Syntax  
   
 ```xml
-<tracking>     <trackingProfile name="Name">       <workflow>          <activityScheduledQueries>             <activityScheduledQuery activityName="String"                 childActivityName="String"/>          </activityScheduledQueries>       </workflow>     </trackingProfile></tracking>  
+<tracking>
+  <trackingProfile name="Name">
+    <workflow>
+      <activityScheduledQueries>
+        <activityScheduledQuery activityName="String"   
+                                childActivityName="String"/>
+      </activityScheduledQueries>
+    </workflow>
+  </trackingProfile>
+</tracking> 
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/wcf/add-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/add-of-wcf.md
@@ -16,7 +16,13 @@ Configure a tracking participant that listens to the tracking records being emit
 ## Syntax  
   
 ```xml
-   <tracking>    <participants>       <add name="String"            profileName="String"           type="String" />    </participants> </tracking>
+<tracking>
+  <participants>
+    <add name="String"           
+         profileName="String"
+         type="String" />
+  </participants>
+</tracking>  
 ```
 
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/wcf/nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/nettcpbinding.md
@@ -15,36 +15,39 @@ Specifies a secure, reliable, optimized binding suitable for cross-machine commu
 ## Syntax  
   
 ```xml  
-<netTcpBinding>  
-   <binding   
-      closeTimeout="TimeSpan"  
-      hostNameComparisonMode="StrongWildCard/Exact/WeakWildcard"  
-      listenBacklog="Integer"  
-      maxBufferPoolSize="integer"  
-      maxBufferSize="Integer"  
-      maxConnections="Integer"   
-      maxReceivedMessageSize="Integer"  
-      name="string"  
-      openTimeout="TimeSpan"  
-      portSharingEnabled="Boolean"  
-      receiveTimeout="TimeSpan"  
-      sendTimeout="TimeSpan"  
-      transactionFlow="Boolean"   
-      transactionProtocol="OleTransactions/WSAtomicTransactionOctober2004"   
-            transferMode="Buffered/Streamed/StreamedRequest/StreamedResponse"  
-  
-      <reliableSession ordered="Boolean"  
-            inactivityTimeout="TimeSpan"  
-            enabled="Boolean" />  
-      <security mode="None/Transport/Message/Both">  
-            <message clientCredentialType="None/Windows/UserName/Certificate/CardSpace"  
-                defaultProtectionLevel="None/Sign/EncryptAndSign"   
-algorithmSuite="Basic128/Basic192/Basic256/Basic128Rsa15/Basic256Rsa15/TripleDes/TripleDesRsa15/Basic128Sha256/Basic192Sha256/TripleDesSha256/Basic128Sha256Rsa15/Basic192Sha256Rsa15/Basic256Sha256Rsa15/TripleDesSha256Rsa15" />  
-            <transport clientCredentialType="None/Windows/Certificate"  
-                protectionLevel="None/Sign/EncryptAndSign" />  
-      </security>  
-       <readerQuotas             maxArrayLength="Integer"            maxBytesPerRead="Integer"            maxDepth="Integer"             maxNameTableCharCount="Integer"                     maxStringContentLength="Integer" />   </binding>  
-</netTcpBinding>  
+<netTcpBinding>
+  <binding closeTimeout="TimeSpan"  
+           hostNameComparisonMode="StrongWildCard/Exact/WeakWildcard"
+           listenBacklog="Integer"  
+           maxBufferPoolSize="integer"  
+           maxBufferSize="Integer"  
+           maxConnections="Integer"   
+           maxReceivedMessageSize="Integer"  
+           name="string"  
+           openTimeout="TimeSpan"  
+           portSharingEnabled="Boolean"  
+           receiveTimeout="TimeSpan"  
+           sendTimeout="TimeSpan"  
+           transactionFlow="Boolean"   
+           transactionProtocol="OleTransactions/WSAtomicTransactionOctober2004"   
+           transferMode="Buffered/Streamed/StreamedRequest/StreamedResponse">
+    <reliableSession ordered="Boolean"  
+                     inactivityTimeout="TimeSpan"  
+                     enabled="Boolean" />
+    <security mode="None/Transport/Message/Both">
+      <message clientCredentialType="None/Windows/UserName/Certificate/CardSpace"  
+               defaultProtectionLevel="None/Sign/EncryptAndSign"   
+               algorithmSuite="Basic128/Basic192/Basic256/Basic128Rsa15/Basic256Rsa15/TripleDes/TripleDesRsa15/Basic128Sha256/Basic192Sha256/TripleDesSha256/Basic128Sha256Rsa15/Basic192Sha256Rsa15/Basic256Sha256Rsa15/TripleDesSha256Rsa15" />
+      <transport clientCredentialType="None/Windows/Certificate"  
+                 protectionLevel="None/Sign/EncryptAndSign" />
+    </security>
+    <readerQuotas maxArrayLength="Integer"     
+                  maxBytesPerRead="Integer"      
+                  maxDepth="Integer" 
+                  maxNameTableCharCount="Integer"
+                  maxStringContentLength="Integer" />
+  </binding>
+</netTcpBinding> 
 ```  
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/wcf/participants-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/participants-of-wcf.md
@@ -15,7 +15,13 @@ Configure a list of tracking participants that listen to the tracking records be
 ## Syntax  
   
 ```xml
-   <tracking>    <participants>       <add name="String"            profileName="String"           type="String" />    </participants> </tracking>   
+<tracking>
+  <participants>
+    <add name="String"           
+         profileName="String"
+         type="String" />
+  </participants>
+</tracking>    
 ```
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/wcf/tracking-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/tracking-of-wcf.md
@@ -14,7 +14,59 @@ Represents a configuration section for defining tracking settings for a workflow
 ## Syntax  
   
 ```xml
-   <system.serviceModel>  <tracking>       <participants>       <add name="String"            profileName="String"           type="String" />      </participants>     <trackingProfile name="String">      <workflow activityDefinitionId="String">          <activityScheduledQueries>             <activityScheduledQuery activityName="String"                 childActivityName="String"/>          </activityScheduledQueries>             <activityStateQuery activityName="String" />                <arguments>                   <argument name="String"/>                </arguments>                <states>                   <state name="String"/>                </states>                <variables>                   <variable name="String"/>                </variables>          </activityStateQueries>          <bookmarkResumptionQueries>             <bookmarkResumptionQuery name="String" />          </bookmarkResumptionQueries>          <cancelRequestQueries>             <cancelRequestQuery activityName="String"                 childActivityName="String"/>          </cancelRequestQueries>          <customTrackingQueries>             <customTrackingQuery activityName="String"                 name="String"/>          </customTrackingQueries>          <faultPropagationQueries>             <faultPropagationQuery activityName="String"                 faultHandlerActivityName="String"/>          </faultPropagationQueries>         <workflowInstanceQueries>            <workflowInstanceQuery>              <states>                 <state name="String"/>              </states>          </workflowInstanceQuery>        </workflowInstanceQueries>      </workflow>    </trackingProfile>           </profiles>  </tracking></system.serviceModel>  
+<system.serviceModel>
+  <tracking>
+    <participants>
+      <add name="String" 
+           profileName="String" 
+           type="String" />
+    </participants>
+    <profiles>
+      <trackingProfile name="String">
+        <workflow activityDefinitionId="String">
+          <activityScheduledQueries>
+            <activityScheduledQuery activityName="String"       
+                                    childActivityName="String"/>
+          </activityScheduledQueries>
+          <activityStateQueries>
+            <activityStateQuery activityName="String" />
+            <arguments>
+              <argument name="String"/>
+            </arguments>
+            <states>
+              <state name="String"/>
+            </states>
+            <variables>
+              <variable name="String"/>
+            </variables>
+          </activityStateQueries>
+          <bookmarkResumptionQueries>
+            <bookmarkResumptionQuery name="String" />
+          </bookmarkResumptionQueries>
+          <cancelRequestQueries>
+            <cancelRequestQuery activityName="String" 
+                                childActivityName="String"/>
+          </cancelRequestQueries>
+          <customTrackingQueries>
+            <customTrackingQuery activityName="String" 
+                                 name="String"/>
+          </customTrackingQueries>
+          <faultPropagationQueries>
+            <faultPropagationQuery activityName="String" 
+                                   faultHandlerActivityName="String"/>
+          </faultPropagationQueries>
+          <workflowInstanceQueries>
+            <workflowInstanceQuery>
+              <states>
+                <state name="String"/>
+              </states>
+            </workflowInstanceQuery>
+          </workflowInstanceQueries>
+        </workflow>
+      </trackingProfile>
+    </profiles>
+  </tracking>
+</system.serviceModel>   
 ```
   
 ## Attributes and Elements  

--- a/docs/framework/configure-apps/file-schema/wcf/trackingprofile-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/trackingprofile-of-wcf.md
@@ -15,7 +15,52 @@ Represents a configuration section for creating a subscription to workflow track
 ## Syntax  
   
 ```xml
-   <system.serviceModel>  <tracking>      <trackingProfile name="String">      <workflow activityDefinitionId="String">          <activityScheduledQueries>             <activityScheduledQuery activityName="String"                 childActivityName="String"/>          </activityScheduledQueries>             <activityStateQuery activityName="String" />                <arguments>                   <argument name="String"/>                </arguments>                <states>                   <state name="String"/>                </states>                <variables>                   <variable name="String"/>                </variables>          </activityStateQueries>          <bookmarkResumptionQueries>             <bookmarkResumptionQuery name="String" />          </bookmarkResumptionQueries>          <cancelRequestQueries>             <cancelRequestQuery activityName="String"                 childActivityName="String"/>          </cancelRequestQueries>          <customTrackingQueries>             <customTrackingQuery activityName="String"                 name="String"/>          </customTrackingQueries>          <faultPropagationQueries>             <faultPropagationQuery activityName="String"                 faultHandlerActivityName="String"/>          </faultPropagationQueries>         <workflowInstanceQueries>            <workflowInstanceQuery>              <states>                 <state name="String"/>              </states>          </workflowInstanceQuery>        </workflowInstanceQueries>      </workflow>    </trackingProfile>           </profiles>  </tracking></system.serviceModel>    
+<system.serviceModel>
+  <tracking>
+    <trackingProfile name="String">
+      <workflow activityDefinitionId="String">
+        <activityScheduledQueries>
+          <activityScheduledQuery activityName="String"       
+                                  childActivityName="String"/>
+        </activityScheduledQueries>
+        <activityStateQueries>
+          <activityStateQuery activityName="String" />
+          <arguments>
+            <argument name="String"/>
+          </arguments>
+          <states>
+            <state name="String"/>
+          </states>
+          <variables>
+            <variable name="String"/>
+          </variables>
+        </activityStateQueries>
+        <bookmarkResumptionQueries>
+          <bookmarkResumptionQuery name="String" />
+        </bookmarkResumptionQueries>
+        <cancelRequestQueries>
+          <cancelRequestQuery activityName="String" 
+                              childActivityName="String"/>
+        </cancelRequestQueries>
+        <customTrackingQueries>
+          <customTrackingQuery activityName="String" 
+                               name="String"/>
+        </customTrackingQueries>
+        <faultPropagationQueries>
+          <faultPropagationQuery activityName="String" 
+                                 faultHandlerActivityName="String"/>
+        </faultPropagationQueries>
+        <workflowInstanceQueries>
+          <workflowInstanceQuery>
+            <states>
+              <state name="String"/>
+            </states>
+          </workflowInstanceQuery>
+        </workflowInstanceQueries>
+      </workflow>
+    </trackingProfile>
+  </tracking>
+</system.serviceModel>     
 ```  
   
 ## Attributes and Elements  


### PR DESCRIPTION
## Fix syntax block of multiple pages in WCF configuration Schema

Fix the syntax blocks of:
\<tracking>
\<participants>
\<add>
\<trackingProfile>
\<activityScheduledQueries>
\<activityScheduledQuery>
\<netTcpBinding>

Addresses some of the issues from #8125 

