### PR TITLE
Update how-to-split-a-file-into-many-files-by-using-groups-linq.md

### DIFF
--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-split-a-file-into-many-files-by-using-groups-linq.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-split-a-file-into-many-files-by-using-groups-linq.md
@@ -62,7 +62,7 @@ Class SplitWithGroups
         ' Note that nested foreach loops are required to access  
         ' individual items with each group.  
         For Each gGroup In groupQuery  
-            Dim fileName As String = "..'..'..'testFile_" & gGroup.groupKey & ".txt"  
+            Dim fileName As String = "../../../testFile_" & gGroup.groupKey & ".txt"  
             Dim sw As New System.IO.StreamWriter(fileName)  
             Console.WriteLine(gGroup.groupKey)  
             For Each item In gGroup.groupName  


### PR DESCRIPTION
Per https://github.com/dotnet/docs/issues/8840

## Summary

Replaced ticks with slashes. The output files will be adjacent to the input files

Fixes #8840