### PR TITLE
Update F# tour to point to Fable REPL for online execution.

### DIFF
--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -1,13 +1,17 @@
 ---
 title: Tour of F#
 description: Examine some of the key features of the F# programming language in this tour with code samples.
-ms.date: 02/28/2018
+ms.date: 11/06/2018
 ---
 # Tour of F# #
 
-The best way to learn about F# is to read and write F# code.  This article will act as a tour through some of the key features of the F# language and give you some code snippets that you can execute on your machine.  To learn about setting up a development environment, check out [Getting Started](tutorials/getting-started/index.md).
+The best way to learn about F# is to read and write F# code. This article will act as a tour through some of the key features of the F# language and give you some code snippets that you can execute on your machine. To learn about setting up a development environment, check out [Getting Started](tutorials/getting-started/index.md).
 
 There are two primary concepts in F#: functions and types.  This tour will emphasize features of the language which fall into these two concepts.
+
+## Executing the code online
+
+If you don't have F# installed on your machine, you can execute all of the samples online with the [Fable REPL](http://fable.io/repl/). Fable is a dialect of F# that executes directly in your browser. To view the samples that follow in the REPL, check out **Samples > Learn > Tour of F#** in the left-hand menu bar of the Fable REPL.
 
 ## Functions and Modules
 


### PR DESCRIPTION
The Fable REPL now has the same code samples: http://fable.io/repl/

Since this is a viable way to execute the code in the browser, I've included it.