### PR TITLE
Update porting to .NET Core docs

### DIFF
--- a/docs/core/migration/index.md
+++ b/docs/core/migration/index.md
@@ -1,17 +1,19 @@
 ---
-title: .NET Core migration to the csproj format
-description: .NET Core project.json to csproj migration
+title: .NET Core migration from project.json
+description: Learn how to migrate an older .NET Core project using project.json
 author: blackdwarf
 ms.author: mairaw
 ms.date: 07/19/2017
 ---
-# Migrating .NET Core projects to the .csproj format
+# Migrating .NET Core projects from project.json
 
 This document will cover migration scenarios for .NET Core projects and will go over the following three migration scenarios:
 
 1. [Migration from a valid latest schema of *project.json* to *csproj*](#migration-from-projectjson-to-csproj)
 2. [Migration from DNX to csproj](#migration-from-dnx-to-csproj)
 3. [Migration from RC3 and previous .NET Core csproj projects to the final format](#migration-from-earlier-net-core-csproj-formats-to-rtm-csproj)
+
+This document is only applicable to older .NET Core projects that still use project.json. It is not applicable for migrating from .NET Framework to .NET Core.
 
 ## Migration from project.json to csproj
 

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -3,7 +3,7 @@ title: Porting to .NET Core from .NET Framework
 description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET Core.
 author: cartermp
 ms.author: mairaw
-ms.date: 10/23/2018
+ms.date: 12/04/2018
 ---
 # Porting to .NET Core from .NET Framework
 
@@ -15,7 +15,7 @@ This is the process we recommend you take when porting your project to .NET Core
 
 1. Identify and account for your third-party dependencies.
 
-  This step involves understanding what your third-party dependencies are, how you depend on them, how to check if they also run on .NET Core and steps you can take if they don't.
+   This step involves understanding what your third-party dependencies are, how you depend on them, how to check if they also run on .NET Core, and steps you can take if they don't. It also covers how you can migrate your dependencies over to the `PackageReference` format that is used in .NET Core.
 
 2. Retarget all projects you wish to port to target the latest version of .NET Framework.
 
@@ -35,10 +35,12 @@ This is the process we recommend you take when porting your project to .NET Core
 
 The following list shows tools you might find helpful to use during the porting process:
 
-* NuGet - [Nuget Client](https://dist.nuget.org/index.html) or [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer), Microsoft's package manager for .NET implementations.
+* NuGet - [Nuget Client](https://dist.nuget.org/index.html) or [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer)
 * .NET Portability Analyzer - [command line tool](https://github.com/Microsoft/dotnet-apiport/releases) or [Visual Studio Extension](https://visualstudiogallery.msdn.microsoft.com/1177943e-cfb7-4822-a8a6-e56c7905292b), a toolchain that can generate a report of how portable your code is between .NET Framework and .NET Core, with an assembly-by-assembly breakdown of issues. For more information, see [.NET Portability Analyzer](../../standard/analyzers/portability-analyzer.md).
 * .NET API analyzer - A Roslyn analyzer that discovers potential compatibility risks for C# APIs on different platforms and detects calls to deprecated APIs. For more information, see [.NET API analyzer](../../standard/analyzers/api-analyzer.md).
 * Reverse Package Search - A [useful web service](https://packagesearch.azurewebsites.net) that allows you to search for a type and find packages containing that type.
+
+Additionally, you can attempt to port smaller solutions or individual projects to the appropriate project file format with the [CsprojToVs2017](https://github.com/hvanbakel/CsprojToVs2017) tool. **Be warned:** There is no guarantee that this tool will work for all of your projects, and it may cause subtle changes in behavior that you depend on. This tool should be used as a _starting point_ that automates the basic things that can be automated.
 
 >[!div class="step-by-step"]
 >[Next](third-party-deps.md)

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -35,7 +35,7 @@ This is the process we recommend you take when porting your project to .NET Core
 
 The following list shows tools you might find helpful to use during the porting process:
 
-* NuGet - [Nuget Client](https://dist.nuget.org/index.html) or [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer)
+* NuGet - [Nuget Client](https://dist.nuget.org/index.html) or [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer).
 * .NET Portability Analyzer - [command line tool](https://github.com/Microsoft/dotnet-apiport/releases) or [Visual Studio Extension](https://visualstudiogallery.msdn.microsoft.com/1177943e-cfb7-4822-a8a6-e56c7905292b), a toolchain that can generate a report of how portable your code is between .NET Framework and .NET Core, with an assembly-by-assembly breakdown of issues. For more information, see [.NET Portability Analyzer](../../standard/analyzers/portability-analyzer.md).
 * .NET API analyzer - A Roslyn analyzer that discovers potential compatibility risks for C# APIs on different platforms and detects calls to deprecated APIs. For more information, see [.NET API analyzer](../../standard/analyzers/api-analyzer.md).
 * Reverse Package Search - A [useful web service](https://packagesearch.azurewebsites.net) that allows you to search for a type and find packages containing that type.

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -15,7 +15,7 @@ This is the process we recommend you take when porting your project to .NET Core
 
 1. Identify and account for your third-party dependencies.
 
-   This step involves understanding what your third-party dependencies are, how you depend on them, how to check if they also run on .NET Core, and steps you can take if they don't. It also covers how you can migrate your dependencies over to the `PackageReference` format that is used in .NET Core.
+   This step involves understanding what your third-party dependencies are, how you depend on them, how to check if they also run on .NET Core, and steps you can take if they don't. It also covers how you can migrate your dependencies over to the [PackageReference](/nuget/consume-packages/package-references-in-project-files) format that is used in .NET Core.
 
 2. Retarget all projects you wish to port to target the latest version of .NET Framework.
 

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -40,7 +40,7 @@ The following list shows tools you might find helpful to use during the porting 
 * .NET API analyzer - A Roslyn analyzer that discovers potential compatibility risks for C# APIs on different platforms and detects calls to deprecated APIs. For more information, see [.NET API analyzer](../../standard/analyzers/api-analyzer.md).
 * Reverse Package Search - A [useful web service](https://packagesearch.azurewebsites.net) that allows you to search for a type and find packages containing that type.
 
-Additionally, you can attempt to port smaller solutions or individual projects to the appropriate project file format with the [CsprojToVs2017](https://github.com/hvanbakel/CsprojToVs2017) tool. **Be warned:** There is no guarantee that this tool will work for all of your projects, and it may cause subtle changes in behavior that you depend on. This tool should be used as a _starting point_ that automates the basic things that can be automated.
+Additionally, you can attempt to port smaller solutions or individual projects to the .NET Core project file format with the [CsprojToVs2017](https://github.com/hvanbakel/CsprojToVs2017) tool. **Be warned:** There is no guarantee that this tool will work for all of your projects, and it may cause subtle changes in behavior that you depend on. This tool should be used as a _starting point_ that automates the basic things that can be automated.
 
 >[!div class="step-by-step"]
 >[Next](third-party-deps.md)

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -107,7 +107,7 @@ For more information on how to suppress compiler warnings in Visual Studio, see 
 
 ### Port your packages to `PackageReference`
 
-.NET Core uses [PackageReference](nuget/consume-packages/package-references-in-project-files_) to specify package dependencies. If you are using [packages.config](/nuget/reference/packages-config) to specify your packages, you will need to convert over to `PackageReference`.
+.NET Core uses [PackageReference](/nuget/consume-packages/package-references-in-project-files) to specify package dependencies. If you are using [packages.config](/nuget/reference/packages-config) to specify your packages, you will need to convert over to `PackageReference`.
 
 You can learn more at [Migrate from packages.config to PackageReference](/nuget/reference/migrate-packages-config-to-package-reference).
 

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -3,19 +3,19 @@ title: Porting to .NET Core - Analyze your third-party dependencies
 description: Learn how to analyze third-party dependencies in order to port your project from .NET Framework to .NET Core.
 author: cartermp
 ms.author: mairaw
-ms.date: 02/15/2018
+ms.date: 12/04/2018
 ---
 # Analyze your third-party dependencies
 
 If you're looking to port your code to .NET Core or .NET Standard, the first step in the porting process is to understand your third-party dependencies. Third-party dependencies are either [NuGet packages](#analyze-referenced-nuget-packages-on-your-project) or [DLLs](#analyze-dependencies-that-arent-nuget-packages) you're referencing in your project. Evaluate each dependency and develop a contingency plan for the dependencies that aren't compatible with .NET Core. This article shows you how to determine if the dependency is compatible with .NET Core.
 
-## Analyze referenced NuGet packages in your project
+## Analyze referenced NuGet packages in your projects
 
 If you're referencing NuGet packages in your project, you need to verify if they're compatible with .NET Core.
 There are two ways to accomplish that:
 
-* [Using the NuGet Package Explorer app](#analyze-nuget-packages-using-nuget-package-explorer) (the most reliable method).
-* [Using the nuget.org site](#analyze-nuget-packages-using-nugetorg).
+* [Using the NuGet Package Explorer app](#analyze-nuget-packages-using-nuget-package-explorer)
+* [Using the nuget.org site](#analyze-nuget-packages-using-nugetorg)
 
 After analyzing the packages, if they're not compatible with .NET Core and only target .NET Framework, you can check if the [.NET Framework compatibility mode](#net-framework-compatibility-mode) can help with your porting process.
 
@@ -103,6 +103,12 @@ To suppress the warning by editing the project file, find the `PackageReference`
 ```
 
 For more information on how to suppress compiler warnings in Visual Studio, see [Suppressing warnings for NuGet packages](/visualstudio/ide/how-to-suppress-compiler-warnings#suppressing-warnings-for-nuget-packages).
+
+### Port your packages to `PackageReference`
+
+.NET Core uses `PackageReference` to specify package dependencies. If you are using `packages.config` to specify your packages, you will need to convert over to `PackageReference`.
+
+You can learn more at [Migrate from packages.config to PackageReference](../../../nuget/reference/migrate-packages-config-to-package-reference).
 
 ### What to do when your NuGet package dependency doesn't run on .NET Core
 

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -46,6 +46,7 @@ netcoreapp1.0
 netcoreapp1.1
 netcoreapp2.0
 netcoreapp2.1
+netcoreapp2.2
 portable-net45-win8
 portable-win8-wpa8
 portable-net451-win81
@@ -106,9 +107,9 @@ For more information on how to suppress compiler warnings in Visual Studio, see 
 
 ### Port your packages to `PackageReference`
 
-.NET Core uses `PackageReference` to specify package dependencies. If you are using `packages.config` to specify your packages, you will need to convert over to `PackageReference`.
+.NET Core uses [PackageReference](nuget/consume-packages/package-references-in-project-files_) to specify package dependencies. If you are using [packages.config](/nuget/reference/packages-config) to specify your packages, you will need to convert over to `PackageReference`.
 
-You can learn more at [Migrate from packages.config to PackageReference](../../../nuget/reference/migrate-packages-config-to-package-reference).
+You can learn more at [Migrate from packages.config to PackageReference](/nuget/reference/migrate-packages-config-to-package-reference).
 
 ### What to do when your NuGet package dependency doesn't run on .NET Core
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -97,7 +97,7 @@
 ### [Additions to the csproj format](core/tools/csproj.md)
 ## Migration
 ### [.NET Core 2.0 to 2.1](core/migration/20-21.md)
-### [Migration to csproj format](core/migration/index.md)
+### [Migration from project.sjon](core/migration/index.md)
 ### [Mapping between project.json and csproj](core/tools/project-json-to-csproj.md)
 ### [Migrating from DNX](core/migration/from-dnx.md)
 ## [Application Deployment](core/deploying/index.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -97,7 +97,7 @@
 ### [Additions to the csproj format](core/tools/csproj.md)
 ## Migration
 ### [.NET Core 2.0 to 2.1](core/migration/20-21.md)
-### [Migration from project.sjon](core/migration/index.md)
+### [Migrating from project.json](core/migration/index.md)
 ### [Mapping between project.json and csproj](core/tools/project-json-to-csproj.md)
 ### [Migrating from DNX](core/migration/from-dnx.md)
 ## [Application Deployment](core/deploying/index.md)


### PR DESCRIPTION
Small updates:

* Include link to tool that can help automate some things
* Clarify that the "migration" page is for project.json
* Include section on `PackageReference`
* Clean some things up