### PR TITLE
Fixed typo in Design-GuideLines/Attributes page

### DIFF
--- a/docs/standard/design-guidelines/attributes.md
+++ b/docs/standard/design-guidelines/attributes.md
@@ -1,5 +1,5 @@
 ---
-title: "Attributes1"
+title: "Attributes"
 ms.date: "10/22/2008"
 ms.technology: dotnet-standard
 helpviewer_keywords: 


### PR DESCRIPTION
This bugged me so hard, i forked a massive repository.

## Summary

Removed an accidental additional character from the title attribute.
