### PR TITLE
AssemblyInformationalVersion does not produce a build warning

### DIFF
--- a/docs/standard/library-guidance/versioning.md
+++ b/docs/standard/library-guidance/versioning.md
@@ -71,6 +71,9 @@ The assembly file version is used to display a file version in Windows and has n
 
 ![Windows Explorer](./media/versioning/win-properties.png "Windows Explorer")
 
+> [!NOTE]
+> An innocuous build warning is raised if this version does not follow the format `Major.Minor.Build.Revision`. The warning can be safely ignored.
+
 **✔️ CONSIDER** including a continuous integration build number as the AssemblyFileVersion revision.
 
 > For example, you are building version 1.0.0 of your project, and the continuous integration build number is 99 so your AssemblyFileVersion is 1.0.0.99.
@@ -82,9 +85,6 @@ The assembly informational version is used to record additional version informat
 ```xml
 <AssemblyInformationalVersion>The quick brown fox jumped over the lazy dog.</AssemblyInformationalVersion>
 ```
-
-> [!NOTE]
-> An innocuous build warning is raised if this version does not follow the format `Major.Minor.Build.Revision`. The warning can be safely ignored.
 
 **❌ AVOID** setting the assembly informational version yourself.
 


### PR DESCRIPTION
## Summary
The documentation says that if you use a version for `<AssemblyInformationalVersion>` which does not follow the format `Major.Minor.Build.Revision` a build warning is produced, but this is not correct.

The build warning is produced for the `<FileVersion>`. If its version does not follow the format above then we see the following warning:
`The specified version string does not conform to the recommended format - major.minor.build.revision`

This PR moves the "Note" about the build warning under the "Assembly file version" section.  See the demo project I created to exemplify this: https://github.com/joaopgrassi/fileversion-buildwarning
