### PR TITLE
Fix style formatting

### DIFF
--- a/docs/standard/base-types/composite-formatting.md
+++ b/docs/standard/base-types/composite-formatting.md
@@ -20,8 +20,8 @@ ms.author: "ronpet"
 
 The .NET composite formatting feature takes a list of objects and a composite format string as input. A composite format string consists of fixed text intermixed with indexed placeholders, called format items, that correspond to the objects in the list. The formatting operation yields a result string that consists of the original fixed text intermixed with the string representation of the objects in the list.  
   
->  [!IMPORTANT]
->  Instead of using composite format strings, you can use *interpolated strings* if the language and language version that you're using support them. An interpolated string is a string that contains *interpolated expressions*. Each interpolated expression is resolved with the expression's value and included in the result string when the string is assigned. For more information, see [String interpolation (C# Reference)](../../csharp/language-reference/tokens/interpolated.md) and [Interpolated strings (Visual Basic Reference)](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md).
+> [!IMPORTANT]
+> Instead of using composite format strings, you can use *interpolated strings* if the language and language version that you're using support them. An interpolated string is a string that contains *interpolated expressions*. Each interpolated expression is resolved with the expression's value and included in the result string when the string is assigned. For more information, see [String interpolation (C# Reference)](../../csharp/language-reference/tokens/interpolated.md) and [Interpolated strings (Visual Basic Reference)](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md).
 
 The composite formatting feature is supported by methods such as the following:  
   


### PR DESCRIPTION
The current display of the alarm box at [Composite formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/composite-formatting):
![image](https://user-images.githubusercontent.com/15279990/48535488-d2e3db80-e8ab-11e8-8382-ce134c86011c.png)

My guess, it's caused by two white spaces after the `>` characters
Does removal of excessive white spaces fix rendering?
