### PR TITLE
Added missing backslash to PowerShell command

### DIFF
--- a/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
+++ b/docs/framework/migration-guide/how-to-determine-which-versions-are-installed.md
@@ -163,7 +163,7 @@ Users can install and run multiple versions of the .NET Framework on their compu
 - The following example checks the value of the `Release` keyword to determine whether .NET Framework 4.6.2 or higher is installed, regardless of Windows OS version (returning `True` if it is and `False` otherwise).
 
     ```PowerShell
-    Get-ChildItem "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\" | Get-ItemPropertyValue -Name Release | ForEach-Object { $_ -ge 394802 } 
+    Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\' | Get-ItemPropertyValue -Name Release | Foreach-Object { $_ -ge 394802 } 
     ```
 
     You can replace `394802` in the previous example with another value from the following table to check for a different minimum-required .NET Framework version.


### PR DESCRIPTION
## Summary

Added a missing backslash to the PowerShell command in the **To check for a minimum-required .NET Framework version by querying the registry in PowerShell (.NET Framework 4.5 and later)** section.
