### PR TITLE
Add documentation for interactive option in add package and restore commands

### DIFF
--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -15,7 +15,7 @@ ms.date: 05/25/2018
 
 ## Synopsis
 
-`dotnet add [<PROJECT>] package <PACKAGE_NAME> [-h|--help] [-f|--framework] [-n|--no-restore] [--package-directory] [-s|--source] [-v|--version]`
+`dotnet add [<PROJECT>] package <PACKAGE_NAME> [-h|--help] [-f|--framework] [-n|--no-restore] [--package-directory] [-s|--source] [-v|--version] [--interactive]`
 
 ## Description
 
@@ -76,6 +76,10 @@ Uses a specific NuGet package source during the restore operation.
 `-v|--version <VERSION>`
 
 Version of the package.
+
+`--interactive`
+
+Allows the command to stop and wait for user input or action (for example to complete authentication). Since .NET Core 2.1.400.
 
 ## Examples
 

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -18,7 +18,7 @@ ms.date: 05/29/2018
 # [.NET Core 2.x](#tab/netcore2x)
 ```
 dotnet restore [<ROOT>] [--configfile] [--disable-parallel] [--force] [--ignore-failed-sources] [--no-cache]
-    [--no-dependencies] [--packages] [-r|--runtime] [-s|--source] [-v|--verbosity]
+    [--no-dependencies] [--packages] [-r|--runtime] [-s|--source] [-v|--verbosity] [--interactive]
 dotnet restore [-h|--help]
 ```
 # [.NET Core 1.x](#tab/netcore1x)
@@ -112,6 +112,10 @@ Specifies a NuGet package source to use during the restore operation. This setti
 `--verbosity <LEVEL>`
 
 Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+`--interactive`
+
+Allows the command to stop and wait for user input or action (for example to complete authentication). Since .NET Core 2.1.400.
 
 # [.NET Core 1.x](#tab/netcore1x)
 


### PR DESCRIPTION
As added in SDK 2.1.400:
- https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.400-SDK/2.1.400-sdk.md#notable-changes-in-sdk-21400
- https://github.com/NuGet/Home/issues/7017

## Summary
Provides documentation on the `--interactive` parameter for `dotnet restore` and `dotnet add package` as documented in the CLI help output, as added in [CLI release 2.1.400](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1.400-SDK/2.1.400-sdk.md#notable-changes-in-sdk-21400)

Fixes #8384 