### PR TITLE
Update safely-cast-using-pattern-matching-is-and-as-operators.md

### DIFF
--- a/docs/csharp/how-to/safely-cast-using-pattern-matching-is-and-as-operators.md
+++ b/docs/csharp/how-to/safely-cast-using-pattern-matching-is-and-as-operators.md
@@ -17,7 +17,7 @@ The following code demonstrates the pattern matching `is` statement. It contains
 
 [!code-csharp-interactive[Pattern matching is statement](../../../samples/snippets/csharp/how-to/safelycast/patternmatching/Program.cs#PatternMatchingIs)]
 
-The preceding sample demonstrates a few features of pattern matching syntax. The `if (a is Mammal m)` and `if (o is Mammal m)` statements combine the test with an initialization assignment. TThe assignment occurs only when the test succeeds. The variable `m` is only in scope in the embedded `if` statement where it has been assigned. You cannot access `m` later in the same method. Try it in the interactive window.
+The preceding sample demonstrates a few features of pattern matching syntax. The `if (a is Mammal m)` and `if (o is Mammal m)` statements combine the test with an initialization assignment. The assignment occurs only when the test succeeds. The variable `m` is only in scope in the embedded `if` statement where it has been assigned. You cannot access `m` later in the same method. Try it in the interactive window.
 
 You can also use the same syntax for testing if a [nullable type](../programming-guide/nullable-types/index.md) has a value, as shown in the following sample code:
 


### PR DESCRIPTION
Fixes #9406