### PR TITLE
Update symbol packages guidance

### DIFF
--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -97,7 +97,7 @@ NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbo
 > [!IMPORTANT]
 > The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
 
-An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
+An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger, but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project, then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -112,7 +112,7 @@ An alternative to creating a symbol package is embedding symbol files in the mai
 
 > Embedding symbol files in the main NuGet package gives developers a better debugging experience by default. They don't need to find and configure the NuGet symbol server in their IDE to get symbol files.
 >
-> The downside to embedded symbol files is they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern then you should publish symbols in a symbol package instead.
+> The downside to embedded symbol files is they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern, you should publish symbols in a symbol package instead.
 
 >[!div class="step-by-step"]
 [Previous](./strong-naming.md)

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -110,7 +110,9 @@ An alternative to creating a symbol package is embedding symbol files in the mai
 
 **✔️ CONSIDER** embedding symbol files in the main NuGet package.
 
-**❌ AVOID** creating a symbols package containing symbol files.
+> Embedding symbol files in the main NuGet package gives developers a better debugging experience by default. They don't need to find and configure the NuGet symbol server in their IDE to get symbol files.
+>
+> The downside to embedded symbol files is they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern then you should publish symbols in a symbol package instead.
 
 >[!div class="step-by-step"]
 [Previous](./strong-naming.md)

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -90,11 +90,11 @@ NuGet packages with a version suffix are considered [pre-release](/nuget/create-
 
 ## Symbol packages
 
-Symbol files (`*.pdb`) are produced by the .NET compiler alongside assemblies. Symbol files map execution locations to the original source code so you can step through source code as it is running using a debugger. NuGet supports [generating a separate symbol package](/nuget/create-packages/symbol-packages-snupkg) containing symbol files alongside the main package containing .NET assemblies. The idea of symbol packages is they're hosted on a symbol server and are only downloaded by a tool like Visual Studio on demand.
+Symbol files (`*.pdb`) are produced by the .NET compiler alongside assemblies. Symbol files map execution locations to the original source code so you can step through source code as it is running using a debugger. NuGet supports [generating a separate symbol package (`*.snupkg`)](/nuget/create-packages/symbol-packages-snupkg) containing symbol files alongside the main package containing .NET assemblies. The idea of symbol packages is they're hosted on a symbol server and are only downloaded by a tool like Visual Studio on demand.
 
 NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-server). Developers can use the symbols published to the NuGet.org symbol server by adding `https://symbols.nuget.org/download/symbols` to their [symbol sources in Visual Studio](/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger).
 
-An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you are building your NuGet package using an SDK-style project you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property: 
+An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you are building your NuGet package using an SDK-style project you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -94,7 +94,10 @@ Symbol files (`*.pdb`) are produced by the .NET compiler alongside assemblies. S
 
 NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-server). Developers can use the symbols published to the NuGet.org symbol server by adding `https://symbols.nuget.org/download/symbols` to their [symbol sources in Visual Studio](/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger).
 
-An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you are building your NuGet package using an SDK-style project you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
+> [!IMPORTANT]
+> The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
+
+An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -90,9 +90,11 @@ NuGet packages with a version suffix are considered [pre-release](/nuget/create-
 
 ## Symbol packages
 
-Symbol files (`*.pdb`) are produced by the .NET compiler alongside assemblies. Symbol files map execution locations to the original source code so you can step through source code as it is running using a debugger. NuGet supports [generating a separate symbol package](/nuget/create-packages/symbol-packages) containing symbol files alongside the main package containing .NET assemblies. The idea of symbol packages is they're hosted on a symbol server and are only downloaded by a tool like Visual Studio on demand.
+Symbol files (`*.pdb`) are produced by the .NET compiler alongside assemblies. Symbol files map execution locations to the original source code so you can step through source code as it is running using a debugger. NuGet supports [generating a separate symbol package](/nuget/create-packages/symbol-packages-snupkg) containing symbol files alongside the main package containing .NET assemblies. The idea of symbol packages is they're hosted on a symbol server and are only downloaded by a tool like Visual Studio on demand.
 
-Currently the main public host for symbols - [SymbolSource](http://www.symbolsource.org/) - doesn't support the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects, and symbol packages aren't useful. Until there is a recommended host for symbol packages, symbol files can be embedded in the main NuGet package. If you are building your NuGet package using an SDK-style project you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property: 
+NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-server). Developers can use the symbols published to the NuGet.org symbol server by adding `https://symbols.nuget.org/download/symbols` to their [symbol sources in Visual Studio](/visualstudio/debugger/specify-symbol-dot-pdb-and-source-files-in-the-visual-studio-debugger).
+
+An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you are building your NuGet package using an SDK-style project you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property: 
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">


### PR DESCRIPTION
Remove mention of ye olde SymbolSource, include details about NuGet.org symbol server.

**Open question:**

I haven't updated the guidance, currently it recommends embedding PDBs over a source package. Should .NET libraries continue to embed PDBs in the main NuGet package? Download size is larger, but doesn't require developers to configure the source in VS. Are there other advantages or disadvantages?