### PR TITLE
Quick fix to Static Constructors page sample code

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/static-constructors_2.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/static-constructors_2.cs
@@ -35,7 +35,7 @@
             // actual bus times. Do not do this in your actual bus schedule program!
             Console.WriteLine("{0} is starting its route {1:N2} minutes after global start time {2}.",
                                     this.RouteNumber,
-                                    elapsedTime.TotalMilliseconds,
+                                    elapsedTime.Milliseconds,
                                     globalStartTime.ToShortTimeString());
         }
     }


### PR DESCRIPTION
## Summary

Just changed the code snippet verbatim from @BillWagner's comment on this issue. In the `Drive` method, changed `elapsedTime.TotalMilliseconds` to `elapsedTime.Milliseconds`

Fixes #6417 
