### PR TITLE
Added reference to DocFX

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/xml-documentation-comments.md
+++ b/docs/csharp/programming-guide/xmldoc/xml-documentation-comments.md
@@ -23,7 +23,7 @@ In Visual C# you can create documentation for your code by including XML element
 public class MyClass {}  
 ```  
   
- When you compile with the [/doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md) option, the compiler will search for all XML tags in the source code and create an XML documentation file. To create the final documentation based on the compiler-generated file, you can create a custom tool or use a tool such as [Sandcastle](https://github.com/EWSoftware/SHFB).  
+ When you compile with the [/doc](../../../csharp/language-reference/compiler-options/doc-compiler-option.md) option, the compiler will search for all XML tags in the source code and create an XML documentation file. To create the final documentation based on the compiler-generated file, you can create a custom tool or use a tool such as [Sandcastle](https://github.com/EWSoftware/SHFB) or [DocFX](https://dotnet.github.io/docfx/).  
   
  To refer to XML elements (for example, your function processes specific XML elements that you want to describe in an XML documentation comment), you can use the standard quoting mechanism (`<` and `>`).  To refer to generic identifiers in code reference (`cref`) elements, you can use either the escape characters (for example, `cref="List&lt;T&gt;"`) or braces (`cref="List{T}"`).  As a special case, the compiler parses the braces as angle brackets to make the documentation comment less cumbersome to author when referring to generic identifiers.  
   


### PR DESCRIPTION
DocFX has become the primary documentation project for Microsoft and it makes sense to refer to it in the main C# Xml Comments section.

## Summary

Added reference to the DocFX project.