### PR TITLE
Updated link to the MSTest test framework

### DIFF
--- a/docs/core/testing/index.md
+++ b/docs/core/testing/index.md
@@ -38,7 +38,7 @@ More information on unit testing in .NET Core projects:
 You can also choose between:
 * [xUnit](https://xunit.github.io) 
 * [NUnit](https://nunit.org)
-* [MSTest](https://github.com/Microsoft/vstest-docs)
+* [MSTest](https://github.com/Microsoft/testfx-docs)
 
 You can learn more in the following walkthroughs:
 


### PR DESCRIPTION
The current link (https://github.com/Microsoft/vstest-docs) refers to the docs of the [Visual Studio Test Platform](https://github.com/Microsoft/vstest), which "supports running tests written in various test frameworks, and using a pluggable adapter model". I guess, Test Platform supports running tests written in the MSTest framework, for example. However, it's not the test framework itself.

The [MSTest examples docs](https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-mstest) show that the [`MSTest.TestFramework` package](https://www.nuget.org/packages/MSTest.TestFramework/) is used. That package is built from https://github.com/microsoft/testfx. As the current link refers to the docs, the updated link also points to the docs of the MSTest framework. 
