### PR TITLE
Fixed URl of 'nameof' operator

### DIFF
--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -69,7 +69,7 @@ C# version 3.0 came in late 2007, along with Visual Studio 2008, though the full
 - [Query expressions](../linq/query-expression-basics.md)
 - [Lambda expression](https://www.daedtech.com/introduction-to-c-lambda-expressions/)
 - [Expression trees](https://blogs.msdn.microsoft.com/charlie/2008/01/31/expression-tree-basics/)
-- [Extension methods](https://www.codeproject.com/Tips/709310/Extension-Method-In-Csharp)
+- [Extension methods](../programming-guide/classes-and-structs/extension-methods.md)
 - [Implicitly typed local variables](../language-reference/keywords/var.md)
 - [Partial methods](../language-reference/keywords/partial-method.md)
 - [Object and collection initializers](../programming-guide/classes-and-structs/object-and-collection-initializers.md)

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -124,7 +124,7 @@ With versions 3.0 and 5.0, C# had added major new features in an object-oriented
 - [Expression bodied members](https://lostechies.com/jimmybogard/2015/12/17/c-6-feature-review-expression-bodied-function-members/)
 - [Null propagator](https://davefancher.com/2014/08/14/c-6-0-null-propagation-operator/)
 - [String interpolation](../language-reference/tokens/interpolated.md)
-- [nameof operator](https://stackoverflow.com/questions/31695900/what-is-the-purpose-of-nameof)
+- [nameof operator](../language-reference/keywords/nameof.md)
 - [Index initializers](csharp-6.md#index-initializers)
 
 Other new features include:


### PR DESCRIPTION
## Summary

Updated URL for 'nameof' operator to internal documentation rather than
the stackoverflow page

Fixes #8773 
