### PR TITLE
Fix Remarks table broken in fsharp "constraints"

### DIFF
--- a/docs/fsharp/language-reference/generics/constraints.md
+++ b/docs/fsharp/language-reference/generics/constraints.md
@@ -30,6 +30,7 @@ There are several different constraints you can apply to limit the types that ca
 |Comparison Constraint|: comparison|The provided type must support comparison.|
 |Equality Constraint|: equality|The provided type must support equality.|
 |Unmanaged Constraint|: unmanaged|The provided type must be an unmanaged type. Unmanaged types are either certain primitive types (`sbyte`, `byte`, `char`, `nativeint`, `unativeint`, `float32`, `float`, `int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`, or `decimal`), enumeration types, `nativeptr<_>`, or a non-generic structure whose fields are all unmanaged types.|
+
 You have to add a constraint when your code has to use a feature that is available on the constraint type but not on types in general. For example, if you use the type constraint to specify a class type, you can use any one of the methods of that class in the generic function or type.
 
 Specifying constraints is sometimes required when writing type parameters explicitly, because without a constraint, the compiler has no way of verifying that the features that you are using will be available on any type that might be supplied at run time for the type parameter.


### PR DESCRIPTION
I don't think this line should be part of the table, github markdown formatter integrate it but it look weird and it completely break formatting on the real website.

![image](https://user-images.githubusercontent.com/131878/48342627-7d6fba80-e670-11e8-871f-d048fff9e3a6.png)