### PR TITLE
C57267: Adding spaces before code to avoid broken display

### DIFF
--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -94,7 +94,8 @@ The `TaxiTripFarePrediction` class represents predicted results. It has a single
 
 ## Define data and model paths
 
-Add the following additional `using` statements to the top of the *Program.cs* file:  
+Add the following additional `using` statements to the top of the *Program.cs* file:
+
 [!code-csharp[AddUsings](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#1 "Add necessary usings")]
 
 You need to create three fields to hold the paths to the files with data sets and the file to save the model, and a global variable for the `TextLoader`:

--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -94,7 +94,7 @@ The `TaxiTripFarePrediction` class represents predicted results. It has a single
 
 ## Define data and model paths
 
-Add the following additional `using` statements to the top of the *Program.cs* file:
+Add the following additional `using` statements to the top of the *Program.cs* file:  
 [!code-csharp[AddUsings](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#1 "Add necessary usings")]
 
 You need to create three fields to hold the paths to the files with data sets and the file to save the model, and a global variable for the `TextLoader`:


### PR DESCRIPTION
Hello, @JRAlexander ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: add to spaces after end of line so that code snippet can be seen.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR then share your PR number so we can confirm and close this PR.
Many thanks in advance.