### PR TITLE
Point to specific parts of the specification

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0178.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0178.md
@@ -18,7 +18,7 @@ Invalid rank specifier: expected ',' or ']'
   
 -   A comma enclosed in brackets  
   
- For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/index.md)) section on array initializers.  
+ For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays.md#array-initializers) section on array initializers.  
   
 ## Example  
  The following sample generates CS0178.  

--- a/docs/csharp/language-reference/compiler-messages/cs0178.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0178.md
@@ -18,7 +18,7 @@ Invalid rank specifier: expected ',' or ']'
   
 -   A comma enclosed in brackets  
   
- For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays#array-initializers) section on array initializers.  
+ For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays.md#array-initializers) section on array initializers.  
   
 ## Example  
  The following sample generates CS0178.  

--- a/docs/csharp/language-reference/compiler-messages/cs0178.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0178.md
@@ -18,7 +18,7 @@ Invalid rank specifier: expected ',' or ']'
   
 -   A comma enclosed in brackets  
   
- For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays.md#array-initializers) section on array initializers.  
+ For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays.md#array-initializers)) section on array initializers.  
   
 ## Example  
  The following sample generates CS0178.  

--- a/docs/csharp/language-reference/compiler-messages/cs0178.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0178.md
@@ -18,7 +18,7 @@ Invalid rank specifier: expected ',' or ']'
   
 -   A comma enclosed in brackets  
   
- For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays.md#array-initializers) section on array initializers.  
+ For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays#array-initializers) section on array initializers.  
   
 ## Example  
  The following sample generates CS0178.  

--- a/docs/csharp/language-reference/compiler-messages/cs0178.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0178.md
@@ -18,7 +18,7 @@ Invalid rank specifier: expected ',' or ']'
   
 -   A comma enclosed in brackets  
   
- For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](../../../csharp/language-reference/language-specification/arrays.md#array-initializers)) section on array initializers.  
+ For more information, see [Arrays](../../../csharp/programming-guide/arrays/index.md) and the C# specification ([C# Language Specification](~/_csharplang/spec/arrays.md#array-initializers)) section on array initializers.  
   
 ## Example  
  The following sample generates CS0178.  

--- a/docs/csharp/language-reference/keywords/explicit-numeric-conversions-table.md
+++ b/docs/csharp/language-reference/keywords/explicit-numeric-conversions-table.md
@@ -55,7 +55,7 @@ The following table shows the predefined explicit conversions between .NET numer
   
 - When you convert `decimal` to `float` or `double`, the `decimal` value is rounded to the nearest `double` or `float` value.  
   
- For more information about explicit conversions, see the [Explicit conversions](/dotnet/csharp/language-reference/language-specification/conversions#explicit-conversions) section of the [C# language specification](../language-specification/index.md).
+ For more information about explicit conversions, see the [Explicit conversions](~/_csharplang/spec/conversions.md#explicit-conversions) section of the [C# language specification](../language-specification/index.md).
   
 ## See also
 

--- a/docs/csharp/language-reference/keywords/for.md
+++ b/docs/csharp/language-reference/keywords/for.md
@@ -103,7 +103,7 @@ The following example defines the infinite `for` loop:
 
 ## See also
 
-- [The for statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-for-statement)
+- [The for statement (C# language specification)](~/_csharplang/spec/statements.md#the-for-statement)
 - [C# Reference](../index.md)
 - [C# Programming Guide](../../programming-guide/index.md)
 - [C# Keywords](index.md)

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -41,7 +41,7 @@ Beginning with C# 7.3, if the enumerator's `Current` property returns a [referen
 
 ## See also
 
-- [The foreach statement (C# language specification)](/dotnet/csharp/language-reference/language-specification/statements#the-foreach-statement)
+- [The foreach statement (C# language specification)](~/_csharplang/spec/statements.md#the-foreach-statement)
 - [Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)
 - [for](for.md)
 - [Iteration Statements](iteration-statements.md)

--- a/docs/csharp/language-reference/keywords/implicit-numeric-conversions-table.md
+++ b/docs/csharp/language-reference/keywords/implicit-numeric-conversions-table.md
@@ -42,7 +42,7 @@ The following table shows the predefined implicit conversions between .NET numer
   byte b = 300;   // CS0031: Constant value '300' cannot be converted to a 'byte'
   ```
 
-For more information about implicit conversions, see the [Implicit conversions](/dotnet/csharp/language-reference/language-specification/conversions#implicit-conversions) section of the [C# language specification](../language-specification/index.md).
+For more information about implicit conversions, see the [Implicit conversions](~/_csharplang/spec/conversions.md#implicit-conversions) section of the [C# language specification](../language-specification/index.md).
   
 ## See also
 

--- a/docs/csharp/language-reference/keywords/switch.md
+++ b/docs/csharp/language-reference/keywords/switch.md
@@ -183,7 +183,7 @@ Note that the `when` clause in the example that attempts to test whether a `Shap
 
 ## C# language specification
 
-For more information, see [The switch statement](/dotnet/csharp/language-reference/language-specification/statements#the-switch-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [The switch statement](~/_csharplang/spec/statements.md#the-switch-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/value-types-table.md
+++ b/docs/csharp/language-reference/keywords/value-types-table.md
@@ -37,9 +37,9 @@ You use a type suffix to specify a type of a numerical literal. For example:
 decimal a = 0.1M;
 ```
 
-If an [integer numerical literal](/dotnet/csharp/language-reference/language-specification/lexical-structure#integer-literals) has no suffix, it has the first of the following types in which its value can be represented: `int`, `uint`, `long`, `ulong`.
+If an [integer numerical literal](~/_csharplang/spec/lexical-structure.md#integer-literals) has no suffix, it has the first of the following types in which its value can be represented: `int`, `uint`, `long`, `ulong`.
 
-If a [real numerical literal](/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals) has no suffix, it's of type `double`.
+If a [real numerical literal](~/_csharplang/spec/lexical-structure.md#real-literals) has no suffix, it's of type `double`.
 
 ## See also
 

--- a/docs/csharp/language-reference/operators/remainder-operator.md
+++ b/docs/csharp/language-reference/operators/remainder-operator.md
@@ -27,7 +27,7 @@ For the [float](../keywords/float.md) and [double](../keywords/double.md) operan
 - the sign of `z`, if non-zero, is the same as the sign of `x`;
 - the absolute value of `z` is the value produced by `|x| - n * |y|` where `n` is the largest possible integer that is less than or equal to `|x| / |y|` and `|x|` and `|y|` are the absolute values of `x` and `y`, respectively.
 
-For information about behavior of the `%` operator in case of non-finite operands, see the [Remainder operator](/dotnet/csharp/language-reference/language-specification/expressions#remainder-operator) section of the [C# language specification](/dotnet/csharp/language-reference/language-specification/index).
+For information about behavior of the `%` operator in case of non-finite operands, see the [Remainder operator](~/_csharplang/spec/expressions.md#remainder-operator) section of the [C# language specification](/dotnet/csharp/language-reference/language-specification/index).
 
 > [!NOTE]
 > This method of computing the remainder is analogous to that used for integer operands, but differs from the IEEE 754. If you need the remainder operation that complies with the IEEE 754, use the <xref:System.Math.IEEERemainder%2A?displayProperty=nameWithType> method.

--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
 
 - A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](../programming-guide/concepts/linq/introduction-to-linq-queries.md).
 
-- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/index.md) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
+- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
 
 - As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.
 

--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
 
 - A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](../programming-guide/concepts/linq/introduction-to-linq-queries.md).
 
-- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
+- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/expressions#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
 
 - As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.
 

--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
 
 - A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](../programming-guide/concepts/linq/introduction-to-linq-queries.md).
 
-- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/expressions#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
+- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
 
 - As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.
 

--- a/docs/csharp/linq/index.md
+++ b/docs/csharp/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
 
 - A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](../programming-guide/concepts/linq/introduction-to-linq-queries.md).
 
-- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
+- At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](~/_csharplang/spec/expressions.md#query-expressions) and [Standard query operators overview](../programming-guide/concepts/linq/standard-query-operators-overview.md).
 
 - As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.
 

--- a/docs/csharp/misc/cs0135.md
+++ b/docs/csharp/misc/cs0135.md
@@ -32,6 +32,6 @@ public class MyClass2
 }  
 ```  
   
-From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
+From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts#declarations):  
   
 It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0135.md
+++ b/docs/csharp/misc/cs0135.md
@@ -32,6 +32,6 @@ public class MyClass2
 }  
 ```  
   
-From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
+From the [C# Language Specification](~/_csharplang/spec/basic-concepts.md#declarations):  
   
 It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0135.md
+++ b/docs/csharp/misc/cs0135.md
@@ -32,6 +32,6 @@ public class MyClass2
 }  
 ```  
   
- From the [C# Language Specification](../../csharp/language-reference/language-specification/index.md), Section 7.5.2.1:  
+From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
   
- For each occurrence of a given identifier as a simple-name in an expression or declarator, within the local variable declaration space (§3.3) immediately enclosing that occurrence, every other occurrence of the same identifier as a simple-name in an expression or declarator must refer to the same entity. This rule ensures that the meaning of a name is always the same within a given block, switch block, for-, foreach- or using-statement, or anonymous function.
+It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0135.md
+++ b/docs/csharp/misc/cs0135.md
@@ -32,6 +32,6 @@ public class MyClass2
 }  
 ```  
   
-From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts#declarations):  
+From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
   
 It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0136.md
+++ b/docs/csharp/misc/cs0136.md
@@ -33,6 +33,6 @@ namespace MyNamespace
 }  
 ```  
   
- From the [C# Language Specification](../../csharp/language-reference/language-specification/index.md), Section 7.5.2.1:  
+From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
   
- For each occurrence of a given identifier as a simple-name in an expression or declarator, within the local variable declaration space (§3.3) immediately enclosing that occurrence, every other occurrence of the same identifier as a simple-name in an expression or declarator must refer to the same entity. This rule ensures that the meaning of a name is always the same within a given block, switch block, for-, foreach- or using-statement, or anonymous function.
+It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0136.md
+++ b/docs/csharp/misc/cs0136.md
@@ -33,6 +33,6 @@ namespace MyNamespace
 }  
 ```  
   
-From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
+From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts#declarations):  
   
 It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0136.md
+++ b/docs/csharp/misc/cs0136.md
@@ -33,6 +33,6 @@ namespace MyNamespace
 }  
 ```  
   
-From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts#declarations):  
+From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
   
 It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/misc/cs0136.md
+++ b/docs/csharp/misc/cs0136.md
@@ -33,6 +33,6 @@ namespace MyNamespace
 }  
 ```  
   
-From the [C# Language Specification](../../csharp/language-reference/language-specification/basic-concepts.md#declarations):  
+From the [C# Language Specification](~/_csharplang/spec/basic-concepts.md#declarations):  
   
 It is an error for a local variable declaration space and a nested local variable declaration space to contain elements with the same name. Thus, within a nested declaration space it is not possible to declare a local variable or constant with the same name as a local variable or constant in an enclosing declaration space. It is possible for two declaration spaces to contain elements with the same name as long as neither declaration space contains the other.

--- a/docs/csharp/programming-guide/concepts/iterators.md
+++ b/docs/csharp/programming-guide/concepts/iterators.md
@@ -336,7 +336,7 @@ On each successive iteration of the `foreach` loop (or the direct call to `IEnum
 
 Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To reiterate from the start, you must obtain a new iterator. Calling <xref:System.Collections.IEnumerator.Reset%2A> on the iterator returned by an iterator method throws a <xref:System.NotSupportedException>.
 
-For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes#iterators).
+For additional information, see the [C# Language Specification](~/_csharplang/spec/classes.md#iterators).
 
 ## Use of Iterators
 

--- a/docs/csharp/programming-guide/concepts/iterators.md
+++ b/docs/csharp/programming-guide/concepts/iterators.md
@@ -336,7 +336,7 @@ On each successive iteration of the `foreach` loop (or the direct call to `IEnum
 
 Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To reiterate from the start, you must obtain a new iterator. Calling <xref:System.Collections.IEnumerator.Reset%2A> on the iterator returned by an iterator method throws a <xref:System.NotSupportedException>.
 
-For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).
+For additional information, see the [C# Language Specification](../../../csharp/language-reference/anguage-specification/classes.md#iterators).
 
 ## Use of Iterators
 

--- a/docs/csharp/programming-guide/concepts/iterators.md
+++ b/docs/csharp/programming-guide/concepts/iterators.md
@@ -336,7 +336,7 @@ On each successive iteration of the `foreach` loop (or the direct call to `IEnum
 
 Iterators don't support the <xref:System.Collections.IEnumerator.Reset%2A?displayProperty=nameWithType> method. To reiterate from the start, you must obtain a new iterator. Calling <xref:System.Collections.IEnumerator.Reset%2A> on the iterator returned by an iterator method throws a <xref:System.NotSupportedException>.
 
-For additional information, see the [C# Language Specification](../../../csharp/language-reference/anguage-specification/classes.md#iterators).
+For additional information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes#iterators).
 
 ## Use of Iterators
 

--- a/docs/csharp/programming-guide/concepts/linq/index.md
+++ b/docs/csharp/programming-guide/concepts/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
   
 -   A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](introduction-to-linq-queries.md).  
   
--   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/index.md) and [Standard query operators overview](standard-query-operators-overview.md).  
+-   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
   
 -   As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.  
   

--- a/docs/csharp/programming-guide/concepts/linq/index.md
+++ b/docs/csharp/programming-guide/concepts/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
   
 -   A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](introduction-to-linq-queries.md).  
   
--   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/expressions#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
+-   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
   
 -   As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.  
   

--- a/docs/csharp/programming-guide/concepts/linq/index.md
+++ b/docs/csharp/programming-guide/concepts/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
   
 -   A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](introduction-to-linq-queries.md).  
   
--   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
+-   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](~/_csharplang/spec/expressions.md#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
   
 -   As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.  
   

--- a/docs/csharp/programming-guide/concepts/linq/index.md
+++ b/docs/csharp/programming-guide/concepts/linq/index.md
@@ -24,7 +24,7 @@ The following example shows the complete query operation. The complete operation
   
 -   A query is not executed until you iterate over the query variable, for example, in a `foreach` statement. For more information, see [Introduction to LINQ queries](introduction-to-linq-queries.md).  
   
--   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/expressions.md#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
+-   At compile time, query expressions are converted to Standard Query Operator method calls according to the rules set forth in the C# specification. Any query that can be expressed by using query syntax can also be expressed by using method syntax. However, in most cases query syntax is more readable and concise. For more information, see [C# language specification](../../../language-reference/language-specification/expressions#query-expressions) and [Standard query operators overview](standard-query-operators-overview.md).  
   
 -   As a rule when you write LINQ queries, we recommend that you use query syntax whenever possible and method syntax whenever necessary. There is no semantic or performance difference between the two different forms. Query expressions are often more readable than equivalent expressions written in method syntax.  
   

--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -37,7 +37,7 @@ A generic method is a method that is declared with type parameters, as follows:
  [!code-csharp[csProgGuideGenerics#28](../../../csharp/programming-guide/generics/codesnippet/CSharp/generic-methods_7.cs)]  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes.md#methods).  
+ For more information, see the [C# Language Specification](~/_csharplang/spec/classes.md#methods).  
   
 ## See Also
 

--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -37,7 +37,7 @@ A generic method is a method that is declared with type parameters, as follows:
  [!code-csharp[csProgGuideGenerics#28](../../../csharp/programming-guide/generics/codesnippet/CSharp/generic-methods_7.cs)]  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes.md#methods).  
+ For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes#methods).  
   
 ## See Also
 

--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -37,7 +37,7 @@ A generic method is a method that is declared with type parameters, as follows:
  [!code-csharp[csProgGuideGenerics#28](../../../csharp/programming-guide/generics/codesnippet/CSharp/generic-methods_7.cs)]  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).  
+ For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes.md#methods).  
   
 ## See Also
 

--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -37,7 +37,7 @@ A generic method is a method that is declared with type parameters, as follows:
  [!code-csharp[csProgGuideGenerics#28](../../../csharp/programming-guide/generics/codesnippet/CSharp/generic-methods_7.cs)]  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes#methods).  
+ For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes.md#methods).  
   
 ## See Also
 

--- a/docs/csharp/programming-guide/generics/index.md
+++ b/docs/csharp/programming-guide/generics/index.md
@@ -51,7 +51,7 @@ Generics were added to version 2.0 of the C# language and the common language ru
 -   [Generics in the Run Time](../../../csharp/programming-guide/generics/generics-in-the-run-time.md)  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/types#constructed-types).  
+ For more information, see the [C# Language Specification](~/_csharplang/spec/types.md#constructed-types).  
   
 ## See Also
 

--- a/docs/csharp/programming-guide/generics/index.md
+++ b/docs/csharp/programming-guide/generics/index.md
@@ -51,7 +51,7 @@ Generics were added to version 2.0 of the C# language and the common language ru
 -   [Generics in the Run Time](../../../csharp/programming-guide/generics/generics-in-the-run-time.md)  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/index.md).  
+ For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes.md).  
   
 ## See Also
 

--- a/docs/csharp/programming-guide/generics/index.md
+++ b/docs/csharp/programming-guide/generics/index.md
@@ -51,7 +51,7 @@ Generics were added to version 2.0 of the C# language and the common language ru
 -   [Generics in the Run Time](../../../csharp/programming-guide/generics/generics-in-the-run-time.md)  
   
 ## C# Language Specification  
- For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/classes.md).  
+ For more information, see the [C# Language Specification](../../../csharp/language-reference/language-specification/types#constructed-types).  
   
 ## See Also
 

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -153,7 +153,7 @@ Beginning with C# 7.3, tuple types support the `==` and `!=` operators. These op
 
 [!code-csharp[TupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#Equality "Testing tuples for equality")]
 
-There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/conversions#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
+There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/conversions.md#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
 
 
 [!code-csharp[NullableTupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#NullableEquality "Comparing Tuples and nullable tuples")]

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -153,7 +153,7 @@ Beginning with C# 7.3, tuple types support the `==` and `!=` operators. These op
 
 [!code-csharp[TupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#Equality "Testing tuples for equality")]
 
-There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/conversions.md#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
+There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/conversions#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
 
 
 [!code-csharp[NullableTupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#NullableEquality "Comparing Tuples and nullable tuples")]

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -153,7 +153,7 @@ Beginning with C# 7.3, tuple types support the `==` and `!=` operators. These op
 
 [!code-csharp[TupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#Equality "Testing tuples for equality")]
 
-There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/conversions.md#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
+There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](~/_csharplang/spec/conversions.md#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
 
 
 [!code-csharp[NullableTupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#NullableEquality "Comparing Tuples and nullable tuples")]

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -153,7 +153,7 @@ Beginning with C# 7.3, tuple types support the `==` and `!=` operators. These op
 
 [!code-csharp[TupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#Equality "Testing tuples for equality")]
 
-There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/index.md) if one of the tuples is a nullable tuple, as shown in the following code:
+There are several rules that make tuple equality tests more convenient. Tuple equality performs [lifted conversions](language-reference/language-specification/conversions.md#lifted-conversion-operators) if one of the tuples is a nullable tuple, as shown in the following code:
 
 
 [!code-csharp[NullableTupleEquality](../../samples/snippets/csharp/tuples/tuples/program.cs#NullableEquality "Comparing Tuples and nullable tuples")]

--- a/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
+++ b/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
@@ -11,7 +11,7 @@ ms.assetid: 53c7f825-a737-4b76-a1fa-f67745b8bd40
 # End of statement expected
 The statement is syntactically complete, but an additional programming element follows the element that completes the statement. A line terminator is required at the end of every statement.
   
- A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/index.md).
+ A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/lexical-grammar.md#line-terminators).
   
  **Error ID:** BC30205
   

--- a/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
+++ b/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
@@ -11,7 +11,7 @@ ms.assetid: 53c7f825-a737-4b76-a1fa-f67745b8bd40
 # End of statement expected
 The statement is syntactically complete, but an additional programming element follows the element that completes the statement. A line terminator is required at the end of every statement.
   
- A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/lexical-grammar#line-terminators).
+ A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/lexical-grammar.md#line-terminators).
   
  **Error ID:** BC30205
   

--- a/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
+++ b/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
@@ -11,7 +11,7 @@ ms.assetid: 53c7f825-a737-4b76-a1fa-f67745b8bd40
 # End of statement expected
 The statement is syntactically complete, but an additional programming element follows the element that completes the statement. A line terminator is required at the end of every statement.
   
- A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/lexical-grammar.md#line-terminators).
+ A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](~/_vblang/spec/lexical-grammar.md#line-terminators).
   
  **Error ID:** BC30205
   

--- a/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
+++ b/docs/visual-basic/language-reference/error-messages/end-of-statement-expected.md
@@ -11,7 +11,7 @@ ms.assetid: 53c7f825-a737-4b76-a1fa-f67745b8bd40
 # End of statement expected
 The statement is syntactically complete, but an additional programming element follows the element that completes the statement. A line terminator is required at the end of every statement.
   
- A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/lexical-grammar.md#line-terminators).
+ A line terminator divides the characters of a Visual Basic source file into lines. Examples of line terminators are the Unicode carriage return character (&HD), the Unicode linefeed character (&HA), and the Unicode carriage return character followed by the Unicode linefeed character. For more information about line terminators, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/lexical-grammar#line-terminators).
   
  **Error ID:** BC30205
   

--- a/docs/visual-basic/language-reference/statements/option-infer-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-infer-statement.md
@@ -44,7 +44,7 @@ IntelliSense when Option Infer is on
 IntelliSense when Option Infer is off  
   
 > [!NOTE]
->  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/index.md).
+>  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/conversions.md#value-type-conversions).
   
  Type inference applies at the procedure level, and does not apply outside a procedure in a class, structure, module, or interface.  
   

--- a/docs/visual-basic/language-reference/statements/option-infer-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-infer-statement.md
@@ -44,7 +44,7 @@ IntelliSense when Option Infer is on
 IntelliSense when Option Infer is off  
   
 > [!NOTE]
->  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/conversions.md#value-type-conversions).
+>  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](~/_vblang/spec/conversions.md#value-type-conversions).
   
  Type inference applies at the procedure level, and does not apply outside a procedure in a class, structure, module, or interface.  
   

--- a/docs/visual-basic/language-reference/statements/option-infer-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-infer-statement.md
@@ -44,7 +44,7 @@ IntelliSense when Option Infer is on
 IntelliSense when Option Infer is off  
   
 > [!NOTE]
->  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/conversions.md#value-type-conversions).
+>  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/conversions#value-type-conversions).
   
  Type inference applies at the procedure level, and does not apply outside a procedure in a class, structure, module, or interface.  
   

--- a/docs/visual-basic/language-reference/statements/option-infer-statement.md
+++ b/docs/visual-basic/language-reference/statements/option-infer-statement.md
@@ -44,7 +44,7 @@ IntelliSense when Option Infer is on
 IntelliSense when Option Infer is off  
   
 > [!NOTE]
->  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/conversions#value-type-conversions).
+>  When a variable is declared as an `Object`, the run-time type can change while the program is running. Visual Basic performs operations called *boxing* and *unboxing* to convert between an `Object` and a value type, which makes execution slower. For information about boxing and unboxing, see the [Visual Basic Language Specification](../../../visual-basic/reference/language-specification/conversions.md#value-type-conversions).
   
  Type inference applies at the procedure level, and does not apply outside a procedure in a class, structure, module, or interface.  
   


### PR DESCRIPTION
Fixes #7890

I'm not 100% sure the links should have the `.md` file ending, but it looked like it.
