### PR TITLE
fix paveover links + formatting

### DIFF
--- a/docs/csharp/programming-guide/inside-a-program/hello-world-your-first-program.md
+++ b/docs/csharp/programming-guide/inside-a-program/hello-world-your-first-program.md
@@ -1,5 +1,5 @@
 ---
-title: "Hello World -- Your First Program - C# Programming Guide"
+title: "Hello World -- Your first program - C# Programming Guide"
 ms.custom: seodec18
 ms.date: 07/20/2015
 f1_keywords: 
@@ -10,123 +10,128 @@ helpviewer_keywords:
   - "Hello World example [C#]"
 ms.assetid: 6493182a-b0b6-4539-a719-518a168cb730
 ---
-# Hello World -- Your First Program (C# Programming Guide)
-The following procedure creates a C# version of the traditional "Hello World!" program. The program displays the string `Hello World!`  
-  
- For more examples of introductory concepts, see [Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic).  
-  
-[!INCLUDE[note_settings_general](~/includes/note-settings-general-md.md)]  
-  
-### To create and run a console application  
-  
-1.  Start Visual Studio.  
-  
-2.  On the menu bar, choose **File**, **New**, **Project**.  
-  
-     The **New Project** dialog box opens.  
-  
-3.  Expand **Installed**, expand **Templates**, expand **Visual C#**, and then choose **Console Application**.  
-  
-4.  In the **Name** box, specify a name for your project, and then choose the **OK** button.  
-  
-     The new project appears in **Solution Explorer**.  
-  
-5.  If Program.cs isn't open in the **Code Editor**, open the shortcut menu for **Program.cs** in **Solution Explorer**, and then choose **View Code**.  
-  
-6.  Replace the contents of Program.cs with the following code.  
-  
-     [!code-csharp[csProgGuide#21](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_1.cs)]  
-  
-7.  Choose the F5 key to run the project. A Command Prompt window appears that contains the line `Hello World!`  
-  
- Next, the important parts of this program are examined.  
-  
-## Comments  
- The first line contains a comment. The characters `//` convert the rest of the line to a comment.  
-  
- [!code-csharp[csProgGuide#32](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_2.cs)]  
-  
- You can also comment out a block of text by enclosing it between the `/*` and `*/` characters. This is shown in the following example.  
-  
- [!code-csharp[csProgGuide#33](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_3.cs)]  
-  
-## Main Method  
- A C# console application must contain a `Main` method, in which control starts and ends. The `Main` method is where you create objects and execute other methods.  
-  
- The `Main` method is a [static](../../../csharp/language-reference/keywords/static.md) method that resides inside a class or a struct. In the previous "Hello World!" example, it resides in a class named `Hello`. You can declare the `Main` method in one of the following ways:  
-  
--   It can return `void`.  
-  
-     [!code-csharp[csProgGuideMain#12](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_4.cs)]  
-  
--   It can also return an integer.  
-  
-     [!code-csharp[csProgGuideMain#13](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_5.cs)]  
-  
--   With either of the return types, it can take arguments.  
-  
-     [!code-csharp[csProgGuideMain#19](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_6.cs)]  
-  
-     -or-  
-  
-     [!code-csharp[csProgGuideMain#18](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_7.cs)]  
-  
- The parameter of the `Main` method, `args`, is a `string` array that contains the command-line arguments used to invoke the program. Unlike in C++, the array does not include the name of the executable (exe) file.  
-  
- For more information about how to use command-line arguments, see the examples in [Main() and Command-Line Arguments](../../../csharp/programming-guide/main-and-command-args/index.md) and [How to: Create and Use Assemblies Using the Command Line](../../../csharp/programming-guide/concepts/assemblies-gac/how-to-create-and-use-assemblies-using-the-command-line.md).  
-  
- The call to <xref:System.Console.ReadKey%2A> at the end of the `Main` method prevents the console window from closing before you have a chance to read the output when you run your program in debug mode, by pressing F5.  
-  
-## Input and Output  
- C# programs generally use the input/output services provided by the run-time library of the .NET Framework. The statement `System.Console.WriteLine("Hello World!");` uses the <xref:System.Console.WriteLine%2A> method. This is one of the output methods of the <xref:System.Console> class in the run-time library. It displays its string parameter on the standard output stream followed by a new line. Other <xref:System.Console> methods are available for different input and output operations. If you include the `using System;` directive at the beginning of the program, you can directly use the <xref:System> classes and methods without fully qualifying them. For example, you can call `Console.WriteLine` instead of `System.Console.WriteLine`:  
-  
- [!code-csharp[csProgGuide#1](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_8.cs)]  
-  
- [!code-csharp[csProgGuide#23](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_9.cs)]  
-  
- For more information about input/output methods, see <xref:System.IO>.  
-  
-## Command-Line Compilation and Execution  
- You can compile the "Hello World!" program by using the command line instead of the Visual Studio Integrated Development Environment (IDE).  
-  
-#### To compile and run from a command prompt  
-  
-1.  Paste the code from the preceding procedure into any text editor, and then save the file as a text file. Name the file `Hello.cs`. C# source code files use the extension `.cs`.  
-  
-2.  Perform one of the following steps to open a command-prompt window:  
-  
-    -   In Windows 10, on the **Start** menu, search for `Developer Command Prompt`, and then tap or choose **Developer Command Prompt for VS 2017**.  
-  
-         A Developer Command Prompt window appears.  
-  
-    -   In Windows 7, open the **Start** menu, expand the folder for the current version of Visual Studio, open the shortcut menu for **Visual Studio Tools**, and then choose **Developer Command Prompt for VS 2017**.  
-  
-         A Developer Command Prompt window appears.  
-  
-    -   Enable command-line builds from a standard Command Prompt window.  
-  
-         See [How to: Set Environment Variables for the Visual Studio Command Line](../../../csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md).  
-  
-3.  In the command-prompt window, navigate to the folder that contains your `Hello.cs` file.  
-  
-4.  Enter the following command to compile `Hello.cs`.  
-  
-     `csc Hello.cs`  
-  
-     If your program has no compilation errors, an executable file that is named `Hello.exe` is created.  
-  
-5.  In the command-prompt window, enter the following command to run the program:  
-  
-     `Hello`  
-  
- For more information about the C# compiler and its options, see [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md).
-  
-## See Also
+# Hello World -- Your first program (C# Programming Guide)
 
-- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
-- [Inside a C# Program](../../../csharp/programming-guide/inside-a-program/index.md)  
-- [Strings](../../../csharp/programming-guide/strings/index.md)  
-- [\<paveover>C# Sample Applications](https://msdn.microsoft.com/library/9a9d7aaa-51d3-4224-b564-95409b0f3e15)  
-- [C# Reference](../../../csharp/language-reference/index.md)  
-- [Main() and Command-Line Arguments](../../../csharp/programming-guide/main-and-command-args/index.md)  
+The following procedure creates a C# version of the traditional "Hello World!" program. The program displays the string `Hello World!`
+
+For more examples of introductory concepts, see [Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic).
+
+[!INCLUDE[note_settings_general](~/includes/note-settings-general-md.md)]
+
+## To create and run a console application
+
+1. Start Visual Studio.
+
+2. On the menu bar, choose **File**, **New**, **Project**.
+
+     The **New Project** dialog box opens.
+
+3. Expand **Installed**, expand **Templates**, expand **Visual C#**, and then choose **Console Application**.
+
+4. In the **Name** box, specify a name for your project, and then choose the **OK** button.
+
+     The new project appears in **Solution Explorer**.
+
+5. If Program.cs isn't open in the **Code Editor**, open the shortcut menu for **Program.cs** in **Solution Explorer**, and then choose **View Code**.
+
+6. Replace the contents of Program.cs with the following code.
+
+     [!code-csharp[csProgGuide#21](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_1.cs)]
+
+7. Choose the F5 key to run the project. A Command Prompt window appears that contains the line `Hello World!`
+
+Next, the important parts of this program are examined.
+
+## Comments
+
+The first line contains a comment. The characters `//` convert the rest of the line to a comment.
+
+[!code-csharp[csProgGuide#32](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_2.cs)]
+
+You can also comment out a block of text by enclosing it between the `/*` and `*/` characters. This is shown in the following example.
+
+[!code-csharp[csProgGuide#33](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_3.cs)]
+
+## Main method
+
+A C# console application must contain a `Main` method, in which control starts and ends. The `Main` method is where you create objects and execute other methods.
+
+The `Main` method is a [static](../../../csharp/language-reference/keywords/static.md) method that resides inside a class or a struct. In the previous "Hello World!" example, it resides in a class named `Hello`. You can declare the `Main` method in one of the following ways:
+
+- It can return `void`.
+
+     [!code-csharp[csProgGuideMain#12](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_4.cs)]
+
+- It can also return an integer.
+
+     [!code-csharp[csProgGuideMain#13](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_5.cs)]
+
+- With either of the return types, it can take arguments.
+
+     [!code-csharp[csProgGuideMain#19](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_6.cs)]
+
+     -or-
+
+     [!code-csharp[csProgGuideMain#18](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_7.cs)]
+
+The parameter of the `Main` method, `args`, is a `string` array that contains the command-line arguments used to invoke the program. Unlike in C++, the array does not include the name of the executable (exe) file.
+
+For more information about how to use command-line arguments, see the examples in [Main() and Command-Line Arguments](../../../csharp/programming-guide/main-and-command-args/index.md) and [How to: Create and Use Assemblies Using the Command Line](../../../csharp/programming-guide/concepts/assemblies-gac/how-to-create-and-use-assemblies-using-the-command-line.md).
+
+The call to <xref:System.Console.ReadKey%2A> at the end of the `Main` method prevents the console window from closing before you have a chance to read the output when you run your program in debug mode, by pressing F5.
+
+## Input and output
+
+C# programs generally use the input/output services provided by the run-time library of the .NET Framework. The statement `System.Console.WriteLine("Hello World!");` uses the <xref:System.Console.WriteLine%2A> method. This is one of the output methods of the <xref:System.Console> class in the run-time library. It displays its string parameter on the standard output stream followed by a new line. Other <xref:System.Console> methods are available for different input and output operations. If you include the `using System;` directive at the beginning of the program, you can directly use the <xref:System> classes and methods without fully qualifying them. For example, you can call `Console.WriteLine` instead of `System.Console.WriteLine`:
+
+[!code-csharp[csProgGuide#1](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_8.cs)]
+
+[!code-csharp[csProgGuide#23](../../../csharp/programming-guide/inside-a-program/codesnippet/CSharp/hello-world-your-first-program_9.cs)]
+
+For more information about input/output methods, see <xref:System.IO>.
+
+## Command-line compilation and execution
+
+You can compile the "Hello World!" program by using the command line instead of the Visual Studio Integrated Development Environment (IDE).
+
+### To compile and run from a command prompt
+
+1. Paste the code from the preceding procedure into any text editor, and then save the file as a text file. Name the file `Hello.cs`. C# source code files use the extension `.cs`.
+
+2. Perform one of the following steps to open a command-prompt window:
+
+    - In Windows 10, on the **Start** menu, search for `Developer Command Prompt`, and then tap or choose **Developer Command Prompt for VS 2017**.
+
+         A Developer Command Prompt window appears.
+
+    - In Windows 7, open the **Start** menu, expand the folder for the current version of Visual Studio, open the shortcut menu for **Visual Studio Tools**, and then choose **Developer Command Prompt for VS 2017**.
+
+         A Developer Command Prompt window appears.
+
+    - Enable command-line builds from a standard Command Prompt window.
+
+         See [How to: Set Environment Variables for the Visual Studio Command Line](../../../csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md).
+
+3. In the command-prompt window, navigate to the folder that contains your `Hello.cs` file.
+
+4. Enter the following command to compile `Hello.cs`.
+
+     `csc Hello.cs`
+
+     If your program has no compilation errors, an executable file that is named `Hello.exe` is created.
+
+5. In the command-prompt window, enter the following command to run the program:
+
+     `Hello`
+
+ For more information about the C# compiler and its options, see [C# Compiler Options](../../../csharp/language-reference/compiler-options/index.md).
+
+## See also
+
+- [C# Programming Guide](../../../csharp/programming-guide/index.md)
+- [Inside a C# Program](../../../csharp/programming-guide/inside-a-program/index.md)
+- [Strings](../../../csharp/programming-guide/strings/index.md)
+- [Samples and tutorials](../../../samples-and-tutorials/index.md)
+- [C# Reference](../../../csharp/language-reference/index.md)
+- [Main() and Command-Line Arguments](../../../csharp/programming-guide/main-and-command-args/index.md)
 - [Getting Started with Visual C# and Visual Basic](/visualstudio/ide/getting-started-with-visual-csharp-and-visual-basic)

--- a/docs/csharp/programming-guide/inside-a-program/index.md
+++ b/docs/csharp/programming-guide/inside-a-program/index.md
@@ -1,33 +1,39 @@
 ---
-title: "Inside a C# Program"
+title: "Inside a C# program"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "C# language, about C# program"
   - "Visual C#, program structure"
 ms.assetid: 9551354b-33f0-4e11-bbf0-1a35e3702b22
 ---
-# Inside a C# Program
-The section discusses the general structure of a C# program, and includes the standard "Hello, World!" example.  
-  
-## In This Section  
-  
--   [Hello World -- Your First Program](../../../csharp/programming-guide/inside-a-program/hello-world-your-first-program.md)  
-  
--   [General Structure of a C# Program](../../../csharp/programming-guide/inside-a-program/general-structure-of-a-csharp-program.md)  
-  
-## Related Sections  
-  
--   [Getting Started with C#](../../../csharp/getting-started/index.md)  
-  
--   [C# Programming Guide](../../../csharp/programming-guide/index.md)  
-  
--   [C# Reference](../../../csharp/language-reference/index.md)  
-  
--   [\<paveover>C# Sample Applications](https://msdn.microsoft.com/library/9a9d7aaa-51d3-4224-b564-95409b0f3e15)  
-  
-## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
-## See Also
+# Inside a C# program
 
-- [C# Programming Guide](../../../csharp/programming-guide/index.md)
+The section discusses the general structure of a C# program, and includes the standard "Hello, World!" example.
+
+## In this section
+
+- [Hello World -- Your First Program](hello-world-your-first-program.md)
+
+- [General Structure of a C# Program](general-structure-of-a-csharp-program.md)
+
+- [Identifier names](identifier-names.md)
+
+- [C# Coding Conventions](coding-conventions.md)
+
+## Related sections
+
+- [Getting Started with C#](../../getting-started/index.md)
+
+- [C# Programming Guide](../../programming-guide/index.md)
+
+- [C# Reference](../../language-reference/index.md)
+
+- [Samples and tutorials](../../../samples-and-tutorials/index.md)
+
+## C# language specification
+
+[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+
+## See also
+
+- [C# Programming Guide](../../programming-guide/index.md)

--- a/docs/framework/configure-apps/file-schema/startup/index.md
+++ b/docs/framework/configure-apps/file-schema/startup/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Startup Settings Schema"
+title: "Startup settings schema"
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "startup settings schema"
@@ -9,15 +9,17 @@ ms.assetid: 03de6972-442a-4648-9f3e-efa654e3b949
 author: "mcleblanc"
 ms.author: "markl"
 ---
-# Startup Settings Schema
+# Startup settings schema
+
 Startup settings specify the version of the common language runtime that should run the application.  
   
 |Element|Description|  
 |-------------|-----------------|  
-|[\<requiredRuntime>](../../../../../docs/framework/configure-apps/file-schema/startup/requiredruntime-element.md)|Specifies that the application supports only version 1.0 of the common language runtime. Applications built with runtime version 1.1 should use the **\<supportedRuntime>** element.|  
-|[\<supportedRuntime>](../../../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md)|Specifies which versions of the common language runtime the application supports.|  
-|[\<startup>](../../../../../docs/framework/configure-apps/file-schema/startup/startup-element.md)|Contains the **\<requiredRuntime>** and **\<supportedRuntime>** elements.|  
+|[\<requiredRuntime>](requiredruntime-element.md)|Specifies that the application supports only version 1.0 of the common language runtime. Applications built with runtime version 1.1 should use the **\<supportedRuntime>** element.|  
+|[\<supportedRuntime>](supportedruntime-element.md)|Specifies which versions of the common language runtime the application supports.|  
+|[\<startup>](startup-element.md)|Contains the **\<requiredRuntime>** and **\<supportedRuntime>** elements.|  
   
-## See Also  
- [Configuration File Schema](../../../../../docs/framework/configure-apps/file-schema/index.md)  
- [\<PaveOver> Specifying Which Runtime Version to Use](https://msdn.microsoft.com/library/c376208d-980d-42b4-865b-fbe0d9cc97c2)
+## See also
+
+- [Configuration File Schema](../index.md)  
+- [How to: Configure an app to support .NET Framework 4 or later versions](../../../migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)

--- a/docs/framework/configure-apps/file-schema/startup/requiredruntime-element.md
+++ b/docs/framework/configure-apps/file-schema/startup/requiredruntime-element.md
@@ -1,5 +1,5 @@
 ---
-title: "&lt;requiredRuntime&gt; Element"
+title: "&lt;requiredRuntime&gt; element"
 ms.date: "03/30/2017"
 f1_keywords: 
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#requiredRuntime"
@@ -9,74 +9,77 @@ helpviewer_keywords:
   - "<requiredRuntime> element"
   - "container tags, <requiredRuntime> element"
 ms.assetid: 9fa1639e-beb8-43be-b7a4-12f7b229c34b
-author: "mcleblanc"
-ms.author: "markl"
 ---
-# &lt;requiredRuntime&gt; Element
+# &lt;requiredRuntime&gt; element
+
 Specifies that the application supports only version 1.0 of the common language runtime. This element is deprecated and should no longer be used. The [`supportedRuntime`](supportedruntime-element.md) element should be used instead.
-  
- \<configuration>  
-\<startup>  
-\<requiredRuntime>  
-  
-## Syntax  
-  
-```xml  
-   <requiredRuntime    
-version="runtime version"  
-safemode="true|false"/>  
-```  
-  
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
-  
-### Attributes  
-  
-|Attribute|Description|  
-|---------------|-----------------|  
-|`version`|Optional attribute.<br /><br /> A string value that specifies the version of the .NET Framework that this application supports. The string value must match the directory name found under the .NET Framework installation root. The contents of the string value are not parsed.|  
-|`safemode`|Optional attribute.<br /><br /> Specifies whether the runtime startup code searches the registry to determine the runtime version.|  
-  
-## safemode Attribute  
-  
-|Value|Description|  
-|-----------|-----------------|  
-|`false`|The runtime startup code looks in the registry. This is the default value.|  
-|`true`|The runtime startup code does not look in the registry.|  
-  
-### Child Elements  
- None.  
-  
-### Parent Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|  
-|`startup`|Contains the `<requiredRuntime>` element.|  
-  
-## Remarks  
- Applications built to support only version 1.0 of the runtime must use the `<requiredRuntime>` element. Applications built using version 1.1 or later of the runtime must use the `<supportedRuntime>` element.  
-  
+
+\<configuration>
+\<startup>
+\<requiredRuntime>
+
+## Syntax
+
+```xml
+   <requiredRuntime  
+version="runtime version"
+safemode="true|false"/>
+```
+
+## Attributes and elements
+
+The following sections describe attributes, child elements, and parent elements.
+
+### Attributes
+
+|Attribute|Description|
+|---------------|-----------------|
+|`version`|Optional attribute.<br /><br /> A string value that specifies the version of the .NET Framework that this application supports. The string value must match the directory name found under the .NET Framework installation root. The contents of the string value are not parsed.|
+|`safemode`|Optional attribute.<br /><br /> Specifies whether the runtime startup code searches the registry to determine the runtime version.|
+
+## safemode attribute
+
+|Value|Description|
+|-----------|-----------------|
+|`false`|The runtime startup code looks in the registry. This is the default value.|
+|`true`|The runtime startup code does not look in the registry.|
+
+### Child elements
+
+None.
+
+### Parent elements
+
+|Element|Description|
+|-------------|-----------------|
+|`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|
+|`startup`|Contains the `<requiredRuntime>` element.|
+
+## Remarks
+ Applications built to support only version 1.0 of the runtime must use the `<requiredRuntime>` element. Applications built using version 1.1 or later of the runtime must use the `<supportedRuntime>` element.
+
 > [!NOTE]
->  If you use the [CorBindToRuntimeByCfg](../../../../../docs/framework/unmanaged-api/hosting/corbindtoruntimebycfg-function.md) function to specify the configuration file, you must use the `<requiredRuntime>` element for all versions of the runtime. The `<supportedRuntime>` element is ignored when you use [CorBindToRuntimeByCfg](../../../../../docs/framework/unmanaged-api/hosting/corbindtoruntimebycfg-function.md).  
-  
- The `version` attribute string must match the installation folder name for the specified version of the .NET Framework. This string is not interpreted. If the runtime startup code does not find a matching folder, the runtime is not loaded; the startup code shows an error message and quits.  
-  
+> If you use the [CorBindToRuntimeByCfg](../../../unmanaged-api/hosting/corbindtoruntimebycfg-function.md) function to specify the configuration file, you must use the `<requiredRuntime>` element for all versions of the runtime. The `<supportedRuntime>` element is ignored when you use [CorBindToRuntimeByCfg](../../../unmanaged-api/hosting/corbindtoruntimebycfg-function.md).
+
+ The `version` attribute string must match the installation folder name for the specified version of the .NET Framework. This string is not interpreted. If the runtime startup code does not find a matching folder, the runtime is not loaded; the startup code shows an error message and quits.
+
 > [!NOTE]
->  The startup code for an application that is hosted in Microsoft Internet Explorer ignores the `<requiredRuntime>` element.  
-  
-## Example  
- The following example shows how to specify the runtime version in a configuration file.  
-  
-```xml  
-<configuration>  
-   <startup>  
-      <requiredRuntime version="v1.0.3705" safemode="true"/>  
-   </startup>  
-</configuration>  
-```  
-  
-## See Also  
- [Startup Settings Schema](../../../../../docs/framework/configure-apps/file-schema/startup/index.md)  
- [Configuration File Schema](../../../../../docs/framework/configure-apps/file-schema/index.md)  
- [\<PaveOver> Specifying Which Runtime Version to Use](https://msdn.microsoft.com/library/c376208d-980d-42b4-865b-fbe0d9cc97c2)
+> The startup code for an application that is hosted in Microsoft Internet Explorer ignores the `<requiredRuntime>` element.
+
+## Example
+
+The following example shows how to specify the runtime version in a configuration file.
+
+```xml
+<configuration>
+   <startup>
+      <requiredRuntime version="v1.0.3705" safemode="true"/>
+   </startup>
+</configuration>
+```
+
+## See also
+
+- [Startup Settings Schema](index.md)
+- [Configuration File Schema](../index.md)
+- [How to: Configure an app to support .NET Framework 4 or later versions](../../../migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)

--- a/docs/framework/configure-apps/file-schema/startup/startup-element.md
+++ b/docs/framework/configure-apps/file-schema/startup/startup-element.md
@@ -1,5 +1,5 @@
 ---
-title: "&lt;startup&gt; Element"
+title: "&lt;startup&gt; element"
 ms.date: "03/30/2017"
 f1_keywords: 
   - "http://schemas.microsoft.com/.NetConfiguration/v2.0#configuration/startup"
@@ -12,81 +12,87 @@ ms.assetid: 536acfd8-f827-452f-838a-e14fa3b87621
 author: "mcleblanc"
 ms.author: "markl"
 ---
-# &lt;startup&gt; Element
-Specifies common language runtime startup information.  
-  
- \<configuration>  
-\<startup>  
-  
-## Syntax  
-  
-```xml  
-<startup useLegacyV2RuntimeActivationPolicy="true|false" >   
-</startup>  
-```  
-  
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
-  
-### Attributes  
-  
-|Attribute|Description|  
-|---------------|-----------------|  
-|`useLegacyV2RuntimeActivationPolicy`|Optional attribute.<br /><br /> Specifies whether to enable the [!INCLUDE[dnprdnext](../../../../../includes/dnprdnext-md.md)] runtime activation policy or to use the [!INCLUDE[net_v40_long](../../../../../includes/net-v40-long-md.md)] activation policy.|  
-  
-## useLegacyV2RuntimeActivationPolicy Attribute  
-  
-|Value|Description|  
-|-----------|-----------------|  
-|`true`|Enable [!INCLUDE[dnprdnext](../../../../../includes/dnprdnext-md.md)] runtime activation policy for the chosen runtime, which is to bind legacy runtime activation techniques (such as the [CorBindToRuntimeEx function](../../../../../docs/framework/unmanaged-api/hosting/corbindtoruntimeex-function.md)) to the runtime chosen from the configuration file instead of capping them at CLR version 2.0. Thus, if CLR version 4 or later is chosen from the configuration file, mixed-mode assemblies created with earlier versions of the .NET Framework are loaded with the chosen CLR version. Setting this value prevents CLR version 1.1 or CLR version 2.0 from loading into the same process, effectively disabling the in-process side-by-side feature.|  
-|`false`|Use the default activation policy for the [!INCLUDE[net_v40_short](../../../../../includes/net-v40-short-md.md)] and later, which is to allow legacy runtime activation techniques to load CLR version 1.1 or 2.0 into the process. Setting this value prevents mixed-mode assemblies from loading into the .NET Framework 4 or later unless they were built with the .NET Framework 4 or later. This value is the default.|  
-  
-### Child Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<requiredRuntime>](../../../../../docs/framework/configure-apps/file-schema/startup/requiredruntime-element.md)|Specifies that the application supports only version 1.0 of the common language runtime. Applications built with runtime version 1.1 or later should use the **\<supportedRuntime>** element.|  
-|[\<supportedRuntime>](../../../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md)|Specifies which versions of the common language runtime the application supports.|  
-  
-### Parent Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|  
-  
-## Remarks  
- The **\<supportedRuntime>** element should be used by all applications built using version 1.1 or later of the runtime. Applications built to support only version 1.0 of the runtime must use the **\<requiredRuntime>** element.  
-  
- The startup code for an application hosted in Microsoft Internet Explorer ignores the **\<startup>** element and its child elements.  
-  
-## The useLegacyV2RuntimeActivationPolicy Attribute  
- This attribute is useful if your application uses legacy activation paths, such as the [CorBindToRuntimeEx function](../../../../../docs/framework/unmanaged-api/hosting/corbindtoruntimeex-function.md), and you want those paths to activate version 4 of the CLR instead of an earlier version, or if your application is built with the [!INCLUDE[net_v40_short](../../../../../includes/net-v40-short-md.md)] but has a dependency on a mixed-mode assembly built with an earlier version of the .NET Framework. In those scenarios, set the attribute to `true`.  
-  
+# &lt;startup&gt; element
+
+Specifies common language runtime startup information.
+
+ \<configuration>
+\<startup>
+
+## Syntax
+
+```xml
+<startup useLegacyV2RuntimeActivationPolicy="true|false" > 
+</startup>
+```
+
+## Attributes and elements
+
+ The following sections describe attributes, child elements, and parent elements.
+
+### Attributes
+
+|Attribute|Description|
+|---------------|-----------------|
+|`useLegacyV2RuntimeActivationPolicy`|Optional attribute.<br /><br /> Specifies whether to enable the [!INCLUDE[dnprdnext](../../../../../includes/dnprdnext-md.md)] runtime activation policy or to use the [!INCLUDE[net_v40_long](../../../../../includes/net-v40-long-md.md)] activation policy.|
+
+## useLegacyV2RuntimeActivationPolicy attribute
+
+|Value|Description|
+|-----------|-----------------|
+|`true`|Enable [!INCLUDE[dnprdnext](../../../../../includes/dnprdnext-md.md)] runtime activation policy for the chosen runtime, which is to bind legacy runtime activation techniques (such as the [CorBindToRuntimeEx function](../../../unmanaged-api/hosting/corbindtoruntimeex-function.md)) to the runtime chosen from the configuration file instead of capping them at CLR version 2.0. Thus, if CLR version 4 or later is chosen from the configuration file, mixed-mode assemblies created with earlier versions of the .NET Framework are loaded with the chosen CLR version. Setting this value prevents CLR version 1.1 or CLR version 2.0 from loading into the same process, effectively disabling the in-process side-by-side feature.|
+|`false`|Use the default activation policy for the [!INCLUDE[net_v40_short](../../../../../includes/net-v40-short-md.md)] and later, which is to allow legacy runtime activation techniques to load CLR version 1.1 or 2.0 into the process. Setting this value prevents mixed-mode assemblies from loading into the .NET Framework 4 or later unless they were built with the .NET Framework 4 or later. This value is the default.|
+
+### Child elements
+
+|Element|Description|
+|-------------|-----------------|
+|[\<requiredRuntime>](requiredruntime-element.md)|Specifies that the application supports only version 1.0 of the common language runtime. Applications built with runtime version 1.1 or later should use the **\<supportedRuntime>** element.|
+|[\<supportedRuntime>](supportedruntime-element.md)|Specifies which versions of the common language runtime the application supports.|
+
+### Parent elements
+
+|Element|Description|
+|-------------|-----------------|
+|`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|
+
+## Remarks
+
+ The **\<supportedRuntime>** element should be used by all applications built using version 1.1 or later of the runtime. Applications built to support only version 1.0 of the runtime must use the **\<requiredRuntime>** element.
+
+ The startup code for an application hosted in Microsoft Internet Explorer ignores the **\<startup>** element and its child elements.
+
+## The useLegacyV2RuntimeActivationPolicy attribute
+
+ This attribute is useful if your application uses legacy activation paths, such as the [CorBindToRuntimeEx function](../../../unmanaged-api/hosting/corbindtoruntimeex-function.md), and you want those paths to activate version 4 of the CLR instead of an earlier version, or if your application is built with the [!INCLUDE[net_v40_short](../../../../../includes/net-v40-short-md.md)] but has a dependency on a mixed-mode assembly built with an earlier version of the .NET Framework. In those scenarios, set the attribute to `true`.
+
 > [!NOTE]
->  Setting the attribute to `true` prevents CLR version 1.1 or CLR version 2.0 from loading into the same process, effectively disabling the in-process side-by-side feature (see [Side-by-Side Execution for COM Interop](https://msdn.microsoft.com/library/4302318c-3586-49bf-8620-b9a39cdf4a32)).  
-  
-## Example  
- The following example shows how to specify the runtime version in a configuration file.  
-  
-```xml  
-<!-- When used with version 1.0 of the .NET Framework runtime -->  
-<configuration>  
-   <startup>  
-      <requiredRuntime version="v1.0.3705" safemode="true"/>  
-   </startup>  
-</configuration>  
-<!-- When used with version 1.1 (or later) of the runtime -->  
-<configuration>  
-   <startup>  
-      <supportedRuntime version="v1.1.4322"/>  
-      <supportedRuntime version="v1.0.3705"/>  
-   </startup>  
-</configuration>  
-```  
-  
-## See Also  
- [Startup Settings Schema](../../../../../docs/framework/configure-apps/file-schema/startup/index.md)  
- [Configuration File Schema](../../../../../docs/framework/configure-apps/file-schema/index.md)  
- [\<PaveOver> Specifying Which Runtime Version to Use](https://msdn.microsoft.com/library/c376208d-980d-42b4-865b-fbe0d9cc97c2)  
- [Side-by-Side Execution for COM Interop](https://msdn.microsoft.com/library/4302318c-3586-49bf-8620-b9a39cdf4a32)  
- [In-Process Side-by-Side Execution](../../../../../docs/framework/deployment/in-process-side-by-side-execution.md)
+> Setting the attribute to `true` prevents CLR version 1.1 or CLR version 2.0 from loading into the same process, effectively disabling the in-process side-by-side feature (see [Side-by-Side Execution for COM Interop](https://msdn.microsoft.com/library/4302318c-3586-49bf-8620-b9a39cdf4a32)).
+
+## Example
+
+ The following example shows how to specify the runtime version in a configuration file.
+
+```xml
+<!-- When used with version 1.0 of the .NET Framework runtime -->
+<configuration>
+   <startup>
+      <requiredRuntime version="v1.0.3705" safemode="true"/>
+   </startup>
+</configuration>
+<!-- When used with version 1.1 (or later) of the runtime -->
+<configuration>
+   <startup>
+      <supportedRuntime version="v1.1.4322"/>
+      <supportedRuntime version="v1.0.3705"/>
+   </startup>
+</configuration>
+```
+
+## See also
+
+- [Startup Settings Schema](index.md)
+- [Configuration File Schema](../index.md)
+- [How to: Configure an app to support .NET Framework 4 or later versions](../../../migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)
+- [Side-by-Side Execution for COM Interop](https://msdn.microsoft.com/library/4302318c-3586-49bf-8620-b9a39cdf4a32)
+- [In-Process Side-by-Side Execution](../../../deployment/in-process-side-by-side-execution.md)

--- a/docs/framework/deployment/how-to-debug-clr-activation-issues.md
+++ b/docs/framework/deployment/how-to-debug-clr-activation-issues.md
@@ -1,5 +1,5 @@
 ---
-title: "How to: Debug CLR Activation Issues"
+title: "How to debug CLR activation issues"
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "CLR activation, debugging issues"
@@ -7,109 +7,112 @@ ms.assetid: 4fe17546-d56e-4344-a930-6d8e4a545914
 author: "mairaw"
 ms.author: "mairaw"
 ---
-# How to: Debug CLR Activation Issues
-If you encounter problems in getting your application to run with the correct version of the common language runtime (CLR), you can view and debug CLR activation logs. These logs can be very useful in determining the root cause of an activation issue, when your application either loads a different CLR version than expected or doesn't load the CLR at all. The [.NET Framework Initialization Errors: Managing the User Experience](../../../docs/framework/deployment/initialization-errors-managing-the-user-experience.md) discusses the experience when no CLR is found for an application.  
-  
- CLR activation logging can be enabled system-wide by using an HKEY_LOCAL_MACHINE registry key or a system environment variable. The log will be generated until the registry entry or the environment variable is removed. Alternatively, you can use a user or process-local environment variable to enable logging with a different scope and duration.  
-  
- CLR activation logs shouldn't be confused with [assembly binding logs](../../../docs/framework/tools/fuslogvw-exe-assembly-binding-log-viewer.md), which are entirely different.  
-  
-## To enable CLR activation logging  
-  
-#### Using the registry  
-  
-1.  In the Registry Editor, navigate to HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework (on a 32-bit computer) or HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\\.NETFramework folder (on a 64-bit computer).  
-  
-2.  Add a string value named `CLRLoadLogDir`, and set it to the full path of an existing directory where you'd like to store CLR activation logs.  
-  
- Activation logging remains enabled until you remove the string value.  
-  
-#### Using an environment variable  
-  
--   Set the `COMPLUS_CLRLoadLogDir` environment variable to a string that represents the full path of an existing directory where you'd like to store CLR activation logs.  
-  
-     How you set the environment variable determines its scope:  
-  
-    -   If you set it at the system level, activation logging is enabled for all .NET Framework applications on that computer until the environment variable is removed.  
-  
-    -   If you set it at the user level, activation logging is enabled only for the current user account. Logging continues until the environment variable is removed.  
-  
-    -   If you set it from within the process before loading the CLR, activation logging is enabled until the process terminates.  
-  
-    -   If you set it at a command prompt before you run an application, activation logging is enabled for any application that is run from that command prompt.  
-  
-     For example, to store activation logs in the c:\clrloadlogs directory with process-level scope, open a Command Prompt window and type the following before you run the application:  
-  
-    ```  
-    set COMPLUS_CLRLoadLogDir=c:\clrloadlogs  
-    ```  
-  
-## Example  
- CLR activation logs provide a large amount of data about CLR activation and the use of the CLR hosting APIs. Most of this data is used internally by Microsoft, but some of the data can also be useful to developers, as described in this article.  
-  
- The log reflects the order in which the CLR hosting APIs were called. It also includes useful data about the set of installed runtimes detected on the computer. The CLR activation log format is not itself documented, but can be used to aid developers who need to resolve CLR activation issues.  
-  
+# How to debug CLR activation issues
+
+If you encounter problems in getting your application to run with the correct version of the common language runtime (CLR), you can view and debug CLR activation logs. These logs can be very useful in determining the root cause of an activation issue, when your application either loads a different CLR version than expected or doesn't load the CLR at all. The [.NET Framework Initialization Errors: Managing the User Experience](../../../docs/framework/deployment/initialization-errors-managing-the-user-experience.md) discusses the experience when no CLR is found for an application.
+
+CLR activation logging can be enabled system-wide by using an HKEY_LOCAL_MACHINE registry key or a system environment variable. The log will be generated until the registry entry or the environment variable is removed. Alternatively, you can use a user or process-local environment variable to enable logging with a different scope and duration.
+
+CLR activation logs shouldn't be confused with [assembly binding logs](../../../docs/framework/tools/fuslogvw-exe-assembly-binding-log-viewer.md), which are entirely different.
+
+## To enable CLR activation logging
+
+### Using the registry
+
+1. In the Registry Editor, navigate to HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\\.NETFramework (on a 32-bit computer) or HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\\.NETFramework folder (on a 64-bit computer).
+
+2. Add a string value named `CLRLoadLogDir`, and set it to the full path of an existing directory where you'd like to store CLR activation logs.
+
+Activation logging remains enabled until you remove the string value.
+
+### Using an environment variable
+
+- Set the `COMPLUS_CLRLoadLogDir` environment variable to a string that represents the full path of an existing directory where you'd like to store CLR activation logs.
+
+     How you set the environment variable determines its scope:
+
+    - If you set it at the system level, activation logging is enabled for all .NET Framework applications on that computer until the environment variable is removed.
+
+    - If you set it at the user level, activation logging is enabled only for the current user account. Logging continues until the environment variable is removed.
+
+    - If you set it from within the process before loading the CLR, activation logging is enabled until the process terminates.
+
+    - If you set it at a command prompt before you run an application, activation logging is enabled for any application that is run from that command prompt.
+
+     For example, to store activation logs in the c:\clrloadlogs directory with process-level scope, open a Command Prompt window and type the following before you run the application:
+
+    ```
+    set COMPLUS_CLRLoadLogDir=c:\clrloadlogs
+    ```
+
+## Example
+
+CLR activation logs provide a large amount of data about CLR activation and the use of the CLR hosting APIs. Most of this data is used internally by Microsoft, but some of the data can also be useful to developers, as described in this article.
+
+The log reflects the order in which the CLR hosting APIs were called. It also includes useful data about the set of installed runtimes detected on the computer. The CLR activation log format is not itself documented, but can be used to aid developers who need to resolve CLR activation issues.
+
 > [!NOTE]
->  You cannot open an activation log until the process that uses the CLR has terminated.  
-  
+> You cannot open an activation log until the process that uses the CLR has terminated.
+
 > [!NOTE]
->  CLR activation logs are not localized; they are always generated in the English language.  
-  
- In the following example of an activation log, the most useful information is highlighted and described after the log.  
-  
-```  
-532,205950.367,CLR Loading log for C:\Tests\myapp.exe   
-532,205950.367,Log started at 4:26:12 PM on 10/6/2011   
-532,205950.367,-----------------------------------   
-532,205950.382,FunctionCall: _CorExeMain   
-532,205950.382,FunctionCall: ClrCreateInstance, Clsid: {2EBCD49A-1B47-4A61-B13A-4A03701E594B}, Iid: {E2190695-77B2-492E-8E14-C4B3A7FDD593}   
-532,205950.382,MethodCall: ICLRMetaHostPolicy::GetRequestedRuntime. Version: (null), Metahost Policy Flags: 0x168, Binary: (null), Iid: {BD39D1D2-BA2F-486A-89B0-B4B0CB466891}   
-532,205950.382,Installed Runtime: v4.0.30319. VERSION_ARCHITECTURE: 0   
-532,205950.382,Input values for ComputeVersionString follow this line   
-532,205950.382,-----------------------------------   
-532,205950.382,Default Application Name: C:\Tests\myapp.exe   
-532,205950.382,IsLegacyBind is: 0   
-532,205950.382,IsCapped is 0   
-532,205950.382,SkuCheckFlags are 0   
-532,205950.382,ShouldEmulateExeLaunch is 0   
-532,205950.382,LegacyBindRequired is 0   
-532,205950.382,-----------------------------------   
-532,205950.382,Parsing config file: C:\Tests\myapp.exe   
-532,205950.382,UseLegacyV2RuntimeActivationPolicy is set to 0   
-532,205950.382,LegacyFunctionCall: GetFileVersion. Filename: C:\Tests\myapp.exe   
-532,205950.382,LegacyFunctionCall: GetFileVersion. Filename: C:\Tests\myapp.exe   
-532,205950.382,C:\Tests\myapp.exe was built with version: v2.0.50727   
-532,205950.382,ERROR: Version v2.0.50727 is not present on the machine.   
-532,205950.398,SEM_FAILCRITICALERRORS is set to 0   
-532,205950.398,Launching feature-on-demand installation. CmdLine: C:\Windows\system32\fondue.exe /enable-feature:NetFx3   
-532,205950.398,FunctionCall: RealDllMain. Reason: 0   
-532,205950.398,FunctionCall: OnShimDllMainCalled. Reason: 0  
-```  
-  
--   **CLR Loading log** provides the path to the executable that started the process that loaded managed code. Note that this could be a native host.  
-  
-    ```  
-    532,205950.367,CLR Loading log for C:\Tests\myapp.exe  
-    ```  
-  
--   **Installed Runtime** is the set of CLR versions installed on the computer that are candidates for the activation request.  
-  
-    ```  
-    532,205950.382,Installed Runtime: v4.0.30319. VERSION_ARCHITECTURE: 0  
-    ```  
-  
--   **built with version** is the version of the CLR that was used to build the binary that was provided to a method such as [ICLRMetaHostPolicy::GetRequestedRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahostpolicy-getrequestedruntime-method.md).  
-  
-    ```  
-    532,205950.382,C:\Tests\myapp.exe was built with version: v2.0.50727  
-    ```  
-  
--   **feature-on-demand installation** refers to enabling the .NET Framework 3.5 on Windows 8. See [.NET Framework Initialization Errors: Managing the User Experience](../../../docs/framework/deployment/initialization-errors-managing-the-user-experience.md) for more information about this scenario.  
-  
-    ```  
-    532,205950.398,Launching feature-on-demand installation. CmdLine: C:\Windows\system32\fondue.exe /enable-feature:NetFx3  
-    ```  
-  
-## See Also  
-- [Deployment](../../../docs/framework/deployment/index.md)  
-- [How to: Configure an App to Support .NET Framework 4 or 4.5](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)
+> CLR activation logs are not localized; they are always generated in the English language.
+
+In the following example of an activation log, the most useful information is highlighted and described after the log.
+
+```
+532,205950.367,CLR Loading log for C:\Tests\myapp.exe 
+532,205950.367,Log started at 4:26:12 PM on 10/6/2011 
+532,205950.367,----------------------------------- 
+532,205950.382,FunctionCall: _CorExeMain 
+532,205950.382,FunctionCall: ClrCreateInstance, Clsid: {2EBCD49A-1B47-4A61-B13A-4A03701E594B}, Iid: {E2190695-77B2-492E-8E14-C4B3A7FDD593} 
+532,205950.382,MethodCall: ICLRMetaHostPolicy::GetRequestedRuntime. Version: (null), Metahost Policy Flags: 0x168, Binary: (null), Iid: {BD39D1D2-BA2F-486A-89B0-B4B0CB466891} 
+532,205950.382,Installed Runtime: v4.0.30319. VERSION_ARCHITECTURE: 0 
+532,205950.382,Input values for ComputeVersionString follow this line 
+532,205950.382,----------------------------------- 
+532,205950.382,Default Application Name: C:\Tests\myapp.exe 
+532,205950.382,IsLegacyBind is: 0 
+532,205950.382,IsCapped is 0 
+532,205950.382,SkuCheckFlags are 0 
+532,205950.382,ShouldEmulateExeLaunch is 0 
+532,205950.382,LegacyBindRequired is 0 
+532,205950.382,----------------------------------- 
+532,205950.382,Parsing config file: C:\Tests\myapp.exe 
+532,205950.382,UseLegacyV2RuntimeActivationPolicy is set to 0 
+532,205950.382,LegacyFunctionCall: GetFileVersion. Filename: C:\Tests\myapp.exe 
+532,205950.382,LegacyFunctionCall: GetFileVersion. Filename: C:\Tests\myapp.exe 
+532,205950.382,C:\Tests\myapp.exe was built with version: v2.0.50727 
+532,205950.382,ERROR: Version v2.0.50727 is not present on the machine. 
+532,205950.398,SEM_FAILCRITICALERRORS is set to 0 
+532,205950.398,Launching feature-on-demand installation. CmdLine: C:\Windows\system32\fondue.exe /enable-feature:NetFx3 
+532,205950.398,FunctionCall: RealDllMain. Reason: 0 
+532,205950.398,FunctionCall: OnShimDllMainCalled. Reason: 0
+```
+
+- **CLR Loading log** provides the path to the executable that started the process that loaded managed code. Note that this could be a native host.
+
+    ```
+    532,205950.367,CLR Loading log for C:\Tests\myapp.exe
+    ```
+
+- **Installed Runtime** is the set of CLR versions installed on the computer that are candidates for the activation request.
+
+    ```
+    532,205950.382,Installed Runtime: v4.0.30319. VERSION_ARCHITECTURE: 0
+    ```
+
+- **built with version** is the version of the CLR that was used to build the binary that was provided to a method such as [ICLRMetaHostPolicy::GetRequestedRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahostpolicy-getrequestedruntime-method.md).
+
+    ```
+    532,205950.382,C:\Tests\myapp.exe was built with version: v2.0.50727
+    ```
+
+- **feature-on-demand installation** refers to enabling the .NET Framework 3.5 on Windows 8. See [.NET Framework Initialization Errors: Managing the User Experience](../../../docs/framework/deployment/initialization-errors-managing-the-user-experience.md) for more information about this scenario.
+
+    ```
+    532,205950.398,Launching feature-on-demand installation. CmdLine: C:\Windows\system32\fondue.exe /enable-feature:NetFx3
+    ```
+
+## See also
+
+- [Deployment](../../../docs/framework/deployment/index.md)
+- [How to: Configure an app to support .NET Framework 4 or later versions](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)

--- a/docs/framework/deployment/initialization-errors-managing-the-user-experience.md
+++ b/docs/framework/deployment/initialization-errors-managing-the-user-experience.md
@@ -1,5 +1,5 @@
 ---
-title: ".NET Framework Initialization Errors: Managing the User Experience"
+title: ".NET Framework initialization errors: Managing the user experience"
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "no framework found experience"
@@ -9,79 +9,87 @@ ms.assetid: 680a7382-957f-4f6e-b178-4e866004a07e
 author: "mairaw"
 ms.author: "mairaw"
 ---
-# .NET Framework Initialization Errors: Managing the User Experience
-The common language runtime (CLR) activation system determines the version of the CLR that will be used to run managed application code. In some cases, the activation system might not be able to find a version of the CLR to load. This situation typically occurs when an application requires a CLR version that is invalid or not installed on a given computer. If the requested version is not found, the CLR activation system returns an HRESULT error code from the function or interface that was called, and may display an error message to the user who is running the application. This article provides a list of HRESULT codes and explains how you can prevent the error message from being displayed.  
-  
- The CLR provides logging infrastructure to help you debug CLR activation issues, as described in [How to: Debug CLR Activation Issues](../../../docs/framework/deployment/how-to-debug-clr-activation-issues.md). This infrastructure should not be confused with [assembly binding logs](../../../docs/framework/tools/fuslogvw-exe-assembly-binding-log-viewer.md), which are entirely different.  
-  
-## CLR Activation HRESULT Codes  
- The CLR activation APIs return HRESULT codes to report the result of an activation operation to a host. CLR hosts should always consult these return values before proceeding with additional operations.  
-  
--   CLR_E_SHIM_RUNTIMELOAD  
-  
--   CLR_E_SHIM_RUNTIMEEXPORT  
-  
--   CLR_E_SHIM_INSTALLROOT  
-  
--   CLR_E_SHIM_INSTALLCOMP  
-  
--   CLR_E_SHIM_LEGACYRUNTIMEALREADYBOUND  
-  
--   CLR_E_SHIM_SHUTDOWNINPROGRESS  
-  
-## UI for Initialization Errors  
- If the CLR activation system cannot load the correct version of the runtime that is required by an application, it displays an error message to users to inform them that their computer is not properly configured to run the application, and provides them with an opportunity to remedy the situation. The following error message is typically presented in this situation. The user can choose **Yes** to go to a Microsoft website where they can download the correct .NET Framework version for the application.  
-  
- ![.NET Framework Initialization Error dialog box](../../../docs/framework/deployment/media/initerrordialog.png "InitErrorDialog")  
-Typical error message for initialization errors  
-  
-## Resolving the Initialization Error  
- As a developer, you have a variety of options for controlling the .NET Framework initialization error message. For example, you can use an API flag to prevent the message from being displayed, as discussed in the next section. However, you still have to resolve the issue that prevented your application from loading the requested runtime. Otherwise, your application may not run at all, or some functionality may not be available.  
-  
- To resolve the underlying issues and provide the best user experience (fewer error messages), we recommend the following:  
-  
--   For .NET Framework 3.5 (and earlier) applications: Configure your application to support the .NET Framework 4 or 4.5 (see [instructions](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)).  
-  
--   For .NET Framework 4 applications: Install the .NET Framework 4 redistributable package as part of your application setup. See [Deployment Guide for Developers](../../../docs/framework/deployment/deployment-guide-for-developers.md).  
-  
-## Controlling the Error Message  
- Displaying an error message to communicate that a requested .NET Framework version was not found can be viewed as either a helpful service or a minor annoyance to users. In either case, you can control this UI by passing flags to the activation APIs.  
-  
- The [ICLRMetaHostPolicy::GetRequestedRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahostpolicy-getrequestedruntime-method.md) method accepts a [METAHOST_POLICY_FLAGS](../../../docs/framework/unmanaged-api/hosting/metahost-policy-flags-enumeration.md) enumeration member as input. You can include the METAHOST_POLICY_SHOW_ERROR_DIALOG flag to request an error message if the requested version of the CLR is not found. By default, the error message is not displayed. (The [ICLRMetaHost::GetRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahost-getruntime-method.md) method does not accept this flag, and does not provide any other way to display the error message.)  
-  
- Windows provides a [SetErrorMode](https://go.microsoft.com/fwlink/p/?LinkID=255242) function that you can use to declare whether you want error messages to be shown as a result of code that runs within your process. You can specify the SEM_FAILCRITICALERRORS flag to prevent the error message from being displayed.  
-  
- However, in some scenarios, it is important to override the SEM_FAILCRITICALERRORS setting set by an application process. For example, if you have a native COM component that hosts the CLR and that is hosted in a process where SEM_FAILCRITICALERRORS is set, you may want to override the flag, depending on the impact of displaying error messages within that particular application process. In this case, you can use one of the following flags to override SEM_FAILCRITICALERRORS:  
-  
--   Use METAHOST_POLICY_IGNORE_ERROR_MODE with the [ICLRMetaHostPolicy::GetRequestedRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahostpolicy-getrequestedruntime-method.md) method.  
-  
--   Use RUNTIME_INFO_IGNORE_ERROR_MODE with the [GetRequestedRuntimeInfo](../../../docs/framework/unmanaged-api/hosting/getrequestedruntimeinfo-function.md) function.  
-  
-## UI Policy for CLR-Provided Hosts  
- The CLR includes a set of hosts for a variety of scenarios, and these hosts all display an error message when they encounter problems loading the required version of the runtime. The following table provides a list of hosts and their error message policies.  
-  
-|CLR host|Description|Error message policy|Can error message be disabled?|  
-|--------------|-----------------|--------------------------|------------------------------------|  
-|Managed EXE host|Launches managed EXEs.|Is shown in case of a missing .NET Framework version|No|  
-|Managed COM host|Loads managed COM components into a process.|Is shown in case of a missing .NET Framework version|Yes, by setting the SEM_FAILCRITICALERRORS flag|  
-|ClickOnce host|Launches ClickOnce applications.|Is shown in case of a missing .NET Framework version, starting with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)]|No|  
-|XBAP host|Launches WPF XBAP applications.|Is shown in case of a missing .NET Framework version, starting with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)]|No|  
-  
-## [!INCLUDE[win8](../../../includes/win8-md.md)] Behavior and UI  
- The CLR activation system provides the same behavior and UI on [!INCLUDE[win8](../../../includes/win8-md.md)] as it does on other versions of the Windows operating system, except when it encounters issues loading CLR 2.0. [!INCLUDE[win8](../../../includes/win8-md.md)] includes the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)], which uses CLR 4.5. However, [!INCLUDE[win8](../../../includes/win8-md.md)] does not include the .NET Framework 2.0, 3.0, or 3.5, which all use CLR 2.0. As a result, applications that depend on CLR 2.0 do not run on [!INCLUDE[win8](../../../includes/win8-md.md)] by default. Instead, they display the following dialog box to enable users to install the .NET Framework 3.5. Users can also enable the .NET Framework 3.5 in Control Panel. Both options are discussed in the article [Install the .NET Framework 3.5 on Windows 10, Windows 8.1, and Windows 8](../../../docs/framework/install/dotnet-35-windows-10.md).  
-  
- ![Dialog box for 3.5 install on Windows 8](../../../docs/framework/deployment/media/installdialog.png "installdialog")  
-Prompt for installing the .NET Framework 3.5 on demand  
-  
+# .NET Framework initialization errors: Managing the user experience
+
+The common language runtime (CLR) activation system determines the version of the CLR that will be used to run managed application code. In some cases, the activation system might not be able to find a version of the CLR to load. This situation typically occurs when an application requires a CLR version that is invalid or not installed on a given computer. If the requested version is not found, the CLR activation system returns an HRESULT error code from the function or interface that was called, and may display an error message to the user who is running the application. This article provides a list of HRESULT codes and explains how you can prevent the error message from being displayed.
+
+The CLR provides logging infrastructure to help you debug CLR activation issues, as described in [How to: Debug CLR Activation Issues](../../../docs/framework/deployment/how-to-debug-clr-activation-issues.md). This infrastructure should not be confused with [assembly binding logs](../../../docs/framework/tools/fuslogvw-exe-assembly-binding-log-viewer.md), which are entirely different.
+
+## CLR activation HRESULT codes
+
+The CLR activation APIs return HRESULT codes to report the result of an activation operation to a host. CLR hosts should always consult these return values before proceeding with additional operations.
+
+- CLR_E_SHIM_RUNTIMELOAD
+
+- CLR_E_SHIM_RUNTIMEEXPORT
+
+- CLR_E_SHIM_INSTALLROOT
+
+- CLR_E_SHIM_INSTALLCOMP
+
+- CLR_E_SHIM_LEGACYRUNTIMEALREADYBOUND
+
+- CLR_E_SHIM_SHUTDOWNINPROGRESS
+
+## UI for initialization errors
+
+If the CLR activation system cannot load the correct version of the runtime that is required by an application, it displays an error message to users to inform them that their computer is not properly configured to run the application, and provides them with an opportunity to remedy the situation. The following error message is typically presented in this situation. The user can choose **Yes** to go to a Microsoft website where they can download the correct .NET Framework version for the application.
+
+![.NET Framework Initialization Error dialog box](../../../docs/framework/deployment/media/initerrordialog.png "InitErrorDialog")
+Typical error message for initialization errors
+
+## Resolving the initialization error
+
+As a developer, you have a variety of options for controlling the .NET Framework initialization error message. For example, you can use an API flag to prevent the message from being displayed, as discussed in the next section. However, you still have to resolve the issue that prevented your application from loading the requested runtime. Otherwise, your application may not run at all, or some functionality may not be available.
+
+To resolve the underlying issues and provide the best user experience (fewer error messages), we recommend the following:
+
+- For .NET Framework 3.5 (and earlier) applications: Configure your application to support the .NET Framework 4 or later versions (see [instructions](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)).
+
+- For .NET Framework 4 applications: Install the .NET Framework 4 redistributable package as part of your application setup. See [Deployment Guide for Developers](../../../docs/framework/deployment/deployment-guide-for-developers.md).
+
+## Controlling the error message
+
+Displaying an error message to communicate that a requested .NET Framework version was not found can be viewed as either a helpful service or a minor annoyance to users. In either case, you can control this UI by passing flags to the activation APIs.
+
+The [ICLRMetaHostPolicy::GetRequestedRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahostpolicy-getrequestedruntime-method.md) method accepts a [METAHOST_POLICY_FLAGS](../../../docs/framework/unmanaged-api/hosting/metahost-policy-flags-enumeration.md) enumeration member as input. You can include the METAHOST_POLICY_SHOW_ERROR_DIALOG flag to request an error message if the requested version of the CLR is not found. By default, the error message is not displayed. (The [ICLRMetaHost::GetRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahost-getruntime-method.md) method does not accept this flag, and does not provide any other way to display the error message.)
+
+Windows provides a [SetErrorMode](https://go.microsoft.com/fwlink/p/?LinkID=255242) function that you can use to declare whether you want error messages to be shown as a result of code that runs within your process. You can specify the SEM_FAILCRITICALERRORS flag to prevent the error message from being displayed.
+
+However, in some scenarios, it is important to override the SEM_FAILCRITICALERRORS setting set by an application process. For example, if you have a native COM component that hosts the CLR and that is hosted in a process where SEM_FAILCRITICALERRORS is set, you may want to override the flag, depending on the impact of displaying error messages within that particular application process. In this case, you can use one of the following flags to override SEM_FAILCRITICALERRORS:
+
+- Use METAHOST_POLICY_IGNORE_ERROR_MODE with the [ICLRMetaHostPolicy::GetRequestedRuntime](../../../docs/framework/unmanaged-api/hosting/iclrmetahostpolicy-getrequestedruntime-method.md) method.
+
+- Use RUNTIME_INFO_IGNORE_ERROR_MODE with the [GetRequestedRuntimeInfo](../../../docs/framework/unmanaged-api/hosting/getrequestedruntimeinfo-function.md) function.
+
+## UI policy for CLR-provided hosts
+
+The CLR includes a set of hosts for a variety of scenarios, and these hosts all display an error message when they encounter problems loading the required version of the runtime. The following table provides a list of hosts and their error message policies.
+
+|CLR host|Description|Error message policy|Can error message be disabled?|
+|--------------|-----------------|--------------------------|------------------------------------|
+|Managed EXE host|Launches managed EXEs.|Is shown in case of a missing .NET Framework version|No|
+|Managed COM host|Loads managed COM components into a process.|Is shown in case of a missing .NET Framework version|Yes, by setting the SEM_FAILCRITICALERRORS flag|
+|ClickOnce host|Launches ClickOnce applications.|Is shown in case of a missing .NET Framework version, starting with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)]|No|
+|XBAP host|Launches WPF XBAP applications.|Is shown in case of a missing .NET Framework version, starting with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)]|No|
+
+## Windows 8 behavior and UI
+
+The CLR activation system provides the same behavior and UI on [!INCLUDE[win8](../../../includes/win8-md.md)] as it does on other versions of the Windows operating system, except when it encounters issues loading CLR 2.0. [!INCLUDE[win8](../../../includes/win8-md.md)] includes the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)], which uses CLR 4.5. However, [!INCLUDE[win8](../../../includes/win8-md.md)] does not include the .NET Framework 2.0, 3.0, or 3.5, which all use CLR 2.0. As a result, applications that depend on CLR 2.0 do not run on [!INCLUDE[win8](../../../includes/win8-md.md)] by default. Instead, they display the following dialog box to enable users to install the .NET Framework 3.5. Users can also enable the .NET Framework 3.5 in Control Panel. Both options are discussed in the article [Install the .NET Framework 3.5 on Windows 10, Windows 8.1, and Windows 8](../../../docs/framework/install/dotnet-35-windows-10.md).
+
+![Dialog box for 3.5 install on Windows 8](../../../docs/framework/deployment/media/installdialog.png "installdialog")
+Prompt for installing the .NET Framework 3.5 on demand
+
 > [!NOTE]
->  The [!INCLUDE[net_v45](../../../includes/net-v45-md.md)] replaces the .NET Framework 4 (CLR 4) on the user's computer. Therefore, .NET Framework 4 applications run seamlessly, without displaying this dialog box, on [!INCLUDE[win8](../../../includes/win8-md.md)].  
-  
- When the .NET Framework 3.5 is installed, users can run applications that depend on the .NET Framework 2.0, 3.0, or 3.5 on their [!INCLUDE[win8](../../../includes/win8-md.md)] computers. They can also run .NET Framework 1.0 and 1.1 applications, provided that those applications are not explicitly configured to run only on the .NET Framework 1.0 or 1.1. See [Migrating from the .NET Framework 1.1](../../../docs/framework/migration-guide/migrating-from-the-net-framework-1-1.md).  
-  
- Starting with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)], CLR activation logging has been improved to include log entries that record when and why the initialization error message is displayed. For more information, see [How to: Debug CLR Activation Issues](../../../docs/framework/deployment/how-to-debug-clr-activation-issues.md).  
-  
-## See Also  
-- [Deployment Guide for Developers](../../../docs/framework/deployment/deployment-guide-for-developers.md)  
-- [How to: Configure an App to Support .NET Framework 4 or 4.5](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)  
-- [How to: Debug CLR Activation Issues](../../../docs/framework/deployment/how-to-debug-clr-activation-issues.md)  
+> The [!INCLUDE[net_v45](../../../includes/net-v45-md.md)] replaces the .NET Framework 4 (CLR 4) on the user's computer. Therefore, .NET Framework 4 applications run seamlessly, without displaying this dialog box, on [!INCLUDE[win8](../../../includes/win8-md.md)].
+
+When the .NET Framework 3.5 is installed, users can run applications that depend on the .NET Framework 2.0, 3.0, or 3.5 on their [!INCLUDE[win8](../../../includes/win8-md.md)] computers. They can also run .NET Framework 1.0 and 1.1 applications, provided that those applications are not explicitly configured to run only on the .NET Framework 1.0 or 1.1. See [Migrating from the .NET Framework 1.1](../../../docs/framework/migration-guide/migrating-from-the-net-framework-1-1.md).
+
+Starting with the [!INCLUDE[net_v45](../../../includes/net-v45-md.md)], CLR activation logging has been improved to include log entries that record when and why the initialization error message is displayed. For more information, see [How to: Debug CLR Activation Issues](../../../docs/framework/deployment/how-to-debug-clr-activation-issues.md).
+
+## See also
+
+- [Deployment Guide for Developers](../../../docs/framework/deployment/deployment-guide-for-developers.md)
+- [How to: Configure an app to support .NET Framework 4 or later versions](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)
+- [How to: Debug CLR Activation Issues](../../../docs/framework/deployment/how-to-debug-clr-activation-issues.md)
 - [Install the .NET Framework 3.5 on Windows 10, Windows 8.1, and Windows 8](../../../docs/framework/install/dotnet-35-windows-10.md)

--- a/docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md
+++ b/docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md
@@ -1,80 +1,81 @@
 ---
-title: "How to: Configure an App to Support .NET Framework 4 or 4.5"
+title: "How to: Configure an app to support .NET Framework 4 or later versions"
 ms.date: "03/30/2017"
 helpviewer_keywords: 
-  - "configuring apps to support .NET Framework 4"
-  - ".NET Framework 4, configuring apps"
-  - ".NET Framework 4.5, configuring apps"
+  - "configuring apps to support .NET Framework"
+  - ".NET Framework, configuring apps"
 ms.assetid: 63c6b9a8-0088-4077-9aa3-521ab7290f79
 author: "mairaw"
 ms.author: "mairaw"
 ---
-# How to: Configure an App to Support .NET Framework 4 or 4.5
-All apps that host the common language runtime (CLR) need to start, or *activate*, the CLR in order to run managed code. Typically, a   .NET Framework app runs on the version of the CLR that it was built on, but you can change this behavior for desktop apps by using an application configuration file (sometimes referred to as an app.config file). However, you cannot change the default activation behavior for Windows Store apps or Windows Phone apps by using an application configuration file. This article explains how to enable your desktop app to run on another version of the .NET Framework and provides an example of how to target version 4 or 4.5.  
-  
- The version of the .NET Framework that an app runs on is determined in the following order:  
-  
--   Configuration file.  
-  
-     If the application configuration file includes [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) entries that specify one or more .NET Framework versions, and one of those versions is present on the user's computer, the app runs on that version. The configuration file reads [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) entries in the order they are listed, and uses the first .NET Framework version listed that is present on the user's computer. (Use the [\<requiredRuntime> element](../../../docs/framework/configure-apps/file-schema/startup/requiredruntime-element.md) for version 1.0.)  
-  
--   Compiled version.  
-  
-     If there is no configuration file, but the version of the .NET Framework that the app was built on is present on the user's computer, the app runs on that version.  
-  
--   Latest version installed.  
-  
-     If the version of the .NET Framework that the app was built on is not present and a configuration file does not specify a version in a [\<supportedRuntime> element](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md), the app tries to run on the latest version of the .NET Framework that is present on the user's computer.  
-  
-     However, .NET Framework 1.0, 1.1, 2.0, 3.0, and 3.5 apps do not automatically run on the .NET Framework 4 or later, and in some cases, the user may receive an error and may be prompted to install the .NET Framework 3.5. The activation behavior may also depend on the user’s operating system, because  different versions of Windows system include different versions of the .NET Framework. If your app supports both the .NET Framework 3.5 and 4 or later, we recommend that you indicate this with multiple entries in the configuration file to avoid .NET Framework initialization errors. For more information, see [Versions and Dependencies](../../../docs/framework/migration-guide/versions-and-dependencies.md).  
-  
- You might also want to configure your .NET Framework 3.5 apps to run on the .NET Framework 4 or 4.5, even on computers that have the .NET Framework 3.5 installed, to take advantage of the performance improvements in versions 4 and 4.5.  
-  
+# How to: Configure an App to Support .NET Framework 4 or later versions
+
+All apps that host the common language runtime (CLR) need to start, or *activate*, the CLR in order to run managed code. Typically, a   .NET Framework app runs on the version of the CLR that it was built on, but you can change this behavior for desktop apps by using an application configuration file (sometimes referred to as an app.config file). However, you cannot change the default activation behavior for Windows Store apps or Windows Phone apps by using an application configuration file. This article explains how to enable your desktop app to run on another version of the .NET Framework and provides an example of how to target version 4 or later versions.
+
+ The version of the .NET Framework that an app runs on is determined in the following order:
+
+- Configuration file.
+
+     If the application configuration file includes [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) entries that specify one or more .NET Framework versions, and one of those versions is present on the user's computer, the app runs on that version. The configuration file reads [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) entries in the order they are listed, and uses the first .NET Framework version listed that is present on the user's computer. (Use the [\<requiredRuntime> element](../../../docs/framework/configure-apps/file-schema/startup/requiredruntime-element.md) for version 1.0.)
+
+- Compiled version.
+
+     If there is no configuration file, but the version of the .NET Framework that the app was built on is present on the user's computer, the app runs on that version.
+
+- Latest version installed.
+
+     If the version of the .NET Framework that the app was built on is not present and a configuration file does not specify a version in a [\<supportedRuntime> element](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md), the app tries to run on the latest version of the .NET Framework that is present on the user's computer.
+
+     However, .NET Framework 1.0, 1.1, 2.0, 3.0, and 3.5 apps do not automatically run on the .NET Framework 4 or later, and in some cases, the user may receive an error and may be prompted to install the .NET Framework 3.5. The activation behavior may also depend on the user’s operating system, because  different versions of Windows system include different versions of the .NET Framework. If your app supports both the .NET Framework 3.5 and 4 or later, we recommend that you indicate this with multiple entries in the configuration file to avoid .NET Framework initialization errors. For more information, see [Versions and Dependencies](versions-and-dependencies.md).
+
+ You might also want to configure your .NET Framework 3.5 apps to run on the .NET Framework 4 or later versions, even on computers that have the .NET Framework 3.5 installed, to take advantage of the performance improvements in versions 4 and later versions.
+
 > [!IMPORTANT]
->  We recommend that you always test your app on every .NET Framework version that you support. See [Version Compatibility](../../../docs/framework/migration-guide/version-compatibility.md) for information about upgrading your application to support later .NET Framework versions.  
-  
- For information about modifying your .NET Framework 1.0 and 1.1 apps to support Windows 7 and Windows 8, see [Migrating from the .NET Framework 1.1](../../../docs/framework/migration-guide/migrating-from-the-net-framework-1-1.md).  
-  
-### To configure your app to run on the .NET Framework 4 or 4.5  
-  
-1.  Add or locate the configuration file for the .NET Framework project. The configuration file for an app is in the same directory and has the same name as the app, but has a .config extension. For example, for an app named MyExecutable.exe, the application configuration file is named MyExecutable.exe.config.  
-  
-     To add a configuration file, on the Visual Studio menu bar, choose **Project**, **Add New Item**. Choose **General** from the left pane, and then choose **Configuration File**.  Name the configuration file *appName*.exe.config. These menu choices are not available for Windows Store app or Windows phone app projects, because you cannot change the activation policy on those platforms.  
-  
-2.  Add the [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) element as follows to the application configuration file:  
-  
-    ```xml  
-    <configuration>  
-      <startup>  
-        <supportedRuntime version="<version>"/>  
-      </startup>  
-    </configuration>  
-    ```  
-  
-     where *\<version>* specifies the CLR version that aligns with the .NET Framework version that your app supports. Use the following strings:  
-  
-    -   .NET Framework 1.0: "v1.0.3705"  
-  
-    -   .NET Framework 1.1: "v1.1.4322"  
-  
-    -   .NET Framework 2.0, 3.0, and 3.5: "v2.0.50727"  
-  
-    -   .NET Framework 4 and 4.5 (including point releases such as 4.5.1): "v4.0"  
-  
-     You can add multiple [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) elements, listed in order of preference, to specify support for multiple versions of the .NET Framework.  
-  
- The following table demonstrates how application configuration file settings and the .NET Framework versions installed on a computer determine the version that a .NET Framework 3.5 app runs on. The examples are specific to a .NET Framework 3.5 application, but you can use similar logic to target applications built with earlier .NET Framework versions. Note that the .NET Framework 2.0 version number (v2.0.50727) is used to specify the .NET Framework 3.5 in the application configuration file.  
-  
-|App.config file setting|On computer with version 3.5 installed|On computer with versions 3.5 and 4 or 4.5 installed|On computer with version 4 or 4.5 installed|  
-|-|-|-|-|  
-|None|Runs on 3.5|Runs on 3.5|Displays error message that prompts user to install the correct version*|  
-|`<supportedRuntime version="v2.0.50727"/>`|Runs on 3.5|Runs on 3.5|Displays error message that prompts user to install the correct version*|  
-|`<supportedRuntime version="v2.0.50727"/>` <br /> `<supportedRuntime version="v4.0"/>`|Runs on 3.5|Runs on 3.5|Runs on 4 or 4.5|  
-|`<supportedRuntime version="v4.0"/>` <br /> `<supportedRuntime version="v2.0.50727"/>`|Runs on 3.5|Runs on 4 or 4.5|Runs on 4 or 4.5|  
-|`<supportedRuntime version="v4.0"/>`|Displays error message that prompts user to install the correct version*|Runs on 4 or 4.5|Runs on 4 or 4.5|  
-  
- \* For more information about this error message and ways to avoid it, see [.NET Framework Initialization Errors: Managing the User Experience](../../../docs/framework/deployment/initialization-errors-managing-the-user-experience.md).  
-  
-## See Also  
- [Migrating from the .NET Framework 1.1](../../../docs/framework/migration-guide/migrating-from-the-net-framework-1-1.md)  
- [Migration Guide](../../../docs/framework/migration-guide/index.md)
+> We recommend that you always test your app on every .NET Framework version that you support. See [Version Compatibility](version-compatibility.md) for information about upgrading your application to support later .NET Framework versions.
+
+ For information about modifying your .NET Framework 1.0 and 1.1 apps to support Windows 7 and Windows 8, see [Migrating from the .NET Framework 1.1](migrating-from-the-net-framework-1-1.md).
+
+## To configure your app to run on the .NET Framework 4 or later versions
+
+1. Add or locate the configuration file for the .NET Framework project. The configuration file for an app is in the same directory and has the same name as the app, but has a .config extension. For example, for an app named MyExecutable.exe, the application configuration file is named MyExecutable.exe.config.
+
+     To add a configuration file, on the Visual Studio menu bar, choose **Project**, **Add New Item**. Choose **General** from the left pane, and then choose **Configuration File**. Name the configuration file *appName*.exe.config. These menu choices are not available for Windows Store app or Windows phone app projects, because you cannot change the activation policy on those platforms.
+
+2. Add the [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) element as follows to the application configuration file:
+
+    ```xml
+    <configuration>
+      <startup>
+        <supportedRuntime version="<version>"/>
+      </startup>
+    </configuration>
+    ```
+
+     where *\<version>* specifies the CLR version that aligns with the .NET Framework version that your app supports. Use the following strings:
+
+    - .NET Framework 1.0: "v1.0.3705"
+
+    - .NET Framework 1.1: "v1.1.4322"
+
+    - .NET Framework 2.0, 3.0, and 3.5: "v2.0.50727"
+
+    - .NET Framework 4 and later versions: "v4.0"
+
+     You can add multiple [\<supportedRuntime>](../../../docs/framework/configure-apps/file-schema/startup/supportedruntime-element.md) elements, listed in order of preference, to specify support for multiple versions of the .NET Framework.
+
+ The following table demonstrates how application configuration file settings and the .NET Framework versions installed on a computer determine the version that a .NET Framework 3.5 app runs on. The examples are specific to a .NET Framework 3.5 application, but you can use similar logic to target applications built with earlier .NET Framework versions. Note that the .NET Framework 2.0 version number (v2.0.50727) is used to specify the .NET Framework 3.5 in the application configuration file.
+
+|App.config file setting|On computer with version 3.5 installed|On computer with versions 3.5 and 4 or later versions installed|On computer with version 4 or later versions installed|
+|-|-|-|-|
+|None|Runs on 3.5|Runs on 3.5|Displays error message that prompts user to install the correct version*|
+|`<supportedRuntime version="v2.0.50727"/>`|Runs on 3.5|Runs on 3.5|Displays error message that prompts user to install the correct version*|
+|`<supportedRuntime version="v2.0.50727"/>` <br /> `<supportedRuntime version="v4.0"/>`|Runs on 3.5|Runs on 3.5|Runs on 4 or later versions|
+|`<supportedRuntime version="v4.0"/>` <br /> `<supportedRuntime version="v2.0.50727"/>`|Runs on 3.5|Runs on 4 or later versions|Runs on 4 or later versions|
+|`<supportedRuntime version="v4.0"/>`|Displays error message that prompts user to install the correct version*|Runs on 4 or later versions|Runs on 4 or later versions|
+
+ \* For more information about this error message and ways to avoid it, see [.NET Framework Initialization Errors: Managing the User Experience](../../../docs/framework/deployment/initialization-errors-managing-the-user-experience.md).
+
+## See also
+
+- [Migrating from the .NET Framework 1.1](migrating-from-the-net-framework-1-1.md)
+- [Migration Guide](index.md)

--- a/docs/framework/migration-guide/index.md
+++ b/docs/framework/migration-guide/index.md
@@ -9,30 +9,33 @@ ms.assetid: 02d55147-9b3a-4557-a45f-fa936fadae3b
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
-# Migration Guide to the .NET Framework 4.7, 4.6, and 4.5 
-If you created your app using an earlier version of the .NET Framework, you can generally upgrade it to the .NET Framework 4.5 and its point releases (4.5.1 and 4.5.2), the .NET Framework 4.6 and its point releases (4.6.1 and 4.6.2), or the .NET Framework 4.7 and its point releases (4.7.1 and 4.7.2) easily. Open your project in Visual Studio. If your project was created in an earlier version of Visual Studio, the **Project Compatibility** dialog box automatically opens. For more information about upgrading a project in Visual Studio, see [Port, Migrate, and Upgrade Visual Studio Projects](/visualstudio/porting/port-migrate-and-upgrade-visual-studio-projects) and [Visual Studio 2017 Platform Targeting and Compatibility](/visualstudio/productinfo/vs2017-compatibility-vs).  
-  
- However, some changes in the .NET Framework require changes to your code. You may also want to take advantage of functionality that is new in the .NET Framework 4.5 and its point releases, in the .NET Framework 4.6 and its point releases, or in the .NET Framework 4.7 and its point releases. Making these types of changes to your app for a new version of the .NET Framework is typically referred to as *migration*. If your app doesn't have to be migrated, you can run it in the .NET Framework 4.5 or a later version without recompiling it.  
-  
-## Migration resources  
- Review the following documents before you migrate your app from earlier versions of the .NET Framework to version 4.5, 4.5.1, 4.5.2, 4.6, 4.6.1, 4.6.2, 4.7, 4.7.1, or 4.7.2:  
-  
--   See [Versions and Dependencies](../../../docs/framework/migration-guide/versions-and-dependencies.md) to understand the CLR version underlying each version of the .NET Framework and to review guidelines for targeting your apps successfully.  
-  
--   Review [Application Compatibility](../../../docs/framework/migration-guide/application-compatibility.md) to find out about runtime and retargeting changes that might affect your app and how to handle them.  
-  
--   Review [What's Obsolete in the Class Library](../../../docs/framework/whats-new/whats-obsolete.md) to determine any types or members in your code that have been made obsolete, and the recommended alternatives.  
-  
--   See [What's New](../../../docs/framework/whats-new/index.md) for descriptions of new features that you may want to add to your app.  
-  
-## See Also  
- [Application Compatibility](../../../docs/framework/migration-guide/application-compatibility.md)  
- [Migrating from the .NET Framework 1.1](../../../docs/framework/migration-guide/migrating-from-the-net-framework-1-1.md)  
- [Version Compatibility](../../../docs/framework/migration-guide/version-compatibility.md)  
- [Versions and Dependencies](../../../docs/framework/migration-guide/versions-and-dependencies.md)  
- [How to: Configure an App to Support .NET Framework 4 or 4.5](../../../docs/framework/migration-guide/how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)  
- [What's New](../../../docs/framework/whats-new/index.md)  
- [What's Obsolete in the Class Library](../../../docs/framework/whats-new/whats-obsolete.md)  
- [.NET Framework Version and Assembly Information](https://go.microsoft.com/fwlink/?LinkId=201701)  
- [Microsoft .NET Framework Support Lifecycle Policy](https://go.microsoft.com/fwlink/?LinkId=196607)
- [.NET Framework 4 migration issues](net-framework-4-migration-issues.md)
+# Migration Guide to the .NET Framework 4.7, 4.6, and 4.5
+
+If you created your app using an earlier version of the .NET Framework, you can generally upgrade it to the .NET Framework 4.5 and its point releases (4.5.1 and 4.5.2), the .NET Framework 4.6 and its point releases (4.6.1 and 4.6.2), or the .NET Framework 4.7 and its point releases (4.7.1 and 4.7.2) easily. Open your project in Visual Studio. If your project was created in an earlier version of Visual Studio, the **Project Compatibility** dialog box automatically opens. For more information about upgrading a project in Visual Studio, see [Port, Migrate, and Upgrade Visual Studio Projects](/visualstudio/porting/port-migrate-and-upgrade-visual-studio-projects) and [Visual Studio 2017 Platform Targeting and Compatibility](/visualstudio/productinfo/vs2017-compatibility-vs).
+
+ However, some changes in the .NET Framework require changes to your code. You may also want to take advantage of functionality that is new in the .NET Framework 4.5 and its point releases, in the .NET Framework 4.6 and its point releases, or in the .NET Framework 4.7 and its point releases. Making these types of changes to your app for a new version of the .NET Framework is typically referred to as *migration*. If your app doesn't have to be migrated, you can run it in the .NET Framework 4.5 or a later version without recompiling it.
+
+## Migration resources
+
+Review the following documents before you migrate your app from earlier versions of the .NET Framework to version 4.5, 4.5.1, 4.5.2, 4.6, 4.6.1, 4.6.2, 4.7, 4.7.1, or 4.7.2:
+
+- See [Versions and Dependencies](versions-and-dependencies.md) to understand the CLR version underlying each version of the .NET Framework and to review guidelines for targeting your apps successfully.
+
+- Review [Application Compatibility](application-compatibility.md) to find out about runtime and retargeting changes that might affect your app and how to handle them.
+
+- Review [What's Obsolete in the Class Library](../whats-new/whats-obsolete.md) to determine any types or members in your code that have been made obsolete, and the recommended alternatives.
+
+- See [What's New](../whats-new/index.md) for descriptions of new features that you may want to add to your app.
+
+## See also
+
+- [Application Compatibility](application-compatibility.md)
+- [Migrating from the .NET Framework 1.1](migrating-from-the-net-framework-1-1.md)
+- [Version Compatibility](version-compatibility.md)
+- [Versions and Dependencies](versions-and-dependencies.md)
+- [How to: Configure an app to support .NET Framework 4 or later versions](how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)
+- [What's New](../whats-new/index.md)
+- [What's Obsolete in the Class Library](../whats-new/whats-obsolete.md)
+- [.NET Framework Version and Assembly Information](https://go.microsoft.com/fwlink/?LinkId=201701)
+- [Microsoft .NET Framework Support Lifecycle Policy](https://go.microsoft.com/fwlink/?LinkId=196607)
+- [.NET Framework 4 migration issues](net-framework-4-migration-issues.md)

--- a/docs/framework/migration-guide/toc.md
+++ b/docs/framework/migration-guide/toc.md
@@ -6,6 +6,6 @@
 ## [Versions and Dependencies](versions-and-dependencies.md)
 ### [How to: Determine Which .NET Framework Versions Are Installed](how-to-determine-which-versions-are-installed.md)
 ### [How to: Determine Which .NET Framework Updates Are Installed](how-to-determine-which-net-framework-updates-are-installed.md)
-## [How to: Configure an App to Support .NET Framework 4 or 4.5](how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)
+## [How to: Configure an app to support .NET Framework 4 or later versions](how-to-configure-an-app-to-support-net-framework-4-or-4-5.md)
 ## [Migrating from the .NET Framework 1.1](migrating-from-the-net-framework-1-1.md)
 ## [.NET Framework 4 migration issues](net-framework-4-migration-issues.md)


### PR DESCRIPTION
Fixes #9567

Summary:

- Removed paveover links
- added missing topics to the in this section for docs/csharp/programming-guide/inside-a-program/index.md
- simplified links
- while changing one of the links to point to how-to-configure-an-app-to-support-net-framework-4-or-4-5.md, noticed that probably that topic needed to cover versions greater than 4.5 so changed that topic a bit and incoming links to use a new title

Hide whitespace changes for easier diff