### PR TITLE
Fix typo

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # .NET Core Guide
 
-[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general-purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform (supporting Windows, macOS, and Linux) and can be used to build device, cloud, and IoT applications.
+[.NET Core](about.md) is an [open-source](https://github.com/dotnet/coreclr/blob/master/LICENSE.TXT), general purpose development platform maintained by Microsoft and the .NET community on [GitHub](https://github.com/dotnet/core). It's cross-platform (supporting Windows, macOS, and Linux) and can be used to build device, cloud, and IoT applications.
 
 See [About .NET Core](about.md) to learn more about .NET Core, including its characteristics, supported languages and frameworks, and key APIs.
 


### PR DESCRIPTION
## Summary

Fixed typo because "general purpose" is not hyphenated.
 
Fixes #Issue_Number (if available)
