### PR TITLE
add some internal sql apis

### DIFF
--- a/docs/framework/additional-apis/_autoredirects.md
+++ b/docs/framework/additional-apis/_autoredirects.md
@@ -25,7 +25,7 @@ private int _AutoRedirects
 ```
 
 > [!WARNING]
-> The `HttpWebRequest._AutoRedirects` field is internal and not meant to be used directly in your code.
+> The `HttpWebRequest._AutoRedirects` field is internal and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/connection.md
+++ b/docs/framework/additional-apis/connection.md
@@ -25,7 +25,7 @@ internal class Connection : PooledStream
 ```
 
 > [!WARNING]
-> The `Connection` class is internal and not meant to be used directly in your code.
+> The `Connection` class is internal and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this class in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/connectiongroup.md
+++ b/docs/framework/additional-apis/connectiongroup.md
@@ -25,7 +25,7 @@ internal class ConnectionGroup
 ```
 
 > [!WARNING]
-> The `ConnectionGroup` class is internal and not meant to be used directly in your code.
+> The `ConnectionGroup` class is internal and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this class in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/datamemberfieldeditor-class.md
+++ b/docs/framework/additional-apis/datamemberfieldeditor-class.md
@@ -27,7 +27,7 @@ internal class DataMemberFieldEditor : UITypeEditor
 ```
 
 > [!WARNING]
-> The `DataMemberFieldEditor` class is internal and not meant to be used directly in your code.
+> The `DataMemberFieldEditor` class is internal and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this class in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/datamemberlisteditor-class.md
+++ b/docs/framework/additional-apis/datamemberlisteditor-class.md
@@ -27,7 +27,7 @@ internal class DataMemberListEditor : UITypeEditor
 ```
 
 > [!WARNING]
-> The `DataMemberListEditor` class is internal and not meant to be used directly in your code.
+> The `DataMemberListEditor` class is internal and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this class in a production application under any circumstance.
   

--- a/docs/framework/additional-apis/m_connectiongrouplist.md
+++ b/docs/framework/additional-apis/m_connectiongrouplist.md
@@ -25,7 +25,7 @@ private Hashtable m_ConnectionGroupList
 ```
 
 > [!WARNING]
-> The `ServicePoint.m_ConnectionGroupList` field is private and not meant to be used directly in your code.
+> The `ServicePoint.m_ConnectionGroupList` field is private and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/m_connectionlist.md
+++ b/docs/framework/additional-apis/m_connectionlist.md
@@ -25,7 +25,7 @@ private ArrayList m_ConnectionList
 ```
 
 > [!WARNING]
-> The `ConnectionGroup.m_ConnectionList` field is private and not meant to be used directly in your code.
+> The `ConnectionGroup.m_ConnectionList` field is private and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/m_writelist.md
+++ b/docs/framework/additional-apis/m_writelist.md
@@ -25,7 +25,7 @@ private ArrayList m_WriteList
 ```
 
 > [!WARNING]
-> The `Connection.m_WriteList` field is private and not meant to be used directly in your code.
+> The `Connection.m_WriteList` field is private and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/microsoft.sqlserver.server.smiorderproperty.item.md
+++ b/docs/framework/additional-apis/microsoft.sqlserver.server.smiorderproperty.item.md
@@ -2,7 +2,7 @@
 title: SmiOrderProperty.Item Property (Microsoft.SqlServer.Server)
 author: douglaslMS
 ms.author: douglasl
-ms.date: 12/19/2018
+ms.date: 12/20/2018
 ms.technology:
   - "dotnet-data"
 api_name:

--- a/docs/framework/additional-apis/microsoft.sqlserver.server.smiorderproperty.item.md
+++ b/docs/framework/additional-apis/microsoft.sqlserver.server.smiorderproperty.item.md
@@ -30,9 +30,9 @@ The column order.
 ## Remarks
 
 > [!WARNING]
-> The `SmiOrderProperty.Item` property is private and not meant to be used directly in your code.
+> The `SmiOrderProperty.Item` property is internal and is not meant to be used directly in your code.
 >
-> Microsoft does not support the use of this field in a production application under any circumstance.
+> Microsoft does not support the use of this property in a production application under any circumstance.
 
 ## Requirements
 

--- a/docs/framework/additional-apis/microsoft.sqlserver.server.smiorderproperty.item.md
+++ b/docs/framework/additional-apis/microsoft.sqlserver.server.smiorderproperty.item.md
@@ -1,0 +1,43 @@
+---
+title: SmiOrderProperty.Item Property (Microsoft.SqlServer.Server)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/19/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "Microsoft.SqlServer.Server.SmiOrderProperty.Item"
+  - "Microsoft.SqlServer.Server.SmiOrderProperty.get_Item"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SmiOrderProperty.Item Property
+
+Gets the column order for the entity. The assembly that contains this property has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+## Syntax
+
+```csharp
+internal SmiColumnOrder Item { get; }
+```
+
+## Property value
+
+The column order.
+
+## Remarks
+
+> [!WARNING]
+> The `SmiOrderProperty.Item` property is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:Microsoft.SqlServer.Server>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/s-isdebuggercheckdisabledfortestpurposes-field.md
+++ b/docs/framework/additional-apis/s-isdebuggercheckdisabledfortestpurposes-field.md
@@ -10,7 +10,6 @@ api_location:
 api_type: 
   - "Assembly"
 ms.assetid: 9033a513-c255-4f31-b6d7-09b8d8c50e2d
-robots: noindex,nofollow
 ---
 
 # s_isDebuggerCheckDisabledForTestPurposes Field

--- a/docs/framework/additional-apis/s_servicepointtable.md
+++ b/docs/framework/additional-apis/s_servicepointtable.md
@@ -25,7 +25,7 @@ private static Hashtable s_ServicePointTable
 ```
 
 > [!WARNING]
-> The `ServicePointManager.s_ServicePointTable` field is private and not meant to be used directly in your code.
+> The `ServicePointManager.s_ServicePointTable` field is private and is not meant to be used directly in your code.
 > 
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlchars.stream.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlchars.stream.md
@@ -1,0 +1,43 @@
+---
+title: SqlChars.Stream Property (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/19/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlChars.Stream"
+  - "System.Data.SqlTypes.SqlChars.get_Stream"
+  - "System.Data.SqlTypes.SqlChars.set_Stream"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlChars.Stream Property
+
+Gets or sets the character stream. The assembly that contains this property has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+internal SqlStreamChars Stream { get; set; }
+```
+
+## Property value
+
+`System.Data.SqlTypes.SqlStreamChars`
+The character stream.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlChars.Stream` property is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlchars.stream.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlchars.stream.md
@@ -24,15 +24,15 @@ internal SqlStreamChars Stream { get; set; }
 
 ## Property value
 
-`System.Data.SqlTypes.SqlStreamChars`
+`System.Data.SqlTypes.SqlStreamChars`\
 The character stream.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlChars.Stream` property is private and not meant to be used directly in your code.
+> The `SqlChars.Stream` property is internal and is not meant to be used directly in your code.
 >
-> Microsoft does not support the use of this field in a production application under any circumstance.
+> Microsoft does not support the use of this property in a production application under any circumstance.
 
 ## Requirements
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.-ctor.md
@@ -17,13 +17,13 @@ api_type:
 Initializes a new instance of the `SqlStreamChars` class. The assembly that contains this constructor has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
 
 ```csharp
-oublic SqlStreamChars ();
+protected SqlStreamChars ();
 ```
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars` constructor is private and not meant to be used directly in your code.
+> The `SqlStreamChars` constructor is protected and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.-ctor.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.-ctor.md
@@ -1,0 +1,36 @@
+---
+title: SqlStreamChars Constructor (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars..ctor"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars Constructor
+
+Initializes a new instance of the `SqlStreamChars` class. The assembly that contains this constructor has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+oublic SqlStreamChars ();
+```
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars` constructor is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.canseek.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.canseek.md
@@ -1,0 +1,42 @@
+---
+title: SqlStreamChars.CanSeek Property (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/19/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.CanSeek"
+  - "System.Data.SqlTypes.SqlStreamChars.get_CanSeek"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.CanSeek Property
+
+When overridden in a derived class, gets a value that indicates whether the current steam supports the seek operation. The assembly that contains this property has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+public abstract bool CanSeek { get; }
+```
+
+## Property value
+
+<xref:System.Boolean>  
+`true` if the current steam supports the seek operation; otherwise, `false`.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.CanSeek` property is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.canseek.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.canseek.md
@@ -23,13 +23,13 @@ public abstract bool CanSeek { get; }
 
 ## Property value
 
-<xref:System.Boolean>  
+<xref:System.Boolean>\
 `true` if the current steam supports the seek operation; otherwise, `false`.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.CanSeek` property is private and not meant to be used directly in your code.
+> The `SqlStreamChars.CanSeek` property is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.close.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.close.md
@@ -23,7 +23,7 @@ public virtual void Close ();
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Close` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Close` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.close.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.close.md
@@ -1,0 +1,36 @@
+---
+title: SqlStreamChars.Close Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Close"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Close Method
+
+Closes the current stream and releases any system resources associated with the stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+public virtual void Close ();
+```
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Close` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.dispose.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.dispose.md
@@ -1,0 +1,41 @@
+---
+title: SqlStreamChars.Dispose(Boolean) Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Dispose"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Dispose(Boolean) Method
+
+When overridden in a derived class, releases the resources used by the stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+protected virtual void Dispose (bool disposing);
+```
+
+## Parameters
+
+`disposing`  
+`true` to release both managed and unmanaged resources; `false` to release only unmanaged resources.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Dispose` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.dispose.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.dispose.md
@@ -22,13 +22,13 @@ protected virtual void Dispose (bool disposing);
 
 ## Parameters
 
-`disposing`  
+`disposing`\
 `true` to release both managed and unmanaged resources; `false` to release only unmanaged resources.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Dispose` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Dispose` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.flush.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.flush.md
@@ -1,0 +1,38 @@
+---
+title: SqlStreamChars.Flush Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Flush"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Flush Method
+
+When overridden in a derived class, clears all buffers for this stream and causes any buffered data to be written to the underlying device. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+## Syntax
+
+```csharp
+public abstract void Flush ();
+```
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Flush` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.flush.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.flush.md
@@ -25,7 +25,7 @@ public abstract void Flush ();
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Flush` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Flush` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.isnull.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.isnull.md
@@ -25,13 +25,13 @@ public abstract bool IsNull { get; }
 
 ## Property value
 
-<xref:System.Boolean>  
+<xref:System.Boolean>\
 `true` if the stream is `null`; otherwise, `false`.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.IsNull` property is private and not meant to be used directly in your code.
+> The `SqlStreamChars.IsNull` property is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.isnull.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.isnull.md
@@ -1,0 +1,44 @@
+---
+title: SqlStreamChars.IsNull Property (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/19/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.IsNull"
+  - "System.Data.SqlTypes.SqlStreamChars.get_IsNull"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.IsNull Property
+
+When overridden in a derived class, gets a value that indicates whether the stream is `null`. The assembly that contains this property has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+## Syntax
+
+```csharp
+public abstract bool IsNull { get; }
+```
+
+## Property value
+
+<xref:System.Boolean>  
+`true` if the stream is `null`; otherwise, `false`.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.IsNull` property is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.length.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.length.md
@@ -25,13 +25,13 @@ public abstract long Length { get; }
 
 ## Property value
 
-<xref:System.Int64>  
+<xref:System.Int64>\
 The length of the stream.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Length` property is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Length` property is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.length.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.length.md
@@ -1,0 +1,44 @@
+---
+title: SqlStreamChars.Length Property (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/19/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Length"
+  - "System.Data.SqlTypes.SqlStreamChars.get_Length"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Length Property
+
+When overridden in a derived class, gets the length of the current stream. The assembly that contains this property has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+## Syntax
+
+```csharp
+public abstract long Length { get; }
+```
+
+## Property value
+
+<xref:System.Int64>  
+The length of the stream.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Length` property is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.read.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.read.md
@@ -14,7 +14,7 @@ api_type:
 ---
 # SqlStreamChars.Read(Char[], Int32, Int32) Method
 
-When overridden in a derived class, reads the next character or next set of characters from the input stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+When overridden in a derived class, reads the next set of characters from the input stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
 
 ```csharp
 public abstract int Read (char[] buffer, int offset, int count);
@@ -22,24 +22,24 @@ public abstract int Read (char[] buffer, int offset, int count);
 
 ## Parameters
 
-`buffer`  
+`buffer`\
 A char array to read.
 
-`offset`  
+`offset`\
 An offset relative to origin.
 
-`count`  
+`count`\
 The number of characters to be read from the current stream.
 
 ## Returns
 
-<xref:System.Int32>
+<xref:System.Int32>\
 The total number of characters read into the buffer.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Read` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Read` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.read.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.read.md
@@ -1,0 +1,52 @@
+---
+title: SqlStreamChars.Read(Char[], Int32, Int32) Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Read"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Read(Char[], Int32, Int32) Method
+
+When overridden in a derived class, reads the next character or next set of characters from the input stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+public abstract int Read (char[] buffer, int offset, int count);
+```
+
+## Parameters
+
+`buffer`  
+A char array to read.
+
+`offset`  
+An offset relative to origin.
+
+`count`  
+The number of characters to be read from the current stream.
+
+## Returns
+
+<xref:System.Int32>
+The total number of characters read into the buffer.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Read` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.seek.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.seek.md
@@ -30,7 +30,7 @@ One of the enumeration values that indicates the reference point from which to o
 
 ## Returns
 
-<xref:System.Int36>
+<xref:System.Int32>
 The new position within the current stream.
 
 ## Remarks

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.seek.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.seek.md
@@ -22,21 +22,21 @@ public abstract long Seek (long offset, System.IO.SeekOrigin origin);
 
 ## Parameters
 
-`offset`  
+`offset`\
 A byte offset relative to `origin`.
 
-`origin`  
+`origin`\
 One of the enumeration values that indicates the reference point from which to obtain the new position.
 
 ## Returns
 
-<xref:System.Int32>
+<xref:System.Int32>\
 The new position within the current stream.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Seek` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Seek` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.seek.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.seek.md
@@ -1,0 +1,49 @@
+---
+title: SqlStreamChars.Seek(Int64, SeekOrigin) Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Seek"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Seek(Int64, SeekOrigin) Method
+
+When overridden in a derived class, sets the position within the current stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+public abstract long Seek (long offset, System.IO.SeekOrigin origin);
+```
+
+## Parameters
+
+`offset`  
+A byte offset relative to `origin`.
+
+`origin`  
+One of the enumeration values that indicates the reference point from which to obtain the new position.
+
+## Returns
+
+<xref:System.Int36>
+The new position within the current stream.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Seek` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.setlength.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.setlength.md
@@ -22,13 +22,13 @@ public abstract void SetLength (long value);
 
 ## Parameters
 
-`value`  
+`value`\
 The desired length of the current stream in bytes.
 
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.SetLength` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.SetLength` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.setlength.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.setlength.md
@@ -1,0 +1,41 @@
+---
+title: SqlStreamChars.SetLength(Int64) Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.SetLength"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.SetLength(Int64) Method
+
+When overridden in a derived class, releases the resources used by the stream. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+public abstract void SetLength (long value);
+```
+
+## Parameters
+
+`value`  
+The desired length of the current stream in bytes.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.SetLength` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.write.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.write.md
@@ -34,7 +34,7 @@ The number of characters to be written to the current stream.
 ## Remarks
 
 > [!WARNING]
-> The `SqlStreamChars.Write` method is private and not meant to be used directly in your code.
+> The `SqlStreamChars.Write` method is private and is not meant to be used directly in your code.
 >
 > Microsoft does not support the use of this field in a production application under any circumstance.
 

--- a/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.write.md
+++ b/docs/framework/additional-apis/system.data.sqltypes.sqlstreamchars.write.md
@@ -1,0 +1,47 @@
+---
+title: SqlStreamChars.Write(Char[], Int32, Int32) Method (System.Data.SqlTypes)
+author: douglaslMS
+ms.author: douglasl
+ms.date: 12/20/2018
+ms.technology:
+  - "dotnet-data"
+api_name:
+  - "System.Data.SqlTypes.SqlStreamChars.Write"
+api_location:
+  - "System.Data.dll"
+api_type:
+  - "Assembly"
+---
+# SqlStreamChars.Write(Char[], Int32, Int32) Method
+
+When overridden in a derived class, writes a sequence of characters to the current stream and advances the current position within this stream by the number of characters written. The assembly that contains this method has a friend relationship with SQLAccess.dll. It's intended for use by SQL Server. For other databases, use the hosting mechanism provided by that database.
+
+```csharp
+public abstract void Write (char[] buffer, int offset, int count);
+```
+
+## Parameters
+
+`buffer`  
+A char array to write.
+
+`offset`  
+An offset relative to origin.
+
+`count`  
+The number of characters to be written to the current stream.
+
+## Remarks
+
+> [!WARNING]
+> The `SqlStreamChars.Write` method is private and not meant to be used directly in your code.
+>
+> Microsoft does not support the use of this field in a production application under any circumstance.
+
+## Requirements
+
+**Namespace:** <xref:System.Data.SqlTypes>
+
+**Assembly:** System.Data (in System.Data.dll)
+
+**.NET Framework versions:** Available since 2.0.

--- a/docs/framework/additional-apis/toc.md
+++ b/docs/framework/additional-apis/toc.md
@@ -1,4 +1,19 @@
 # [Additional class libraries and APIs](index.md)
+## System.Data.SqlTypes
+### SqlChars Class
+#### [SqlChars.Stream Property](sqlchars-stream.md)
+### SqlStreamChars Class
+#### [SqlStreamChars Constructor](system.data.sqltypes.sqlstreamchars.-ctor.md)
+#### [CanSeek Property](system.data.sqltypes.sqlstreamchars.canseek.md)
+#### [IsNull Property](system.data.sqltypes.sqlstreamchars.isnull.md)
+#### [Length Property](system.data.sqltypes.sqlstreamchars.length.md)
+#### [Close Method](system.data.sqltypes.sqlstreamchars.close.md)
+#### [Dispose Method](system.data.sqltypes.sqlstreamchars.dispose.md)
+#### [Flush Method](system.data.sqltypes.sqlstreamchars.flush.md)
+#### [Read Method](system.data.sqltypes.sqlstreamchars.read.md)
+#### [Seek Method](system.data.sqltypes.sqlstreamchars.seek.md)
+#### [SetLength Method](system.data.sqltypes.sqlstreamchars.setlength.md)
+#### [Write Method](system.data.sqltypes.sqlstreamchars.write.md)
 ## System.Net
 ### [Connection Class](connection.md)
 #### [m_WriteList Field](m_writelist.md)

--- a/docs/framework/additional-apis/toc.md
+++ b/docs/framework/additional-apis/toc.md
@@ -1,7 +1,10 @@
 # [Additional class libraries and APIs](index.md)
+## Microsoft.SqlServer.Server
+### SmiOrderProperty Class
+#### [SmiOrderProperty.Item](microsoft.sqlserver.server.smiorderproperty.item.md)
 ## System.Data.SqlTypes
 ### SqlChars Class
-#### [SqlChars.Stream Property](sqlchars-stream.md)
+#### [SqlChars.Stream Property](system.data.sqltypes.sqlchars.stream.md)
 ### SqlStreamChars Class
 #### [SqlStreamChars Constructor](system.data.sqltypes.sqlstreamchars.-ctor.md)
 #### [CanSeek Property](system.data.sqltypes.sqlstreamchars.canseek.md)


### PR DESCRIPTION
This is needed for APIscan.

A lot of these existed prior in MSDN (e.g. https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/bb882618%28v%3dvs.100%29)

Made some changes according to our API style guide and also made some fixes (for example, there's no get_Stream method - that's just the getter for the Stream property).

@douglaslMS put you as the author since this is in the SQL arena.
