### PR TITLE
fixing 404 due to tilde not being interpolated

### DIFF
--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -13,7 +13,7 @@ You can install custom templates from a NuGet package on any NuGet feed, by refe
 
 The template engine is open source, and the online code repository is at [dotnet/templating](https://github.com/dotnet/templating/) on GitHub. Visit the [dotnet/dotnet-template-samples](https://github.com/dotnet/dotnet-template-samples) repo for samples of templates. More templates, including templates from third parties, are found at [Available templates for dotnet new](https://github.com/dotnet/templating/wiki/Available-templates-for-dotnet-new) on GitHub. For more information about creating and using custom templates, see [How to create your own templates for dotnet new](https://blogs.msdn.microsoft.com/dotnet/2017/04/02/how-to-create-your-own-templates-for-dotnet-new/) and the [dotnet/templating GitHub repo Wiki](https://github.com/dotnet/templating/wiki).
 
-To follow a walkthrough and create a template, see the [Create a custom template for dotnet new](~/docs/core/tutorials/create-custom-template.md) tutorial.
+To follow a walkthrough and create a template, see the [Create a custom template for dotnet new](/dotnet/docs/blob/master/docs/core/tutorials/create-custom-template.md) tutorial.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
The link to the create custom template tutorial would 404 due to the tilde.  Not sure Github appropriately interpolates that?  Also not sure that my addition is the 'right' URL format; only that it works?

Fixes #Issue_Number (if available)
