### PR TITLE
replace msdn link with docs

### DIFF
--- a/docs/csharp/async.md
+++ b/docs/csharp/async.md
@@ -1,11 +1,11 @@
 ---
-title: Asynchronous programming
+title: Asynchronous programming - C#
 description: Learn about the C# language-level asynchronous programming model provided by .NET Core.
 author: cartermp
 ms.date: 06/20/2016
 ms.assetid: b878c34c-a78f-419e-a594-a2b44fa521a4
+ms.custom: seodec18
 ---
-
 # Asynchronous programming
 
 If you have any I/O-bound needs (such as requesting data from a network or accessing a database), you'll want to utilize asynchronous programming.  You could also have CPU-bound code, such as performing an expensive calculation, which is also a good scenario for writing async code.
@@ -259,5 +259,5 @@ A recommended goal is to achieve complete or near-complete [Referential Transpar
 ## Other Resources
 
 * [Async in-depth](../standard/async-in-depth.md) provides more information about how Tasks work.
-* [Asynchronous programming with async and await (C#)](../csharp/programming-guide/concepts/async/index.md)
+* [Asynchronous programming with async and await (C#)](./programming-guide/concepts/async/index.md)
 * Lucian Wischik's [Six Essential Tips for Async](https://channel9.msdn.com/Series/Three-Essential-Tips-for-Async) are a wonderful resource for async programming

--- a/docs/framework/performance/writing-large-responsive-apps.md
+++ b/docs/framework/performance/writing-large-responsive-apps.md
@@ -355,7 +355,8 @@ public Symbol FindMatchingSymbol(string name)
  This code doesn’t use LINQ extension methods, lambdas, or enumerators, and it incurs no allocations. There are no allocations because the compiler can see that the `symbols` collection is a <xref:System.Collections.Generic.List%601> and can bind the resulting enumerator (a structure) to a local variable with the right type to avoid boxing. The original version of this function was a great example of the expressive power of C# and the productivity of the .NET Framework. This new and more efficient version preserves those qualities without adding any complex code to maintain. 
   
 ### Async method caching  
- The next example shows a common problem when you try to use cached results in an [async](https://msdn.microsoft.com/library/db854f91-ccef-4035-ae4d-0911fde808c7) method. 
+
+The next example shows a common problem when you try to use cached results in an [async](../../csharp/programming-guide/concepts/async/index.md) method.
   
  **Example 6: caching in async methods**  
   

--- a/docs/standard/io/asynchronous-file-i-o.md
+++ b/docs/standard/io/asynchronous-file-i-o.md
@@ -34,7 +34,7 @@ C# and Visual Basic each have two keywords for asynchronous programming:
 
 - `Await` (Visual Basic) or `await` (C#) operator, which is applied to the result of an async method.
 
-To implement asynchronous I/O operations, use these keywords in conjunction with the async methods, as shown in the following examples. For more information, see [Asynchronous Programming with Async and Await](https://msdn.microsoft.com/library/db854f91-ccef-4035-ae4d-0911fde808c7).
+To implement asynchronous I/O operations, use these keywords in conjunction with the async methods, as shown in the following examples. For more information, see [Asynchronous programming with async and await (C#)](../../csharp/programming-guide/concepts/async/index.md) or [Asynchronous Programming with Async and Await (Visual Basic)](../../visual-basic/programming-guide/concepts/async/index.md).
 
 The following example demonstrates how to use two <xref:System.IO.FileStream> objects to copy files asynchronously from one directory to another. Notice that the <xref:System.Web.UI.WebControls.Button.Click> event handler for the <xref:System.Windows.Controls.Button> control is marked with the `async` modifier because it calls an asynchronous method.
 
@@ -56,5 +56,6 @@ The next example shows the code-behind file and the XAML file that are used to o
 ## See also
 
 - <xref:System.IO.Stream>
-- [File and Stream I/O](../../../docs/standard/io/index.md)
-- [Asynchronous Programming with Async and Await](https://msdn.microsoft.com/library/db854f91-ccef-4035-ae4d-0911fde808c7)
+- [File and Stream I/O](index.md)
+- [Asynchronous programming with async and await (C#)](../../csharp/programming-guide/concepts/async/index.md)
+- [Asynchronous Programming with Async and Await (Visual Basic)](../../visual-basic/programming-guide/concepts/async/index.md)


### PR DESCRIPTION
Fixes #9637, related to #2037

Also added C# brand suffix to the main async article 