### PR TITLE
Issue 8668 - various expression operators

### DIFF
--- a/docs/csharp/language-reference/keywords/byte.md
+++ b/docs/csharp/language-reference/keywords/byte.md
@@ -96,7 +96,8 @@ SampleMethod((byte)5);
  For more information on implicit numeric conversion rules, see the [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also  
 

--- a/docs/csharp/language-reference/keywords/char.md
+++ b/docs/csharp/language-reference/keywords/char.md
@@ -30,9 +30,9 @@ A `char` can be implicitly converted to [ushort](../../../csharp/language-refere
 
 The <xref:System.Char?displayProperty=nameWithType> type provides several static methods for working with `char` values.
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/int.md
+++ b/docs/csharp/language-reference/keywords/int.md
@@ -70,7 +70,8 @@ int y = (int)3.0;    // OK: explicit conversion.
  For more information on arithmetic expressions with mixed floating-point types and integral types, see [float](../../../csharp/language-reference/keywords/float.md) and [double](../../../csharp/language-reference/keywords/double.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/internal.md
+++ b/docs/csharp/language-reference/keywords/internal.md
@@ -81,7 +81,8 @@ public class TestAccess
 ```  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/long.md
+++ b/docs/csharp/language-reference/keywords/long.md
@@ -94,7 +94,8 @@ long y = (long)3.0;   // OK: explicit conversion
 ```  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/private.md
+++ b/docs/csharp/language-reference/keywords/private.md
@@ -36,9 +36,9 @@ In this example, the `Employee` class contains two private data members, `name` 
 
 [!code-csharp[csrefKeywordsModifiers#10](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#10)]
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/protected.md
+++ b/docs/csharp/language-reference/keywords/protected.md
@@ -40,9 +40,9 @@ If you change the access levels of `x` and `y` to [private](private.md), the com
 
 `'Point.x' is inaccessible due to its protection level.`
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/public.md
+++ b/docs/csharp/language-reference/keywords/public.md
@@ -31,9 +31,9 @@ If you change the `public` access level to [private](private.md) or [protected](
 
 'PointTest.y' is inaccessible due to its protection level.
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/sbyte.md
+++ b/docs/csharp/language-reference/keywords/sbyte.md
@@ -96,7 +96,8 @@ sbyte y = (sbyte)3.0;  // OK: explicit conversion
  For more information about implicit numeric conversion rules, see the [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/short.md
+++ b/docs/csharp/language-reference/keywords/short.md
@@ -94,7 +94,7 @@ For more information on implicit numeric conversion rules, see the [Implicit Num
 
 ## C# language specification
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/uint.md
+++ b/docs/csharp/language-reference/keywords/uint.md
@@ -79,7 +79,8 @@ uint y = (uint)3.0;
  For more information about implicit numeric conversion rules, see the [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/ulong.md
+++ b/docs/csharp/language-reference/keywords/ulong.md
@@ -87,7 +87,8 @@ ulong y = (ulong)3.0;
  For more information on implicit numeric conversion rules, see the [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/ushort.md
+++ b/docs/csharp/language-reference/keywords/ushort.md
@@ -95,7 +95,8 @@ ushort y = (ushort)3.0;
  For more information about implicit numeric conversion rules, see the [Implicit Numeric Conversions Table](../../../csharp/language-reference/keywords/implicit-numeric-conversions-table.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Integral types](~/_csharplang/spec/types.md#integral-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 


### PR DESCRIPTION
## Summary

Update "C# Language Specification" link in various operators to deep link to the appropriate section on the `Expressions` page instead of the introduction.

Fixes #8668 