### PR TITLE
Add missing assembly to 'Creating the Data Set' section in the 'Working with linq' tutorial

### DIFF
--- a/docs/csharp/tutorials/working-with-linq.md
+++ b/docs/csharp/tutorials/working-with-linq.md
@@ -86,6 +86,7 @@ These two methods both utilize the `yield return` syntax to produce a sequence a
 For this to compile you’ll need to add the following two lines to the top of the file:
 
 ```csharp
+using System;
 using System.Collections.Generic;
 using System.Linq;
 ```

--- a/docs/csharp/tutorials/working-with-linq.md
+++ b/docs/csharp/tutorials/working-with-linq.md
@@ -83,6 +83,13 @@ static IEnumerable<string> Ranks()
 
 These two methods both utilize the `yield return` syntax to produce a sequence as they run. The compiler builds an object that implements `IEnumerable<T>` and generates the sequence of strings as they are requested.
 
+For this to compile you’ll need to add the following two lines to the top of the file:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+```
+
 Go ahead and run the sample you've built at this point. It will display all 52 cards in the deck. You may find it very helpful to run this sample under a debugger to observe how the `Suits()` and `Values()` methods execute. You can clearly see that each string in each sequence is generated only as it is needed.
 
 ![Console window showing the app writing out 52 cards](./media/working-with-linq/console.png)


### PR DESCRIPTION
## Summary

The Creating the Data Set section was missing two assembly that it needs in order to compile. If the the user tried to compile the code as the tutorial told him to do, he would see an error message, instead of what was prompted in the image used at the end of this section.
