### PR TITLE
Added mutually recursive records example to records documentation

### DIFF
--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -88,7 +88,7 @@ let rr3 = { defaultRecord1 with Field2 = 42 }
 
  Sometime when creating a record, you may want to have it depend on another type that you would like to define afterwards. This is a compile error unless you define the record types to be mutually recursive.
 
-This can be achieved by using the `and` keyword to link 2 or more record types together by what is known as mutual recursion.
+ Defining mutually recursive records is done with the `and` keyword. This lets you link 2 or more record types together.
 
 The following records are created using the `and` keyword:
 

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -90,7 +90,7 @@ let rr3 = { defaultRecord1 with Field2 = 42 }
 
  Defining mutually recursive records is done with the `and` keyword. This lets you link 2 or more record types together.
 
-The following records are created using the `and` keyword:
+For example, the following code defines a `Person` and `Address` type as mutually recursive:
 
 ```fsharp
 // Create a Person type and use the Address type that is not defined

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -86,7 +86,7 @@ let rr3 = { defaultRecord1 with Field2 = 42 }
 
 ## Creating Mutually Recursive Records
 
-Sometimes when creating a record, you may have the need to use a type which isn't defined and which you intend to create later.
+ Sometime when creating a record, you may want to have it depend on another type that you would like to define afterwards. This is a compile error unless you define the record types to be mutually recursive.
 
 This can be achieved by using the `and` keyword to link 2 or more record types together by what is known as mutual recursion.
 

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -84,6 +84,42 @@ let defaultRecord2 = { Field1 = 1; Field2 = 25 }
 let rr3 = { defaultRecord1 with Field2 = 42 }
 ```
 
+## Creating Mutually Recursive Records
+
+Sometimes when creating a record, you may have the need to use a type which isn't defined and which you intend to create later.
+
+This can be achieved by using the `and` keyword to link 2 or more record types together by what is known as mutual recursion.
+
+The following records are created using the `and` keyword:
+
+```fsharp
+// Create a Person type and use the Address type that is not defined
+type Person =
+  { Name: string
+    Age: int
+    Address: Address }
+// Define the Address type which is used in the Person record
+and Address =
+  { Line1: string
+    Line2: string
+    PostCode: string }
+```
+
+The following records are not created with the `and` keyword and would not compile:
+
+```fsharp
+// This will error as the Person record tries to use the Address type which is not defined using the `and` keyword 
+type Person =
+  { Name: string
+    Age: int
+    Address: Address }
+
+type Address =
+  { Line1: string
+    Line2: string
+    PostCode: string }
+```
+
 ## Pattern Matching with Records
 
 Records can be used with pattern matching. You can specify some fields explicitly and provide variables for other fields that will be assigned when a match occurs. The following code example illustrates this.

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -105,7 +105,7 @@ and Address =
     PostCode: string }
 ```
 
-The following records are not created with the `and` keyword and would not compile:
+If you were to define the previous example without the `and` keyword, then it would not compile. The `and` keyword is required for mutually recursive definitions.
 
 ```fsharp
 // This will error as the Person record tries to use the Address type which is not defined using the `and` keyword 

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -107,19 +107,6 @@ and Address =
 
 If you were to define the previous example without the `and` keyword, then it would not compile. The `and` keyword is required for mutually recursive definitions.
 
-```fsharp
-// This will error as the Person record tries to use the Address type which is not defined using the `and` keyword 
-type Person =
-  { Name: string
-    Age: int
-    Address: Address }
-
-type Address =
-  { Line1: string
-    Line2: string
-    PostCode: string }
-```
-
 ## Pattern Matching with Records
 
 Records can be used with pattern matching. You can specify some fields explicitly and provide variables for other fields that will be assigned when a match occurs. The following code example illustrates this.

--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -86,9 +86,9 @@ let rr3 = { defaultRecord1 with Field2 = 42 }
 
 ## Creating Mutually Recursive Records
 
- Sometime when creating a record, you may want to have it depend on another type that you would like to define afterwards. This is a compile error unless you define the record types to be mutually recursive.
+Sometime when creating a record, you may want to have it depend on another type that you would like to define afterwards. This is a compile error unless you define the record types to be mutually recursive.
 
- Defining mutually recursive records is done with the `and` keyword. This lets you link 2 or more record types together.
+Defining mutually recursive records is done with the `and` keyword. This lets you link 2 or more record types together.
 
 For example, the following code defines a `Person` and `Address` type as mutually recursive:
 


### PR DESCRIPTION
## Added mutually recursive records example to records documentation

I have added a code example for creating mutually recursive record types as I couldn't find any information about them on the official documentation.

I noticed in the records.md file, some of the snippets were defined in the markdown file but most were in the samples repo. I have added the code inline but can move to the samples repo if desired.