### PR TITLE
fixes #8941

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/properties.md
@@ -27,7 +27,7 @@ A property is a member that provides a flexible mechanism to read, write, or com
 
 One basic pattern for implementing a property involves using a private backing field for setting and retrieving the property value. The `get` accessor returns the value of the private field, and the `set` accessor may perform some data validation before assigning a value to the private field. Both accessors may also perform some conversion or computation on the data before it is stored or returned.
 
-The following example illustrates this pattern. In this example, the `TimePeriod` class represents an interval of time. Internally, the class stores the time interval in seconds in a private field named `seconds`. A read-write property named `Hours` allows the customer to specify the time interval in hours. Both the `get` and the `set` accessors perform the necessary conversion between hours and seconds. In addition, the `set` accessor validates the data and throws an <xref:System.ArgumentOutOfRangeException> if the number of hours is invalid. 
+The following example illustrates this pattern. In this example, the `TimePeriod` class represents an interval of time. Internally, the class stores the time interval in seconds in a private field named `_seconds`. A read-write property named `Hours` allows the customer to specify the time interval in hours. Both the `get` and the `set` accessors perform the necessary conversion between hours and seconds. In addition, the `set` accessor validates the data and throws an <xref:System.ArgumentOutOfRangeException> if the number of hours is invalid. 
    
  [!code-csharp[Properties#1](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/properties-1.cs)]  
   


### PR DESCRIPTION
## Summary

Use an `_` as per new guidelines to differentiate between the backing field and the property. 

This change adjusts the reference to the `seconds` variable to `_seconds`. A pull request against the samples repository will be created to update the actual code samples.

Fixes #8941
