### PR TITLE
Value types: define simple types

### DIFF
--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -1,5 +1,5 @@
 ---
-title: "Value Types (C# Reference)"
+title: "Value types (C# Reference)"
 ms.date: 07/20/2015
 f1_keywords: 
   - "cs.valuetypes"
@@ -9,26 +9,28 @@ helpviewer_keywords:
   - "C# language, value types"
 ms.assetid: 471eb994-2958-49d5-a6be-19b4313f80a3
 ---
-# Value Types (C# Reference)
-The value types consist of two main categories:  
+# Value types (C# Reference)
+
+The value types consist of two main categories:
+
+- [Structs](struct.md)
+
+- [Enumerations](enum.md)
+ 
+ Structs fall into these categories:
+
+- Numeric types and [char](char.md)
+
+    - [Integral types](integral-types-table.md) (including the [char](char.md) type)
+
+    - [Floating-point types](floating-point-types-table.md)
+
+- [bool](bool.md)
+
+- User-defined structs.
   
--   [Structs](../../../csharp/language-reference/keywords/struct.md)  
-  
--   [Enumerations](../../../csharp/language-reference/keywords/enum.md)  
-  
- Structs fall into these categories:  
-  
--   Numeric types  
-  
-    -   [Integral types](../../../csharp/language-reference/keywords/integral-types-table.md)  
-  
-    -   [Floating-point types](../../../csharp/language-reference/keywords/floating-point-types-table.md)  
-  
--   [bool](../../../csharp/language-reference/keywords/bool.md)  
-  
--   User defined structs.  
-  
-## Main Features of Value Types  
+## Main features of value types
+
  Variables that are based on value types directly contain values. Assigning one value type variable to another copies the contained value. This differs from the assignment of reference type variables, which copies a reference to the object but not the object itself.  
   
  All value types are derived implicitly from the <xref:System.ValueType?displayProperty=nameWithType>.  
@@ -37,16 +39,18 @@ The value types consist of two main categories:
   
  Unlike reference types, a value type cannot contain the `null` value. However, the [nullable types](../../../csharp/programming-guide/nullable-types/index.md) feature does allow for value types to be assigned to `null`.  
   
- Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default Values Table](../../../csharp/language-reference/keywords/default-values-table.md).  
+ Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](../../../csharp/language-reference/keywords/default-values-table.md).  
   
-## Main Features of Simple Types  
- All of the simple types -- those integral to the C# language -- are aliases of the .NET Framework System types. For example, [int](../../../csharp/language-reference/keywords/int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-In Types Table](../../../csharp/language-reference/keywords/built-in-types-table.md).  
+## Main features of simple types
+
+ All of the simple types -- those integral to the C# language -- are aliases of the .NET <xref:System> types. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](../../../csharp/language-reference/keywords/built-in-types-table.md).  
   
  Constant expressions, whose operands are all simple type constants, are evaluated at compilation time.  
   
- Simple types can be initialized by using literals. For example, 'A' is a literal of the type `char` and 2001 is a literal of the type `int`.  
+ Simple types can be initialized by using literals. For example, `'A'` is a literal of the type `char` and `2001` is a literal of the type `int`.  
   
-## Initializing Value Types  
+## Initializing value types
+
  Local variables in C# must be initialized before they are used. For example, you might declare a local variable without initialization as in the following example:  
   
 ```csharp  
@@ -77,9 +81,9 @@ int myInt = new int();
 int myInt = 0;  
 ```  
   
- Using the [new](../../../csharp/language-reference/keywords/new.md) operator calls the default constructor of the specific type and assigns the default value to the variable. In the preceding example, the default constructor assigned the value `0` to `myInt`. For more information about values assigned by calling default constructors, see [Default Values Table](../../../csharp/language-reference/keywords/default-values-table.md).  
+ Using the [new](new.md) operator calls the default constructor of the specific type and assigns the default value to the variable. In the preceding example, the default constructor assigned the value `0` to `myInt`. For more information about values assigned by calling default constructors, see [Default values table](default-values-table.md).  
   
- With user-defined types, use [new](../../../csharp/language-reference/keywords/new.md) to invoke the default constructor. For example, the following statement invokes the default constructor of the `Point` struct:  
+ With user-defined types, use [new](new.md) to invoke the default constructor. For example, the following statement invokes the default constructor of the `Point` struct:  
   
 ```csharp  
 Point p = new Point(); // Invoke default constructor for the struct.  
@@ -87,16 +91,16 @@ Point p = new Point(); // Invoke default constructor for the struct.
   
  After this call, the struct is considered to be definitely assigned; that is, all its members are initialized to their default values.  
   
- For more information about the new operator, see [new](../../../csharp/language-reference/keywords/new.md).  
+ For more information about the `new` operator, see [new](new.md).  
   
- For information about formatting the output of numeric types, see [Formatting Numeric Results Table](../../../csharp/language-reference/keywords/formatting-numeric-results-table.md).  
+ For information about formatting the output of numeric types, see [Formatting numeric results table](formatting-numeric-results-table.md).  
   
-## See Also
+## See also
 
-- [C# Reference](../../../csharp/language-reference/index.md)  
-- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
-- [C# Keywords](../../../csharp/language-reference/keywords/index.md)  
-- [Types](../../../csharp/language-reference/keywords/types.md)  
-- [Reference Tables for Types](../../../csharp/language-reference/keywords/reference-tables-for-types.md)  
-- [Reference Types](../../../csharp/language-reference/keywords/reference-types.md)  
+- [C# Reference](../index.md)  
+- [C# Programming Guide](../../programming-guide/index.md)  
+- [C# Keywords](index.md)  
+- [Types](types.md)  
+- [Reference tables for types](reference-tables-for-types.md)  
+- [Reference Types](reference-types.md)  
 - [Nullable types](../../programming-guide/nullable-types/index.md)  

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -11,7 +11,7 @@ ms.assetid: 471eb994-2958-49d5-a6be-19b4313f80a3
 ---
 # Value types (C# Reference)
 
-The value types consist of two main categories:
+There are two kinds of value types:
 
 - [Structs](struct.md)
 
@@ -19,15 +19,15 @@ The value types consist of two main categories:
 
 ## Main features of value types
 
- Variables that are based on value types directly contain values. Assigning one value type variable to another copies the contained value. This differs from the assignment of reference type variables, which copies a reference to the object but not the object itself.  
+A variable of a value type contains a value of the type. For example, a variable of the `int` type might contain the value `42`. This differs from a variable of a reference type, which contains a reference to an instance of the type, also known as an object. When you assign a new value to a variable of a value type, that value is copied. When you assign a new value to a variable of a reference type, the reference is copied, not the object itself.
+
+All value types are derived implicitly from the <xref:System.ValueType?displayProperty=nameWithType>.  
   
- All value types are derived implicitly from the <xref:System.ValueType?displayProperty=nameWithType>.  
+Unlike with reference types, you cannot derive a new type from a value type. However, like reference types, structs can implement interfaces.  
   
- Unlike with reference types, you cannot derive a new type from a value type. However, like reference types, structs can implement interfaces.  
+Value type variables cannot be `null` by default. However, variables of the corresponding [nullable types](../../../csharp/programming-guide/nullable-types/index.md) can be `null`.
   
- Unlike reference types, a value type cannot contain the `null` value. However, the [nullable types](../../../csharp/programming-guide/nullable-types/index.md) feature does allow for value types to be assigned to `null`.  
-  
- Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](default-values-table.md).  
+Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](default-values-table.md).  
   
 ## Simple types
 

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -39,11 +39,11 @@ The value types consist of two main categories:
   
  Unlike reference types, a value type cannot contain the `null` value. However, the [nullable types](../../../csharp/programming-guide/nullable-types/index.md) feature does allow for value types to be assigned to `null`.  
   
- Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](../../../csharp/language-reference/keywords/default-values-table.md).  
+ Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](default-values-table.md).  
   
 ## Main features of simple types
 
- All of the simple types -- those integral to the C# language -- are aliases of the .NET <xref:System> types. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](../../../csharp/language-reference/keywords/built-in-types-table.md).  
+ All of the simple types -- those integral to the C# language -- are aliases of the .NET <xref:System> types. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](built-in-types-table.md).  
   
  Constant expressions, whose operands are all simple type constants, are evaluated at compilation time.  
   

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -37,8 +37,7 @@ The *simple types* are a set of predefined struct types provided by C# and compr
 - [Floating-point types](floating-point-types-table.md)
 - [bool](bool.md)
 
-The simple types are identified through keywords, but these keywords are simply aliases for predefined struct types in the <xref:System>
-namespace. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](built-in-types-table.md).
+The simple types are identified through keywords, but these keywords are simply aliases for predefined struct types in the <xref:System> namespace. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](built-in-types-table.md).
 
 The simple types differ from other struct types in that they permit certain additional operations:
 

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -46,6 +46,8 @@ The simple types differ from other struct types in that they permit certain addi
 - You can declare constants of the simple types with the [const](const.md) keyword. It's not possible to have constants of other struct types.
 
 - Constant expressions, whose operands are all simple type constants, are evaluated at compile time.
+
+For more information, see the [Simple types](~/_csharplang/spec/types.md#simple-types) section of the [C# language specification](../language-specification/index.md).
   
 ## Initializing value types
 

--- a/docs/csharp/language-reference/keywords/value-types.md
+++ b/docs/csharp/language-reference/keywords/value-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Value types (C# Reference)"
-ms.date: 07/20/2015
+ms.date: 11/26/2018
 f1_keywords: 
   - "cs.valuetypes"
 helpviewer_keywords: 
@@ -16,19 +16,7 @@ The value types consist of two main categories:
 - [Structs](struct.md)
 
 - [Enumerations](enum.md)
- 
- Structs fall into these categories:
 
-- Numeric types and [char](char.md)
-
-    - [Integral types](integral-types-table.md) (including the [char](char.md) type)
-
-    - [Floating-point types](floating-point-types-table.md)
-
-- [bool](bool.md)
-
-- User-defined structs.
-  
 ## Main features of value types
 
  Variables that are based on value types directly contain values. Assigning one value type variable to another copies the contained value. This differs from the assignment of reference type variables, which copies a reference to the object but not the object itself.  
@@ -41,13 +29,24 @@ The value types consist of two main categories:
   
  Each value type has an implicit default constructor that initializes the default value of that type. For information about default values of value types, see [Default values table](default-values-table.md).  
   
-## Main features of simple types
+## Simple types
 
- All of the simple types -- those integral to the C# language -- are aliases of the .NET <xref:System> types. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](built-in-types-table.md).  
-  
- Constant expressions, whose operands are all simple type constants, are evaluated at compilation time.  
-  
- Simple types can be initialized by using literals. For example, `'A'` is a literal of the type `char` and `2001` is a literal of the type `int`.  
+The *simple types* are a set of predefined struct types provided by C# and comprise the following types:
+
+- [Integral types](integral-types-table.md): integer numeric types and the [char](char.md) type
+- [Floating-point types](floating-point-types-table.md)
+- [bool](bool.md)
+
+The simple types are identified through keywords, but these keywords are simply aliases for predefined struct types in the <xref:System>
+namespace. For example, [int](int.md) is an alias of <xref:System.Int32?displayProperty=nameWithType>. For a complete list of aliases, see [Built-in types table](built-in-types-table.md).
+
+The simple types differ from other struct types in that they permit certain additional operations:
+
+- Simple types can be initialized by using literals. For example, `'A'` is a literal of the type `char` and `2001` is a literal of the type `int`.
+
+- You can declare constants of the simple types with the [const](const.md) keyword. It's not possible to have constants of other struct types.
+
+- Constant expressions, whose operands are all simple type constants, are evaluated at compile time.
   
 ## Initializing value types
 


### PR DESCRIPTION
While the `char` type is an integral type, I think it's still worth an explicit mention in the list of structs.

Other changes are minor style updates.
