### PR TITLE
Update docfx.json to use Markdig engine

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "markdownEngineName": "dfm-latest",
+    "markdownEngineName": "markdig",
     "content": [
       {
         "files": [


### PR DESCRIPTION
Addresses https://github.com/dotnet/docs/issues/8480

Turning on the Markdig engine
