### PR TITLE
Quick fix: add iteration example to string literal indexing docs

### DIFF
--- a/docs/csharp/language-reference/keywords/string.md
+++ b/docs/csharp/language-reference/keywords/string.md
@@ -50,6 +50,18 @@ string str = "test";
 char x = str[2];  // x = 's';
 ```
 
+In similar fashion, the [] operator can also be used for iterating over each character in a `string`:
+
+```csharp
+string str = "test";
+
+for (int i = 0; i < str.Length; i++)
+{
+  Console.Write(str[i] + " ");
+}
+// Output: test
+```
+
 String literals are of type `string` and can be written in two forms, quoted and @-quoted. Quoted string literals are enclosed in double quotation marks ("):
 
 ```csharp

--- a/docs/csharp/language-reference/keywords/string.md
+++ b/docs/csharp/language-reference/keywords/string.md
@@ -59,8 +59,8 @@ for (int i = 0; i < str.Length; i++)
 {
   Console.Write(str[i] + " ");
 }
-// Output: test
-```
+// Output: t e s t
+``` 
 
 String literals are of type `string` and can be written in two forms, quoted and @-quoted. Quoted string literals are enclosed in double quotation marks ("):
 


### PR DESCRIPTION
## Summary

Added an example of iterating over the characters in a string literal on the `string` keyword page of the docs. I don't know what the Microsoft precedent is for the phrase `iterating over` because of the following StackOverflow question: [Is it “iterate through” or “iterate over” something?](https://stackoverflow.com/questions/2715388)

I left it as `iterating over` since it's in common usage, even though the accepted answer says that the `over` is a useless adverb. I'll change it if requested.

Fixes #9286 
