### PR TITLE
UDP service - fix sample descriptions

### DIFF
--- a/docs/framework/network-programming/using-udp-services.md
+++ b/docs/framework/network-programming/using-udp-services.md
@@ -38,7 +38,6 @@ Broadcasts can be directed to specific portions of a network by setting all bits
 The following code example uses a <xref:System.Net.Sockets.UdpClient> to listen for UDP datagrams on port 11,000. The client receives a message string and writes the message to the console.
 
 ```vb
-Imports System
 Imports System.Net
 Imports System.Net.Sockets
 Imports System.Text
@@ -56,7 +55,7 @@ Public Class UDPListener
             Console.WriteLine("Received broadcast from {0} :", groupEP)
             Console.WriteLine(Encoding.ASCII.GetString(bytes, 0, bytes.Length))
          End While
-      Catch e As Exception
+      Catch e As SocketException
          Console.WriteLine(e)
       Finally
          listener.Close()
@@ -95,7 +94,7 @@ public class UDPListener
                 Console.WriteLine($" {Encoding.ASCII.GetString(bytes, 0, bytes.Length)}");
             }
         }
-        catch (Exception e)
+        catch (SocketException e)
         {
             Console.WriteLine(e);
         }
@@ -115,7 +114,6 @@ public class UDPListener
 The following code example uses a <xref:System.Net.Sockets.Socket> to send UDP datagrams to the directed broadcast address 192.168.1.255, using port 11,000. The client sends the message string specified on the command line.
 
 ```vb
-Imports System
 Imports System.Net
 Imports System.Net.Sockets
 Imports System.Text

--- a/docs/framework/network-programming/using-udp-services.md
+++ b/docs/framework/network-programming/using-udp-services.md
@@ -21,156 +21,141 @@ author: "mcleblanc"
 ms.author: "markl"
 ---
 # Using UDP Services
-The <xref:System.Net.Sockets.UdpClient> class communicates with network services using UDP. The properties and methods of the <xref:System.Net.Sockets.UdpClient> class abstract the details of creating a <xref:System.Net.Sockets.Socket> for requesting and receiving data using UDP.  
-  
- User Datagram Protocol (UDP) is a simple protocol that makes a best effort to deliver data to a remote host. However, because the UDP protocol is a connectionless protocol, UDP datagrams sent to the remote endpoint are not guaranteed to arrive, nor are they guaranteed to arrive in the same sequence in which they are sent. Applications that use UDP must be prepared to handle missing, duplicate, and out-of-sequence datagrams.  
-  
- To send a datagram using UDP, you must know the network address of the network device hosting the service you need and the UDP port number that the service uses to communicate. The Internet Assigned Numbers Authority (Iana) defines port numbers for common services (see [Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)). Services not on the Iana list can have port numbers in the range 1,024 to 65,535.  
-  
- Special network addresses are used to support UDP broadcast messages on IP-based networks. The following discussion uses the IP version 4 address family used on the Internet as an example.  
-  
- IP version 4 addresses use 32 bits to specify a network address. For class C addresses using a netmask of 255.255.255.0, these bits are separated into four octets. When expressed in decimal, the four octets form the familiar dotted-quad notation, such as 192.168.100.2. The first two octets (192.168 in this example) form the network number, the third octet (100) defines the subnet, and the final octet (2) is the host identifier.  
-  
- Setting all the bits of an IP address to one, or 255.255.255.255, forms the limited broadcast address. Sending a UDP datagram to this address delivers the message to any host on the local network segment. Because routers never forward messages sent to this address, only hosts on the network segment receive the broadcast message.  
-  
- Broadcasts can be directed to specific portions of a network by setting all bits of the host identifier. For example, to send a broadcast to all hosts on the network identified by IP addresses starting with 192.168.1, use the address 192.168.1.255.  
-  
- The following code example uses a <xref:System.Net.Sockets.UdpClient> to listen for UDP datagrams sent to the directed broadcast address 192.168.1.255 on port 11,000. The client receives a message string and writes the message to the console.  
-  
-```vb  
-Imports System  
-Imports System.Net  
-Imports System.Net.Sockets  
-Imports System.Text  
-  
-Public Class UDPListener  
-   Private Const listenPort As Integer = 11000  
-  
-   Private Shared Sub StartListener()  
-      Dim done As Boolean = False  
-      Dim listener As New UdpClient(listenPort)  
-      Dim groupEP As New IPEndPoint(IPAddress.Any, listenPort)  
-      Try  
-         While Not done  
-            Console.WriteLine("Waiting for broadcast")  
-            Dim bytes As Byte() = listener.Receive(groupEP)  
-            Console.WriteLine("Received broadcast from {0} :", _  
-                groupEP.ToString())   
-            Console.WriteLine( _  
-                Encoding.ASCII.GetString(bytes, 0, bytes.Length))  
-            Console.WriteLine()  
-         End While  
-      Catch e As Exception  
-         Console.WriteLine(e.ToString())  
-      Finally  
-         listener.Close()  
-      End Try  
-   End Sub 'StartListener  
-  
-   Public Shared Function Main() As Integer  
-      StartListener()  
-      Return 0  
-   End Function 'Main  
-End Class 'UDPListener  
-```  
-  
-```csharp  
-using System;  
-using System.Net;  
-using System.Net.Sockets;  
-using System.Text;  
-  
-public class UDPListener   
-{  
-    private const int listenPort = 11000;  
-  
-    private static void StartListener()   
-    {  
-        bool done = false;  
-  
-        UdpClient listener = new UdpClient(listenPort);  
-        IPEndPoint groupEP = new IPEndPoint(IPAddress.Any,listenPort);  
-  
-        try   
-        {  
-            while (!done)   
-            {  
-                Console.WriteLine("Waiting for broadcast");  
-                byte[] bytes = listener.Receive( ref groupEP);  
-  
-                Console.WriteLine("Received broadcast from {0} :\n {1}\n",  
-                    groupEP.ToString(),  
-                    Encoding.ASCII.GetString(bytes,0,bytes.Length));  
-            }  
-  
-        }   
-        catch (Exception e)   
-        {  
-            Console.WriteLine(e.ToString());  
-        }  
-        finally  
-        {  
-            listener.Close();  
-        }  
-    }  
-  
-    public static int Main()   
-    {  
-        StartListener();  
-  
-        return 0;  
-    }  
-}  
-```  
-  
- The following code example uses a <xref:System.Net.Sockets.UdpClient> to send UDP datagrams to the directed broadcast address 192.168.1.255, using port 11,000. The client sends the message string specified on the command line.  
-  
-```vb  
-Imports System  
-Imports System.Net  
-Imports System.Net.Sockets  
-Imports System.Text  
-  
-Public Class Program  
-  
-    Overloads Public Shared Function Main(args() As [String]) As Integer  
-      Dim s As New Socket(AddressFamily.InterNetwork, SocketType.Dgram,  
-          ProtocolType.Udp)  
-      Dim broadcast As IPAddress = IPAddress.Parse("192.168.1.255")  
-      Dim sendbuf As Byte() = Encoding.ASCII.GetBytes(args(0))  
-      Dim ep As New IPEndPoint(broadcast, 11000)  
-      s.SendTo(sendbuf, ep)  
-      Console.WriteLine("Message sent to the broadcast address")  
-   End Function 'Main  
-End Class   
-```  
-  
-```csharp  
-using System;  
-using System.Net;  
-using System.Net.Sockets;  
-using System.Text;  
-  
-class Program   
-{  
-    static void Main(string[] args)   
-    {  
-        Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram,  
-            ProtocolType.Udp);  
-  
-        IPAddress broadcast = IPAddress.Parse("192.168.1.255");  
-  
-        byte[] sendbuf = Encoding.ASCII.GetBytes(args[0]);  
-        IPEndPoint ep = new IPEndPoint(broadcast, 11000);  
-  
-        s.SendTo(sendbuf, ep);  
-  
-        Console.WriteLine("Message sent to the broadcast address");  
-    }  
-}  
-```  
-  
-## See Also  
- <xref:System.Net.Sockets.UdpClient>  
- <xref:System.Net.IPAddress>  
- 
+The <xref:System.Net.Sockets.UdpClient> class communicates with network services using UDP. The properties and methods of the <xref:System.Net.Sockets.UdpClient> class abstract the details of creating a <xref:System.Net.Sockets.Socket> for requesting and receiving data using UDP.
+
+User Datagram Protocol (UDP) is a simple protocol that makes a best effort to deliver data to a remote host. However, because the UDP protocol is a connectionless protocol, UDP datagrams sent to the remote endpoint are not guaranteed to arrive, nor are they guaranteed to arrive in the same sequence in which they are sent. Applications that use UDP must be prepared to handle missing, duplicate, and out-of-sequence datagrams.
+
+To send a datagram using UDP, you must know the network address of the network device hosting the service you need and the UDP port number that the service uses to communicate. The Internet Assigned Numbers Authority (Iana) defines port numbers for common services (see [Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml)). Services not on the Iana list can have port numbers in the range 1,024 to 65,535.
+
+Special network addresses are used to support UDP broadcast messages on IP-based networks. The following discussion uses the IP version 4 address family used on the Internet as an example.
+
+IP version 4 addresses use 32 bits to specify a network address. For class C addresses using a netmask of 255.255.255.0, these bits are separated into four octets. When expressed in decimal, the four octets form the familiar dotted-quad notation, such as 192.168.100.2. The first two octets (192.168 in this example) form the network number, the third octet (100) defines the subnet, and the final octet (2) is the host identifier.
+
+Setting all the bits of an IP address to one, or 255.255.255.255, forms the limited broadcast address. Sending a UDP datagram to this address delivers the message to any host on the local network segment. Because routers never forward messages sent to this address, only hosts on the network segment receive the broadcast message.
+
+Broadcasts can be directed to specific portions of a network by setting all bits of the host identifier. For example, to send a broadcast to all hosts on the network identified by IP addresses starting with 192.168.1, use the address 192.168.1.255.
+
+The following code example uses a <xref:System.Net.Sockets.UdpClient> to listen for UDP datagrams on port 11,000. The client receives a message string and writes the message to the console.
+
+```vb
+Imports System
+Imports System.Net
+Imports System.Net.Sockets
+Imports System.Text
+
+Public Class UDPListener
+   Private Const listenPort As Integer = 11000
+   
+   Private Shared Sub StartListener()
+      Dim listener As New UdpClient(listenPort)
+      Dim groupEP As New IPEndPoint(IPAddress.Any, listenPort)
+      Try
+         While True
+            Console.WriteLine("Waiting for broadcast")
+            Dim bytes As Byte() = listener.Receive(groupEP)
+            Console.WriteLine("Received broadcast from {0} :", groupEP)
+            Console.WriteLine(Encoding.ASCII.GetString(bytes, 0, bytes.Length))
+         End While
+      Catch e As Exception
+         Console.WriteLine(e)
+      Finally
+         listener.Close()
+      End Try
+   End Sub 'StartListener
+   
+   Public Shared Sub Main()
+      StartListener()
+   End Sub 'Main
+End Class 'UDPListener
+```
+
+```csharp
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+public class UDPListener
+{
+    private const int listenPort = 11000;
+    
+    private static void StartListener()
+    {
+        UdpClient listener = new UdpClient(listenPort);
+        IPEndPoint groupEP = new IPEndPoint(IPAddress.Any, listenPort);
+        
+        try
+        {
+            while (true)
+            {
+                Console.WriteLine("Waiting for broadcast");
+                byte[] bytes = listener.Receive(ref groupEP);
+                
+                Console.WriteLine($"Received broadcast from {groupEP} :");
+                Console.WriteLine($" {Encoding.ASCII.GetString(bytes, 0, bytes.Length)}");
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+        }
+        finally
+        {
+            listener.Close();
+        }
+    }
+    
+    public static void Main()
+    {
+        StartListener();
+    }
+}
+```
+
+The following code example uses a <xref:System.Net.Sockets.Socket> to send UDP datagrams to the directed broadcast address 192.168.1.255, using port 11,000. The client sends the message string specified on the command line.
+
+```vb
+Imports System
+Imports System.Net
+Imports System.Net.Sockets
+Imports System.Text
+
+Public Class Program
+    Public Shared Sub Main(args() As [String])
+      Dim s As New Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp)
+      Dim broadcast As IPAddress = IPAddress.Parse("192.168.1.255")
+      Dim sendbuf As Byte() = Encoding.ASCII.GetBytes(args(0))
+      Dim ep As New IPEndPoint(broadcast, 11000)
+      s.SendTo(sendbuf, ep)
+      Console.WriteLine("Message sent to the broadcast address")
+   End Sub 'Main
+End Class
+```
+
+```csharp
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        
+        IPAddress broadcast = IPAddress.Parse("192.168.1.255");
+        
+        byte[] sendbuf = Encoding.ASCII.GetBytes(args[0]);
+        IPEndPoint ep = new IPEndPoint(broadcast, 11000);
+        
+        s.SendTo(sendbuf, ep);
+        
+        Console.WriteLine("Message sent to the broadcast address");
+    }
+}
+```
+
+## See Also
+ <xref:System.Net.Sockets.UdpClient>
+ <xref:System.Net.IPAddress>


### PR DESCRIPTION
Fix sample descriptions

Additional changes:
* Remove extra spaces at the start and end of text and code.
* Simplify code samples

Fixes https://github.com/dotnet/docs/issues/6070