### PR TITLE
typo: InteropServicxes.MarshalAs -> InteropServices.MarshalAsAttribute

### DIFF
--- a/docs/standard/native-interop.md
+++ b/docs/standard/native-interop.md
@@ -254,7 +254,7 @@ Both of the above examples depend on parameters, and in both cases, the paramete
 
 **Marshalling** is the process of transforming types when they need to cross the managed boundary into native and vice versa.
 
-The reason marshalling is needed is because the types in the managed and unmanaged code are different. In managed code, for instance, you have a `String`, while in the unmanaged world strings can be Unicode ("wide"), non-Unicode, null-terminated, ASCII, etc. By default, the P/Invoke subsystem will try to do the right thing based on the [default behavior](../../docs/framework/interop/default-marshaling-behavior.md). However, for those situations where you need extra control, you can employ the [MarshalAs](xref:System.Runtime.InteropServicxes.MarshalAs) attribute to specify what is the expected type on the unmanaged side. For instance, if we want the string to be sent as a null-terminated ANSI string, we could do it like this:
+The reason marshalling is needed is because the types in the managed and unmanaged code are different. In managed code, for instance, you have a `String`, while in the unmanaged world strings can be Unicode ("wide"), non-Unicode, null-terminated, ASCII, etc. By default, the P/Invoke subsystem will try to do the right thing based on the [default behavior](../../docs/framework/interop/default-marshaling-behavior.md). However, for those situations where you need extra control, you can employ the [MarshalAs](xref:System.Runtime.InteropServices.MarshalAsAttribute) attribute to specify what is the expected type on the unmanaged side. For instance, if we want the string to be sent as a null-terminated ANSI string, we could do it like this:
 
 ```csharp
 [DllImport("somenativelibrary.dll")]


### PR DESCRIPTION
## Summary

OpenBuild was failing from the typo. This change also isn't in master
