### PR TITLE
Link various operators to relevant language spec page.

### DIFF
--- a/docs/csharp/language-reference/keywords/as.md
+++ b/docs/csharp/language-reference/keywords/as.md
@@ -36,8 +36,9 @@ expression is type ? (type)expression : (type)null
 [!code-csharp[csrefKeywordsOperator#2](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsOperator/CS/csrefKeywordsOperators.cs#2)]
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
+
+For more information, see [The as operator](~/_csharplang/spec/expressions.md#the-as-operator) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+ 
 ## See Also  
 - [C# Reference](../../../csharp/language-reference/index.md)  
 - [C# Programming Guide](../../../csharp/programming-guide/index.md)  

--- a/docs/csharp/language-reference/keywords/nameof.md
+++ b/docs/csharp/language-reference/keywords/nameof.md
@@ -125,8 +125,9 @@ class C {
  There is no way to get a signatures information such as "`Method1 (str, str)`".  One way to do that is to use an Expression, `Expression e = () => A.B.Method1("s1", "s2")`, and pull the MemberInfo from the resulting expression tree.  
   
 ## Language Specifications  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
+
+For more information, see [Nameof expressions](~/_csharplang/spec/expressions.md#nameof-expressions) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+ 
 ## See Also
 
 - [C# Reference](../../../csharp/language-reference/index.md)  

--- a/docs/csharp/language-reference/keywords/typeof.md
+++ b/docs/csharp/language-reference/keywords/typeof.md
@@ -38,8 +38,9 @@ System.Type type = i.GetType();
  [!code-csharp[csrefKeywordsOperator#13](../../../csharp/language-reference/keywords/codesnippet/CSharp/typeof_2.cs)]  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
+
+For more information, see [The typeof operator](~/_csharplang/spec/expressions.md#the-typeof-operator) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+ 
 ## See Also
 
 - <xref:System.Type?displayProperty=nameWithType>  

--- a/docs/csharp/language-reference/operators/conditional-and-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-and-operator.md
@@ -34,7 +34,8 @@ x & y
  [!code-csharp[csRefOperators#48](../../../csharp/language-reference/operators/codesnippet/CSharp/conditional-and-operator_1.cs)]  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Conditional logical operators](~/_csharplang/spec/expressions.md#conditional-logical-operators) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/operators/conditional-or-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-or-operator.md
@@ -34,6 +34,10 @@ x | y
   
  [!code-csharp[csRefOperators#52](../../../csharp/language-reference/operators/codesnippet/CSharp/conditional-or-operator_1.cs)]  
   
+## C# Language Specification  
+
+For more information, see [Conditional logical operators](~/_csharplang/spec/expressions.md#conditional-logical-operators) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+  
 ## See Also
 
 - [C# Reference](../../../csharp/language-reference/index.md)  

--- a/docs/csharp/language-reference/operators/null-coalescing-operator.md
+++ b/docs/csharp/language-reference/operators/null-coalescing-operator.md
@@ -22,6 +22,10 @@ The `??` operator is called the null-coalescing operator.  It returns the left-h
 ## Example  
  [!code-csharp[csRefOperators#53](../../../csharp/language-reference/operators/codesnippet/CSharp/null-conditional-operator_1.cs)]  
   
+## C# Language Specification  
+
+For more information, see [The null coalescing operator](~/_csharplang/spec/expressions.md#the-null-coalescing-operator) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+  
 ## See Also
 
 - [C# Reference](../../../csharp/language-reference/index.md)  

--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -43,7 +43,8 @@ PropertyChanged?.Invoke(…)
  The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in a temporary variable. You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  
   
 ## Language Specifications  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Null-conditional operator](~/_csharplang/spec/expressions.md#null-conditional-operator) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 


### PR DESCRIPTION
## Summary

Update "C# Language Specification" link in various operators to deep link to the appropriate section on the `Expressions` page instead of the introduction.

contributes to #8668 

edit by @BillWagner : change fixes to contributes to.