### PR TITLE
Update text to match code example

### DIFF
--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -41,7 +41,7 @@ Let's do a quick walkthrough:
    The project file specifies everything that's needed to restore dependencies and build the program.
 
    * The `OutputType` tag specifies that we're building an executable, in other words a console application.
-   * The `TargetFramework` tag specifies what .NET implementation we're targeting. In an advanced scenario, you can specify multiple target frameworks and build to all those in a single operation. In this tutorial, we'll stick to building only for .NET Core 1.0.
+   * The `TargetFramework` tag specifies what .NET implementation we're targeting. In an advanced scenario, you can specify multiple target frameworks and build to all those in a single operation. In this tutorial, we'll stick to building only for .NET Core 2.1.
 
    `Program.cs`:
 


### PR DESCRIPTION
Update the text below a code example. The code example is using .NET Core 2.1 as the target framework, but the text under it explaining the code says the example is for .NET Core 1.0.

This is my first PR for this project. If I've submitted the change in error, please let me know what to fix for next time.