### PR TITLE
fixing WCF syntax

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/activityscheduledqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activityscheduledqueries-of-wcf.md
@@ -8,9 +8,9 @@ Represents a collection of queries that are used to track an activity scheduled 
   
 For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
-\<system.serviceModel>
-\<tracking>
-\<profiles>
+\<system.serviceModel>  
+\<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<activityScheduledQueries>  

--- a/docs/framework/configure-apps/file-schema/wcf/activityscheduledqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activityscheduledqueries-of-wcf.md
@@ -6,10 +6,11 @@ ms.assetid: e351329f-9676-4f11-9b19-f4bac82f36fc
 # &lt;activityScheduledQueries&gt; of WCF
 Represents a collection of queries that are used to track an activity scheduled for execution by a parent activity. The query is necessary for a tracking participant to subscribe to activity scheduled records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
-\<tracking>  
+\<system.serviceModel>
+\<tracking>
+\<profiles>
 \<trackingProfile>  
 \<workflow>  
 \<activityScheduledQueries>  
@@ -18,37 +19,42 @@ Represents a collection of queries that are used to track an activity scheduled 
   
 ```xml  
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <activityScheduledQueries>
-        <activityScheduledQuery activityName="String"   
-                                childActivityName="String"/>
-      </activityScheduledQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <activityScheduledQueries>
+          <activityScheduledQuery activityName="String"   
+                                  childActivityName="String"/>
+        </activityScheduledQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>
 ```  
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements  
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
- None.  
+
+None.  
   
-### Child Elements  
+### Child elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<activityScheduledQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activityscheduledquery.md)|A query that is used to track an activity scheduled for execution by a parent activity.|  
+|[\<activityScheduledQuery>](activityscheduledquery-of-wcf.md)|A query that is used to track an activity scheduled for execution by a parent activity.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the `activityDefinitionId` property.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityScheduledQueryElementCollection>     
- <xref:System.Activities.Tracking.ActivityScheduledQuery>     
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also  
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityScheduledQueryElementCollection>
+- <xref:System.Activities.Tracking.ActivityScheduledQuery>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/activityscheduledquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activityscheduledquery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: 25f6eee1-3d98-4c39-b517-c0813f03f106
 ---
 # &lt;activityScheduledQuery&gt; of WCF
+
 Represents a collection of queries that are used to track an activity scheduled for execution by a parent activity. The query is necessary for a tracking participant to subscribe to activity scheduled records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<activityScheduledQueries>  
@@ -19,38 +21,43 @@ Represents a collection of queries that are used to track an activity scheduled 
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <activityScheduledQueries>
-        <activityScheduledQuery activityName="String"   
-                                childActivityName="String"/>
-      </activityScheduledQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <activityScheduledQueries>
+          <activityScheduledQuery activityName="String"   
+                                  childActivityName="String"/>
+        </activityScheduledQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking> 
 ```  
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements  
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|activityName|A string that specifies the name of the activity that is requesting the cancellation.|  
-|childActivityName|A string that specifies the name of the child activity for which cancellation was requested.|  
+|`activityName`|A string that specifies the name of the activity that is requesting the cancellation.|  
+|`childActivityName`|A string that specifies the name of the child activity for which cancellation was requested.|  
   
-### Child Elements  
- None.  
+### Child elements
+
+None.
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<activityScheduledQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activityscheduledquery.md)|A query that is used to track an activity scheduled for execution by a parent activity.|  
+|[\<activityScheduledQueries>](activityscheduledqueries-of-wcf.md)|A collection of queries that are used to track an activity scheduled for execution by a parent activity.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityScheduledQueryElement>     
- <xref:System.Activities.Tracking.ActivityScheduledQuery>     
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityScheduledQueryElement>
+- <xref:System.Activities.Tracking.ActivityScheduledQuery>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/activitystatequeries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activitystatequeries-of-wcf.md
@@ -9,12 +9,12 @@ Represents a collection of queries that are used to track life cycle changes of 
 
 For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).
 
-\<system.serviceModel>
-\<tracking>
-\<profiles>
-\<trackingProfile>
-\<workflow> 
-\<activityStateQueries>
+\<system.serviceModel>  
+\<tracking>  
+\<profiles>  
+\<trackingProfile>  
+\<workflow>  
+\<activityStateQueries>  
 
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/activitystatequeries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activitystatequeries-of-wcf.md
@@ -1,62 +1,70 @@
 ---
 title: "&lt;activityStateQueries&gt; of WCF"
-ms.date: "03/30/2017"
+ms.date: "10/08/2018"
 ms.assetid: 9e45db49-ed85-4fdf-bd65-0d5477e31823
 ---
 # &lt;activityStateQueries&gt; of WCF
-Represents a collection of queries that are used to track life cycle changes of the activities that make up a workflow instance. For example, you may want to keep track of every time the "Send E-Mail" activity completes within a workflow instance. This query is necessary for a tracking participant to subscribe to activity state record objects. The available states to subscribe to are specified in ActivityStates.  
-  
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
-  
- \<system.serviceModel>  
-\<tracking>  
-\<trackingProfile>  
-\<workflow>  
-\<activityStateQueries>  
-  
+
+Represents a collection of queries that are used to track life cycle changes of the activities that make up a workflow instance. For example, you may want to keep track of every time the "Send E-Mail" activity completes within a workflow instance. This query is necessary for a tracking participant to subscribe to activity state record objects. The available states to subscribe to are specified in ActivityStates.
+
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).
+
+\<system.serviceModel>
+\<tracking>
+\<profiles>
+\<trackingProfile>
+\<workflow> 
+\<activityStateQueries>
+
 ## Syntax  
   
-```xml  
+```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <activityStateQueries>
-        <activityStateQuery activityName="String" />
-        <arguments>
-          <argument name="String"/>
-        </arguments>
-        <states>
-          <state name="String"/>
-        </states>
-        <variables>
-          <variable name="String"/>
-        </variables>
-      </activityStateQueries>
-    </workflow>
-  </trackingProfile>
-</tracking>  
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <activityStateQueries>
+          <activityStateQuery activityName="String">
+            <arguments>
+              <argument name="String"/>
+            </arguments>
+            <states>
+              <state name="String"/>
+            </states>
+            <variables>
+              <variable name="String"/>
+            </variables>
+          </activityStateQuery>
+        </activityStateQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
+</tracking>
 ```  
-  
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
   
 ### Attributes  
- None.  
-  
-### Child Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<activityStateQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md)|A query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|  
-  
-### Parent Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the `activityDefinitionId` property.|  
-  
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityStateQueryElementCollection>    
- <xref:System.Activities.Tracking.ActivityStateQuery>    
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+
+None.  
+
+### Child elements
+
+|Element|Description|
+|-------------|-----------------|
+|[\<activityStateQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md)|A query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|
+
+### Parent elements
+
+|Element|Description|
+|-------------|-----------------|
+|[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the `activityDefinitionId` property.|
+
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityStateQueryElementCollection>    
+- <xref:System.Activities.Tracking.ActivityStateQuery>    
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/activitystatequeries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activitystatequeries-of-wcf.md
@@ -54,7 +54,7 @@ None.
 
 |Element|Description|
 |-------------|-----------------|
-|[\<activityStateQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md)|A query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|
+|[\<activityStateQuery>](activitystatequery-of-wcf.md)|A query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|
 
 ### Parent elements
 

--- a/docs/framework/configure-apps/file-schema/wcf/activitystatequery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activitystatequery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: d6cdc04b-6f3a-4097-a623-ee4a1be3b5c4
 ---
 # &lt;activityStateQuery&gt; of WCF
+
 Represents a query that is used to track life cycle changes of the activities that make up a workflow instance. For example, you may want to keep track of every time the "Send E-Mail" activity completes within a workflow instance. This query is necessary for a tracking participant to subscribe to activity state record objects. The available states to subscribe to are specified in ActivityStates.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
-  
- \<system.serviceModel>  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).
+
+\<system.serviceModel>
 \<tracking>  
+\<profiles>
 \<trackingProfile>  
 \<workflow>  
 \<activityStateQueries>  
@@ -19,27 +21,31 @@ Represents a query that is used to track life cycle changes of the activities th
   
 ```xml  
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <activityStateQueries>
-        <activityStateQuery activityName="String" />
-        <arguments>
-          <argument name="String"/>
-        </arguments>
-        <states>
-          <state name="String"/>
-        </states>
-        <variables>
-          <variable name="String"/>
-        </variables>
-      </activityStateQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <activityStateQueries>
+          <activityStateQuery activityName="String">
+            <arguments>
+              <argument name="String"/>
+            </arguments>
+            <states>
+              <state name="String"/>
+            </states>
+            <variables>
+              <variable name="String"/>
+            </variables>
+          </activityStateQuery>
+        </activityStateQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```  
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements  
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
   
@@ -47,7 +53,7 @@ Represents a query that is used to track life cycle changes of the activities th
 |---------------|-----------------|  
 |activityName|A string that specifies the name of the activity to filter <xref:System.Activities.Tracking.ActivityStateRecord> instances on.|  
   
-### Child Elements  
+### Child elements  
   
 |Element|Description|  
 |-------------|-----------------|  
@@ -55,14 +61,15 @@ Represents a query that is used to track life cycle changes of the activities th
 |[\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md)|A collection of configuration elements that contain the states of the subscribed activity for which a tracking record should be emitted.|  
 |[\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md)|A collection of variables associated with this activity query.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<faultPropagationQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/faultpropagationquery.md)|Represents a list of configuration elements that are used to track requests to cancel a child activity by the parent activity. The query is necessary for a tracking participant to subscribe to cancel request record objects.|  
   
-## Remarks  
- One unique feature of an ActivityStateQuery is the ability to extract data when tracking the execution of a workflow. This provides additional context when accessing the tracking records post execution. You can use the [\<arguments>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/arguments.md), [\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md) and [\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md) elements to extract any variable or argument from any activity in a workflow.The following example shows an activity state query that extracts variables and arguments when the activity’s `Closed` tracking record is emitted. Variables and arguments can be extracted only with an ActivityStateRecord and thus are subscribed to within a tracking profile using [\<activityStateQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md).  
+## Remarks
+
+One unique feature of an ActivityStateQuery is the ability to extract data when tracking the execution of a workflow. This provides additional context when accessing the tracking records post execution. You can use the [\<arguments>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/arguments.md), [\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md) and [\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md) elements to extract any variable or argument from any activity in a workflow.The following example shows an activity state query that extracts variables and arguments when the activity’s `Closed` tracking record is emitted. Variables and arguments can be extracted only with an ActivityStateRecord and thus are subscribed to within a tracking profile using [\<activityStateQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md).  
   
 ```xml  
 <activityStateQuery activityName="SendEmailActivity">  
@@ -78,8 +85,9 @@ Represents a query that is used to track life cycle changes of the activities th
 </activityStateQuery>  
 ```  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityStateQueryElement>    
- <xref:System.Activities.Tracking.ActivityStateQuery>     
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.ActivityStateQueryElement>
+- <xref:System.Activities.Tracking.ActivityStateQuery>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/bookmarkresumptionqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/bookmarkresumptionqueries-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: ed086712-1dc7-4932-a592-d1116a0155f3
 ---
 # &lt;bookmarkResumptionQueries&gt; of WCF
+
 Represents a collection of queries that are used to track resumption of a bookmark within a workflow instance. The query is necessary for a tracking participant to subscribe to bookmark resumption records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<bookmarkResumptionQueries>  
@@ -19,36 +21,41 @@ Represents a collection of queries that are used to track resumption of a bookma
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <bookmarkResumptionQueries>
-        <bookmarkResumptionQuery name="String" />
-      </bookmarkResumptionQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <bookmarkResumptionQueries>
+          <bookmarkResumptionQuery name="String" />
+        </bookmarkResumptionQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```
 
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.  
   
-### Attributes  
- None.  
+### Attributes
+
+None.  
   
-### Child Elements  
+### Child elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<bookmarkResumptionQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/bookmarkresumptionquery.md)|A query that is used to track resumption of a bookmark within a workflow instance. The query is necessary for a tracking participant to subscribe to bookmark resumption records.|  
+|[\<bookmarkResumptionQuery>](bookmarkresumptionquery-of-wcf.md)|A query that is used to track resumption of a bookmark within a workflow instance. The query is necessary for a tracking participant to subscribe to bookmark resumption records.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the `activityDefinitionId` property.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.BookmarkResumptionQueryElementCollection?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.BookmarkResumptionQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.BookmarkResumptionQueryElementCollection?displayProperty=nameWithType> 
+- <xref:System.Activities.Tracking.BookmarkResumptionQuery?displayProperty=nameWithType>       
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/bookmarkresumptionquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/bookmarkresumptionquery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: 755a34f0-87c9-4a1e-ae4d-0fb8a6fbdc0e
 ---
 # &lt;bookmarkResumptionQuery&gt; of WCF
+
 Represents a query that is used to track resumption of a bookmark within a workflow instance. The query is necessary for a tracking participant to subscribe to bookmark resumption records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<bookmarkResumptionQueries>  
@@ -19,36 +21,41 @@ Represents a query that is used to track resumption of a bookmark within a workf
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <bookmarkResumptionQueries>
-        <bookmarkResumptionQuery name="String" />
-      </bookmarkResumptionQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <bookmarkResumptionQueries>
+          <bookmarkResumptionQuery name="String" />
+        </bookmarkResumptionQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```
 
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|name|A string that specifies the name of the bookmark record to subscribe to.|  
+|`name`|A string that specifies the name of the bookmark record to subscribe to.|  
   
-### Child Elements  
- None.  
+### Child elements
+
+None.
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<bookmarkResumptionQueries>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/bookmarkresumptionqueries.md)|Represents a collection of queries that are used to track resumption of a bookmark within a workflow instance.|  
+|[\<bookmarkResumptionQueries>](bookmarkresumptionqueries-of-wcf.md)|Represents a collection of queries that are used to track resumption of a bookmark within a workflow instance.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.BookmarkResumptionQueryElementCollection?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.BookmarkResumptionQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.BookmarkResumptionQueryElementCollection?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.BookmarkResumptionQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/cancelrequestedqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/cancelrequestedqueries-of-wcf.md
@@ -6,10 +6,11 @@ ms.assetid: a7cc7125-9ea3-4d3f-99c0-878cdeb1258a
 # &lt;cancelRequestedQueries&gt; of WCF
 Represents a collection of queries that are used to track requests to cancel a child activity by the parent activity. The query is necessary for a tracking participant to subscribe to cancel request record objects.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>
 \<trackingProfile>  
 \<workflow>  
 \<cancelRequestedQueries>  
@@ -18,36 +19,41 @@ Represents a collection of queries that are used to track requests to cancel a c
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <cancelRequestQueries>
-        <cancelRequestQuery activityName="String"
-                            childActivityName="String"/>
-      </cancelRequestQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <cancelRequestQueries>
+          <cancelRequestQuery activityName="String"
+                              childActivityName="String"/>
+        </cancelRequestQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```
 
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements  
+
+The following sections describe attributes, child elements, and parent elements.  
   
-### Attributes  
- None.  
+### Attributes
+
+None.
   
-### Child Elements  
+### Child elements
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<cancelRequestedQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/cancelrequestedquery.md)|A query that is used to track requests to cancel a child activity by the parent activity|  
+|[\<cancelRequestedQuery>](cancelrequestedquery-of-wcf.md)|A query that is used to track requests to cancel a child activity by the parent activity|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the <xref:System.ServiceModel.Activities.Tracking.Configuration.ProfileWorkflowElement.ActivityDefinitionId> property.|  
   
-## See Also  
- <xref:System.Activities.Tracking.CancelRequestedQuery>  
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.Activities.Tracking.CancelRequestedQuery>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/cancelrequestedquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/cancelrequestedquery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: b690d870-02eb-4c56-8bc3-e5ca99d7097b
 ---
 # &lt;cancelRequestedQuery&gt; of WCF
+
 Represents a query that is used to track requests to cancel a child activity by the parent activity. The query is necessary for a tracking participant to subscribe to cancel request record objects.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<cancelRequestedQueries>  
@@ -19,38 +21,43 @@ Represents a query that is used to track requests to cancel a child activity by 
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <cancelRequestQueries>
-        <cancelRequestQuery activityName="String"
-                            childActivityName="String"/>
-      </cancelRequestQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <cancelRequestedQueries>
+          <cancelRequestedQuery activityName="String"
+                              childActivityName="String"/>
+        </cancelRequestedQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```
 
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
-  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
+
 ### Attributes  
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|activityName|A string that specifies the name of the activity that is requesting the cancellation.|  
-|childActivityName|A string that specifies the name of the child activity for which cancellation was requested.|  
+|`activityName`|A string that specifies the name of the activity that is requesting the cancellation.|  
+|`childActivityName`|A string that specifies the name of the child activity for which cancellation was requested.|  
   
-### Child Elements  
- None.  
+### Child elements
+
+None.
   
-### Parent Elements  
+### Parent elements
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<faultPropagationQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/faultpropagationquery.md)|Represents a list of configuration elements that are used to track requests to cancel a child activity by the parent activity. The query is necessary for a tracking participant to subscribe to cancel request record objects.|  
+|[\<cancelRequestedQueries>](cancelrequestedqueries-of-wcf.md)|Represents a collection of queries that are used to track requests to cancel a child activity by the parent activity.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.CancelRequestedQueryElement?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.CancelRequestedQuery?displayProperty=nameWithType>     
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also  
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.CancelRequestedQueryElement?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.CancelRequestedQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/customtrackingqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/customtrackingqueries-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: 14cfe47e-9935-4120-84f1-8f38de8ca4c1
 ---
 # &lt;customTrackingQueries&gt; of WCF
+
 Represents a collection of queries that are used to track events that you define in your code activities. The query is necessary for a tracking participant to subscribe to custom tracking records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+ For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<customTrackingQueries>  
@@ -18,37 +20,42 @@ Represents a collection of queries that are used to track events that you define
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <customTrackingQueries>
-        <customTrackingQuery activityName="String"
-                             name="String"/>
-      </customTrackingQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <customTrackingQueries>
+          <customTrackingQuery activityName="String"
+                               name="String"/>
+        </customTrackingQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```  
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.  
   
-### Attributes  
- None.  
+### Attributes
+
+None.
   
-### Child Elements  
+### Child elements
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<customTrackingQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/customtrackingquery.md)|A query that is used to track events that you define in your code activities.|  
+|[\<customTrackingQuery>](customtrackingquery-of-wcf.md)|A query that is used to track events that you define in your code activities.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the `activityDefinitionId` property.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.CustomTrackingQueryElementCollection?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.CustomTrackingQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.CustomTrackingQueryElementCollection?displayProperty=nameWithType>       
+- <xref:System.Activities.Tracking.CustomTrackingQuery?displayProperty=nameWithType>       
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/customtrackingquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/customtrackingquery-of-wcf.md
@@ -53,7 +53,7 @@ None.
 
 |Element|Description|  
 |-------------|-----------------|  
-|[\<customTrackingQuery>](customtrackingqueries-of-wcf.md)|Represents a collection of queries that are used to track events that you define in your code activities.|
+|[\<customTrackingQueries>](customtrackingqueries-of-wcf.md)|Represents a collection of queries that are used to track events that you define in your code activities.|
   
 ## See also
 

--- a/docs/framework/configure-apps/file-schema/wcf/customtrackingquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/customtrackingquery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: 164446ae-8440-4b67-b217-6786cfae1e01
 ---
 # &lt;customTrackingQuery&gt; of WCF
-Represents a collection of queries that are used to track events that you define in your code activities. The query is necessary for a tracking participant to subscribe to custom tracking records.  
+
+Represents a query that is used to track events that you define in your code activities. The query is necessary for a tracking participant to subscribe to custom tracking records.
+
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
-  
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<customTrackingQueries>  
@@ -19,38 +21,43 @@ Represents a collection of queries that are used to track events that you define
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <customTrackingQueries>
-        <customTrackingQuery activityName="String"
-                             name="String"/>
-      </customTrackingQueries>
-    </workflow>
-  </trackingProfile>
-</tracking>  
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <customTrackingQueries>
+          <customTrackingQuery activityName="String"
+                               name="String"/>
+        </customTrackingQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
+</tracking>
 ```
 
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements  
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|activityName|A string that specifies the name of the activity that generated the tracking record.|  
-|name|A string that specifies the name of the custom tracking record that is emitted.|  
+|`activityName`|A string that specifies the name of the activity that generated the tracking record.|  
+|`name`|A string that specifies the name of the custom tracking record that is emitted.|  
   
-### Child Elements  
- None.  
-  
-### Parent Elements  
-  
+### Child elements
+
+None.
+
+### Parent elements
+
 |Element|Description|  
 |-------------|-----------------|  
-|[\<customTrackingQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/customtrackingquery.md)|A query that is used to track events that you define in your code activities.|  
+|[\<customTrackingQuery>](customtrackingqueries-of-wcf.md)|Represents a collection of queries that are used to track events that you define in your code activities.|
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.CustomTrackingQueryElementCollection?displayProperty=nameWithType>      
- <xref:System.Activities.Tracking.CustomTrackingQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.CustomTrackingQueryElementCollection?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.CustomTrackingQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/faultpropagationqueries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/faultpropagationqueries-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: d85f66a7-e7b0-4dbb-83cc-89fa06fc9161
 ---
 # &lt;faultPropagationQueries&gt; of WCF
+
 Represents a collection of queries that are used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault. You should use such query to track the handling of faults that occur within an activity. The query is necessary for a  tracking participant to subscribe to fault propagation records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<faultPropagationQueries>  
@@ -18,37 +20,42 @@ Represents a collection of queries that are used to track the handling of faults
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <faultPropagationQueries>
-        <faultPropagationQuery activityName="String"
-                               faultHandlerActivityName="String"/>
-      </faultPropagationQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <faultPropagationQueries>
+          <faultPropagationQuery faultSourceActivityName="String"
+                                 faultHandlerActivityName="String"/>
+        </faultPropagationQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```
 
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
   
-### Attributes  
- None.  
+### Attributes
+
+None.
   
-### Child Elements  
-  
+### Child elements
+
 |Element|Description|  
 |-------------|-----------------|  
-|[\<faultPropagationQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/faultpropagationquery.md)|A query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|  
+|[\<faultPropagationQuery>](faultpropagationquery-of-wcf.md)|A query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the `activityDefinitionId` property.|  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.FaultPropagationQueryElementCollection?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.FaultPropagationQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.FaultPropagationQueryElementCollection?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.FaultPropagationQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/faultpropagationquery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/faultpropagationquery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: fabafbc8-3e45-4feb-8321-0725e9f4079c
 ---
 # &lt;faultPropagationQuery&gt; of WCF
+
 Represents a query that is used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault. You should use such query to track the handling of faults that occur within an activity. The query is necessary for a  tracking participant to subscribe to fault propagation records.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md).  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<faultPropagationQueries>  
@@ -19,38 +21,43 @@ Represents a query that is used to track the handling of faults that occur withi
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <faultPropagationQueries>
-        <faultPropagationQuery activityName="String"
-                               faultHandlerActivityName="String"/>
-      </faultPropagationQueries>
-    </workflow>
-  </trackingProfile>
-</tracking>  
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <faultPropagationQueries>
+          <faultPropagationQuery faultSourceActivityName="String"
+                                 faultHandlerActivityName="String"/>
+        </faultPropagationQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
+</tracking>
 ```
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
-  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
+
 ### Attributes  
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|activityName|A string that specifies the name of the fault hander activity that propagated the fault. The default is *, which indicates that fault propagation records are returned for all activities.|  
-|faultHandlerActivityName|A string that specifies the name of the activity that was the source of the fault.|  
+|`faultSourceActivityName`|A string that specifies the name of the fault hander activity that propagated the fault. The default is \*, which indicates that fault propagation records are returned for all activities.|  
+|`faultHandlerActivityName`|A string that specifies the name of the activity that was the source of the fault.|  
   
-### Child Elements  
- None.  
+### Child elements
+
+None.
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<faultPropagationQueries>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/faultpropagationqueries.md)|Represents a list of configuration elements that are used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|  
+|[\<faultPropagationQueries>](faultpropagationqueries-of-wcf.md)|Represents a list of configuration elements that are used to track the handling of faults that occur within an activity.  This event occurs each time a FaultHandler processes a fault.|
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.FaultPropagationQueryElement?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.FaultPropagationQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also  
+ 
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.FaultPropagationQueryElement?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.FaultPropagationQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/nettcpbinding.md
@@ -6,9 +6,10 @@ helpviewer_keywords:
 ms.assetid: 5c5104a7-8754-4335-8233-46a45322503e
 ---
 # &lt;netTcpBinding&gt;
-Specifies a secure, reliable, optimized binding suitable for cross-machine communication. By default, it generates a runtime communication stack with Windows Security for message security and authentication, TCP for message delivery, and binary message encoding.  
-  
- \<system.ServiceModel>  
+
+Specifies a secure, reliable, optimized binding suitable for cross-machine communication. By default, it generates a runtime communication stack with Windows Security for message security and authentication, TCP for message delivery, and binary message encoding.
+
+\<system.ServiceModel>  
 \<bindings>  
 \<netTcpBinding>  
   
@@ -36,7 +37,6 @@ Specifies a secure, reliable, optimized binding suitable for cross-machine commu
                      enabled="Boolean" />
     <security mode="None/Transport/Message/Both">
       <message clientCredentialType="None/Windows/UserName/Certificate/CardSpace"  
-               defaultProtectionLevel="None/Sign/EncryptAndSign"   
                algorithmSuite="Basic128/Basic192/Basic256/Basic128Rsa15/Basic256Rsa15/TripleDes/TripleDesRsa15/Basic128Sha256/Basic192Sha256/TripleDesSha256/Basic128Sha256Rsa15/Basic192Sha256Rsa15/Basic256Sha256Rsa15/TripleDesSha256Rsa15" />
       <transport clientCredentialType="None/Windows/Certificate"  
                  protectionLevel="None/Sign/EncryptAndSign" />
@@ -50,30 +50,31 @@ Specifies a secure, reliable, optimized binding suitable for cross-machine commu
 </netTcpBinding> 
 ```  
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
   
 |Attribute|Description|  
 |---------------|-----------------|  
-|closeTimeout|A <xref:System.TimeSpan> value that specifies the interval of time provided for a close operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:01:00.|  
-|hostnameComparisonMode|Specifies the HTTP hostname comparison mode used to parse URIs. This attribute is of type `System.ServiceModel.HostnameComparisonMode`, which indicates whether the hostname is used to reach the service when matching on the URI. The default value is `StrongWildcard`, which ignores the hostname in the match.|  
-|listenBacklog|A positive integer that specifies the maximum number of channels waiting to be accepted on the listener. Connections in excess of this limit are queued until space below the limit becomes available. The `connectionTimeout` attribute limits the time a client will wait to be connected before throwing a connection exception. The default is 10.|  
-|maxBufferPoolSize|An integer that specifies the maximum buffer pool size for this binding. The default is 512 * 1024 bytes. Many parts of Windows Communication Foundation (WCF) use buffers. Creating and destroying buffers each time they are used is expensive, and garbage collection for buffers is also expensive. With buffer pools, you can take a buffer from the pool, use it, and return it to the pool once you are done. Thus the overhead in creating and destroying buffers is avoided.|  
-|maxBufferSize|A positive integer that specifies the maximum size, in bytes, of the buffer used to store messages in memory.<br /><br /> If the `transferMode` attribute equals to `Buffered`, this attribute should be equal to the `maxReceivedMessageSize` attribute value.<br /><br /> If the `transferMode` attribute equals to `Streamed`, this attribute cannot be more than the `maxReceivedMessageSize` attribute value, and should be at least the size of the headers.<br /><br /> The default is 65536. For more information, see <xref:System.ServiceModel.Configuration.NetNamedPipeBindingElement.MaxBufferSize%2A>.|  
-|maxConnections|An integer that specifies the maximum number of outbound and inbound connections the service will create/accept. Incoming and outgoing connections are counted against a separate limit specified by this attribute.<br /><br /> Inbound connections in excess of the limit are queued until a space below the limit becomes available.<br /><br /> Outbound connections in excess of the limit are queued until a space below the limit becomes available.<br /><br /> The default is 10.|  
-|maxReceivedMessageSize|A positive integer that specifies the maximum message size, in bytes, including headers, that can be received on a channel configured with this binding. The sender of a message exceeding this limit will receive a SOAP fault. The receiver drops the message and creates an entry of the event in the trace log. The default is 65536.|  
-|name|A string that contains the configuration name of the binding. This value should be unique because it is used as an identification for the binding. Starting with [!INCLUDE[netfx40_short](../../../../../includes/netfx40-short-md.md)], bindings and behaviors are not required to have a name. For more information about default configuration and nameless bindings and behaviors, see [Simplified Configuration](../../../../../docs/framework/wcf/simplified-configuration.md) and [Simplified Configuration for WCF Services](../../../../../docs/framework/wcf/samples/simplified-configuration-for-wcf-services.md).|  
-|openTimeout|A <xref:System.TimeSpan> value that specifies the interval of time provided for an open operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:01:00.|  
-|portSharingEnabled|A Boolean value that specifies whether TCP port sharing is enabled for this connection. If this is `false`, each binding uses its own exclusive port. This setting is relevant only to services, because clients are not affected.|  
-|receiveTimeout|A <xref:System.TimeSpan> value that specifies the interval of time provided for a receive operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:10:00.|  
-|sendTimeout|A <xref:System.TimeSpan> value that specifies the interval of time provided for a send operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:01:00.|  
-|transactionFlow|A Boolean value that specifies whether the binding supports flowing WS-Transactions. The default is `false`.|  
-|transactionProtocol|Specifies the transaction protocol to be used with this binding. Valid values are<br /><br /> -   OleTransactions<br />-   WSAtomicTransactionOctober2004<br /><br /> The default is OleTransactions. This attribute is of type <xref:System.ServiceModel.TransactionProtocol>.|  
-|transferMode|A <xref:System.ServiceModel.TransferMode> value that specifies whether messages are buffered or streamed or a request or response.|  
+|`closeTimeout`|A <xref:System.TimeSpan> value that specifies the interval of time provided for a close operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:01:00.|  
+|`hostnameComparisonMode`|Specifies the HTTP hostname comparison mode used to parse URIs. This attribute is of type `System.ServiceModel.HostnameComparisonMode`, which indicates whether the hostname is used to reach the service when matching on the URI. The default value is `StrongWildcard`, which ignores the hostname in the match.|  
+|`listenBacklog`|A positive integer that specifies the maximum number of channels waiting to be accepted on the listener. Connections in excess of this limit are queued until space below the limit becomes available. The `connectionTimeout` attribute limits the time a client will wait to be connected before throwing a connection exception. The default is 10.|  
+|`maxBufferPoolSize`|An integer that specifies the maximum buffer pool size for this binding. The default is 512 * 1024 bytes. Many parts of Windows Communication Foundation (WCF) use buffers. Creating and destroying buffers each time they are used is expensive, and garbage collection for buffers is also expensive. With buffer pools, you can take a buffer from the pool, use it, and return it to the pool once you are done. Thus the overhead in creating and destroying buffers is avoided.|  
+|`maxBufferSize`|A positive integer that specifies the maximum size, in bytes, of the buffer used to store messages in memory.<br /><br /> If the `transferMode` attribute equals to `Buffered`, this attribute should be equal to the `maxReceivedMessageSize` attribute value.<br /><br /> If the `transferMode` attribute equals to `Streamed`, this attribute cannot be more than the `maxReceivedMessageSize` attribute value, and should be at least the size of the headers.<br /><br /> The default is 65536. For more information, see <xref:System.ServiceModel.Configuration.NetNamedPipeBindingElement.MaxBufferSize%2A>.|  
+|`maxConnections`|An integer that specifies the maximum number of outbound and inbound connections the service will create/accept. Incoming and outgoing connections are counted against a separate limit specified by this attribute.<br /><br /> Inbound connections in excess of the limit are queued until a space below the limit becomes available.<br /><br /> Outbound connections in excess of the limit are queued until a space below the limit becomes available.<br /><br /> The default is 10.|  
+|`maxReceivedMessageSize`|A positive integer that specifies the maximum message size, in bytes, including headers, that can be received on a channel configured with this binding. The sender of a message exceeding this limit will receive a SOAP fault. The receiver drops the message and creates an entry of the event in the trace log. The default is 65536.|  
+|`name`|A string that contains the configuration name of the binding. This value should be unique because it is used as an identification for the binding. Starting with [!INCLUDE[netfx40_short](../../../../../includes/netfx40-short-md.md)], bindings and behaviors are not required to have a name. For more information about default configuration and nameless bindings and behaviors, see [Simplified Configuration](../../../../../docs/framework/wcf/simplified-configuration.md) and [Simplified Configuration for WCF Services](../../../../../docs/framework/wcf/samples/simplified-configuration-for-wcf-services.md).|  
+|`openTimeout`|A <xref:System.TimeSpan> value that specifies the interval of time provided for an open operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:01:00.|  
+|`portSharingEnabled`|A Boolean value that specifies whether TCP port sharing is enabled for this connection. If this is `false`, each binding uses its own exclusive port. This setting is relevant only to services, because clients are not affected.|  
+|`receiveTimeout`|A <xref:System.TimeSpan> value that specifies the interval of time provided for a receive operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:10:00.|  
+|`sendTimeout`|A <xref:System.TimeSpan> value that specifies the interval of time provided for a send operation to complete. This value should be greater than or equal to <xref:System.TimeSpan.Zero>. The default is 00:01:00.|  
+|`transactionFlow`|A Boolean value that specifies whether the binding supports flowing WS-Transactions. The default is `false`.|  
+|`transactionProtocol`|Specifies the transaction protocol to be used with this binding. Valid values are<br /><br /> -   OleTransactions<br />-   WSAtomicTransactionOctober2004<br /><br /> The default is OleTransactions. This attribute is of type <xref:System.ServiceModel.TransactionProtocol>.|  
+|`transferMode`|A <xref:System.ServiceModel.TransferMode> value that specifies whether messages are buffered or streamed or a request or response.|  
   
-### Child Elements  
+### Child elements  
   
 |Element|Description|  
 |-------------|-----------------|  
@@ -81,19 +82,21 @@ Specifies a secure, reliable, optimized binding suitable for cross-machine commu
 |[\<readerQuotas>](https://msdn.microsoft.com/library/3e5e42ff-cef8-478f-bf14-034449239bfd)|Defines the constraints on the complexity of SOAP messages that can be processed by endpoints configured with this binding. This element is of type <xref:System.ServiceModel.Configuration.XmlDictionaryReaderQuotasElement>.|  
 |[reliableSession](https://msdn.microsoft.com/library/9c93818a-7dfa-43d5-b3a1-1aafccf3a00b)|Specifies if reliable sessions are established between channel endpoints.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<bindings>](../../../../../docs/framework/configure-apps/file-schema/wcf/bindings.md)|This element holds a collection of standard and custom bindings.|  
+|[\<bindings>](bindings.md)|This element holds a collection of standard and custom bindings.|  
   
-## Remarks  
- This binding generates a run-time communication stack by default, which uses transport security, TCP for message delivery, and a binary message encoding. This binding is an appropriate Windows Communication Foundation (WCF) system-provided choice for communicating over an Intranet.  
+## Remarks
+
+This binding generates a run-time communication stack by default, which uses transport security, TCP for message delivery, and a binary message encoding. This binding is an appropriate Windows Communication Foundation (WCF) system-provided choice for communicating over an Intranet.  
   
  The default configuration for the `netTcpBinding` is faster than the configuration provided by the `wsHttpBinding`, but it is intended only for WCF communication. The security behavior is configurable using the optional `securityMode` attribute. The use of WS-ReliableMessaging is configurable using the optional `reliableSessionEnabled` attribute. But reliable messaging is off by default. More generally, the HTTP system-provided bindings such as `wsHttpBinding` and `basicHttpBinding` are configured to turn things on by default, whereas the `netTcpBinding` binding turns things off by default so that you have to opt-in to get support, for example, for one of the WS-* specifications. This means that the default configuration for TCP is faster at exchanging messages between endpoints than those configured for the HTTP bindings by default.  
   
-## Example  
- The binding is specified in the configuration files for the client and service. The binding type is specified in the `binding` attribute of the `<endpoint>` element. If you want to configure the netTcpBinding binding and change some of its settings, it is necessary to define a binding configuration. The endpoint must reference the binding configuration with a `bindingConfiguration` attribute. In the following example, a binding configuration is defined.  
+## Example
+
+The binding is specified in the configuration files for the client and service. The binding type is specified in the `binding` attribute of the `<endpoint>` element. If you want to configure the netTcpBinding binding and change some of its settings, it is necessary to define a binding configuration. The endpoint must reference the binding configuration with a `bindingConfiguration` attribute. In the following example, a binding configuration is defined.  
   
 ```xml  
 <services>  
@@ -139,10 +142,11 @@ Specifies a secure, reliable, optimized binding suitable for cross-machine commu
 </bindings>  
 ```  
   
-## See Also  
- <xref:System.ServiceModel.NetTcpBinding>  
- <xref:System.ServiceModel.Configuration.NetTcpBindingElement>  
- [Bindings](../../../../../docs/framework/wcf/bindings.md)  
- [Configuring System-Provided Bindings](../../../../../docs/framework/wcf/feature-details/configuring-system-provided-bindings.md)  
- [Using Bindings to Configure Services and Clients](../../../../../docs/framework/wcf/using-bindings-to-configure-services-and-clients.md)  
- [\<binding>](../../../../../docs/framework/misc/binding.md)
+## See also  
+
+- <xref:System.ServiceModel.NetTcpBinding>  
+- <xref:System.ServiceModel.Configuration.NetTcpBindingElement>  
+- [Bindings](../../../../../docs/framework/wcf/bindings.md)  
+- [Configuring System-Provided Bindings](../../../../../docs/framework/wcf/feature-details/configuring-system-provided-bindings.md)  
+- [Using Bindings to Configure Services and Clients](../../../../../docs/framework/wcf/using-bindings-to-configure-services-and-clients.md)  
+- [\<binding>](../../../../../docs/framework/misc/binding.md)

--- a/docs/framework/configure-apps/file-schema/wcf/state-of-wcf-workflowinstancequery.md
+++ b/docs/framework/configure-apps/file-schema/wcf/state-of-wcf-workflowinstancequery.md
@@ -8,8 +8,9 @@ Represents a collection of subscribed states from the tracked workflow instance 
   
  For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>
 \<trackingProfile>  
 \<workflow>  
 \<workflowInstanceQueries>  
@@ -21,42 +22,47 @@ Represents a collection of subscribed states from the tracked workflow instance 
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <workflowInstanceQueries>
-        <workflowInstanceQuery>
-          <states>
-            <state name="Name"/>
-          </states>
-        </workflowInstanceQuery>
-      </workflowInstanceQueries>
-    </workflow>
-  </trackingProfile>
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <workflowInstanceQueries>
+          <workflowInstanceQuery>
+            <states>
+              <state name="Name"/>
+            </states>
+          </workflowInstanceQuery>
+        </workflowInstanceQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
 </tracking>  
 ```
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
   
-### Attributes  
-  
+### Attributes
+
 |Attribute|Description|  
 |---------------|-----------------|  
-|name|A string that specifies a subscribed state from the tracked workflow instance when the tracking record is created.|  
+|`name`|A string that specifies a subscribed state from the tracked workflow instance when the tracking record is created.|  
   
-### Child Elements  
- None.  
-  
-### Parent Elements  
-  
+### Child elements
+
+None.
+
+### Parent elements
+
 |Element|Description|  
 |-------------|-----------------|  
-|[\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md)|A collection of subscribed states from the tracked workflow instance when the tracking records are created.|  
+|[\<states>](states-of-wcf-workflowinstancequery.md)|A collection of subscribed states from the tracked workflow instance when the tracking records are created.|  
   
 ## Remarks  
- The returned records are filtered by the states in this collection.  
+
+The returned records are filtered by the states in this collection.  
   
- Possible state values are described in the following table.  
+Possible state values are described in the following table:
   
 |State|Description|  
 |-----------|-----------------|  
@@ -74,22 +80,24 @@ Represents a collection of subscribed states from the tracked workflow instance 
 |Terminated|The workflow instance is terminated.|  
 |Unsuspended|The workflow instance is unsuspended.|  
   
-## Example  
- The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
+## Example
+
+The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
   
-```xml  
-<workflowInstanceQueries>  
-    <workflowInstanceQuery>  
-      <states>  
-        <state name="Started"/>  
-      </states>  
-    </workflowInstanceQuery>  
-</workflowInstanceQueries>  
+```xml
+<workflowInstanceQueries>
+  <workflowInstanceQuery>  
+    <states>  
+      <state name="Started"/>  
+    </states>  
+  </workflowInstanceQuery>  
+</workflowInstanceQueries>
 ```  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElement?displayProperty=nameWithType>       
- <xref:System.ServiceModel.Activities.Tracking.Configuration.StateElement?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElement?displayProperty=nameWithType>
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.StateElement?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/state-of-wcf-workflowinstancequery.md
+++ b/docs/framework/configure-apps/file-schema/wcf/state-of-wcf-workflowinstancequery.md
@@ -10,7 +10,7 @@ Represents a collection of subscribed states from the tracked workflow instance 
   
 \<system.serviceModel>  
 \<tracking>  
-\<profiles>
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<workflowInstanceQueries>  

--- a/docs/framework/configure-apps/file-schema/wcf/states-of-wcf-workflowinstancequery.md
+++ b/docs/framework/configure-apps/file-schema/wcf/states-of-wcf-workflowinstancequery.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: d17f7525-8035-4e9e-85a0-4cddae59f85d
 ---
 # &lt;states&gt; of WCF, &lt;workflowInstanceQuery&gt;
+
 Represents a collection of subscribed states from the tracked workflow instance when the tracking records are created.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
+\<system.serviceModel>
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<workflowInstanceQueries>  
@@ -20,42 +22,47 @@ Represents a collection of subscribed states from the tracked workflow instance 
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <workflowInstanceQueries>
-        <workflowInstanceQuery>
-          <states>
-            <state name="Name"/>
-          </states>
-        </workflowInstanceQuery>
-      </workflowInstanceQueries>
-    </workflow>
-  </trackingProfile>
-</tracking>  
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <workflowInstanceQueries>
+          <workflowInstanceQuery>
+            <states>
+              <state name="Name"/>
+            </states>
+          </workflowInstanceQuery>
+        </workflowInstanceQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
+</tracking>
 ```
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
- None.  
+
+None.  
   
-### Child Elements  
+### Child elements
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md)|A subscribed state from the tracked workflow instance when the tracking record is created.|  
+|[\<states>](state-of-wcf-workflowinstancequery.md)|A subscribed state from the tracked workflow instance when the tracking record is created.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflowInstanceQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflowinstancequery.md)|A query that tracks workflow instance life cycle changes such as a started or completed event.|  
   
-## Remarks  
- The returned records are filtered by the states in this collection.  
+## Remarks
+
+The returned records are filtered by the states in this collection.  
   
- Possible state values are described in the following table.  
+Possible state values are described in the following table.  
   
 |State|Description|  
 |-----------|-----------------|  
@@ -73,8 +80,9 @@ Represents a collection of subscribed states from the tracked workflow instance 
 |Terminated|The workflow instance is terminated.|  
 |Unsuspended|The workflow instance is unsuspended.|  
   
-## Example  
- The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
+## Example
+
+The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
   
 ```xml  
 <workflowInstanceQueries>  
@@ -86,9 +94,10 @@ Represents a collection of subscribed states from the tracked workflow instance 
 </workflowInstanceQueries>  
 ```  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElement?displayProperty=nameWithType>       
- <xref:System.ServiceModel.Activities.Tracking.Configuration.StateElementCollection?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also  
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElement?displayProperty=nameWithType>       
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.StateElementCollection?displayProperty=nameWithType>       
+- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>       
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/workflowinstancequeries-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/workflowinstancequeries-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: b0852f77-16e4-4d55-8eb7-a19feb0e8fc4
 ---
 # &lt;workflowInstanceQueries&gt; of WCF
+
 Represents a collection of configuration elements that track workflow instance life cycle changes such as a started or completed event.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<workflowInstanceQueries>  
@@ -18,66 +20,73 @@ Represents a collection of configuration elements that track workflow instance l
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <workflowInstanceQueries>
-        <workflowInstanceQuery>
-          <states>
-            <state name="Name"/>
-          </states>
-        </workflowInstanceQuery>
-      </workflowInstanceQueries>
-    </workflow>
-  </trackingProfile>
-</tracking>  
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <workflowInstanceQueries>
+          <workflowInstanceQuery>
+            <states>
+              <state name="Name"/>
+            </states>
+          </workflowInstanceQuery>
+        </workflowInstanceQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
+</tracking>
 ```
   
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
- None.  
+
+None.  
   
-### Child Elements  
+### Child elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<workflowInstanceQuery>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflowinstancequery.md)|A query that is used to track workflow instance life cycle changes.|  
+|[\<workflowInstanceQuery>](workflowinstancequery-of-wcf.md)|A query that is used to track workflow instance life cycle changes.|  
   
-### Parent Elements  
+### Parent elements  
   
 |Element|Description|  
 |-------------|-----------------|  
 |[\<workflow>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflow.md)|A configuration element that contains all queries for a specific workflow identified by the [activityDefinitionId](https://msdn.microsoft.com/library/system.servicemodel.activities.tracking.configuration.profileworkflowelement.activitydefinitionid(VS.100).aspx) property.|  
   
-## Remarks  
- The <xref:System.Activities.Tracking.WorkflowInstanceQuery> is used to subscribe to the following <xref:System.Activities.Tracking.TrackingRecord> objects:  
+## Remarks
+
+The <xref:System.Activities.Tracking.WorkflowInstanceQuery> is used to subscribe to the following <xref:System.Activities.Tracking.TrackingRecord> objects:  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceAbortedRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceAbortedRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceUnhandledExceptionRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceUnhandledExceptionRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceTerminatedRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceTerminatedRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceSuspendedRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceSuspendedRecord>  
   
 ## Example  
- The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
+
+The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
   
 ```xml  
-<workflowInstanceQueries>  
-    <workflowInstanceQuery>  
-      <states>  
-        <state name="Started"/>  
-      </states>  
-    </workflowInstanceQuery>  
-</workflowInstanceQueries>  
-```  
+<workflowInstanceQueries>
+  <workflowInstanceQuery>  
+    <states>  
+      <state name="Started"/>  
+    </states>  
+  </workflowInstanceQuery>  
+</workflowInstanceQueries>
+```
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElementCollection?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElementCollection?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)

--- a/docs/framework/configure-apps/file-schema/wcf/workflowinstancequery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/workflowinstancequery-of-wcf.md
@@ -4,12 +4,14 @@ ms.date: "03/30/2017"
 ms.assetid: 35c73f9d-474e-42eb-874d-ddc04b1987f3
 ---
 # &lt;workflowInstanceQuery&gt; of WCF
+
 Represents a query that tracks workflow instance life cycle changes such as a started or completed event.  
   
- For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
+For more information on tracking profile queries, see [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)  
   
- \<system.serviceModel>  
+\<system.serviceModel>  
 \<tracking>  
+\<profiles>  
 \<trackingProfile>  
 \<workflow>  
 \<workflowInstanceQueries>  
@@ -19,53 +21,59 @@ Represents a query that tracks workflow instance life cycle changes such as a st
   
 ```xml
 <tracking>
-  <trackingProfile name="Name">
-    <workflow>
-      <workflowInstanceQueries>
-        <workflowInstanceQuery>
-          <states>
-            <state name="Name"/>
-          </states>
-        </workflowInstanceQuery>
-      </workflowInstanceQueries>
-    </workflow>
-  </trackingProfile>
-</tracking>  
+  <profiles>
+    <trackingProfile name="Name">
+      <workflow>
+        <workflowInstanceQueries>
+          <workflowInstanceQuery>
+            <states>
+              <state name="Name"/>
+            </states>
+          </workflowInstanceQuery>
+        </workflowInstanceQueries>
+      </workflow>
+    </trackingProfile>
+  </profiles>
+</tracking>
 ```
-  
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+
+## Attributes and elements  
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
- None.  
+
+None.  
   
-### Child Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<states>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/states.md)|A collection of subscribed states from the tracked workflow instance when the tracking records are created.|  
-  
-### Parent Elements  
+### Child elements  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<workflowInstanceQueries>](../../../../../docs/framework/configure-apps/file-schema/windows-workflow-foundation/workflowinstancequeries.md)|Represents a collection of configuration elements that track workflow instance life cycle changes such as a started or completed event.|  
+|[\<states>](states-of-wcf-workflowinstancequery.md)|A collection of subscribed states from the tracked workflow instance when the tracking records are created.|  
+  
+### Parent elements  
+  
+|Element|Description|  
+|-------------|-----------------|  
+|[\<workflowInstanceQueries>](workflowinstancequeries-of-wcf.md)|Represents a collection of configuration elements that track workflow instance life cycle changes such as a started or completed event.|  
   
 ## Remarks  
- The <xref:System.Activities.Tracking.WorkflowInstanceQuery> is used to subscribe to the following <xref:System.Activities.Tracking.TrackingRecord> objects:  
+
+The <xref:System.Activities.Tracking.WorkflowInstanceQuery> is used to subscribe to the following <xref:System.Activities.Tracking.TrackingRecord> objects:  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceAbortedRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceAbortedRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceUnhandledExceptionRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceUnhandledExceptionRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceTerminatedRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceTerminatedRecord>  
   
--   <xref:System.Activities.Tracking.WorkflowInstanceSuspendedRecord>  
+- <xref:System.Activities.Tracking.WorkflowInstanceSuspendedRecord>  
   
 ## Example  
- The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
+
+The following configuration subscribes to workflow instance-level tracking records for the `Started` instance state using this query.  
   
 ```xml  
 <workflowInstanceQueries>  
@@ -77,8 +85,9 @@ Represents a query that tracks workflow instance life cycle changes such as a st
 </workflowInstanceQueries>  
 ```  
   
-## See Also  
- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElement?displayProperty=nameWithType>       
- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>       
- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)  
- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)
+## See also
+
+- <xref:System.ServiceModel.Activities.Tracking.Configuration.WorkflowInstanceQueryElement?displayProperty=nameWithType>
+- <xref:System.Activities.Tracking.WorkflowInstanceQuery?displayProperty=nameWithType>
+- [Workflow Tracking and Tracing](../../../../../docs/framework/windows-workflow-foundation/workflow-tracking-and-tracing.md)
+- [Tracking Profiles](../../../../../docs/framework/windows-workflow-foundation/tracking-profiles.md)


### PR DESCRIPTION
Contributes to #8125 

Hide whitespace changes for easier diff. This edits the content that has been updated with recent PRs. Two things that I also noticed in addition to the broken syntax blocks that we had:
- links are linking to the WF folder instead of the WCF attribute
- there were some missing elements from the syntax blocks

This PR doesn't change the link to the workflow topic and others. That one seems severely broken.