### PR TITLE
Markdig fixes wcf

### DIFF
--- a/docs/framework/wcf/configuring-services-using-configuration-files.md
+++ b/docs/framework/wcf/configuring-services-using-configuration-files.md
@@ -180,9 +180,9 @@ Configuring a Windows Communication Foundation (WCF) service with a configuratio
 ## Behavior Merge  
  The behavior merge feature makes it easier to manage behaviors when you want a set of common behaviors to be used consistently. This feature allows you to specify behaviors at different levels of the configuration hierarchy and have services inherit behaviors from multiple levels of the configuration hierarchy. To illustrate how this works assume you have the following virtual directory layout in IIS:  
   
- ~\Web.config~\Service.svc~\Child\Web.config~\Child\Service.svc  
+ `~\Web.config~\Service.svc~\Child\Web.config~\Child\Service.svc`
   
- And your ~\Web.config file has the following contents:  
+ And your `~\Web.config` file has the following contents:  
   
 ```xml  
 <configuration>  

--- a/docs/framework/wcf/feature-details/how-to-retrieve-metadata-and-implement-a-compliant-service.md
+++ b/docs/framework/wcf/feature-details/how-to-retrieve-metadata-and-implement-a-compliant-service.md
@@ -45,10 +45,13 @@ Often, the same person does not design and implement services. In environments w
   
 -   A conversion of the client-side configuration file to a service-side version.  
   
- [!code-csharp[ClientProxyCodeSample#1](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/proxycode.cs#1)]    
- [!code-xml[ClientProxyCodeSample#10](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/client.exe.config#10)]     
- [!code-csharp[ClientProxyCodeSample#5](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/hostapplication.cs#5)]    
- [!code-xml[ClientProxyCodeSample#20](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/hostapplication.exe.config#20)]    
+[!code-csharp[ClientProxyCodeSample#1](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/proxycode.cs#1)]
+
+[!code-xml[ClientProxyCodeSample#10](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/client.exe.config#10)]     
+
+[!code-csharp[ClientProxyCodeSample#5](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/hostapplication.cs#5)]    
+
+[!code-xml[ClientProxyCodeSample#20](../../../../samples/snippets/csharp/VS_Snippets_CFX/clientproxycodesample/cs/hostapplication.exe.config#20)]    
   
 ## See Also  
  [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md)

--- a/docs/framework/wcf/feature-details/messaging-protocols.md
+++ b/docs/framework/wcf/feature-details/messaging-protocols.md
@@ -41,18 +41,18 @@ Specification/document:
 
 The following XML namespaces and associated prefixes are used throughout this topic:
 
-|Prefix|Namespace Uniform Resource Identifier (URI)|
+| Prefix | Namespace Uniform Resource Identifier (URI) |
 [------------|---------------------------------------------------|
-|s11|`http://schemas.xmlsoap.org/soap/envelope`|
-|s12|`http://www.w3.org/2003/05/soap-envelope`|
-|wsa|`http://www.w3.org/2004/08/addressing`|
-|wsam|`http://www.w3.org/2007/05/addressing/metadata`|
-|wsap|`http://schemas.xmlsoap.org/ws/2004/09/policy/addressing`|
-|wsa10|`http://www.w3.org/2005/08/addressing`|
-|wsaw10|`http://www.w3.org/2006/05/addressing/wsdl`|
-|xop|`http://www.w3.org/2004/08/xop/include`|
-|xmime|`http://www.w3.org/2004/06/xmlmime`<br /><br /> `http://www.w3.org/2005/05/xmlmime`|
-|dp|`http://schemas.microsoft.com/net/2006/06/duplex`|
+| s11 | `http://schemas.xmlsoap.org/soap/envelope` |
+| s12 |`http://www.w3.org/2003/05/soap-envelope` |
+| wsa |`http://www.w3.org/2004/08/addressing` |
+| wsam |`http://www.w3.org/2007/05/addressing/metadata` |
+| wsap |`http://schemas.xmlsoap.org/ws/2004/09/policy/addressing` |
+| wsa10 |`http://www.w3.org/2005/08/addressing` |
+| wsaw10 |`http://www.w3.org/2006/05/addressing/wsdl` |
+| xop |`http://www.w3.org/2004/08/xop/include` |
+| xmime |`http://www.w3.org/2004/06/xmlmime`<br /><br /> `http://www.w3.org/2005/05/xmlmime` |
+| dp |`http://schemas.microsoft.com/net/2006/06/duplex` |
 
 ## SOAP 1.1 and SOAP 1.2
 
@@ -195,20 +195,20 @@ When a WCF endpoint is configured for a message with a given `Action` to follow 
 ### Web Services Addressing Faults
 R3411: WCF produces the following faults defined by WS-Addressing 2004/08.
 
-|Code|Cause|
+| Code | Cause |
 |----------|-----------|
-|`wsa:DestinationUnreachable`|The message arrived with a `ReplyTo` that is different from the reply address established for this channel; there is no endpoint listening at the address specified in the To header.|
-|`wsa:ActionNotSupported`|the infrastructure channels or dispatcher associated with the endpoint do not recognize the action specified in the `Action` header.|
+| `wsa:DestinationUnreachable` | The message arrived with a `ReplyTo` that is different from the reply address established for this channel; there is no endpoint listening at the address specified in the To header. |
+| `wsa:ActionNotSupported` | the infrastructure channels or dispatcher associated with the endpoint do not recognize the action specified in the `Action` header. |
 
 R3412: WCF produces the following faults defined by WS-Addressing 1.0.
 
-|Code|Cause|
+| Code | Cause |
 |----------|-----------|
-|`wsa10:InvalidAddressingHeader`|Duplicate `wsa:To`, `wsa:ReplyTo`, `wsa:From` or `wsa:MessageID`. Duplicate `wsa:RelatesTo` with the same `RelationshipType`.|
-|`wsa10:MessageAddressingHeaderRequired`|The required Addressing header is missing.|
-|`wsa10:DestinationUnreachable`|The message arrived with a `ReplyTo` that is different from the reply address established for this channel. There is no endpoint listening at the address specified in the To header.|
-|`wsa10:ActionNotSupported`|An action specified in the `Action` header is not recognized by the infrastructure channels or dispatcher associated with the endpoint.|
-|`wsa10:EndpointUnavailable`|The RM channel sends this fault back, indicating the endpoint will not process the sequence based upon examination of the `CreateSequence` message’s addressing headers.|
+| `wsa10:InvalidAddressingHeader` | Duplicate `wsa:To`, `wsa:ReplyTo`, `wsa:From` or `wsa:MessageID`. Duplicate `wsa:RelatesTo` with the same `RelationshipType`. |
+| `wsa10:MessageAddressingHeaderRequired` | The required Addressing header is missing. |
+| `wsa10:DestinationUnreachable` | The message arrived with a `ReplyTo` that is different from the reply address established for this channel. There is no endpoint listening at the address specified in the To header. |
+| `wsa10:ActionNotSupported` | An action specified in the `Action` header is not recognized by the infrastructure channels or dispatcher associated with the endpoint. |
+| `wsa10:EndpointUnavailable` | The RM channel sends this fault back, indicating the endpoint will not process the sequence based upon examination of the `CreateSequence` message’s addressing headers. |
 
 Code in the preceding tables maps to `FaultCode` in SOAP 1.1 and `SubCode` (with Code=Sender) in SOAP 1.2.
 

--- a/docs/framework/wcf/specifying-service-run-time-behavior.md
+++ b/docs/framework/wcf/specifying-service-run-time-behavior.md
@@ -64,7 +64,7 @@ Once you have designed a service contract ([Designing Service Contracts](../../.
   
  For example, the publication of metadata is configured by using the <xref:System.ServiceModel.Description.ServiceMetadataBehavior> object. The following application configuration file shows the most common usage.  
   
- [!code-csharp[ServiceMetadataBehavior#1](../../../samples/snippets/csharp/VS_Snippets_CFX/servicemetadatabehavior/cs/hostapplication.cs#1)]  
+ [!code-xml[ServiceMetadataBehavior#1](../../../samples/snippets/csharp/VS_Snippets_CFX/servicemetadatabehavior/cs/hostapplication.exe.config#1)]  
   
  The following sections describe many of the most useful system-provided behaviors that you can use to modify the runtime delivery of your service or client. See the reference topic to determine how to use each one.  
   


### PR DESCRIPTION
Fix the markdig parser issues in WCF.

There is one left that relates to  multi-language samples.