### PR TITLE
SEO pass on Porting titles, H1, and intro paragraphs

### DIFF
--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -8,7 +8,7 @@ ms.custom: seodec18
 ---
 # Port your code from .NET Framework to .NET Core
 
-If you've got code that runs on the .NET Framework, you may be interested in running your code on .NET Core for its cross-platform capabilities. Here's an overview of the porting process and a list of the tools you may find helpful when porting to .NET Core.
+If you've got code that runs on the .NET Framework, you may be interested in running your code on .NET Core, too. Here's an overview of the porting process and a list of the tools you may find helpful when porting your code to .NET Core.
 
 ## Overview of the porting process
 

--- a/docs/core/porting/index.md
+++ b/docs/core/porting/index.md
@@ -1,13 +1,14 @@
 ---
-title: Porting to .NET Core from .NET Framework
+title: Port code from .NET Framework to .NET Core
 description: Understand the porting process and discover tools you may find helpful when porting a .NET Framework project to .NET Core.
 author: cartermp
 ms.author: mairaw
 ms.date: 12/04/2018
+ms.custom: seodec18
 ---
-# Porting to .NET Core from .NET Framework
+# Port your code from .NET Framework to .NET Core
 
-If you've got code running on the .NET Framework, you may be interested in running your code on .NET Core. This article gives you an overview of the porting process and a list of the tools you may find helpful when porting to .NET Core.
+If you've got code that runs on the .NET Framework, you may be interested in running your code on .NET Core for its cross-platform capabilities. Here's an overview of the porting process and a list of the tools you may find helpful when porting to .NET Core.
 
 ## Overview of the porting process
 

--- a/docs/core/porting/libraries.md
+++ b/docs/core/porting/libraries.md
@@ -1,13 +1,14 @@
 ---
-title: Porting to .NET Core - Libraries
+title: Port libraries to .NET Core
 description: Learn how to port library projects from the .NET Framework to .NET Core.
 author: cartermp
 ms.author: mairaw
 ms.date: 07/14/2017
+ms.custom: seodec18
 ---
-# Porting to .NET Core - Libraries
+# Port .NET Framework libraries to .NET Core
 
-This article discusses porting library code to .NET Core so that it runs cross-platform.
+Learn how to port .NET Framework library code to .NET Core, to run cross-platform and expand the reach of the apps that use it.
 
 ## Prerequisites
 

--- a/docs/core/porting/project-structure.md
+++ b/docs/core/porting/project-structure.md
@@ -1,13 +1,14 @@
 ---
-title: Organizing your project to support .NET Framework and .NET Core
+title: Organize projects for .NET Framework and .NET Core
 description: Help for project owners who want to compile their solution against .NET Framework and .NET Core side-by-side.
 author: conniey
 ms.author: mairaw
 ms.date: 04/06/2017
+ms.custom: seodec18
 ---
-# Organizing your project to support .NET Framework and .NET Core
+# Organize your project to support both .NET Framework and .NET Core
 
-This article helps project owners who want to compile their solution against .NET Framework and .NET Core side-by-side. It provides several options to organize projects to help developers achieve this goal. The following list provides some typical scenarios to consider when you're deciding how to setup your project layout with .NET Core. The list may not cover everything you want; prioritize based on your project's needs.
+Learn how to create a solution that compiles for both .NET Framework and .NET Core side-by-side. See several options to organize projects to help you achieve this goal. Here are some typical scenarios to consider when you're deciding how to setup your project layout with .NET Core. The list may not cover everything you want; prioritize based on your project's needs.
 
 * [**Combine existing projects and .NET Core projects into single projects**][option-csproj]
 
@@ -69,7 +70,7 @@ Changes to note are:
 [example-initial-project]: media/project-structure/project.png "Existing project"
 [example-initial-project-code]: https://github.com/dotnet/samples/tree/master/framework/libraries/migrate-library/
 
-[example-csproj]: media/project-structure/project.csproj.png "Create an csproj that targets multiple frameworks"
+[example-csproj]: media/project-structure/project.csproj.png "Create a csproj that targets multiple frameworks"
 [example-csproj-code]: https://github.com/dotnet/samples/tree/master/framework/libraries/migrate-library-csproj/
 [example-csproj-netcore]: https://github.com/dotnet/samples/tree/master/framework/libraries/migrate-library-csproj/src/Car/Car.csproj
 

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -1,17 +1,18 @@
 ---
-title: Porting to .NET Core - Analyze your third-party dependencies
+title: Analyze dependencies to port to .NET Core
 description: Learn how to analyze third-party dependencies in order to port your project from .NET Framework to .NET Core.
 author: cartermp
 ms.author: mairaw
 ms.date: 12/04/2018
+ms.custom: seodec18
 ---
-# Analyze your third-party dependencies
+# Analyze your third-party dependencies to port code to .NET Core
 
-If you're looking to port your code to .NET Core or .NET Standard, the first step in the porting process is to understand your third-party dependencies. Third-party dependencies are either [NuGet packages](#analyze-referenced-nuget-packages-on-your-project) or [DLLs](#analyze-dependencies-that-arent-nuget-packages) you're referencing in your project. Evaluate each dependency and develop a contingency plan for the dependencies that aren't compatible with .NET Core. This article shows you how to determine if the dependency is compatible with .NET Core.
+To port your code to .NET Core or .NET Standard, you must understand your third-party dependencies. Third-party dependencies are the [NuGet packages](#analyze-referenced-nuget-packages-on-your-project) or [DLLs](#analyze-dependencies-that-arent-nuget-packages) you reference in your project. Evaluate each dependency and develop a contingency plan for the ones that aren't compatible with .NET Core. Here's how to determine if a dependency is compatible with .NET Core.
 
 ## Analyze referenced NuGet packages in your projects
 
-If you're referencing NuGet packages in your project, you need to verify if they're compatible with .NET Core.
+If you reference NuGet packages in your project, you need to verify if they're compatible with .NET Core.
 There are two ways to accomplish that:
 
 * [Using the NuGet Package Explorer app](#analyze-nuget-packages-using-nuget-package-explorer)

--- a/docs/core/porting/third-party-deps.md
+++ b/docs/core/porting/third-party-deps.md
@@ -1,14 +1,14 @@
 ---
-title: Analyze dependencies to port to .NET Core
-description: Learn how to analyze third-party dependencies in order to port your project from .NET Framework to .NET Core.
+title: Analyze dependencies to port code to .NET Core
+description: Learn how to analyze external dependencies in order to port your project from .NET Framework to .NET Core.
 author: cartermp
 ms.author: mairaw
 ms.date: 12/04/2018
 ms.custom: seodec18
 ---
-# Analyze your third-party dependencies to port code to .NET Core
+# Analyze your dependencies to port code to .NET Core
 
-To port your code to .NET Core or .NET Standard, you must understand your third-party dependencies. Third-party dependencies are the [NuGet packages](#analyze-referenced-nuget-packages-on-your-project) or [DLLs](#analyze-dependencies-that-arent-nuget-packages) you reference in your project. Evaluate each dependency and develop a contingency plan for the ones that aren't compatible with .NET Core. Here's how to determine if a dependency is compatible with .NET Core.
+To port your code to .NET Core or .NET Standard, you must understand your dependencies. External dependencies are the [NuGet packages](#analyze-referenced-nuget-packages-on-your-project) or [DLLs](#analyze-dependencies-that-arent-nuget-packages) you reference in your project, but that you don't build. Evaluate each dependency and develop a contingency plan for the ones that aren't compatible with .NET Core. Here's how to determine if a dependency is compatible with .NET Core.
 
 ## Analyze referenced NuGet packages in your projects
 

--- a/docs/core/porting/windows-compat-pack.md
+++ b/docs/core/porting/windows-compat-pack.md
@@ -1,5 +1,5 @@
 ---
-title: Use the Windows Compatibility Pack to port to .NET Core
+title: Use the Windows Compatibility Pack to port code to .NET Core
 description: Learn about the Windows Compatibility Pack and how can you use it to port existing .NET Framework code to .NET Core
 author: terrajobst
 ms.author: mairaw

--- a/docs/core/porting/windows-compat-pack.md
+++ b/docs/core/porting/windows-compat-pack.md
@@ -1,17 +1,18 @@
 ---
-title: Porting to .NET Core - Using the Windows Compatibility Pack
+title: Use the Windows Compatibility Pack to port to .NET Core
 description: Learn about the Windows Compatibility Pack and how can you use it to port existing .NET Framework code to .NET Core
 author: terrajobst
 ms.author: mairaw
 ms.date: 11/13/2017
+ms.custom: seodec18
 ---
-# Using the Windows Compatibility Pack
+# Use the Windows Compatibility Pack to port code to .NET Core
 
-One of the most common issues that developers face when porting their existing
-code to .NET Core is that they depend on APIs and technologies that only exist
-in the .NET Framework. The *Windows Compatibility Pack* is about providing many
-of these technologies so that building .NET Core applications as well as .NET
-Standard libraries becomes much more viable for existing code.
+Some of the most common issues found when porting existing
+code to .NET Core are dependencies on APIs and technologies that are only
+found in the .NET Framework. The *Windows Compatibility Pack* provides many
+of these technologies, so it's much easier to build .NET Core applications and .NET
+Standard libraries.
 
 This package is a logical [extension of .NET Standard 2.0](../whats-new/dotnet-core-2-0.md#api-changes-and-library-support)
 that significantly increases API set and existing code compiles with almost no


### PR DESCRIPTION
## Summary

Simplify titles, H1, and clarify intro paragraphs where possible to match customer intent.

This PR may need to also include an update for the TOC for the slightly changed titles.

Contributes to #9440 