### PR TITLE
Add Windows Service as a host for IHostedService

### DIFF
--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
@@ -231,7 +231,7 @@ The following image 8-26 shows a visual summary of the classes and interfaced in
 
 ### Deployment considerations and takeaways
 
-It is important to note that the way you deploy your ASP.NET Core `WebHost` or .NET Core `Host` might impact the final solution. For instance, if you deploy your `WebHost` on IIS or a regular Azure App Service, your host can be shut down because of app pool recycles. But if you are deploying your host as a container into an orchestrator like Kubernetes or Service Fabric, you can control the assured number of live instances of your host. In addition, you could consider other approaches in the cloud especially made for these scenarios, like Azure Functions. 
+It is important to note that the way you deploy your ASP.NET Core `WebHost` or .NET Core `Host` might impact the final solution. For instance, if you deploy your `WebHost` on IIS or a regular Azure App Service, your host can be shut down because of app pool recycles. But if you are deploying your host as a container into an orchestrator like Kubernetes or Service Fabric, you can control the assured number of live instances of your host. In addition, you could consider other approaches in the cloud especially made for these scenarios, like Azure Functions. Finally, if you need the service to be running all the time and are deploying on a Windows Server you could use a Windows Service.
 
 But even for a `WebHost` deployed into an app pool, there are scenarios like repopulating or flushing application’s in-memory cache, that would be still applicable.
 


### PR DESCRIPTION
## Summary

Running a IHostedService in App Service or IIS is subject to app pool recycles.  Add a suggestion to use a Windows Service if the service is being hosted on Windows Server and must stay running all the time.
