### PR TITLE
Asynchronous programming patterns: removed duplication

### DIFF
--- a/docs/standard/asynchronous-programming-patterns/index.md
+++ b/docs/standard/asynchronous-programming-patterns/index.md
@@ -1,25 +1,25 @@
 ---
-title: "Asynchronous Programming Patterns"
-ms.date: "03/30/2017"
+title: "Asynchronous programming patterns"
+ms.date: "10/16/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
-  - "asynchronous design patterns, .NET Framework"
+  - "asynchronous design patterns, .NET"
   - ".NET Framework, asynchronous design patterns"
 ms.assetid: 4ece5c0b-f8fe-4114-9862-ac02cfe5a5d7
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Asynchronous Programming Patterns
+# Asynchronous programming patterns
 
-The .NET Framework provides three patterns for performing asynchronous operations:  
+.NET provides three patterns for performing asynchronous operations:  
+
+- **Task-based Asynchronous Pattern (TAP)**, which uses a single method to represent the initiation and completion of an asynchronous operation. TAP was introduced in the .NET Framework 4. **It's the recommended approach to asynchronous programming in .NET.** The [async](~/docs/csharp/language-reference/keywords/async.md) and [await](~/docs/csharp/language-reference/keywords/await.md) keywords in C# and the [Async](~/docs/visual-basic/language-reference/modifiers/async.md) and [Await](~/docs/visual-basic/language-reference/operators/await-operator.md) operators in Visual Basic add language support for TAP. For more information, see [Task-based Asynchronous Pattern (TAP)](task-based-asynchronous-pattern-tap.md).  
+
+- **Event-based Asynchronous Pattern (EAP)**, which is the event-based legacy model for providing asynchronous behavior. It requires a method that has the `Async` suffix and one or more events, event handler delegate types, and `EventArg`-derived types. EAP was introduced in the .NET Framework 2.0. It's no longer recommended for new development. For more information, see [Event-based Asynchronous Pattern (EAP)](event-based-asynchronous-pattern-eap.md).  
+
+- **Asynchronous Programming Model (APM)** pattern (also called the <xref:System.IAsyncResult> pattern), which is the legacy model that uses the <xref:System.IAsyncResult> interface to provide asynchronous behavior. In this pattern, synchronous operations require `Begin` and `End` methods (for example, `BeginWrite` and `EndWrite` to implement an asynchronous write operation). This pattern is no longer recommended for new development. For more information, see [Asynchronous Programming Model (APM)](asynchronous-programming-model-apm.md).  
   
-- **Asynchronous Programming Model (APM)** pattern (also called the <xref:System.IAsyncResult> pattern), where asynchronous operations require `Begin` and `End` methods (for example, `BeginWrite` and `EndWrite` for asynchronous write operations). This pattern is no longer recommended for new development. For more information, see [Asynchronous Programming Model (APM)](../../../docs/standard/asynchronous-programming-patterns/asynchronous-programming-model-apm.md).  
-  
-- **Event-based Asynchronous Pattern (EAP)**, which requires a method that has the `Async` suffix, and also requires one or more events, event handler delegate types, and `EventArg`-derived types. EAP was introduced in the .NET Framework 2.0. It is no longer recommended for new development. For more information, see [Event-based Asynchronous Pattern (EAP)](../../../docs/standard/asynchronous-programming-patterns/event-based-asynchronous-pattern-eap.md).  
-  
-- **Task-based Asynchronous Pattern (TAP)**, which uses a single method to represent the initiation and completion of an asynchronous operation. TAP was introduced in the .NET Framework 4 and is the recommended approach to asynchronous programming in the .NET Framework. The [async](~/docs/csharp/language-reference/keywords/async.md) and [await](~/docs/csharp/language-reference/keywords/await.md) keywords in C# and the [Async](~/docs/visual-basic/language-reference/modifiers/async.md) and [Await](~/docs/visual-basic/language-reference/operators/await-operator.md) operators in Visual Basic Language add language support for TAP. For more information, see [Task-based Asynchronous Pattern (TAP)](../../../docs/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md).  
-  
-## Comparing Patterns  
+## Comparison of patterns
 
 For a quick comparison of how the three patterns model asynchronous operations, consider a `Read` method that reads a specified amount of data into a provided buffer starting at a specified offset:  
   
@@ -29,19 +29,16 @@ public class MyClass
     public int Read(byte [] buffer, int offset, int count);  
 }  
 ```  
+
+The TAP counterpart of this method would expose the following single `ReadAsync` method:  
   
-The APM counterpart of this method would expose the `BeginRead` and `EndRead` methods:  
-  
-```csharp  
+```csharp
 public class MyClass  
 {  
-    public IAsyncResult BeginRead(  
-        byte [] buffer, int offset, int count,   
-        AsyncCallback callback, object state);  
-    public int EndRead(IAsyncResult asyncResult);  
+    public Task<int> ReadAsync(byte [] buffer, int offset, int count);  
 }  
-```  
-  
+```
+
 The EAP counterpart would expose the following set of types and members:  
   
 ```csharp  
@@ -52,27 +49,21 @@ public class MyClass
 }  
 ```  
   
-The TAP counterpart would expose the following single `ReadAsync` method:  
+The APM counterpart would expose the `BeginRead` and `EndRead` methods:  
   
 ```csharp  
 public class MyClass  
 {  
-    public Task<int> ReadAsync(byte [] buffer, int offset, int count);  
+    public IAsyncResult BeginRead(  
+        byte [] buffer, int offset, int count,   
+        AsyncCallback callback, object state);  
+    public int EndRead(IAsyncResult asyncResult);  
 }  
 ```  
-  
-For a comprehensive discussion of TAP, APM, and EAP, see the links provided in the next section.  
-  
-## Related topics
-
-| Title | Description |
-| ----- | ----------- |
-| [Asynchronous Programming Model (APM)](../../../docs/standard/asynchronous-programming-patterns/asynchronous-programming-model-apm.md) | Describes the legacy model that uses the <xref:System.IAsyncResult> interface to provide asynchronous behavior. This model is no longer recommended for new development. |
-| [Event-based Asynchronous Pattern (EAP)](../../../docs/standard/asynchronous-programming-patterns/event-based-asynchronous-pattern-eap.md) | Describes the event-based legacy model for providing asynchronous behavior. This model is no longer recommended for new development. |
-| [Task-based Asynchronous Pattern (TAP)](../../../docs/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md) | Describes the new asynchronous pattern based on the <xref:System.Threading.Tasks> namespace. This model is the recommended approach to asynchronous programming in the .NET Framework 4 and later versions. |
 
 ## See also
 
-- [Asynchronous programming in C#](~/docs/csharp/async.md)   
-- [Async Programming in F#](~/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md)   
+- [Async in depth](../async-in-depth.md)
+- [Asynchronous programming in C#](~/docs/csharp/async.md)
+- [Async Programming in F#](~/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md)
 - [Asynchronous Programming with Async and Await (Visual Basic)](~/docs/visual-basic/programming-guide/concepts/async/index.md)


### PR DESCRIPTION
The list at the beginning of the async programming patterns overview:
https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/

duplicates the table at the end of the article. Thus, the table can be removed.

Also reordered listing of patterns, such that it matches TOC and the recommend TAP goes first.
