### PR TITLE
Update arithmetic-operations-on-pointers.md

### DIFF
--- a/docs/csharp/programming-guide/unsafe-code-pointers/arithmetic-operations-on-pointers.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/arithmetic-operations-on-pointers.md
@@ -1,5 +1,5 @@
 ---
-title: "Arithmetic Operations on Pointers (C# Programming Guide)"
+title: "Arithmetic operations on pointers (C# Programming Guide)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "pointers [C#], arithmetic operations"

--- a/docs/csharp/programming-guide/unsafe-code-pointers/arithmetic-operations-on-pointers.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/arithmetic-operations-on-pointers.md
@@ -5,19 +5,19 @@ helpviewer_keywords:
   - "pointers [C#], arithmetic operations"
 ms.assetid: d4f0b623-827e-45ce-8649-cfcebc8692aa
 ---
-# Arithmetic Operations on Pointers (C# Programming Guide)
-This topic discusses using the arithmetic operators `+` and **-** to manipulate pointers.  
+# Arithmetic operations on pointers (C# Programming Guide)
+This topic discusses using the arithmetic operators `+` and `-` to manipulate pointers.  
   
 > [!NOTE]
 >  You cannot perform any arithmetic operations on void pointers.  
   
-## Adding and Subtracting Numeric Values to or From Pointers  
- You can add a value `n` of type [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), or [ulong](../../../csharp/language-reference/keywords/ulong.md) to a pointer, `p`,of any type except `void*`. The result `p+n` is the pointer resulting from adding `n * sizeof(p) to the address of p`. Similarly, `p-n` is the pointer resulting from subtracting `n * sizeof(p)` from the address of `p`.  
+## Adding and subtracting numeric values to or from pointers  
+ You can add a value `n` of type [int](../../../csharp/language-reference/keywords/int.md), [uint](../../../csharp/language-reference/keywords/uint.md), [long](../../../csharp/language-reference/keywords/long.md), or [ulong](../../../csharp/language-reference/keywords/ulong.md) to a pointer. If `p` is a pointer of the type `pointer-type*`, the result `p+n` is the pointer resulting from adding `n * sizeof(pointer-type)` to the address of `p`. Similarly, `p-n` is the pointer resulting from subtracting `n * sizeof(pointer-type)` from the address of `p`.  
   
-## Subtracting Pointers  
+## Subtracting pointers  
  You can also subtract pointers of the same type. The result is always of the type `long`. For example, if `p1` and `p2` are pointers of the type `pointer-type*`, then the expression `p1-p2` results in:  
   
- `((long)p1 - (long)p2)/sizeof(pointer_type)`  
+ `((long)p1 - (long)p2)/sizeof(pointer-type)`  
   
  No exceptions are generated when the arithmetic operation overflows the domain of the pointer, and the result depends on the implementation.  
   
@@ -26,10 +26,10 @@ This topic discusses using the arithmetic operators `+` and **-** to manipulate 
   
  [!code-csharp[csProgGuidePointers#15](../../../csharp/programming-guide/unsafe-code-pointers/codesnippet/CSharp/arithmetic-operations-on-pointers_2.cs)]  
   
-## C# Language Specification  
+## C# language specification  
  [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
   
-## See Also
+## See also
 
 - [C# Programming Guide](../../../csharp/programming-guide/index.md)  
 - [Unsafe Code and Pointers](../../../csharp/programming-guide/unsafe-code-pointers/index.md)  


### PR DESCRIPTION
- Sentence-casing for titles
- Style fixes
- Corrected the "Adding and subtracting numeric values to or from pointers" section: if `p` is a pointer, `sizeof(p)` is not defined. What is meant is `sizeof(pointer-type)`.
