### PR TITLE
C53994: "|" is breaking formatting

### DIFF
--- a/docs/fsharp/language-reference/keyword-reference.md
+++ b/docs/fsharp/language-reference/keyword-reference.md
@@ -58,7 +58,7 @@ The following table shows all F# keywords in alphabetical order, together with b
 |`null`|[Null Values](values/null-values.md)<br /><br />[Constraints](generics/constraints.md)|Indicates the absence of an object.<br /><br />Also used in generic parameter constraints.|
 |`of`|[Discriminated Unions](discriminated-unions.md)<br /><br />[Delegates](delegates.md)<br /><br />[Exception Types](exception-handling/exception-types.md)|Used in discriminated unions to indicate the type of categories of values, and in delegate and exception declarations.|
 |`open`|[Import Declarations: The `open` Keyword](import-declarations-the-open-keyword.md)|Used to make the contents of a namespace or module available without qualification.|
-|`or`|[Symbol and Operator Reference](symbol-and-operator-reference/index.md)<br /><br />[Constraints](generics/constraints.md)|Used with Boolean conditions as a Boolean `or` operator. Equivalent to `||`.<br /><br />Also used in member constraints.|
+|`or`|[Symbol and Operator Reference](symbol-and-operator-reference/index.md)<br /><br />[Constraints](generics/constraints.md)|Used with Boolean conditions as a Boolean `or` operator. Equivalent to `&#124;&#124;`.<br /><br />Also used in member constraints.|
 |`override`|[Members](members/index.md)|Used to implement a version of an abstract or virtual method that differs from the base version.|
 |`private`|[Access Control](access-control.md)|Restricts access to a member to code in the same type or module.|
 |`public`|[Access Control](access-control.md)|Allows access to a member from outside the type.|


### PR DESCRIPTION
Hello, @cartermp, @mairaw,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
