### PR TITLE
Add example to unwrap DU in function parameter

### DIFF
--- a/docs/fsharp/language-reference/discriminated-unions.md
+++ b/docs/fsharp/language-reference/discriminated-unions.md
@@ -89,10 +89,18 @@ The following example demonstrates this:
 ```fsharp
 type ShaderProgram = | ShaderProgram of id:int
 
-let someMethodUsingShaderProgram shaderProgram =
+let someFunctionUsingShaderProgram shaderProgram =
     let (ShaderProgram id) = shaderProgram
     // Use the unwrapped value
-    ..
+    ...
+```
+
+Pattern matching is also allowed directly in function parameters, so you can unwrap a single case there:
+
+```fsharp
+let someFunctionUsingShaderProgram (ShaderProgram id) =
+    // Use the unwrapped value
+    ...
 ```
 
 ## Struct Discriminated Unions


### PR DESCRIPTION
I've added an example that shows a more common and less verbose way to unwrap single-case DUs.