### PR TITLE
Clarify relationship between project and directory names

### DIFF
--- a/docs/core/tools/project-json-to-csproj.md
+++ b/docs/core/tools/project-json-to-csproj.md
@@ -33,7 +33,7 @@ The new format, \*.csproj, is an XML-based format. The following example shows t
 }
 ```
 
-No longer supported. In csproj, this is determined by the project filename, which is defined by the directory name. For example, `MyProjectName.csproj`.
+No longer supported. In csproj, this is determined by the project filename, which usually matches the directory name. For example, `MyProjectName.csproj`.
 
 By default, the project filename also specifies the value of the `<AssemblyName>` and `<PackageId>` properties.
 


### PR DESCRIPTION
The project name does not have to match the directory name, although they are usually created in this way. I feel this change makes it clearer where the default `<AssemblyName>` and `<PackageId>` properties come from.

A subject matter expert should confirm this however.