### PR TITLE
Update cross-platform-targeting.md

### DIFF
--- a/docs/standard/library-guidance/cross-platform-targeting.md
+++ b/docs/standard/library-guidance/cross-platform-targeting.md
@@ -70,8 +70,8 @@ To shield your consumers from having to build for individual frameworks, you sho
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- This project will output netstandard2.0 and net471 assemblies -->
-    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+    <!-- This project will output netstandard2.0 and net461 assemblies -->
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 </Project>
 ```


### PR DESCRIPTION
I think it would better if we target the `netstandard2.0` and `net461` in this sample, this way it follows the point made earlier about `consider adding a target for net461 when you're offering a netstandard2.0 target`.
