### PR TITLE
Quoted backticks

### DIFF
--- a/docs/standard/base-types/regular-expression-language-quick-reference.md
+++ b/docs/standard/base-types/regular-expression-language-quick-reference.md
@@ -170,7 +170,7 @@ ms.author: "ronpet"
 |`${` *name* `}`|Substitutes the substring matched by the named group *name*.|`\b(?<word1>\w+)(\s)(?<word2>\w+)\b`|`${word2} ${word1}`|"one two"|"two one"|  
 |`$$`|Substitutes a literal "$".|`\b(\d+)\s?USD`|`$$$1`|"103 USD"|"$103"|  
 |`$&`|Substitutes a copy of the whole match.|`\$?\d*\.?\d+`|`**$&**`|"$1.30"|"\*\*$1.30\*\*"|  
-|<code>$`</code>|Substitutes all the text of the input string before the match.|`B+`|<code>$`</code>|"AABBCC"|"AAAACC"|  
+|``$` ``|Substitutes all the text of the input string before the match.|`B+`|``$` ``|"AABBCC"|"AAAACC"|  
 |`$'`|Substitutes all the text of the input string after the match.|`B+`|`$'`|"AABBCC"|"AACCCC"|  
 |`$+`|Substitutes the last group that was captured.|`B+(C+)`|`$+`|"AABBCCDD"|"AACCDD"|  
 |`$_`|Substitutes the entire input string.|`B+`|`$_`|"AABBCC"|"AAAABBCCCC"|  

--- a/docs/standard/base-types/substitutions-in-regular-expressions.md
+++ b/docs/standard/base-types/substitutions-in-regular-expressions.md
@@ -27,7 +27,7 @@ ms.author: "ronpet"
 |`${` *name* `}`|Includes the last substring matched by the named group that is designated by `(?<`*name*`> )` in the replacement string. For more information, see [Substituting a Named Group](#Named).|  
 |`$$`|Includes a single "$" literal in the replacement string. For more information, see [Substituting a "$" Symbol](#DollarSign).|  
 |`$&`|Includes a copy of the entire match in the replacement string. For more information, see [Substituting the Entire Match](#EntireMatch).|  
-|<code>$\`</code>|Includes all the text of the input string before the match in the replacement string. For more information, see [Substituting the Text before the Match](#BeforeMatch).|  
+|``$` ``|Includes all the text of the input string before the match in the replacement string. For more information, see [Substituting the Text before the Match](#BeforeMatch).|  
 |`$'`|Includes all the text of the input string after the match in the replacement string. For more information, see [Substituting the Text after the Match](#AfterMatch).|  
 |`$+`|Includes the last group captured in the replacement string. For more information, see [Substituting the Last Captured Group](#LastGroup).|  
 |`$_`|Includes the entire input string in the replacement string. For more information, see [Substituting the Entire Input String](#EntireString).|  
@@ -136,14 +136,14 @@ ms.author: "ronpet"
   
 <a name="BeforeMatch"></a>   
 ## Substituting the Text Before the Match  
- The <code>$\`</code> substitution replaces the matched string with the entire input string before the match. That is, it duplicates the input string up to the match while removing the matched text. Any text that follows the matched text is unchanged in the result string. If there are multiple matches in an input string, the replacement text is derived from the original input string, rather than from the string in which text has been replaced by earlier matches. \(The example provides an illustration.\) If there is no match, the <code>$\`</code> substitution has no effect.  
+ The ``$` `` substitution replaces the matched string with the entire input string before the match. That is, it duplicates the input string up to the match while removing the matched text. Any text that follows the matched text is unchanged in the result string. If there are multiple matches in an input string, the replacement text is derived from the original input string, rather than from the string in which text has been replaced by earlier matches. \(The example provides an illustration.\) If there is no match, the ``$` `` substitution has no effect.  
   
- The following example uses the regular expression pattern `\d+` to match a sequence of one or more decimal digits in the input string. The replacement string <code>$`</code> replaces these digits with the text that precedes the match.  
+ The following example uses the regular expression pattern `\d+` to match a sequence of one or more decimal digits in the input string. The replacement string ``$` `` replaces these digits with the text that precedes the match.  
   
  [!code-csharp[Conceptual.Regex.Language.Substitutions#4](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.regex.language.substitutions/cs/before1.cs#4)]
  [!code-vb[Conceptual.Regex.Language.Substitutions#4](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.regex.language.substitutions/vb/before1.vb#4)]  
   
- In this example, the input string `"aa1bb2cc3dd4ee5"` contains five matches. The following table illustrates how the <code>$`</code> substitution causes the regular expression engine to replace each match in the input string. Inserted text is shown in bold in the results column.  
+ In this example, the input string `"aa1bb2cc3dd4ee5"` contains five matches. The following table illustrates how the ``$` `` substitution causes the regular expression engine to replace each match in the input string. Inserted text is shown in bold in the results column.  
   
 |Match|Position|String before match|Result string|  
 |-----------|--------------|-------------------------|-------------------|  


### PR DESCRIPTION
## Summary

On https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference

The rendering of ``<code>$`</code>`` differs slightly between GitHub (GFM) and docs-site (Markdig). GitHub renders the page as intended, but the docs site messes up when rendering the unescaped backtick under Substitutions.
A better way to format the code is to use double backticks (``` `` ```).

Fixes #9798 
