### PR TITLE
Link various pages about classes to relevant language spec page.

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
@@ -152,7 +152,8 @@ partial void onNameChanged()
 -   You can make a [delegate](../../../csharp/language-reference/keywords/delegate.md) to a partial method that has been defined and implemented, but not to a partial method that has only been defined.  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Partial types](~/_csharplang/spec/classes.md#partial-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/passing-parameters.md
+++ b/docs/csharp/programming-guide/classes-and-structs/passing-parameters.md
@@ -23,7 +23,8 @@ In C#, arguments can be passed to parameters either by value or by reference. Pa
 -   [Passing Reference-Type Parameters](../../../csharp/programming-guide/classes-and-structs/passing-reference-type-parameters.md)  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Argument lists](~/_csharplang/spec/expressions.md#argument-lists) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
@@ -25,7 +25,8 @@ A private constructor is a special instance constructor. It is generally used in
  [!code-csharp[csProgGuideObjects#13](../../../csharp/programming-guide/classes-and-structs/codesnippet/CSharp/private-constructors_3.cs)]  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Private constructors](~/_csharplang/spec/classes.md#private-constructors) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/properties.md
@@ -64,7 +64,8 @@ If a property has both a `get` and a `set` accessor, both must be auto-implement
 -   [Auto-Implemented Properties](../../../csharp/programming-guide/classes-and-structs/auto-implemented-properties.md)  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Properties](~/_csharplang/spec/classes.md#properties) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
@@ -78,7 +78,8 @@ Console.WriteLine(Math.Round(Math.Abs(dub)));
  A call to a static method generates a call instruction in Microsoft intermediate language (MSIL), whereas a call to an instance method generates a `callvirt` instruction, which also checks for a null object references. However, most of the time the performance difference between the two is not significant.  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Static classes](~/_csharplang/spec/classes.md#static-classes) and [Static and instance members](~/_csharplang/spec/classes.md#static-and-instance-members) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -82,7 +82,8 @@ Console.WriteLine("{0}, {1}", a, b);
  A constructor can be declared static by using the [static](../../../csharp/language-reference/keywords/static.md) keyword. Static constructors are called automatically, immediately before any static fields are accessed, and are generally used to initialize static class members. For more information, see [Static Constructors](../../../csharp/programming-guide/classes-and-structs/static-constructors.md).  
   
 ## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
+
+For more information, see [Instance constructors](~/_csharplang/spec/classes.md#instance-constructors) and [Static constructors](~/_csharplang/spec/classes.md#static-constructors) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 


### PR DESCRIPTION
## Summary

Update "C# Language Specification" link in class pages to deep link to the appropriate section of the `Classes` page instead of the introduction.

Contributes to #8668 

Edit by @BillWagner change "Fixes" to "Contributes to"