### PR TITLE
Provide guidance on how to properly release unmanaged resources for t…

### DIFF
--- a/docs/standard/design-guidelines/dispose-pattern.md
+++ b/docs/standard/design-guidelines/dispose-pattern.md
@@ -185,10 +185,12 @@ public class Stream : IDisposable {
   
 <a name="finalizable_types"></a>   
 ## Finalizable Types  
- Finalizable types are types that extend the Basic Dispose Pattern by overriding the finalizer and providing finalization code path in the `Dispose(bool)` method.  
+ Finalizable types are types that extend the Basic Dispose Pattern by overriding the finalizer and providing finalization code path in the `Dispose(bool)` method.   Usually they are implemented to properly release unmanaged resources.
   
- Finalizers are notoriously difficult to implement correctly, primarily because you cannot make certain (normally valid) assumptions about the state of the system during their execution. The following guidelines should be taken into careful consideration.  
-  
+ Finalizers are notoriously difficult to implement correctly, primarily because you cannot make certain (normally valid) assumptions about the state of the system during their execution, this is because the finalizers are executing on the finalizer thread, concurrently with your application, so access to global state in your application can corrupt the state of your application.
+ 
+ The following guidelines should be taken into careful consideration.  
+ 
  Note that some of the guidelines apply not just to the `Finalize` method, but to any code called from a finalizer. In the case of the Basic Dispose Pattern previously defined, this means logic that executes inside `Dispose(bool disposing)` when the `disposing` parameter is false.  
   
  If the base class already is finalizable and implements the Basic Dispose Pattern, you should not override `Finalize` again. You should instead just override the `Dispose(bool)` method to provide additional resource cleanup logic.  
@@ -207,7 +209,7 @@ public class ComplexResourceHolder : IDisposable {
     }  
   
     protected virtual void Dispose(bool disposing) {  
-            ReleaseBuffer(buffer); // release unmanaged memory  
+        ReleaseBuffer(buffer); // release unmanaged memory  
         if (disposing) { // release other disposable objects  
             if (resource!= null) resource.Dispose();  
         }  
@@ -223,7 +225,13 @@ public class ComplexResourceHolder : IDisposable {
     }  
 }  
 ```  
-  
+
+When it comes to **releasing unmanaged resources** you need to take into consideration whether the underlying library that exposes the resource is thread safe.   If they are thread safe, you can call those methods directly, but if they are not thread safe, you will need to design a complementary solution.
+
+For example, consider the pair of C APIs `malloc()` and `free()`.  These are thread-safe, which means that if you were to use `malloc` in your finalizable type, you can very safely call the `free` method from your `Dispose` method above.   There are many unmanaged APIs that are not thread safe, for example, many UI toolkit APIs are not thread safe.  Consider the pair of calls `gtk_window_new()` and `gtk_window_destroy()`, if you were to call `gtk_window_destroy()` from the finalizer, you would most likely corrupt the state of the running application.   
+
+In those scenarios, the implementation for releasing your unmanaged resources should use the finalizer to queue the release of the operation to take place on the proper thread.   Typically this is done by adding the unamanged resource handle to a queue (remember to lock it), and triggering the main loop of the application to invoke the resource disposing task that would drain that queue on the main thread.
+
  **X AVOID** making types finalizable.  
   
  Carefully consider any case in which you think a finalizer is needed. There is a real cost associated with instances with finalizers, from both a performance and code complexity standpoint. Prefer using resource wrappers such as <xref:System.Runtime.InteropServices.SafeHandle> to encapsulate unmanaged resources where possible, in which case a finalizer becomes unnecessary because the wrapper is responsible for its own resource cleanup.  

--- a/docs/standard/design-guidelines/dispose-pattern.md
+++ b/docs/standard/design-guidelines/dispose-pattern.md
@@ -185,7 +185,7 @@ public class Stream : IDisposable {
   
 <a name="finalizable_types"></a>   
 ## Finalizable Types  
- Finalizable types are types that extend the Basic Dispose Pattern by overriding the finalizer and providing finalization code path in the `Dispose(bool)` method.   Usually they are implemented to properly release unmanaged resources.
+ Finalizable types are types that extend the Basic Dispose Pattern by overriding the finalizer and providing finalization code path in the `Dispose(bool)` method. Usually they are implemented to properly release unmanaged resources.
   
  Finalizers are notoriously difficult to implement correctly, primarily because you cannot make certain (normally valid) assumptions about the state of the system during their execution, this is because the finalizers are executing on the finalizer thread, concurrently with your application, so access to global state in your application can corrupt the state of your application.
  
@@ -228,9 +228,9 @@ public class ComplexResourceHolder : IDisposable {
 
 When it comes to **releasing unmanaged resources** you need to take into consideration whether the underlying library that exposes the resource is thread safe.   If they are thread safe, you can call those methods directly, but if they are not thread safe, you will need to design a complementary solution.
 
-For example, consider the pair of C APIs `malloc()` and `free()`.  These are thread-safe, which means that if you were to use `malloc` in your finalizable type, you can very safely call the `free` method from your `Dispose` method above.   There are many unmanaged APIs that are not thread safe, for example, many UI toolkit APIs are not thread safe.  Consider the pair of calls `gtk_window_new()` and `gtk_window_destroy()`, if you were to call `gtk_window_destroy()` from the finalizer, you would most likely corrupt the state of the running application.   
+For example, consider the pair of C APIs `malloc()` and `free()`. These are thread-safe, which means that if you were to use `malloc` in your finalizable type, you can very safely call the `free` method from your `Dispose` method above. There are many unmanaged APIs that are not thread safe, for example, many UI toolkit APIs are not thread safe.  Consider the pair of calls `gtk_window_new()` and `gtk_window_destroy()`, if you were to call `gtk_window_destroy()` from the finalizer, you would most likely corrupt the state of the running application.   
 
-In those scenarios, the implementation for releasing your unmanaged resources should use the finalizer to queue the release of the operation to take place on the proper thread.   Typically this is done by adding the unamanged resource handle to a queue (remember to lock it), and triggering the main loop of the application to invoke the resource disposing task that would drain that queue on the main thread.
+In those scenarios, the implementation for releasing your unmanaged resources should use the finalizer to queue the release of the operation to take place on the proper thread. Typically this is done by adding the unamanged resource handle to a queue (remember to lock it), and triggering the main loop of the application to invoke the resource disposing task that would drain that queue on the main thread.
 
  **X AVOID** making types finalizable.  
   


### PR DESCRIPTION
…hread-unsafe APIs

Provide the guidance that developers lack on how to avoid heap corruption when releasing unmanaged buffers.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
