### PR TITLE
Remainder assignment operator: definition first

### DIFF
--- a/docs/csharp/language-reference/operators/remainder-assignment-operator.md
+++ b/docs/csharp/language-reference/operators/remainder-assignment-operator.md
@@ -26,7 +26,7 @@ x = x % y
 
 except that `x` is only evaluated once.
   
-The [remainder operator](remainder-operator.md) `%` is supported by all numeric types and computes the remainder after division of its operands.
+The [remainder operator](remainder-operator.md) `%` computes the remainder after division of its operands. It's supported by all numeric types.
 
 If a user-defined type [overloads](../keywords/operator.md) the [remainder operator](remainder-operator.md) `%`, the remainder assignment operator `%=` is implicitly overloaded.
   


### PR DESCRIPTION
Nit pick: first say what operator does and only then that it's supported by numeric types.
