### PR TITLE
List alternate alias for Razor Pages 2.1 project template

### DIFF
--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -59,27 +59,27 @@ The template to instantiate when the command is invoked. Each template might hav
 
 The command contains a default list of templates. Use `dotnet new -l` to obtain a list of the available templates. The following table shows the templates that come pre-installed with the .NET Core SDK 2.1.300. The default language for the template is shown inside the brackets.
 
-|Template description                          | Template name   | Languages     |
-|----------------------------------------------|-----------------|---------------|
-| Console application                          | `console`       | [C#], F#, VB  |
-| Class library                                | `classlib`      | [C#], F#, VB  |
-| Unit test project                            | `mstest`        | [C#], F#, VB  |
-| xUnit test project                           | `xunit`         | [C#], F#, VB  |
-| Razor page                                   | `page`          | [C#]          |
-| MVC ViewImports                              | `viewimports`   | [C#]          |
-| MVC ViewStart                                | `viewstart`     | [C#]          |
-| ASP.NET Core empty                           | `web`           | [C#], F#      |
-| ASP.NET Core Web App (Model-View-Controller) | `mvc`           | [C#], F#      |
-| ASP.NET Core Web App                         | `razor`         | [C#]          |
-| ASP.NET Core with Angular                    | `angular`       | [C#]          |
-| ASP.NET Core with React.js                   | `react`         | [C#]          |
-| ASP.NET Core with React.js and Redux         | `reactredux`    | [C#]          |
-| ASP.NET Core Web API                         | `webapi`        | [C#], F#      |
-| Razor class library                          | `razorclasslib` | [C#]          |
-| global.json file                             | `globaljson`    |               |
-| NuGet config                                 | `nugetconfig`   |               |
-| Web config                                   | `webconfig`     |               |
-| Solution file                                | `sln`           |               |
+|Template description                          | Template name    | Languages     |
+|----------------------------------------------|------------------|---------------|
+| Console application                          | `console`        | [C#], F#, VB  |
+| Class library                                | `classlib`       | [C#], F#, VB  |
+| Unit test project                            | `mstest`         | [C#], F#, VB  |
+| xUnit test project                           | `xunit`          | [C#], F#, VB  |
+| Razor page                                   | `page`           | [C#]          |
+| MVC ViewImports                              | `viewimports`    | [C#]          |
+| MVC ViewStart                                | `viewstart`      | [C#]          |
+| ASP.NET Core empty                           | `web`            | [C#], F#      |
+| ASP.NET Core Web App (Model-View-Controller) | `mvc`            | [C#], F#      |
+| ASP.NET Core Web App                         | `razor`, `webapp`| [C#]          |
+| ASP.NET Core with Angular                    | `angular`        | [C#]          |
+| ASP.NET Core with React.js                   | `react`          | [C#]          |
+| ASP.NET Core with React.js and Redux         | `reactredux`     | [C#]          |
+| ASP.NET Core Web API                         | `webapi`         | [C#], F#      |
+| Razor class library                          | `razorclasslib`  | [C#]          |
+| global.json file                             | `globaljson`     |               |
+| NuGet config                                 | `nugetconfig`    |               |
+| Web config                                   | `webconfig`      |               |
+| Solution file                                | `sln`            |               |
 
 # [.NET Core 2.0](#tab/netcore20)
 

--- a/docs/core/tools/dotnet-new.md
+++ b/docs/core/tools/dotnet-new.md
@@ -3,7 +3,7 @@ title: dotnet new command - .NET Core CLI
 description: The dotnet new command creates new .NET Core projects based on the specified template.
 author: mairaw
 ms.author: mairaw
-ms.date: 07/31/2018
+ms.date: 10/24/2018
 ---
 # dotnet new
 


### PR DESCRIPTION
As of .NET Core SDK 2.1.300 (2.1 RTM), there are 2 valid aliases for using the ASP.NET Core 2.1 Razor Pages project template: `razor` and `webapp`. The CLI only lists the first alias in the array, due to a limitation in its current design. Adding the other alias here to raise awareness. Related discussion: https://github.com/aspnet/Docs/pull/9159#issuecomment-432518051.