### PR TITLE
Removed not necessary line

### DIFF
--- a/docs/csharp/programming-guide/namespaces/index.md
+++ b/docs/csharp/programming-guide/namespaces/index.md
@@ -32,8 +32,8 @@ Namespaces have the following properties:
   
 - They organize large code projects.  
 - They are delimited by using the `.` operator.  
-- The `using directive` obviates the requirement to specify the name of the namespace for every class.  
-- The `global` namespace is the "root" namespace: `global::System` will always refer to the .NET Framework namespace `System`.  
+- The `using` directive obviates the requirement to specify the name of the namespace for every class.  
+- The `global` namespace is the "root" namespace: `global::System` will always refer to the .NET namespace `System`.  
 
 ## C# Language Specification
 
@@ -50,4 +50,3 @@ Namespaces have the following properties:
 - [using Directive](../../language-reference/keywords/using-directive.md)  
 - [:: Operator](../../language-reference/operators/namespace-alias-qualifer.md)  
 - [. Operator](../../language-reference/operators/member-access-operator.md)
->>>>>>> add identifier naming rules

--- a/docs/csharp/programming-guide/namespaces/index.md
+++ b/docs/csharp/programming-guide/namespaces/index.md
@@ -33,7 +33,7 @@ Namespaces have the following properties:
 - They organize large code projects.  
 - They are delimited by using the `.` operator.  
 - The `using` directive obviates the requirement to specify the name of the namespace for every class.  
-- The `global` namespace is the "root" namespace: `global::System` will always refer to the .NET namespace `System`.  
+- The `global` namespace is the "root" namespace: `global::System` will always refer to the .NET <xref:System> namespace.  
 
 ## C# Language Specification
 


### PR DESCRIPTION
The last line in the file was added in #7164
I guess, it was a reminder to add the following line in the "See also" section:
```
[Identifier names](../inside-a-program/identifier-names.md)
```
That line is in the section, so let's remove the reminder.
