### PR TITLE
Link access modifiers to relevant language spec page.

### DIFF
--- a/docs/csharp/language-reference/keywords/internal.md
+++ b/docs/csharp/language-reference/keywords/internal.md
@@ -81,7 +81,8 @@ public class TestAccess
 ```  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/language-reference/keywords/private.md
+++ b/docs/csharp/language-reference/keywords/private.md
@@ -36,9 +36,9 @@ In this example, the `Employee` class contains two private data members, `name` 
 
 [!code-csharp[csrefKeywordsModifiers#10](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#10)]
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/protected.md
+++ b/docs/csharp/language-reference/keywords/protected.md
@@ -40,9 +40,9 @@ If you change the access levels of `x` and `y` to [private](private.md), the com
 
 `'Point.x' is inaccessible due to its protection level.`
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/public.md
+++ b/docs/csharp/language-reference/keywords/public.md
@@ -31,9 +31,9 @@ If you change the `public` access level to [private](private.md) or [protected](
 
 'PointTest.y' is inaccessible due to its protection level.
 
-## C# language specification
+## C# language specification  
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [Declared accessibility](~/_csharplang/spec/basic-concepts.md#declared-accessibility) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Update "C# Language Specification" link in various access modifiers to deep link to the `Declared accessibility` section of the Basic Concepts page instead of the introduction.

Contributes to #8668 