### PR TITLE
Remove unnecessary cast syntax.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-interface-members_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/how-to-explicitly-implement-interface-members_1.cs
@@ -31,7 +31,7 @@ class Box : IDimensions
         Box box1 = new Box(30.0f, 20.0f);
 
         // Declare an interface instance dimensions:
-        IDimensions dimensions = (IDimensions)box1;
+        IDimensions dimensions = box1;
 
         // The following commented lines would produce compilation 
         // errors because they try to access an explicitly implemented


### PR DESCRIPTION
## Summary

The cast syntax is unnecessary here, which is consistent with changes introduced in #6507.
