### PR TITLE
Nullable reference types tutorial, and nullable references overview

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -7,13 +7,17 @@ ms.date: 12/03/2018
 
 C# 8 introduces **nullable reference types** and **non-nullable reference types** that enable you to make important statements about the properties for reference type variables:
 
-- **A reference is not supposed to be null**. When variables aren't supposed to be null, the compiler enforces these rules: The variable must be initialized to a non-null value. The variable can never be assigned the value `null`. Because of those two rules, it's safe to de-reference the variable without first checking that it isn't null.
-- **A reference may be null**. When variables may be null, the compiler enforces different rules. The variable may only be de-referenced when the compiler can guarantee that the value isn't null. These variables may be initialized with the default `null` value, and may be assigned the value `null` in other code.
+- **A reference is not supposed to be null**. When variables aren't supposed to be null, the compiler enforces rules that ensure it is safe to dereference these variables without first checking that it isn't null:
+  - The variable must be initialized to a non-null value.
+  - The variable can never be assigned the value `null`.
+- **A reference may be null**. When variables may be null, the compiler enforces different rules to ensure that you've correctly checked for a null reference:
+  - The variable may only be dereferenced when the compiler can guarantee that the value isn't null.
+  - These variables may be initialized with the default `null` value and may be assigned the value `null` in other code.
 
-This new feature provides significant benefits over the earlier reference variables where the design intent couldn't be determined from the variable declaration. The compiler didn't provide safety for reference types:
+This new feature provides significant benefits over the handling of reference variables in earlier versions of C# where the design intent couldn't be determined from the variable declaration. The compiler didn't provide safety against null reference exceptions for reference types:
 
-- **A reference could be null**. No warnings are issued when a reference type is initialized to null, or later assigned to null.
-- **A reference is assumed to be not null**. The compiler doesn't issue any warnings when reference types are dereferenced.
+- **A reference can be null**. No warnings are issued when a reference type is initialized to null, or later assigned to null.
+- **A reference is assumed to be not null**. The compiler doesn't issue any warnings when reference types are dereferenced. (With nullable references,  the compiler issues warnings whenever you dereference a variable that may be null).
 
 A **nullable reference type** is noted using the same syntax as [nullable value types](programming-guide/nullable-types/index.md): a `?` is appended to the type of the variable. For example, the following variable declaration represents a nullable string variable, `name`:
 
@@ -21,17 +25,19 @@ A **nullable reference type** is noted using the same syntax as [nullable value 
 string? name;
 ```
 
-Any variable where the `?` is not appended to the type name is a **non-nullable reference type**. That includes all reference type variables in existing code, when you have enabled this feature.
+Any variable where the `?` is not appended to the type name is a **non-nullable reference type**. That includes all reference type variables in existing code when you have enabled this feature.
 
-The compiler uses static analysis to determine if a nullable reference is known to be non-null. THe compiler warns you if you dereference a nullable reference when it may be null. You can override this behavior using the **null-forgiving operator** (`!`) following a variable name. For example, if you know the `name` variable isn't null but the compiler issues a warning, you can write the following code to override the compiler's analysis:
+The compiler uses static analysis to determine if a nullable reference is known to be non-null. The compiler warns you if you dereference a nullable reference when it may be null. You can override this behavior by using the **null-forgiving operator** (`!`) following a variable name. For example, if you know the `name` variable isn't null but the compiler issues a warning, you can write the following code to override the compiler's analysis:
 
 ```csharp
 name!.Length;
 ```
 
+You can read details about this operator in the [draft nullable reference types](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md#the-null-forgiving-operator) specification proposal on GitHub.
+
 ## Nullable contexts
 
-Nullable contexts enable fine-grained control for how the compiler interprets reference type variables. The nullable context of any given source line is `enabled` or `disabled`. You can think of the pre-C# 8 compiler as compiling all your code in a `disabled` nullable context: Any reference type may be null. Warnings are not generated when variables of reference type are de-referenced.
+Nullable contexts enable fine-grained control for how the compiler interprets reference type variables. The nullable context of any given source line is `enabled` or `disabled`. You can think of the pre-C# 8 compiler as compiling all your code in a `disabled` nullable context: Any reference type may be null. Warnings are not generated when variables of a reference type are dereferenced.
 
 The nullable context is controlled using a new pragma:
 
@@ -44,19 +50,19 @@ The compiler uses the following rules in a disabled nullable context:
 
 - You can't declare nullable references in a disabled context.
 - All reference variables may be assigned to null.
-- No warnings are generated when a variable of a reference type is de-referenced.
+- No warnings are generated when a variable of a reference type is dereferenced.
 - The null-forgiving operator may not be used in a disabled context.
 
 The behavior is the same as previous versions of C#.
 
 The compiler uses the following rules in an enabled nullable context:
 
-- Any variable of a reference type is a **non-nullable reference type**
-- Any non-nullable reference may be de-referenced safely.
-- Any nullable reference type (noted by `?` after the type in the variable declaration) may be null, and must be verified as not-null before it can be dereferenced.
+- Any variable of a reference type is a **non-nullable reference type**.
+- Any non-nullable reference may be dereferenced safely.
+- Any nullable reference type (noted by `?` after the type in the variable declaration) may be null, and must be verified as not null before it can be dereferenced.
 - You can use the null-forgiving operator to declare that a nullable reference isn't null.
 
-A richer grammar is proposed for nullable contexts and will be available in future previews. For more information about nullable contexts, see the draft [nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md#nullable-contexts).
+A richer grammar is proposed for nullable contexts and will be available in future previews. For more information about nullable contexts, see the [nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md#nullable-contexts) draft.
 
 ## Safely reference types by specifying nullable and non-nullable
 
@@ -71,4 +77,3 @@ The compiler enforces that non-nullable references may never be set to the null 
 
 - [Draft Nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md)
 - [Intro to nullable references tutorial](tutorials/nullable-reference-types.md)
-- 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -1,0 +1,74 @@
+---
+title: Nullable reference types
+description: This article provides an overview of nullable reference types, a feature added in C# 8. You'll learn how the feature works, what it does for your code and more....
+ms.date: 12/03/2018
+---
+# Nullable reference types
+
+C# 8 introduces **nullable reference types** and **non-nullable reference types** that enable you to make important statements about the properties for reference type variables:
+
+- **A reference is not supposed to be null**. When variables are not supposed to be null, the compiler enforces three rules: The variable must be initialized to a non-null value. The variable can never be assigned the value `null`. Because of those two rules, it is safe to de-reference the variable without first checking that it is not nul.
+- **A reference may be null**. When variables may be null, the compiler enforces different rules. The variable may only be de-referenced when the compiler can guarantee that the value is not null. These variables may be initialized with the default `null` value, and may be assigned the value `null` in other code.
+
+This new feature provides significant benefits over the earlier reference type variables where the design intent could not be determined from the variable declaration. The compiler did not provide safety for reference types:
+
+- **A reference could be null**. No warnings are issued when a reference type is initialized to null, or later assigned to null.
+- **A reference is assumed to be not null**. The compiler doesn't issue any warnings when reference types are dereferenced.
+
+A **nullable reference type** is noted using the same syntax as [nullable value types](programming-guide/nullable-types/index.md): a `?` is appended to the type of the variable. For example the following variable declaration represents a nullable string variable, `name`:
+
+```csharp
+string? name;
+```
+
+Any variable where the `?` is not appended to the type name is a **non-nullable reference type**. That includes all reference type variables in existing code, when you have enabled this feature.
+
+The compiler uses static analysis to determine if a nullable reference is known to be non-null. THe compiler warns you if you dereference a nullable reference when it may be null. You can override this behavior using the **null-forgiving operator** (`!`) following a variable name. For example, if you know the `name` variable is not null but the compiler issues a warning, you can write the following code to override the compiler's analysis:
+
+```csharp
+name!.Length;
+```
+
+## Nullable contexts
+
+Nullable contexts enables fine-grained control for how the compiler interprets reference type variables. The nullable context of any given source line is `enabled` or `disabled`. You can think of the pre-C# 8 compiler as compiling all your code in a `disabled` nullable context: Any reference type may be null. Warnings are not generated when variables of reference type are de-referenced.
+
+The nullable context is controlled using a new pragma:
+
+- `#nullable enable` sets the nullable context to enabled.
+- `#nullable disable` sets the nullable context to disabled.
+
+The default nullable context is `disabled`. That decision means that your existing code compiles without changes and without generating any new warnings.
+
+The compiler uses the following rules in a disabled nullable context:
+
+- You cannot declare nullable references in a disabled context.
+- All reference variables may be assigned to null.
+- No warnings are generated when a variable of a reference type is de-referenced.
+- The null-forgiving operator may not be used in a disabled context.
+
+This is the same behavior as the previous versions of C#.
+
+The compiler uses the following rules in an enabled nullable context:
+
+- Any variable of a reference type is a **non-nullable reference type**
+- Any non-nullable reference may be de-referenced safely.
+- Any nullable reference type (noted by `?` after the type in the variable declaration) may be null, and must be verified as not-null before it can be dereferenced.
+- You can use the null-forgiving operator to declare that a nullable reference is not null.
+
+A richer grammar is proposed for nullable contexts and will be available in future previews. See the draft [nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md#nullable-contexts) for more details.
+
+## Safely reference types by specifying nullable and non-nullable
+
+The compiler uses static analysis to determine the **null state** of any nullable reference. The null state is either **not null** or **maybe null**. If you dereference a nullable reference when the compiler has determined it is **maybe null**, the compiler warns you. The state of a nullable reference is **maybe null** unless the compiler can detmerine one of two conditions:
+
+1. The variable has been definitely assigned to a non-null value.
+1. The variable has been checked against null before de-referencing it.
+
+The compiler enforces that non-nullable references may never be set to the null value. You must initialize them to a non-null value. If you don't, the compiler warns that a non-nullable reference wasn't initialized. The compiler also warns you whenever you assign a non-nullable reference to a value that **maybe null**. That implies you can only assign a non-nullable reference to a nullable reference if that nullable reference is **not null**.
+
+## Learn more
+
+- [Draft Nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md)
+- [Intro to nullables tutorial](tutorials/nullable-reference-types.md)
+- 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -1,21 +1,21 @@
 ---
 title: Nullable reference types
-description: This article provides an overview of nullable reference types, a feature added in C# 8. You'll learn how the feature works, what it does for your code and more....
+description: This article provides an overview of nullable reference types, added in C# 8. You'll learn how the feature provides safety against null reference exceptions, for new and existing projects.
 ms.date: 12/03/2018
 ---
 # Nullable reference types
 
 C# 8 introduces **nullable reference types** and **non-nullable reference types** that enable you to make important statements about the properties for reference type variables:
 
-- **A reference is not supposed to be null**. When variables are not supposed to be null, the compiler enforces three rules: The variable must be initialized to a non-null value. The variable can never be assigned the value `null`. Because of those two rules, it is safe to de-reference the variable without first checking that it is not nul.
-- **A reference may be null**. When variables may be null, the compiler enforces different rules. The variable may only be de-referenced when the compiler can guarantee that the value is not null. These variables may be initialized with the default `null` value, and may be assigned the value `null` in other code.
+- **A reference is not supposed to be null**. When variables aren't supposed to be null, the compiler enforces these rules: The variable must be initialized to a non-null value. The variable can never be assigned the value `null`. Because of those two rules, it's safe to de-reference the variable without first checking that it isn't null.
+- **A reference may be null**. When variables may be null, the compiler enforces different rules. The variable may only be de-referenced when the compiler can guarantee that the value isn't null. These variables may be initialized with the default `null` value, and may be assigned the value `null` in other code.
 
-This new feature provides significant benefits over the earlier reference type variables where the design intent could not be determined from the variable declaration. The compiler did not provide safety for reference types:
+This new feature provides significant benefits over the earlier reference variables where the design intent couldn't be determined from the variable declaration. The compiler didn't provide safety for reference types:
 
 - **A reference could be null**. No warnings are issued when a reference type is initialized to null, or later assigned to null.
 - **A reference is assumed to be not null**. The compiler doesn't issue any warnings when reference types are dereferenced.
 
-A **nullable reference type** is noted using the same syntax as [nullable value types](programming-guide/nullable-types/index.md): a `?` is appended to the type of the variable. For example the following variable declaration represents a nullable string variable, `name`:
+A **nullable reference type** is noted using the same syntax as [nullable value types](programming-guide/nullable-types/index.md): a `?` is appended to the type of the variable. For example, the following variable declaration represents a nullable string variable, `name`:
 
 ```csharp
 string? name;
@@ -23,7 +23,7 @@ string? name;
 
 Any variable where the `?` is not appended to the type name is a **non-nullable reference type**. That includes all reference type variables in existing code, when you have enabled this feature.
 
-The compiler uses static analysis to determine if a nullable reference is known to be non-null. THe compiler warns you if you dereference a nullable reference when it may be null. You can override this behavior using the **null-forgiving operator** (`!`) following a variable name. For example, if you know the `name` variable is not null but the compiler issues a warning, you can write the following code to override the compiler's analysis:
+The compiler uses static analysis to determine if a nullable reference is known to be non-null. THe compiler warns you if you dereference a nullable reference when it may be null. You can override this behavior using the **null-forgiving operator** (`!`) following a variable name. For example, if you know the `name` variable isn't null but the compiler issues a warning, you can write the following code to override the compiler's analysis:
 
 ```csharp
 name!.Length;
@@ -31,7 +31,7 @@ name!.Length;
 
 ## Nullable contexts
 
-Nullable contexts enables fine-grained control for how the compiler interprets reference type variables. The nullable context of any given source line is `enabled` or `disabled`. You can think of the pre-C# 8 compiler as compiling all your code in a `disabled` nullable context: Any reference type may be null. Warnings are not generated when variables of reference type are de-referenced.
+Nullable contexts enable fine-grained control for how the compiler interprets reference type variables. The nullable context of any given source line is `enabled` or `disabled`. You can think of the pre-C# 8 compiler as compiling all your code in a `disabled` nullable context: Any reference type may be null. Warnings are not generated when variables of reference type are de-referenced.
 
 The nullable context is controlled using a new pragma:
 
@@ -42,25 +42,25 @@ The default nullable context is `disabled`. That decision means that your existi
 
 The compiler uses the following rules in a disabled nullable context:
 
-- You cannot declare nullable references in a disabled context.
+- You can't declare nullable references in a disabled context.
 - All reference variables may be assigned to null.
 - No warnings are generated when a variable of a reference type is de-referenced.
 - The null-forgiving operator may not be used in a disabled context.
 
-This is the same behavior as the previous versions of C#.
+The behavior is the same as previous versions of C#.
 
 The compiler uses the following rules in an enabled nullable context:
 
 - Any variable of a reference type is a **non-nullable reference type**
 - Any non-nullable reference may be de-referenced safely.
 - Any nullable reference type (noted by `?` after the type in the variable declaration) may be null, and must be verified as not-null before it can be dereferenced.
-- You can use the null-forgiving operator to declare that a nullable reference is not null.
+- You can use the null-forgiving operator to declare that a nullable reference isn't null.
 
-A richer grammar is proposed for nullable contexts and will be available in future previews. See the draft [nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md#nullable-contexts) for more details.
+A richer grammar is proposed for nullable contexts and will be available in future previews. For more information about nullable contexts, see the draft [nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md#nullable-contexts).
 
 ## Safely reference types by specifying nullable and non-nullable
 
-The compiler uses static analysis to determine the **null state** of any nullable reference. The null state is either **not null** or **maybe null**. If you dereference a nullable reference when the compiler has determined it is **maybe null**, the compiler warns you. The state of a nullable reference is **maybe null** unless the compiler can detmerine one of two conditions:
+The compiler uses static analysis to determine the **null state** of any nullable reference. The null state is either **not null** or **maybe null**. If you dereference a nullable reference when the compiler has determined it's **maybe null**, the compiler warns you. The state of a nullable reference is **maybe null** unless the compiler can determine one of two conditions:
 
 1. The variable has been definitely assigned to a non-null value.
 1. The variable has been checked against null before de-referencing it.
@@ -70,5 +70,5 @@ The compiler enforces that non-nullable references may never be set to the null 
 ## Learn more
 
 - [Draft Nullable reference specification](https://github.com/dotnet/csharplang/blob/master/proposals/nullable-reference-types-specification.md)
-- [Intro to nullables tutorial](tutorials/nullable-reference-types.md)
+- [Intro to nullable references tutorial](tutorials/nullable-reference-types.md)
 - 

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -65,13 +65,9 @@ on your machine.
 The following tutorials enable you to build C# programs using [.NET Core](../../core/index.md):
 
 * [Console Application](console-teleprompter.md): demonstrates Console I/O, the structure of a Console application, and the basics of the task-based asynchronous programming model.
-
 * [REST Client](console-webapiclient.md): demonstrates web communications, JSON serialization, and object-oriented features in the C# language.
-
 * [Inheritance in C# and .NET](inheritance.md): demonstrates inheritance in C#, including the use of inheritance to define base classes, abstract base classes, and derived classes.
-
 * [Working with LINQ](working-with-linq.md): demonstrates many of the features of LINQ and the language elements that support it.
-
 * [String Interpolation](string-interpolation.md): demonstrates how to use string interpolation to create formatted strings in C#.
-
 * [Using Attributes](attributes.md): demonstrates how to create and use attributes in C#.
+* [Nullable reference types](nullable-reference-types.md): demonstrates how to use nullable reference types, and express your intent in when a reference may be null.

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -70,4 +70,4 @@ The following tutorials enable you to build C# programs using [.NET Core](../../
 * [Working with LINQ](working-with-linq.md): demonstrates many of the features of LINQ and the language elements that support it.
 * [String Interpolation](string-interpolation.md): demonstrates how to use string interpolation to create formatted strings in C#.
 * [Using Attributes](attributes.md): demonstrates how to create and use attributes in C#.
-* [Nullable reference types](nullable-reference-types.md): demonstrates how to use nullable reference types, and express your intent in when a reference may be null.
+* [Nullable reference types](nullable-reference-types.md): demonstrates how to use nullable reference types to express your intent for null references.

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -1,7 +1,7 @@
 ---
 title: Design with nullable reference types
 description: This advanced tutorial provides an introduction to nullable reference types. You'll learn to express your design intent on when reference values may be null, and have the compiler enforce when they cannot be null.
-ms.date: 11/30/2018
+ms.date: 12/03/2018
 ---
 # Tutorial: Express your design intent more clearly with nullable and non-nullable reference types
 
@@ -337,4 +337,4 @@ Experiment by changing the type declarations between nullable and non-nullable r
 
 Learn more by reading an overview of nullable reference types...
 > [!div class="nextstepaction"]
-> [Next steps button](../programming-guide/nullable-references.md)
+> [Next steps button](../nullable-references.md)

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -2,6 +2,7 @@
 title: Design with nullable reference types
 description: This advanced tutorial provides an introduction to nullable reference types. You'll learn to express your design intent on when reference values may be null, and have the compiler enforce when they cannot be null.
 ms.date: 12/03/2018
+ms.custom: mvc
 ---
 # Tutorial: Express your design intent more clearly with nullable and non-nullable reference types
 
@@ -17,25 +18,25 @@ In this tutorial, you'll learn how to:
 
 ## Prerequisites
 
-You’ll need to set up your machine to run .NET Core, including the C# 8 beta compiler.  The C# 8 beta compiler is available with Visual Studio 2019 preview 1, or .NET Core 3.0 preview 1.
+You’ll need to set up your machine to run .NET Core, including the C# 8 beta compiler. The C# 8 beta compiler is available with [Visual Studio 2019 preview 1](https://visualstudio.microsoft.com/vs/preview/), or [.NET Core 3.0 preview 1](https://dotnet.microsoft.com/download/dotnet-core/3.0).
 
 This tutorial assumes you're familiar with C# and .NET, including either Visual Studio or the .NET Core CLI.
 
 ## Incorporate nullable reference types into your designs
 
-In this tutorial, you'll build a library that models running a survey. The code uses both nullable reference types and non-nullable reference types to represent the real world concepts. The survey questions would never be null. A respondent might prefer not to answer an optional question. The responses might be null in this example.
+In this tutorial, you'll build a library that models running a survey. The code uses both nullable reference types and non-nullable reference types to represent the real-world concepts. The survey questions can never be null. A respondent might prefer not to answer an optional question. The responses might be null in this example.
 
 The code you'll write for this sample expresses that intent, and the compiler enforces that intent.
 
 ## Create the application and enable nullable reference types
 
-Create a new console application, either in Visual Studio or from the command line using `dotnet new console`. Name the application `NullableIntroduction`. Once you've created the application, you'll need to enable C# 8 beta features. Open the `csproj` file, and add a `LangVersion` element to the `PropertyGroup` element:
+Create a new console application either in Visual Studio or from the command line using `dotnet new console`. Name the application `NullableIntroduction`. Once you've created the application, you'll need to enable C# 8 beta features. Open the `csproj` file, and add a `LangVersion` element to the `PropertyGroup` element:
 
 ```xml
 <LangVersion>8.0</LangVersion>
 ```
 
-Alternatively, you can use the Visual Studio project properties to enable C# 8. Right click on the project node, select **Properties**. Then, select the **build** tab, and click **Advanced...**. In the dropdown for language version, select **C# 8.0 (beta)**.
+Alternatively, you can use the Visual Studio project properties to enable C# 8. In Solution Explorer, right click on the project node, select **Properties**. Then, select the **build** tab, and click **Advanced...**. In the dropdown for language version, select **C# 8.0 (beta)**.
 
 You must opt into the **nullable reference types** feature, even in C# 8 projects. That's because once the feature is turned on, existing reference variable declarations become **non-nullable reference types**. While that decision will help find issues where existing code may not have proper null-checks, it may not accurately reflect your original design intent. You turn on the feature with a new pragma:
 
@@ -56,23 +57,23 @@ This survey application requires creating a number of classes:
 - A class that models a list of people contacted for the survey.
 - A class that models the answers from a person that took the survey.
 
-These types will make use of both nullable and non-nullable reference types to express which members are required, and which members are optional. Nullable reference types communicate that design intent clearly:
+These types will make use of both nullable and non-nullable reference types to express which members are required and which members are optional. Nullable reference types communicate that design intent clearly:
 
 - The questions that are part of the survey can never be null: It makes no sense to ask a blank question.
 - The respondents can never be null. You'll want to track people you contacted, even respondents that declined to participate.
-- Any response to a question may be null. Respondents can decline to answer some, or all questions.
+- Any response to a question may be null. Respondents can decline to answer some or all questions.
 
 If you've programmed in C#, you may be so accustomed to reference types that allow null values that you may have missed other opportunities to declare non-nullable instances:
 
 - The collection of questions should be non-nullable.
 - The collection of respondents should be non-nullable.
 
-As you write the code, you'll see that a non-nullable reference type as the default for references avoids common mistakes that could lead to null reference exceptions. This tutorial points out where you may have made a default decision in your C# coding.
+As you write the code, you'll see that a non-nullable reference type as the default for references avoids common mistakes that could lead to null reference exceptions. One lesson from this tutorial is that you made decisions about which variables could or could not be null. The language didn't provide syntax to express those decisions. Now it does.
 
 The app you'll build will do the following steps:
 
 1. Create a survey and add questions to it.
-1. Create a pseudo-random set of respondents for the survey
+1. Create a pseudo-random set of respondents for the survey.
 1. Contact respondents until the completed survey size reaches the goal number.
 1. Write out important statistics on the survey responses.
 
@@ -136,23 +137,27 @@ namespace NullableIntroduction
 }
 ```
 
-As before, you must initialize the list object to a non-null value or the compiler issues a warning. There's no null checks in the second overload of `AddQuestion` because it's not needed: You've declared that variable to be non-nullable. Its value can't be `null`.
+As before, you must initialize the list object to a non-null value or the compiler issues a warning. There are no null checks in the second overload of `AddQuestion` because they aren't needed: You've declared that variable to be non-nullable. Its value can't be `null`.
 
-Switch to `program.cs` in your editor, and replace the contents of `Main` with the following lines of code:
+Switch to `Program.cs` in your editor and replace the contents of `Main` with the following lines of code:
 
 [!code-csharp[AddQuestions](../../../samples/csharp/NullableIntroduction/NullableIntroduction/Program.cs#AddQuestions)]
 
-Without the `#nullable enable` pragma at the top of the file, the compiler doesn't issue a warning when you pass `null` as the text for the `AddQuestion` argument. Fix that by adding `#nullable enable` following the `using` statement. Now, that last line generates a warning. Remove that line because it can cause bugs later.
+Without the `#nullable enable` pragma at the top of the file, the compiler doesn't issue a warning when you pass `null` as the text for the `AddQuestion` argument. Fix that by adding `#nullable enable` following the `using` statement. Try it by adding the following line to `Main`:
+
+```csharp
+surveyRun.AddQuestion(QuestionType.Text, default);
+```
 
 ## Create respondents and get answers to the survey
 
 Next, write the code that generates answers to the survey. This involves several small tasks:
 
 1. Build a method that generates respondent objects. These represent people asked to fill out the survey.
-1. Build logic to simulate asking the questions to a respondent, collecting answers or noting that a respondent didn't answer.
+1. Build logic to simulate asking the questions to a respondent and collecting answers or noting that a respondent didn't answer.
 1. Repeat until enough respondents have answered the survey.
 
-You'll need a class to represent a survey response, so add that now. Enable nullable support. Add an Id field and a constructor that initializes the ID field, as shown in the following code:
+You'll need a class to represent a survey response, so add that now. Enable nullable support. Add an `Id` field and a constructor that initializes the ID field, as shown in the following code:
 
 ```csharp
 #nullable enable
@@ -167,7 +172,7 @@ namespace NullableIntroduction
 }
 ```
 
-Next, add a `static` method to create new participants by generating a random id:
+Next, add a `static` method to create new participants by generating a random ID:
 
 [!code-csharp[GenerateRespondents](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#Random)]
 
@@ -194,13 +199,13 @@ The last step to run the survey is to add a call to perform the survey at the en
 
 ## Examine survey responses
 
-The last step is to display survey results. You'll add code to many of the classes you've written. This code demonstrates the value of distinguishing nullable and non-nullable reference types. Start by adding the following two expression bodied members to the `SurveyResponse` class:
+The last step is to display survey results. You'll add code to many of the classes you've written. This code demonstrates the value of distinguishing nullable and non-nullable reference types. Start by adding the following two expression-bodied members to the `SurveyResponse` class:
 
 [!code-csharp[ReportResponses](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#SurveyStatus)]
 
-Because `surveyResponses` is a non-nullable reference type no checks are necessary before de-referencing it. The `Answer` method returns a non-nullable string, so choose the overload of `GetValueOrDefault` that takes a second argument for the default value.
+Because `surveyResponses` is a non-nullable reference, type no checks are necessary before de-referencing it. The `Answer` method returns a non-nullable string, so choose the overload of `GetValueOrDefault` that takes a second argument for the default value.
 
-Next, add these three expression bodied members to the `SurveyRun` class:
+Next, add these three expression-bodied members to the `SurveyRun` class:
 
 [!code-csharp[ReportResults](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyRun.cs#RunReport)]
 
@@ -214,12 +219,12 @@ You don't need any `null` checks in this code because you've designed the underl
 
 ## Get the code
 
-You can get the code for the finished tutorial from our [samples](https://github.com/dotnet/samples) repository int the [csharp/IntroToNullables](https://github.com/dotnet/samples/tree/master/csharp/IntroToNullables) folder.
+You can get the code for the finished tutorial from our [samples](https://github.com/dotnet/samples) repository in the [csharp/IntroToNullables](https://github.com/dotnet/samples/tree/master/csharp/NullableIntroduction) folder.
 
-Experiment by changing the type declarations between nullable and non-nullable reference types. See how that generates different warnings to ensure you don't accidentally de-reference a `null`.
+Experiment by changing the type declarations between nullable and non-nullable reference types. See how that generates different warnings to ensure you don't accidentally dereference a `null`.
 
 ## Next steps
 
-Learn more by reading an overview of nullable reference types...
+Learn more by reading an overview of nullable reference types..
 > [!div class="nextstepaction"]
-> [Next steps button](../nullable-references.md)
+> [An overview of nullable references](../nullable-references.md)

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -113,7 +113,7 @@ namespace NullableIntroduction
 
 Because you haven't initialized `QuestionText`, the compiler issues a warning that a non-nullable property hasn't been initialized. Your design requires the question text to be non-null, so you add a constructor to initialize it and the `QuestionType` value as well. The finished class definition looks like the following code:
 
-[!code-csharp[DefineQuestion](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/SurveyQuestion.cs)]
+[!code-csharp[DefineQuestion](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyQuestion.cs)]
 
 Adding the constructor removes the warning. The constructor argument is also a non-nullable reference type, so the compiler doesn't issue any warnings.
 
@@ -140,7 +140,7 @@ As before, you must initialize the list object to a non-null value or the compil
 
 Switch to `program.cs` in your editor, and replace the contents of `Main` with the following lines of code:
 
-[!code-csharp[AddQuestions](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/Program.cs#AddQuestions)]
+[!code-csharp[AddQuestions](../../../samples/csharp/NullableIntroduction/NullableIntroduction/Program.cs#AddQuestions)]
 
 Without the `#nullable enable` pragma at the top of the file, the compiler doesn't issue a warning when you pass `null` as the text for the `AddQuestion` argument. Fix that by adding `#nullable enable` following the `using` statement. Now, that last line generates a warning. Remove that line because it can cause bugs later.
 
@@ -169,7 +169,7 @@ namespace NullableIntroduction
 
 Next, add a `static` method to create new participants by generating a random id:
 
-[!code-csharp[GenerateRespondents](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#Random)]
+[!code-csharp[GenerateRespondents](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#Random)]
 
 The main responsibility of this class is to generate the responses for a participant to the questions in the survey. This responsibility has a few steps:
 
@@ -178,37 +178,37 @@ The main responsibility of this class is to generate the responses for a partici
 
 Add the following code to your `SurveyRespondent` class:
 
-[!code-csharp[AnswerSurvey](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#AnswerSurvey)]
+[!code-csharp[AnswerSurvey](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#AnswerSurvey)]
 
 The storage for the survey answers is a `Dictionary<int, string>?`, indicating that it may be null. You're using the new language feature to declare your design intent, both to the compiler and to anyone reading your code later. If you ever dereference `surveyResponses` without checking for the null value first, you'll get a compiler warning. You don't get a warning in the `AnswerSurvey` method because the compiler can determine the `surveyResponses` variable was set to a non-null value above.
 
 Next, you need to write the `PerformSurvey` method in the `SurveyRun` class. Add the following code in the `SurveyRun` class:
 
-[!code-csharp[PerformSurvey](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/SurveyRun.cs#PerformSurvey)]
+[!code-csharp[PerformSurvey](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyRun.cs#PerformSurvey)]
 
 Here again, your choice of a nullable `List<SurveyResponse>?` indicates the response may be null. That indicates the survey hasn't been given to any respondents yet. Notice that respondents are added until enough have consented.
 
 The last step to run the survey is to add a call to perform the survey at the end of the `Main` method:
 
-[!code-csharp[RunSurvey](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/Program.cs#RunSurvey)]
+[!code-csharp[RunSurvey](../../../samples/csharp/NullableIntroduction/NullableIntroduction/Program.cs#RunSurvey)]
 
 ## Examine survey responses
 
 The last step is to display survey results. You'll add code to many of the classes you've written. This code demonstrates the value of distinguishing nullable and non-nullable reference types. Start by adding the following two expression bodied members to the `SurveyResponse` class:
 
-[!code-csharp[ReportResponses](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#SurveyStatus)]
+[!code-csharp[ReportResponses](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyResponse.cs#SurveyStatus)]
 
 Because `surveyResponses` is a non-nullable reference type no checks are necessary before de-referencing it. The `Answer` method returns a non-nullable string, so choose the overload of `GetValueOrDefault` that takes a second argument for the default value.
 
 Next, add these three expression bodied members to the `SurveyRun` class:
 
-[!code-csharp[ReportResults](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/SurveyRun.cs#RunReport)]
+[!code-csharp[ReportResults](../../../samples/csharp/NullableIntroduction/NullableIntroduction/SurveyRun.cs#RunReport)]
 
 The `AllParticipants` member must take into account that the `respondents` variable might be null, but the return value can't be null. If you change that expression by removing the `??` and the empty sequence that follows, the compiler warns you the method might return `null` and its return signature returns a non-nullable type.
 
 Finally, add the following loop at the bottom of the `Main` method:
 
-[!code-csharp[DisplaySurveyResults](../../../samples/csharp/tutorials/NullableIntroduction/NullableIntroduction/Program.cs#WriteAnswers)]
+[!code-csharp[DisplaySurveyResults](../../../samples/csharp/NullableIntroduction/NullableIntroduction/Program.cs#WriteAnswers)]
 
 You don't need any `null` checks in this code because you've designed the underlying interfaces so that they all return non-nullable reference types.
 

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -1,0 +1,340 @@
+---
+title: Design with nullable reference types
+description: This advanced tutorial provides an introduction to nullable reference types. You'll learn to express your design intent on when reference values may be null, and have the compiler enforce when they cannot be null.
+ms.date: 11/30/2018
+---
+# Tutorial: Express your design intent more clearly with nullable and non-nullable reference types
+
+C# 8 introduces **nullable reference types**, which complement reference types the same way nullable value types complement value types. You declare a variable to be a **nullable reference type** by appending a `?` to the type. For example, `string?` represents a nullable `string`. You can use these new types to more clearly express your design intent: some variables *must always have a value*, others *may be missing a value*.
+
+In this tutorial, you'll learn how to:
+
+> [!div class="checklist"]
+> * Incorporate nullable and non-nullable reference types into your designs
+> * Enable nullable reference type checks throughout your code.
+> * Write code where the compiler enforces those design decisions.
+> * Use the nullable reference feature in your own designs
+
+## Prerequisites
+
+You’ll need to setup your machine to run .NET Core, including the C# 8 beta compiler.  The C# 8 beta compiler is available with Visual Studio 2019 preview 1, or .NET Core 3.0 preview 1.
+
+This tutorial assumes you are familiar with C# and .NET, including either Visual Studio or the .NET Core CLI.
+
+## Incorporate nullable reference types into your designs
+
+In this tutorial, you'll build a library that models running a survey. The code uses both nullable reference types and non-nullable reference types to represent the real world concepts. For example, the survey questions would never be null. However, a respondent might prefer not to answer an optional question. The responses might be null in this example.
+
+The code you'll write for this sample expresses that intent, and the compiler enforces that intent.
+
+## Create the application and enable nullable reference types
+
+Create a new console application, either in Visual Studio or from the command line using `dotnet new console`. Name the application `NullableIntroduction`. Once you've created the application, you'll need to enable C# 8 beta features. Open the `csproj` file, and add a `LangVersion` element to the `PropertyGroup` element:
+
+```xml
+<LangVersion>8.0</LangVersion>
+```
+
+Alternatively, you can use the Visual Studio project properties to enable C# 8. Right click on the project node, select **Properties**. Then, select the **build** tab, and click **Advanced...**. In the dropdown for language version, select **C# 8.0 (beta)**.
+
+You must opt into the **nullable reference types** feature, even in C# 8 projects. That's because once the feature is turned on, existing reference variable declarations become **non-nullable reference types**. While that decision will help find issues where existing code may not have proper null-checks, it may not accurately reflect your original design intent. You turn on the feature with a new pragma:
+
+```csharp
+#nullable enable
+```
+
+You can add the preceding pragma anywhere in a source file, and the nullable reference type feature is turned on from that point. The pragma also supports the `disable` argument to turn off the feature.
+
+> [!NOTE]
+> Future previews will build on the `#nullable` pragma to control the feature at a project level. In preview 1, you'll need to add this pragma to every source file.
+
+### Design the types for the application
+
+This survey application requires creating a number of classes:
+
+- A class that models the list of questions.
+- A class that models a list of people contacted for the survey.
+- A class that models the answers from a person that took the survey.
+
+These types will make use of both nullable and non-nullable reference types to express which members are required, and which members are optional. Nullable reference types communicates that design intent clearly:
+
+- The questions that are part of the survey can never be null: It makes no sense to ask a blank question.
+- The respondents can never be null. You'll want to track people you contacted, even those that declined to participate.
+- Any response to a question may be null. Respondents can decline to answer some, or all questions.
+
+If you've programmed in C#, you may be so accustomed to reference types allowing null values that you may have missed other opportunities to declare non-nullable instances:
+
+- The collection of questions should be non-nullable.
+- The collection of respondents should be non-nullable.
+
+As you write the code, you'll see that selecting a non-nullable reference type as the default for references avoids common mistakes that could lead to null reference exceptions. This tutorial points out where you may have made a default decision in your C# coding.
+
+The app you'll build will do the following steps:
+
+1. Create a survey and add questions to it.
+1. Create a pseudo-random set of respondents for the survey
+1. Contact respondents until the completed survey size reaches the goal number.
+1. Write out imprtant statistics on the survey responses.
+
+## Build the survey with nullable and non-nullable types
+
+The first code you'll write creates the survey. You'll write classes to model a survey question and a survey run. Your survey has three types of questions, distinguished by the format of the answer: Yes/No answers, number answers, and text answers. Create a `public` `SurveyQuestion` class. Include the `nullable enable` pragma immediately after the `using` statements:
+
+```csharp
+#nullable enable
+namespace NullableIntroduction
+{
+    public class SurveyQuestion
+    {
+    }
+}
+```
+
+Adding the `#nullable enable` pragma means the compiler interprets every reference type variable declaration as a **non-nullable** reference type. You can see your first warning by adding properties for the question text and the type of question, as shown in the following code:
+
+```csharp
+#nullable enable
+namespace NullableIntroduction
+{
+    public enum QuestionType
+    {
+        YesNo,
+        Number,
+        Text
+    }
+
+    public class SurveyQuestion
+    {
+        public string QuestionText { get; }
+        public QuestionType TypeOfQuestion { get; }
+    }
+}
+```
+
+Because you haven't initialized `QuestionText`, the compiler issues a warning that a non-nullable property has not been initialized. Your design requires the question text to be non-null, so you add a constructor to initialize it and the `QuestionType` value as well. The finished class definition looks like the following code:
+
+```csharp
+#nullable enable
+namespace NullableIntroduction
+{
+    public enum QuestionType
+    {
+        YesNo,
+        Number,
+        Text
+    }
+
+    public class SurveyQuestion
+    {
+        public string QuestionText { get; }
+        public QuestionType TypeOfQuestion { get; }
+
+        public SurveyQuestion(QuestionType typeOfQuestion, string text) =>
+            (TypeOfQuestion, QuestionText) = (typeOfQuestion, text);
+    }
+}
+```
+
+Adding the constructor removes the warning. The constructor argument is also a non-nullable reference type, so the compiler does not issue any warnings.
+
+Next, create a `public` class named `SurveyRun`. Include the `nullable enable` pragma following the `using` statements. This class contains a list of `SurveyQuestion` objects and methods to add questions to the survey, as shown in the following code:
+
+```csharp
+using System.Collections.Generic;
+
+#nullable enable
+namespace NullableIntroduction
+{
+    public class SurveyRun
+    {
+        private List<SurveyQuestion> surveyQuestions = new List<SurveyQuestion>();
+
+       public void AddQuestion(QuestionType type, string question) =>
+            AddQuestion(new SurveyQuestion(type, question));
+        public void AddQuestion(SurveyQuestion surveyQuestion) => surveyQuestions.Add(surveyQuestion);
+    }
+}
+```
+
+As before, you must initialize the list object to a non-null value or the compiler issues a warning. There's no null checks in the second overload of `AddQuestion` because it's not needed: You've declared that variable to be non-nullable. Its value can't be `null`.
+
+Switch to `program.cs` in your editor, and replace the contents of `Main` with the following lines of code:
+
+```csharp
+var surveyRun = new SurveyRun();
+surveyRun.AddQuestion(QuestionType.YesNo, "Has your code ever thrown a NullReferenceException?");
+surveyRun.AddQuestion(new SurveyQuestion(QuestionType.Number, "How many times (to the nearest 100) has that happened?"));
+surveyRun.AddQuestion(QuestionType.Text, "What is your favorite color?");
+surveyRun.AddQuestion(QuestionType.Text, default);
+```
+
+Without the `#nullable enable` pragma at the top of the file, the compiler doesn't issue a warning when you pass `null` as the text for the `AddQuestion` argument. Fix that by adding `#nullable enable` following the `using` statement. Now, that last line generates a warning. Remove that line because it can cause bugs later.
+
+## Create respondents and get answers to the survey
+
+Next, write the code that generates answers to the survey. This involves several small tasks:
+
+1. Build a method that generates respondent objects. These represent people asked to fill out the survey.
+1. Build logic to simulate asking the questions to a respondent, collecting answers or noting that a respondent did not answer.
+1. Repeat until enough respondents have answered the survey.
+
+You'll need a class to represent a survey response, so add that now. Enable nullable support. Add an Id field and a constructor that initializes the ID field, as shown in the following code:
+
+```csharp
+#nullable enable
+namespace NullableIntroduction
+{
+    public class SurveyResponse
+    {
+        public int Id { get; }
+
+        public SurveyResponse(int id) => Id = id;
+    }
+}
+```
+
+Next, add a `static` method to create new participants by generating a random id:
+
+```csharp
+private static Random idGenerator = new Random();
+public static SurveyResponse GetRandomId() => new SurveyResponse(idGenerator.Next());
+```
+
+The main responsibility of this this class is to generate the responses for a participant to the questions in the survey. This responsibility has a few steps:
+
+1. Ask for participation in the survey. If the person doesn't consent, return a missing (or null) response.
+1. Ask each question and record the answer. Each answer may also be missing (or null).
+
+Add the following code to your `SurveyRespondent` class:
+
+```csharp
+private Dictionary<int, string>? surveyResponses;
+public void AnswerSurvey(IEnumerable<SurveyQuestion> questions)
+{
+    if (ConsentToSurvey())
+    {
+        surveyResponses = new Dictionary<int, string>();
+        int index = 0;
+        foreach (var question in questions)
+        {
+            var answer = GenerateAnswer(question);
+            if (answer != null)
+            {
+                surveyResponses.Add(index, answer);
+            }
+            index++;
+        }
+    }
+}
+
+private bool ConsentToSurvey() => randomGenerator.Next(0, 2) == 1;
+
+private string? GenerateAnswer(SurveyQuestion question)
+{
+    switch (question.TypeOfQuestion)
+    {
+        case QuestionType.YesNo:
+            int n = randomGenerator.Next(-1, 2);
+            return (n == -1) ? default : (n == 0) ? "No" : "Yes";
+        case QuestionType.Number:
+            n = randomGenerator.Next(-30, 101);
+            return (n < 0) ? default : n.ToString();
+        case QuestionType.Text:
+        default:
+            switch (randomGenerator.Next(0, 5))
+            {
+                case 0:
+                    return default;
+                case 1:
+                    return "Red";
+                case 2:
+                    return "Green";
+                case 3:
+                    return "Blue";
+            }
+            return "Red. No, Green. Wait.. Blue... AAARGGGGGHHH!";
+    }
+}
+```
+
+The storage for the survey answers is a `Dictionary<int, string>?`, indicating that it may be null. You're using the new language feature to declare your design intent, both to the compiler and to anyone reading your code later. If you ever dereference `surveyResponses` without checking for the null value first, you'll get a compiler warning. You don't get a warning in the `AnswerSurvey` method because the compiler can determine the `surveyResponses` variable was set to a non-null value above.
+
+Next, you need to write the `PerformSurvey` method in the `SurveyRun` class. Add the following code in the `SurveyRun` class:
+
+```csharp
+private List<SurveyResponse>? respondents;
+public void PerformSurvey(int numberOfRespondents)
+{
+    int respondentsConsenting = 0;
+    respondents = new List<SurveyResponse>();
+    while (respondentsConsenting < numberOfRespondents)
+    {
+        var respondent = SurveyResponse.GetRandomId();
+        if (respondent.AnswerSurvey(surveyQuestions))
+            respondentsConsenting++;
+        respondents.Add(respondent);
+    }
+}
+```
+
+Here again, your choice of a nullable `List<SurveyResponse>?` indicates that the response may be null. That indicates that the survey has not been given to any respondents yet. Notice that respondents are added until enough have consented.
+
+The last step to run the survey is to add a call to perform the survey at the end of the `Main` method:
+
+```csharp
+surveyRun.PerformSurvey(50);
+```
+
+## Examine survey responses
+
+The last step is to display survey results. You'll add code to many of the classes you've written. This code demonstrates the value of distinguishing nullable and non-nullable reference types. Start by adding the following two expression bodied members to the `SurveyResponse` class:
+
+```csharp
+public bool AnsweredSurvey => surveyResponses != null;
+public string Answer(int index) => surveyResponses?.GetValueOrDefault(index) ?? "No answer";
+```
+
+Because `surveyResponses` is a non-nullable reference type no checks are necessary before de-referencing it. The `Answer` method returns a non-nullable string, so choose the overload of `GetValueOrDefault` that takes a second argument for the default value.
+
+Next, add these three expression bodied members to the `SurveyRun` class:
+
+```csharp
+public IEnumerable<SurveyResponse> AllParticipants => (respondents ?? Enumerable.Empty<SurveyResponse>());
+public ICollection<SurveyQuestion> Questions => surveyQuestions;
+public SurveyQuestion GetQuestion(int index) => surveyQuestions[index];
+```
+
+The `AllParticipants` member must take into account that the `respondents` variable might be null, but the return value can't be null. If you change that expression by removing the `??` and the empty sequence that follows, the compiler warns you that the method might return `null` and its return signature returns a non-nullable type.
+
+Finally, add the following loop at the bottom of the `Main` method:
+
+```csharp
+foreach (var participant in surveyRun.AllParticipants)
+{
+    Console.WriteLine($"Participant: {participant.Id}:");
+    if (participant.AnsweredSurvey)
+    {
+        for (int i = 0; i < surveyRun.Questions.Count; i++)
+        {
+            string answer = participant.Answer(i);
+            Console.WriteLine($"\t{surveyRun.GetQuestion(i)} : {answer}");
+        }
+    }
+    else
+        Console.WriteLine("\tNo responses");
+}
+```
+
+You don't need any `null` checks in this code because you've designed the underlying interfaces so that they all return non-nullable reference types.
+
+## Get the code
+
+You can get the code for the finished tutorial from our [samples](https://github.com/dotnet/samples) repository int the [csharp/IntroToNullables](https://github.com/dotnet/samples/tree/master/csharp/IntroToNullables) folder.
+
+Experiment by changing the type declarations between nullable and non-nullable reference types. See how that generates different warnings to ensure you don't accidentally de-reference a `null`.
+
+## Next steps
+
+Learn more by reading an overview of nullable reference types...
+> [!div class="nextstepaction"]
+> [Next steps button](../programming-guide/nullable-references.md)

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -17,13 +17,13 @@ In this tutorial, you'll learn how to:
 
 ## Prerequisites
 
-You’ll need to setup your machine to run .NET Core, including the C# 8 beta compiler.  The C# 8 beta compiler is available with Visual Studio 2019 preview 1, or .NET Core 3.0 preview 1.
+You’ll need to set up your machine to run .NET Core, including the C# 8 beta compiler.  The C# 8 beta compiler is available with Visual Studio 2019 preview 1, or .NET Core 3.0 preview 1.
 
-This tutorial assumes you are familiar with C# and .NET, including either Visual Studio or the .NET Core CLI.
+This tutorial assumes you're familiar with C# and .NET, including either Visual Studio or the .NET Core CLI.
 
 ## Incorporate nullable reference types into your designs
 
-In this tutorial, you'll build a library that models running a survey. The code uses both nullable reference types and non-nullable reference types to represent the real world concepts. For example, the survey questions would never be null. However, a respondent might prefer not to answer an optional question. The responses might be null in this example.
+In this tutorial, you'll build a library that models running a survey. The code uses both nullable reference types and non-nullable reference types to represent the real world concepts. The survey questions would never be null. A respondent might prefer not to answer an optional question. The responses might be null in this example.
 
 The code you'll write for this sample expresses that intent, and the compiler enforces that intent.
 
@@ -56,25 +56,25 @@ This survey application requires creating a number of classes:
 - A class that models a list of people contacted for the survey.
 - A class that models the answers from a person that took the survey.
 
-These types will make use of both nullable and non-nullable reference types to express which members are required, and which members are optional. Nullable reference types communicates that design intent clearly:
+These types will make use of both nullable and non-nullable reference types to express which members are required, and which members are optional. Nullable reference types communicate that design intent clearly:
 
 - The questions that are part of the survey can never be null: It makes no sense to ask a blank question.
-- The respondents can never be null. You'll want to track people you contacted, even those that declined to participate.
+- The respondents can never be null. You'll want to track people you contacted, even respondents that declined to participate.
 - Any response to a question may be null. Respondents can decline to answer some, or all questions.
 
-If you've programmed in C#, you may be so accustomed to reference types allowing null values that you may have missed other opportunities to declare non-nullable instances:
+If you've programmed in C#, you may be so accustomed to reference types that allow null values that you may have missed other opportunities to declare non-nullable instances:
 
 - The collection of questions should be non-nullable.
 - The collection of respondents should be non-nullable.
 
-As you write the code, you'll see that selecting a non-nullable reference type as the default for references avoids common mistakes that could lead to null reference exceptions. This tutorial points out where you may have made a default decision in your C# coding.
+As you write the code, you'll see that a non-nullable reference type as the default for references avoids common mistakes that could lead to null reference exceptions. This tutorial points out where you may have made a default decision in your C# coding.
 
 The app you'll build will do the following steps:
 
 1. Create a survey and add questions to it.
 1. Create a pseudo-random set of respondents for the survey
 1. Contact respondents until the completed survey size reaches the goal number.
-1. Write out imprtant statistics on the survey responses.
+1. Write out important statistics on the survey responses.
 
 ## Build the survey with nullable and non-nullable types
 
@@ -111,7 +111,7 @@ namespace NullableIntroduction
 }
 ```
 
-Because you haven't initialized `QuestionText`, the compiler issues a warning that a non-nullable property has not been initialized. Your design requires the question text to be non-null, so you add a constructor to initialize it and the `QuestionType` value as well. The finished class definition looks like the following code:
+Because you haven't initialized `QuestionText`, the compiler issues a warning that a non-nullable property hasn't been initialized. Your design requires the question text to be non-null, so you add a constructor to initialize it and the `QuestionType` value as well. The finished class definition looks like the following code:
 
 ```csharp
 #nullable enable
@@ -135,7 +135,7 @@ namespace NullableIntroduction
 }
 ```
 
-Adding the constructor removes the warning. The constructor argument is also a non-nullable reference type, so the compiler does not issue any warnings.
+Adding the constructor removes the warning. The constructor argument is also a non-nullable reference type, so the compiler doesn't issue any warnings.
 
 Next, create a `public` class named `SurveyRun`. Include the `nullable enable` pragma following the `using` statements. This class contains a list of `SurveyQuestion` objects and methods to add questions to the survey, as shown in the following code:
 
@@ -175,7 +175,7 @@ Without the `#nullable enable` pragma at the top of the file, the compiler doesn
 Next, write the code that generates answers to the survey. This involves several small tasks:
 
 1. Build a method that generates respondent objects. These represent people asked to fill out the survey.
-1. Build logic to simulate asking the questions to a respondent, collecting answers or noting that a respondent did not answer.
+1. Build logic to simulate asking the questions to a respondent, collecting answers or noting that a respondent didn't answer.
 1. Repeat until enough respondents have answered the survey.
 
 You'll need a class to represent a survey response, so add that now. Enable nullable support. Add an Id field and a constructor that initializes the ID field, as shown in the following code:
@@ -200,7 +200,7 @@ private static Random idGenerator = new Random();
 public static SurveyResponse GetRandomId() => new SurveyResponse(idGenerator.Next());
 ```
 
-The main responsibility of this this class is to generate the responses for a participant to the questions in the survey. This responsibility has a few steps:
+The main responsibility of this class is to generate the responses for a participant to the questions in the survey. This responsibility has a few steps:
 
 1. Ask for participation in the survey. If the person doesn't consent, return a missing (or null) response.
 1. Ask each question and record the answer. Each answer may also be missing (or null).
@@ -277,7 +277,7 @@ public void PerformSurvey(int numberOfRespondents)
 }
 ```
 
-Here again, your choice of a nullable `List<SurveyResponse>?` indicates that the response may be null. That indicates that the survey has not been given to any respondents yet. Notice that respondents are added until enough have consented.
+Here again, your choice of a nullable `List<SurveyResponse>?` indicates the response may be null. That indicates the survey hasn't been given to any respondents yet. Notice that respondents are added until enough have consented.
 
 The last step to run the survey is to add a call to perform the survey at the end of the `Main` method:
 
@@ -304,7 +304,7 @@ public ICollection<SurveyQuestion> Questions => surveyQuestions;
 public SurveyQuestion GetQuestion(int index) => surveyQuestions[index];
 ```
 
-The `AllParticipants` member must take into account that the `respondents` variable might be null, but the return value can't be null. If you change that expression by removing the `??` and the empty sequence that follows, the compiler warns you that the method might return `null` and its return signature returns a non-nullable type.
+The `AllParticipants` member must take into account that the `respondents` variable might be null, but the return value can't be null. If you change that expression by removing the `??` and the empty sequence that follows, the compiler warns you the method might return `null` and its return signature returns a non-nullable type.
 
 Finally, add the following loop at the bottom of the `Main` method:
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -245,6 +245,7 @@
 ##### [String interpolation](csharp/tutorials/intro-to-csharp/interpolated-strings-local.md)
 ##### [List collections](csharp/tutorials/intro-to-csharp/arrays-and-collections.md)
 ##### [Introduction to classes](csharp/tutorials/intro-to-csharp/introduction-to-classes.md)
+### [Work with nullable reference types](csharo/tutorials/nullable-reference-types.md)
 ### [Console Application](csharp/tutorials/console-teleprompter.md)
 ### [REST Client](csharp/tutorials/console-webapiclient.md)
 ### [Inheritance in C# and .NET](csharp/tutorials/inheritance.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -270,6 +270,7 @@
 ### [Namespaces](csharp/programming-guide/namespaces/index.md)
 ### [Basic Types](csharp/basic-types.md)
 ### [Classes](csharp/programming-guide/classes-and-structs/classes.md)
+### [Nullable reference types](csharp/nullable-references.md)
 ### [Structs](csharp/structs.md)
 ### [Tuples](csharp/tuples.md)
 ### [Deconstructing tuples and other types](csharp/deconstruct.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -245,7 +245,7 @@
 ##### [String interpolation](csharp/tutorials/intro-to-csharp/interpolated-strings-local.md)
 ##### [List collections](csharp/tutorials/intro-to-csharp/arrays-and-collections.md)
 ##### [Introduction to classes](csharp/tutorials/intro-to-csharp/introduction-to-classes.md)
-### [Work with nullable reference types](csharo/tutorials/nullable-reference-types.md)
+### [Work with nullable reference types](csharp/tutorials/nullable-reference-types.md)
 ### [Console Application](csharp/tutorials/console-teleprompter.md)
 ### [REST Client](csharp/tutorials/console-webapiclient.md)
 ### [Inheritance in C# and .NET](csharp/tutorials/inheritance.md)


### PR DESCRIPTION
Fixes #8208 
Fixes #8204 

Relies on dotnet/samples#491

Add the overview and first tutorial for nullable reference types.

[Overview preview link](https://review.docs.microsoft.com/en-us/dotnet/csharp/nullable-references?branch=pr-en-us-9345)
[Tutorial link](https://review.docs.microsoft.com/en-us/dotnet/csharp/tutorials/nullable-reference-types?branch=pr-en-us-9345)