### PR TITLE
Methods: Return Values - Removing conditional and return null

### DIFF
--- a/docs/csharp/methods.md
+++ b/docs/csharp/methods.md
@@ -191,10 +191,7 @@ Sometimes, you want your method to return more than a single value. Starting wit
 public (string, string, string, int) GetPersonalInfo(string id)
 {
     PersonInfo per = PersonInfo.RetrieveInfoById(id);
-    if (per != null)
-       return (per.FirstName, per.MiddleName, per.LastName, per.Age);
-    else
-       return null;
+    return (per.FirstName, per.MiddleName, per.LastName, per.Age);
 }
 ```
 
@@ -202,8 +199,7 @@ The caller can then consume the returned tuple with code like the following:
 
 ```csharp
 var person = GetPersonalInfo("111111111")
-if (person != null)
-   Console.WriteLine("{person.Item1} {person.Item3}: age = {person.Item4}");
+Console.WriteLine("{person.Item1} {person.Item3}: age = {person.Item4}");
 ```
 
 Names can also be assigned to the tuple elements in the tuple type definition. The following example shows an alternate version of the `GetPersonalInfo` method that uses named elements:
@@ -212,10 +208,7 @@ Names can also be assigned to the tuple elements in the tuple type definition. T
 public (string FName, string MName, string LName, int Age) GetPersonalInfo(string id)
 {
     PersonInfo per = PersonInfo.RetrieveInfoById(id);
-    if (per != null)
-       return (per.FirstName, per.MiddleName, per.LastName, per.Age);
-    else
-       return null;
+    return (per.FirstName, per.MiddleName, per.LastName, per.Age);
 }
 ```
 
@@ -223,8 +216,7 @@ The previous call to the `GetPersonInfo` method can then be modified as follows:
 
 ```csharp
 var person = GetPersonalInfo("111111111");
-if (person != null)
-   Console.WriteLine("{person.FName} {person.LName}: age = {person.Age}");
+Console.WriteLine("{person.FName} {person.LName}: age = {person.Age}");
 ```
 
 If a method is passed an array as an argument and modifies the value of individual elements, it is not necessary for the method to return the array, although you may choose to do so for good style or functional flow of values.  This is because C# passes all reference types by value, and the value of an array reference is the pointer to the array. In the following example, changes to the contents of the `values` array that are made in the `DoubleValues` method are observable by any code that has a reference to the array.


### PR DESCRIPTION
## Summary

This PR came out from this [issue](https://github.com/dotnet/docs/issues/8959).

I gave two ideas, but I believe the first one is more important and objective. I remove conditional and return nulls from examples of return values with tuples.

I'm not sure if an example with nullable return it's so important to the docs, that's why I didn't do it.

Fixes #8959