### PR TITLE
C57274: Changing wrong closing bracket in link structure

### DIFF
--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/data-driven-crud-microservice.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/data-driven-crud-microservice.md
@@ -251,7 +251,7 @@ The docker-compose.yml files at the solution level are not only more flexible th
 
 Finally, you can get that value from your code by using Configuration\["ConnectionString"\], as shown in the ConfigureServices method in an earlier code example.
 
-However, for production environments, you might want to explore additional ways on how to store secrets like the connection strings. An excellent way to manage application secrets is using [Azure Key Vault}(https://azure.microsoft.com/services/key-vault/).
+However, for production environments, you might want to explore additional ways on how to store secrets like the connection strings. An excellent way to manage application secrets is using [Azure Key Vault](https://azure.microsoft.com/services/key-vault/).
 
 Azure Key Vault helps to store and safeguard cryptographic keys and secrets used by your cloud applications and services. A secret is anything you want to keep strict control of, like API keys, connection strings, passwords, etc. and strict control includes usage logging, setting expiration, managing access, <span class="underline">among others</span>.
 


### PR DESCRIPTION
Hello, @CESARDELATORRE,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: There is "\}" bracket instead of "\]" in link that is breaking formatting on EN and some LOC pages.
 
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.