### PR TITLE
Revised the Numerics in .NET article

### DIFF
--- a/docs/csharp/language-reference/keywords/double.md
+++ b/docs/csharp/language-reference/keywords/double.md
@@ -14,7 +14,7 @@ The `double` keyword signifies a simple type that stores 64-bit floating-point v
 
 |Type|Approximate range|Precision|.NET type|
 |----------|-----------------------|---------------|-------------------------|
-|`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|<xref:System.Double?displayProperty=nameWithType>|
+|`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-17 digits|<xref:System.Double?displayProperty=nameWithType>|
 
 ## Literals
 

--- a/docs/csharp/language-reference/keywords/double.md
+++ b/docs/csharp/language-reference/keywords/double.md
@@ -14,7 +14,7 @@ The `double` keyword signifies a simple type that stores 64-bit floating-point v
 
 |Type|Approximate range|Precision|.NET type|
 |----------|-----------------------|---------------|-------------------------|
-|`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-17 digits|<xref:System.Double?displayProperty=nameWithType>|
+|`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|~15-17 digits|<xref:System.Double?displayProperty=nameWithType>|
 
 ## Literals
 

--- a/docs/csharp/language-reference/keywords/float.md
+++ b/docs/csharp/language-reference/keywords/float.md
@@ -15,7 +15,7 @@ The `float` keyword signifies a simple type that stores 32-bit floating-point va
 
 |Type|Approximate range|Precision|.NET type|  
 |----------|-----------------------|---------------|-------------------------|  
-|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|6-9 digits|<xref:System.Single?displayProperty=nameWithType>|  
+|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|~6-9 digits|<xref:System.Single?displayProperty=nameWithType>|  
 
 ## Literals
 

--- a/docs/csharp/language-reference/keywords/float.md
+++ b/docs/csharp/language-reference/keywords/float.md
@@ -15,7 +15,7 @@ The `float` keyword signifies a simple type that stores 32-bit floating-point va
 
 |Type|Approximate range|Precision|.NET type|  
 |----------|-----------------------|---------------|-------------------------|  
-|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|7 digits|<xref:System.Single?displayProperty=nameWithType>|  
+|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|6-9 digits|<xref:System.Single?displayProperty=nameWithType>|  
 
 ## Literals
 

--- a/docs/csharp/language-reference/keywords/floating-point-types-table.md
+++ b/docs/csharp/language-reference/keywords/floating-point-types-table.md
@@ -14,8 +14,8 @@ The following table shows the precision and approximate ranges for the floating-
   
 |Type|Approximate range|Precision|  
 |----------|-----------------------|---------------|  
-|[float](float.md)|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|7 digits|  
-|[double](double.md)|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|  
+|[float](float.md)|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|6-9 digits|  
+|[double](double.md)|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-17 digits|  
 |[decimal](decimal.md)|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
 ## See also

--- a/docs/csharp/language-reference/keywords/floating-point-types-table.md
+++ b/docs/csharp/language-reference/keywords/floating-point-types-table.md
@@ -14,8 +14,8 @@ The following table shows the precision and approximate ranges for the floating-
   
 |Type|Approximate range|Precision|  
 |----------|-----------------------|---------------|  
-|[float](float.md)|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|6-9 digits|  
-|[double](double.md)|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-17 digits|  
+|[float](float.md)|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|~6-9 digits|  
+|[double](double.md)|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|~15-17 digits|  
 |[decimal](decimal.md)|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
 ## See also

--- a/docs/standard/numerics.md
+++ b/docs/standard/numerics.md
@@ -1,6 +1,6 @@
 ---
 title: "Numerics in .NET"
-ms.date: "10/12/2018"
+ms.date: "10/17/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "SIMD"
@@ -16,11 +16,11 @@ ms.author: "ronpet"
 ---
 # Numerics in .NET
 
-.NET provides the standard numeric integral and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, a type that represents complex numbers, and a set of SIMD-enabled vector types in the <xref:System.Numerics> namespace.
+.NET provides the standard numeric integral and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, which is an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, which represents complex numbers, and a set of SIMD-enabled vector types in the <xref:System.Numerics> namespace.
   
 ## Integral types
 
-.NET supports both signed and unsigned integers ranging from one byte to eight bytes in size. The following table lists the integral types and their size, indicates whether they are signed or unsigned, and documents their range. All integers are value types.  
+.NET supports both signed and unsigned integers ranging from one byte to eight bytes in size. The following table lists .NET integer types:
   
 |Type|Signed/Unsigned|Size (in bytes)|Minimum value|Maximum value|  
 |----------|----------------------|--------------------|-------------------|-------------------|  
@@ -33,13 +33,20 @@ ms.author: "ronpet"
 |<xref:System.UInt32?displayProperty=nameWithType>|Unsigned|4|0|4,294,967,295|  
 |<xref:System.UInt64?displayProperty=nameWithType>|Unsigned|8|0|18,446,744,073,709,551,615|  
   
- Each integral type supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators. Each integer also includes methods to perform equality comparisons and relative comparisons, to convert the string representation of a number to that integer, and to convert an integer to its string representation. Some additional mathematical operations beyond those handled by the standard operators, such as rounding and identifying the smaller or larger value of two integers, are available from the <xref:System.Math?displayProperty=nameWithType> class. You can also work with the individual bits in an integer value by using the <xref:System.BitConverter?displayProperty=nameWithType> class.  
-  
- Note that the unsigned integral types are not CLS-compliant. For more information, see [Language Independence and Language-Independent Components](language-independence-and-language-independent-components.md).  
+Each integral type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions.
+
+You can also work with the individual bits in an integer value by using the <xref:System.BitConverter?displayProperty=nameWithType> class.  
+
+> [!NOTE]  
+> The unsigned integral types are not CLS-compliant. For more information, see [Language Independence and Language-Independent Components](language-independence-and-language-independent-components.md).
+
+## BigInteger
+
+The <xref:System.Numerics.BigInteger?displayProperty=nameWithType> structure is an immutable type that represents an arbitrarily large integer whose value in theory has no upper or lower bounds. The methods of the <xref:System.Numerics.BigInteger> type closely parallel those of the other integral types.
   
 ## Floating-point types
 
-.NET includes three primitive floating-point types, which are listed in the following table.  
+.NET includes three primitive floating-point types, which are listed in the following table:
   
 |Type|Size (in bytes)|Approximate range|Precision|  
 |----------|--------|---------------------|--------------------|  
@@ -47,36 +54,37 @@ ms.author: "ronpet"
 |<xref:System.Double?displayProperty=nameWithType>|8|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|  
 |<xref:System.Decimal?displayProperty=nameWithType>|16|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
-Each floating-point type supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators. Each also includes methods to perform equality comparisons and relative comparisons, to convert the string representation of a floating-point number, and to convert a floating-point number to its string representation. Some additional mathematical, algebraic, and trigonometric operations are available from the <xref:System.Math?displayProperty=nameWithType> class. .NET Core 2.0 and later provides <xref:System.MathF?displayProperty=nameWithType> class to perform operations on <xref:System.Single> operands. You can also work with the individual bits in <xref:System.Double> and <xref:System.Single> values by using the <xref:System.BitConverter?displayProperty=nameWithType> class.
+Each floating-point type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions. .NET Core 2.0 and later includes the <xref:System.MathF?displayProperty=nameWithType> class that provides methods which accept arguments of the <xref:System.Single> type.
 
-The <xref:System.Decimal?displayProperty=nameWithType> structure has its own methods, <xref:System.Decimal.GetBits%2A?displayProperty=nameWithType> and <xref:System.Decimal.%23ctor%28System.Int32%5B%5D%29?displayProperty=nameWithType>, for working with a decimal value's individual bits, as well as its own set of methods for performing some additional mathematical operations.  
+You can also work with the individual bits in <xref:System.Double> and <xref:System.Single> values by using the <xref:System.BitConverter?displayProperty=nameWithType> class. The <xref:System.Decimal?displayProperty=nameWithType> structure has its own methods, <xref:System.Decimal.GetBits%2A?displayProperty=nameWithType> and <xref:System.Decimal.%23ctor%28System.Int32%5B%5D%29?displayProperty=nameWithType>, for working with a decimal value's individual bits, as well as its own set of methods for performing some additional mathematical operations.
   
- The <xref:System.Double> and <xref:System.Single> types are intended to be used for values that by their nature are imprecise (such as the distance between two stars) and for applications in which a high degree of precision and small rounding error is not required. You should use the <xref:System.Decimal?displayProperty=nameWithType> type for cases in which greater precision is required and rounding error is undesirable.
-  
-## BigInteger
-
-<xref:System.Numerics.BigInteger?displayProperty=nameWithType> is an immutable type that represents an arbitrarily large integer whose value in theory has no upper or lower bounds. The methods of the <xref:System.Numerics.BigInteger> type closely parallel those of the other integral types.
+The <xref:System.Double> and <xref:System.Single> types are intended to be used for values that by their nature are imprecise (such as the distance between two stars) and for applications in which a high degree of precision and small rounding error is not required. You should use the <xref:System.Decimal?displayProperty=nameWithType> type for cases in which greater precision is required and rounding error is undesirable.
   
 ## Complex
 
-The <xref:System.Numerics.Complex?displayProperty=nameWithType> type represents a complex number, that is, a number with a real number part and an imaginary number part. It supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators, as well as mathematical, algebraic, and trigonometric methods.  
+The <xref:System.Numerics.Complex?displayProperty=nameWithType> structure represents a complex number, that is, a number with a real number part and an imaginary number part. It supports a standard set of arithmetic, comparison, equality, explicit and implicit conversion operators, as well as mathematical, algebraic, and trigonometric methods.  
   
 ## SIMD-enabled vector types
 
-The <xref:System.Numerics> namespace includes a set of SIMD-enabled vector types for the .NET Framework. SIMD (Single Instruction Multiple Data operations) allows some operations to be parallelized at the hardware level, which results in huge performance improvements in mathematical, scientific, and graphics apps that perform computations over vectors.  
+The <xref:System.Numerics> namespace includes a set of .NET SIMD-enabled vector types. SIMD (Single Instruction Multiple Data) operations can be parallelized at the hardware level. That increases the throughput of the vectorized computations, which are common in mathematical, scientific, and graphics apps.
   
- The SIMD-enabled vector types in the .NET Framework include the following: .  In addition, System.Numerics.Vectors includes a Plane type and a Quaternion type.  
+The .NET SIMD-enabled vector types include the following:
+
+- The <xref:System.Numerics.Vector2>, <xref:System.Numerics.Vector3>, and <xref:System.Numerics.Vector4> types, which represent vectors with 2, 3, and 4 <xref:System.Single> values.
+
+- Two matrix types, <xref:System.Numerics.Matrix3x2>, which represents a 3x2 matrix, and <xref:System.Numerics.Matrix4x4>, which represents a 4x4 matrix.
+
+- The <xref:System.Numerics.Plane> type, which represents a plane in three-dimensional space.
+
+- The <xref:System.Numerics.Quaternion> type, which represents a vector that is used to encode three-dimensional physical rotations.
+
+- The <xref:System.Numerics.Vector%601> type, which represents a vector of a specified numeric type and provides a broad set of operators that benefit from SIMD support.
+  > [!NOTE]
+  > The <xref:System.Numerics.Vector%601> type is not included into the .NET Framework. You must install the [System.Numerics.Vectors](https://www.nuget.org/packages/System.Numerics.Vectors) NuGet package to get access to this type.
   
--   <xref:System.Numerics.Vector2>,  <xref:System.Numerics.Vector3>, and  <xref:System.Numerics.Vector4> types, which are 2-, 3-, and 4-dimensional vectors of type <xref:System.Single>.  
-  
--   Two matrix types, <xref:System.Numerics.Matrix3x2>, which represents a 3x2 matrix; and <xref:System.Numerics.Matrix4x4>, which represents a 4x4 matrix.  
-  
--   The <xref:System.Numerics.Plane> and <xref:System.Numerics.Quaternion> types.  
-  
- The SimD-enabled vector types are implemented in IL, which allows them to be used on non-SimD-enabled hardware and JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be compiled by the new 64-bit JIT Compiler for managed code, which is included with the .NET Framework 4.6; it adds SIMD support when targeting x64 processors.  
-  
- SIMD can also be downloaded as a [NuGet package](https://www.nuget.org/packages/System.Numerics.Vectors).  The NuGET package also includes a generic <xref:System.Numerics.Vector%601> structure that allows you to create a vector of any primitive numeric type. (The primitive numeric types include all numeric types in the <xref:System> namespace except for <xref:System.Decimal>.) In addition, the <xref:System.Numerics.Vector%601> structure provides a library of convenience methods that you can call when working with vectors.  
-  
+The SIMD-enabled vector types are implemented in IL, which allows them to be used on non-SIMD-enabled hardware and JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be compiled by the new 64-bit JIT Compiler for managed code, which is included with the .NET Framework 4.6; it adds SIMD support when targeting x64 processors.  
+
 ## See also
 
 - [Application Essentials](application-essentials.md)
+- [Standard Numeric Format Strings](base-types/standard-numeric-format-strings.md)

--- a/docs/standard/numerics.md
+++ b/docs/standard/numerics.md
@@ -1,6 +1,6 @@
 ---
 title: "Numerics in .NET"
-ms.date: "10/17/2018"
+ms.date: "10/18/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "SIMD"
@@ -16,11 +16,11 @@ ms.author: "ronpet"
 ---
 # Numerics in .NET
 
-.NET provides the standard numeric integral and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, which is an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, which represents complex numbers, and a set of SIMD-enabled vector types in the <xref:System.Numerics> namespace.
+.NET provides the range of numeric integer and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, which is an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, which represents complex numbers, and a set of SIMD-enabled types in the <xref:System.Numerics> namespace.
   
-## Integral types
+## Integer types
 
-.NET supports both signed and unsigned integers ranging from one byte to eight bytes in size. The following table lists .NET integer types:
+.NET supports both signed and unsigned 8-, 16-, 32-, and 64-bit integer types, which are listed in the following table:
   
 |Type|Signed/Unsigned|Size (in bytes)|Minimum value|Maximum value|  
 |----------|----------------------|--------------------|-------------------|-------------------|  
@@ -33,12 +33,12 @@ ms.author: "ronpet"
 |<xref:System.UInt32?displayProperty=nameWithType>|Unsigned|4|0|4,294,967,295|  
 |<xref:System.UInt64?displayProperty=nameWithType>|Unsigned|8|0|18,446,744,073,709,551,615|  
   
-Each integral type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions.
+Each integer type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions.
 
 You can also work with the individual bits in an integer value by using the <xref:System.BitConverter?displayProperty=nameWithType> class.  
 
 > [!NOTE]  
-> The unsigned integral types are not CLS-compliant. For more information, see [Language Independence and Language-Independent Components](language-independence-and-language-independent-components.md).
+> The unsigned integer types are not CLS-compliant. For more information, see [Language Independence and Language-Independent Components](language-independence-and-language-independent-components.md).
 
 ## BigInteger
 
@@ -50,25 +50,30 @@ The <xref:System.Numerics.BigInteger?displayProperty=nameWithType> structure is 
   
 |Type|Size (in bytes)|Approximate range|Precision|  
 |----------|--------|---------------------|--------------------|  
-|<xref:System.Single?displayProperty=nameWithType>|4|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|7 digits|  
-|<xref:System.Double?displayProperty=nameWithType>|8|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|  
+|<xref:System.Single?displayProperty=nameWithType>|4|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|6-9 digits|  
+|<xref:System.Double?displayProperty=nameWithType>|8|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-17 digits|  
 |<xref:System.Decimal?displayProperty=nameWithType>|16|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
+Both <xref:System.Single> and <xref:System.Double> types support special values that represent non-a-number and infinity. For example, the <xref:System.Double> type provides the following values: <xref:System.Double.NaN?displayProperty=nameWithType>, <xref:System.Double.NegativeInfinity?displayProperty=nameWithType>, and <xref:System.Double.PositiveInfinity?displayProperty=nameWithType>. You use the <xref:System.Double.IsNaN%2A?displayProperty=nameWithType>, <xref:System.Double.IsInfinity%2A?displayProperty=nameWithType>, <xref:System.Double.IsPositiveInfinity%2A?displayProperty=nameWithType>, and <xref:System.Double.IsNegativeInfinity%2A?displayProperty=nameWithType> methods to test for these special values.
+
 Each floating-point type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions. .NET Core 2.0 and later includes the <xref:System.MathF?displayProperty=nameWithType> class that provides methods which accept arguments of the <xref:System.Single> type.
 
 You can also work with the individual bits in <xref:System.Double> and <xref:System.Single> values by using the <xref:System.BitConverter?displayProperty=nameWithType> class. The <xref:System.Decimal?displayProperty=nameWithType> structure has its own methods, <xref:System.Decimal.GetBits%2A?displayProperty=nameWithType> and <xref:System.Decimal.%23ctor%28System.Int32%5B%5D%29?displayProperty=nameWithType>, for working with a decimal value's individual bits, as well as its own set of methods for performing some additional mathematical operations.
   
-The <xref:System.Double> and <xref:System.Single> types are intended to be used for values that by their nature are imprecise (such as the distance between two stars) and for applications in which a high degree of precision and small rounding error is not required. You should use the <xref:System.Decimal?displayProperty=nameWithType> type for cases in which greater precision is required and rounding error is undesirable.
+The <xref:System.Double> and <xref:System.Single> types are intended to be used for values that by their nature are imprecise (for example, the distance between two stars) and for applications in which a high degree of precision and small rounding error is not required. You should use the <xref:System.Decimal?displayProperty=nameWithType> type for cases in which greater precision is required and rounding errors should be minimized.
+
+> [!NOTE]
+> The <xref:System.Decimal> type doesn't eliminate the need for rounding. Rather, it minimizes errors due to rounding.
   
 ## Complex
 
 The <xref:System.Numerics.Complex?displayProperty=nameWithType> structure represents a complex number, that is, a number with a real number part and an imaginary number part. It supports a standard set of arithmetic, comparison, equality, explicit and implicit conversion operators, as well as mathematical, algebraic, and trigonometric methods.  
   
-## SIMD-enabled vector types
+## SIMD-enabled types
 
-The <xref:System.Numerics> namespace includes a set of .NET SIMD-enabled vector types. SIMD (Single Instruction Multiple Data) operations can be parallelized at the hardware level. That increases the throughput of the vectorized computations, which are common in mathematical, scientific, and graphics apps.
+The <xref:System.Numerics> namespace includes a set of .NET SIMD-enabled types. SIMD (Single Instruction Multiple Data) operations can be parallelized at the hardware level. That increases the throughput of the vectorized computations, which are common in mathematical, scientific, and graphics apps.
   
-The .NET SIMD-enabled vector types include the following:
+The .NET SIMD-enabled types include the following:
 
 - The <xref:System.Numerics.Vector2>, <xref:System.Numerics.Vector3>, and <xref:System.Numerics.Vector4> types, which represent vectors with 2, 3, and 4 <xref:System.Single> values.
 
@@ -78,11 +83,11 @@ The .NET SIMD-enabled vector types include the following:
 
 - The <xref:System.Numerics.Quaternion> type, which represents a vector that is used to encode three-dimensional physical rotations.
 
-- The <xref:System.Numerics.Vector%601> type, which represents a vector of a specified numeric type and provides a broad set of operators that benefit from SIMD support.
+- The <xref:System.Numerics.Vector%601> type, which represents a vector of a specified numeric type and provides a broad set of operators that benefit from SIMD support. The count of a <xref:System.Numerics.Vector%601> instance is fixed, but its value <xref:System.Numerics.Vector%601.Count%2A?displayProperty=nameWithType> depends on the CPU of the machine, on which code is executed.
   > [!NOTE]
   > The <xref:System.Numerics.Vector%601> type is not included into the .NET Framework. You must install the [System.Numerics.Vectors](https://www.nuget.org/packages/System.Numerics.Vectors) NuGet package to get access to this type.
   
-The SIMD-enabled vector types are implemented in IL, which allows them to be used on non-SIMD-enabled hardware and JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be compiled by the new 64-bit JIT Compiler for managed code, which is included with the .NET Framework 4.6; it adds SIMD support when targeting x64 processors.  
+The SIMD-enabled types are implemented in such a way that they can be used with non-SIMD-enabled hardware or JIT compilers. To take advantage of SIMD instructions, your 64-bit apps must be run by the runtime that uses the RyuJIT compiler, which is included in .NET Core and in the .NET Framework 4.6 and later versions. It adds SIMD support when targeting 64-bit processors.
 
 ## See also
 

--- a/docs/standard/numerics.md
+++ b/docs/standard/numerics.md
@@ -1,6 +1,6 @@
 ---
-title: "Numerics in the .NET Framework"
-ms.date: "03/30/2017"
+title: "Numerics in .NET"
+ms.date: "10/12/2018"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "SIMD"
@@ -14,15 +14,15 @@ ms.assetid: dfebc18e-acde-4510-9fa7-9a0f4aa3bd11
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Numerics in the .NET Framework
-The .NET Framework supports the standard numeric integral and floating-point primitives, as well as <xref:System.Numerics.BigInteger>, an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex>, a type that represents complex numbers, and a set of SIMD-enabled vector types in the <xref:System.Numerics> namespace.  
+# Numerics in .NET
+
+.NET provides the standard numeric integral and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, a type that represents complex numbers, and a set of SIMD-enabled vector types in the <xref:System.Numerics> namespace.
   
- In addition, System.Numerics.Vectors, the SIMD-enabled library of vectory types, was released as a NuGet package.  
+## Integral types
+
+.NET supports both signed and unsigned integers ranging from one byte to eight bytes in size. The following table lists the integral types and their size, indicates whether they are signed or unsigned, and documents their range. All integers are value types.  
   
-## Integral types  
- The .NET Framework supports both signed and unsigned integers ranging from one byte to eight bytes in length. The following table lists the integral types and their size, indicates whether they are signed or unsigned, and documents their range. All integers are value types.  
-  
-|Type|Signed/Unsigned|Size (bytes)|Minimum value|Maximum Value|  
+|Type|Signed/Unsigned|Size (in bytes)|Minimum value|Maximum value|  
 |----------|----------------------|--------------------|-------------------|-------------------|  
 |<xref:System.Byte?displayProperty=nameWithType>|Unsigned|1|0|255|  
 |<xref:System.Int16?displayProperty=nameWithType>|Signed|2|-32,768|32,767|  
@@ -33,31 +33,37 @@ The .NET Framework supports the standard numeric integral and floating-point pri
 |<xref:System.UInt32?displayProperty=nameWithType>|Unsigned|4|0|4,294,967,295|  
 |<xref:System.UInt64?displayProperty=nameWithType>|Unsigned|8|0|18,446,744,073,709,551,615|  
   
- Each integral type supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators. Each integer also includes methods to perform equality comparisons and relative comparisons, to convert the string representation of a number to that integer, and to convert an integer to its string representation. Some additional mathematical operations beyond those handled by the standard operators, such as rounding and identifying the smaller or larger value of two integers, are available from the <xref:System.Math> class. You can also work with the individual bits in an integer value by using the <xref:System.BitConverter> class.  
+ Each integral type supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators. Each integer also includes methods to perform equality comparisons and relative comparisons, to convert the string representation of a number to that integer, and to convert an integer to its string representation. Some additional mathematical operations beyond those handled by the standard operators, such as rounding and identifying the smaller or larger value of two integers, are available from the <xref:System.Math?displayProperty=nameWithType> class. You can also work with the individual bits in an integer value by using the <xref:System.BitConverter?displayProperty=nameWithType> class.  
   
- Note that the unsigned integral types are not CLS-compliant. For more information, see [Language Independence and Language-Independent Components](../../docs/standard/language-independence-and-language-independent-components.md).  
+ Note that the unsigned integral types are not CLS-compliant. For more information, see [Language Independence and Language-Independent Components](language-independence-and-language-independent-components.md).  
   
-## Floating-point types  
- The .NET Framework includes three primitive floating point types, which are listed in the following table.  
+## Floating-point types
+
+.NET includes three primitive floating-point types, which are listed in the following table.  
   
-|Type|Size (in bytes)|Minimum|Maximum|  
-|----------|-----------------------|-------------|-------------|  
-|<xref:System.Double?displayProperty=nameWithType>|8|-1.79769313486232e308|1.79769313486232e308|  
-|<xref:System.Single?displayProperty=nameWithType>|4|-3.402823e38|3.402823e38|  
-|<xref:System.Decimal?displayProperty=nameWithType>|16|-79,228,162,514,264,337,593,543,950,335|79,228,162,514,264,337,593,543,950,335|  
+|Type|Size (in bytes)|Approximate range|Precision|  
+|----------|--------|---------------------|--------------------|  
+|<xref:System.Single?displayProperty=nameWithType>|4|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|7 digits|  
+|<xref:System.Double?displayProperty=nameWithType>|8|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-16 digits|  
+|<xref:System.Decimal?displayProperty=nameWithType>|16|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
- Each floating-point type supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators. Each also includes methods to perform equality comparisons and relative comparisons, to convert the string representation of a floating-point number, and to convert a floating-point number to its string representation. Some additional mathematical, algebraic, and trigonometric operations are available from the <xref:System.Math> class. You can also work with the individual bits in <xref:System.Double> and <xref:System.Single> values by using the <xref:System.BitConverter> class. The <xref:System.Decimal?displayProperty=nameWithType> structure has its own methods, <xref:System.Decimal.GetBits%2A?displayProperty=nameWithType> and <xref:System.Decimal.%23ctor%28System.Int32%5B%5D%29?displayProperty=nameWithType>, for working with a decimal value's individual bits, as well as its own set of methods for performing some additional mathematical operations.  
+Each floating-point type supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators. Each also includes methods to perform equality comparisons and relative comparisons, to convert the string representation of a floating-point number, and to convert a floating-point number to its string representation. Some additional mathematical, algebraic, and trigonometric operations are available from the <xref:System.Math?displayProperty=nameWithType> class. .NET Core 2.0 and later provides <xref:System.MathF?displayProperty=nameWithType> class to perform operations on <xref:System.Single> operands. You can also work with the individual bits in <xref:System.Double> and <xref:System.Single> values by using the <xref:System.BitConverter?displayProperty=nameWithType> class.
+
+The <xref:System.Decimal?displayProperty=nameWithType> structure has its own methods, <xref:System.Decimal.GetBits%2A?displayProperty=nameWithType> and <xref:System.Decimal.%23ctor%28System.Int32%5B%5D%29?displayProperty=nameWithType>, for working with a decimal value's individual bits, as well as its own set of methods for performing some additional mathematical operations.  
   
- The <xref:System.Double> and <xref:System.Single> types are intended to be used for values that by their nature are imprecise (such as the distance between two stars in the solar system) and for applications in which a high degree of precision and small rounding error is not required. You should use the <xref:System.Decimal?displayProperty=nameWithType> type for cases in which greater precision is required and rounding error is undesirable,  
+ The <xref:System.Double> and <xref:System.Single> types are intended to be used for values that by their nature are imprecise (such as the distance between two stars) and for applications in which a high degree of precision and small rounding error is not required. You should use the <xref:System.Decimal?displayProperty=nameWithType> type for cases in which greater precision is required and rounding error is undesirable.
   
-## BigInteger  
- <xref:System.Numerics.BigInteger?displayProperty=nameWithType> is an immutable type that represents an arbitrarily large integer whose value in theory has no upper or lower bounds. The methods of the <xref:System.Numerics.BigInteger> type closely parallel those of the other integral types.  
+## BigInteger
+
+<xref:System.Numerics.BigInteger?displayProperty=nameWithType> is an immutable type that represents an arbitrarily large integer whose value in theory has no upper or lower bounds. The methods of the <xref:System.Numerics.BigInteger> type closely parallel those of the other integral types.
   
-## Complex  
- The <xref:System.Numerics.Complex> type represents a complex number, that is, a number with a real number part and an imaginary number part. It supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators, as well as mathematical, algebraic, and trigonometric methods.  
+## Complex
+
+The <xref:System.Numerics.Complex?displayProperty=nameWithType> type represents a complex number, that is, a number with a real number part and an imaginary number part. It supports a standard set of arithmetic, comparison, equality, explicit conversion, and implicit conversion operators, as well as mathematical, algebraic, and trigonometric methods.  
   
-## SIMD-enabled vector types  
- The <xref:System.Numerics> namespace includes a set of SIMD-enabled vector types for the .NET Framework. SIMD (Single Instruction Multiple Data operations) allows some operations to be parallelized at the hardware level, which results in huge performance improvements in mathematical, scientific, and graphics apps that perform computations over vectors.  
+## SIMD-enabled vector types
+
+The <xref:System.Numerics> namespace includes a set of SIMD-enabled vector types for the .NET Framework. SIMD (Single Instruction Multiple Data operations) allows some operations to be parallelized at the hardware level, which results in huge performance improvements in mathematical, scientific, and graphics apps that perform computations over vectors.  
   
  The SIMD-enabled vector types in the .NET Framework include the following: .  In addition, System.Numerics.Vectors includes a Plane type and a Quaternion type.  
   
@@ -73,4 +79,4 @@ The .NET Framework supports the standard numeric integral and floating-point pri
   
 ## See also
 
-- [Application Essentials](../../docs/standard/application-essentials.md)
+- [Application Essentials](application-essentials.md)

--- a/docs/standard/numerics.md
+++ b/docs/standard/numerics.md
@@ -16,7 +16,7 @@ ms.author: "ronpet"
 ---
 # Numerics in .NET
 
-.NET provides the range of numeric integer and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, which is an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, which represents complex numbers, and a set of SIMD-enabled types in the <xref:System.Numerics> namespace.
+.NET provides a range of numeric integer and floating-point primitives, as well as <xref:System.Numerics.BigInteger?displayProperty=nameWithType>, which is an integral type with no theoretical upper or lower bound, <xref:System.Numerics.Complex?displayProperty=nameWithType>, which represents complex numbers, and a set of SIMD-enabled types in the <xref:System.Numerics> namespace.
   
 ## Integer types
 
@@ -33,7 +33,7 @@ ms.author: "ronpet"
 |<xref:System.UInt32?displayProperty=nameWithType>|Unsigned|4|0|4,294,967,295|  
 |<xref:System.UInt64?displayProperty=nameWithType>|Unsigned|8|0|18,446,744,073,709,551,615|  
   
-Each integer type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions.
+Each integer type supports a set of standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions.
 
 You can also work with the individual bits in an integer value by using the <xref:System.BitConverter?displayProperty=nameWithType> class.  
 
@@ -50,13 +50,13 @@ The <xref:System.Numerics.BigInteger?displayProperty=nameWithType> structure is 
   
 |Type|Size (in bytes)|Approximate range|Precision|  
 |----------|--------|---------------------|--------------------|  
-|<xref:System.Single?displayProperty=nameWithType>|4|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|6-9 digits|  
-|<xref:System.Double?displayProperty=nameWithType>|8|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|15-17 digits|  
+|<xref:System.Single?displayProperty=nameWithType>|4|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|~6-9 digits|  
+|<xref:System.Double?displayProperty=nameWithType>|8|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|~15-17 digits|  
 |<xref:System.Decimal?displayProperty=nameWithType>|16|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
   
-Both <xref:System.Single> and <xref:System.Double> types support special values that represent non-a-number and infinity. For example, the <xref:System.Double> type provides the following values: <xref:System.Double.NaN?displayProperty=nameWithType>, <xref:System.Double.NegativeInfinity?displayProperty=nameWithType>, and <xref:System.Double.PositiveInfinity?displayProperty=nameWithType>. You use the <xref:System.Double.IsNaN%2A?displayProperty=nameWithType>, <xref:System.Double.IsInfinity%2A?displayProperty=nameWithType>, <xref:System.Double.IsPositiveInfinity%2A?displayProperty=nameWithType>, and <xref:System.Double.IsNegativeInfinity%2A?displayProperty=nameWithType> methods to test for these special values.
+Both <xref:System.Single> and <xref:System.Double> types support special values that represent not-a-number and infinity. For example, the <xref:System.Double> type provides the following values: <xref:System.Double.NaN?displayProperty=nameWithType>, <xref:System.Double.NegativeInfinity?displayProperty=nameWithType>, and <xref:System.Double.PositiveInfinity?displayProperty=nameWithType>. You use the <xref:System.Double.IsNaN%2A?displayProperty=nameWithType>, <xref:System.Double.IsInfinity%2A?displayProperty=nameWithType>, <xref:System.Double.IsPositiveInfinity%2A?displayProperty=nameWithType>, and <xref:System.Double.IsNegativeInfinity%2A?displayProperty=nameWithType> methods to test for these special values.
 
-Each floating-point type supports standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions. .NET Core 2.0 and later includes the <xref:System.MathF?displayProperty=nameWithType> class that provides methods which accept arguments of the <xref:System.Single> type.
+Each floating-point type supports a set of standard arithmetic operators. The <xref:System.Math?displayProperty=nameWithType> class provides methods for a broader set of mathematical functions. .NET Core 2.0 and later includes the <xref:System.MathF?displayProperty=nameWithType> class that provides methods which accept arguments of the <xref:System.Single> type.
 
 You can also work with the individual bits in <xref:System.Double> and <xref:System.Single> values by using the <xref:System.BitConverter?displayProperty=nameWithType> class. The <xref:System.Decimal?displayProperty=nameWithType> structure has its own methods, <xref:System.Decimal.GetBits%2A?displayProperty=nameWithType> and <xref:System.Decimal.%23ctor%28System.Int32%5B%5D%29?displayProperty=nameWithType>, for working with a decimal value's individual bits, as well as its own set of methods for performing some additional mathematical operations.
   


### PR DESCRIPTION
This PR updates the [Numerics in .NET](https://docs.microsoft.com/en-us/dotnet/standard/numerics) article:
- When talking about floating-point types, it's more interesting to know the precision, than min/max value. Thus, replace the floating-point types table with the one from the C# reference: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/floating-point-types-table

- Fixed typos in the section about SIMD-enabled types and mentioned that only .NET Framework needs a NuGet package for `Vector<T>`.

- As most probably, this article aims at those who wants to do some calculations, I've shortened paragraphs that describe the set of available operations for integral and floating-point types.
