### PR TITLE
Add NuGet repository metadata, fixes #8378

### DIFF
--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -53,6 +53,7 @@ A NuGet package supports many [metadata properties](/nuget/reference/nuspec). Th
 | `PackageIconUrl`                   | `iconUrl`                  | A URL for an image to use as the icon for the package. URL should be HTTPS and the image should be 64x64 and have a transparent background.             |
 | `PackageProjectUrl`                | `projectUrl`               | A URL for the project homepage or source repository.             |
 | `PackageLicenseUrl`                | `licenseUrl`               | A URL to the project license. Can be the URL to the `LICENSE` file in source control.             |
+| `RepositoryUrl` and `RepositoryType` | `repository url="" type=""` | A URL that can be directly used by source control software of the specified type. It should not be an HTML page. |
 
 **✔️ CONSIDER** choosing a NuGet package name with a prefix that meets NuGet's prefix reservation [criteria](/nuget/reference/id-prefix-reservation).
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -51,7 +51,6 @@ A NuGet package supports many [metadata properties](/nuget/reference/nuspec). Th
 | `PackageIconUrl`                   | `iconUrl`                  | A URL for an image to use as the icon for the package. URL should be HTTPS and the image should be 64x64 and have a transparent background.             |
 | `PackageProjectUrl`                | `projectUrl`               | A URL for the project homepage or source repository.             |
 | `PackageLicenseUrl`                | `licenseUrl`               | A URL to the project license. Can be the URL to the `LICENSE` file in source control.             |
-| `RepositoryUrl` and `RepositoryType` | `repository url="" type=""` | A URL that can be directly used by source control software of the specified type. It should not be an HTML page. |
 
 **✔️ CONSIDER** choosing a NuGet package name with a prefix that meets NuGet's prefix reservation [criteria](/nuget/reference/id-prefix-reservation).
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -32,8 +32,6 @@ The older way of creating a NuGet package is with a `*.nuspec` file and the `nug
 
 **✔️ CONSIDER** using an SDK-style project file to create the NuGet package.
 
-**✔️ CONSIDER** setting up SourceLink to add source control metadata to your assemblies and NuGet package.
-
 ## Package dependencies
 
 NuGet package dependencies are covered in detail in the [Dependencies](./dependencies.md) article.
@@ -67,6 +65,12 @@ A NuGet package supports many [metadata properties](/nuget/reference/nuspec). Th
 > Sites like NuGet.org run with HTTPS enabled and displaying a non-HTTPS image will create a mixed content warning.
 
 **✔️ DO** use a package icon image that is 64x64 and has a transparent background for best viewing results.
+
+**✔️ CONSIDER** setting up [SourceLink](./sourcelink.md) to add source control metadata to your assemblies and NuGet package.
+
+> SourceLink automatically adds `RepositoryUrl` and `RepositoryType` metadata to the NuGet package.
+> SourceLink also adds information about the exact source code the package was built from.
+> For example, a package created from a Git repository will have the commit hash added as metadata.
 
 ## Pre-release packages
 


### PR DESCRIPTION
Adds NuGet `RepositoryUrl` and `RepositoryType` metadata fields in .NET library guidance.

Fixes #8378
