### PR TITLE
Added topic for Visual Basic null-conditional operators 

### DIFF
--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -1,16 +1,10 @@
 ---
-title: "Null-conditional Operators (C# and Visual Basic)"
+title: "Null-conditional Operators (C# Reference)"
 ms.date: 04/03/2015
-dev_langs: 
-  - "csharp"
-  - "vb"
 helpviewer_keywords: 
   - "null-conditional operators [C#]"
-  - "null-conditional operators [Visual Basic]"
   - "?. operator [C#]"
-  - "?. operator [Visual Basic]"
   - "?[] operator [C#]"
-  - "?[] operator [Visual Basic]"
 ms.assetid: 9c7b2c8f-a785-44ca-836c-407bfb6d27f5
 ---
 # ?. and ?[] null-conditional Operators (C# and Visual Basic)
@@ -24,24 +18,13 @@ Customer first = customers?[0];  // null if customers is null
 int? count = customers?[0]?.Orders?.Count();  // null if customers, the first customer, or Orders is null  
 ```  
   
-```vb  
-Dim length = customers?.Length  ' null if customers is null  
-Dim first as Customer = customers?(0)  ' null if customers is null  
-Dim count as Integer? = customers?(0)?.Orders?.Count()  ' null if customers, the first customer, or Orders is null  
-```  
-  
- The null-conditional operators are short-circuiting.  If one operation in a chain of conditional member access and index operation returns null, then the rest of the chain’s execution stops.  In the following example, `E` doesn't execute if `A`, `B`, or `C` evaluates to null.
+ The null-conditional operators are short-circuiting.  If one operation in a chain of conditional member access and index operations returns null, the rest of the chain’s execution stops.  In the following example, `E` doesn't execute if `A`, `B`, or `C` evaluates to null.
   
 ```csharp
 A?.B?.C?.Do(E);
 A?.B?.C?[E];
 ```
 
-```vb
-A?.B?.C?.Do(E);
-A?.B?.C?(E);
-```  
-  
  Another use for the null-conditional member access is invoking delegates in a thread-safe way with much less code.  The old way requires code like the following:  
   
 ```csharp  
@@ -50,11 +33,6 @@ if (handler != null)
     handler(…);
 ```  
   
-```vb  
-Dim handler = AddressOf(Me.PropertyChanged)  
-If handler IsNot Nothing  
-    Call handler(…)  
-```  
   
  The new way is much simpler:  
   
@@ -62,20 +40,13 @@ If handler IsNot Nothing
 PropertyChanged?.Invoke(…)  
 ```  
 
-```vb
-PropertyChanged?.Invoke(…)
-```  
-  
  The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in a temporary variable. You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  
   
 ## Language Specifications  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
- For more information, see the [Visual Basic Language Reference](../../../visual-basic/language-reference/index.md).  
   
 ## See Also
 
 - [?? (null-coalescing operator)](null-coalescing-operator.md)  
 - [C# Reference](../../../csharp/language-reference/index.md)  
 - [C# Programming Guide](../../../csharp/programming-guide/index.md)  
-- [Visual Basic Programming Guide](../../../visual-basic/programming-guide/index.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -700,6 +700,8 @@
 ##### [\= Operator](visual-basic/language-reference/operators/integer-division-assignment-operator.md)
 ##### [^ Operator](visual-basic/language-reference/operators/exponentiation-operator.md)
 ##### [^= Operator](visual-basic/language-reference/operators/exponentiation-assignment-operator.md)
+##### [?() Operator](visual-basic/language-reference/operators/null-conditional-operators.md)
+##### [?. Operator](visual-basic/language-reference/operators/null-conditional-operators.md)
 ##### [AddressOf Operator](visual-basic/language-reference/operators/addressof-operator.md)
 ##### [And Operator](visual-basic/language-reference/operators/and-operator.md)
 ##### [AndAlso Operator](visual-basic/language-reference/operators/andalso-operator.md)

--- a/docs/visual-basic/getting-started/whats-new.md
+++ b/docs/visual-basic/getting-started/whats-new.md
@@ -151,7 +151,7 @@ For more information, see [Reference Return Values](../programming-guide/languag
 [String interpolation](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md)  
  You can use string interpolation expressions to construct strings.  An interpolated string expression looks like a template string that contains expressions.  An interpolated string is easier to understand with respect to arguments than [Composite Formatting](../../standard/base-types/composite-format.md).  
   
-[Null-conditional member access and indexing](../../csharp/language-reference/operators/null-conditional-operators.md)  
+[Null-conditional member access and indexing](../language-reference/operators/null-conditional-operators.md)  
 You can test for null in a very light syntactic way before performing a member access (`?.`) or index (`?[]`) operation.  These operators help you write less code to handle null checks, especially for descending into data structures.  If the left operand or object reference is null, the operations returns null.  
   
 [Multi-line string literals](../../visual-basic/programming-guide/language-features/strings/string-basics.md)  

--- a/docs/visual-basic/language-reference/operators/index.md
+++ b/docs/visual-basic/language-reference/operators/index.md
@@ -1,39 +1,42 @@
 ---
 title: "Operators (Visual Basic)"
-ms.date: 07/20/2015
+ms.date: 10/17/2018
 helpviewer_keywords: 
   - "operators [Visual Basic]"
 ms.assetid: 3d3421df-fcc5-4888-9249-d78f16774ce6
 ---
 # Operators (Visual Basic)
-## In This Section  
- [Operator Precedence in Visual Basic](../../../visual-basic/language-reference/operators/operator-precedence.md)  
+## In this section
+
+ [Operator precedence in Visual Basic](operator-precedence.md)  
   
- [Operators Listed by Functionality](../../../visual-basic/language-reference/operators/operators-listed-by-functionality.md)  
+ [Operators listed by functionality](operators-listed-by-functionality.md)  
   
- [Data Types of Operator Results](../../../visual-basic/language-reference/operators/data-types-of-operator-results.md)  
+ [Data types of operator results](data-types-of-operator-results.md)  
   
- [DirectCast Operator](../../../visual-basic/language-reference/operators/directcast-operator.md)  
+ [DirectCast operator](directcast-operator.md)  
   
- [TryCast Operator](../../../visual-basic/language-reference/operators/trycast-operator.md)  
+ [TryCast operator](trycast-operator.md)  
   
- [New Operator](../../../visual-basic/language-reference/operators/new-operator.md)  
+ [New operator](new-operator.md)  
+
+ [Null-conditional operators](null-conditional-operators.md)
+
+ [Arithmetic operators](arithmetic-operators.md)  
   
- [Arithmetic Operators](../../../visual-basic/language-reference/operators/arithmetic-operators.md)  
+ [Assignment operators](assignment-operators.md)  
   
- [Assignment Operators](../../../visual-basic/language-reference/operators/assignment-operators.md)  
+ [Bit Shift operators](bit-shift-operators.md)  
   
- [Bit Shift Operators](../../../visual-basic/language-reference/operators/bit-shift-operators.md)  
+ [Comparison operators](comparison-operators.md)  
   
- [Comparison Operators](../../../visual-basic/language-reference/operators/comparison-operators.md)  
+ [Concatenation operators](concatenation-operators.md)  
   
- [Concatenation Operators](../../../visual-basic/language-reference/operators/concatenation-operators.md)  
+ [Logical/Bitwise operators](logical-bitwise-operators.md)  
   
- [Logical/Bitwise Operators](../../../visual-basic/language-reference/operators/logical-bitwise-operators.md)  
+ [Miscellaneous operators](miscellaneous-operators.md)  
   
- [Miscellaneous Operators](../../../visual-basic/language-reference/operators/miscellaneous-operators.md)  
-  
-## Related Sections  
- [Visual Basic Language Reference](../../../visual-basic/language-reference/index.md)  
+## Related sections  
+ [Visual Basic language reference](../../../visual-basic/language-reference/index.md)  
   
  [Visual Basic](../../../visual-basic/index.md)

--- a/docs/visual-basic/language-reference/operators/miscellaneous-operators.md
+++ b/docs/visual-basic/language-reference/operators/miscellaneous-operators.md
@@ -1,25 +1,30 @@
 ---
-title: "Miscellaneous Operators (Visual Basic)"
-ms.date: 07/20/2015
+title: "Miscellaneous operators (Visual Basic)"
+ms.date: 10/18/2018
 helpviewer_keywords: 
   - "operators [Visual Basic]"
   - "operators [Visual Basic], miscellaneous"
 ms.assetid: 2423b3c5-fc3f-479c-bcd2-2c6ebe92814f
 ---
-# Miscellaneous Operators (Visual Basic)
+# Miscellaneous operators (Visual Basic)
 The following are miscellaneous operators defined in Visual Basic.  
   
- [AddressOf Operator](../../../visual-basic/language-reference/operators/addressof-operator.md)  
+[?. null-conditional operator](null-conditional-operators.md)
+
+[?() null-conditional operator](null-conditional-operators.md)
+
+ [AddressOf operator](../../../visual-basic/language-reference/operators/addressof-operator.md)  
   
- [Await Operator](../../../visual-basic/language-reference/operators/await-operator.md)  
+ [Await operator](../../../visual-basic/language-reference/operators/await-operator.md)  
   
- [GetType Operator](../../../visual-basic/language-reference/operators/gettype-operator.md)  
+ [GetType operator](../../../visual-basic/language-reference/operators/gettype-operator.md)  
   
- [Function Expression](../../../visual-basic/language-reference/operators/function-expression.md)  
+ [Function expression](../../../visual-basic/language-reference/operators/function-expression.md)  
+
+ [If operator](../../../visual-basic/language-reference/operators/if-operator.md)  
   
- [If Operator](../../../visual-basic/language-reference/operators/if-operator.md)  
+ [TypeOf operator](../../../visual-basic/language-reference/operators/typeof-operator.md)  
   
- [TypeOf Operator](../../../visual-basic/language-reference/operators/typeof-operator.md)  
-  
-## See Also  
- [Operators Listed by Functionality](../../../visual-basic/language-reference/operators/operators-listed-by-functionality.md)
+## See Also
+
+ [Operators listed by functionality](../../../visual-basic/language-reference/operators/operators-listed-by-functionality.md)

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -1,0 +1,57 @@
+---
+title: "Null-conditional Operators (Visual Basic)"
+ms.date: 10/16/2015
+helpviewer_keywords: 
+  - "null-conditional operators [Visual Basic]"
+  - "?. operator [Visual Basic]"
+  - "?[] operator [C#]"
+  - "?[] operator [Visual Basic]"
+
+# ?. and ?[] null-conditional operators (Visual Basic)
+
+Tests the value of the left-hand operand for null (`Nothing`) before performing a member access (`?.`) or index (`?()`) operation; returns `Nothing` if the left-hand operand evaluates to `Nothing`.
+
+These operators help you write less code to handle null checks, especially when descending into data structures. For example:
+
+```vb
+Dim length = customers?.Length  ' Nothing if customers is Nothing  
+Dim first as Customer = customers?(0)  ' Nothing if customers is Nothing  
+Dim count as Integer? = customers?(0)?.Orders?.Count()  ' Nothing if customers, the first customer, or Orders is Nothing  
+```
+
+For comparison, the alternative code for the first of these expressions without a null-conditional operator is:
+
+```vb
+Dim length As Integer
+If customers IsNot Nothing Then
+   length = customers.Length
+End If
+```
+
+The null-conditional operators are short-circuiting.  If one operation in a chain of conditional member access and index operations returns Nothing, the rest of the chain’s execution stops.  In the following example, C(E) isn't evaluated if `A`, `B`, or `C` evaluates to Nothing.
+
+```vb
+A?.B?.C?(E);
+```
+
+Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The old way requires code like the following:  
+
+```vb  
+Dim handler = AddressOf(Me.PropertyChanged)  
+If handler IsNot Nothing  
+    Call handler(…)  
+```
+
+The new way is much simpler:  
+
+```vb
+PropertyChanged?.Invoke(…)
+```
+
+The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in a temporary variable. You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  
+
+## See also
+
+- [Operators (Visual Basic)](operators.md)
+- [Visual Basic Programming Guide](../../../visual-basic/programming-guide/index.md)
+- [Visual Basic Language Reference](../../../visual-basic/language-reference/index.md)  

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -9,14 +9,14 @@ helpviewer_keywords:
 ---
 # ?. and ?() null-conditional operators (Visual Basic)
 
-Tests the value of the left-hand operand for null (`Nothing`) before performing a member access (`?.`) or index (`?()`) operation; returns `Nothing` if the left-hand operand evaluates to `Nothing`.
+Tests the value of the left-hand operand for null (`Nothing`) before performing a member access (`?.`) or index (`?()`) operation; returns `Nothing` if the left-hand operand evaluates to `Nothing`. Note that, in the expressions that would ordinarily return value types, the null-conditional operator returns a <xref:System.Nullable%601>.
 
 These operators help you write less code to handle null checks, especially when descending into data structures. For example:
 
 ```vb
-Dim length = customers?.Length  ' Nothing if customers is Nothing  
-Dim first as Customer = customers?(0)  ' Nothing if customers is Nothing  
-Dim count as Integer? = customers?(0)?.Orders?.Count()  ' Nothing if customers, the first customer, or Orders is Nothing  
+Dim length As Integer? = customers?.Length  ' Nothing if customers is Nothing  
+Dim first As Customer = customers?(0)  ' Nothing if customers is Nothing  
+Dim count As Integer? = customers?(0)?.Orders?.Count()  ' Nothing if customers, the first customer, or Orders is Nothing  
 ```
 
 For comparison, the alternative code for the first of these expressions without a null-conditional operator is:

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -6,8 +6,8 @@ helpviewer_keywords:
   - "?. operator [Visual Basic]"
   - "?[] operator [C#]"
   - "?[] operator [Visual Basic]"
-
-# ?. and ?[] null-conditional operators (Visual Basic)
+---
+# ?. and ?() null-conditional operators (Visual Basic)
 
 Tests the value of the left-hand operand for null (`Nothing`) before performing a member access (`?.`) or index (`?()`) operation; returns `Nothing` if the left-hand operand evaluates to `Nothing`.
 


### PR DESCRIPTION
## Added topic for Visual Basic null-conditional operators 

This PR:
- Replaces the combined C#/VB null-conditional operators topic with separate topics.
- Modifies the link in the Visual Basic what's new topic to point to the VB topic.
- Updates index- and TOC-related content to include the null-conditional topic.

Fixes #7559 

//cc @svick @KathleenDollard 
