### PR TITLE
Add dotnet Pack the projec using a .nuspec example

### DIFF
--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -185,6 +185,6 @@ Pack the project and use a specific runtime (Windows 10) for the restore operati
 
 `dotnet pack --runtime win10-x64`
 
-Pack the projec using a [.nuspec file](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-using-a-nuspec)
+Pack the projec using a [.nuspec file](https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-using-a-nuspec)
 
 `dotnet pack  ~/projects/app1/project.csproj /p:NuspecFile=~/projects/app1/project.nuspec /p:NuspecBasePath=~/projects/app1/nuget`

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -184,3 +184,7 @@ Pack the project for a specific [target framework](../../standard/frameworks.md)
 Pack the project and use a specific runtime (Windows 10) for the restore operation (.NET Core SDK 2.0 and later versions):
 
 `dotnet pack --runtime win10-x64`
+
+Pack the projec using a [.nuspec file](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-using-a-nuspec)
+
+`dotnet pack  ~/projects/app1/project.csproj /p:NuspecFile=~/projects/app1/project.nuspec /p:NuspecBasePath=~/projects/app1/nuget`


### PR DESCRIPTION
## Summary

Added an example of how you can use a .nuspec file to pack your project along with SDK project file and link to where it's documented. MSBuild targets probably isn't where people go looking for this, so this example makes it a bit more discoverable.

