### PR TITLE
review CLI commands for 2.2 + style changes - 1/2

### DIFF
--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet add package command - .NET Core CLI
 description: The 'dotnet add package' command provides a convenient option to add a NuGet package reference to a project.
-author: mairaw
-ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/03/2018
 ---
 # dotnet add package
 
@@ -15,82 +13,91 @@ ms.date: 05/25/2018
 
 ## Synopsis
 
-`dotnet add [<PROJECT>] package <PACKAGE_NAME> [-h|--help] [-f|--framework] [-n|--no-restore] [--package-directory] [-s|--source] [-v|--version] [--interactive]`
+`dotnet add [<PROJECT>] package <PACKAGE_NAME> [-h|--help] [-f|--framework] [--interactive] [-n|--no-restore] [--package-directory] [-s|--source] [-v|--version]`
 
 ## Description
 
 The `dotnet add package` command provides a convenient option to add a package reference to a project file. After running the command, there's a compatibility check to ensure the package is compatible with the frameworks in the project. If the check passes, a `<PackageReference>` element is added to the project file and [dotnet restore](dotnet-restore.md) is run.
 
-[!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]
+[!INCLUDE[DotNet Restore Note](../../../includes/dotnet-restore-note.md)]
 
 For example, adding `Newtonsoft.Json` to *ToDo.csproj* produces output similar to the following example:
 
 ```console
   Writing C:\Users\mairaw\AppData\Local\Temp\tmp95A8.tmp
 info : Adding PackageReference for package 'Newtonsoft.Json' into project 'C:\projects\ToDo\ToDo.csproj'.
-log  : Restoring packages for C:\projects\ToDo\ToDo.csproj...
+log  : Restoring packages for C:\Temp\projects\consoleproj\consoleproj.csproj...
 info :   GET https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json
-info :   OK https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json 235ms
+info :   OK https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json 79ms
+info :   GET https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.1/newtonsoft.json.12.0.1.nupkg
+info :   OK https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.1/newtonsoft.json.12.0.1.nupkg 232ms
+log  : Installing Newtonsoft.Json 12.0.1.
 info : Package 'Newtonsoft.Json' is compatible with all the specified frameworks in project 'C:\projects\ToDo\ToDo.csproj'.
-info : PackageReference for package 'Newtonsoft.Json' version '10.0.3' added to file 'C:\projects\ToDo\ToDo.csproj'.
+info : PackageReference for package 'Newtonsoft.Json' version '12.0.1' added to file 'C:\projects\ToDo\ToDo.csproj'.
 ```
 
 The *ToDo.csproj* file now contains a [`<PackageReference>`](/nuget/consume-packages/package-references-in-project-files) element for the referenced package.
 
 ```xml
-<PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 ```
 
 ## Arguments
 
-`PROJECT`
+* **`PROJECT`**
 
-Specifies the project file. If not specified, the command searches the current directory for one.
+  Specifies the project file. If not specified, the command searches the current directory for one.
 
-`PACKAGE_NAME`
+* **`PACKAGE_NAME`**
 
-The package reference to add.
+  The package reference to add.
 
 ## Options
 
-`-h|--help`
+* **`-f|--framework <FRAMEWORK>`**
 
-Prints out a short help for the command.
+  Adds a package reference only when targeting a specific [framework](../../standard/frameworks.md).
 
-`-f|--framework <FRAMEWORK>`
+* **`-h|--help`**
 
-Adds a package reference only when targeting a specific [framework](../../standard/frameworks.md).
+  Prints out a short help for the command.
 
-`-n|--no-restore`
+* **`--interactive`**
 
-Adds a package reference without performing a restore preview and compatibility check.
+  Allows the command to stop and wait for user input or action (for example to complete authentication). Available since .NET Core 2.1 SDK, version 2.1.400 or later.
 
-`--package-directory <PACKAGE_DIRECTORY>`
+* **`-n|--no-restore`**
 
-Restores the package to the specified directory.
+  Adds a package reference without performing a restore preview and compatibility check.
 
-`-s|--source <SOURCE>`
+* **`--package-directory <PACKAGE_DIRECTORY>`**
 
-Uses a specific NuGet package source during the restore operation.
+  Restores the package to the specified directory.
 
-`-v|--version <VERSION>`
+* **`-s|--source <SOURCE>`**
 
-Version of the package.
+  Uses a specific NuGet package source during the restore operation.
 
-`--interactive`
+* **`-v|--version <VERSION>`**
 
-Allows the command to stop and wait for user input or action (for example to complete authentication). Since .NET Core 2.1.400.
+  Version of the package.
 
 ## Examples
 
-Add `Newtonsoft.Json` NuGet package to a project:
+* Add `Newtonsoft.Json` NuGet package to a project:
 
-`dotnet add package Newtonsoft.Json`
+  ```console
+  dotnet add package Newtonsoft.Json
+  ```
 
-Add a specific version of a package to a project:
+* Add a specific version of a package to a project:
 
-`dotnet add ToDo.csproj package Microsoft.Azure.DocumentDB.Core -v 1.0.0`
+  ```console
+  dotnet add ToDo.csproj package Microsoft.Azure.DocumentDB.Core -v 1.0.0
+  ```
 
-Add a package using a specific NuGet source:
+* Add a package using a specific NuGet source:
 
-`dotnet add package Microsoft.AspNetCore.StaticFiles -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json`
+  ```console
+  dotnet add package Microsoft.AspNetCore.StaticFiles -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
+  ```

--- a/docs/core/tools/dotnet-add-package.md
+++ b/docs/core/tools/dotnet-add-package.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet add package command - .NET Core CLI
 description: The 'dotnet add package' command provides a convenient option to add a NuGet package reference to a project.
-ms.date: 12/03/2018
+ms.date: 12/04/2018
 ---
 # dotnet add package
 

--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -3,7 +3,7 @@ title: dotnet-add reference command - .NET Core CLI
 description: The dotnet add reference command provides a convenient option to add project to project references.
 author: mairaw
 ms.author: mairaw
-ms.date: 12/03/2018
+ms.date: 12/04/2018
 ---
 # dotnet-add reference
 

--- a/docs/core/tools/dotnet-add-reference.md
+++ b/docs/core/tools/dotnet-add-reference.md
@@ -3,7 +3,7 @@ title: dotnet-add reference command - .NET Core CLI
 description: The dotnet add reference command provides a convenient option to add project to project references.
 author: mairaw
 ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/03/2018
 ---
 # dotnet-add reference
 
@@ -31,34 +31,40 @@ The `dotnet add reference` command provides a convenient option to add project r
 
 ## Arguments
 
-`PROJECT`
+* **`PROJECT`**
 
-Specifies the project file. If not specified, the command searches the current directory for one.
+  Specifies the project file. If not specified, the command searches the current directory for one.
 
-`PROJECT_REFERENCES`
+* **`PROJECT_REFERENCES`**
 
-Project-to-project (P2P) references to add. Specify one or more projects. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux-based systems.
+  Project-to-project (P2P) references to add. Specify one or more projects. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are supported on Unix/Linux-based systems.
 
 ## Options
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`-f|--framework <FRAMEWORK>`
+* **`-f|--framework <FRAMEWORK>`**
 
-Adds project references only when targeting a specific [framework](../../standard/frameworks.md).
+  Adds project references only when targeting a specific [framework](../../standard/frameworks.md).
 
 ## Examples
 
-Add a project reference:
+* Add a project reference:
 
-`dotnet add app/app.csproj reference lib/lib.csproj`
+  ```console
+  dotnet add app/app.csproj reference lib/lib.csproj
+  ```
 
-Add multiple project references to the project in the current directory:
+* Add multiple project references to the project in the current directory:
 
-`dotnet add reference lib1/lib1.csproj lib2/lib2.csproj`
+  ```console
+  dotnet add reference lib1/lib1.csproj lib2/lib2.csproj
+  ```
 
-Add multiple project references using a globbing pattern on Linux/Unix:
+* Add multiple project references using a globbing pattern on Linux/Unix:
 
-`dotnet add app/app.csproj reference **/*.csproj`
+  ```console
+  dotnet add app/app.csproj reference **/*.csproj
+  ```

--- a/docs/core/tools/dotnet-build-server.md
+++ b/docs/core/tools/dotnet-build-server.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet build-server command - .NET Core CLI
 description: The dotnet build-server command interacts with servers started by a build.
-ms.date: 12/03/2018
+ms.date: 12/04/2018
 ---
 # dotnet build-server
 

--- a/docs/core/tools/dotnet-build-server.md
+++ b/docs/core/tools/dotnet-build-server.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet build-server command - .NET Core CLI
 description: The dotnet build-server command interacts with servers started by a build.
-author: mairaw
-ms.author: mairaw
-ms.date: 07/02/2018
+ms.date: 12/03/2018
 ---
 # dotnet build-server
 
@@ -23,24 +21,24 @@ dotnet build-server [-h|--help]
 
 ## Commands
 
-`shutdown`
+* **`shutdown`**
 
-Shuts down build servers that are started from dotnet. By default, all servers are shut down.
+  Shuts down build servers that are started from dotnet. By default, all servers are shut down.
 
 ## Options
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`--msbuild`
+* **`--msbuild`**
 
-Shuts down the MSBuild build server.
+  Shuts down the MSBuild build server.
 
-`--razor`
+* **`--razor`**
 
-Shuts down the Razor build server.
+  Shuts down the Razor build server.
 
-`--vbcscompiler`
+* **`--vbcscompiler`**
 
-Shuts down the VB/C# compiler build server.
+  Shuts down the VB/C# compiler build server.

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -1,8 +1,6 @@
 ---
 title: dotnet build command - .NET Core CLI
 description: The dotnet build command builds a project and all of its dependencies.
-author: mairaw
-ms.author: mairaw
 ms.date: 12/03/2018
 ---
 # dotnet build

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -3,7 +3,7 @@ title: dotnet build command - .NET Core CLI
 description: The dotnet build command builds a project and all of its dependencies.
 author: mairaw
 ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/03/2018
 ---
 # dotnet build
 
@@ -65,104 +65,112 @@ The project or solution file to build. If a project or solution file is not spec
 
 # [.NET Core 2.x](#tab/netcore2x)
 
-`-c|--configuration {Debug|Release}`
+* **`-c|--configuration {Debug|Release}`**
 
-Defines the build configuration. The default value is `Debug`.
+  Defines the build configuration. The default value is `Debug`.
 
-`-f|--framework <FRAMEWORK>`
+* **`-f|--framework <FRAMEWORK>`**
 
-Compiles for a specific [framework](../../standard/frameworks.md). The framework must be defined in the [project file](csproj.md).
+  Compiles for a specific [framework](../../standard/frameworks.md). The framework must be defined in the [project file](csproj.md).
 
-`--force`
+* **`--force`**
 
-Forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is the same as deleting the *project.assets.json* file.
+  Forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is the same as deleting the *project.assets.json* file.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`--no-dependencies`
+* **`--no-dependencies`**
 
-Ignores project-to-project (P2P) references and only builds the specified root project.
+  Ignores project-to-project (P2P) references and only builds the specified root project.
 
-`--no-incremental`
+* **`--no-incremental`**
 
-Marks the build as unsafe for incremental build. This flag turns off incremental compilation and forces a clean rebuild of the project's dependency graph.
+  Marks the build as unsafe for incremental build. This flag turns off incremental compilation and forces a clean rebuild of the project's dependency graph.
 
-`--no-restore`
+* **`--no-restore`**
 
-Doesn't execute an implicit restore during build.
+  Doesn't execute an implicit restore during build.
 
-`-o|--output <OUTPUT_DIRECTORY>`
+* **`-o|--output <OUTPUT_DIRECTORY>`**
 
-Directory in which to place the built binaries. You also need to define `--framework` when you specify this option.
+  Directory in which to place the built binaries. You also need to define `--framework` when you specify this option.
 
-`-r|--runtime <RUNTIME_IDENTIFIER>`
+* **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 
-Specifies the target runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
+  Specifies the target runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
 
-`-v|--verbosity <LEVEL>`
+* **`-v|--verbosity <LEVEL>`**
 
-Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
-`--version-suffix <VERSION_SUFFIX>`
+* **`--version-suffix <VERSION_SUFFIX>`**
 
-Defines the version suffix for an asterisk (`*`) in the version field of the project file. The format follows NuGet's version guidelines.
+  Defines the version suffix for an asterisk (`*`) in the version field of the project file. The format follows NuGet's version guidelines.
 
 # [.NET Core 1.x](#tab/netcore1x)
 
-`-c|--configuration {Debug|Release}`
+* **`-c|--configuration {Debug|Release}`**
 
-Defines the build configuration. The default value is `Debug`.
+  Defines the build configuration. The default value is `Debug`.
 
-`-f|--framework <FRAMEWORK>`
+* **`-f|--framework <FRAMEWORK>`**
 
-Compiles for a specific [framework](../../standard/frameworks.md). The framework must be defined in the [project file](csproj.md).
+  Compiles for a specific [framework](../../standard/frameworks.md). The framework must be defined in the [project file](csproj.md).
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`--no-dependencies`
+* **`--no-dependencies`**
 
-Ignores project-to-project (P2P) references and only builds the specified root project.
+  Ignores project-to-project (P2P) references and only builds the specified root project.
 
-`--no-incremental`
+* **`--no-incremental`**
 
-Marks the build as unsafe for incremental build. This flag turns off incremental compilation and forces a clean rebuild of the project's dependency graph.
+  Marks the build as unsafe for incremental build. This flag turns off incremental compilation and forces a clean rebuild of the project's dependency graph.
 
-`-o|--output <OUTPUT_DIRECTORY>`
+* **`-o|--output <OUTPUT_DIRECTORY>`**
 
-Directory in which to place the built binaries. You also need to define `--framework` when you specify this option.
+  Directory in which to place the built binaries. You also need to define `--framework` when you specify this option.
 
-`-r|--runtime <RUNTIME_IDENTIFIER>`
+* **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 
-Specifies the target runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
+  Specifies the target runtime. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
 
-`-v|--verbosity <LEVEL>`
+* **`-v|--verbosity <LEVEL>`**
 
-Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
-`--version-suffix <VERSION_SUFFIX>`
+* **`--version-suffix <VERSION_SUFFIX>`**
 
-Defines the version suffix for an asterisk (`*`) in the version field of the project file. The format follows NuGet's version guidelines.
+  Defines the version suffix for an asterisk (`*`) in the version field of the project file. The format follows NuGet's version guidelines.
 
 ---
 
 ## Examples
 
-Build a project and its dependencies:
+* Build a project and its dependencies:
 
-`dotnet build`
+  ```console
+  dotnet build
+  ```
 
-Build a project and its dependencies using Release configuration:
+* Build a project and its dependencies using Release configuration:
 
-`dotnet build --configuration Release`
+  ```console
+  dotnet build --configuration Release
+  ```
 
-Build a project and its dependencies for a specific runtime (in this example, Ubuntu 16.04):
+* Build a project and its dependencies for a specific runtime (in this example, Ubuntu 16.04):
 
-`dotnet build --runtime ubuntu.16.04-x64`
+  ```console
+  dotnet build --runtime ubuntu.16.04-x64
+  ```
 
-Build the project and use the specified NuGet package source during the restore operation (.NET Core SDK 2.0 and later versions):
+* Build the project and use the specified NuGet package source during the restore operation (.NET Core 2.0 SDK and later versions):
 
-`dotnet build --source c:\packages\mypackages`
+  ```
+  dotnet build --source c:\packages\mypackages
+  ```

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet build command - .NET Core CLI
 description: The dotnet build command builds a project and all of its dependencies.
-ms.date: 12/03/2018
+ms.date: 12/04/2018
 ---
 # dotnet build
 
@@ -53,7 +53,9 @@ In order to produce a library, omit the `<OutputType>` property. The main differ
 
 `dotnet build` uses MSBuild to build the project, so it supports both parallel and incremental builds. For more information, see [Incremental Builds](/visualstudio/msbuild/incremental-builds).
 
-In addition to its options, the `dotnet build` command accepts MSBuild options, such as `-p` for setting properties or `-l` to define a logger. For more information about these options, see the [MSBuild Command-Line Reference](/visualstudio/msbuild/msbuild-command-line-reference).
+In addition to its options, the `dotnet build` command accepts MSBuild options, such as `-p` for setting properties or `-l` to define a logger. For more information about these options, see the [MSBuild Command-Line Reference](/visualstudio/msbuild/msbuild-command-line-reference). Or you can also use the [dotnet msbuild](dotnet-msbuild.md) command.
+
+Running `dotnet build` is equivalent to `dotnet msbuild -restore -target:Build`.
 
 ## Arguments
 

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -97,7 +97,7 @@ The project or solution file to build. If a project or solution file is not spec
 
 * **`-o|--output <OUTPUT_DIRECTORY>`**
 
-  Directory in which to place the built binaries. You also need to define `--framework` when you specify this option.
+  Directory in which to place the built binaries. You also need to define `--framework` when you specify this option. If not specified, the default path is `./bin/<configuration>/<framework>/`.
 
 * **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet clean command - .NET Core CLI
 description: The dotnet clean command cleans the current directory.
-author: mairaw
-ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/03/2018
 ---
 # dotnet clean
 
@@ -15,17 +13,10 @@ ms.date: 05/25/2018
 
 ## Synopsis
 
-# [.NET Core 2.x](#tab/netcore2x)
 ```
 dotnet clean [<PROJECT>] [-c|--configuration] [-f|--framework] [-o|--output] [-r|--runtime] [-v|--verbosity]
 dotnet clean [-h|--help]
 ```
-# [.NET Core 1.x](#tab/netcore1x)
-```
-dotnet clean [<PROJECT>] [-c|--configuration] [-f|--framework] [-o|--output] [-v|--verbosity]
-dotnet clean [-h|--help]
-```
----
 
 ## Description
 
@@ -39,62 +30,40 @@ The MSBuild project to clean. If a project file is not specified, MSBuild search
 
 ## Options
 
-# [.NET Core 2.x](#tab/netcore2x)
+* **`-c|--configuration {Debug|Release}`**
 
-`-c|--configuration {Debug|Release}`
+  Defines the build configuration. The default value is `Debug`. This option is only required when cleaning if you specified it during build time.
 
-Defines the build configuration. The default value is `Debug`. This option is only required when cleaning if you specified it during build time.
+* **`-f|--framework <FRAMEWORK>`**
 
-`-f|--framework <FRAMEWORK>`
+  The [framework](../../standard/frameworks.md) that was specified at build time. The framework must be defined in the [project file](csproj.md). If you specified the framework at build time, you must specify the framework when cleaning.
 
-The [framework](../../standard/frameworks.md) that was specified at build time. The framework must be defined in the [project file](csproj.md). If you specified the framework at build time, you must specify the framework when cleaning.
+* **`-h|--help`**
 
-`-h|--help`
+  Prints out a short help for the command.
 
-Prints out a short help for the command.
+* **`-o|--output <OUTPUT_DIRECTORY>`**
 
-`-o|--output <OUTPUT_DIRECTORY>`
+  Directory in which the build outputs are placed. Specify the `-f|--framework <FRAMEWORK>` switch with the output directory switch if you specified the framework when the project was built.
 
-Directory in which the build outputs are placed. Specify the `-f|--framework <FRAMEWORK>` switch with the output directory switch if you specified the framework when the project was built.
+* **`-r|--runtime <RUNTIME_IDENTIFIER>`**
 
-`-r|--runtime <RUNTIME_IDENTIFIER>`
+  Cleans the output folder of the specified runtime. This is used when a [self-contained deployment](../deploying/index.md#self-contained-deployments-scd) was created. Option available since .NET Core 2.0 SDK.
 
-Cleans the output folder of the specified runtime. This is used when a [self-contained deployment](../deploying/index.md#self-contained-deployments-scd) was created.
+* **`-v|--verbosity <LEVEL>`**
 
-`-v|--verbosity <LEVEL>`
-
-Sets the verbosity level of the command. Allowed levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
-# [.NET Core 1.x](#tab/netcore1x)
-
-`-c|--configuration {Debug|Release}`
-
-Defines the build configuration. The default value is `Debug`. This option is only required when cleaning if you specified it during build time.
-
-`-f|--framework <FRAMEWORK>`
-
-The [framework](../../standard/frameworks.md) that was specified at build time. The framework must be defined in the [project file](csproj.md). If you specified the framework at build time, you must specify the framework when cleaning.
-
-`-h|--help`
-
-Prints out a short help for the command.
-
-`-o|--output <OUTPUT_DIRECTORY>`
-
-Directory in which the build outputs are placed. Specify the `-f|--framework <FRAMEWORK>` switch with the output directory switch if you specified the framework when the project was built.
-
-`-v|--verbosity <LEVEL>`
-
-Sets the verbosity level of the command. Allowed levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
-
----
+  Sets the verbosity level of the command. Allowed levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
 
 ## Examples
 
-Clean a default build of the project:
+* Clean a default build of the project:
 
-`dotnet clean`
+  ```console
+  dotnet clean
+  ```
 
-Clean a project built using the Release configuration:
+* Clean a project built using the Release configuration:
 
-`dotnet clean --configuration Release`
+  ```console
+  dotnet clean --configuration Release
+  ```

--- a/docs/core/tools/dotnet-clean.md
+++ b/docs/core/tools/dotnet-clean.md
@@ -1,7 +1,7 @@
 ---
 title: dotnet clean command - .NET Core CLI
 description: The dotnet clean command cleans the current directory.
-ms.date: 12/03/2018
+ms.date: 12/04/2018
 ---
 # dotnet clean
 

--- a/docs/core/tools/dotnet-help.md
+++ b/docs/core/tools/dotnet-help.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet help command - .NET Core CLI
 description: The dotnet help command shows more detailed documentation online for the specified command.
-author: mairaw
-ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/04/2018
 ---
 # dotnet help reference
 
@@ -23,18 +21,20 @@ The `dotnet help` command opens up the reference page for more detailed informat
 
 ## Arguments
 
-`COMMAND_NAME`
+* **`COMMAND_NAME`**
 
-Name of the .NET Core CLI command. For a list of the valid CLI commands, see [CLI commands](index.md#cli-commands).
+  Name of the .NET Core CLI command. For a list of the valid CLI commands, see [CLI commands](index.md#cli-commands).
 
 ## Options
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
 ## Examples
 
-Opens the documentation page for the [dotnet new](dotnet-new.md) command:
+* Opens the documentation page for the [dotnet new](dotnet-new.md) command:
 
-`dotnet help new`
+  ```console
+  dotnet help new
+  ```

--- a/docs/core/tools/dotnet-list-reference.md
+++ b/docs/core/tools/dotnet-list-reference.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet list reference command - .NET Core CLI
 description: The dotnet list reference command provides a convenient option to list project to project references.
-author: mairaw
-ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/03/2018
 ---
 # dotnet list reference
 
@@ -19,26 +17,30 @@ ms.date: 05/25/2018
 
 ## Description
 
-The `dotnet list reference` command provides a convenient option to list project references for a given project.
+The `dotnet list reference` command provides a convenient option to list project references for a given project or solution.
 
 ## Arguments
 
-`PROJECT`
+* **`PROJECT`**
 
-Specifies the project file to use for listing references. If not specified, the command searches the current directory for a project file.
+  Specifies the project file to use for listing references. If not specified, the command searches the current directory for a project file.
 
 ## Options
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
 ## Examples
 
-List the project references for the specified project:
+* List the project references for the specified project:
 
-`dotnet list app/app.csproj reference`
+  ```console
+  dotnet list app/app.csproj reference
+  ```
 
-List the project references for the project in the current directory:
+* List the project references for the project in the current directory:
 
-`dotnet list reference`
+  ```console
+  dotnet list reference
+  ```

--- a/docs/core/tools/dotnet-msbuild.md
+++ b/docs/core/tools/dotnet-msbuild.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet msbuild command - .NET Core CLI
 description: The dotnet msbuild command provides access to the MSBuild command line.
-author: mairaw
-ms.author: mairaw
-ms.date: 05/25/2018
+ms.date: 12/03/2018
 ---
 # dotnet msbuild
 
@@ -21,22 +19,32 @@ ms.date: 05/25/2018
 
 The `dotnet msbuild` command allows access to a fully functional MSBuild.
 
-The command has the exact same capabilities as existing MSBuild command-line client. The options are all the same. For more information about the available options, see the [MSBuild Command-Line Reference](/visualstudio/msbuild/msbuild-command-line-reference).
+The command has the exact same capabilities as the existing MSBuild command-line client for SDK-style project only. The options are all the same. For more information about the available options, see the [MSBuild Command-Line Reference](/visualstudio/msbuild/msbuild-command-line-reference).
+
+The [dotnet build](dotnet-build.md) command is equivalent to `dotnet msbuild -restore -target:Build`. `dotnet build` is more commonly used for building projects, but `dotnet msbuild` gives you more control. For example, if you have a specific target you want to run (without running the build target), you probably want to use `dotnet msbuild`.
 
 ## Examples
 
-Build a project and its dependencies:
+* Build a project and its dependencies:
 
-`dotnet msbuild`
+  ```console
+  dotnet msbuild
+  ```
 
-Build a project and its dependencies using Release configuration:
+* Build a project and its dependencies using Release configuration:
 
-`dotnet msbuild -p:Configuration=Release`
+  ```console
+  dotnet msbuild -p:Configuration=Release
+  ```
 
-Run the publish target and publish for the `osx.10.11-x64` RID:
+* Run the publish target and publish for the `osx.10.11-x64` RID:
 
-`dotnet msbuild -t:Publish -p:RuntimeIdentifiers=osx.10.11-x64`
+  ```console
+  dotnet msbuild -t:Publish -p:RuntimeIdentifiers=osx.10.11-x64
+  ```
 
-See the whole project with all targets included by the SDK:
+* See the whole project with all targets included by the SDK:
 
-`dotnet msbuild -pp`
+  ```console
+  dotnet msbuild -pp
+  ```

--- a/docs/core/tools/dotnet-nuget-delete.md
+++ b/docs/core/tools/dotnet-nuget-delete.md
@@ -2,8 +2,7 @@
 title: dotnet nuget delete command - .NET Core CLI
 description: The dotnet-nuget-delete command deletes or unlists a package from the server.
 author: karann-msft
-ms.author: mairaw
-ms.date: 06/01/2018
+ms.date: 12/04/2018
 ---
 # dotnet nuget delete
 
@@ -15,16 +14,10 @@ ms.date: 06/01/2018
 
 ## Synopsis
 
-# [.NET Core 2.1](#tab/netcore21)
+# [.NET Core 2.x](#tab/netcore2x)
 ```
-dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [-k|--api-key] [--no-service-endpoint]
+dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [--interactive] [-k|--api-key] [--no-service-endpoint]
     [--non-interactive] [-s|--source]
-dotnet nuget delete [-h|--help]
-```
-# [.NET Core 2.0](#tab/netcore20)
-```
-dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [-k|--api-key] [--non-interactive]
-    [-s|--source]
 dotnet nuget delete [-h|--help]
 ```
 # [.NET Core 1.x](#tab/netcore1x)
@@ -41,93 +34,80 @@ The `dotnet nuget delete` command deletes or unlists a package from the server. 
 
 ## Arguments
 
-`PACKAGE_NAME`
+* **`PACKAGE_NAME`**
 
-Name/ID of the package to delete.
+  Name/ID of the package to delete.
 
-`PACKAGE_VERSION`
+* **`PACKAGE_VERSION`**
 
-Version of the package to delete.
+  Version of the package to delete.
 
 ## Options
 
 # [.NET Core 2.1](#tab/netcore21)
 
-`--force-english-output`
+* **`--force-english-output`**
 
- Forces the application to run using an invariant, English-based culture.
+  Forces the application to run using an invariant, English-based culture.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`-k|--api-key <API_KEY>`
+* **`--interactive`**
 
-The API key for the server.
+  Allows the command to block and requires manual action for operations like authentication. Option available since .NET Core 2.2 SDK.
 
-`--no-service-endpoint`
-Doesn't append "api/v2/package" to the source URL.
+* **`-k|--api-key <API_KEY>`**
 
-`--non-interactive`
+  The API key for the server.
 
-Doesn't prompt for user input or confirmations.
+* **`--no-service-endpoint`**
 
-`-s|--source <SOURCE>`
+  Doesn't append "api/v2/package" to the source URL. Option available since .NET Core 2.1 SDK.
 
-Specifies the server URL. Supported URLs for nuget.org include `https://www.nuget.org`, `https://www.nuget.org/api/v3`, and `https://www.nuget.org/api/v2/package`. For private feeds, replace the host name (for example, `%hostname%/api/v3`).
+* **`--non-interactive`**
 
-# [.NET Core 2.0](#tab/netcore20)
+  Doesn't prompt for user input or confirmations.
 
-`--force-english-output`
+* **`-s|--source <SOURCE>`**
 
- Forces the application to run using an invariant, English-based culture.
-
-`-h|--help`
-
-Prints out a short help for the command.
-
-`-k|--api-key <API_KEY>`
-
-The API key for the server.
-
-`--non-interactive`
-
-Doesn't prompt for user input or confirmations.
-
-`-s|--source <SOURCE>`
-
-Specifies the server URL. Supported URLs for nuget.org include `https://www.nuget.org`, `https://www.nuget.org/api/v3`, and `https://www.nuget.org/api/v2/package`. For private feeds, replace the host name (for example, `%hostname%/api/v3`).
+  Specifies the server URL. Supported URLs for nuget.org include `https://www.nuget.org`, `https://www.nuget.org/api/v3`, and `https://www.nuget.org/api/v2/package`. For private feeds, replace the host name (for example, `%hostname%/api/v3`).
 
 # [.NET Core 1.x](#tab/netcore1x)
 
-`--force-english-output`
+* **`--force-english-output`**
 
- Forces the application to run using an invariant, English-based culture.
+  Forces the application to run using an invariant, English-based culture.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`-k|--api-key <API_KEY>`
+* **`-k|--api-key <API_KEY>`**
 
-The API key for the server.
+  The API key for the server.
 
-`--non-interactive`
+* **`--non-interactive`**
 
-Doesn't prompt for user input or confirmations.
+  Doesn't prompt for user input or confirmations.
 
-`-s|--source <SOURCE>`
+* **`-s|--source <SOURCE>`**
 
-Specifies the server URL. Supported URLs for nuget.org include `https://www.nuget.org`, `https://www.nuget.org/api/v3`, and `https://www.nuget.org/api/v2/package`. For private feeds, replace the host name (for example, `%hostname%/api/v3`).
+  Specifies the server URL. Supported URLs for nuget.org include `https://www.nuget.org`, `https://www.nuget.org/api/v3`, and `https://www.nuget.org/api/v2/package`. For private feeds, replace the host name (for example, `%hostname%/api/v3`).
 
 ---
 
 ## Examples
 
-Deletes version 1.0 of package `Microsoft.AspNetCore.Mvc`:
+* Deletes version 1.0 of package `Microsoft.AspNetCore.Mvc`:
 
-`dotnet nuget delete Microsoft.AspNetCore.Mvc 1.0`
+  ```console
+  dotnet nuget delete Microsoft.AspNetCore.Mvc 1.0
+  ```
 
-Deletes version 1.0 of package `Microsoft.AspNetCore.Mvc`, not prompting user for credentials or other input:
+* Deletes version 1.0 of package `Microsoft.AspNetCore.Mvc`, not prompting user for credentials or other input:
 
-`dotnet nuget delete Microsoft.AspNetCore.Mvc 1.0 --non-interactive`
+  ```console
+  dotnet nuget delete Microsoft.AspNetCore.Mvc 1.0 --non-interactive
+  ```

--- a/docs/core/tools/dotnet-nuget-locals.md
+++ b/docs/core/tools/dotnet-nuget-locals.md
@@ -2,8 +2,7 @@
 title: dotnet nuget locals command - .NET Core CLI
 description: The dotnet nuget locals command clears or lists local NuGet resources such as http-request cache, temporary cache, or machine-wide global packages folder.
 author: karann-msft
-ms.author: mairaw
-ms.date: 05/29/2018
+ms.date: 12/04/2018
 ---
 # dotnet nuget locals
 
@@ -26,54 +25,64 @@ The `dotnet nuget locals` command clears or lists local NuGet resources in the h
 
 ## Arguments
 
-`CACHE_LOCATION`
+* **`CACHE_LOCATION`**
 
-The cache location to list or clear. It accepts one of the following values:
+  The cache location to list or clear. It accepts one of the following values:
 
-* `all` - Indicates that the specified operation is applied to all cache types: http-request cache, global packages cache, and the temporary cache.
-* `http-cache` - Indicates that the specified operation is applied only to the http-request cache. The other cache locations aren't affected.
-* `global-packages` - Indicates that the specified operation is applied only to the global packages cache. The other cache locations aren't affected.
-* `temp` - Indicates that the specified operation is applied only to the temporary cache. The other cache locations aren't affected.
+  * `all` - Indicates that the specified operation is applied to all cache types: http-request cache, global packages cache, and the temporary cache.
+  * `http-cache` - Indicates that the specified operation is applied only to the http-request cache. The other cache locations aren't affected.
+  * `global-packages` - Indicates that the specified operation is applied only to the global packages cache. The other cache locations aren't affected.
+  * `temp` - Indicates that the specified operation is applied only to the temporary cache. The other cache locations aren't affected.
 
 ## Options
 
-`--force-english-output`
+* **`--force-english-output`**
 
-Forces the application to run using an invariant, English-based culture.
+  Forces the application to run using an invariant, English-based culture.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`-c|--clear`
+* **`-c|--clear`**
 
-The clear option executes a clear operation on the specified cache type. The contents of the cache directories are deleted recursively. The executing user/group must have permission to the files in the cache directories. If not, an error is displayed indicating the files/folders that weren't cleared.
+  The clear option executes a clear operation on the specified cache type. The contents of the cache directories are deleted recursively. The executing user/group must have permission to the files in the cache directories. If not, an error is displayed indicating the files/folders that weren't cleared.
 
-`-l|--list`
+* **`-l|--list`**
 
-The list option is used to display the location of the specified cache type.
+  The list option is used to display the location of the specified cache type.
 
 ## Examples
 
-Displays the paths of all the local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
+* Displays the paths of all the local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
 
-`dotnet nuget locals –l all`
+  ```console
+  dotnet nuget locals –l all
+  ```
 
-Displays the path for the local http-cache directory:
+* Displays the path for the local http-cache directory:
 
-`dotnet nuget locals --list http-cache`
+  ```console
+  dotnet nuget locals --list http-cache
+  ```
 
-Clears all files from all local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
+* Clears all files from all local cache directories (http-cache directory, global-packages cache directory, and temporary cache directory):
 
-`dotnet nuget locals --clear all`
+  ```console
+  dotnet nuget locals --clear all
+  ```
 
-Clears all files in local global-packages cache directory:
+* Clears all files in local global-packages cache directory:
 
-`dotnet nuget locals -c global-packages`
+  ```console
+  dotnet nuget locals -c global-packages
+  ```
 
-Clears all files in local temporary cache directory:
+* Clears all files in local temporary cache directory:
 
-`dotnet nuget locals -c temp`
+  ```console
+  dotnet nuget locals -c temp
+  ```
 
 ## Troubleshooting
 

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -2,8 +2,7 @@
 title: dotnet nuget push command - .NET Core CLI
 description: The dotnet nuget push command pushes a package to the server and publishes it.
 author: karann-msft
-ms.author: mairaw
-ms.date: 09/04/2018
+ms.date: 12/04/2018
 ---
 # dotnet nuget push
 
@@ -15,16 +14,10 @@ ms.date: 09/04/2018
 
 ## Synopsis
 
-# [.NET Core 2.1](#tab/netcore21)
+# [.NET Core 2.x](#tab/netcore2x)
 ```
-dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [-k|--api-key] [-n|--no-symbols]
+dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [--interactive] [-k|--api-key] [-n|--no-symbols]
     [--no-service-endpoint] [-s|--source] [-sk|--symbol-api-key] [-ss|--symbol-source] [-t|--timeout]
-dotnet nuget push [-h|--help]
-```
-# [.NET Core 2.0](#tab/netcore20)
-```
-dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [-k|--api-key] [-n|--no-symbols]
-    [-s|--source] [-sk|--symbol-api-key] [-ss|--symbol-source] [-t|--timeout]
 dotnet nuget push [-h|--help]
 ```
 # [.NET Core 1.x](#tab/netcore1x)
@@ -41,154 +34,132 @@ The `dotnet nuget push` command pushes a package to the server and publishes it.
 
 ## Arguments
 
-`ROOT`
+* **`ROOT`**
 
-Specifies the file path to the package to be pushed.
+  Specifies the file path to the package to be pushed.
 
 ## Options
 
-# [.NET Core 2.1](#tab/netcore21)
+# [.NET Core 2.x](#tab/netcore2x)
 
-`-d|--disable-buffering`
+* **`-d|--disable-buffering`**
 
-Disables buffering when pushing to an HTTP(S) server to reduce memory usage.
+  Disables buffering when pushing to an HTTP(S) server to reduce memory usage.
 
-`--force-english-output`
+* **`--force-english-output`**
 
-Forces the application to run using an invariant, English-based culture.
+  Forces the application to run using an invariant, English-based culture.
 
-`-h|--help`
-
-Prints out a short help for the command.
-
-`-k|--api-key <API_KEY>`
-
-The API key for the server.
-
-`-n|--no-symbols`
-
-Doesn't push symbols (even if present).
-
-`--no-service-endpoint`
-
-Doesn't append "api/v2/package" to the source URL.
-
-`-s|--source <SOURCE>`
-
-Specifies the server URL. This option is required unless `DefaultPushSource` config value is set in the NuGet config file.
-
-`-sk|--symbol-api-key <API_KEY>`
-
-The API key for the symbol server.
-
-`-ss|--symbol-source <SOURCE>`
-
-Specifies the symbol server URL.
-
-`-t|--timeout <TIMEOUT>`
-
-Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
-
-# [.NET Core 2.0](#tab/netcore20)
-
-`-d|--disable-buffering`
-
-Disables buffering when pushing to an HTTP(S) server to reduce memory usage.
-
-`--force-english-output`
-
-Forces the application to run using an invariant, English-based culture.
-
-`-h|--help`
+* **`-h|--help`**
 
 Prints out a short help for the command.
 
-`-k|--api-key <API_KEY>`
+* **`--interactive`**
 
-The API key for the server.
+  Allows the command to block and requires manual action for operations like authentication. Option available since .NET Core 2.2 SDK.
 
-`-n|--no-symbols`
+* **`-k|--api-key <API_KEY>`**
 
-Doesn't push symbols (even if present).
+  The API key for the server.
 
-`-s|--source <SOURCE>`
+* **`-n|--no-symbols`**
 
-Specifies the server URL. This option is required unless `DefaultPushSource` config value is set in the NuGet config file.
+  Doesn't push symbols (even if present).
 
-`-sk|--symbol-api-key <API_KEY>`
+* **`--no-service-endpoint`**
 
-The API key for the symbol server.
+  Doesn't append "api/v2/package" to the source URL. Option available since .NET Core 2.1 SDK.
 
-`-ss|--symbol-source <SOURCE>`
+* **`-s|--source <SOURCE>`**
 
-Specifies the symbol server URL.
+  Specifies the server URL. This option is required unless `DefaultPushSource` config value is set in the NuGet config file.
 
-`-t|--timeout <TIMEOUT>`
+* **`-sk|--symbol-api-key <API_KEY>`**
 
-Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
+  The API key for the symbol server.
+
+* **`-ss|--symbol-source <SOURCE>`**
+
+  Specifies the symbol server URL.
+
+* **`-t|--timeout <TIMEOUT>`**
+
+  Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
 
 # [.NET Core 1.x](#tab/netcore1x)
 
-`-d|--disable-buffering`
+* **`-d|--disable-buffering`**
 
-Disables buffering when pushing to an HTTP(S) server to reduce memory usage.
+  Disables buffering when pushing to an HTTP(S) server to reduce memory usage.
 
-`--force-english-output`
+* **`--force-english-output`**
 
-Forces the application to run using an invariant, English-based culture.
+  Forces the application to run using an invariant, English-based culture.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`-k|--api-key <API_KEY>`
+* **`-k|--api-key <API_KEY>`**
 
-The API key for the server.
+  The API key for the server.
 
-`-n|--no-symbols`
+* **`-n|--no-symbols`**
 
-Doesn't push symbols (even if present).
+  Doesn't push symbols (even if present).
 
-`-s|--source <SOURCE>`
+* **`-s|--source <SOURCE>`**
 
-Specifies the server URL. This option is required unless `DefaultPushSource` config value is set in the NuGet config file.
+  Specifies the server URL. This option is required unless `DefaultPushSource` config value is set in the NuGet config file.
 
-`-sk|--symbol-api-key <API_KEY>`
+* **`-sk|--symbol-api-key <API_KEY>`**
 
-The API key for the symbol server.
+  The API key for the symbol server.
 
-`-ss|--symbol-source <SOURCE>`
+* **`-ss|--symbol-source <SOURCE>`**
 
-Specifies the symbol server URL.
+  Specifies the symbol server URL.
 
-`-t|--timeout <TIMEOUT>`
+* **`-t|--timeout <TIMEOUT>`**
 
-Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
+  Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes). Specifying 0 (zero seconds) applies the default value.
 
 ---
 
 ## Examples
 
-Pushes *foo.nupkg* to the default push source, specifying an API key:
+* Pushes *foo.nupkg* to the default push source, specifying an API key:
 
-`dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a`
+  ```console
+  dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a
+  ```
 
-Push *foo.nupkg* to the custom push source `https://customsource`, specifying an API key:
+* Push *foo.nupkg* to the custom push source `https://customsource`, specifying an API key:
 
-`dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -s https://customsource/`
+  ```console
+  dotnet nuget push foo.nupkg -k 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a -s https://customsource/
+  ```
 
-Pushes *foo.nupkg* to the default push source:
+* Pushes *foo.nupkg* to the default push source:
 
-`dotnet nuget push foo.nupkg`
+  ```console
+  dotnet nuget push foo.nupkg
+  ```
 
-Pushes *foo.symbols.nupkg* to the default symbols source:
+* Pushes *foo.symbols.nupkg* to the default symbols source:
 
-`dotnet nuget push foo.symbols.nupkg`
+  ```console
+  dotnet nuget push foo.symbols.nupkg
+  ```
 
-Pushes *foo.nupkg* to the default push source, specifying a 360-second timeout:
+* Pushes *foo.nupkg* to the default push source, specifying a 360-second timeout:
 
-`dotnet nuget push foo.nupkg --timeout 360`
+  ```console
+  dotnet nuget push foo.nupkg --timeout 360
+  ```
 
-Pushes all *.nupkg* files in the current directory to the default push source:
+* Pushes all *.nupkg* files in the current directory to the default push source:
 
-`dotnet nuget push *.nupkg`
+  ```console
+  dotnet nuget push *.nupkg
+  ```

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -1,9 +1,7 @@
 ---
 title: dotnet pack command - .NET Core CLI
 description: The dotnet pack command creates NuGet packages for your .NET Core project.
-author: mairaw
-ms.author: mairaw
-ms.date: 05/29/2018
+ms.date: 12/04/2018
 ---
 # dotnet pack
 
@@ -43,65 +41,65 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
 ## Arguments
 
-`PROJECT`
+* **`PROJECT`**
 
-The project to pack. It's either a path to a [csproj file](csproj.md) or to a directory. If not specified, it defaults to the current directory.
+  The project to pack. It's either a path to a [csproj file](csproj.md) or to a directory. If not specified, it defaults to the current directory.
 
 ## Options
 
 # [.NET Core 2.x](#tab/netcore2x)
 
-`-c|--configuration {Debug|Release}`
+* **`-c|--configuration {Debug|Release}`**
 
-Defines the build configuration. The default value is `Debug`.
+  Defines the build configuration. The default value is `Debug`.
 
-`--force`
+* **`--force`**
 
-Forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is the same as deleting the *project.assets.json* file.
+  Forces all dependencies to be resolved even if the last restore was successful. Specifying this flag is the same as deleting the *project.assets.json* file.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`--include-source`
+* **`--include-source`**
 
-Includes the source files in the NuGet package. The sources files are included in the `src` folder within the `nupkg`.
+  Includes the source files in the NuGet package. The sources files are included in the `src` folder within the `nupkg`.
 
-`--include-symbols`
+* **`--include-symbols`**
 
-Generates the symbols `nupkg`.
+  Generates the symbols `nupkg`.
 
-`--no-build`
+* **`--no-build`**
 
-Doesn't build the project before packing. It also implicit sets the `--no-restore` flag.
+  Doesn't build the project before packing. It also implicit sets the `--no-restore` flag.
 
-`--no-dependencies`
+* **`--no-dependencies`**
 
-Ignores project-to-project references and only restores the root project.
+  Ignores project-to-project references and only restores the root project.
 
-`--no-restore`
+* **`--no-restore`**
 
-Doesn't execute an implicit restore when running the command.
+  Doesn't execute an implicit restore when running the command.
 
-`-o|--output <OUTPUT_DIRECTORY>`
+* **`-o|--output <OUTPUT_DIRECTORY>`**
 
-Places the built packages in the directory specified.
+  Places the built packages in the directory specified.
 
-`--runtime <RUNTIME_IDENTIFIER>`
+* **`--runtime <RUNTIME_IDENTIFIER>`**
 
-Specifies the target runtime to restore packages for. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
+  Specifies the target runtime to restore packages for. For a list of Runtime Identifiers (RIDs), see the [RID catalog](../rid-catalog.md).
 
-`-s|--serviceable`
+* **`-s|--serviceable`**
 
-Sets the serviceable flag in the package. For more information, see [.NET Blog: .NET 4.5.1 Supports Microsoft Security Updates for .NET NuGet Libraries](https://aka.ms/nupkgservicing).
+  Sets the serviceable flag in the package. For more information, see [.NET Blog: .NET 4.5.1 Supports Microsoft Security Updates for .NET NuGet Libraries](https://aka.ms/nupkgservicing).
 
-`--version-suffix <VERSION_SUFFIX>`
+* **`--version-suffix <VERSION_SUFFIX>`**
 
-Defines the value for the `$(VersionSuffix)` MSBuild property in the project.
+  Defines the value for the `$(VersionSuffix)` MSBuild property in the project.
 
-`-v|--verbosity <LEVEL>`
+* **`-v|--verbosity <LEVEL>`**
 
-Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
 > [!NOTE]
 > Web projects aren't packable by default. To override the default behavior, add the following property to your *.csproj* file:
@@ -113,78 +111,96 @@ Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal
 
 # [.NET Core 1.x](#tab/netcore1x)
 
-`-c|--configuration {Debug|Release}`
+* **`-c|--configuration {Debug|Release}`**
 
-Defines the build configuration. The default value is `Debug`.
+  Defines the build configuration. The default value is `Debug`.
 
-`-h|--help`
+* **`-h|--help`**
 
-Prints out a short help for the command.
+  Prints out a short help for the command.
 
-`--include-source`
+* **`--include-source`**
 
-Includes the source files in the NuGet package. The sources files are included in the `src` folder within the `nupkg`.
+  Includes the source files in the NuGet package. The sources files are included in the `src` folder within the `nupkg`.
 
-`--include-symbols`
+* **`--include-symbols`**
 
-Generates the symbols `nupkg`.
+  Generates the symbols `nupkg`.
 
-`--no-build`
+* **`--no-build`**
 
-Doesn't build the project before packing.
+  Doesn't build the project before packing.
 
-`-o|--output <OUTPUT_DIRECTORY>`
+* **`-o|--output <OUTPUT_DIRECTORY>`**
 
-Places the built packages in the directory specified.
+  Places the built packages in the directory specified.
 
-`-s|--serviceable`
+* **`-s|--serviceable`**
 
-Sets the serviceable flag in the package. For more information, see [.NET Blog: .NET 4.5.1 Supports Microsoft Security Updates for .NET NuGet Libraries](https://aka.ms/nupkgservicing).
+  Sets the serviceable flag in the package. For more information, see [.NET Blog: .NET 4.5.1 Supports Microsoft Security Updates for .NET NuGet Libraries](https://aka.ms/nupkgservicing).
 
-`--version-suffix <VERSION_SUFFIX>`
+* **`--version-suffix <VERSION_SUFFIX>`**
 
-Defines the value for the `$(VersionSuffix)` MSBuild property in the project.
+  Defines the value for the `$(VersionSuffix)` MSBuild property in the project.
 
-`-v|--verbosity <LEVEL>`
+* **`-v|--verbosity <LEVEL>`**
 
-Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+  Sets the verbosity level of the command. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
 
 ---
 
 ## Examples
 
-Pack the project in the current directory:
+* Pack the project in the current directory:
 
-`dotnet pack`
+  ```console
+  dotnet pack
+  ```
 
-Pack the `app1` project:
+* Pack the `app1` project:
 
-`dotnet pack ~/projects/app1/project.csproj`
+  ```console
+  dotnet pack ~/projects/app1/project.csproj
+  ```
 
-Pack the project in the current directory and place the resulting packages into the `nupkgs` folder:
+* Pack the project in the current directory and place the resulting packages into the `nupkgs` folder:
 
-`dotnet pack --output nupkgs`
+  ```console
+  dotnet pack --output nupkgs
+  ```
 
-Pack the project in the current directory into the `nupkgs` folder and skip the build step:
+* Pack the project in the current directory into the `nupkgs` folder and skip the build step:
 
-`dotnet pack --no-build --output nupkgs`
+  ```console
+  dotnet pack --no-build --output nupkgs
+  ```
 
-With the project's version suffix configured as `<VersionSuffix>$(VersionSuffix)</VersionSuffix>` in the *.csproj* file, pack the current project and update the resulting package version with the given suffix:
+* With the project's version suffix configured as `<VersionSuffix>$(VersionSuffix)</VersionSuffix>` in the *.csproj* file, pack the current project and update the resulting package version with the given suffix:
 
-`dotnet pack --version-suffix "ci-1234"`
+  ```console
+  dotnet pack --version-suffix "ci-1234"
+  ```
 
-Set the package version to `2.1.0` with the `PackageVersion` MSBuild property:
+* Set the package version to `2.1.0` with the `PackageVersion` MSBuild property:
 
-`dotnet pack -p:PackageVersion=2.1.0`
+  ```console
+  dotnet pack -p:PackageVersion=2.1.0
+  ```
 
-Pack the project for a specific [target framework](../../standard/frameworks.md):
+* Pack the project for a specific [target framework](../../standard/frameworks.md):
 
-`dotnet pack -p:TargetFrameworks=net45`
+  ```console
+  dotnet pack -p:TargetFrameworks=net45
+  ```
 
-Pack the project and use a specific runtime (Windows 10) for the restore operation (.NET Core SDK 2.0 and later versions):
+* Pack the project and use a specific runtime (Windows 10) for the restore operation (.NET Core SDK 2.0 and later versions):
 
-`dotnet pack --runtime win10-x64`
+  ```console
+  dotnet pack --runtime win10-x64
+  ```
 
-Pack the projec using a [.nuspec file](https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-using-a-nuspec)
+* Pack the projec using a [.nuspec file](https://docs.microsoft.com/nuget/reference/msbuild-targets#packing-using-a-nuspec):
 
-`dotnet pack  ~/projects/app1/project.csproj /p:NuspecFile=~/projects/app1/project.nuspec /p:NuspecBasePath=~/projects/app1/nuget`
+  ```console
+  dotnet pack  ~/projects/app1/project.csproj /p:NuspecFile=~/projects/app1/project.nuspec /p:NuspecBasePath=~/projects/app1/nuget
+  ```

--- a/includes/dotnet-restore-note.md
+++ b/includes/dotnet-restore-note.md
@@ -1,3 +1,3 @@
 > [!NOTE]
-> Starting with .NET Core 2.0, you don't have to run [`dotnet restore`](~/docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
+> Starting with .NET Core 2.0 SDK, you don't have to run [`dotnet restore`](~/docs/core/tools/dotnet-restore.md) because it's run implicitly by all commands that require a restore to occur, such as `dotnet new`, `dotnet build` and `dotnet run`.
 > It's still a valid command in certain scenarios where doing an explicit restore makes sense, such as [continuous integration builds in Azure DevOps Services](https://docs.microsoft.com/azure/devops/build-release/apps/aspnet/build-aspnet-core) or in build systems that need to explicitly control the time at which the restore occurs.

--- a/includes/topic-appliesto-net-core-2plus.md
+++ b/includes/topic-appliesto-net-core-2plus.md
@@ -1,1 +1,1 @@
-**This topic applies to: ✓** .NET Core SDK 2.0 and later versions
+**This topic applies to: ✓** .NET Core 2.0 SDK and later versions

--- a/includes/topic-appliesto-net-core-all.md
+++ b/includes/topic-appliesto-net-core-all.md
@@ -1,1 +1,1 @@
-**This topic applies to: ✓** .NET Core SDK 1.x **✓** .NET Core SDK 2.x
+**This topic applies to: ✓** .NET Core 1.x SDK **✓** .NET Core 2.x SDK


### PR DESCRIPTION
Review CLI commands for .NET Core 2.2 SDK + style changes (same as done for [dotnet-install scripts](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script) already)

Contributes to #9256 
Fixes #8902 
Fixes #6666 

Hide whitespace changes for easier diff: https://github.com/dotnet/docs/pull/9364/files?utf8=%E2%9C%93&diff=split&w=1

I also removed the tabs from the dotnet clear command page. That perhaps could work better for commands that have simple differences between versions. Thoughts?