### PR TITLE
Added documentation for PackageDescription

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -194,8 +194,12 @@ A human-friendly title of the package, typically used in UI displays as on nuget
 ### Authors
 A semicolon-separated list of packages authors, matching the profile names on nuget.org. These are displayed in the NuGet Gallery on nuget.org and are used to cross-reference packages by the same authors.
 
-### Description
+### PackageDescription
+
 A long description of the package for UI display.
+
+### Description
+A long description of the package for UI display. This property is used if `PackageDescription` is not specified. It is also used to specify the generated assembly's description.
 
 ### Copyright
 Copyright details for the package.

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -199,7 +199,7 @@ A semicolon-separated list of packages authors, matching the profile names on nu
 A long description of the package for UI display.
 
 ### Description
-A long description of the package for UI display. This property is used if `PackageDescription` is not specified. It is also used to specify the generated assembly's description.
+A long description for an assembly. This property is used if `PackageDescription` is not specified.
 
 ### Copyright
 Copyright details for the package.

--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -199,7 +199,7 @@ A semicolon-separated list of packages authors, matching the profile names on nu
 A long description of the package for UI display.
 
 ### Description
-A long description for an assembly. This property is used if `PackageDescription` is not specified.
+A long description for the assembly. If `PackageDescription` is not specified then this property is also used as the description of the package.
 
 ### Copyright
 Copyright details for the package.


### PR DESCRIPTION
## Summary
Added documentation for PackageDescription. Adjusted documentation for Description to convey its dual purpose and when it is used. 

Fixes #8578
