### PR TITLE
Provide link to source in outlined text example

### DIFF
--- a/docs/framework/wpf/advanced/how-to-create-outlined-text.md
+++ b/docs/framework/wpf/advanced/how-to-create-outlined-text.md
@@ -51,5 +51,7 @@ Example of an image brush applied to the stroke and highlight
  [!code-csharp[OutlineTextControlViewer#OnRender](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs#onrender)]
  [!code-vb[OutlineTextControlViewer#OnRender](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb#onrender)]  
   
+  For the source of the example custom user control object, see ![OutlineTextControl](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs)
+  
 ## See Also  
  [Drawing Formatted Text](../../../../docs/framework/wpf/advanced/drawing-formatted-text.md)

--- a/docs/framework/wpf/advanced/how-to-create-outlined-text.md
+++ b/docs/framework/wpf/advanced/how-to-create-outlined-text.md
@@ -51,7 +51,7 @@ Example of an image brush applied to the stroke and highlight
  [!code-csharp[OutlineTextControlViewer#OnRender](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs#onrender)]
  [!code-vb[OutlineTextControlViewer#OnRender](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb#onrender)]  
   
-  For the source of the example custom user control object, see [OutlineTextControl.cs for C#](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs) and [outlinetextcontrol.vb for Visual Basic](https://github.com/dotnet/samples/blob/master/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/OutlineTextControl.vb). 
+  For the source of the example custom user control object, see [OutlineTextControl.cs for C#](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs) and [OutlineTextControl.vb for Visual Basic](https://github.com/dotnet/samples/blob/master/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb). 
   
 ## See Also  
  [Drawing Formatted Text](../../../../docs/framework/wpf/advanced/drawing-formatted-text.md)

--- a/docs/framework/wpf/advanced/how-to-create-outlined-text.md
+++ b/docs/framework/wpf/advanced/how-to-create-outlined-text.md
@@ -51,7 +51,7 @@ Example of an image brush applied to the stroke and highlight
  [!code-csharp[OutlineTextControlViewer#OnRender](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs#onrender)]
  [!code-vb[OutlineTextControlViewer#OnRender](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb#onrender)]  
   
-  For the source of the example custom user control object, see ![OutlineTextControl](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs)
+  For the source of the example custom user control object, see [OutlineTextControl.cs for C#](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs) and [OutlineTextControl.vb for Visual Basic](https://github.com/dotnet/samples/blob/master/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/OutlineTextControl.vb). 
   
 ## See Also  
  [Drawing Formatted Text](../../../../docs/framework/wpf/advanced/drawing-formatted-text.md)

--- a/docs/framework/wpf/advanced/how-to-create-outlined-text.md
+++ b/docs/framework/wpf/advanced/how-to-create-outlined-text.md
@@ -51,7 +51,7 @@ Example of an image brush applied to the stroke and highlight
  [!code-csharp[OutlineTextControlViewer#OnRender](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs#onrender)]
  [!code-vb[OutlineTextControlViewer#OnRender](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb#onrender)]  
   
-  For the source of the example custom user control object, see ![OutlineTextControl](~/samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs)
+  For the source of the example custom user control object, see ![OutlineTextControl](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs)
   
 ## See Also  
  [Drawing Formatted Text](../../../../docs/framework/wpf/advanced/drawing-formatted-text.md)

--- a/docs/framework/wpf/advanced/how-to-create-outlined-text.md
+++ b/docs/framework/wpf/advanced/how-to-create-outlined-text.md
@@ -51,7 +51,7 @@ Example of an image brush applied to the stroke and highlight
  [!code-csharp[OutlineTextControlViewer#OnRender](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs#onrender)]
  [!code-vb[OutlineTextControlViewer#OnRender](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb#onrender)]  
   
-  For the source of the example custom user control object, see [OutlineTextControl.cs for C#](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs) and [OutlineTextControl.vb for Visual Basic](https://github.com/dotnet/samples/blob/master/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/OutlineTextControl.vb). 
+  For the source of the example custom user control object, see [OutlineTextControl.cs for C#](https://github.com/dotnet/samples/blob/master/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs) and [outlinetextcontrol.vb for Visual Basic](https://github.com/dotnet/samples/blob/master/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/OutlineTextControl.vb). 
   
 ## See Also  
  [Drawing Formatted Text](../../../../docs/framework/wpf/advanced/drawing-formatted-text.md)

--- a/docs/framework/wpf/advanced/how-to-create-outlined-text.md
+++ b/docs/framework/wpf/advanced/how-to-create-outlined-text.md
@@ -51,7 +51,7 @@ Example of an image brush applied to the stroke and highlight
  [!code-csharp[OutlineTextControlViewer#OnRender](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs#onrender)]
  [!code-vb[OutlineTextControlViewer#OnRender](../../../../samples/snippets/visualbasic/VS_Snippets_Wpf/OutlineTextControlViewer/visualbasic/outlinetextcontrol.vb#onrender)]  
   
-  For the source of the example custom user control object, see ![OutlineTextControl](../../../../samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs)
+  For the source of the example custom user control object, see ![OutlineTextControl](~/samples/snippets/csharp/VS_Snippets_Wpf/OutlineTextControlViewer/CSharp/OutlineTextControl.cs)
   
 ## See Also  
  [Drawing Formatted Text](../../../../docs/framework/wpf/advanced/drawing-formatted-text.md)


### PR DESCRIPTION
## Summary

A user expressed that it would be useful to have a link to the full example of the code instead of having to know github-fu to track it down from the snippets.

Fixes dotnet/docs#7818
