### PR TITLE
Improve the documentation for the --roll-forward-on-no-candidate-fx

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -72,9 +72,14 @@ Displays the installed .NET Core runtimes.
 
 Displays the installed .NET Core SDKs.
 
-`--roll-forward-on-no-candidate-fx`
+`--roll-forward-on-no-candidate-fx <N>`
 
- Disables minor version roll forward, if set to `0`. For more information, see [Roll forward](../whats-new/dotnet-core-2-1.md#roll-forward).
+Defines behavior when the required shared framework is not available. `N` can be:
+ * `0` - Disable even minor version roll forward.
+ * `1` - Roll forward on minor version, but not on major version. This is the default behavior.
+ * `2` - Roll forward on minor and major versions.
+
+ For more information, see [Roll forward](../whats-new/dotnet-core-2-1.md#roll-forward).
 
 `-v|--verbosity <LEVEL>`
 

--- a/docs/core/whats-new/dotnet-core-2-1.md
+++ b/docs/core/whats-new/dotnet-core-2-1.md
@@ -92,21 +92,28 @@ Starting with .NET Core 2.0, if the version of .NET Core that an application was
 > [!IMPORTANT]
 > This roll-forward behavior doesn't apply to preview releases. Nor does it apply to major releases. For example, a .NET Core 1.0 application wouldn't roll forward to .NET Core 2.0 or .NET Core 2.1.
 
-You can also disable minor version roll forward in any of three ways:
+You can modify this behavior by changing the setting for the roll-forward on no candidate shared framework. The available settings are:
+- `0` - disable minor version roll forward behavior
+- `1` - enable minor version roll forward behavior. This is the default value for the setting.
+- `2` - enable minor and major version roll forward behavior. If this is set, even different major versions will be considered, so it's possible that .NET Core 2.0 application runs on .NET Core 3.0 shared framework.
 
-- Set the `DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX` environment variable to 0.
+You can modify this setting in any of three ways:
 
-- Add the following line to the runtimeconfig.json file:
+- Set the `DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX` environment variable to the desired value.
+
+- Add the following line to the runtimeconfig.json file with the desired value:
 
    ```json
    "rollForwardOnNoCandidateFx" : 0
    ```
 
-- When using [.NET Core CLI tools](../tools/index.md), include the following option with a .NET Core command such as `run`:
+- When using [.NET Core CLI tools](../tools/index.md), include the following option with a .NET Core command such as `run` with the desired value:
 
    ```console
    dotnet run --rollForwardOnNoCandidateFx=0
    ```
+
+Patch version roll forward is independent of this setting and is done after any potential minor or major version roll forward is applied.
 
 ## Deployment
 

--- a/docs/core/whats-new/dotnet-core-2-1.md
+++ b/docs/core/whats-new/dotnet-core-2-1.md
@@ -90,12 +90,12 @@ All .NET Core applications starting with the .NET Core 2.0 automatically roll fo
 Starting with .NET Core 2.0, if the version of .NET Core that an application was built with is not present at runtime, the application automatically runs against the latest installed *minor version* of .NET Core. In other words, if an application is built with .NET Core 2.0, and .NET Core 2.0 is not present on the host system but .NET Core 2.1 is, the application runs with .NET Core 2.1.
 
 > [!IMPORTANT]
-> This roll-forward behavior doesn't apply to preview releases. Nor does it apply to major releases. For example, a .NET Core 1.0 application wouldn't roll forward to .NET Core 2.0 or .NET Core 2.1.
+> This roll-forward behavior doesn't apply to preview releases. By default it also doesn't apply to major releases, but this can be changed with the settings below.
 
 You can modify this behavior by changing the setting for the roll-forward on no candidate shared framework. The available settings are:
-- `0` - disable minor version roll forward behavior
-- `1` - enable minor version roll forward behavior. This is the default value for the setting.
-- `2` - enable minor and major version roll forward behavior. If this is set, even different major versions will be considered, so it's possible that .NET Core 2.0 application runs on .NET Core 3.0 shared framework.
+- `0` - disable minor version roll forward behavior. With this setting application built for .NET Core 2.0.0 will roll forward to .NET Core 2.0.1, but not .NET Core 2.2.0 nor .NET Core 3.0.0.
+- `1` - enable minor version roll forward behavior. This is the default value for the setting. With this setting application built for .NET Core 2.0.0 will roll forward to either .NET Core 2.0.1 or .NET Core 2.2.0 depending on which one is installed, but it will not roll forward to .NET Core 3.0.0.
+- `2` - enable minor and major version roll forward behavior. If this is set, even different major versions will be considered, so application built for .NET Core 2.0.0 will roll forward to .NET Core 3.0.0.
 
 You can modify this setting in any of three ways:
 

--- a/docs/core/whats-new/dotnet-core-2-1.md
+++ b/docs/core/whats-new/dotnet-core-2-1.md
@@ -85,29 +85,29 @@ In .NET Core 2.1 SDK, all tools operations use the `dotnet tool` command. The fo
 
 ## Roll forward
 
-All .NET Core applications starting with the .NET Core 2.0 automatically roll forward to the latest *minor version* installed on a system.
+All .NET Core applications starting with .NET Core 2.0 automatically roll forward to the latest *minor version* installed on a system.
 
 Starting with .NET Core 2.0, if the version of .NET Core that an application was built with is not present at runtime, the application automatically runs against the latest installed *minor version* of .NET Core. In other words, if an application is built with .NET Core 2.0, and .NET Core 2.0 is not present on the host system but .NET Core 2.1 is, the application runs with .NET Core 2.1.
 
 > [!IMPORTANT]
-> This roll-forward behavior doesn't apply to preview releases. By default it also doesn't apply to major releases, but this can be changed with the settings below.
+> This roll-forward behavior doesn't apply to preview releases. By default, it also doesn't apply to major releases, but this can be changed with the settings below.
 
 You can modify this behavior by changing the setting for the roll-forward on no candidate shared framework. The available settings are:
-- `0` - disable minor version roll forward behavior. With this setting application built for .NET Core 2.0.0 will roll forward to .NET Core 2.0.1, but not .NET Core 2.2.0 nor .NET Core 3.0.0.
-- `1` - enable minor version roll forward behavior. This is the default value for the setting. With this setting application built for .NET Core 2.0.0 will roll forward to either .NET Core 2.0.1 or .NET Core 2.2.0 depending on which one is installed, but it will not roll forward to .NET Core 3.0.0.
-- `2` - enable minor and major version roll forward behavior. If this is set, even different major versions will be considered, so application built for .NET Core 2.0.0 will roll forward to .NET Core 3.0.0.
+- `0` - disable minor version roll-forward behavior. With this setting, an application built for .NET Core 2.0.0 will roll forward to .NET Core 2.0.1, but not to .NET Core 2.2.0 or .NET Core 3.0.0.
+- `1` - enable minor version roll-forward behavior. This is the default value for the setting. With this setting, an application built for .NET Core 2.0.0 will roll forward to either .NET Core 2.0.1 or .NET Core 2.2.0, depending on which one is installed, but it will not roll forward to .NET Core 3.0.0.
+- `2` - enable minor and major version roll-forward behavior. If set, even different major versions are considered, so an application built for .NET Core 2.0.0 will roll forward to .NET Core 3.0.0.
 
 You can modify this setting in any of three ways:
 
 - Set the `DOTNET_ROLL_FORWARD_ON_NO_CANDIDATE_FX` environment variable to the desired value.
 
-- Add the following line to the runtimeconfig.json file with the desired value:
+- Add the following line with the desired value to the `runtimeconfig.json` file:
 
    ```json
    "rollForwardOnNoCandidateFx" : 0
    ```
 
-- When using [.NET Core CLI tools](../tools/index.md), include the following option with a .NET Core command such as `run` with the desired value:
+- When using [.NET Core CLI tools](../tools/index.md), add the following option with the desired value to a .NET Core command such as `run`:
 
    ```console
    dotnet run --rollForwardOnNoCandidateFx=0


### PR DESCRIPTION
The argument requires a value, so making that explicit in the docs along with the description of possibly values.
Also improved the description of this argument to document the option to roll forward on major versions as well.

Related to dotnet/core-setup#4873