### PR TITLE
Whitespace - new cases in connection-strings.md

### DIFF
--- a/docs/framework/data/adonet/connection-strings.md
+++ b/docs/framework/data/adonet/connection-strings.md
@@ -13,9 +13,9 @@ A connection string is a semicolon-delimited list of key/value parameter pairs:
   
 	keyword1=value; keyword2=value;
   
-Keywords are not case-sensitive. Values, however, may be case-sensitive, depending on the data source. Both keywords and values may contain [whitespace characters](https://en.wikipedia.org/wiki/Whitespace_character#Unicode). Leading and trailing whitespace is ignored in keywords and unquoted values.
+Keywords are not case-sensitive. Values, however, may be case-sensitive, depending on the data source. Both keywords and values may contain [whitespace characters](https://en.wikipedia.org/wiki/Whitespace_character#Unicode). Leading and trailing white space is ignored in keywords and unquoted values.
 
-If a value contains the semicolon, [Unicode control characters](https://en.wikipedia.org/wiki/Unicode_control_characters), or leading or trailing whitespace, it must be enclosed in single or double quotation marks. For example:
+If a value contains the semicolon, [Unicode control characters](https://en.wikipedia.org/wiki/Unicode_control_characters), or leading or trailing white space, it must be enclosed in single or double quotation marks. For example:
 
 	Keyword=" whitespace  ";
 	Keyword='special;character';


### PR DESCRIPTION
Hello @rpetrusha and @mairaw . I was curious if this error came back after our treatment and apparently it did.  :/

## Fix "whitespace" words - docs/framework.

This PR came out from this [issue](https://github.com/dotnet/docs/issues/4439) on docs/framework. 

## Brief explanation
We should use **white-space** for adjectives and **white space** for nouns.

## Suggested Reviewers
@mairaw @rpetrusha 