### PR TITLE
Iteration keywords: added links to the C# specification

### DIFF
--- a/docs/csharp/language-reference/keywords/do.md
+++ b/docs/csharp/language-reference/keywords/do.md
@@ -26,13 +26,12 @@ The following example shows the usage of the `do` statement. Select **Run** to r
 
 ## C# language specification
 
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [The do statement](~/_csharplang/spec/statements.md#the-do-statement) section of the [C# language specification](../language-specification/index.md).
 
 ## See also
 
-- [C# Reference](../index.md)  
-- [C# Programming Guide](../../programming-guide/index.md)  
-- [C# Keywords](index.md)  
-- [do-while Statement (C++)](/cpp/cpp/do-while-statement-cpp)  
-- [Iteration Statements](iteration-statements.md)  
-- [while statement](while.md)  
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [Iteration Statements](iteration-statements.md)
+- [while statement](while.md)

--- a/docs/csharp/language-reference/keywords/for.md
+++ b/docs/csharp/language-reference/keywords/for.md
@@ -99,14 +99,12 @@ The following example defines the infinite `for` loop:
 
 ## C# language specification
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [The for statement](~/_csharplang/spec/statements.md#the-for-statement) section of the [C# language specification](../language-specification/index.md).
 
 ## See also
 
-- [The for statement (C# language specification)](~/_csharplang/spec/statements.md#the-for-statement)
 - [C# Reference](../index.md)
 - [C# Programming Guide](../../programming-guide/index.md)
 - [C# Keywords](index.md)
-- [foreach, in](foreach-in.md)
-- [for Statement (C++)](/cpp/cpp/for-statement-cpp)
 - [Iteration Statements](iteration-statements.md)
+- [foreach, in](foreach-in.md)

--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -37,14 +37,13 @@ Beginning with C# 7.3, if the enumerator's `Current` property returns a [referen
 
 ## C# language specification
 
-[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [The foreach statement](~/_csharplang/spec/statements.md#the-foreach-statement) section of the [C# language specification](../language-specification/index.md).
 
 ## See also
 
-- [The foreach statement (C# language specification)](~/_csharplang/spec/statements.md#the-foreach-statement)
-- [Using foreach with Arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)
-- [for](for.md)
-- [Iteration Statements](iteration-statements.md)
-- [C# Keywords](index.md)
 - [C# Reference](../index.md)
 - [C# Programming Guide](../../programming-guide/index.md)
+- [C# Keywords](index.md)
+- [Iteration Statements](iteration-statements.md)
+- [Using foreach with arrays](../../programming-guide/arrays/using-foreach-with-arrays.md)
+- [for statement](for.md)

--- a/docs/csharp/language-reference/keywords/while.md
+++ b/docs/csharp/language-reference/keywords/while.md
@@ -26,13 +26,12 @@ The following example shows the usage of the `while` statement. Select **Run** t
 
 ## C# language specification
 
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+For more information, see [The while statement](~/_csharplang/spec/statements.md#the-while-statement) section of the [C# language specification](../language-specification/index.md).
 
 ## See also
 
 - [C# Reference](../index.md)  
 - [C# Programming Guide](../../programming-guide/index.md)  
 - [C# Keywords](index.md)  
-- [while Statement (C++)](/cpp/cpp/while-statement-cpp)  
 - [Iteration Statements](iteration-statements.md)  
 - [do statement](do.md)  

--- a/docs/csharp/programming-guide/arrays/using-foreach-with-arrays.md
+++ b/docs/csharp/programming-guide/arrays/using-foreach-with-arrays.md
@@ -1,12 +1,12 @@
 ---
-title: "Using foreach with Arrays (C# Programming Guide)"
+title: "Using foreach with arrays (C# Programming Guide)"
 ms.date: 05/23/2018
 helpviewer_keywords: 
   - "arrays [C#], foreach"
   - "foreach statement [C#], using with arrays"
 ms.assetid: 5f2da2a9-1f56-4de5-94cc-e07f4f7a0244
 ---
-# Using foreach with Arrays (C# Programming Guide)
+# Using foreach with arrays (C# Programming Guide)
 
 The [foreach](../../language-reference/keywords/foreach-in.md) statement provides a simple, clean way to iterate through the elements of an array.
 


### PR DESCRIPTION
Also:
- consistently ordered the **See also** sections
- removed links to the C++ docs 
