### PR TITLE
Update F# optional parameters docs

### DIFF
--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -119,7 +119,7 @@ The output is as follows.
 Baud Rate: 9600 Duplex: Full Parity: false
 Baud Rate: 4800 Duplex: Half Parity: false
 Baud Rate: 300 Duplex: Half Parity: true
-Baud Rate: 9600 Duplex: Full Parity: false4
+Baud Rate: 9600 Duplex: Full Parity: false
 Baud Rate: 9600 Duplex: Full Parity: false
 Baud Rate: 4800 Duplex: Half Parity: false
 ```

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -137,11 +137,11 @@ type C =
 The value given as argument to `DefaultParameterValue` must match the type of the parameter, i.e. the following is not allowed:
 
 ```fsharp
-type C() =
+type C =
     static member Wrong([<Optional; DefaultParameterValue("string")>] i:int) = ()
 ```
 
-In this case compiler generate a warning, and ignore both attributes altogether. Note that the default value `null` needs to be type-annotated, as otherwise the compiler infers the wrong type, i.e. `[<Optional; DefaultParameterValue(null:obj)>] o:obj`.
+In this case, the compiler generates a warning and will ignore both attributes altogether. Note that the default value `null` needs to be type-annotated, as otherwise the compiler infers the wrong type, i.e. `[<Optional; DefaultParameterValue(null:obj)>] o:obj`.
 
 ## Passing by Reference
 

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -138,10 +138,10 @@ The value given as argument to `DefaultParameterValue` must match the type of th
 
 ```fsharp
 type C() =
-    static member Wrong([<Optional;DefaultParameterValue("string")>] i:int) = ()
+    static member Wrong([<Optional; DefaultParameterValue("string")>] i:int) = ()
 ```
 
-In this case compiler generate a warning, and ignore both attributes altogether. Note that the default value `null` needs to be type-annotated, as otherwise the compiler infers the wrong type, i.e. `[<Optional;DefaultParameterValue(null:obj)>] o:obj`.
+In this case compiler generate a warning, and ignore both attributes altogether. Note that the default value `null` needs to be type-annotated, as otherwise the compiler infers the wrong type, i.e. `[<Optional; DefaultParameterValue(null:obj)>] o:obj`.
 
 ## Passing by Reference
 

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -119,6 +119,9 @@ The output is as follows.
 Baud Rate: 9600 Duplex: Full Parity: false
 Baud Rate: 4800 Duplex: Half Parity: false
 Baud Rate: 300 Duplex: Half Parity: true
+Baud Rate: 9600 Duplex: Full Parity: false4
+Baud Rate: 9600 Duplex: Full Parity: false
+Baud Rate: 4800 Duplex: Half Parity: false
 ```
 
 Since F# 4.1 you can use the attributes `[<Optional; DefaultParameterValue<(...)>]` in F# for C# and VB interop, so that C#/VB callers will see an argument as optional. This is equivalent to defining the argument as optional in C# as in `MyMethod(int i = 3)`.

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -105,6 +105,8 @@ For more information, see [Constructors (F#)](https://msdn.microsoft.com/library
 
 You can specify an optional parameter for a method by using a question mark in front of the parameter name. Optional parameters are interpreted as the F# option type, so you can query them in the regular way that option types are queried, by using a `match` expression with `Some` and `None`. Optional parameters are permitted only on members, not on functions created by using `let` bindings.
 
+You can pass existing optional values to method by parameter name, such as `?arg=None` or `?arg=Some(3)` or `?arg=arg`. This can be useful when building a method that passes optional arguments on to another method.
+
 You can also use a function `defaultArg`, which sets a default value of an optional argument. The `defaultArg` function takes the optional parameter as the first argument and the default value as the second.
 
 The following example illustrates the use of optional parameters.
@@ -117,6 +119,16 @@ The output is as follows.
 Baud Rate: 9600 Duplex: Full Parity: false
 Baud Rate: 4800 Duplex: Half Parity: false
 Baud Rate: 300 Duplex: Half Parity: true
+```
+
+Since F# 4.1 you can use the attributes `[<Optional; DefaultParameterValue<(...)>]` in F# for C# and VB interop, so that C#/VB callers will see an argument as optional. This is equivalent to defining the argument as optional in C# as in `MyMethod(int i = 3)`.
+
+```fsharp
+open System
+open System.Runtime.InteropServices
+type C = 
+    static member Foo([<Optional; DefaultParameterValue("Hello world")>] message) =
+        printfn "%s" message
 ```
 
 ## Passing by Reference

--- a/docs/fsharp/language-reference/parameters-and-arguments.md
+++ b/docs/fsharp/language-reference/parameters-and-arguments.md
@@ -105,7 +105,7 @@ For more information, see [Constructors (F#)](https://msdn.microsoft.com/library
 
 You can specify an optional parameter for a method by using a question mark in front of the parameter name. Optional parameters are interpreted as the F# option type, so you can query them in the regular way that option types are queried, by using a `match` expression with `Some` and `None`. Optional parameters are permitted only on members, not on functions created by using `let` bindings.
 
-You can pass existing optional values to method by parameter name, such as `?arg=None` or `?arg=Some(3)` or `?arg=arg`. This can be useful when building a method that passes optional arguments on to another method.
+You can pass existing optional values to method by parameter name, such as `?arg=None` or `?arg=Some(3)` or `?arg=arg`. This can be useful when building a method that passes optional arguments to another method.
 
 You can also use a function `defaultArg`, which sets a default value of an optional argument. The `defaultArg` function takes the optional parameter as the first argument and the default value as the second.
 
@@ -124,7 +124,7 @@ Baud Rate: 9600 Duplex: Full Parity: false
 Baud Rate: 4800 Duplex: Half Parity: false
 ```
 
-Since F# 4.1 you can use the attributes `[<Optional; DefaultParameterValue<(...)>]` in F# for C# and VB interop, so that C#/VB callers will see an argument as optional. This is equivalent to defining the argument as optional in C# as in `MyMethod(int i = 3)`.
+For the purposes of C# and Visual Basic interop you can use the attributes `[<Optional; DefaultParameterValue<(...)>]` in F#, so that callers will see an argument as optional. This is equivalent to defining the argument as optional in C# as in `MyMethod(int i = 3)`.
 
 ```fsharp
 open System
@@ -133,6 +133,15 @@ type C =
     static member Foo([<Optional; DefaultParameterValue("Hello world")>] message) =
         printfn "%s" message
 ```
+
+The value given as argument to `DefaultParameterValue` must match the type of the parameter, i.e. the following is not allowed:
+
+```fsharp
+type C() =
+    static member Wrong([<Optional;DefaultParameterValue("string")>] i:int) = ()
+```
+
+In this case compiler generate a warning, and ignore both attributes altogether. Note that the default value `null` needs to be type-annotated, as otherwise the compiler infers the wrong type, i.e. `[<Optional;DefaultParameterValue(null:obj)>] o:obj`.
 
 ## Passing by Reference
 


### PR DESCRIPTION
## Summary

+ add information about passing existing optional values to method with optional parameters
+ add description of F# 4.1 `DefaultParameterValue` feature
+ snippet https://github.com/dotnet/samples/pull/429/

@cartermp Review, please!