### PR TITLE
adding language designations to code samples

### DIFF
--- a/docs/framework/wcf/feature-details/anticipating-adopting-the-wcf-easing-future-integration.md
+++ b/docs/framework/wcf/feature-details/anticipating-adopting-the-wcf-easing-future-integration.md
@@ -12,7 +12,7 @@ If you use ASP.NET today, and anticipate using WCF in the future, this topic pro
 ## Protocols  
  Use ASP.NET 2.0’s new facility for validating conformity to the WS-I Basic Profile 1.1:  
   
-```  
+```csharp  
 [WebService(Namespace = "http://tempuri.org/")]  
 [WebServiceBinding(  
      ConformsTo = WsiProfiles.BasicProfile1_1,  

--- a/docs/framework/wcf/feature-details/anticipating-adopting-wcf-migration.md
+++ b/docs/framework/wcf/feature-details/anticipating-adopting-wcf-migration.md
@@ -30,7 +30,7 @@ To ensure an easier future migration of new ASP.NET applications to WCF, follow 
   
 -   Provide explicit names for the operations of a service using the `MessageName` parameter of the <xref:System.Web.Services.WebMethodAttribute>.  
   
-    ```  
+    ```csharp  
     [WebMethod(MessageName="ExplicitName")]  
     string Echo(string input);  
     ```  
@@ -41,7 +41,7 @@ To ensure an easier future migration of new ASP.NET applications to WCF, follow 
   
 -   Use the <xref:System.Web.Services.Protocols.SoapDocumentMethodAttribute> to provide explicit values for the SOAPAction HTTP headers by which HTTP requests will be routed to methods.  
   
-    ```  
+    ```csharp  
     [WebMethod]  
     [SoapDocumentMethod(RequestElementName="ExplicitAction")]  
     string Echo(string input);  
@@ -57,7 +57,7 @@ To ensure an easier future migration of new ASP.NET applications to WCF, follow 
 ## Exception Handling  
  In designing the structures of the data types to be sent and received by a service, also design structures to represent the various types of exceptions that might occur within a service that one might wish to convey to a client.  
   
-```  
+```csharp  
 [Serializable]  
 [XmlRoot(  
      Namespace="ExplicitNamespace", IsNullable=true)]  
@@ -78,7 +78,7 @@ To ensure an easier future migration of new ASP.NET applications to WCF, follow 
   
  Give such classes the ability to serialize themselves to XML:  
   
-```  
+```csharp  
 public XmlNode ToXML()  
 {  
      XmlSerializer serializer = new XmlSerializer(  
@@ -97,7 +97,7 @@ public XmlNode ToXML()
   
  The classes can then be used to provide the details for explicitly thrown <xref:System.Web.Services.Protocols.SoapException> instances:  
   
-```  
+```csharp  
 AnctipatedException exception = new AnticipatedException();  
 exception.AnticipatedExceptionInformation = "…";  
 throw new SoapException(  
@@ -107,7 +107,7 @@ throw new SoapException(
      exception.ToXML());  
 ```  
   
- These exception classes will be readily reusable with the WCF<xref:System.ServiceModel.FaultException%601> class to throw a new `FaultException<AnticipatedException>(anticipatedException);`  
+ These exception classes will be readily reusable with the WCF <xref:System.ServiceModel.FaultException%601> class to throw a new `FaultException<AnticipatedException>(anticipatedException);`  
   
 ## Security  
  The following are some security recommendations.  

--- a/docs/framework/wcf/feature-details/changing-the-cache-sharing-levels-for-send-activities.md
+++ b/docs/framework/wcf/feature-details/changing-the-cache-sharing-levels-for-send-activities.md
@@ -25,7 +25,7 @@ The <xref:System.ServiceModel.Activities.SendMessageChannelCache> extension enab
   
  First, declare an instance of type <xref:System.ServiceModel.Activities.SendMessageChannelCache>.  
   
-```  
+```csharp  
 // Create an instance of SendMessageChannelCache with default cache settings.  
 static SendMessageChannelCache sharedChannelCacheExtension =  
     new SendMessageChannelCache();  
@@ -33,7 +33,7 @@ static SendMessageChannelCache sharedChannelCacheExtension =
   
  Next, add the cache extension to each client workflow instance.  
   
-```  
+```csharp 
 WorkflowApplication clientInstance1 = new WorkflowApplication(new clientWorkflow1());  
 WorkflowApplication clientInstance2 = new WorkflowApplication(new clientWorkflow2());  
   
@@ -48,7 +48,7 @@ clientInstance2.Extensions.Add(sharedChannelCacheExtension);
   
  First, declare an instance  of type <xref:System.ServiceModel.Activities.SendMessageChannelCache> at the class level.  
   
-```  
+```csharp  
 // Create static instance of SendMessageChannelCache with default cache settings.  
 static SendMessageChannelCache sharedChannelCacheExtension = new  
     SendMessageChannelCache();  
@@ -56,7 +56,7 @@ static SendMessageChannelCache sharedChannelCacheExtension = new
   
  Next, add the static cache extension to each workflow service host.  
   
-```  
+```csharp  
 WorkflowServiceHost host1 = new WorkflowServiceHost(new serviceWorkflow1(), new Uri(baseAddress1));  
 WorkflowServiceHost host2 = new WorkflowServiceHost(new serviceWorkflow2(), new Uri(baseAddress2));  
   
@@ -67,7 +67,7 @@ host2.WorkflowExtensions.Add(sharedChannelCacheExtension);
   
  To set the cache sharing in a hosted workflow service to the instance level, add a `Func<SendMessageChannelCache>` delegate as an extension to the workflow service host and assign this delegate to the code that instantiates a new instance of the <xref:System.ServiceModel.Activities.SendMessageChannelCache> class. This results in a different cache for each individual workflow instance, instead of a single cache shared by all workflow instances in the workflow service host. The following code example shows how to achieve this by using a lambda expression to directly define the <xref:System.ServiceModel.Activities.SendMessageChannelCache> extension that the delegate points to.  
   
-```  
+```csharp 
 serviceHost.WorkflowExtensions.Add(() => new SendMessageChannelCache  
 {  
     // Use FactorySettings property to add custom factory cache settings.  
@@ -89,7 +89,7 @@ serviceHost.WorkflowExtensions.Add(() => new SendMessageChannelCache
   
  To customize the factory cache and channel cache settings, instantiate the <xref:System.ServiceModel.Activities.SendMessageChannelCache> class using the parameterized constructor <xref:System.ServiceModel.Activities.SendMessageChannelCache.%23ctor%2A> and pass a new instance of the <xref:System.ServiceModel.Activities.ChannelCacheSettings> with custom values to each of the `factorySettings` and `channelSettings` parameters. Next, add the new instance of this class as an extension to a workflow service host or a workflow instance. The following code example shows how to perform these steps for a workflow instance.  
   
-```  
+```csharp  
 ChannelCacheSettings factorySettings = new ChannelCacheSettings{  
                         MaxItemsInCache = 5,   
                         IdleTimeout = TimeSpan.FromMinutes(5),   
@@ -108,7 +108,7 @@ clientInstance.Extensions.Add(customChannelCacheExtension);
   
  To enable caching when your workflow service has endpoints defined in configuration, instantiate the <xref:System.ServiceModel.Activities.SendMessageChannelCache> class using the parameterized constructor <xref:System.ServiceModel.Activities.SendMessageChannelCache.%23ctor%2A> with the `allowUnsafeCaching` parameter set to `true`. Next, add the new instance of this class as an extension to a workflow service host or a workflow instance. The following code example shows how to enable caching for a workflow instance.  
   
-```  
+```csharp  
 SendMessageChannelCache customChannelCacheExtension =   
     new SendMessageChannelCache{ AllowUnsafeCaching = true };  
   
@@ -117,7 +117,7 @@ clientInstance.Extensions.Add(customChannelCacheExtension);
   
  To disable the cache completely for the channel factories and the channels, disable the channel factory cache. Doing so also turns off the channel cache as the channels are owned by their corresponding channel factories. To disable the channel factory cache, pass the `factorySettings` parameter to the <xref:System.ServiceModel.Activities.SendMessageChannelCache.%23ctor%2A> constructor initialized to a <xref:System.ServiceModel.Activities.ChannelCacheSettings> instance with a <xref:System.ServiceModel.Activities.ChannelCacheSettings.MaxItemsInCache%2A> value of 0. The following code example shows this.  
   
-```  
+```csharp  
 // Disable the factory cache. This results in the channel cache to be turned off as well.  
 ChannelCacheSettings factorySettings = new ChannelCacheSettings  
     { MaxItemsInCache = 0 };  
@@ -132,7 +132,7 @@ clientInstance.Extensions.Add(customChannelCacheExtension);
   
  You can choose to use only the channel factory cache and disable the channel cache by passing the `channelSettings` parameter to the <xref:System.ServiceModel.Activities.SendMessageChannelCache.%23ctor%2A> constructor initialized to a <xref:System.ServiceModel.Activities.ChannelCacheSettings> instance with a <xref:System.ServiceModel.Activities.ChannelCacheSettings.MaxItemsInCache%2A> value of 0. The following code example shows this.  
   
-```  
+```csharp  
 ChannelCacheSettings factorySettings = new ChannelCacheSettings();  
 // Disable only the channel cache.  
 ChannelCacheSettings channelSettings = new ChannelCacheSettings  

--- a/docs/framework/wcf/feature-details/channel-factory-and-caching.md
+++ b/docs/framework/wcf/feature-details/channel-factory-and-caching.md
@@ -32,7 +32,7 @@ WCF client applications use the <xref:System.ServiceModel.ChannelFactory%601> cl
   
  The following code snippets illustrate how to use the <xref:System.ServiceModel.ClientBase%601.CacheSetting%2A> property.  
   
-```  
+```csharp  
 class Program   
 {   
    static void Main(string[] args)   
@@ -55,7 +55,7 @@ public partial class TestClient : System.ServiceModel.ClientBase, ITest { }
   
  In the above code, all instances of `TestClient` will use the same channel factory.  
   
-```  
+```csharp  
 class Program   
 {   
    static void Main(string[] args)   
@@ -83,7 +83,7 @@ public partial class TestClient : System.ServiceModel.ClientBase, ITest {}
   
  In the example above, all instances of `TestClient` would use the same channel factory except instance #4. Instance #4 would use a channel factory that is created specifically for its use. This setting would work for scenarios where a particular endpoint needs different security settings from the other endpoints of the same channel factory type (in this case `ITest`).  
   
-```  
+```csharp  
 class Program   
 {   
    static void Main(string[] args)   

--- a/docs/framework/wcf/feature-details/client-app-discovery-proxy-to-find-a-service.md
+++ b/docs/framework/wcf/feature-details/client-app-discovery-proxy-to-find-a-service.md
@@ -23,76 +23,76 @@ This topic is the third of three topics that discusses how to implement a discov
   
 4.  Open the Program.cs file and add the following method. This method takes an endpoint address and uses it to initialize the service client (proxy).  
   
-    ```  
+    ```csharp  
     static void InvokeCalculatorService(EndpointAddress endpointAddress)  
-            {  
-                // Create a client  
-                CalculatorServiceClient client = new CalculatorServiceClient(new NetTcpBinding(), endpointAddress);  
-                Console.WriteLine("Invoking CalculatorService at {0}", endpointAddress.Uri);  
-                Console.WriteLine();  
-  
-                double value1 = 100.00D;  
-                double value2 = 15.99D;  
-  
-                // Call the Add service operation.  
-                double result = client.Add(value1, value2);  
-                Console.WriteLine("Add({0},{1}) = {2}", value1, value2, result);  
-  
-                // Call the Subtract service operation.  
-                result = client.Subtract(value1, value2);  
-                Console.WriteLine("Subtract({0},{1}) = {2}", value1, value2, result);  
-  
-                // Call the Multiply service operation.  
-                result = client.Multiply(value1, value2);  
-                Console.WriteLine("Multiply({0},{1}) = {2}", value1, value2, result);  
-  
-                // Call the Divide service operation.  
-                result = client.Divide(value1, value2);  
-                Console.WriteLine("Divide({0},{1}) = {2}", value1, value2, result);  
-                Console.WriteLine();  
-  
-                // Closing the client gracefully closes the connection and cleans up resources  
-                client.Close();  
-            }  
+    {  
+        // Create a client  
+        CalculatorServiceClient client = new CalculatorServiceClient(new NetTcpBinding(), endpointAddress);  
+        Console.WriteLine("Invoking CalculatorService at {0}", endpointAddress.Uri);  
+        Console.WriteLine();  
+
+        double value1 = 100.00D;  
+        double value2 = 15.99D;  
+
+        // Call the Add service operation.  
+        double result = client.Add(value1, value2);  
+        Console.WriteLine("Add({0},{1}) = {2}", value1, value2, result);  
+
+        // Call the Subtract service operation.  
+        result = client.Subtract(value1, value2);  
+        Console.WriteLine("Subtract({0},{1}) = {2}", value1, value2, result);  
+
+        // Call the Multiply service operation.  
+        result = client.Multiply(value1, value2);  
+        Console.WriteLine("Multiply({0},{1}) = {2}", value1, value2, result);  
+
+        // Call the Divide service operation.  
+        result = client.Divide(value1, value2);  
+        Console.WriteLine("Divide({0},{1}) = {2}", value1, value2, result);  
+        Console.WriteLine();  
+
+        // Closing the client gracefully closes the connection and cleans up resources  
+        client.Close();  
+    }  
     ```  
   
 5.  Add the following code to the `Main` method.  
   
-    ```  
+    ```csharp  
     public static void Main()  
+    {  
+        // Create a DiscoveryEndpoint that points to the DiscoveryProxy  
+        Uri probeEndpointAddress = new Uri("net.tcp://localhost:8001/Probe");  
+        DiscoveryEndpoint discoveryEndpoint = new DiscoveryEndpoint(new NetTcpBinding(), new EndpointAddress(probeEndpointAddress));  
+
+        // Create a DiscoveryClient passing in the discovery endpoint  
+        DiscoveryClient discoveryClient = new DiscoveryClient(discoveryEndpoint);  
+
+        Console.WriteLine("Finding ICalculatorService endpoints using the proxy at {0}", probeEndpointAddress);  
+        Console.WriteLine();  
+
+        try  
+        {  
+            // Search for services that implement ICalculatorService              
+            FindResponse findResponse = discoveryClient.Find(new FindCriteria(typeof(ICalculatorService)));  
+
+            Console.WriteLine("Found {0} ICalculatorService endpoint(s).", findResponse.Endpoints.Count);  
+            Console.WriteLine();  
+
+            // Check to see if endpoints were found, if so then invoke the service.  
+            if (findResponse.Endpoints.Count > 0)  
             {  
-                // Create a DiscoveryEndpoint that points to the DiscoveryProxy  
-                Uri probeEndpointAddress = new Uri("net.tcp://localhost:8001/Probe");  
-                DiscoveryEndpoint discoveryEndpoint = new DiscoveryEndpoint(new NetTcpBinding(), new EndpointAddress(probeEndpointAddress));  
-  
-                // Create a DiscoveryClient passing in the discovery endpoint  
-                DiscoveryClient discoveryClient = new DiscoveryClient(discoveryEndpoint);  
-  
-                Console.WriteLine("Finding ICalculatorService endpoints using the proxy at {0}", probeEndpointAddress);  
-                Console.WriteLine();  
-  
-                try  
-                {  
-                    // Search for services that implement ICalculatorService              
-                    FindResponse findResponse = discoveryClient.Find(new FindCriteria(typeof(ICalculatorService)));  
-  
-                    Console.WriteLine("Found {0} ICalculatorService endpoint(s).", findResponse.Endpoints.Count);  
-                    Console.WriteLine();  
-  
-                    // Check to see if endpoints were found, if so then invoke the service.  
-                    if (findResponse.Endpoints.Count > 0)  
-                    {  
-                        InvokeCalculatorService(findResponse.Endpoints[0].Address);  
-                    }  
-                }  
-                catch (TargetInvocationException)  
-                {  
-                    Console.WriteLine("This client was unable to connect to and query the proxy. Ensure that the proxy is up and running.");  
-                }  
-  
-                Console.WriteLine("Press <ENTER> to exit.");  
-                Console.ReadLine();  
+                InvokeCalculatorService(findResponse.Endpoints[0].Address);  
             }  
+        }  
+        catch (TargetInvocationException)  
+        {  
+            Console.WriteLine("This client was unable to connect to and query the proxy. Ensure that the proxy is up and running.");  
+        }  
+
+        Console.WriteLine("Press <ENTER> to exit.");  
+        Console.ReadLine();  
+    }  
     ```  
   
  You have completed implementing the client application. Continue on to [How to: Test the Discovery Proxy](../../../../docs/framework/wcf/feature-details/how-to-test-the-discovery-proxy.md).  
@@ -100,7 +100,7 @@ This topic is the third of three topics that discusses how to implement a discov
 ## Example  
  This is the full code listing for this topic.  
   
-```  
+```csharp  
 // GeneratedClient.cs  
 //----------------------------------------------------------------  
 // Copyright (c) Microsoft Corporation.  All rights reserved.  
@@ -192,7 +192,7 @@ namespace Microsoft.Samples.Discovery
 }  
 ```  
   
-```  
+```csharp  
 // Program.cs  
 //----------------------------------------------------------------  
 // Copyright (c) Microsoft Corporation.  All rights reserved.  

--- a/docs/framework/wcf/feature-details/collection-types-in-data-contracts.md
+++ b/docs/framework/wcf/feature-details/collection-types-in-data-contracts.md
@@ -81,7 +81,7 @@ A *collection* is a list of items of a certain type. In the [!INCLUDE[dnprdnshor
   
 -   When the <xref:System.Runtime.Serialization.CollectionDataContractAttribute> attribute is not applied, the default name and namespace for collection types depend on the names and namespaces of types contained within the collection. They are not affected by the name and namespace of the collection type itself. For an example, see the following types.  
   
-    ```  
+    ```csharp  
     public CustomerList1 : Collection<string> {}  
     public StringList1 : Collection<string> {}  
     ```  
@@ -243,7 +243,7 @@ A *collection* is a list of items of a certain type. In the [!INCLUDE[dnprdnshor
   
  For example, to cause all lists to be imported as Generic <xref:System.Collections.Generic.List%601>.  
   
-```  
+```console  
 svcutil.exe MyService.wsdl MyServiceSchema.xsd /r:C:\full_path_to_system_dll\System.dll /ct:System.Collections.Generic.List`1  
 ```  
   

--- a/docs/framework/wcf/feature-details/comparing-aspnet-web-services-to-wcf-based-on-development.md
+++ b/docs/framework/wcf/feature-details/comparing-aspnet-web-services-to-wcf-based-on-development.md
@@ -23,7 +23,7 @@ Windows Communication Foundation (WCF) has an ASP.NET compatibility mode option 
   
  The WCF<xref:System.Runtime.Serialization.DataContractAttribute> and <xref:System.Runtime.Serialization.DataMemberAttribute> can be added to .NET Framework types to indicate that instances of the type are to be serialized into XML, and which particular fields or properties of the type are to be serialized, as shown in the following sample code.  
   
-```  
+```csharp  
 //Example One:   
 [DataContract]  
 public class LineItem  
@@ -143,7 +143,7 @@ public class LineItem
   
 -   The <xref:System.Xml.Serialization.XmlSerializer> and the attributes of the <xref:System.Xml.Serialization> namespace are designed to allow you to map .NET Framework types to any valid type defined in XML Schema, and so they provide for very precise control over how a type is represented in XML. The <xref:System.Runtime.Serialization.DataContractSerializer>, <xref:System.Runtime.Serialization.DataContractAttribute> and <xref:System.Runtime.Serialization.DataMemberAttribute> provide very little control over how a type is represented in XML. You can only specify the namespaces and names used to represent the type and its fields or properties in the XML, and the sequence in which the fields and properties appear in the XML:  
   
-    ```  
+    ```csharp  
     [DataContract(  
     Namespace="urn:Contoso:2006:January:29",  
     Name="LineItem")]  
@@ -178,7 +178,7 @@ public class LineItem
   
  Despite all of the differences, the XML into which the <xref:System.Xml.Serialization.XmlSerializer> serializes a type by default is semantically identical to the XML into which the <xref:System.Runtime.Serialization.DataContractSerializer> serializes a type, provided the namespace for the XML is explicitly defined. The following class, which has attributes for use with both of the serializers, is translated into semantically identical XML by the <xref:System.Xml.Serialization.XmlSerializer> and by the <xref:System.Runtime.Serialization.DataContractAttribute>:  
   
-```  
+```csharp  
 [Serializable]  
 [XmlRoot(Namespace="urn:Contoso:2006:January:29")]  
 [DataContract(Namespace="urn:Contoso:2006:January:29")]  
@@ -201,7 +201,7 @@ public class LineItem
 ## Service Development  
  To develop a service using ASP.NET, it has been customary to add the <xref:System.Web.Services.WebService> attribute to a class, and the <xref:System.Web.Services.WebMethodAttribute> to any of that class’ methods that are to be operations of the service:  
   
-```  
+```csharp  
 [WebService]  
 public class Service : T:System.Web.Services.WebService  
 {  
@@ -215,7 +215,7 @@ public class Service : T:System.Web.Services.WebService
   
  ASP.NET 2.0 introduced the option of adding the attribute <xref:System.Web.Services.WebService> and <xref:System.Web.Services.WebMethodAttribute> to an interface rather than to a class, and writing a class to implement the interface:  
   
-```  
+```csharp  
 [WebService]  
 public interface IEcho  
 {  
@@ -239,7 +239,7 @@ public class Service : IEcho
   
  The service contract is usually defined first, by adding <xref:System.ServiceModel.ServiceContractAttribute> and <xref:System.ServiceModel.OperationContractAttribute> to an interface:  
   
-```  
+```csharp  
 [ServiceContract]  
 public interface IEcho  
 {  
@@ -252,7 +252,7 @@ public interface IEcho
   
  Once a service contract has been defined, it is implemented in a class, by having the class implement the interface by which the service contract is defined:  
   
-```  
+```csharp  
 public class Service : IEcho  
 {  
     public string Echo(string input)  
@@ -302,7 +302,7 @@ public class Service : IEcho
   
  The internal behavior of service types can be adjusted using the properties of a family of classes called behaviors. Here, the <xref:System.ServiceModel.ServiceBehaviorAttribute> class is used to specify that the service type is to be multithreaded.  
   
-```  
+```csharp  
 [ServiceBehavior(ConcurrencyMode=ConcurrencyMode.Multiple]  
 public class DerivativesCalculatorServiceType: IDerivativesCalculator  
 ```  
@@ -340,7 +340,7 @@ public class DerivativesCalculatorServiceType: IDerivativesCalculator
   
  To host a WCF service within a .NET application, compile the service type into a class library assembly referenced by the application, and program the application to host the service using the <xref:System.ServiceModel.ServiceHost> class. The following is an example of the basic programming required:  
   
-```  
+```csharp  
 string httpBaseAddress = "http://www.contoso.com:8000/";  
 string tcpBaseAddress = "net.tcp://www.contoso.com:8080/";  
   
@@ -369,7 +369,7 @@ typeof(Service), //"Service" is the name of the service type baseAdresses))
   
 1.  The programmer must add the <xref:System.ServiceModel.Activation.AspNetCompatibilityRequirementsAttribute> attribute to the service type and specify that ASP.NET compatibility mode is either allowed or required.  
   
-    ```  
+    ```csharp  
     [System.ServiceModel.Activation.AspNetCompatibilityRequirements(  
           RequirementsMode=AspNetCompatbilityRequirementsMode.Require)]  
     public class DerivativesCalculatorServiceType: IDerivativesCalculator  
@@ -420,7 +420,7 @@ typeof(Service), //"Service" is the name of the service type baseAdresses))
 ## Message Representation  
  The headers of the SOAP messages sent and received by ASP.NET Web services can be customized. A class is derived from <xref:System.Web.Services.Protocols.SoapHeader> to define the structure of the header, and then the <xref:System.Web.Services.Protocols.SoapHeaderAttribute> is used to indicate the presence of the header.  
   
-```  
+```csharp  
 public class SomeProtocol : SoapHeader  
 {  
      public long CurrentValue;  
@@ -467,7 +467,7 @@ public class Service: WebService, IEcho
   
  The WCF provides the attributes, <xref:System.ServiceModel.MessageContractAttribute>, <xref:System.ServiceModel.MessageHeaderAttribute>, and <xref:System.ServiceModel.MessageBodyMemberAttribute> to describe the structure of the SOAP messages sent and received by a service.  
   
-```  
+```csharp  
 [DataContract]  
 public class SomeProtocol  
 {  
@@ -530,7 +530,7 @@ public interface IItemService
   
  ASP.NET 2.0 made it possible to validate that a service is compliant with the Basic Profile 1.1 of the Web Services-Interoperability Organization (WS-I), and to insert a claim that the service is compliant into its WSDL. That is done using the `ConformsTo` and `EmitConformanceClaims` parameters of the <xref:System.Web.Services.WebServiceBindingAttribute> attribute.  
   
-```  
+```csharp  
 [WebService(Namespace = "http://tempuri.org/")]  
 [WebServiceBinding(  
      ConformsTo = WsiProfiles.BasicProfile1_1,  
@@ -566,7 +566,7 @@ public interface IEcho
   
  To return SOAP faults to clients, you can throw instances of the generic type, <xref:System.ServiceModel.FaultException%601>, using the data contract type as the generic type. You can also add <xref:System.ServiceModel.FaultContractAttribute> attributes to operations to specify the faults that an operation might yield.  
   
-```  
+```csharp  
 [DataContract]  
 public class MathFault  
 {   
@@ -587,7 +587,7 @@ public interface ICalculator
   
  Doing so results in the possible faults being advertised in the WSDL for the service, allowing client programmers to anticipate which faults can result from an operation, and write the appropriate catch statements.  
   
-```  
+```csharp  
 try  
 {  
      result = client.Divide(value1, value2);  
@@ -604,7 +604,7 @@ catch (FaultException<MathFault> e)
 ## State Management  
  The class used to implement an ASP.NET Web service may be derived from <xref:System.Web.Services.WebService>.  
   
-```  
+```csharp  
 public class Service : WebService, IEcho  
 {  
   
@@ -623,14 +623,14 @@ public class Service : WebService, IEcho
   
  Here, the service type, `TradingSystem`, has a <xref:System.ServiceModel.ServiceBehaviorAttribute> that specifies that all calls from the same WCF client instance are routed to the same instance of the service type.  
   
-```  
+```csharp  
 [ServiceBehavior(InstanceContextMode = InstanceContextMode.PerSession)]  
 public class TradingSystem: ITradingService  
 ```  
   
  The class, `DealData`, defines state that can be accessed by any code running in the same instance of a service type.  
   
-```  
+```csharp  
 internal class DealData: IExtension<InstanceContext>  
 {  
  public string DealIdentifier = null;  
@@ -640,7 +640,7 @@ internal class DealData: IExtension<InstanceContext>
   
  In the code of the service type that implements one of the operations of the service contract, a `DealData` state object is added to the state of the current instance of the service type.  
   
-```  
+```csharp  
 string ITradingService.BeginDeal()  
 {  
  string dealIdentifier = Guid.NewGuid().ToString();  
@@ -652,7 +652,7 @@ string ITradingService.BeginDeal()
   
  That state object can then be retrieved and modified by the code that implements another of the service contract’s operations.  
   
-```  
+```csharp  
 void ITradingService.AddTrade(Trade trade)  
 {  
  DealData dealData =  OperationContext.Current.InstanceContext.Extensions.Find<DealData>();  
@@ -685,7 +685,7 @@ void ITradingService.AddTrade(Trade trade)
   
  Service operations can be configured to impersonate whichever user’s credentials are provided with the current request.  
   
-```  
+```csharp  
 [OperationBehavior(Impersonation = ImpersonationOption.Required)]  
 public void Receive(Message input)  
 ```  

--- a/docs/framework/wcf/feature-details/configuring-http-and-https.md
+++ b/docs/framework/wcf/feature-details/configuring-http-and-https.md
@@ -26,7 +26,7 @@ WCF services and clients can communicate over HTTP and HTTPS. The HTTP/HTTPS set
   
  The following shows the syntax of the Httpcfg command with the `set urlacl` option  
   
-```  
+```console  
 httpcfg set urlacl /u {http://URL:Port/ | https://URL:Port/} /aACL  
 ```  
   
@@ -36,14 +36,14 @@ httpcfg set urlacl /u {http://URL:Port/ | https://URL:Port/} /aACL
   
  The following shows an example of using this command.  
   
-```  
+```console  
 httpcfg.exe set urlacl /u http://myhost:8000/ /a "O:AOG:DAD:(A;;RPWPCCDCLCSWRCWDWOGA;;;S-1-0-0)"  
 ```  
   
 ### Running Windows Vista, Windows Server 2008 R2 or Windows 7  
  If you are running on [!INCLUDE[wv](../../../../includes/wv-md.md)], Windows Server 2008 R2 or Windows 7, use the Netsh.exe tool. The following shows an example of using this command.  
   
-```  
+```console  
 netsh http add urlacl url=http://+:80/MyUri user=DOMAIN\user  
 ```  
   
@@ -65,14 +65,14 @@ netsh http add urlacl url=http://+:80/MyUri user=DOMAIN\user
 ### Running Windows XP or Server 2003  
  Use the httpcfg tool to modify the IP Listen List, as shown in the following example. The [Windows Support Tools documentation](https://go.microsoft.com/fwlink/?LinkId=94840) explains the syntax for the httpcfg.exe tool.  
   
-```  
+```console  
 httpcfg.exe set iplisten -i 0.0.0.0:8000  
 ```  
   
 ### Running Windows Vista or Windows 7  
  Use the netsh tool to modify the IP Listen List, as shown in the following example.  
   
-```  
+```console  
 netsh http add iplisten ipaddress=0.0.0.0:8000  
 ```  
   

--- a/docs/framework/wcf/feature-details/configuring-iis-for-wcf.md
+++ b/docs/framework/wcf/feature-details/configuring-iis-for-wcf.md
@@ -50,19 +50,15 @@ Internet Information Services (IIS) 7.0 has a modular design that allows you to 
 ## Request Limits
  On [!INCLUDE[wv](../../../../includes/wv-md.md)] with IIS 7 the default value of the `maxUri` and `maxQueryStringSize` settings have been changed. By default, request filtering in IIS 7.0 allows a URL length of 4096 characters and a query string length of 2048 characters. To change these defaults add the following XML to your App.config file.
 
- `<system.webServer>`
-
- `<security>`
-
- `<requestFiltering>`
-
- `<requestLimits maxUrl="8192" maxQueryString="8192" />`
-
- `</requestFiltering>`
-
- `</security>`
-
- `</system.webServer>`
+```xml
+ <system.webServer>
+    <security>
+        <requestFiltering>
+            <requestLimits maxUrl="8192" maxQueryString="8192" />
+        </requestFiltering>
+    </security>
+ </system.webServer>
+ ```
 
 ## See Also
 

--- a/docs/framework/wcf/feature-details/configuring-serialization-in-a-workflow-service.md
+++ b/docs/framework/wcf/feature-details/configuring-serialization-in-a-workflow-service.md
@@ -10,7 +10,7 @@ Workflow services are Windows Communication Foundation (WCF) services and so hav
   
  The serializer can also be set in code as shown in the following example,  
   
-```  
+```csharp  
 Receive approveExpense = new Receive  
             {  
                 OperationName = "ApproveExpense",  

--- a/docs/framework/wcf/feature-details/configuring-the-net-tcp-port-sharing-service.md
+++ b/docs/framework/wcf/feature-details/configuring-the-net-tcp-port-sharing-service.md
@@ -9,9 +9,7 @@ Self-hosted services that use the Net.TCP transport can control several advanced
  When a net.tcp binding enables port sharing (by setting `portSharingEnabled =true` on the transport binding element), it implicitly allows an external process (namely the SMSvcHost.exe, which hosts the Net.TCP Port Sharing Service) to manage the TCP socket on its behalf. For example, when using TCP, specify:  
   
 ```xml  
-    <tcpTransport   
-        portSharingEnabled="true"  
-/>  
+<tcpTransport portSharingEnabled="true"  />  
 ```  
   
  When configured in this way, any socket settings specified on the service's transport binding element are ignored in favor of the socket settings specified by SMSvcHost.exe.  

--- a/docs/framework/wcf/feature-details/configuring-the-wpa--service-for-use-with-wcf.md
+++ b/docs/framework/wcf/feature-details/configuring-the-wpa--service-for-use-with-wcf.md
@@ -21,7 +21,7 @@ This topic describes the steps required to set up Windows Process Activation Ser
   
  The following command adds a net.tcp site binding to the default Web site using appcmd.exe (this command is entered as a single line).  
   
-```  
+```console  
 appcmd.exe set site "Default Web Site" -+bindings.[protocol='net.tcp',bindingInformation='808:*']  
 ```  
   
@@ -42,7 +42,7 @@ appcmd.exe set site "Default Web Site" -+bindings.[protocol='net.tcp',bindingInf
 ## Enabling an Application to Use Non-HTTP Protocols  
  You can enable or disable individual network protocolsat the application level. The following command illustrates how to enable both the HTTP and net.tcp protocols for an application that runs in the `Default Web Site`.  
   
-```  
+```console  
 appcmd.exe set app "Default Web Site/appOne" /enabledProtocols:net.tcp  
 ```  
   
@@ -79,7 +79,7 @@ appcmd.exe set app "Default Web Site/appOne" /enabledProtocols:net.tcp
   
  If you attempt to activate a service using WAS for Non-HTTP activation and you have not installed and configured WAS you may see the following error:  
   
-```Output  
+```output  
 [InvalidOperationException: The protocol 'net.tcp' does not have an implementation of HostedTransportConfiguration type registered.]   System.ServiceModel.AsyncResult.End(IAsyncResult result) +15778592   System.ServiceModel.Activation.HostedHttpRequestAsyncResult.End(IAsyncResult result) +15698937   System.ServiceModel.Activation.HostedHttpRequestAsyncResult.ExecuteSynchronous(HttpApplication context, Boolean flowContext) +265   System.ServiceModel.Activation.HttpModule.ProcessRequest(Object sender, EventArgs e) +227   System.Web.SyncEventExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +80   System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously) +171  
 ```  
   


### PR DESCRIPTION
## Summary

updating to include language designation for code samples, plus a couple of minor formatting changes (removed extra tabs, converted multiple single-line code blocks into a single code block)