### PR TITLE
Change library package manager -> nuget package manager

### DIFF
--- a/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
+++ b/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
@@ -1,6 +1,6 @@
 ---
 title: "The .NET Framework and Out-of-Band Releases"
-ms.date: "03/30/2017"
+ms.date: 10/10/2018
 ms.assetid: 721f10fa-3189-4124-a00d-56ddabd889b3
 author: "mairaw"
 ms.author: "mairaw"

--- a/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
+++ b/docs/framework/get-started/the-net-framework-and-out-of-band-releases.md
@@ -6,47 +6,48 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # The .NET Framework and Out-of-Band Releases
-The .NET Framework is evolving to accommodate different platforms such as Windows Phone and Windows Store apps as well as traditional desktop and web apps, and to maximize code reuse. In addition to our regular .NET Framework releases, we release new features out of band (OOB) to improve cross-platform development or to introduce new functionality. This topic discusses the future direction of the .NET Framework and its OOB releases.  
-  
-## Advantages of OOB releases  
- Shipping new components or updates to components out of band enables Microsoft to provide more frequent updates to the .NET Framework. In addition, we can gather and respond to customer feedback more quickly.  
-  
- When you use an OOB feature in your app, your users do not have to install the latest version of the .NET Framework to run your app, because the OOB assemblies deploy with your app package.  
-  
-## How OOB packages are distributed  
-OOB releases for core common language runtime (CLR) components are delivered through the [NuGet](https://www.nuget.org/), which is a package manager for .NET. NuGet enables you to browse and add libraries to your .NET Framework projects easily from the Solution Explorer in Visual Studio. NuGet is included with all editions of Visual Studio starting with Visual Studio 2012. To see if NuGet is installed, look for **Library Package Manager** on the Visual Studio **Tools** menu. If it’s not installed:  
-  
-1.  On the Visual Studio menu bar, choose **Tools**, **Extensions and Updates** (in Visual Studio 2010, choose **Extension Manager**).  
-  
-     The **Extensions and Updates** dialog box opens.  
-  
-2.  Choose **Online**, **NuGet Package Manager**, and then choose **Download**.  
-  
-3.  After the download completes, restart Visual Studio.  
-  
- For detailed installation instructions, see [Installing NuGet](http://docs.nuget.org/docs/start-here/installing-nuget) on the NuGet Docs website. For more information about NuGet, see the [NuGet documentation](http://docs.nuget.org/).  
-  
-## Using a NuGet OOB package  
- After you install NuGet, you can browse and add references to NuGet packages by using Solution Explorer in Visual Studio:  
-  
-1.  Open the shortcut menu for your project in Visual Studio, and then choose **Manage NuGet Packages**. (This option is also available from the **Project** menu.)  
-  
-2.  In the left pane, choose **Online**.  
-  
-3.  If you want to use prerelease packages, in the drop-down list box in the middle pane, choose **Include Prerelease** instead of **Stable Only**.  
-  
-4.  In the right pane, use the **Search** box to locate the package you would like to use. Some Microsoft packages are identified by the Microsoft .NET Framework logo, and all identify Microsoft as the publisher.  
-  
- ![NuGet Package Manager](../../../docs/framework/get-started/media/clrnugetdialog.png "clrNugetDialog")  
-  
- As mentioned previously, when you deploy an app that uses an OOB package, the OOB assemblies will ship with your app package.  
-  
-## Types of OOB releases  
- Typically, an OOB package has one or more prerelease versions and a stable version. The license that accompanies a prerelease doesn't typically allow redistribution, but enables you to try out a package and provide feedback. Feedback is incorporated in any updates made to the package. A final release is distributed as a stable package with NuGet and includes a license that lets you redistribute the NuGet package with your app. Stable packages are supported by Microsoft. Microsoft provides IntelliSense support as well as other types of documentation such as blog posts and forum answers for all packages. In addition, source code may be available with some, but not all, packages. For announcements regarding new and updated packages, you can subscribe to [the .NET Framework Blog](https://blogs.msdn.com/b/dotnet/).  
-  
- To find both prerelease and stable packages, choose **Include Prerelease** in the NuGet Package Manager.  
-  
- If you want to be notified of stable package releases, subscribe to [the .NET Framework feed](https://nuget.org/api/v2/curated-feeds/dotnetframework/Packages/).  
-  
-## See Also  
- [Getting Started](../../../docs/framework/get-started/index.md)
+The .NET Framework is evolving to accommodate different platforms such as Windows Phone and Windows Store apps as well as traditional desktop and web apps, and to maximize code reuse. In addition to our regular .NET Framework releases, we release new features out of band (OOB) to improve cross-platform development or to introduce new functionality. This topic discusses the future direction of the .NET Framework and its OOB releases.
+
+## Advantages of OOB releases
+ Shipping new components or updates to components out of band enables Microsoft to provide more frequent updates to the .NET Framework. In addition, we can gather and respond to customer feedback more quickly.
+
+ When you use an OOB feature in your app, your users do not have to install the latest version of the .NET Framework to run your app, because the OOB assemblies deploy with your app package.
+
+## How OOB packages are distributed
+OOB releases for core common language runtime (CLR) components are delivered through the [NuGet](https://www.nuget.org/), which is a package manager for .NET. NuGet enables you to browse and add libraries to your .NET Framework projects easily from the Solution Explorer in Visual Studio. NuGet is included with all editions of Visual Studio starting with Visual Studio 2012. To see if NuGet is installed, look for **NuGet Package Manager** on the Visual Studio **Tools** menu. If it’s not installed:
+
+1.  On the Visual Studio menu bar, choose **Tools**, **Extensions and Updates** (in Visual Studio 2010, choose **Extension Manager**).
+
+     The **Extensions and Updates** dialog box opens.
+
+2.  Choose **Online**, **NuGet Package Manager**, and then choose **Download**.
+
+3.  After the download completes, restart Visual Studio.
+
+ For detailed installation instructions, see [Installing NuGet](http://docs.nuget.org/docs/start-here/installing-nuget) on the NuGet Docs website. For more information about NuGet, see the [NuGet documentation](http://docs.nuget.org/).
+
+## Using a NuGet OOB package
+ After you install NuGet, you can browse and add references to NuGet packages by using Solution Explorer in Visual Studio:
+
+1.  Open the shortcut menu for your project in Visual Studio, and then choose **Manage NuGet Packages**. (This option is also available from the **Project** menu.)
+
+2.  In the left pane, choose **Online**.
+
+3.  If you want to use prerelease packages, in the drop-down list box in the middle pane, choose **Include Prerelease** instead of **Stable Only**.
+
+4.  In the right pane, use the **Search** box to locate the package you would like to use. Some Microsoft packages are identified by the Microsoft .NET Framework logo, and all identify Microsoft as the publisher.
+
+ ![NuGet Package Manager](../../../docs/framework/get-started/media/clrnugetdialog.png "clrNugetDialog")
+
+ As mentioned previously, when you deploy an app that uses an OOB package, the OOB assemblies will ship with your app package.
+
+## Types of OOB releases
+ Typically, an OOB package has one or more prerelease versions and a stable version. The license that accompanies a prerelease doesn't typically allow redistribution, but enables you to try out a package and provide feedback. Feedback is incorporated in any updates made to the package. A final release is distributed as a stable package with NuGet and includes a license that lets you redistribute the NuGet package with your app. Stable packages are supported by Microsoft. Microsoft provides IntelliSense support as well as other types of documentation such as blog posts and forum answers for all packages. In addition, source code may be available with some, but not all, packages. For announcements regarding new and updated packages, you can subscribe to [the .NET Framework Blog](https://blogs.msdn.com/b/dotnet/).
+
+ To find both prerelease and stable packages, choose **Include Prerelease** in the NuGet Package Manager.
+
+ If you want to be notified of stable package releases, subscribe to [the .NET Framework feed](https://nuget.org/api/v2/curated-feeds/dotnetframework/Packages/).
+
+## See Also
+
+- [Getting Started](../../../docs/framework/get-started/index.md)

--- a/docs/framework/security/downloading-the-json-web-token-handler-package.md
+++ b/docs/framework/security/downloading-the-json-web-token-handler-package.md
@@ -3,32 +3,32 @@ title: "Downloading the JSON Web Token Handler Package"
 ms.date: "03/30/2017"
 ms.assetid: d12b3f5b-f1f1-4a9d-a159-0c13e5976c90
 ---
-# Downloading the JSON Web Token Handler Package
-This topic discusses how to download and use the JSON Web Token Handler in your project.  
-  
-## Downloading the JSON Web Token Handler  
- The JSON Web Token Handler extension is available as a NuGet package, which adds the necessary assemblies and references to your project. If you do not already have NuGet installed, go to [nuget.org](http://nuget.org) to install it. You can see the versioning history for the extension by visiting its page on NuGet: [JSON Web Token Handler on NuGet](http://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/)  
-  
-#### Downloading the JSON Web Token Handler by using the Package Manager GUI  
-  
-1.  In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.  
-  
-2.  In the **Manage NuGet Packages** window, click the search box and enter `JWT Token Handler` and press **Enter**.  
-  
-3.  From the results pane, click the **Install** button for the first result.  
-  
-4.  The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.  
-  
-5.  The latest JSON Web Token Handler assemblies will be downloaded and added to your project.  
-  
-#### Downloading the JSON Web Token Handler by using the Package Manager Console  
-  
-1.  In Visual Studio, click **Tools**, **Library Package Manager**, and then **Package Manager Console**.  
-  
-2.  The **Package Manager Console** appears. Enter the following text and press **Enter**:  
-  
-    ```powershell  
-    Install-Package System.IdentityModel.Tokens.Jwt  
-    ```  
-  
+# Download the JSON Web Token Handler Package
+
+This topic discusses how to download and use the JSON Web Token Handler in your project.
+
+The JSON Web Token Handler extension is available as a NuGet package, which adds the necessary assemblies and references to your project. If you do not already have NuGet installed, go to [nuget.org](http://nuget.org) to install it. You can see the versioning history for the extension by visiting its page on NuGet: [JSON Web Token Handler on NuGet](http://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/)
+
+## Use the Package Manager GUI
+
+1.  In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.
+
+2.  In the **Manage NuGet Packages** window, click the search box and enter `JWT Token Handler` and press **Enter**.
+
+3.  From the results pane, click the **Install** button for the first result.
+
+4.  The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.
+
+5.  The latest JSON Web Token Handler assemblies will be downloaded and added to your project.
+
+## Use the Package Manager Console
+
+1.  In Visual Studio, click **Tools** > **NuGet Package Manager** > **Package Manager Console**.
+
+2.  The **Package Manager Console** appears. Enter the following text and press **Enter**:
+
+    ```powershell
+    Install-Package System.IdentityModel.Tokens.Jwt
+    ```
+
 3.  The latest JSON Web Token Handler assemblies will be downloaded and added to your project.

--- a/docs/framework/security/downloading-the-json-web-token-handler-package.md
+++ b/docs/framework/security/downloading-the-json-web-token-handler-package.md
@@ -1,6 +1,6 @@
 ---
 title: "Downloading the JSON Web Token Handler Package"
-ms.date: "03/30/2017"
+ms.date: 10/10/2018
 ms.assetid: d12b3f5b-f1f1-4a9d-a159-0c13e5976c90
 ---
 # Download the JSON Web Token Handler Package
@@ -11,24 +11,24 @@ The JSON Web Token Handler extension is available as a NuGet package, which adds
 
 ## Use the Package Manager GUI
 
-1.  In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.
+1. In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.
 
-2.  In the **Manage NuGet Packages** window, click the search box and enter `JWT Token Handler` and press **Enter**.
+2. In the **Manage NuGet Packages** window, click the search box and enter `JWT Token Handler` and press **Enter**.
 
-3.  From the results pane, click the **Install** button for the first result.
+3. From the results pane, click the **Install** button for the first result.
 
-4.  The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.
+4. The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.
 
-5.  The latest JSON Web Token Handler assemblies will be downloaded and added to your project.
+5. The latest JSON Web Token Handler assemblies will be downloaded and added to your project.
 
 ## Use the Package Manager Console
 
-1.  In Visual Studio, click **Tools** > **NuGet Package Manager** > **Package Manager Console**.
+1. In Visual Studio, click **Tools** > **NuGet Package Manager** > **Package Manager Console**.
 
-2.  The **Package Manager Console** appears. Enter the following text and press **Enter**:
+2. The **Package Manager Console** appears. Enter the following text and press **Enter**:
 
     ```powershell
     Install-Package System.IdentityModel.Tokens.Jwt
     ```
 
-3.  The latest JSON Web Token Handler assemblies will be downloaded and added to your project.
+3. The latest JSON Web Token Handler assemblies will be downloaded and added to your project.

--- a/docs/framework/security/downloading-the-validating-issuer-name-registry-package.md
+++ b/docs/framework/security/downloading-the-validating-issuer-name-registry-package.md
@@ -3,32 +3,32 @@ title: "Downloading the Validating Issuer Name Registry Package"
 ms.date: "03/30/2017"
 ms.assetid: ff8b0014-c5d4-4614-90f0-13fcc0ba777a
 ---
-# Downloading the Validating Issuer Name Registry Package
-This topic discusses how to download and use the Validating Issuer Name Registry (VINR) in your project.  
-  
-## Downloading the Validating Issuer Name Registry  
- The VINR is available as a NuGet package, which adds the necessary assemblies and references to your project. If you do not already have NuGet installed, go to [nuget.org](http://nuget.org) to install it. You can see the versioning history for the extension by visiting its page on NuGet: [Microsoft Validating Issuer Name Registry on NuGet](https://nuget.org/packages/System.IdentityModel.Tokens.ValidatingIssuerNameRegistry/)  
-  
-#### Downloading the Validating Issuer Name Registry by using the Package Manager GUI  
-  
-1.  In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.  
-  
-2.  In the **Manage NuGet Packages** window, click the search box and enter `ValidatingIssuerNameRegistry` and press **Enter**.  
-  
-3.  From the results pane, click the **Install** button for the first result.  
-  
-4.  The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.  
-  
-5.  The latest VINR assemblies will be downloaded and added to your project.  
-  
-#### Downloading the Validating Issuer Name Registry by using the Package Manager Console  
-  
-1.  In Visual Studio, click **Tools**, **Library Package Manager**, and then **Package Manager Console**.  
-  
-2.  The **Package Manager Console** appears. Enter the following text and press **Enter**:  
-  
-    ```powershell  
-    Install-Package System.IdentityModel.Tokens.ValidatingIssuerNameRegistry  
-    ```  
-  
+# Download the Validating Issuer Name Registry Package
+
+This topic discusses how to download and use the Validating Issuer Name Registry (VINR) in your project.
+
+The VINR is available as a NuGet package, which adds the necessary assemblies and references to your project. If you do not already have NuGet installed, go to [nuget.org](http://nuget.org) to install it. You can see the versioning history for the extension by visiting its page on NuGet: [Microsoft Validating Issuer Name Registry on NuGet](https://nuget.org/packages/System.IdentityModel.Tokens.ValidatingIssuerNameRegistry/)
+
+## Use the Package Manager GUI
+
+1.  In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.
+
+2.  In the **Manage NuGet Packages** window, click the search box and enter `ValidatingIssuerNameRegistry` and press **Enter**.
+
+3.  From the results pane, click the **Install** button for the first result.
+
+4.  The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.
+
+5.  The latest VINR assemblies will be downloaded and added to your project.
+
+## Use the Package Manager Console
+
+1.  In Visual Studio, click **Tools** > **NuGet Package Manager** > **Package Manager Console**.
+
+2.  The **Package Manager Console** appears. Enter the following text and press **Enter**:
+
+    ```powershell
+    Install-Package System.IdentityModel.Tokens.ValidatingIssuerNameRegistry
+    ```
+
 3.  The latest VINR assemblies will be downloaded and added to your project.

--- a/docs/framework/security/downloading-the-validating-issuer-name-registry-package.md
+++ b/docs/framework/security/downloading-the-validating-issuer-name-registry-package.md
@@ -1,6 +1,6 @@
 ---
 title: "Downloading the Validating Issuer Name Registry Package"
-ms.date: "03/30/2017"
+ms.date: 10/10/2018
 ms.assetid: ff8b0014-c5d4-4614-90f0-13fcc0ba777a
 ---
 # Download the Validating Issuer Name Registry Package
@@ -11,24 +11,24 @@ The VINR is available as a NuGet package, which adds the necessary assemblies an
 
 ## Use the Package Manager GUI
 
-1.  In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.
+1. In Visual Studio, right-click your project in **Solution Explorer**, and then select **Manage NuGet Packages**.
 
-2.  In the **Manage NuGet Packages** window, click the search box and enter `ValidatingIssuerNameRegistry` and press **Enter**.
+2. In the **Manage NuGet Packages** window, click the search box and enter `ValidatingIssuerNameRegistry` and press **Enter**.
 
-3.  From the results pane, click the **Install** button for the first result.
+3. From the results pane, click the **Install** button for the first result.
 
-4.  The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.
+4. The package will begin downloading. Before it is added to your project, the License Acceptance dialog will appear. If you agree to the license terms, click **I Accept**.
 
-5.  The latest VINR assemblies will be downloaded and added to your project.
+5. The latest VINR assemblies will be downloaded and added to your project.
 
 ## Use the Package Manager Console
 
-1.  In Visual Studio, click **Tools** > **NuGet Package Manager** > **Package Manager Console**.
+1. In Visual Studio, click **Tools** > **NuGet Package Manager** > **Package Manager Console**.
 
-2.  The **Package Manager Console** appears. Enter the following text and press **Enter**:
+2. The **Package Manager Console** appears. Enter the following text and press **Enter**:
 
     ```powershell
     Install-Package System.IdentityModel.Tokens.ValidatingIssuerNameRegistry
     ```
 
-3.  The latest VINR assemblies will be downloaded and added to your project.
+3. The latest VINR assemblies will be downloaded and added to your project.


### PR DESCRIPTION
Library Package Manager (VS 2013) is now NuGet Package Manager (>= VS 2015).
Also cleaned up whitespace and a few headings.
(Recommend hiding whitespace changes in the diff.)