### PR TITLE
Added link to Records page from the 'and' section of the Keyword Reference table

### DIFF
--- a/docs/fsharp/language-reference/keyword-reference.md
+++ b/docs/fsharp/language-reference/keyword-reference.md
@@ -14,7 +14,7 @@ The following table shows all F# keywords in alphabetical order, together with b
 |Keyword|Link|Description|
 |-------|----|-----------|
 |`abstract`|[Members](members/index.md)<br /><br />[Abstract Classes](abstract-classes.md)|Indicates a method that either has no implementation in the type in which it is declared or that is virtual and has a default implementation.|
-|`and`|[`let` Bindings](functions/let-bindings.md)<br /><br />[Members](members/index.md)<br /><br />[Constraints](generics/constraints.md)|Used in mutually recursive bindings, in property declarations, and with multiple constraints on generic parameters.|
+|`and`|[`let` Bindings](functions/let-bindings.md)<br /><br />[Records](records.md)<br /><br />[Members](members/index.md)<br /><br />[Constraints](generics/constraints.md)|Used in mutually recursive bindings and records, in property declarations, and with multiple constraints on generic parameters.|
 |`as`|[Classes](classes.md)<br /><br />[Pattern Matching](Pattern-Matching.md)|Used to give the current class object an object name. Also used to give a name to a whole pattern within a pattern match.|
 |`assert`|[Assertions](assertions.md)|Used to verify code during debugging.|
 |`base`|[Classes](classes.md)<br /><br />[Inheritance](inheritance.md)|Used as the name of the base class object.|


### PR DESCRIPTION
## Added a link to records page from the 'and' section of the keyword table 

Last month I added a section to the Records page about [creating mutually recursive records](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/records#creating-mutually-recursive-records). PR [here](https://github.com/dotnet/docs/pull/9664)

I've since noticed that on the [Keyword Reference](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/keyword-reference) page, it could do with having records linked from the _and_ section of the table which is what's included in this PR.