### PR TITLE
WPA also includes msmq

### DIFF
--- a/docs/framework/wcf/samples/windows-process-activation.md
+++ b/docs/framework/wcf/samples/windows-process-activation.md
@@ -12,3 +12,6 @@ This section contains samples that demonstrate service activation through networ
   
  [TCP Activation](../../../../docs/framework/wcf/samples/tcp-activation.md)  
  Demonstrates hosting a service that uses Windows Process Activation Services (WAS) to activate a service that communicates over the net.tcp protocol.
+
+ [MSMQ Activation](../../../../docs/framework/wcf/samples/msmq-activation.md)  
+ Demonstrates hosting a service that uses Windows Process Activation Services (WAS) to activate a service that communicates over the net.msmq protocol.


### PR DESCRIPTION
Windows Process Activation, root page: "in this section" was missing MSMQ activation, though it is also a page in this section.

Docs url: https://docs.microsoft.com/en-us/dotnet/framework/wcf/samples/windows-process-activation