### PR TITLE
Update linux-prerequisites.md

### DIFF
--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -64,7 +64,8 @@ The following are intended to be examples. The exact versions and names may vary
 Ubuntu distributions require the following libraries installed:
 
 * liblttng-ust0
-* libcurl3
+* libcurl3 (for 14.x and 16.x)
+* libcurl4 (for 18.x)
 * libssl1.0.0
 * libkrb5-3
 * zlib1g


### PR DESCRIPTION
Ubuntu 18.x provides libcurl4 in the base packages by default, while libcurl3 is available if universal is enabled.
libcurl4 should be fine for dotnet based on comment here: https://github.com/Microsoft/azure-pipelines-agent/issues/1990#issuecomment-442508288

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
