### PR TITLE
Revised index (element access) operator article

### DIFF
--- a/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_1.cs
+++ b/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_1.cs
@@ -1,2 +1,0 @@
-            int[] fib; // fib is of type int[], "array of int".
-            fib = new int[100]; // Create a 100-element int array.

--- a/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_2.cs
+++ b/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_2.cs
@@ -1,2 +1,0 @@
-            fib[0] = fib[1] = 1;
-            for (int i = 2; i < 100; ++i) fib[i] = fib[i - 1] + fib[i - 2];

--- a/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_3.cs
+++ b/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_3.cs
@@ -1,2 +1,0 @@
-            System.Collections.Hashtable h = new System.Collections.Hashtable();
-            h["a"] = 123; // Note: using a string as the index.

--- a/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_4.cs
+++ b/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_4.cs
@@ -1,3 +1,0 @@
-        // using System.Diagnostics;
-        [Conditional("DEBUG")] 
-        void TraceMethod() {}

--- a/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_5.cs
+++ b/docs/csharp/language-reference/operators/codesnippet/CSharp/index-operator_5.cs
@@ -1,9 +1,0 @@
-        unsafe void M()
-        {
-            int[] nums = {0,1,2,3,4,5};
-            fixed ( int* p = nums )
-            {
-                p[0] = p[1] = 1;
-                for( int i=2; i<100; ++i ) p[i] = p[i-1] + p[i-2];
-            }
-        }

--- a/docs/csharp/language-reference/operators/index-operator.md
+++ b/docs/csharp/language-reference/operators/index-operator.md
@@ -1,8 +1,7 @@
 ---
 title: "[] Operator - C# Reference"
 ms.custom: seodec18
-
-ms.date: 07/20/2015
+ms.date: 01/10/2019
 f1_keywords: 
   - "[]_CSharpKeyword"
 helpviewer_keywords: 
@@ -13,44 +12,54 @@ helpviewer_keywords:
 ms.assetid: 5c16bb45-88f7-45ff-b42c-1af1972b042c
 ---
 # [] Operator (C# Reference)
-Square brackets (`[]`) are used for arrays, indexers, and attributes. They can also be used with pointers.  
-  
-## Remarks  
- An array type is a type followed by `[]`:  
-  
- [!code-csharp[csRefOperators#43](../../../csharp/language-reference/operators/codesnippet/CSharp/index-operator_1.cs)]  
-  
- To access an element of an array, the index of the desired element is enclosed in brackets:  
-  
- [!code-csharp[csRefOperators#44](../../../csharp/language-reference/operators/codesnippet/CSharp/index-operator_2.cs)]  
-  
- An exception is thrown if an array index is out of range.  
-  
- The array indexing operator cannot be overloaded; however, types can define indexers that take one or more parameters. Indexer parameters are enclosed in square brackets, just like array indexes, but indexer parameters can be declared to be of any type, unlike array indexes, which must be integral.  
-  
- For example, the .NET Framework defines a `Hashtable` type that associates keys and values of arbitrary type:  
-  
- [!code-csharp[csRefOperators#45](../../../csharp/language-reference/operators/codesnippet/CSharp/index-operator_3.cs)]  
-  
- Square brackets are also used to specify [Attributes](../../../csharp/programming-guide/concepts/attributes/index.md):  
-  
- [!code-csharp[csRefOperators#46](../../../csharp/language-reference/operators/codesnippet/CSharp/index-operator_4.cs)]  
-  
- You can use square brackets to index off a pointer:  
-  
- [!code-csharp[csRefOperators#47](../../../csharp/language-reference/operators/codesnippet/CSharp/index-operator_5.cs)]  
-  
- No bounds checking is performed.  
-  
-## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
-## See Also
 
-- [C# Reference](../../../csharp/language-reference/index.md)  
-- [C# Programming Guide](../../../csharp/programming-guide/index.md)  
-- [C# Operators](../../../csharp/language-reference/operators/index.md)  
-- [Arrays](../../../csharp/programming-guide/arrays/index.md)  
-- [Indexers](../../../csharp/programming-guide/indexers/index.md)  
-- [unsafe](../../../csharp/language-reference/keywords/unsafe.md)  
-- [fixed Statement](../../../csharp/language-reference/keywords/fixed-statement.md)
+Square brackets, `[]`, are typically used for array, indexer, or pointer element access.
+
+For more information about pointer element access, see [How to: access an array element with a pointer](../../programming-guide/unsafe-code-pointers/how-to-access-an-array-element-with-a-pointer.md).
+
+You also use square brackets to specify [attributes](../../programming-guide/concepts/attributes/index.md):
+
+```csharp
+[System.Diagnostics.Conditional("DEBUG")]
+void TraceMethod() {}
+```
+
+## Array access
+
+The following example demonstrates how to access array elements:
+
+[!code-csharp-interactive[array access](~/samples/snippets/csharp/language-reference/operators/IndexOperatorExamples.cs#Arrays)]
+
+If an array index is outside the bounds of the corresponding dimension of an array, an <xref:System.IndexOutOfRangeException> is thrown.
+
+As the preceding example shows, you also use square brackets in declaration of an array type and instantiation of array instances.
+
+For more information about arrays, see [Arrays](../../programming-guide/arrays/index.md).
+
+## Indexer access
+
+The following example uses .NET <xref:System.Collections.Generic.Dictionary%602> type to demonstrate indexer access:
+
+[!code-csharp-interactive[indexer access](~/samples/snippets/csharp/language-reference/operators/IndexOperatorExamples.cs#Indexers)]
+
+Indexers allow you to index instances of a user-defined type in the similar way as array indexing. Unlike array indices, which must be integer, the indexer arguments can be declared to be of any type.
+
+For more information about indexers, see [Indexers](../../programming-guide/indexers/index.md).
+
+## Operator overloadability
+
+Element access `[]` is not considered an overloadable operator. Use [indexers](../../programming-guide/indexers/index.md) to support indexing with user-defined types.
+
+## C# language specification
+
+For more information, see the [Element access](~/_csharplang/spec/expressions.md#element-access) and [Pointer element access](~/_csharplang/spec/unsafe-code.md#pointer-element-access) sections of the [C# language specification](../language-specification/index.md).
+
+## See also
+
+- [C# Reference](../index.md)
+- [C# Programming Guide](../../programming-guide/index.md)
+- [C# Operators](index.md)
+- [Arrays](../../programming-guide/arrays/index.md)
+- [Indexers](../../programming-guide/indexers/index.md)
+- [Pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md)
+- [Attributes](../../programming-guide/concepts/attributes/index.md)

--- a/docs/csharp/programming-guide/unsafe-code-pointers/how-to-access-an-array-element-with-a-pointer.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/how-to-access-an-array-element-with-a-pointer.md
@@ -1,12 +1,12 @@
 ---
-title: "How to access an array element with a pointer - C# Programming Guide"
+title: "How to: access an array element with a pointer - C# Programming Guide"
 ms.custom: seodec18
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "pointers [C#], array access"
 ms.assetid: 6c46f2af-a730-4855-8638-f136d9abaa12
 ---
-# How to access an array element with a pointer (C# Programming Guide)
+# How to: access an array element with a pointer (C# Programming Guide)
 
 In an unsafe context, you can access an element in memory by using pointer element access, as shown in the following example:
 
@@ -30,10 +30,10 @@ Notice that the expression `charPointer[i]` is equivalent to the expression `*(c
 
 [!code-csharp[csProgGuidePointers#12](../../../csharp/programming-guide/unsafe-code-pointers/codesnippet/CSharp/how-to-access-an-array-element-with-a-pointer_2.cs)]
 
-**Uppercase letters:**
-**ABCDEFGHIJKLMNOPQRSTUVWXYZ**
-**Lowercase letters:**
-**abcdefghijklmnopqrstuvwxyz**
+**Uppercase letters:**  
+**ABCDEFGHIJKLMNOPQRSTUVWXYZ**  
+**Lowercase letters:**  
+**abcdefghijklmnopqrstuvwxyz**  
 
 ## See also
 


### PR DESCRIPTION
- Shortened the article: removed the example with pointers and linked the dedicated article, instead.
- Split in sections and added standard ones about overloadability and C# language spec.
- Moved (remaining) snippets to the dotnet/samples repo.

Supported by dotnet/samples#559
