### PR TITLE
Changed resources article title

### DIFF
--- a/docs/framework/resources/packaging-and-deploying-resources-in-desktop-apps.md
+++ b/docs/framework/resources/packaging-and-deploying-resources-in-desktop-apps.md
@@ -1,5 +1,5 @@
 ---
-title: "Packaging and Deploying Resources in Desktop Apps"
+title: "Packaging and Deploying Resources in .NET Apps"
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -29,7 +29,7 @@ ms.assetid: b224d7c0-35f8-4e82-a705-dd76795e8d16
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Packaging and Deploying Resources in Desktop Apps
+# Packaging and Deploying Resources in .NET Apps
 Applications rely on the .NET Framework Resource Manager, represented by the <xref:System.Resources.ResourceManager> class, to retrieve localized resources. The Resource Manager assumes that a hub and spoke model is used to package and deploy resources. The hub is the main assembly that contains the nonlocalizable executable code and the resources for a single culture, called the neutral or default culture. The default culture is the fallback culture for the application; it is the culture whose resources are used if localized resources cannot be found. Each spoke connects to a satellite assembly that contains the resources for a single culture, but does not contain any code.  
   
  There are several advantages to this model:  


### PR DESCRIPTION
## Changed resources article title

After merging #8920, I realized that we hadn't changed the title to reflect that the article covers both .NET Framework and .NET Core.
