### PR TITLE
Update cs0283.md: added missing types

### DIFF
--- a/docs/csharp/misc/cs0283.md
+++ b/docs/csharp/misc/cs0283.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Error CS0283"
-ms.date: 07/20/2015
+ms.date: 11/27/2018
 f1_keywords: 
   - "CS0283"
 helpviewer_keywords: 
@@ -10,7 +10,7 @@ ms.assetid: f94a5b84-92c5-4602-894d-6f856d57e0e6
 # Compiler Error CS0283
 The type 'type' cannot be declared const  
   
- The type specified in a constant declaration must be `byte`, `char`, `short`, `int`, `long`, `float`, `double`, `decimal`, `bool`, `string`, an enum-type, or a reference type that is assigned a value of null. Each constant-expression must yield a value of the target type or of a type that can be converted to the target type by implicit conversion.  
+The type specified in a [constant](../language-reference/keywords/const.md) declaration must be `byte`, `sbyte`, `ushort`, `short`, `uint`, `int`, `ulong`, `long`, `char`, `float`, `double`, `decimal`, `bool`, `string`, an [enum](../language-reference/keywords/enum.md) type, or a reference type that is assigned a value of `null`. Each constant expression must yield a value of the target type or of a type that is implicitly convertible to the target type.  
   
 ## Example  
  The following example generates CS0283.  


### PR DESCRIPTION
Half of the integer types was missing from the list of the types that are allowed in the constant declaration.
