### PR TITLE
Made it more clear page is for SQL Server; added Access info.

### DIFF
--- a/docs/framework/data/adonet/sql/linq/downloading-sample-databases.md
+++ b/docs/framework/data/adonet/sql/linq/downloading-sample-databases.md
@@ -1,6 +1,6 @@
 ---
-title: "Get the sample databases for ADO.NET code samples"
-description: "Download the sample databases used in the code samples in the ADO.NET documentation, as well as SQL Server and management tools"
+title: "Get the sample SQL Server databases for ADO.NET code samples"
+description: "Download the sample SQL Server databases used in the code samples in the ADO.NET documentation, as well as SQL Server and management tools"
 ms.date: "10/18/2018"
 ms.assetid: ef9d69a1-9461-43fe-94bb-7c836754bcb5
 ---
@@ -8,17 +8,20 @@ ms.assetid: ef9d69a1-9461-43fe-94bb-7c836754bcb5
 
 A number of examples and walkthroughs in the [!INCLUDE[vbtecdlinq](../../../../../../includes/vbtecdlinq-md.md)] documentation use sample SQL Server databases and SQL Server Express. You can download these products free of charge from Microsoft.
 
-## Get the Northwind sample database
+## Get the Northwind sample database for SQL Server
 
-Download the script `instnwnd.sql` to create and load the Northwind sample database from the following GitHub repository:
+Download the script `instnwnd.sql` from the following GitHub repository to create and load the Northwind sample database for SQL Server:
 
 [Northwind and pubs sample databases for Microsoft SQL Server](https://github.com/Microsoft/sql-server-samples/tree/master/samples/databases/northwind-pubs)
 
 Before you can use the Northwind database, you have to run the downloaded `instnwnd.sql` script file to recreate the database on an instance of SQL Server by using [SQL Server Management Studio](#get_ssms) or a similar tool. Follow the instructions in the Readme file in the repository.
 
-## Get the AdventureWorks sample database
+> [!TIP]
+> If you're looking for the Northwind database for Microsoft Access, see [Install the Northwind sample database for Microsoft Access](#northwind_access).
 
-Download the AdventureWorks sample database from the following GitHub repository:
+## Get the AdventureWorks sample database for SQL Server
+
+Download the AdventureWorks sample database for SQL Server from the following GitHub repository:
 
 [AdventureWorks sample databases](https://github.com/Microsoft/sql-server-samples/releases/tag/adventureworks)
 
@@ -38,7 +41,23 @@ If you want to view or modify a database that you've downloaded, you can use SQL
 [Download SQL Server Management Studio (SSMS)](/sql/ssms/download-sql-server-management-studio-ssms) 
 
 You can also view and manage databases in the Visual Studio integrated development environment (IDE). In [Visual Studio](https://www.visualstudio.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=button+cta&utm_content=download+vs2017), connect to the database from **SQL Server Object Explorer**, or create a Data Connection to the database in **Server Explorer**. Open these explorer panes from the **View** menu.
-  
+
+## <a name="northwind_access"></a> Install the Northwind sample database for Microsoft Access
+
+The Northwind sample database for Microsoft Access is not available on the Microsoft Download Center. To install Northwind directly from within Access, do the following things:
+
+1. Open Access.
+
+1. Enter **Northwind** in the **Search for Online Templates** box, and then select **Enter**.
+
+1. On the results screen, select **Northwind**. A new window opens with a description of the Northwind database.
+
+1. In the new window, in the **File Name** text box, provide a filename for your copy of the Northwind database.
+
+1. Select **Create**. Access downloads the Northwind database and prepares the file.
+
+1. When this process is complete, the database opens with a Welcome screen.
+
 ## See also
 
 - [Getting Started](../../../../../../docs/framework/data/adonet/sql/linq/getting-started.md)


### PR DESCRIPTION
## Summary

The CSAT for this page has continued to decline (from 60% to 43%) even after I simplified the page and updated the links. 85% of visitors come from search, and most have searched for "Northwind database." I can only guess that lots of customers want it for Access, not for SQL. This seems to be the de facto Sample Databases page since there isn't one in the SQL or Access content. So I have done 2 things: (1) make it more clear that this page is for SQL Server, and (2) add brief info for Access users, since this info is not available except on third-party sites.
