### PR TITLE
Fix typo in generic-interfaces.md

### DIFF
--- a/docs/csharp/programming-guide/generics/generic-interfaces.md
+++ b/docs/csharp/programming-guide/generics/generic-interfaces.md
@@ -25,7 +25,7 @@ It is often useful to define interfaces either for generic collection classes, o
   
  [!code-csharp[csProgGuideGenerics#32](../../../csharp/programming-guide/generics/codesnippet/CSharp/generic-interfaces_4.cs)]  
   
- Generic interfaces can inherit from non-generic interfaces if the generic interface is contrvariant, which means it only uses its type parameter as a return value. In the .NET Framework class library, <xref:System.Collections.Generic.IEnumerable%601> inherits from <xref:System.Collections.IEnumerable> because <xref:System.Collections.Generic.IEnumerable%601> only uses `T` in the return value of <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> and in the <xref:System.Collections.Generic.IEnumerator%601.Current%2A> property getter.  
+ Generic interfaces can inherit from non-generic interfaces if the generic interface is contravariant, which means it only uses its type parameter as a return value. In the .NET Framework class library, <xref:System.Collections.Generic.IEnumerable%601> inherits from <xref:System.Collections.IEnumerable> because <xref:System.Collections.Generic.IEnumerable%601> only uses `T` in the return value of <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> and in the <xref:System.Collections.Generic.IEnumerator%601.Current%2A> property getter.  
   
  Concrete classes can implement closed constructed interfaces, as follows:  
   

--- a/docs/csharp/programming-guide/generics/generic-interfaces.md
+++ b/docs/csharp/programming-guide/generics/generic-interfaces.md
@@ -25,7 +25,7 @@ It is often useful to define interfaces either for generic collection classes, o
   
  [!code-csharp[csProgGuideGenerics#32](../../../csharp/programming-guide/generics/codesnippet/CSharp/generic-interfaces_4.cs)]  
   
- Generic interfaces can inherit from non-generic interfaces if the generic interface is contra-variant, which means it only uses its type parameter as a return value. In the .NET Framework class library, <xref:System.Collections.Generic.IEnumerable%601> inherits from <xref:System.Collections.IEnumerable> because <xref:System.Collections.Generic.IEnumerable%601> only uses `T` in the return value of <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> and in the <xref:System.Collections.Generic.IEnumerator%601.Current%2A> property getter.  
+ Generic interfaces can inherit from non-generic interfaces if the generic interface is contrvariant, which means it only uses its type parameter as a return value. In the .NET Framework class library, <xref:System.Collections.Generic.IEnumerable%601> inherits from <xref:System.Collections.IEnumerable> because <xref:System.Collections.Generic.IEnumerable%601> only uses `T` in the return value of <xref:System.Collections.Generic.IEnumerable%601.GetEnumerator%2A> and in the <xref:System.Collections.Generic.IEnumerator%601.Current%2A> property getter.  
   
  Concrete classes can implement closed constructed interfaces, as follows:  
   


### PR DESCRIPTION
fixed a simple typo, that is **"contravariant"** is a single word.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
