### PR TITLE
Fix link to numbers in C#

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -12,7 +12,7 @@ ms.custom: "updateeachrelease"
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 
-Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running. If you want to try .NET Core in you browser, look at the [Numbers in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/hello-world) quickstart.
+Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a simple .NET Core application. It only takes a few minutes to get your first app up and running. If you want to try .NET Core in you browser, look at the [Numbers in C#](https://docs.microsoft.com/dotnet/csharp/quick-starts/numbers-in-csharp) quickstart.
 
 ## Download .NET Core 2.1
 


### PR DESCRIPTION
The actual link points to "hello world" quickstart

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
