### PR TITLE
Missing call to base serialization constructor

### DIFF
--- a/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/creating-and-throwing-exceptions_4.cs
+++ b/docs/csharp/programming-guide/exceptions/codesnippet/CSharp/creating-and-throwing-exceptions_4.cs
@@ -8,5 +8,5 @@
         // A constructor is needed for serialization when an
         // exception propagates from a remoting server to the client. 
         protected InvalidDepartmentException(System.Runtime.Serialization.SerializationInfo info,
-            System.Runtime.Serialization.StreamingContext context) { }
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }


### PR DESCRIPTION
Without the call to the base class constructor, the class does not deserialize correctly.

## Summary

For example, if you serialize and deserialize a "`new InvalidDepartmentException("Department '123' is invalid")`" object, the Message property will say "Exception of type 'MyApp.InvalidDepartmentException' was thrown." instead of "Department '123' is invalid". Other properties, such as the Source and StackTrace, will just be initialized to their default values. 