### PR TITLE
Update com-callable-wrapper.md

### DIFF
--- a/docs/framework/interop/com-callable-wrapper.md
+++ b/docs/framework/interop/com-callable-wrapper.md
@@ -169,7 +169,7 @@ public class LoanApp : IAnother {
 ### Restrict using the dual interface option for the class interface.  
  Dual interfaces enable early and late binding to interface members by COM clients. At design time and during testing, you might find it useful to set the class interface to dual. For a managed class (and its base classes) that will never be modified, this option is also acceptable. In all other cases, avoid setting the class interface to dual.  
   
- An automatically generated dual interface might be appropriate in rare cases; however, more often it creates version-related complexity. For example, COM clients using the class interface of a derived class can easily break with changes to the base class. When a third party provides the base class, the layout of the class interface is out of your control. Further, unlike a dispatch-only interface, a dual interface (**ClassInterface.AutoDual**) provides a description of the class interface in the exported type library. Such a description encourages late-bound clients to cache DispIds at run time.  
+ An automatically generated dual interface might be appropriate in rare cases; however, more often it creates version-related complexity. For example, COM clients using the class interface of a derived class can easily break with changes to the base class. When a third party provides the base class, the layout of the class interface is out of your control. Further, unlike a dispatch-only interface, a dual interface (**ClassInterfaceType.AutoDual**) provides a description of the class interface in the exported type library. Such a description encourages late-bound clients to cache DispIds at run time.  
   
 ### Ensure that all COM event notifications are late-bound.
 


### PR DESCRIPTION
line 172:
The value name was corrected:
this "ClassInterface.AutoDual"
on "ClassInterfaceType.AutoDual".