### PR TITLE
turn off feedback and update ms.date

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -103,6 +103,9 @@
       ]
     },
     "fileMetadata": {
+      "feedback_system": {
+        "docs/standard/design-guidelines/**/**.md": "None"
+      },
       "feedback_product_url": {
         "docs/fsharp/**/**.md": "https://github.com/Microsoft/visualfsharp"
       },

--- a/docs/standard/design-guidelines/abstract-class.md
+++ b/docs/standard/design-guidelines/abstract-class.md
@@ -10,8 +10,7 @@ helpviewer_keywords:
   - "classes [.NET Framework], design guidelines"
   - "type design guidelines, classes"
 ms.assetid: d3646e6d-5c1f-4922-8fb0-ec5effb30d60
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Abstract Class Design
 **X DO NOT** define public or protected internal constructors in abstract types.  

--- a/docs/standard/design-guidelines/abstract-class.md
+++ b/docs/standard/design-guidelines/abstract-class.md
@@ -1,6 +1,6 @@
 ---
 title: "Abstract Class Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "type design guidelines, abstract classes"

--- a/docs/standard/design-guidelines/abstractions-abstract-types-and-interfaces.md
+++ b/docs/standard/design-guidelines/abstractions-abstract-types-and-interfaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Abstractions (Abstract Types and Interfaces)"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "interfaces [.NET Framework], abstract"

--- a/docs/standard/design-guidelines/abstractions-abstract-types-and-interfaces.md
+++ b/docs/standard/design-guidelines/abstractions-abstract-types-and-interfaces.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "abstract types [.NET Framework]"
   - "types [.NET Framework], abstract"
 ms.assetid: 0a632bc7-9b03-44ee-8842-c82f88672a45
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Abstractions (Abstract Types and Interfaces)
 An abstraction is a type that describes a contract but does not provide a full implementation of the contract. Abstractions are usually implemented as abstract classes or interfaces, and they come with a well-defined set of reference documentation describing the required semantics of the types implementing the contract. Some of the most important abstractions in the .NET Framework include <xref:System.IO.Stream>, <xref:System.Collections.Generic.IEnumerable%601>, and <xref:System.Object>.  

--- a/docs/standard/design-guidelines/arrays.md
+++ b/docs/standard/design-guidelines/arrays.md
@@ -1,6 +1,6 @@
 ---
 title: "Arrays"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "class library design guidelines [.NET Framework], arrays"

--- a/docs/standard/design-guidelines/arrays.md
+++ b/docs/standard/design-guidelines/arrays.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "arrays [.NET Framework], usage guidelines"
   - "empty arrays"
 ms.assetid: 66a1b3d8-6f3f-4715-b235-e1ff95e32d8e
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Arrays
 **✓ DO** prefer using collections over arrays in public APIs. The [Collections](../../../docs/standard/design-guidelines/guidelines-for-collections.md) section provides details about how to choose between collections and arrays.  

--- a/docs/standard/design-guidelines/attributes.md
+++ b/docs/standard/design-guidelines/attributes.md
@@ -6,8 +6,7 @@ helpviewer_keywords:
   - "attributes [.NET Framework], about"
   - "class library design guidelines [.NET Framework], attributes"
 ms.assetid: ee0038ef-b247-4747-a650-3c5c5cd58d8b
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Attributes
 <xref:System.Attribute?displayProperty=nameWithType> is a base class used to define custom attributes.  

--- a/docs/standard/design-guidelines/attributes.md
+++ b/docs/standard/design-guidelines/attributes.md
@@ -1,6 +1,6 @@
 ---
 title: "Attributes1"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "attributes [.NET Framework], about"

--- a/docs/standard/design-guidelines/base-classes-for-implementing-abstractions.md
+++ b/docs/standard/design-guidelines/base-classes-for-implementing-abstractions.md
@@ -6,8 +6,7 @@ helpviewer_keywords:
   - "abstractions [.NET Framework]"
   - "base classes, abstractions"
 ms.assetid: 37a2d9a4-9721-482a-a40f-eee2c1d97875
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Base Classes for Implementing Abstractions
 Strictly speaking, a class becomes a base class when another class is derived from it. For the purpose of this section, however, a base class is a class designed mainly to provide a common abstraction or for other classes to reuse some default implementation though inheritance. Base classes usually sit in the middle of inheritance hierarchies, between an abstraction at the root of a hierarchy and several custom implementations at the bottom.  

--- a/docs/standard/design-guidelines/base-classes-for-implementing-abstractions.md
+++ b/docs/standard/design-guidelines/base-classes-for-implementing-abstractions.md
@@ -1,6 +1,6 @@
 ---
 title: "Base Classes for Implementing Abstractions"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "abstractions [.NET Framework]"

--- a/docs/standard/design-guidelines/capitalization-conventions.md
+++ b/docs/standard/design-guidelines/capitalization-conventions.md
@@ -1,6 +1,6 @@
 ---
 title: "Capitalization Conventions"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "camel-case names [.NET Framework]"

--- a/docs/standard/design-guidelines/capitalization-conventions.md
+++ b/docs/standard/design-guidelines/capitalization-conventions.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "case sensitivity, capitalization conventions"
   - "names [.NET Framework], capitalization"
 ms.assetid: 4c4ea526-9203-486f-b72d-29d61c5b3c6d
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Capitalization Conventions
 The guidelines in this chapter lay out a simple method for using case that, when applied consistently, make identifiers for types, members, and parameters easy to read.  

--- a/docs/standard/design-guidelines/choosing-between-class-and-struct.md
+++ b/docs/standard/design-guidelines/choosing-between-class-and-struct.md
@@ -1,6 +1,6 @@
 ---
 title: "Choosing Between Class and Struct"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "class library design guidelines [.NET Framework], structures"

--- a/docs/standard/design-guidelines/choosing-between-class-and-struct.md
+++ b/docs/standard/design-guidelines/choosing-between-class-and-struct.md
@@ -12,8 +12,7 @@ helpviewer_keywords:
   - "classes [.NET Framework], vs. structures"
   - "type design guidelines, classes"
 ms.assetid: f8b8ec9b-0ba7-4dea-aadf-a93395cd804f
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Choosing Between Class and Struct
 One of the basic design decisions every framework designer faces is whether to design a type as a class (a reference type) or as a struct (a value type). Good understanding of the differences in the behavior of reference types and value types is crucial in making this choice.  

--- a/docs/standard/design-guidelines/common-design-patterns.md
+++ b/docs/standard/design-guidelines/common-design-patterns.md
@@ -6,8 +6,7 @@ helpviewer_keywords:
   - "design patterns in class libraries"
   - "class library design guidelines [.NET Framework], design patterns"
 ms.assetid: f7bd1361-4ab2-4132-972d-a044b8f197e1
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Common Design Patterns
 There are numerous books on software patterns, pattern languages, and antipatterns that address the very broad subject of patterns. Thus, this chapter provides guidelines and discussion related to a very limited set of patterns that are used frequently in the design of the .NET Framework APIs.  

--- a/docs/standard/design-guidelines/common-design-patterns.md
+++ b/docs/standard/design-guidelines/common-design-patterns.md
@@ -1,6 +1,6 @@
 ---
 title: "Common Design Patterns"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "design patterns in class libraries"

--- a/docs/standard/design-guidelines/constructor.md
+++ b/docs/standard/design-guidelines/constructor.md
@@ -1,6 +1,6 @@
 ---
 title: "Constructor Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "member design guidelines, constructors"

--- a/docs/standard/design-guidelines/constructor.md
+++ b/docs/standard/design-guidelines/constructor.md
@@ -12,8 +12,7 @@ helpviewer_keywords:
   - "default constructors"
   - "static constructors"
 ms.assetid: b4496afe-5fa7-4bb0-85ca-70b0ef21e6fc
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Constructor Design
 There are two kinds of constructors: type constructors and instance constructors.  

--- a/docs/standard/design-guidelines/dependency-properties.md
+++ b/docs/standard/design-guidelines/dependency-properties.md
@@ -1,6 +1,6 @@
 ---
 title: "Dependency Properties"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 212cfb1e-cec4-4047-94a6-47209b387f6f
 author: "rpetrusha"

--- a/docs/standard/design-guidelines/dependency-properties.md
+++ b/docs/standard/design-guidelines/dependency-properties.md
@@ -3,8 +3,7 @@ title: "Dependency Properties"
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 212cfb1e-cec4-4047-94a6-47209b387f6f
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Dependency Properties
 A dependency property (DP) is a regular property that stores its value in a property store instead of storing it in a type variable (field), for example.  

--- a/docs/standard/design-guidelines/designing-for-extensibility.md
+++ b/docs/standard/design-guidelines/designing-for-extensibility.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "class library design guidelines [.NET Framework], extensibility"
   - "class library extensibility [.NET Framework]"
 ms.assetid: 1cdb8740-871a-456c-9bd9-db96ca8d79b3
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Designing for Extensibility
 One important aspect of designing a framework is making sure the extensibility of the framework has been carefully considered. This requires that you understand the costs and benefits associated with various extensibility mechanisms. This chapter helps you decide which of the extensibility mechanisms—subclassing, events, virtual members, callbacks, and so on—can best meet the requirements of your framework.  

--- a/docs/standard/design-guidelines/designing-for-extensibility.md
+++ b/docs/standard/design-guidelines/designing-for-extensibility.md
@@ -1,6 +1,6 @@
 ---
 title: "Designing for Extensibility"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "extending class libraries"

--- a/docs/standard/design-guidelines/dispose-pattern.md
+++ b/docs/standard/design-guidelines/dispose-pattern.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "customizing Dispose method name"
   - "Finalize method"
 ms.assetid: 31a6c13b-d6a2-492b-9a9f-e5238c983bcb
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Dispose Pattern
 All programs acquire one or more system resources, such as memory, system handles, or database connections, during the course of their execution. Developers have to be careful when using such system resources, because they must be released after they have been acquired and used.  

--- a/docs/standard/design-guidelines/dispose-pattern.md
+++ b/docs/standard/design-guidelines/dispose-pattern.md
@@ -1,6 +1,6 @@
 ---
 title: "Dispose Pattern"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "Dispose method"

--- a/docs/standard/design-guidelines/enum.md
+++ b/docs/standard/design-guidelines/enum.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "class library design guidelines [.NET Framework], enumerations"
   - "flags enumerations"
 ms.assetid: dd53c952-9d9a-4736-86ff-9540e815d545
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Enum Design
 Enums are a special kind of value type. There are two kinds of enums: simple enums and flag enums.  

--- a/docs/standard/design-guidelines/enum.md
+++ b/docs/standard/design-guidelines/enum.md
@@ -1,6 +1,6 @@
 ---
 title: "Enum Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "type design guidelines, enumerations"

--- a/docs/standard/design-guidelines/equality-operators.md
+++ b/docs/standard/design-guidelines/equality-operators.md
@@ -1,6 +1,6 @@
 ---
 title: "Equality Operators"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "class library design guidelines [.NET Framework], Equals method"

--- a/docs/standard/design-guidelines/equality-operators.md
+++ b/docs/standard/design-guidelines/equality-operators.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "Equals method"
   - "== operator (equality) [.NET Framework]"
 ms.assetid: bc496a91-fefb-4ce0-ab4c-61f09964119a
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Equality Operators
 This section discusses overloading equality operators and refers to `operator==` and `operator!=` as equality operators.  

--- a/docs/standard/design-guidelines/event.md
+++ b/docs/standard/design-guidelines/event.md
@@ -10,8 +10,7 @@ helpviewer_keywords:
   - "post-events"
   - "signatures, event handling"
 ms.assetid: 67b3c6e2-6a8f-480d-a78f-ebeeaca1b95a
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Event Design
 Events are the most commonly used form of callbacks (constructs that allow the framework to call into user code). Other callback mechanisms include members taking delegates, virtual members, and interface-based plug-ins. Data from usability studies indicate that the majority of developers are more comfortable using events than they are using the other callback mechanisms. Events are nicely integrated with Visual Studio and many languages.  

--- a/docs/standard/design-guidelines/event.md
+++ b/docs/standard/design-guidelines/event.md
@@ -1,6 +1,6 @@
 ---
 title: "Event Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "pre-events"

--- a/docs/standard/design-guidelines/events-and-callbacks.md
+++ b/docs/standard/design-guidelines/events-and-callbacks.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "callback methods"
   - "callbacks"
 ms.assetid: 48b55c60-495f-4089-9396-97f9122bba7c
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Events and Callbacks
 Callbacks are extensibility points that allow a framework to call back into user code through a delegate. These delegates are usually passed to the framework through a parameter of a method.  

--- a/docs/standard/design-guidelines/events-and-callbacks.md
+++ b/docs/standard/design-guidelines/events-and-callbacks.md
@@ -1,6 +1,6 @@
 ---
 title: "Events and Callbacks"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "events [.NET Framework], extensibility"

--- a/docs/standard/design-guidelines/exception-throwing.md
+++ b/docs/standard/design-guidelines/exception-throwing.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "explicitly throwing exceptions"
   - "throwing exceptions, design guidelines"
 ms.assetid: 5388e02b-52f5-460e-a2b5-eeafe60eeebe
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Exception Throwing
 Exception-throwing guidelines described in this section require a good definition of the meaning of execution failure. Execution failure occurs whenever a member cannot do what it was designed to do (what the member name implies). For example, if the `OpenFile` method cannot return an opened file handle to the caller, it would be considered an execution failure.  

--- a/docs/standard/design-guidelines/exception-throwing.md
+++ b/docs/standard/design-guidelines/exception-throwing.md
@@ -1,6 +1,6 @@
 ---
 title: "Exception Throwing"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "exceptions, throwing"

--- a/docs/standard/design-guidelines/exceptions-and-performance.md
+++ b/docs/standard/design-guidelines/exceptions-and-performance.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "exceptions, performance"
   - "throwing exceptions, performance"
 ms.assetid: 3ad6aad9-08e6-4232-b336-0e301f2493e6
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Exceptions and Performance
 One common concern related to exceptions is that if exceptions are used for code that routinely fails, the performance of the implementation will be unacceptable. This is a valid concern. When a member throws an exception, its performance can be orders of magnitude slower. However, it is possible to achieve good performance while strictly adhering to the exception guidelines that disallow using error codes. Two patterns described in this section suggest ways to do this.  

--- a/docs/standard/design-guidelines/exceptions-and-performance.md
+++ b/docs/standard/design-guidelines/exceptions-and-performance.md
@@ -1,6 +1,6 @@
 ---
 title: "Exceptions and Performance"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "tester-doer pattern"

--- a/docs/standard/design-guidelines/exceptions.md
+++ b/docs/standard/design-guidelines/exceptions.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "errors [.NET Framework], exceptions"
   - "reporting errors"
 ms.assetid: bc177b2f-7528-4ae4-83db-aacfb04b86d0
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Design Guidelines for Exceptions
 Exception handling has many advantages over return-value-based error reporting. Good framework design helps the application developer realize the benefits of exceptions. This section discusses the benefits of exceptions and presents guidelines for using them effectively.  

--- a/docs/standard/design-guidelines/exceptions.md
+++ b/docs/standard/design-guidelines/exceptions.md
@@ -1,6 +1,6 @@
 ---
 title: "Design Guidelines for Exceptions"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "exceptions [.NET Framework], design guidelines"

--- a/docs/standard/design-guidelines/extension-methods.md
+++ b/docs/standard/design-guidelines/extension-methods.md
@@ -3,8 +3,7 @@ title: "Extension Methods"
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 5de945cb-88f4-49d7-b0e6-f098300cf357
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Extension Methods
 Extension methods are a language feature that allows static methods to be called using instance method call syntax. These methods must take at least one parameter, which represents the instance the method is to operate on.  

--- a/docs/standard/design-guidelines/extension-methods.md
+++ b/docs/standard/design-guidelines/extension-methods.md
@@ -1,6 +1,6 @@
 ---
 title: "Extension Methods"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 5de945cb-88f4-49d7-b0e6-f098300cf357
 author: "rpetrusha"

--- a/docs/standard/design-guidelines/field.md
+++ b/docs/standard/design-guidelines/field.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "read-only fields"
   - "member design guidelines, fields"
 ms.assetid: 7cb4b0f3-7a10-4c93-b84d-733f7134fcf8
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Field Design
 The principle of encapsulation is one of the most important notions in object-oriented design. This principle states that data stored inside an object should be accessible only to that object.  

--- a/docs/standard/design-guidelines/field.md
+++ b/docs/standard/design-guidelines/field.md
@@ -1,6 +1,6 @@
 ---
 title: "Field Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "fields, design guidelines"

--- a/docs/standard/design-guidelines/general-naming-conventions.md
+++ b/docs/standard/design-guidelines/general-naming-conventions.md
@@ -14,8 +14,7 @@ helpviewer_keywords:
   - "names [.NET Framework], type names"
   - "names [.NET Framework], acronyms"
 ms.assetid: d3a77ea1-75d2-4969-a8c3-3e1e3e1aaedc
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # General Naming Conventions
 This section describes general naming conventions that relate to word choice, guidelines on using abbreviations and acronyms, and recommendations on how to avoid using language-specific names.  

--- a/docs/standard/design-guidelines/general-naming-conventions.md
+++ b/docs/standard/design-guidelines/general-naming-conventions.md
@@ -1,6 +1,6 @@
 ---
 title: "General Naming Conventions"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "names [.NET Framework], conflicts"

--- a/docs/standard/design-guidelines/guidelines-for-collections.md
+++ b/docs/standard/design-guidelines/guidelines-for-collections.md
@@ -3,8 +3,7 @@ title: "Guidelines for Collections"
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 297b8f1d-b11f-4dc6-960a-8e990817304e
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Guidelines for Collections
 Any type designed specifically to manipulate a group of objects having some common characteristic can be considered a collection. It is almost always appropriate for such types to implement <xref:System.Collections.IEnumerable> or <xref:System.Collections.Generic.IEnumerable%601>, so in this section we only consider types implementing one or both of those interfaces to be collections.  

--- a/docs/standard/design-guidelines/guidelines-for-collections.md
+++ b/docs/standard/design-guidelines/guidelines-for-collections.md
@@ -1,6 +1,6 @@
 ---
 title: "Guidelines for Collections"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 297b8f1d-b11f-4dc6-960a-8e990817304e
 author: "rpetrusha"

--- a/docs/standard/design-guidelines/index.md
+++ b/docs/standard/design-guidelines/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Framework Design Guidelines"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "libraries, .NET Framework class library"

--- a/docs/standard/design-guidelines/index.md
+++ b/docs/standard/design-guidelines/index.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "class library design guidelines [.NET Framework], about"
   - "class library design guidelines [.NET Framework]"
 ms.assetid: 5fbcaf4f-ea2a-4d20-b0d6-e61dee202b4b
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Framework Design Guidelines
 This section provides guidelines for designing libraries that extend and interact with the .NET Framework. The goal is to help library designers ensure API consistency and ease of use by providing a unified programming model that is independent of the programming language used for development. We recommend that you follow these design guidelines when developing classes and components that extend the .NET Framework. Inconsistent library design adversely affects developer productivity and discourages adoption.  

--- a/docs/standard/design-guidelines/interface.md
+++ b/docs/standard/design-guidelines/interface.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "type design guidelines, interfaces"
   - "class library design guidelines [.NET Framework], interfaces"
 ms.assetid: a016bd18-6710-4358-9438-9f190a295392
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Interface Design
 Although most APIs are best modeled using classes and structs, there are cases in which interfaces are more appropriate or are the only option.  

--- a/docs/standard/design-guidelines/interface.md
+++ b/docs/standard/design-guidelines/interface.md
@@ -1,6 +1,6 @@
 ---
 title: "Interface Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "interfaces [.NET Framework], design guidelines"

--- a/docs/standard/design-guidelines/member-overloading.md
+++ b/docs/standard/design-guidelines/member-overloading.md
@@ -1,6 +1,6 @@
 ---
 title: "Member Overloading"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "default arguments"

--- a/docs/standard/design-guidelines/member-overloading.md
+++ b/docs/standard/design-guidelines/member-overloading.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "overloaded members"
   - "signatures, members"
 ms.assetid: 964ba19e-8b94-4b5b-b1e3-5a0b531a0bb1
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Member Overloading
 Member overloading means creating two or more members on the same type that differ only in the number or type of parameters but have the same name. For example, in the following, the `WriteLine` method is overloaded:  

--- a/docs/standard/design-guidelines/member.md
+++ b/docs/standard/design-guidelines/member.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "class library design guidelines [.NET Framework], members"
   - "member design guidelines [.NET Framework]"
 ms.assetid: 0ce93180-1d7b-4f8c-9306-f828b2d66b8f
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Member Design Guidelines
 Methods, properties, events, constructors, and fields are collectively referred to as members. Members are ultimately the means by which framework functionality is exposed to the end users of a framework.  

--- a/docs/standard/design-guidelines/member.md
+++ b/docs/standard/design-guidelines/member.md
@@ -1,6 +1,6 @@
 ---
 title: "Member Design Guidelines"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "member design guidelines [.NET Framework], about member design guidelines"

--- a/docs/standard/design-guidelines/names-of-assemblies-and-dlls.md
+++ b/docs/standard/design-guidelines/names-of-assemblies-and-dlls.md
@@ -1,6 +1,6 @@
 ---
 title: "Names of Assemblies and DLLs"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "names [.NET Framework], DLLs"

--- a/docs/standard/design-guidelines/names-of-assemblies-and-dlls.md
+++ b/docs/standard/design-guidelines/names-of-assemblies-and-dlls.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "assemblies [.NET Framework], names"
   - "DLLs, names"
 ms.assetid: e800b610-31b4-4949-9c14-cb60e9f254be
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Names of Assemblies and DLLs
 An assembly is the unit of deployment and identity for managed code programs. Although assemblies can span one or more files, typically an assembly maps one-to-one with a DLL. Therefore, this section describes only DLL naming conventions, which then can be mapped to assembly naming conventions.  

--- a/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
+++ b/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Names of Classes, Structs, and Interfaces"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 helpviewer_keywords: 
   - "type names, guidelines"
   - "classes [.NET Framework], names"

--- a/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
+++ b/docs/standard/design-guidelines/names-of-classes-structs-and-interfaces.md
@@ -12,8 +12,7 @@ helpviewer_keywords:
   - "interfaces [.NET Framework], names"
   - "generic type parameters"
 ms.assetid: 87a4b0da-ed64-43b1-ac43-968576c444ce
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Names of Classes, Structs, and Interfaces
 The naming guidelines that follow apply to general type naming.  

--- a/docs/standard/design-guidelines/names-of-namespaces.md
+++ b/docs/standard/design-guidelines/names-of-namespaces.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "namespaces [.NET Framework], names"
   - "names [.NET Framework], type names"
 ms.assetid: a49058d2-0276-43a7-9502-04adddf857b2
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Names of Namespaces
 As with other naming guidelines, the goal when naming namespaces is creating sufficient clarity for the programmer using the framework to immediately know what the content of the namespace is likely to be. The following template specifies the general rule for naming namespaces:  

--- a/docs/standard/design-guidelines/names-of-namespaces.md
+++ b/docs/standard/design-guidelines/names-of-namespaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Names of Namespaces"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 helpviewer_keywords: 
   - "names [.NET Framework], conflicts"
   - "names [.NET Framework], namespaces"

--- a/docs/standard/design-guidelines/names-of-type-members.md
+++ b/docs/standard/design-guidelines/names-of-type-members.md
@@ -12,8 +12,7 @@ helpviewer_keywords:
   - "names [.NET Framework], type members"
   - "members [.NET Framework], type"
 ms.assetid: af5a0903-36af-4c2a-b848-cf959affeaa5
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Names of Type Members
 Types are made of members: methods, properties, events, constructors, and fields. The following sections describe guidelines for naming type members.  

--- a/docs/standard/design-guidelines/names-of-type-members.md
+++ b/docs/standard/design-guidelines/names-of-type-members.md
@@ -1,6 +1,6 @@
 ---
 title: "Names of Type Members"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "events [.NET Framework], names"

--- a/docs/standard/design-guidelines/naming-guidelines.md
+++ b/docs/standard/design-guidelines/naming-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: "Naming Guidelines"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "names [.NET Framework], about naming guidelines"

--- a/docs/standard/design-guidelines/naming-guidelines.md
+++ b/docs/standard/design-guidelines/naming-guidelines.md
@@ -11,8 +11,7 @@ helpviewer_keywords:
   - "names [.NET Framework]"
   - "format naming guidelines [.NET Framework]"
 ms.assetid: fc076d66-9b5f-42d3-aa65-61d970c794a3
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Naming Guidelines
 Following a consistent set of naming conventions in the development of a framework can be a major contribution to the framework’s usability. It allows the framework to be used by many developers on widely separated projects. Beyond consistency of form, names of framework elements must be easily understood and must convey the function of each element.  

--- a/docs/standard/design-guidelines/naming-parameters.md
+++ b/docs/standard/design-guidelines/naming-parameters.md
@@ -6,8 +6,7 @@ helpviewer_keywords:
   - "parameters, names"
   - "names [.NET Framework], parameters"
 ms.assetid: ca3c956e-725a-441b-b4e3-eab5d472f41c
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Naming Parameters
 Beyond the obvious reason of readability, it is important to follow the guidelines for parameter names because parameters are displayed in documentation and in the designer when visual design tools provide Intellisense and class browsing functionality.  

--- a/docs/standard/design-guidelines/naming-parameters.md
+++ b/docs/standard/design-guidelines/naming-parameters.md
@@ -1,6 +1,6 @@
 ---
 title: "Naming Parameters"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "parameters, names"

--- a/docs/standard/design-guidelines/naming-resources.md
+++ b/docs/standard/design-guidelines/naming-resources.md
@@ -1,6 +1,6 @@
 ---
 title: "Naming Resources"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "names [.NET Framework], localized resources"

--- a/docs/standard/design-guidelines/naming-resources.md
+++ b/docs/standard/design-guidelines/naming-resources.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "global applications, naming guidelines"
   - "international applications, naming guidelines"
 ms.assetid: 8b0e97f3-7877-44fd-bc76-e05d36d5d79c
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Naming Resources
 Because localizable resources can be referenced via certain objects as if they were properties, the naming guidelines for resources are similar to property guidelines.  

--- a/docs/standard/design-guidelines/nested-types.md
+++ b/docs/standard/design-guidelines/nested-types.md
@@ -10,8 +10,7 @@ helpviewer_keywords:
   - "members [.NET Framework], type"
   - "class library design guidelines [.NET Framework], nested types"
 ms.assetid: 12feb7f0-b793-4d96-b090-42d6473bab8c
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Nested Types
 A nested type is a type defined within the scope of another type, which is called the enclosing type. A nested type has access to all members of its enclosing type. For example, it has access to private fields defined in the enclosing type and to protected fields defined in all ascendants of the enclosing type.  

--- a/docs/standard/design-guidelines/nested-types.md
+++ b/docs/standard/design-guidelines/nested-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Nested Types"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "types, nested"

--- a/docs/standard/design-guidelines/operator-overloads.md
+++ b/docs/standard/design-guidelines/operator-overloads.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "member design guidelines, operators"
   - "overloaded operators"
 ms.assetid: 37585bf2-4c27-4dee-849a-af70e3338cc1
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Operator Overloads
 Operator overloads allow framework types to appear as if they were built-in language primitives.  

--- a/docs/standard/design-guidelines/operator-overloads.md
+++ b/docs/standard/design-guidelines/operator-overloads.md
@@ -1,6 +1,6 @@
 ---
 title: "Operator Overloads"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "operators [.NET Framework], overloads"

--- a/docs/standard/design-guidelines/parameter-design.md
+++ b/docs/standard/design-guidelines/parameter-design.md
@@ -1,6 +1,6 @@
 ---
 title: "Parameter Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "member design guidelines [.NET Framework], parameters"

--- a/docs/standard/design-guidelines/parameter-design.md
+++ b/docs/standard/design-guidelines/parameter-design.md
@@ -9,8 +9,7 @@ helpviewer_keywords:
   - "parameters, design guidelines"
   - "reserved parameters"
 ms.assetid: 3f33bf46-4a7b-43b3-bb78-1ffebe0dcfa6
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Parameter Design
 This section provides broad guidelines on parameter design, including sections with guidelines for checking arguments. In addition, you should refer to the guidelines described in [Naming Parameters](../../../docs/standard/design-guidelines/naming-parameters.md).  

--- a/docs/standard/design-guidelines/property.md
+++ b/docs/standard/design-guidelines/property.md
@@ -1,6 +1,6 @@
 ---
 title: "Property Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "member design guidelines, properties"

--- a/docs/standard/design-guidelines/property.md
+++ b/docs/standard/design-guidelines/property.md
@@ -6,8 +6,7 @@ helpviewer_keywords:
   - "member design guidelines, properties"
   - "properties [.NET Framework], design guidelines"
 ms.assetid: 127cbc0c-cbed-48fd-9c89-7c5d4f98f163
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Property Design
 Although properties are technically very similar to methods, they are quite different in terms of their usage scenarios. They should be seen as smart fields. They have the calling syntax of fields, and the flexibility of methods.  

--- a/docs/standard/design-guidelines/protected-members.md
+++ b/docs/standard/design-guidelines/protected-members.md
@@ -1,6 +1,6 @@
 ---
 title: "Protected Members"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "members [.NET Framework], protected"

--- a/docs/standard/design-guidelines/protected-members.md
+++ b/docs/standard/design-guidelines/protected-members.md
@@ -10,8 +10,7 @@ helpviewer_keywords:
   - "unsealed classes"
   - "customizing class behavior"
 ms.assetid: aa0b58ee-3956-494d-ab48-471ae5db8740
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Protected Members
 Protected members by themselves do not provide any extensibility, but they can make extensibility through subclassing more powerful. They can be used to expose advanced customization options without unnecessarily complicating the main public interface.  

--- a/docs/standard/design-guidelines/sealing.md
+++ b/docs/standard/design-guidelines/sealing.md
@@ -1,6 +1,6 @@
 ---
 title: "Sealing"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "limiting extensibility"

--- a/docs/standard/design-guidelines/sealing.md
+++ b/docs/standard/design-guidelines/sealing.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "preventing customization"
   - "sealed classes"
 ms.assetid: cc42267f-bb7a-427a-845e-df97408528d4
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Sealing
 One of the features of object-oriented frameworks is that developers can extend and customize them in ways unanticipated by the framework designers. This is both the power and danger of extensible design. When you design your framework, it is, therefore, very important to carefully design for extensibility when it is desired, and to limit extensibility when it is dangerous.  

--- a/docs/standard/design-guidelines/serialization.md
+++ b/docs/standard/design-guidelines/serialization.md
@@ -3,8 +3,7 @@ title: "Serialization1"
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: bebb27ac-9712-4196-9931-de19fc04dbac
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Serialization
 Serialization is the process of converting an object into a format that can be readily persisted or transported. For example, you can serialize an object, transport it over the Internet using HTTP, and deserialized it at the destination machine.  
@@ -79,14 +78,14 @@ Serialization is the process of converting an object into a format that can be r
   
  **✓ DO** make the serialization constructor protected and provide two parameters typed and named exactly as shown in the sample here.  
   
-```  
+```csharp
 [Serializable]  
 public class Person : ISerializable {  
     protected Person(SerializationInfo info, StreamingContext context) {  
         ...  
     }  
 }  
-```  
+```
   
  **✓ DO** implement the `ISerializable` members explicitly.  
   

--- a/docs/standard/design-guidelines/serialization.md
+++ b/docs/standard/design-guidelines/serialization.md
@@ -1,6 +1,6 @@
 ---
 title: "Serialization1"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: bebb27ac-9712-4196-9931-de19fc04dbac
 author: "rpetrusha"

--- a/docs/standard/design-guidelines/static-class.md
+++ b/docs/standard/design-guidelines/static-class.md
@@ -10,8 +10,7 @@ helpviewer_keywords:
   - "classes [.NET Framework], design guidelines"
   - "type design guidelines, classes"
 ms.assetid: d67c14d8-c4dd-443f-affb-4ccae677c9b6
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Static Class Design
 A static class is defined as a class that contains only static members (of course besides the instance members inherited from <xref:System.Object?displayProperty=nameWithType> and possibly a private constructor). Some languages provide built-in support for static classes. In C# 2.0 and later, when a class is declared to be static, it is sealed, abstract, and no instance members can be overridden or declared.  

--- a/docs/standard/design-guidelines/static-class.md
+++ b/docs/standard/design-guidelines/static-class.md
@@ -1,6 +1,6 @@
 ---
 title: "Static Class Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "type design guidelines, static classes"

--- a/docs/standard/design-guidelines/struct.md
+++ b/docs/standard/design-guidelines/struct.md
@@ -11,8 +11,7 @@ helpviewer_keywords:
   - "type design guidelines, structures"
   - "structures [.NET Framework], design guidelines"
 ms.assetid: 1f48b2d8-608c-4be6-9ba4-d8f203ed9f9f
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Struct Design
 The general-purpose value type is most often referred to as a struct, its C# keyword. This section provides guidelines for general struct design.  

--- a/docs/standard/design-guidelines/struct.md
+++ b/docs/standard/design-guidelines/struct.md
@@ -1,6 +1,6 @@
 ---
 title: "Struct Design"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "class library design guidelines [.NET Framework], structures"

--- a/docs/standard/design-guidelines/system-xml-usage.md
+++ b/docs/standard/design-guidelines/system-xml-usage.md
@@ -1,6 +1,6 @@
 ---
 title: "System.Xml Usage"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 82302f0d-a621-4c6f-b57d-999bd61f21a6
 author: "rpetrusha"

--- a/docs/standard/design-guidelines/system-xml-usage.md
+++ b/docs/standard/design-guidelines/system-xml-usage.md
@@ -3,8 +3,7 @@ title: "System.Xml Usage"
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 ms.assetid: 82302f0d-a621-4c6f-b57d-999bd61f21a6
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # System.Xml Usage
 This section talks about usage of several types residing in <xref:System.Xml?displayProperty=nameWithType> namespaces that can be used to represent XML data.  

--- a/docs/standard/design-guidelines/type.md
+++ b/docs/standard/design-guidelines/type.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "class library design guidelines [.NET Framework], type design guidelines"
   - "types [.NET Framework], design guidelines"
 ms.assetid: 6b49314e-8bba-43ea-97ca-4e0255812f95
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Type Design Guidelines
 From the CLR perspective, there are only two categories of types—reference types and value types—but for the purpose of a discussion about framework design, we divide types into more logical groups, each with its own specific design rules.  

--- a/docs/standard/design-guidelines/type.md
+++ b/docs/standard/design-guidelines/type.md
@@ -1,6 +1,6 @@
 ---
 title: "Type Design Guidelines"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "type design guidelines"

--- a/docs/standard/design-guidelines/unsealed-classes.md
+++ b/docs/standard/design-guidelines/unsealed-classes.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "unsealed classes"
   - "inheritance, classes"
 ms.assetid: 9a3bd505-90f5-4053-9f0d-3cf5fa3d3ebf
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Unsealed Classes
 Sealed classes cannot be inherited from, and they prevent extensibility. In contrast, classes that can be inherited from are called unsealed classes.  

--- a/docs/standard/design-guidelines/unsealed-classes.md
+++ b/docs/standard/design-guidelines/unsealed-classes.md
@@ -1,6 +1,6 @@
 ---
 title: "Unsealed Classes"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "classes [.NET Framework], unsealed"

--- a/docs/standard/design-guidelines/usage-guidelines.md
+++ b/docs/standard/design-guidelines/usage-guidelines.md
@@ -1,6 +1,6 @@
 ---
 title: "Usage guidelines"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "class library design guidelines [.NET Framework], usage guidelines"

--- a/docs/standard/design-guidelines/usage-guidelines.md
+++ b/docs/standard/design-guidelines/usage-guidelines.md
@@ -5,8 +5,7 @@ ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "class library design guidelines [.NET Framework], usage guidelines"
 ms.assetid: 42215ffa-a099-4a26-b14e-fb2bdb6f95b7
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Usage guidelines
 

--- a/docs/standard/design-guidelines/using-standard-exception-types.md
+++ b/docs/standard/design-guidelines/using-standard-exception-types.md
@@ -8,8 +8,7 @@ helpviewer_keywords:
   - "exceptions, catching"
   - "exceptions, throwing"
 ms.assetid: ab22ce03-78f9-4dca-8824-c7ed3bdccc27
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Using Standard Exception Types
 This section describes the standard exceptions provided by the Framework and the details of their usage. The list is by no means exhaustive. Please refer to the .NET Framework reference documentation for usage of other Framework exception types.  

--- a/docs/standard/design-guidelines/using-standard-exception-types.md
+++ b/docs/standard/design-guidelines/using-standard-exception-types.md
@@ -1,6 +1,6 @@
 ---
 title: "Using Standard Exception Types"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "throwing exceptions, standard types"

--- a/docs/standard/design-guidelines/virtual-members.md
+++ b/docs/standard/design-guidelines/virtual-members.md
@@ -1,6 +1,6 @@
 ---
 title: "Virtual Members"
-ms.date: "03/30/2017"
+ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 
   - "overridable members"

--- a/docs/standard/design-guidelines/virtual-members.md
+++ b/docs/standard/design-guidelines/virtual-members.md
@@ -7,8 +7,7 @@ helpviewer_keywords:
   - "virtual members"
   - "members [.NET Framework], virtual"
 ms.assetid: 8ff4eb97-0364-43ec-8a02-934b5cd94d19
-author: "rpetrusha"
-ms.author: "ronpet"
+author: "KrzysztofCwalina"
 ---
 # Virtual Members
 Virtual members can be overridden, thus changing the behavior of the subclass. They are quite similar to callbacks in terms of the extensibility they provide, but they are better in terms of execution performance and memory consumption. Also, virtual members feel more natural in scenarios that require creating a special kind of an existing type (specialization).  


### PR DESCRIPTION
Turning feedback mechanism for the design guidelines since we can't edit that content and updating the ms.date to the date that the book was published.
Also changed the author metadata to use one of the book authors and let ms.author be our default value instead.