### PR TITLE
Cross-referenced docs about ref returns/locals

### DIFF
--- a/docs/csharp/language-reference/keywords/foreach-in.md
+++ b/docs/csharp/language-reference/keywords/foreach-in.md
@@ -17,6 +17,8 @@ The `foreach` statement executes a statement or a block of statements for each e
 - has the public parameterless `GetEnumerator` method whose return type is either class, struct, or interface type,
 - the return type of the `GetEnumerator` method has the public `Current` property and the public parameterless `MoveNext` method whose return type is <xref:System.Boolean>.
 
+Beginning with C# 7.3, if the enumerator's `Current` property returns a [reference return value](ref.md#reference-return-values) (`ref T` where `T` is the type of the collection element), you can declare the iteration variable with the `ref` or `ref readonly` modifier.
+
 At any point within the `foreach` statement block, you can break out of the loop by using the [break](break.md) statement, or step to the next iteration in the loop by using the [continue](continue.md) statement. You also can exit a `foreach` loop by the [goto](goto.md), [return](return.md), or [throw](throw.md) statements.
 
 ## Examples
@@ -31,7 +33,7 @@ The next example uses the `foreach` statement with an instance of the <xref:Syst
 
 [!code-csharp-interactive[span example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#2)]
 
-Beginning with C# 7.3, if the enumerator's `Current` property returns a [reference return value](../../programming-guide/classes-and-structs/ref-returns.md) (`ref T` where `T` is the type of the collection element), you can declare the iteration variable with the `ref` or `ref readonly` modifier. The following example uses a `ref` iteration variable to set the value of each item in a stackalloc array. The `ref readonly` version iterates the collection to print all the values. The `readonly` declaration uses an implicit local variable declaration. Implicit variable declarations can be used with either `ref` or `ref readonly` declarations, as can explicitly typed variable declarations.
+The following example uses a `ref` iteration variable to set the value of each item in a stackalloc array. The `ref readonly` version iterates the collection to print all the values. The `readonly` declaration uses an implicit local variable declaration. Implicit variable declarations can be used with either `ref` or `ref readonly` declarations, as can explicitly typed variable declarations.
 
 [!code-csharp-interactive[ref span example](~/samples/snippets/csharp/keywords/IterationKeywordsExamples.cs#RefSpan)]
 

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -86,7 +86,7 @@ In order for the caller to modify the object's state, the reference return value
 
 The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [ref readonly](#ref-readonly-locals) variable.
 
-For an example, see [A ref returns and ref locals example](#a-ref-returns-and-ref-locals-example)
+For an example, see [A ref returns and ref locals example](#a-ref-returns-and-ref-locals-example).
 
 ## Ref locals
 
@@ -107,6 +107,8 @@ ref VeryLargeStruct reflocal = ref veryLargeStruct;
 ```
 
 Note that in both examples the `ref` keyword must be used in both places, or the compiler generates error CS8172, "Cannot initialize a by-reference variable with a value."
+
+Beginning with C# 7.3, the iteration variable of the `foreach` statement can be ref local or ref readonly local variable. For more information, see the [foreach statement](foreach-in.md) article.
 
 ## Ref readonly locals
 
@@ -148,6 +150,7 @@ You can combine modifiers to declare a struct as `readonly ref`. A `readonly ref
 
 - [Write safe efficient code](../../write-safe-efficient-code.md)  
 - [Ref returns and ref locals](../../programming-guide/classes-and-structs/ref-returns.md)
+- [Conditional ref expression](../operators/conditional-operator.md#conditional-ref-expression)
 - [Passing Parameters](../../programming-guide/classes-and-structs/passing-parameters.md)  
 - [Method Parameters](method-parameters.md)  
 - [C# Reference](../index.md)  

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -147,6 +147,7 @@ You can combine modifiers to declare a struct as `readonly ref`. A `readonly ref
 ## See also
 
 - [Write safe efficient code](../../write-safe-efficient-code.md)  
+- [Ref returns and ref locals](../../programming-guide/classes-and-structs/ref-returns.md)
 - [Passing Parameters](../../programming-guide/classes-and-structs/passing-parameters.md)  
 - [Method Parameters](method-parameters.md)  
 - [C# Reference](../index.md)  

--- a/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
+++ b/docs/csharp/programming-guide/classes-and-structs/ref-returns.md
@@ -121,4 +121,4 @@ closer to the end of the array.
 ## See also
 
 - [ref keyword](../../language-reference/keywords/ref.md)  
-- [Write safe efficient code](../../../csharp/write-safe-efficient-code.md)
+- [Write safe efficient code](../../write-safe-efficient-code.md)

--- a/docs/csharp/whats-new/csharp-7.md
+++ b/docs/csharp/whats-new/csharp-7.md
@@ -17,7 +17,7 @@ C# 7.0 adds a number of new features to the C# language:
 * [Pattern Matching](#pattern-matching)
     - You can create branching logic based on arbitrary types and values of the members of those types.
 * [`ref` locals and returns](#ref-locals-and-returns)
-    - Method arguments and local variables can be references to other storage.
+    - Method local variables and return values can be references to other storage.
 * [Local Functions](#local-functions)
     - You can nest functions inside other functions to limit their scope and visibility.
 * [More expression-bodied members](#more-expression-bodied-members)
@@ -405,6 +405,8 @@ efficient by avoiding copying values, or performing dereferencing operations
 multiple times.
 
 Adding `ref` to the return value is a [source compatible change](version-update-considerations.md#source-compatible-changes). Existing code compiles, but the ref return value is copied when assigned. Callers must update the storage for the return value to a `ref` local variable to store the return as a reference.
+
+For more information, see the [ref keyword](../language-reference/keywords/ref.md) article.
 
 ## Local functions
 

--- a/docs/csharp/write-safe-efficient-code.md
+++ b/docs/csharp/write-safe-efficient-code.md
@@ -4,8 +4,7 @@ description: Recent enhancements to the C# language enable you to write verifiab
 ms.date: 10/23/2018
 ms.custom: mvc
 ---
-
-# Write safe and efficient C# code #
+# Write safe and efficient C# code
 
 New features in C# enable you to write verifiable safe code with better performance. If you carefully apply these techniques, fewer scenarios require unsafe code. These features make it easier to use references to value types as method arguments and method returns. When done safely, these techniques minimize copying value types. By using value types, you can minimize the number of allocations and garbage collection passes.
 
@@ -274,3 +273,8 @@ algorithms where minimizing memory allocations is a major factor in achieving th
 necessary performance. You may find that you don't often use these features in
 the code you write. However, these enhancements have been adopted throughout .NET. As more and more APIs make use of these features, you'll
 see the performance of your applications improve.
+
+## See also
+
+- [ref keyword](language-reference/keywords/ref.md)
+- [Ref returns and ref locals](programming-guide/classes-and-structs/ref-returns.md)


### PR DESCRIPTION
Make the docs about ref returns/locals more browsable.