### PR TITLE
Minor .NET library guidance improvements

### DIFF
--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -16,7 +16,7 @@ Aspects of high-quality open-source .NET libraries:
 > * **Stable** - Good .NET libraries coexist in the .NET ecosystem, running in applications built with many libraries.
 > * **Designed to evolve** - .NET libraries should improve and evolve over time, while supporting existing users.
 > * **Debuggable** - .NET libraries should use the latest tools to create a great debugging experience for users.
-> * **Trusted** - .NET libraries have developers trust by publishing to NuGet using security best practices.
+> * **Trusted** - .NET libraries have developers' trust by publishing to NuGet using security best practices.
 
 > [!div class="nextstepaction"]
 > [Get Started](./get-started.md)

--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -13,9 +13,9 @@ Aspects of high-quality open-source .NET libraries:
 
 > [!div class="checklist"]
 > * **Inclusive** - Good .NET libraries strive to support many platforms and applications.
-> * **Stable** - Good .NET libraries co-exist in the .NET ecosystem, running in applications built with many libraries.
+> * **Stable** - Good .NET libraries coexist in the .NET ecosystem, running in applications built with many libraries.
 > * **Designed to evolve** - .NET libraries should improve and evolve over time, while supporting existing users.
-> * **Debuggable** - A high-quality .NET library should use the latest tools to create a great debugging experience for users.
+> * **Debuggable** - .NET libraries should use the latest tools to create a great debugging experience for users.
 > * **Trusted** - .NET libraries have developers trust by publishing to NuGet using security best practices.
 
 > [!div class="nextstepaction"]

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -39,7 +39,9 @@ The benefits of strong naming are:
 You should strong name your open-source .NET libraries. Strong naming an assembly ensures the most people can use it, and strict assembly loading only affects the .NET Framework.
 
 > [!NOTE]
-> This guidance is specific to .NET libraries. Strong naming is not required by most .NET applications and should not be done by default.
+> This guidance is specific to publicly distributed .NET libraries. For example, .NET libraries published on NuGet.org.
+>
+> Strong naming is not required by most .NET applications and should not be done by default.
 
 **✔️ CONSIDER** strong naming your library's assemblies.
 

--- a/docs/standard/library-guidance/strong-naming.md
+++ b/docs/standard/library-guidance/strong-naming.md
@@ -39,7 +39,7 @@ The benefits of strong naming are:
 You should strong name your open-source .NET libraries. Strong naming an assembly ensures the most people can use it, and strict assembly loading only affects the .NET Framework.
 
 > [!NOTE]
-> This guidance is specific to publicly distributed .NET libraries. For example, .NET libraries published on NuGet.org.
+> This guidance is specific to publicly distributed .NET libraries, such as .NET libraries published on NuGet.org.
 >
 > Strong naming is not required by most .NET applications and should not be done by default.
 


### PR DESCRIPTION
Update the .NET strong naming guidance to make it clear it is for publicly distributed libraries, and not class libraries in a .NET application.

@terrajobst 