### PR TITLE
Removed duplicate example for GroupJoin to fix 8968.

### DIFF
--- a/docs/framework/data/adonet/ef/language-reference/query-expression-syntax-examples-join-operators.md
+++ b/docs/framework/data/adonet/ef/language-reference/query-expression-syntax-examples-join-operators.md
@@ -30,12 +30,6 @@ Joining is an important operation in queries that target data sources that have 
  [!code-csharp[DP L2E Examples#GroupJoin](../../../../../../samples/snippets/csharp/VS_Snippets_Data/DP L2E Examples/CS/Program.cs#groupjoin)]
  [!code-vb[DP L2E Examples#GroupJoin](../../../../../../samples/snippets/visualbasic/VS_Snippets_Data/DP L2E Examples/VB/Module1.vb#groupjoin)]  
   
-### Example  
- The following example performs a <xref:System.Linq.Enumerable.GroupJoin%2A> over the Contact and SalesOrderHeader tables. A group join is the equivalent of a left outer join, which returns each element of the first (left) data source, even if no correlated elements are in the other data source.  
-  
- [!code-csharp[DP L2E Examples#GroupJoin](../../../../../../samples/snippets/csharp/VS_Snippets_Data/DP L2E Examples/CS/Program.cs#groupjoin)]
- [!code-vb[DP L2E Examples#GroupJoin](../../../../../../samples/snippets/visualbasic/VS_Snippets_Data/DP L2E Examples/VB/Module1.vb#groupjoin)]  
-  
 ## Join  
   
 ### Example  


### PR DESCRIPTION
## Summary

The 1st and the 3rd of the 3 examples for GroupJoin were duplicates. I removed example #3.

Fixes #8968 