### PR TITLE
Extend String interpolation doc

### DIFF
--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -26,7 +26,7 @@ As the example shows, you include an expression in an interpolated string by enc
 
 At compile time, an interpolated string is typically transformed into a <xref:System.String.Format%2A?displayProperty=nameWithType> method call. That makes all the capabilities of the [string composite formatting](../../standard/base-types/composite-formatting.md) feature available to you to use with interpolated strings as well.
 
-If all expressions are strings, and none of them have alignment or format specifiers, an interpolated string will be transformed into a more efficient string concatenation <xref:System.String.Concat%2A?displayProperty=nameWithType> at compile time.
+The compiler may substitute a <xref:System.String.Format%2A?displayProperty=nameWithType> for <xref:System.String.Concat%2A?displayProperty=nameWithType> if the analyzed behavior would be equivalent to concatenation.
 
 ## How to specify a format string for an interpolated expression
 

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -26,6 +26,8 @@ As the example shows, you include an expression in an interpolated string by enc
 
 At compile time, an interpolated string is typically transformed into a <xref:System.String.Format%2A?displayProperty=nameWithType> method call. That makes all the capabilities of the [string composite formatting](../../standard/base-types/composite-formatting.md) feature available to you to use with interpolated strings as well.
 
+If all expressions are strings, and none of them have alignment or format specifiers, an interpolated string will be transformed into a more efficient string concatenation <xref:System.String.Concat%2A?displayProperty=nameWithType> at compile time.
+
 ## How to specify a format string for an interpolated expression
 
 You specify a format string that is supported by the type of the expression result by following the interpolated expression with a colon (":") and the format string:


### PR DESCRIPTION
## Extend String interpolation doc according to a new Roslyn's behaviour.

Added a new paragraph according to changes made in the Roslyn. 
Interpolated strings are not transformed into a String.Format method call all time. There is a common case when a String.Concat is used instead.

Please, see the issue #26612 https://github.com/dotnet/roslyn/pull/26612/commits/301eda3fe3618c5e39dd264d84fee1412a944f41 to additional information.