### PR TITLE
Removed incorrect sentence

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/walkthrough-writing-queries-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/walkthrough-writing-queries-linq.md
@@ -151,7 +151,7 @@ This walkthrough demonstrates the C# language features that are used to write LI
   
 #### To use method syntax in a query expression  
   
-1.  As described in [Query Syntax and Method Syntax in LINQ](../../../../csharp/programming-guide/concepts/linq/query-syntax-and-method-syntax-in-linq.md), some query operations can only be expressed by using method syntax. The following code calculates the total score for each `Student` in the source sequence, and then calls the `Average()` method on the results of that query to calculate the average score of the class. Note the placement of parentheses around the query expression.  
+1.  As described in [Query Syntax and Method Syntax in LINQ](../../../../csharp/programming-guide/concepts/linq/query-syntax-and-method-syntax-in-linq.md), some query operations can only be expressed by using method syntax. The following code calculates the total score for each `Student` in the source sequence, and then calls the `Average()` method on the results of that query to calculate the average score of the class.
   
      [!code-csharp[csLINQGettingStarted#19](../../../../csharp/programming-guide/concepts/linq/codesnippet/CSharp/walkthrough-writing-queries-linq_9.cs)]  
   


### PR DESCRIPTION
Fixes https://github.com/dotnet/docs/issues/8535.

Note that the code in question is:

```c#
var studentQuery6 =
    from student in students
    let totalScore = student.Scores[0] + student.Scores[1] +
        student.Scores[2] + student.Scores[3]
    select totalScore;

double averageScore = studentQuery6.Average();
```

i.e. it doesn't contain any parentheses around the query.