### PR TITLE
ref.md: clarify ref readonly return

### DIFF
--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -84,7 +84,7 @@ return ref DecimalArray[0];
 
 In order for the caller to modify the object's state, the reference return value must be stored to a variable that is explicitly defined as a [ref local](#ref-locals).
 
-The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [ref readonly](#ref-readonly-local) variable.
+The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [ref readonly](#ref-readonly-locals) variable.
 
 For an example, see [A ref returns and ref locals example](#a-ref-returns-and-ref-locals-example)
 

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -1,6 +1,6 @@
 ---
 title: "ref keyword (C# Reference)"
-ms.date: 03/06/2018
+ms.date: 10/24/2018
 f1_keywords: 
   - "ref_CSharpKeyword"
   - "ref"
@@ -12,10 +12,10 @@ helpviewer_keywords:
 
 The `ref` keyword indicates a value that is passed by reference. It is used in four different contexts:
 
-- In a method signature and in a method call, to pass an argument to a method by reference. See [Passing an argument by reference](#passing-an-argument-by-reference) for more information.
-- In a method signature, to return a value to the caller by reference. See [Reference return values](#reference-return-values) for more information.
-- In a member body, to indicate that a reference return value is stored locally as a reference that the caller intends to modify or, in general, a local variable accesses another value by reference. See [Ref locals](#ref-locals) for more information.
-- In a `struct` declaration to declare a `ref struct` or a `ref readonly struct`. For more information see [ref struct types](#ref-struct-types).
+- In a method signature and in a method call, to pass an argument to a method by reference. For more information, see [Passing an argument by reference](#passing-an-argument-by-reference).
+- In a method signature, to return a value to the caller by reference. For more information, see [Reference return values](#reference-return-values).
+- In a member body, to indicate that a reference return value is stored locally as a reference that the caller intends to modify or, in general, a local variable accesses another value by reference. For more information, see [Ref locals](#ref-locals).
+- In a `struct` declaration to declare a `ref struct` or a `ref readonly struct`. For more information, see [ref struct types](#ref-struct-types).
 
 
 ## Passing an argument by reference
@@ -108,9 +108,9 @@ ref VeryLargeStruct reflocal = ref veryLargeStruct;
 
 Note that in both examples the `ref` keyword must be used in both places, or the compiler generates error CS8172, "Cannot initialize a by-reference variable with a value."
 
-## ref readonly locals
+## Ref readonly locals
 
-A ref readonly local is used to refer to values returned using `return readonly ref`. A `ref readonly` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
+A ref readonly local is used to refer to values returned by the member that has `ref readonly` in its signature and uses `return ref`. A `ref readonly` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
 
 ## A ref returns and ref locals example
 

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -110,7 +110,7 @@ Note that in both examples the `ref` keyword must be used in both places, or the
 
 ## Ref readonly locals
 
-A ref readonly local is used to refer to values returned by the member that has `ref readonly` in its signature and uses `return ref`. A `ref readonly` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
+A ref readonly local is used to refer to values returned by the method or property that has `ref readonly` in its signature and uses `return ref`. A `ref readonly` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
 
 ## A ref returns and ref locals example
 


### PR DESCRIPTION
Updated the **Ref readonly locals** section, because one cannot use `return readonly ref`. Readonliness of ref is defined by the signature:
```csharp
public ref readonly Point3D Origin() { return ref origin; }
```

Also made updates to follow the "For more information, see..." guidelines.
