### PR TITLE
Improve SourceLink guidance

### DIFF
--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -23,7 +23,14 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 
 **✔️ CONSIDER** using SourceLink to add source control metadata to your assemblies and NuGet package.
 
-**✔️ CONSIDER** including PDB files in the NuGet package.
+> [!TIP]
+> You can further enhance a developer's debugging experience of your library by adding debugger attributes to your types.
+> * <xref:System.Diagnostics.DebuggerDisplayAttribute> can customize how a class or field is displayed in the debugger variable windows.
+> * <xref:System.Diagnostics.DebuggerStepThroughAttribute> instructs the debugger to step through the code instead of stepping into the code.
+
+**✔️ CONSIDER** including symbol files (`*.pdb`) in the NuGet package.
+
+> Currently the main public host for symbols doesn't support the portable symbol files (`*.pdb`) created by SDK-style projects, and [symbol packages](./nuget.md#symbol-packages) aren't useful.
 
 >[!div class="step-by-step"]
 [Previous](./dependencies.md)

--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -24,7 +24,7 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 **✔️ CONSIDER** using SourceLink to add source control metadata to your assemblies and NuGet package.
 
 > [!TIP]
-> You can further enhance a developer's debugging experience adding debugger attributes to your types.
+> You can further enhance a developer's debugging experience by adding debugger attributes to your types.
 > * <xref:System.Diagnostics.DebuggerDisplayAttribute> can customize how a class or field is displayed in the debugger variable windows.
 > * <xref:System.Diagnostics.DebuggerStepThroughAttribute> instructs the debugger to step through the code instead of stepping into the code.
 

--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -24,7 +24,7 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 **✔️ CONSIDER** using SourceLink to add source control metadata to your assemblies and NuGet package.
 
 > [!TIP]
-> You can further enhance a developer's debugging experience of your library by adding debugger attributes to your types.
+> You can further enhance a developer's debugging experience adding debugger attributes to your types.
 > * <xref:System.Diagnostics.DebuggerDisplayAttribute> can customize how a class or field is displayed in the debugger variable windows.
 > * <xref:System.Diagnostics.DebuggerStepThroughAttribute> instructs the debugger to step through the code instead of stepping into the code.
 

--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -21,16 +21,17 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 
 ![SourceLink in NuGet Package Explorer](./media/sourcelink/nuget-package-explorer-sourcelink.png "SourceLink in NuGet Package Explorer")
 
-**✔️ CONSIDER** using SourceLink to add source control metadata to your assemblies and NuGet package.
+**✔️ CONSIDER** using SourceLink to add source control metadata to your assemblies and NuGet packages.
 
 > [!TIP]
 > You can further enhance a developer's debugging experience by adding debugger attributes to your types.
 > * <xref:System.Diagnostics.DebuggerDisplayAttribute> can customize how a class or field is displayed in the debugger variable windows.
 > * <xref:System.Diagnostics.DebuggerStepThroughAttribute> instructs the debugger to step through the code instead of stepping into the code.
+> * <xref:System.Diagnostics.DebuggerBrowsableAttribute> controls whether a member is displayed in the debugger variable windows.
 
 **✔️ CONSIDER** including symbol files (`*.pdb`) in the NuGet package.
 
-> Currently the main public host for symbols doesn't support the portable symbol files (`*.pdb`) created by SDK-style projects, and [symbol packages](./nuget.md#symbol-packages) aren't useful.
+> Ordinarily, you'd publish symbol files in a [symbol package](./nuget.md#symbol-packages). Currently the main public host for symbol packages doesn't support the portable symbol files (`*.pdb`) created by SDK-style projects, and symbol packages aren't useful.
 
 >[!div class="step-by-step"]
 [Previous](./dependencies.md)


### PR DESCRIPTION
* Tip about using .NET debugger attributes
* Further description of why symbol files should be embedded in packages