### PR TITLE
Fix absolute https://docs.microsoft.com/dotnet link (#8364)

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
@@ -19,7 +19,7 @@ This is the type of copy and paste reuse that many developers share between proj
 
 ## The custom Entity base class
 
-The following code is an example of an Entity base class where you can place code that can be used the same way by any domain entity, such as the entity ID, [equality operators](https://docs.microsoft.com/dotnet/csharp/language-reference/operators/equality-comparison-operator), a domain event list per entity, etc.
+The following code is an example of an Entity base class where you can place code that can be used the same way by any domain entity, such as the entity ID, [equality operators](~/docs/csharp/language-reference/operators/equality-comparison-operator.md), a domain event list per entity, etc.
 
 ```csharp
 // COMPATIBLE WITH ENTITY FRAMEWORK CORE (1.1 and later)


### PR DESCRIPTION
## Summary

Fix absolute https://docs.microsoft.com/dotnet link (#8364)

Contributes to #8364

edit by @mairaw: removed the fixes keyword 