### PR TITLE
Fixing article how-to-enable-a-webrequest-to-use-a-proxy-to-communicate-with-the-internet

### DIFF
--- a/docs/framework/network-programming/how-to-enable-a-webrequest-to-use-a-proxy-to-communicate-with-the-internet.md
+++ b/docs/framework/network-programming/how-to-enable-a-webrequest-to-use-a-proxy-to-communicate-with-the-internet.md
@@ -24,7 +24,7 @@ GlobalProxySelection.Select = proxyObject
 ## Compiling the Code  
  This example requires:  
   
--   References to the **System.Net** namespace.  
+-   A [`using` directive](~/docs/csharp/language-reference/keywords/using-directive.md) for the **System.Net** namespace.  
   
 ## See Also  
  [Using Application Protocols](../../../docs/framework/network-programming/using-application-protocols.md)  

--- a/docs/framework/network-programming/how-to-enable-a-webrequest-to-use-a-proxy-to-communicate-with-the-internet.md
+++ b/docs/framework/network-programming/how-to-enable-a-webrequest-to-use-a-proxy-to-communicate-with-the-internet.md
@@ -24,7 +24,7 @@ GlobalProxySelection.Select = proxyObject
 ## Compiling the Code  
  This example requires:  
   
--   A [`using` directive](~/docs/csharp/language-reference/keywords/using-directive.md) for the **System.Net** namespace.  
+-   A [`using` directive](../../csharp/language-reference/keywords/using-directive.md) for the **System.Net** namespace.  
   
 ## See Also  
  [Using Application Protocols](../../../docs/framework/network-programming/using-application-protocols.md)  


### PR DESCRIPTION
## Summary

This PR is from https://github.com/dotnet/docs/issues/6912. It's an error in the same "Accessing the Internet Through a Proxy" section.
