### PR TITLE
Add instructions for linking to the dependent repositories

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -113,6 +113,12 @@ To link to a header in a Markdown file in the same repo, use relative linking + 
 
 - Example: [.NET Community](../docs/welcome.md#community)
 
+The C# language specification and the Visual Basic language specification are included in the .NET docs by including the source from the language repositories. The markdown sources are managed in the [csharplang](../csharplang) and [visual basic](../vblang) repositories.
+
+Links to the spec must point to the source directories where those specs are included. For C#, i'ts **~/_csharplang/spec** and for VB, it's **~/_vblang/spec**.
+
+- Example: [C# Query Expressions](~/_csharplang/spec/expressions.md#query-expressions)
+
 ### External Links
 
 To link to an external file, use the full URL as the link.

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -115,7 +115,7 @@ To link to a header in a Markdown file in the same repo, use relative linking + 
 
 The C# language specification and the Visual Basic language specification are included in the .NET docs by including the source from the language repositories. The markdown sources are managed in the [csharplang](../csharplang) and [visual basic](../vblang) repositories.
 
-Links to the spec must point to the source directories where those specs are included. For C#, i'ts **~/_csharplang/spec** and for VB, it's **~/_vblang/spec**.
+Links to the spec must point to the source directories where those specs are included. For C#, it's **~/_csharplang/spec** and for VB, it's **~/_vblang/spec**.
 
 - Example: [C# Query Expressions](~/_csharplang/spec/expressions.md#query-expressions)
 


### PR DESCRIPTION
The dependent repositories for the language specification requires special handling for the links to resolve correctly by the build system.

See https://github.com/dotnet/docs/pull/8221#issuecomment-428943541 for details.

/cc @Mackiovello 