### PR TITLE
Remove unnecessary cast syntax.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/explicit-interface-implementation_3.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/explicit-interface-implementation_3.cs
@@ -3,10 +3,10 @@
         SampleClass obj = new SampleClass();
         //obj.Paint();  // Compiler error.
 
-        IControl c = (IControl)obj;
+        IControl c = obj;
         c.Paint();  // Calls IControl.Paint on SampleClass.
 
-        ISurface s = (ISurface)obj;
+        ISurface s = obj;
         s.Paint(); // Calls ISurface.Paint on SampleClass.
 
         // Output:


### PR DESCRIPTION
## Summary

The cast syntax is unnecessary here, which is consistent with changes introduced in #6507.