### PR TITLE
Library guidance: clarified intent of the section

### DIFF
--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -25,7 +25,7 @@ Aspects of high-quality open-source .NET libraries:
 
 Articles in this guidance present recommendations of four types: **Do**, **Consider**, **Avoid**, and **Do not**. The type of recommendation indicates how strongly it should be followed.
 
-You almost always should follow a **Do** recommendation. For example:
+You should almost always follow a **Do** recommendation. For example:
 
 **✔️ DO** distribute your library using a NuGet package.
 

--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -23,7 +23,7 @@ Aspects of high-quality open-source .NET libraries:
 
 ## Types of recommendations
 
-Articles in this guidance present recommendations of four types: **Do**, **Consider**, **Avoid**, and **Do not**. The type of a recommendation indicates how strongly the recommendation should be followed.
+Articles in this guidance present recommendations of four types: **Do**, **Consider**, **Avoid**, and **Do not**. The type of recommendation indicates how strongly it should be followed.
 
 You almost always should follow a **Do** recommendation. For example:
 

--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -3,7 +3,7 @@ title: Open-source library guidance
 description: Best practice recommendations for developers to create high quality .NET libraries.
 author: jamesnk
 ms.author: mairaw
-ms.date: 10/02/2018
+ms.date: 10/17/2018
 ---
 # Open-source library guidance
 
@@ -21,11 +21,11 @@ Aspects of high-quality open-source .NET libraries:
 > [!div class="nextstepaction"]
 > [Get Started](./get-started.md)
 
-## Recommendations
+## Types of recommendations
 
-With each article, there is a list of recommendations for your .NET library using **Do**, **Consider**, **Avoid**, and **Do not**. The wording of each recommendation indicates how strongly it should be followed.
+Articles in this guidance present recommendations of four types: **Do**, **Consider**, **Avoid**, and **Do not**. The type of a recommendation indicates how strongly the recommendation should be followed.
 
-A **Do** recommendation is one that should almost always be followed:
+You almost always should follow a **Do** recommendation. For example:
 
 **✔️ DO** distribute your library using a NuGet package.
 
@@ -33,11 +33,11 @@ On the other hand, **Consider** recommendations should generally be followed, bu
 
 **✔️ CONSIDER** using [SemVer 2.0.0](https://semver.org/) to version your NuGet package.
 
-**Avoid** recommendations are things that are generally not a good idea, but breaking the rule sometimes makes sense:
+**Avoid** recommendations mention things that are generally not a good idea, but breaking the rule sometimes makes sense:
 
 **❌ AVOID** NuGet package references that demand an exact version.
 
-And finally, **do not** indicates something you should almost never do:
+And finally, **Do not** recommendations indicate something you should almost never do:
 
 **❌ DO NOT** publish strong-named and non-strong-named versions of your library. For example, `Contoso.Api` and `Contoso.Api.StrongNamed`.
 

--- a/docs/standard/library-guidance/index.md
+++ b/docs/standard/library-guidance/index.md
@@ -23,7 +23,7 @@ Aspects of high-quality open-source .NET libraries:
 
 ## Types of recommendations
 
-Articles in this guidance present recommendations of four types: **Do**, **Consider**, **Avoid**, and **Do not**. The type of recommendation indicates how strongly it should be followed.
+Each article presents four types of recommendations: **Do**, **Consider**, **Avoid**, and **Do not**. The type of recommendation indicates how strongly it should be followed.
 
 You should almost always follow a **Do** recommendation. For example:
 


### PR DESCRIPTION
This PR makes the purpose of the following section clear:
https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/#recommendations

This section is not for recommendations, but introduce the types of recommendations used throughout the guidance.

/cc: @JamesNK  

