### PR TITLE
fix typo

### DIFF
--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/subscribe-events.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/subscribe-events.md
@@ -177,7 +177,7 @@ public async Task<IActionResult> UpdateProduct([FromBody]CatalogItem productToUp
   catalogItem = productToUpdate; 
 
   // Just save the updated product if the Product's Price hasn't changed.
-  if !(raiseProductPriceChangedEvent) 
+  if (!raiseProductPriceChangedEvent) 
   {
       await _catalogContext.SaveChangesAsync();
   }


### PR DESCRIPTION
## Summary

Fix typo in [#implementing-atomicity-when-publishing-integration-events-through-the-event-bus](https://docs.microsoft.com/ru-ru/dotnet/standard/microservices-architecture/multi-container-microservice-net-applications/subscribe-events#implementing-atomicity-when-publishing-integration-events-through-the-event-bus) section
