### PR TITLE
Documented vbruntime compiler setting in SDK projects

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -999,6 +999,7 @@
 #### [Range variable name can be inferred only from a simple or qualified name with no arguments](visual-basic/language-reference/error-messages/range-variable-name-can-be-inferred.md)
 #### [Reference required to assembly '<assemblyidentity>' containing type '<typename>', but a suitable reference could not be found due to ambiguity between projects '<projectname1>' and '<projectname2>'](visual-basic/language-reference/error-messages/reference-required-to-assembly-containing-type-but-suitable-reference-not-found.md)
 #### [Reference required to assembly '<assemblyname>' containing the base class '<classname>'](visual-basic/language-reference/error-messages/reference-required-to-assembly-assemblyname-containing-the-base-class-classname.md)
+#### [Requested operation is not available (BC35000)](visual-basic/language-reference/error-messages/bc35000.md)
 #### [Resume without error](visual-basic/language-reference/error-messages/resume-without-error.md)
 #### [Return type of function '<procedurename>' is not CLS-compliant](visual-basic/language-reference/error-messages/return-type-of-function-procedurename-is-not-cls-compliant.md)
 #### ['Set' accessor of property '<propertyname>' is not accessible](visual-basic/language-reference/error-messages/set-accessor-of-property-propertyname-is-not-accessible.md)

--- a/docs/visual-basic/language-reference/error-messages/bc35000.md
+++ b/docs/visual-basic/language-reference/error-messages/bc35000.md
@@ -15,7 +15,7 @@ Visual Basic is attempting to make an internal call to a function in the Visual 
   
 **Error ID:** BC35000  
 
-This error occurs in SDK-style projects (projects with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`). By default, a only a subject of the Microsoft.VisualBasic.dll assembly is embedded in the application assembly, and *\<function>* is not included in that subset.  
+This error occurs in SDK-style projects (projects with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`). By default, a only a subset of the Microsoft.VisualBasic.dll assembly is embedded in the application assembly, and *\<function>* is not included in that subset.  
 
 ## To correct this error  
 

--- a/docs/visual-basic/language-reference/error-messages/bc35000.md
+++ b/docs/visual-basic/language-reference/error-messages/bc35000.md
@@ -1,0 +1,30 @@
+---
+title: "Requsted operation is not available"
+ms.date: 10/10/2018
+f1_keywords: 
+  - "bc35000"
+  - "vbc35000"
+helpviewer_keywords: 
+  - "BC35000"
+author: rpetrusha
+ms.author: ronpet
+---
+# Requested operation is not available because the runtime library function '\<function>' is not defined.
+
+Visual Basic is attempting to make an internal call to a function in the Visual Basic Runtime (Microsoft.VisualBasic.dll) that cannot be found.
+  
+**Error ID:** BC35000  
+
+This error occurs in SDK-style projects (projects with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`). By default, a only a subject of the Microsoft.VisualBasic.dll assembly is embedded in the application assembly, and *\<function>* is not included in that subset.  
+
+## To correct this error  
+
+Rather than embedding a subset of the Visual Basic Runtime in your assembly, you must compile with a reference to it. You do this by adding the following element to the `<PropertyGroup>` section of your *.vbproj file:
+
+```xml
+<VBRuntime>Default</VBRuntime>
+```
+
+## See also  
+
+[**-vbruntime** compiler option](../../reference/command-line-compiler/vbruntime.md)

--- a/docs/visual-basic/language-reference/error-messages/bc35000.md
+++ b/docs/visual-basic/language-reference/error-messages/bc35000.md
@@ -15,7 +15,7 @@ Visual Basic is attempting to make an internal call to a function in the Visual 
   
 **Error ID:** BC35000  
 
-This error occurs in SDK-style projects (projects with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`). By default, a only a subset of the Microsoft.VisualBasic.dll assembly is embedded in the application assembly, and *\<function>* is not included in that subset.  
+This error occurs in SDK-style projects (projects with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`). By default, only a subset of the Microsoft.VisualBasic.dll assembly is embedded in the application assembly, and *\<function>* is not included in that subset.  
 
 ## To correct this error  
 

--- a/docs/visual-basic/language-reference/error-messages/name-name-is-not-declared.md
+++ b/docs/visual-basic/language-reference/error-messages/name-name-is-not-declared.md
@@ -1,11 +1,13 @@
 ---
 title: "Name &#39;&lt;name&gt;&#39; is not declared"
-ms.date: 07/20/2015
+ms.date: 10/10/2018
 f1_keywords: 
   - "bc30451"
   - "vbc30451"
 helpviewer_keywords: 
   - "BC30451"
+author: rpetrusha
+ms.author: ronpet
 ms.assetid: 765f099b-e21e-47c6-a906-a065444e56b3
 ---
 # Name &#39;&lt;name&gt;&#39; is not declared
@@ -15,16 +17,29 @@ A statement refers to a programming element, but the compiler cannot find an ele
   
 ## To correct this error  
   
-1.  Check the spelling of the name in the referring statement. Visual Basic is case-insensitive, but any other variation in the spelling is regarded as a completely different name. Note that the underscore (`_`) is part of the name and therefore part of the spelling.  
+1. Check the spelling of the name in the referring statement. Visual Basic is case-insensitive, but any other variation in the spelling is regarded as a completely different name. Note that the underscore (`_`) is part of the name and therefore part of the spelling.  
   
-2.  Check that you have the member access operator (`.`) between an object and its member. For example, if you have a <xref:System.Windows.Forms.TextBox> control named `TextBox1`, to access its <xref:System.Windows.Forms.TextBoxBase.Text%2A> property you should type `TextBox1.Text`. If instead you type `TextBox1Text`, you have created a different name.  
+2. Check that you have the member access operator (`.`) between an object and its member. For example, if you have a <xref:System.Windows.Forms.TextBox> control named `TextBox1`, to access its <xref:System.Windows.Forms.TextBoxBase.Text%2A> property you should type `TextBox1.Text`. If instead you type `TextBox1Text`, you have created a different name.  
   
-3.  If the spelling is correct and the syntax of any object member access is correct, verify that the element has been declared. For more information, see [Declared Elements](../../../visual-basic/programming-guide/language-features/declared-elements/index.md).  
+3. If the spelling is correct and the syntax of any object member access is correct, verify that the element has been declared. For more information, see [Declared Elements](../../programming-guide/language-features/declared-elements/index.md).  
   
-4.  If the programming element has been declared, check that it is in scope. If the referring statement is outside the region declaring the programming element, you might need to qualify the element name. For more information, see [Scope in Visual Basic](../../../visual-basic/programming-guide/language-features/declared-elements/scope.md).  
-  
-## See Also  
- [Declarations and Constants Summary](../../../visual-basic/language-reference/keywords/declarations-and-constants-summary.md)  
+4. If the programming element has been declared, check that it is in scope. If the referring statement is outside the region declaring the programming element, you might need to qualify the element name. For more information, see [Scope in Visual Basic](../../programming-guide/language-features/declared-elements/scope.md).  
+
+5. If you are not using a fully qualified type or type and member name (for example, your code refers to a property as <xref:System.Reflection.MethodInfo.Name?displayProperty=nameWithType> instead of `System.Reflection.MethodInfo.Name`), add an [Imports statement](../statements/imports-statement-net-namespace-and-type.md).
+
+6. If you are attempting to compile an SDK-style project (a project with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`), and the error message refers to a type or member in the Microsoft.VisualBasic.dll assembly, configure your application to compile with a reference to the Visual Basic Runtime Library. By default, a subset of the library is embedded in your assembly in an SDK-style project.
+
+   For example, the following example fails to compile because the <xref:Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger%2A?displayProperty=fullName> method cannot be found. It is not embedded in the subset of the Visual Basic Runtime included with your application.  
+
+   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30451\program1.vb)]
+
+   To address this error, add the `<VBRuntime>Default</VBRuntime>` element to the projects `<PropertyGroup>` section, as the following Visual Basic project file shows.
+
+   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30451\vbruntime.vbproj?highlight=6)]
+
+## See also  
+
+[Declarations and Constants Summary](../../../visual-basic/language-reference/keywords/declarations-and-constants-summary.md)  
  [Visual Basic Naming Conventions](../../../visual-basic/programming-guide/program-structure/naming-conventions.md)  
  [Declared Element Names](../../../visual-basic/programming-guide/language-features/declared-elements/declared-element-names.md)  
  [References to Declared Elements](../../../visual-basic/programming-guide/language-features/declared-elements/references-to-declared-elements.md)

--- a/docs/visual-basic/language-reference/error-messages/name-name-is-not-declared.md
+++ b/docs/visual-basic/language-reference/error-messages/name-name-is-not-declared.md
@@ -25,17 +25,17 @@ A statement refers to a programming element, but the compiler cannot find an ele
   
 4. If the programming element has been declared, check that it is in scope. If the referring statement is outside the region declaring the programming element, you might need to qualify the element name. For more information, see [Scope in Visual Basic](../../programming-guide/language-features/declared-elements/scope.md).  
 
-5. If you are not using a fully qualified type or type and member name (for example, your code refers to a property as <xref:System.Reflection.MethodInfo.Name?displayProperty=nameWithType> instead of `System.Reflection.MethodInfo.Name`), add an [Imports statement](../statements/imports-statement-net-namespace-and-type.md).
+5. If you are not using a fully qualified type or type and member name (for example, your code refers to a property as `MethodInfo.Name` instead of `System.Reflection.MethodInfo.Name`), add an [Imports statement](../statements/imports-statement-net-namespace-and-type.md).
 
 6. If you are attempting to compile an SDK-style project (a project with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`), and the error message refers to a type or member in the Microsoft.VisualBasic.dll assembly, configure your application to compile with a reference to the Visual Basic Runtime Library. By default, a subset of the library is embedded in your assembly in an SDK-style project.
 
    For example, the following example fails to compile because the <xref:Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger%2A?displayProperty=fullName> method cannot be found. It is not embedded in the subset of the Visual Basic Runtime included with your application.  
 
-   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30451\program1.vb)]
+   [!code-vb[BC30451](~/samples/snippets/visualbasic/language-reference/error-messages/bc30451/program1.vb)]
 
    To address this error, add the `<VBRuntime>Default</VBRuntime>` element to the projects `<PropertyGroup>` section, as the following Visual Basic project file shows.
 
-   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30451\vbruntime.vbproj?highlight=6)]
+   [!code-vb[BC30451](~/samples/snippets/visualbasic/language-reference/error-messages/bc30451/vbruntime.vbproj?highlight=6)]
 
 ## See also  
 

--- a/docs/visual-basic/misc/bc30456.md
+++ b/docs/visual-basic/misc/bc30456.md
@@ -1,12 +1,13 @@
 ---
 title: "&#39;&lt;name&gt;&#39; is not a member of &#39;&lt;classname&gt;&#39;"
-ms.date: 07/20/2015
+ms.date: 10/10/2018
 f1_keywords: 
   - "bc30456"
   - "vbc30456"
 helpviewer_keywords: 
   - "BC30456"
-ms.assetid: 029f9742-858a-40c5-b771-7cdfb2c777cc
+author: rpetrusha
+ms.author: ronpetms.assetid: 029f9742-858a-40c5-b771-7cdfb2c777cc
 ---
 # &#39;&lt;name&gt;&#39; is not a member of &#39;&lt;classname&gt;&#39;
 The member you have provided is not a member of the class.  
@@ -18,3 +19,14 @@ The member you have provided is not a member of the class.
 1.  Check the name of the member to ensure it is accurate.  
   
 2.  Use an actual member of the class.
+
+3. If you are attempting to compile an SDK-style project (a project with a \*.vbproj file that begins with the line `<Project Sdk="Microsoft.NET.Sdk">`), and the error message refers to a type or member in the Microsoft.VisualBasic.dll assembly, configure your application to compile with a reference to the Visual Basic Runtime Library. By default, a subset of the library is embedded in your assembly in an SDK-style project.
+
+   For example, the following example fails to compile because the <xref:Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger%2A?displayProperty=fullName> method cannot be found. It is not embedded in the subset of the Visual Basic Runtime included with your application.  
+
+   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30456\program.vb)]
+
+   To address this error, add the `<VBRuntime>Default</VBRuntime>` element to the projects `<PropertyGroup>` section, as the following Visual Basic project file shows.
+
+   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30456\bc30456.vbproj?highlight=6)]
+

--- a/docs/visual-basic/misc/bc30456.md
+++ b/docs/visual-basic/misc/bc30456.md
@@ -7,7 +7,8 @@ f1_keywords:
 helpviewer_keywords: 
   - "BC30456"
 author: rpetrusha
-ms.author: ronpetms.assetid: 029f9742-858a-40c5-b771-7cdfb2c777cc
+ms.author: ronpet
+ms.assetid: 029f9742-858a-40c5-b771-7cdfb2c777cc
 ---
 # &#39;&lt;name&gt;&#39; is not a member of &#39;&lt;classname&gt;&#39;
 The member you have provided is not a member of the class.  
@@ -24,9 +25,9 @@ The member you have provided is not a member of the class.
 
    For example, the following example fails to compile because the <xref:Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger%2A?displayProperty=fullName> method cannot be found. It is not embedded in the subset of the Visual Basic Runtime included with your application.  
 
-   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30456\program.vb)]
+   [!code-vb[BC30456](~/samples/snippets/visualbasic/language-reference/error-messages/bc30456/program.vb)]
 
    To address this error, add the `<VBRuntime>Default</VBRuntime>` element to the projects `<PropertyGroup>` section, as the following Visual Basic project file shows.
 
-   [!code-vb[BC30451](~/samples/snippets/visualbasic\language-reference\BC30456\bc30456.vbproj?highlight=6)]
+   [!code-vb[BC30456](~/samples/snippets/visualbasic/language-reference/error-messages/bc30456/bc30456.vbproj?highlight=6)]
 


### PR DESCRIPTION
## Documented vbruntime compiler setting in SDK projects

This should at least address the issue until we create our SDK project reference.

Examples are in dotnet/samples#371

Fixes #7407

See also:
- dotnet/roslyn#28021
- dotnet/roslyn#28017

//cc @KathleenDollard 