### PR TITLE
explain why unmanaged types aren't marked readonly

### DIFF
--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -64,8 +64,6 @@ readonly public struct ReadonlyPoint3D
 
 Follow this recommendation whenever your design intent is to create an immutable value type. Any performance improvements are an added benefit. The `readonly struct` clearly expresses your design intent.
 
-The [unamanaged types](language-reference/keywords/sizeof.md) aren't explicitly marked as a `readonly struct` types, but the compiler treats them as such. These types are considered `readonly` from the perspective of the language. We know them to be immutable which is even a stronger guarantee than `readonly` can provide.
-
 ## Use `ref readonly return` statements for large structures when possible
 
 You can return values by reference when the value being returned isn't local to the returning method. Returning by reference means that only the reference is copied, not the structure. In the following example, the `Origin` property can't use a `ref` return because the value being returned is a local variable:
@@ -142,7 +140,11 @@ expresses a different intent:
 Add the `in` modifier to pass an argument by reference and declare
 your design intent to pass arguments by reference to
 avoid unnecessary copying. You don't intend to modify the object used
-as that argument. The following code shows an example of a method
+as that argument.
+
+This practice often improves performance for readonly value types that are larger than <xref:System.IntPtr.Size?displayProperty=nameWithType>. For simple types (`sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal` and `bool`, and `enum` types), any potential performance gains are minimial. In fact, performance may degrade by using pass-by-reference for types smaller than <xref:System.IntPtr.Size?displayProperty=nameWithType>.
+
+The following code shows an example of a method
 that calculates the distance between two points in 3D space.
 
 [!code-csharp[InArgument](../../samples/csharp/safe-efficient-code/ref-readonly-struct/Program.cs#InArgument "Specifying an in argument")]

--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -64,6 +64,8 @@ readonly public struct ReadonlyPoint3D
 
 Follow this recommendation whenever your design intent is to create an immutable value type. Any performance improvements are an added benefit. The `readonly struct` clearly expresses your design intent.
 
+The [unamanaged types](language-reference/keywords/sizeof.md) aren't explicitly marked as a `readonly struct` types, but the compiler treats them as such. These types are considered `readonly` from the perspective of the language. We know them to be immutable which is even a stronger guarantee than `readonly` can provide.
+
 ## Use `ref readonly return` statements for large structures when possible
 
 You can return values by reference when the value being returned isn't local to the returning method. Returning by reference means that only the reference is copied, not the structure. In the following example, the `Origin` property can't use a `ref` return because the value being returned is a local variable:


### PR DESCRIPTION
Address this customer question: https://github.com/dotnet/docs/issues/3907#issuecomment-432653335
