### PR TITLE
Change "destructor" to "finalizer" in comment

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/destructors_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/destructors_1.cs
@@ -1,6 +1,6 @@
     class Car
     {
-        ~Car()  // destructor
+        ~Car()  // finalizer
         {
             // cleanup statements...
         }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/destructors_2.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/destructors_2.cs
@@ -2,7 +2,7 @@
     {
         ~First()
         {
-            System.Diagnostics.Trace.WriteLine("First's destructor is called.");
+            System.Diagnostics.Trace.WriteLine("First's finalizer is called.");
         }
     }
 
@@ -10,7 +10,7 @@
     {
         ~Second()
         {
-            System.Diagnostics.Trace.WriteLine("Second's destructor is called.");
+            System.Diagnostics.Trace.WriteLine("Second's finalizer is called.");
         }
     }
 
@@ -18,11 +18,11 @@
     {
         ~Third()
         {
-            System.Diagnostics.Trace.WriteLine("Third's destructor is called.");
+            System.Diagnostics.Trace.WriteLine("Third's finalizer is called.");
         }
     }
 
-    class TestDestructors
+    class TestFinalizers
     {
         static void Main()
         {
@@ -31,7 +31,7 @@
 
     }
     /* Output (to VS Output Window):
-        Third's destructor is called.
-        Second's destructor is called.
-        First's destructor is called.
+        Third's finalizer is called.
+        Second's finalizer is called.
+        First's finalizer is called.
     */

--- a/docs/csharp/programming-guide/classes-and-structs/destructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/destructors.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
 ms.assetid: 1ae6e46d-a4b1-4a49-abe5-b97f53d9e049
 ---
 # Finalizers (C# Programming Guide)
-Finalizers are used to destruct instances of classes.  
+Finalizers are used to perform any necessary final clean-up when a class instance is being collected by the garbage collector.
   
 ## Remarks  
   


### PR DESCRIPTION
The word "finalizer" is used everywhere else on the page.

## Summary

Fixes a comment in the sample code to use the same term used everywhere else on the page.


