### PR TITLE
missed a few build errors while reviewing PRs earlier

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
+++ b/docs/csharp/programming-guide/classes-and-structs/partial-classes-and-methods.md
@@ -153,7 +153,7 @@ partial void onNameChanged()
   
 ## C# Language Specification  
 
-For more information, see [Partial types](~/_csharplang/spec/classes.md#partial-types) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Partial types](~/_csharplang/spec/classes.md#partial-types) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/passing-parameters.md
+++ b/docs/csharp/programming-guide/classes-and-structs/passing-parameters.md
@@ -24,7 +24,7 @@ In C#, arguments can be passed to parameters either by value or by reference. Pa
   
 ## C# Language Specification  
 
-For more information, see [Argument lists](~/_csharplang/spec/expressions.md#argument-lists) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Argument lists](~/_csharplang/spec/expressions.md#argument-lists) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/private-constructors.md
@@ -26,7 +26,7 @@ A private constructor is a special instance constructor. It is generally used in
   
 ## C# Language Specification  
 
-For more information, see [Private constructors](~/_csharplang/spec/classes.md#private-constructors) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Private constructors](~/_csharplang/spec/classes.md#private-constructors) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/properties.md
@@ -65,7 +65,7 @@ If a property has both a `get` and a `set` accessor, both must be auto-implement
   
 ## C# Language Specification  
 
-For more information, see [Properties](~/_csharplang/spec/classes.md#properties) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Properties](~/_csharplang/spec/classes.md#properties) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
@@ -79,7 +79,7 @@ Console.WriteLine(Math.Round(Math.Abs(dub)));
   
 ## C# Language Specification  
 
-For more information, see [Static classes](~/_csharplang/spec/classes.md#static-classes) and [Static and instance members](~/_csharplang/spec/classes.md#static-and-instance-members) in the [C# Language Specification](../../language/reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Static classes](~/_csharplang/spec/classes.md#static-classes) and [Static and instance members](~/_csharplang/spec/classes.md#static-and-instance-members) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
+++ b/docs/csharp/programming-guide/classes-and-structs/static-classes-and-static-class-members.md
@@ -79,7 +79,7 @@ Console.WriteLine(Math.Round(Math.Abs(dub)));
   
 ## C# Language Specification  
 
-For more information, see [Static classes](~/_csharplang/spec/classes.md#static-classes) and [Static and instance members](~/_csharplang/spec/classes.md#static-and-instance-members) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Static classes](~/_csharplang/spec/classes.md#static-classes) and [Static and instance members](~/_csharplang/spec/classes.md#static-and-instance-members) in the [C# Language Specification](../../language/reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -83,7 +83,7 @@ Console.WriteLine("{0}, {1}", a, b);
   
 ## C# Language Specification  
 
-For more information, see [Instance constructors](~/_csharplang/spec/classes.md#instance-constructors) and [Static constructors](~/_csharplang/spec/classes.md#static-constructors) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Instance constructors](~/_csharplang/spec/classes.md#instance-constructors) and [Static constructors](~/_csharplang/spec/classes.md#static-constructors) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/delegates/index.md
+++ b/docs/csharp/programming-guide/delegates/index.md
@@ -54,7 +54,7 @@ A [delegate](../../../csharp/language-reference/keywords/delegate.md) is a type 
   
 ## C# Language Specification  
 
-For more information, see [Delegates](~/_csharplang/spec/delegates.md) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Delegates](~/_csharplang/spec/delegates.md) in the [C# Language Specification](../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## Featured Book Chapters  
  [Delegates, Events, and Lambda Expressions](https://msdn.microsoft.com/library/orm-9780596516109-03-09.aspx) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](https://msdn.microsoft.com/library/orm-9780596516109-03.aspx)  

--- a/docs/csharp/programming-guide/events/index.md
+++ b/docs/csharp/programming-guide/events/index.md
@@ -44,7 +44,7 @@ Events enable a [class](../../../csharp/language-reference/keywords/class.md) or
   
 ## C# Language Specification  
 
-For more information, see [Events](~/_csharplang/spec/classes.md#events) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Events](~/_csharplang/spec/classes.md#events) in the [C# Language Specification](../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## Featured Book Chapters  
  [Delegates, Events, and Lambda Expressions](https://msdn.microsoft.com/library/orm-9780596516109-03-09.aspx) in [C# 3.0 Cookbook, Third Edition: More than 250 solutions for C# 3.0 programmers](https://msdn.microsoft.com/library/orm-9780596516109-03.aspx)  

--- a/docs/csharp/programming-guide/exceptions/creating-and-throwing-exceptions.md
+++ b/docs/csharp/programming-guide/exceptions/creating-and-throwing-exceptions.md
@@ -57,7 +57,7 @@ Exceptions are used to indicate that an error has occurred while running the pro
   
 ## C# Language Specification  
 
-For more information, see [Exceptions](~/_csharplang/spec/exceptions.md) and [The throw statement](~/_csharplang/spec/statements.md#the-throw-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Exceptions](~/_csharplang/spec/exceptions.md) and [The throw statement](~/_csharplang/spec/statements.md#the-throw-statement) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/exceptions/exception-handling.md
+++ b/docs/csharp/programming-guide/exceptions/exception-handling.md
@@ -47,7 +47,7 @@ A [try](../../../csharp/language-reference/keywords/try-catch.md) block is used 
   
 ## C# Language Specification  
 
-For more information, see [Exceptions](~/_csharplang/spec/exceptions.md) and [The try statement](~/_csharplang/spec/statements.md#the-try-statement) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Exceptions](~/_csharplang/spec/exceptions.md) and [The try statement](~/_csharplang/spec/statements.md#the-try-statement) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/exceptions/index.md
+++ b/docs/csharp/programming-guide/exceptions/index.md
@@ -56,7 +56,7 @@ The C# language's exception handling features help you deal with any unexpected 
   
 ## C# Language Specification  
 
-For more information, see [Exceptions](~/_csharplang/spec/exceptions.md) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Exceptions](~/_csharplang/spec/exceptions.md) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/indexers/index.md
+++ b/docs/csharp/programming-guide/indexers/index.md
@@ -59,7 +59,7 @@ Starting with C# 7.0, both the get and set accessor can be an implemented as exp
   
 ## C# Language Specification  
 
-For more information, see [Indexers](~/_csharplang/spec/classes.md#indexers) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Indexers](~/_csharplang/spec/classes.md#indexers) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/inside-a-program/general-structure-of-a-csharp-program.md
+++ b/docs/csharp/programming-guide/inside-a-program/general-structure-of-a-csharp-program.md
@@ -25,7 +25,7 @@ C# programs can consist of one or more files. Each file can contain zero or more
   
 ## C# Language Specification  
 
-For more information, see [Basic concepts](~/_csharplang/spec/basic-concepts.md) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Basic concepts](~/_csharplang/spec/basic-concepts.md) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 

--- a/docs/csharp/programming-guide/interop/index.md
+++ b/docs/csharp/programming-guide/interop/index.md
@@ -34,7 +34,7 @@ Interoperability enables you to preserve and take advantage of existing investme
   
 ## C# Language Specification  
 
-For more information, see [Basic concepts](~/_csharplang/spec/unsafe-code.md) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
+For more information, see [Basic concepts](~/_csharplang/spec/unsafe-code.md) in the [C# Language Specification](../../language-reference/language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
   
 ## See Also
 


### PR DESCRIPTION
This PR fixes build warnings on links that I introduced by missing them in the build report for a PR merged earlier today.
