### PR TITLE
Update return type for GetDiscountedPrice sample

### DIFF
--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -323,7 +323,7 @@ public interface IDateTimeProvider
     DayOfWeek DayOfWeek();
 }
 
-public bool GetDiscountedPrice(int price, IDateTimeProvider dateTimeProvider)
+public int GetDiscountedPrice(int price, IDateTimeProvider dateTimeProvider)
 {
     if(dateTimeProvider.DayOfWeek() == DayOfWeek.Tuesday) 
     {


### PR DESCRIPTION
Sample code GetDiscountedPrice should return int instead of bool.

## Summary
Sample code GetDiscountedPrice has return type of bool
The correct return type is int


Fixes #8957 
