### PR TITLE
Fixes #9540

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/polymorphism.md
+++ b/docs/csharp/programming-guide/classes-and-structs/polymorphism.md
@@ -91,8 +91,7 @@ Polymorphism is often referred to as the third pillar of object-oriented program
   
 ## See Also
 
-- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
-- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)
 - [Inheritance](../../../csharp/programming-guide/classes-and-structs/inheritance.md)  
 - [Abstract and Sealed Classes and Class Members](../../../csharp/programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members.md)  
 - [Methods](../../../csharp/programming-guide/classes-and-structs/methods.md)  


### PR DESCRIPTION
## Summary

The link to the C# programming guide is listed twice in the See Also section.

Fixes #9540
