### PR TITLE
Add next button to library guidance index

### DIFF
--- a/docs/standard/library-guidance/get-started.md
+++ b/docs/standard/library-guidance/get-started.md
@@ -40,4 +40,5 @@ Good .NET libraries evolve over time, adding features, fixing bugs, and improvin
 It's important for a .NET library to find a balance between stability for existing users and innovation for the future. Learn about the different kinds of breaking changes and strategies for adding new features while maintaining backwards compatibility.
 
 >[!div class="step-by-step"]
+[Previous](./index.md)
 [Next](./cross-platform-targeting.md)

--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -40,3 +40,6 @@ On the other hand, **Consider** recommendations should generally be followed, bu
 And finally, **do not** indicates something you should almost never do:
 
 **❌ DO NOT** publish strong-named and non-strong-named versions of your library. For example, `Contoso.Api` and `Contoso.Api.StrongNamed`.
+
+>[!div class="step-by-step"]
+[Next](./get-started.md)


### PR DESCRIPTION
Some readers do not notice the Get Started button and menu, and they think the index page is the entire guidance.

Add Next button to the bottom of the page to make it clearer there is more content.

Fixes https://github.com/dotnet/docs/issues/8389
Fixes https://github.com/dotnet/docs/issues/8385