### PR TITLE
fix broken links

### DIFF
--- a/docs/machine-learning/resources/glossary.md
+++ b/docs/machine-learning/resources/glossary.md
@@ -1,8 +1,6 @@
 ---
-title: Machine Learning Glossary
+title: Machine learning glossary
 description: A glossary of machine learning terms.
-author: jralexander
-ms.author: johalex
 ms.date: 05/31/2018
 ms.topic: conceptual
 ---
@@ -14,13 +12,13 @@ The following list is a compilation of important machine learning terms that are
 
 In [classification](#classification), accuracy is the number of correctly classified items divided by the total number of items in the test set. Ranges from 0 (least accurate) to 1 (most accurate). Accuracy is one of evaluation metrics of the performance of your model. Consider it in conjunction with [precision](#precision), [recall](#recall), and [F-score](#f-score).
 
-Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.Accuracy?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.Accuracy?displayProperty=nameWithType>.
 
 ## Area under the curve (AUC)
 
 In [binary classification](#binary-classification), an evaluation metric that is the value of the area under the curve that plots the true positives rate (on the y-axis) against the false positives rate (on the x-axis). Ranges from 0.5 (worst) to 1 (best). Also known as the area under the ROC curve, i.e., receiver operating characteristic curve. For more information, see the [Receiver operating characteristic](https://en.wikipedia.org/wiki/Receiver_operating_characteristic) article on Wikipedia.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.Auc?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.Auc?displayProperty=nameWithType>.
 
 ## Binary classification
 
@@ -34,7 +32,7 @@ When the data is used to predict a category, [supervised machine learning](#supe
 
 In [regression](#regression), an evaluation metric that indicates how well data fits a model. Ranges from 0 to 1. A value of 0 means that the data is random or otherwise cannot be fit to the model. A value of 1 means that the model exactly matches the data. This is often referred to as r<sup>2</sup>, R<sup>2</sup>, or r-squared.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.RegressionMetrics.RSquared?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.RegressionMetrics.RSquared?displayProperty=nameWithType>.
 
 ## Feature
 
@@ -48,7 +46,7 @@ Feature engineering is the process that involves defining a set of [features](#f
 
 In [classification](#classification), an evaluation metric that balances [precision](#precision) and [recall](#recall).
 
-Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.F1Score?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.F1Score?displayProperty=nameWithType>.
 
 ## Hyperparameter
 
@@ -62,13 +60,13 @@ The element to be predicted with the machine learning model. For example, the br
 
 In [classification](#classification), an evaluation metric that characterizes the accuracy of a classifier. The smaller log loss is, the more accurate a classifier is.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.LogLoss?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.LogLoss?displayProperty=nameWithType>.
 
 ## Mean absolute error (MAE)
 
 In [regression](#regression), an evaluation metric that is the average of all the model errors, where model error is the distance between the predicted [label](#label) value and the correct label value.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.RegressionMetrics.L1?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.RegressionMetrics.L1?displayProperty=nameWithType>.
 
 ## Model
 
@@ -94,13 +92,13 @@ All of the operations needed to fit a model to a data set. A pipeline consists o
 
 In [classification](#classification), the precision for a class is the number of items correctly predicted as belonging to that class divided by the total number of items predicted as belonging to the class.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.NegativePrecision?displayProperty=nameWithType>, <xref:Microsoft.ML.Models.BinaryClassificationMetrics.PositivePrecision?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.NegativePrecision?displayProperty=nameWithType>, <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.PositivePrecision?displayProperty=nameWithType>.
 
 ## Recall
 
 In [classification](#classification), the recall for a class is the number of items correctly predicted as belonging to that class divided by the total number of items that actually belong to the class.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.BinaryClassificationMetrics.NegativeRecall?displayProperty=nameWithType>, <xref:Microsoft.ML.Models.BinaryClassificationMetrics.PositiveRecall?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.NegativeRecall?displayProperty=nameWithType>, <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics.PositiveRecall?displayProperty=nameWithType>.
 
 ## Regression
 
@@ -118,7 +116,7 @@ In [regression](#regression), an evaluation metric that is the sum of all square
 
 In [regression](#regression), an evaluation metric that is the square root of the average of the squares of the errors.
 
-Related ML.NET API: <xref:Microsoft.ML.Models.RegressionMetrics.Rms?displayProperty=nameWithType>.
+Related ML.NET API: <xref:Microsoft.ML.Legacy.Models.RegressionMetrics.Rms?displayProperty=nameWithType>.
 
 ## Supervised machine learning
 

--- a/docs/machine-learning/resources/transforms.md
+++ b/docs/machine-learning/resources/transforms.md
@@ -2,10 +2,7 @@
 title: Data transforms
 description: Explore the different data transforms supported in ML.NET.
 ms.date: 08/08/2018
-author: jralexander
-ms.author: johalex
 ---
-
 # Data transforms
 
 The following tables contain information about all of the data transforms supported in ML.NET (select the data transform type to navigate to the corresponding table):
@@ -29,111 +26,111 @@ The following tables contain information about all of the data transforms suppor
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.CategoricalHashOneHotVectorizer> | Encodes the categorical variable with hash-based encoding. |
-| <xref:Microsoft.ML.Transforms.CategoricalOneHotVectorizer> | Encodes the categorical variable with one-hot encoding based on a term dictionary. |
+| <xref:Microsoft.ML.Legacy.Transforms.CategoricalHashOneHotVectorizer> | Encodes the categorical variable with hash-based encoding. |
+| <xref:Microsoft.ML.Legacy.Transforms.CategoricalOneHotVectorizer> | Encodes the categorical variable with one-hot encoding based on a term dictionary. |
 
 ## Combiners and segregators
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.CombinerByContiguousGroupId> | Groups values of a scalar column into a vector based on a contiguous group ID. |
-| <xref:Microsoft.ML.Transforms.FeatureCombiner> | Combines all the features into one feature column. |
-| <xref:Microsoft.ML.Transforms.ManyHeterogeneousModelCombiner> | Combines a sequence of TransformModels and a PredictorModel into a single PredictorModel. |
-| <xref:Microsoft.ML.Transforms.ModelCombiner> | Combines a sequence of TransformModels into a single model. |
-| <xref:Microsoft.ML.Transforms.Segregator> | Ungroups vector columns into sequences of rows; the inverse of Group transform. |
-| <xref:Microsoft.ML.Transforms.TwoHeterogeneousModelCombiner> | Combines a TransformModel and a PredictorModel into a single PredictorModel. |
+| <xref:Microsoft.ML.Legacy.Transforms.CombinerByContiguousGroupId> | Groups values of a scalar column into a vector based on a contiguous group ID. |
+| <xref:Microsoft.ML.Legacy.Transforms.FeatureCombiner> | Combines all the features into one feature column. |
+| <xref:Microsoft.ML.Legacy.Transforms.ManyHeterogeneousModelCombiner> | Combines a sequence of TransformModels and a PredictorModel into a single PredictorModel. |
+| <xref:Microsoft.ML.Legacy.Transforms.ModelCombiner> | Combines a sequence of TransformModels into a single model. |
+| <xref:Microsoft.ML.Legacy.Transforms.Segregator> | Ungroups vector columns into sequences of rows; the inverse of Group transform. |
+| <xref:Microsoft.ML.Legacy.Transforms.TwoHeterogeneousModelCombiner> | Combines a TransformModel and a PredictorModel into a single PredictorModel. |
 
 ## Feature selection
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.FeatureSelectorByCount> | Selects the slots for which the count of non-default values is greater than or equal to a threshold. |
-| <xref:Microsoft.ML.Transforms.FeatureSelectorByMutualInformation> | Selects the top k slots across all specified columns ordered by their mutual information with the label column. |
+| <xref:Microsoft.ML.Legacy.Transforms.FeatureSelectorByCount> | Selects the slots for which the count of non-default values is greater than or equal to a threshold. |
+| <xref:Microsoft.ML.Legacy.Transforms.FeatureSelectorByMutualInformation> | Selects the top k slots across all specified columns ordered by their mutual information with the label column. |
 
 ## Featurizers
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.HashConverter> | Converts column values into hashes. This transform accepts both numeric and text inputs, both single and vector-valued columns. |
-| <xref:Microsoft.ML.Transforms.TreeLeafFeaturizer> | Trains a tree ensemble, or loads it from a file, then maps a numeric feature vector to three outputs: 1. A vector containing the individual tree outputs of the tree ensemble. 2. A vector indicating the leaves that the feature vector falls on in the tree ensemble. 3. A vector indicating the paths that the feature vector falls on in the tree ensemble. If both a model file and a trainer are specified, the vector will use the model file. If neither are specified, the vector will train a default FastTree model. This can handle key labels by training a regression model towards their optionally permuted indices. |
+| <xref:Microsoft.ML.Legacy.Transforms.HashConverter> | Converts column values into hashes. This transform accepts both numeric and text inputs, both single and vector-valued columns. |
+| <xref:Microsoft.ML.Legacy.Transforms.TreeLeafFeaturizer> | Trains a tree ensemble, or loads it from a file, then maps a numeric feature vector to three outputs: 1. A vector containing the individual tree outputs of the tree ensemble. 2. A vector indicating the leaves that the feature vector falls on in the tree ensemble. 3. A vector indicating the paths that the feature vector falls on in the tree ensemble. If both a model file and a trainer are specified, the vector will use the model file. If neither are specified, the vector will train a default FastTree model. This can handle key labels by training a regression model towards their optionally permuted indices. |
 
 ## Label parsing
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.Dictionarizer> | Converts input values (words, numbers, etc.) to index in a dictionary. |
-| <xref:Microsoft.ML.Transforms.LabelColumnKeyBooleanConverter> | Transforms the label to either key or bool (if needed) to make it suitable for classification. |
-| <xref:Microsoft.ML.Transforms.LabelIndicator> | Label remapper used by OVA. |
-| <xref:Microsoft.ML.Transforms.LabelToFloatConverter> | Transforms the label to float to make it suitable for regression. |
-| <xref:Microsoft.ML.Transforms.PredictedLabelColumnOriginalValueConverter> | Transforms a predicted label column to its original values, unless it is of type bool. |
+| <xref:Microsoft.ML.Legacy.Transforms.Dictionarizer> | Converts input values (words, numbers, etc.) to index in a dictionary. |
+| <xref:Microsoft.ML.Legacy.Transforms.LabelColumnKeyBooleanConverter> | Transforms the label to either key or bool (if needed) to make it suitable for classification. |
+| <xref:Microsoft.ML.Legacy.Transforms.LabelIndicator> | Label remapper used by OVA. |
+| <xref:Microsoft.ML.Legacy.Transforms.LabelToFloatConverter> | Transforms the label to float to make it suitable for regression. |
+| <xref:Microsoft.ML.Legacy.Transforms.PredictedLabelColumnOriginalValueConverter> | Transforms a predicted label column to its original values, unless it is of type bool. |
 
 ## Missing Values
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.MissingValueHandler> | Handle missing values by replacing them with either the default value or the mean/min/max value (for non-text columns only). An indicator column can optionally be concatenated, if the input column type is numeric. |
-| <xref:Microsoft.ML.Transforms.MissingValueIndicator> | Create a boolean output column with the same number of slots as the input column, where the output value is true if the value in the input column is missing. |
-| <xref:Microsoft.ML.Transforms.MissingValuesDropper> | Removes NAs from vector columns. |
-| <xref:Microsoft.ML.Transforms.MissingValuesRowDropper> | Filters out rows that contain missing values. |
-| <xref:Microsoft.ML.Transforms.MissingValueSubstitutor> | Create an output column of the same type and size of the input column, where missing values are replaced with either the default value or the mean/min/max value (for non-text columns only). |
+| <xref:Microsoft.ML.Legacy.Transforms.MissingValueHandler> | Handle missing values by replacing them with either the default value or the mean/min/max value (for non-text columns only). An indicator column can optionally be concatenated, if the input column type is numeric. |
+| <xref:Microsoft.ML.Legacy.Transforms.MissingValueIndicator> | Create a boolean output column with the same number of slots as the input column, where the output value is true if the value in the input column is missing. |
+| <xref:Microsoft.ML.Legacy.Transforms.MissingValuesDropper> | Removes NAs from vector columns. |
+| <xref:Microsoft.ML.Legacy.Transforms.MissingValuesRowDropper> | Filters out rows that contain missing values. |
+| <xref:Microsoft.ML.Legacy.Transforms.MissingValueSubstitutor> | Create an output column of the same type and size of the input column, where missing values are replaced with either the default value or the mean/min/max value (for non-text columns only). |
 
 ## Normalization
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.BinNormalizer> | The values are assigned into equidensity bins and a value is mapped to its bin_number / number_of_bins. |
-| <xref:Microsoft.ML.Transforms.ConditionalNormalizer> | Normalize the columns only if needed. |
-| <xref:Microsoft.ML.Transforms.GlobalContrastNormalizer> | Performs a global contrast normalization on input values: Y = (s * X - M) / D, where s is a scale, M is mean and D is either L2 norm or standard deviation. | 
-| <xref:Microsoft.ML.Transforms.LogMeanVarianceNormalizer> | Normalizes the data based on the computed mean and variance of the logarithm of the data. |
-| <xref:Microsoft.ML.Transforms.LpNormalizer> | Normalize vectors (rows) individually by rescaling them to the unit norm (L2, L1 or LInf). Performs the following operation on a vector X: Y = (X - M) / D, where M is mean and D is either the L2 norm, the L1 norm, or the LInf norm. |
-| <xref:Microsoft.ML.Transforms.MeanVarianceNormalizer> | Normalizes the data based on the computed mean and variance of the data. |
-| <xref:Microsoft.ML.Transforms.MinMaxNormalizer> | Normalizes the data based on the observed minimum and maximum values of the data. |
-| <xref:Microsoft.ML.Transforms.SupervisedBinNormalizer> | Similar to <xref:Microsoft.ML.Transforms.BinNormalizer>, but calculates bins based on correlation with the label column, not equidensity. The new value is bin_number / number_of_bins. |
+| <xref:Microsoft.ML.Legacy.Transforms.BinNormalizer> | The values are assigned into equidensity bins and a value is mapped to its bin_number / number_of_bins. |
+| <xref:Microsoft.ML.Legacy.Transforms.ConditionalNormalizer> | Normalize the columns only if needed. |
+| <xref:Microsoft.ML.Legacy.Transforms.GlobalContrastNormalizer> | Performs a global contrast normalization on input values: Y = (s * X - M) / D, where s is a scale, M is mean and D is either L2 norm or standard deviation. | 
+| <xref:Microsoft.ML.Legacy.Transforms.LogMeanVarianceNormalizer> | Normalizes the data based on the computed mean and variance of the logarithm of the data. |
+| <xref:Microsoft.ML.Legacy.Transforms.LpNormalizer> | Normalize vectors (rows) individually by rescaling them to the unit norm (L2, L1 or LInf). Performs the following operation on a vector X: Y = (X - M) / D, where M is mean and D is either the L2 norm, the L1 norm, or the LInf norm. |
+| <xref:Microsoft.ML.Legacy.Transforms.MeanVarianceNormalizer> | Normalizes the data based on the computed mean and variance of the data. |
+| <xref:Microsoft.ML.Legacy.Transforms.MinMaxNormalizer> | Normalizes the data based on the observed minimum and maximum values of the data. |
+| <xref:Microsoft.ML.Legacy.Transforms.SupervisedBinNormalizer> | Similar to <xref:Microsoft.ML.Legacy.Transforms.BinNormalizer>, but calculates bins based on correlation with the label column, not equidensity. The new value is bin_number / number_of_bins. |
 
 ## Row Filters
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.RowRangeFilter> | Filters a dataview on a column of type Single, Double or Key (contiguous). Keeps the values that are in the specified min/max range. NaNs are always filtered out. If the input is a Key type, the min/max are considered percentages of the number of values. |
-| <xref:Microsoft.ML.Transforms.RowSkipAndTakeFilter> | Allows limiting input to a subset of rows at an optional offset. Can be used to implement data paging. |
-| <xref:Microsoft.ML.Transforms.RowSkipFilter> | Allows limiting input to a subset of rows by skipping a number of rows. |
-| <xref:Microsoft.ML.Transforms.RowTakeFilter> | Allows limiting input to a subset of rows by taking N first rows. |
+| <xref:Microsoft.ML.Legacy.Transforms.RowRangeFilter> | Filters a dataview on a column of type Single, Double or Key (contiguous). Keeps the values that are in the specified min/max range. NaNs are always filtered out. If the input is a Key type, the min/max are considered percentages of the number of values. |
+| <xref:Microsoft.ML.Legacy.Transforms.RowSkipAndTakeFilter> | Allows limiting input to a subset of rows at an optional offset. Can be used to implement data paging. |
+| <xref:Microsoft.ML.Legacy.Transforms.RowSkipFilter> | Allows limiting input to a subset of rows by skipping a number of rows. |
+| <xref:Microsoft.ML.Legacy.Transforms.RowTakeFilter> | Allows limiting input to a subset of rows by taking N first rows. |
 
 ## Schema
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.ColumnConcatenator> | Concatenates two columns of the same item type. |
-| <xref:Microsoft.ML.Transforms.ColumnCopier> | Duplicates columns from the dataset.|
-| <xref:Microsoft.ML.Transforms.ColumnDropper> | Drops columns from the dataset. |
-| <xref:Microsoft.ML.Transforms.ColumnSelector> | Selects a set of columns, dropping all others. |
-| <xref:Microsoft.ML.Transforms.ColumnTypeConverter> | Converts a column to a different type, using standard conversions. |
-| <xref:Microsoft.ML.Transforms.KeyToTextConverter> | KeyToValueTransform utilizes KeyValues metadata to map key indices to the corresponding values in the KeyValues metadata. |
-| <xref:Microsoft.ML.Transforms.NGramTranslator> | Produces a bag of counts of ngrams (sequences of consecutive values of length 1-n) in a given vector of keys. It does so by building a dictionary of ngrams and using the id in the dictionary as the index in the bag. | 
-| <xref:Microsoft.ML.Transforms.OptionalColumnCreator> | If the source column does not exist after deserialization, create a column with the right type and default values. |
+| <xref:Microsoft.ML.Legacy.Transforms.ColumnConcatenator> | Concatenates two columns of the same item type. |
+| <xref:Microsoft.ML.Legacy.Transforms.ColumnCopier> | Duplicates columns from the dataset.|
+| <xref:Microsoft.ML.Legacy.Transforms.ColumnDropper> | Drops columns from the dataset. |
+| <xref:Microsoft.ML.Legacy.Transforms.ColumnSelector> | Selects a set of columns, dropping all others. |
+| <xref:Microsoft.ML.Legacy.Transforms.ColumnTypeConverter> | Converts a column to a different type, using standard conversions. |
+| <xref:Microsoft.ML.Legacy.Transforms.KeyToTextConverter> | KeyToValueTransform utilizes KeyValues metadata to map key indices to the corresponding values in the KeyValues metadata. |
+| <xref:Microsoft.ML.Legacy.Transforms.NGramTranslator> | Produces a bag of counts of ngrams (sequences of consecutive values of length 1-n) in a given vector of keys. It does so by building a dictionary of ngrams and using the id in the dictionary as the index in the bag. | 
+| <xref:Microsoft.ML.Legacy.Transforms.OptionalColumnCreator> | If the source column does not exist after deserialization, create a column with the right type and default values. |
 
 ## Text processing and featurization
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.CharacterTokenizer> | Character-oriented tokenizer where text is considered a sequence of characters. |
-| <xref:Microsoft.ML.Transforms.TextFeaturizer> | A transform that turns a collection of text documents into numerical feature vectors. The feature vectors are normalized counts of (word and/or character) ngrams in a given tokenized text. |
-| <xref:Microsoft.ML.Transforms.TextToKeyConverter> | Converts input values (words, numbers, etc.) to index in a dictionary. |
-| <xref:Microsoft.ML.Transforms.WordEmbeddings> | A transform that converts vectors of text tokens into numeric vectors using a pre-trained model. For more information about the technique, see the [Word embedding](https://en.wikipedia.org/wiki/Word_embedding) Wikipedia page. |
-| <xref:Microsoft.ML.Transforms.WordTokenizer> | The input to this transform is text, and the output is a vector of text containing the words (tokens) in the original text. The separator is space, but any other character (or multiple characters) can be specified. |
+| <xref:Microsoft.ML.Legacy.Transforms.CharacterTokenizer> | Character-oriented tokenizer where text is considered a sequence of characters. |
+| <xref:Microsoft.ML.Legacy.Transforms.TextFeaturizer> | A transform that turns a collection of text documents into numerical feature vectors. The feature vectors are normalized counts of (word and/or character) ngrams in a given tokenized text. |
+| <xref:Microsoft.ML.Legacy.Transforms.TextToKeyConverter> | Converts input values (words, numbers, etc.) to index in a dictionary. |
+| <xref:Microsoft.ML.Legacy.Transforms.WordEmbeddings> | A transform that converts vectors of text tokens into numeric vectors using a pre-trained model. For more information about the technique, see the [Word embedding](https://en.wikipedia.org/wiki/Word_embedding) Wikipedia page. |
+| <xref:Microsoft.ML.Legacy.Transforms.WordTokenizer> | The input to this transform is text, and the output is a vector of text containing the words (tokens) in the original text. The separator is space, but any other character (or multiple characters) can be specified. |
 
 ## Miscellaneous
 
 | Transform | Definition |
 | --- | --- |
-| <xref:Microsoft.ML.Transforms.ApproximateBootstrapSampler> | Approximate bootstrap sampling. |
-| <xref:Microsoft.ML.Transforms.BinaryPredictionScoreColumnsRenamer> | For binary prediction, renames the PredictedLabel and Score columns to include the name of the positive class.|
-| <xref:Microsoft.ML.Transforms.DataCache> | Caches using the specified cache option. |
-| <xref:Microsoft.ML.Transforms.DatasetScorer> | Scores a dataset with a predictor model. |
-| <xref:Microsoft.ML.Transforms.DatasetTransformScorer> | Scores a dataset with a transform model. |
-| <xref:Microsoft.ML.Transforms.NoOperation> | Does nothing. |
-| <xref:Microsoft.ML.Transforms.RandomNumberGenerator> | Adds a column with a generated number sequence. |
-| <xref:Microsoft.ML.Transforms.ScoreColumnSelector> | Selects only the last score columns and the extra columns specified in the arguments. |
-| <xref:Microsoft.ML.Transforms.Scorer> | Turns the predictor model into a transform model. |
-| <xref:Microsoft.ML.Transforms.SentimentAnalyzer> | Uses a pretrained sentiment model to score input strings. |
-| <xref:Microsoft.ML.Transforms.TrainTestDatasetSplitter> | Splits the dataset into train and test sets. |
+| <xref:Microsoft.ML.Legacy.Transforms.ApproximateBootstrapSampler> | Approximate bootstrap sampling. |
+| <xref:Microsoft.ML.Legacy.Transforms.BinaryPredictionScoreColumnsRenamer> | For binary prediction, renames the PredictedLabel and Score columns to include the name of the positive class.|
+| <xref:Microsoft.ML.Legacy.Transforms.DataCache> | Caches using the specified cache option. |
+| <xref:Microsoft.ML.Legacy.Transforms.DatasetScorer> | Scores a dataset with a predictor model. |
+| <xref:Microsoft.ML.Legacy.Transforms.DatasetTransformScorer> | Scores a dataset with a transform model. |
+| <xref:Microsoft.ML.Legacy.Transforms.NoOperation> | Does nothing. |
+| <xref:Microsoft.ML.Legacy.Transforms.RandomNumberGenerator> | Adds a column with a generated number sequence. |
+| <xref:Microsoft.ML.Legacy.Transforms.ScoreColumnSelector> | Selects only the last score columns and the extra columns specified in the arguments. |
+| <xref:Microsoft.ML.Legacy.Transforms.Scorer> | Turns the predictor model into a transform model. |
+| <xref:Microsoft.ML.Legacy.Transforms.SentimentAnalyzer> | Uses a pretrained sentiment model to score input strings. |
+| <xref:Microsoft.ML.Legacy.Transforms.TrainTestDatasetSplitter> | Splits the dataset into train and test sets. |

--- a/docs/machine-learning/tutorials/iris-clustering.md
+++ b/docs/machine-learning/tutorials/iris-clustering.md
@@ -133,19 +133,19 @@ The first step to perform is to load the training data set. In our case, the tra
 
 [!code-csharp[Add step to load data](../../../samples/machine-learning/tutorials/IrisClustering/Program.cs#6)]
 
-The next step is to combine all of the feature columns into the **Features** column using the <xref:Microsoft.ML.Transforms.ColumnConcatenator> transformation class. By default, a learning algorithm processes only features from the **Features** column. Add the following code:
+The next step is to combine all of the feature columns into the **Features** column using the <xref:Microsoft.ML.Legacy.Transforms.ColumnConcatenator> transformation class. By default, a learning algorithm processes only features from the **Features** column. Add the following code:
 
 [!code-csharp[Add step to concatenate columns](../../../samples/machine-learning/tutorials/IrisClustering/Program.cs#7)]
 
 ## Choose a learning algorithm
 
-After adding the data to the pipeline and transforming it into the correct input format, you select a learning algorithm (**learner**). The learner trains the model. ML.NET provides a <xref:Microsoft.ML.Trainers.KMeansPlusPlusClusterer> learner that implements [k-means algorithm](https://en.wikipedia.org/wiki/K-means_clustering) with an improved method for choosing the initial cluster centroids.
+After adding the data to the pipeline and transforming it into the correct input format, you select a learning algorithm (**learner**). The learner trains the model. ML.NET provides a <xref:Microsoft.ML.Legacy.Trainers.KMeansPlusPlusClusterer> learner that implements [k-means algorithm](https://en.wikipedia.org/wiki/K-means_clustering) with an improved method for choosing the initial cluster centroids.
 
 Add the following code into the `Train` method following the data processing code added in the previous step:
 
 [!code-csharp[Add a learner step](../../../samples/machine-learning/tutorials/IrisClustering/Program.cs#8)]
 
-Use the <xref:Microsoft.ML.Trainers.KMeansPlusPlusClusterer.K?displayProperty=nameWithType> property to specify number of clusters. The code above specifies that the data set should be split in three clusters.
+Use the <xref:Microsoft.ML.Legacy.Trainers.KMeansPlusPlusClusterer.K?displayProperty=nameWithType> property to specify number of clusters. The code above specifies that the data set should be split in three clusters.
 
 ## Train the model
 

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -171,11 +171,11 @@ public static async Task<PredictionModel<SentimentData, SentimentPrediction>> Tr
 
 ## Ingest the data
 
-Initialize a new instance of <xref:Microsoft.ML.LearningPipeline> that will include the data loading, data processing/featurization, and model. Add the following code as the first line of the `Train` method:
+Initialize a new instance of <xref:Microsoft.ML.Legacy.LearningPipeline> that will include the data loading, data processing/featurization, and model. Add the following code as the first line of the `Train` method:
 
 [!code-csharp[LearningPipeline](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#5 "Create a learning pipeline")]
 
-The <xref:Microsoft.ML.Data.TextLoader> object is the first part of the pipeline, and loads the training file data.
+The <xref:Microsoft.ML.Legacy.Data.TextLoader> object is the first part of the pipeline, and loads the training file data.
 
 [!code-csharp[TextLoader](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#6 "Add a text loader to the pipeline")]
 
@@ -183,13 +183,13 @@ The <xref:Microsoft.ML.Data.TextLoader> object is the first part of the pipeline
 
 Pre-processing and cleaning data are important tasks that occur before a dataset is used effectively for machine learning. Raw data is often noisy and unreliable, and may be missing values. Using data without these modeling tasks can produce misleading results. ML.NET's transform pipelines allow you to compose a custom set of transforms that are applied to your data before training or testing. The transforms' primary purpose is for data featurization. A transform pipeline's advantage is that after transform pipeline definition, save the pipeline to apply it to test data.
 
-Apply a <xref:Microsoft.ML.Transforms.TextFeaturizer> to convert the `SentimentText` column into a [numeric vector](../resources/glossary.md#numerical-feature-vector) called `Features` used by the machine learning algorithm. This is the preprocessing/featurization step. Using additional components available in ML.NET can enable better results with your model. Add `TextFeaturizer` to the pipeline as the next line of code:
+Apply a <xref:Microsoft.ML.Legacy.Transforms.TextFeaturizer> to convert the `SentimentText` column into a [numeric vector](../resources/glossary.md#numerical-feature-vector) called `Features` used by the machine learning algorithm. This is the preprocessing/featurization step. Using additional components available in ML.NET can enable better results with your model. Add `TextFeaturizer` to the pipeline as the next line of code:
 
 [!code-csharp[TextFeaturizer](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#7 "Add a TextFeaturizer to the pipeline")]
 
 ## Choose a learning algorithm
 
-The <xref:Microsoft.ML.Trainers.FastTreeBinaryClassifier> object is a decision tree learner you'll use in this pipeline. Similar to the featurization step, trying out different learners available in ML.NET and changing their parameters leads to different results. For tuning, you can set [hyperparameters](../resources/glossary.md#hyperparameter) like <xref:Microsoft.ML.Trainers.FastTreeBinaryClassifier.NumTrees>, <xref:Microsoft.ML.Trainers.FastTreeBinaryClassifier.NumLeaves>, and <xref:Microsoft.ML.Trainers.FastTreeBinaryClassifier.MinDocumentsInLeafs>. These hyperparameters are set before anything affects the model and are model-specific. They're used to tune the decision tree for performance, so larger values can negatively impact performance.
+The <xref:Microsoft.ML.Legacy.Trainers.FastTreeBinaryClassifier> object is a decision tree learner you'll use in this pipeline. Similar to the featurization step, trying out different learners available in ML.NET and changing their parameters leads to different results. For tuning, you can set [hyperparameters](../resources/glossary.md#hyperparameter) like <xref:Microsoft.ML.Legacy.Trainers.FastTreeBinaryClassifier.NumTrees>, <xref:Microsoft.ML.Legacy.Trainers.FastTreeBinaryClassifier.NumLeaves>, and <xref:Microsoft.ML.Legacy.Trainers.FastTreeBinaryClassifier.MinDocumentsInLeafs>. These hyperparameters are set before anything affects the model and are model-specific. They're used to tune the decision tree for performance, so larger values can negatively impact performance.
 
 Add the following code to the `Train` method:
 
@@ -197,7 +197,7 @@ Add the following code to the `Train` method:
 
 ## Train the model
 
-You train the model, <xref:Microsoft.ML.PredictionModel%602>, based on the dataset that has been loaded and transformed. `pipeline.Train<SentimentData, SentimentPrediction>()` trains the pipeline (loads the data, trains the featurizer and learner). The experiment is not executed until this happens.
+You train the model, <xref:Microsoft.ML.Legacy.PredictionModel%602>, based on the dataset that has been loaded and transformed. `pipeline.Train<SentimentData, SentimentPrediction>()` trains the pipeline (loads the data, trains the featurizer and learner). The experiment is not executed until this happens.
 
 Add the following code to the `Train` method:
 
@@ -235,15 +235,15 @@ Add a call to the new method from the `Main` method, right under the `Train` met
 
 [!code-csharp[CallEvaluate](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#12 "Call the Evaluate method")]
 
-The <xref:Microsoft.ML.Data.TextLoader> class loads the new test dataset with the same schema. You can evaluate the model using this dataset as a quality check. Add the following code to the `Evaluate` method:
+The <xref:Microsoft.ML.Legacy.Data.TextLoader> class loads the new test dataset with the same schema. You can evaluate the model using this dataset as a quality check. Add the following code to the `Evaluate` method:
 
 [!code-csharp[LoadText](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#13 "Load the test dataset")]
 
-The <xref:Microsoft.ML.Models.BinaryClassificationEvaluator> object computes the quality metrics for the `PredictionModel` using the specified dataset. To see those metrics, add the evaluator as the next line in the `Evaluate` method, with the following code:
+The <xref:Microsoft.ML.Legacy.Models.BinaryClassificationEvaluator> object computes the quality metrics for the `PredictionModel` using the specified dataset. To see those metrics, add the evaluator as the next line in the `Evaluate` method, with the following code:
 
 [!code-csharp[BinaryEvaluator](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#14 "Create the binary evaluator")]
 
-The <xref:Microsoft.ML.Models.BinaryClassificationMetrics> contains the overall metrics computed by binary classification evaluators. To display these to determine the quality of the model, you need to get the metrics first. Add the following code:
+The <xref:Microsoft.ML.Legacy.Models.BinaryClassificationMetrics> contains the overall metrics computed by binary classification evaluators. To display these to determine the quality of the model, you need to get the metrics first. Add the following code:
 
 [!code-csharp[CreateMetrics](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#15 "Evaluate the model and create metrics")]
 
@@ -279,7 +279,7 @@ Add some comments to test the trained model's predictions in the `Predict` metho
 
 [!code-csharp[PredictionData](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#18 "Create test data for predictions")]
 
-Now that you have a model, you can use that to predict the positive or negative sentiment of the comment data using the <xref:Microsoft.ML.PredictionModel.Predict%2A?displayProperty=nameWithType> method. To get a prediction, use `Predict` on new data. Note that the input data is a string and the model includes the featurization. Your pipeline is in sync during training and prediction. You didn’t have to write preprocessing/featurization code specifically for predictions, and the same API takes care of both batch and one-time predictions.
+Now that you have a model, you can use that to predict the positive or negative sentiment of the comment data using the <xref:Microsoft.ML.Legacy.PredictionModel.Predict%2A?displayProperty=nameWithType> method. To get a prediction, use `Predict` on new data. Note that the input data is a string and the model includes the featurization. Your pipeline is in sync during training and prediction. You didn’t have to write preprocessing/featurization code specifically for predictions, and the same API takes care of both batch and one-time predictions.
 
 [!code-csharp[Predict](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#19 "Create predictions of sentiments")]
 

--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -145,13 +145,13 @@ pipeline.Add(new TextLoader(_datapath).CreateFrom<TaxiTrip>(useHeader: true, sep
 
 In the next steps we refer to the columns by the names defined in the `TaxiTrip` class.
 
-When the model is trained and evaluated, by default, the values in the **Label** column are considered as correct values to be predicted. As we want to predict the taxi trip fare, copy the `FareAmount` column into the **Label** column. To do that, use <xref:Microsoft.ML.Transforms.ColumnCopier> and add the following code:
+When the model is trained and evaluated, by default, the values in the **Label** column are considered as correct values to be predicted. As we want to predict the taxi trip fare, copy the `FareAmount` column into the **Label** column. To do that, use <xref:Microsoft.ML.Legacy.Transforms.ColumnCopier> and add the following code:
 
 ```csharp
 pipeline.Add(new ColumnCopier(("FareAmount", "Label")));
 ```
 
-The algorithm that trains the model requires **numeric** features, so you have to transform the categorical data (`VendorId`, `RateCode`, and `PaymentType`) values into numbers. To do that, use <xref:Microsoft.ML.Transforms.CategoricalOneHotVectorizer>, which assigns different numeric key values to the different values in each of the columns, and add the following code:
+The algorithm that trains the model requires **numeric** features, so you have to transform the categorical data (`VendorId`, `RateCode`, and `PaymentType`) values into numbers. To do that, use <xref:Microsoft.ML.Legacy.Transforms.CategoricalOneHotVectorizer>, which assigns different numeric key values to the different values in each of the columns, and add the following code:
 
 ```csharp
 pipeline.Add(new CategoricalOneHotVectorizer("VendorId",
@@ -159,7 +159,7 @@ pipeline.Add(new CategoricalOneHotVectorizer("VendorId",
                                              "PaymentType"));
 ```
 
-The last step in data preparation combines all of the feature columns into the **Features** column using the <xref:Microsoft.ML.Transforms.ColumnConcatenator> transformation class. By default, a learning algorithm processes only features from the **Features** column. Add the following code:
+The last step in data preparation combines all of the feature columns into the **Features** column using the <xref:Microsoft.ML.Legacy.Transforms.ColumnConcatenator> transformation class. By default, a learning algorithm processes only features from the **Features** column. Add the following code:
 
 ```csharp
 pipeline.Add(new ColumnConcatenator("Features",
@@ -177,9 +177,9 @@ Notice that the `TripTime` column, which corresponds to the `trip_time_in_secs` 
 
 ## Choose a learning algorithm
 
-After adding the data to the pipeline and transforming it into the correct input format, you select a learning algorithm (**learner**). The learner trains the model. You chose a **regression** task for this problem, so you use a <xref:Microsoft.ML.Trainers.FastTreeRegressor> learner, which is one of the regression learners provided by ML.NET.
+After adding the data to the pipeline and transforming it into the correct input format, you select a learning algorithm (**learner**). The learner trains the model. You chose a **regression** task for this problem, so you use a <xref:Microsoft.ML.Legacy.Trainers.FastTreeRegressor> learner, which is one of the regression learners provided by ML.NET.
 
-<xref:Microsoft.ML.Trainers.FastTreeRegressor> learner utilizes gradient boosting. Gradient boosting is a machine learning technique for regression problems. It builds each regression tree in a step-wise fashion. It uses a pre-defined loss function to measure the error in each step and correct for it in the next. The result is a prediction model that is actually an ensemble of weaker prediction models. For more information about gradient boosting, see [Boosted Decision Tree Regression](/azure/machine-learning/studio-module-reference/boosted-decision-tree-regression).
+<xref:Microsoft.ML.Legacy.Trainers.FastTreeRegressor> learner utilizes gradient boosting. Gradient boosting is a machine learning technique for regression problems. It builds each regression tree in a step-wise fashion. It uses a pre-defined loss function to measure the error in each step and correct for it in the next. The result is a prediction model that is actually an ensemble of weaker prediction models. For more information about gradient boosting, see [Boosted Decision Tree Regression](/azure/machine-learning/studio-module-reference/boosted-decision-tree-regression).
 
 Add the following code into the `Train` method following the data processing code added in the previous step:
 


### PR DESCRIPTION
An APEX engineer warned me that we have lots of broken links due to changes in namespaces for ML.NET.

It seems that we'd only start getting the warnings once we run full builds. So it might be a good practice to run full builds on affected docs repos after each release.

For the transforms article, some tokenizer APIs exist in both namespaces (in our docs at least). So I wasn't sure which one to keep: legacy or not?