### PR TITLE
.NET Core Guide - minor list punctuation fixes, small wording change

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT) general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and IoT applications.
+[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform; supports Windows, macOS and Linux; and can be used to build device, cloud, and IoT applications.
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform; supports Windows, macOS, and Linux; and can be used to build device, cloud, and IoT applications.
+[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform, supporting Windows, macOS, and Linux, and can be used to build device, cloud, and IoT applications.
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform, supporting Windows, macOS, and Linux, and can be used to build device, cloud, and IoT applications.
+[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform (supporting Windows, macOS, and Linux) and can be used to build device, cloud, and IoT applications.
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform; supports Windows, macOS and Linux; and can be used to build device, cloud, and IoT applications.
+[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform; supports Windows, macOS, and Linux; and can be used to build device, cloud, and IoT applications.
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 


### PR DESCRIPTION
## Summary

- Added semi-colons (re: https://docs.microsoft.com/style-guide/punctuation/semicolons)
- Added two missing commas
- Changed "can be used in" to "can be used to build"
