### PR TITLE
Fix #9736 - C# 7.3 and [field:] attributes

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/auto-implemented-properties.md
+++ b/docs/csharp/programming-guide/classes-and-structs/auto-implemented-properties.md
@@ -23,8 +23,6 @@ public string FirstName { get; set; } = "Jane";
   
  The class that is shown in the previous example is mutable. Client code can change the values in objects after they are created. In complex classes that contain significant behavior (methods) as well as data, it is often necessary to have public properties. However, for small classes or structs that just encapsulate a set of values (data) and have little or no behaviors, you should either make the objects immutable by declaring the set accessor as [private](../../../csharp/language-reference/keywords/private.md) (immutable to consumers) or by declaring only a get accessor (immutable everywhere except the constructor).  For more information, see [How to: Implement a Lightweight Class with Auto-Implemented Properties](../../../csharp/programming-guide/classes-and-structs/how-to-implement-a-lightweight-class-with-auto-implemented-properties.md).  
   
- Attributes are permitted on auto-implemented properties but obviously not on the backing fields since those are not accessible from your source code. If you must use an attribute on the backing field of a property, just create a regular property.  
-  
 ## See Also
 
 - [Properties](../../../csharp/programming-guide/classes-and-structs/properties.md)  


### PR DESCRIPTION
## Summary

Removed obsolet sentence as suggested by @BillWagner.

Fixes #9736 
