### PR TITLE
Remove unnecessary cast syntax.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/explicit-interface-implementation_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/explicit-interface-implementation_1.cs
@@ -3,8 +3,8 @@ class Test
     static void Main()
     {
         SampleClass sc = new SampleClass();
-        IControl ctrl = (IControl)sc;
-        ISurface srfc = (ISurface)sc;
+        IControl ctrl = sc;
+        ISurface srfc = sc;
 
         // The following lines all call the same method.
         sc.Paint();


### PR DESCRIPTION
## Summary

The cast syntax is unnecessary here, which is consistent with changes introduced in #6507.
