### PR TITLE
Binding names are case sensitive.

### DIFF
--- a/docs/framework/wcf/extending/ws-metadataexchange-bindings.md
+++ b/docs/framework/wcf/extending/ws-metadataexchange-bindings.md
@@ -10,7 +10,7 @@ This topic describes how the default metadata exchange bindings are constructed 
   
 |Default Binding Name|How the binding is constructed|  
 |--------------------------|------------------------------------|  
-|MexHttpBinding|A <xref:System.ServiceModel.WSHttpBinding> with transport-level security disabled.|  
-|MexHttpsBinding|A <xref:System.ServiceModel.WSHttpBinding> that supports transport-level security.|  
-|MexNamedPipeBinding|A  <xref:System.ServiceModel.Channels.CustomBinding> with a <xref:System.ServiceModel.Channels.NamedPipeTransportBindingElement> using the default values.|  
-|MexTcpBinding|A <xref:System.ServiceModel.Channels.CustomBinding> with a <xref:System.ServiceModel.Channels.TcpTransportBindingElement> using default values.|
+|mexHttpBinding|A <xref:System.ServiceModel.WSHttpBinding> with transport-level security disabled.|  
+|mexHttpsBinding|A <xref:System.ServiceModel.WSHttpBinding> that supports transport-level security.|  
+|mexNamedPipeBinding|A  <xref:System.ServiceModel.Channels.CustomBinding> with a <xref:System.ServiceModel.Channels.NamedPipeTransportBindingElement> using the default values.|  
+|mexTcpBinding|A <xref:System.ServiceModel.Channels.CustomBinding> with a <xref:System.ServiceModel.Channels.TcpTransportBindingElement> using default values.|


### PR DESCRIPTION
## Summary

I just changed the casing of the binding names as they are case sensitive in app.config / web.config files. I think this makes sense and helps avoiding errors.
