### PR TITLE
JMarkman LINQ article improvements

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/features-that-support-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/features-that-support-linq.md
@@ -41,13 +41,22 @@ var query = from str in stringArray
 ```csharp  
 Customer cust = new Customer { Name = "Mike", Phone = "555-1212" };  
 ```  
-  
+Continuing from the previous example, assume that there is a data source called `IncomingOrders`, and that for each order with a large `OrderSize`, we would like to create a new `Customer` based off of that order. A LINQ query can be executed on this data source and use object initialization to fill a collection:
+```csharp
+var newLargeOrderCustomers = from o in IncomingOrders
+                            where o.OrderSize > 5
+                            select new Customer { Name = o.Name, Phone = o.Phone };
+```
+The data source may have more properties lying under the hood than the `Customer` class such as `OrderSize`, but with object initialization, the data returned from the query is molded into the desired data type. As a result, we now have an `IEnumerable` filled with the new `Customer`s we wanted. The above can also be written in LINQ's method syntax:
+```csharp
+var newLargeOrderCustomers = IncomingOrders.Where(x => x.OrderSize > 5).Select(y => new Customer { Name = y.Name, Phone = y.Phone });
+```
  For more information, see [Object and Collection Initializers](../../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md).  
   
 ## Anonymous Types  
  An anonymous type is constructed by the compiler and the type name is only available to the compiler. Anonymous types provide a convenient way to group a set of properties temporarily in a query result without having to define a separate named type. Anonymous types are initialized with a new expression and an object initializer, as shown here:  
   
-```  
+```csharp
 select new {name = cust.Name, phone = cust.Phone};  
 ```  
   
@@ -68,16 +77,7 @@ select new {name = cust.Name, phone = cust.Phone};
 -   [Lambda Expressions](../../../../csharp/programming-guide/statements-expressions-operators/lambda-expressions.md)  
   
 -   [Expression Trees (C#)](../../../../csharp/programming-guide/concepts/expression-trees/index.md)  
-  
-## Auto-Implemented Properties  
- Auto-implemented properties make property-declaration more concise. When you declare a property as shown in the following example, the compiler will create a private, anonymous backing field that is not accessible except through the property getter and setter.  
-  
-```csharp  
-public string Name {get; set;}  
-```  
-  
- For more information, see [Auto-Implemented Properties](../../../../csharp/programming-guide/classes-and-structs/auto-implemented-properties.md).  
-  
+   
 ## See Also
 
 - [Language-Integrated Query (LINQ) (C#)](../../../../csharp/programming-guide/concepts/linq/index.md)

--- a/docs/csharp/programming-guide/concepts/linq/features-that-support-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/features-that-support-linq.md
@@ -41,18 +41,22 @@ var query = from str in stringArray
 ```csharp  
 Customer cust = new Customer { Name = "Mike", Phone = "555-1212" };  
 ```  
-Continuing from the previous example, assume that there is a data source called `IncomingOrders`, and that for each order with a large `OrderSize`, we would like to create a new `Customer` based off of that order. A LINQ query can be executed on this data source and use object initialization to fill a collection:
+Continuing with our `Customer` class, assume that there is a data source called `IncomingOrders`, and that for each order with a large `OrderSize`, we would like to create a new `Customer` based off of that order. A LINQ query can be executed on this data source and use object initialization to fill a collection:
 ```csharp
 var newLargeOrderCustomers = from o in IncomingOrders
                             where o.OrderSize > 5
                             select new Customer { Name = o.Name, Phone = o.Phone };
 ```
-The data source may have more properties lying under the hood than the `Customer` class such as `OrderSize`, but with object initialization, the data returned from the query is molded into the desired data type. As a result, we now have an `IEnumerable` filled with the new `Customer`s we wanted. The above can also be written in LINQ's method syntax:
+The data source may have more properties lying under the hood than the `Customer` class such as `OrderSize`, but with object initialization, the data returned from the query is molded into the desired data type; we choose the data that is relevant to our class. As a result, we now have an `IEnumerable` filled with the new `Customer`s we wanted. The above can also be written in LINQ's method syntax:
 ```csharp
 var newLargeOrderCustomers = IncomingOrders.Where(x => x.OrderSize > 5).Select(y => new Customer { Name = y.Name, Phone = y.Phone });
 ```
- For more information, see [Object and Collection Initializers](../../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md).  
-  
+ For more information, see:
+ 
+ - [Object and Collection Initializers](../../../../csharp/programming-guide/classes-and-structs/object-and-collection-initializers.md)
+
+ - [Query Expression Syntax for Standard Query Operators](../../../../csharp/programming-guide/concepts/linq/query-expression-syntax-for-standard-query-operators.md)
+
 ## Anonymous Types  
  An anonymous type is constructed by the compiler and the type name is only available to the compiler. Anonymous types provide a convenient way to group a set of properties temporarily in a query result without having to define a separate named type. Anonymous types are initialized with a new expression and an object initializer, as shown here:  
   


### PR DESCRIPTION
## Summary

After reading through the issue, I followed @rpetrusha's response to the ticket as closely as I could. I removed the Auto Properties section as noted, and added an example of how object initialization might work with LINQ. The example builds off of the established example in the object/collection initialization section where readers are asked to consider a hypothetical data source (in-memory collection, database, etc.) called IncomingOrders; the query itself is rudimentary, only consisting of two statements, Where and Select.

Supplementing the LINQ query is a duplicate version of said query, but written in method syntax. As such, the "For more information, see" area was modified to no longer be a single sentence but a list containing its original link to the Object and Collection Initializers page and a new link to Query Expression Syntax for Standard Query Operators as mentioned in the ticket comments by @BillWagner 

A minor page fix was also added in the Anonymous Types section: the code snippet was missing a `csharp` tag, so I added it there for syntax highlighting.

Fixes #7331
