### PR TITLE
Include required VS version to use NuGet symbol server

### DIFF
--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -92,6 +92,8 @@ NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbo
 
 > [!IMPORTANT]
 > The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
+>
+> Visual Studio 2017 15.9 or later is required by users of your library use the NuGet.org symbol server when debugging.
 
 An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger, but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project, then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -93,7 +93,7 @@ NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbo
 > [!IMPORTANT]
 > The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
 >
-> Visual Studio 2017 15.9 or later is required by users of your library to use the NuGet.org symbol server when debugging.
+> To use the NuGet.org symbol server when debugging, you must have Visual Studio 2017 15.9 or later.
 
 An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger, but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project, then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -93,7 +93,7 @@ NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbo
 > [!IMPORTANT]
 > The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
 >
-> Visual Studio 2017 15.9 or later is required by users of your library use the NuGet.org symbol server when debugging.
+> Visual Studio 2017 15.9 or later is required by users of your library to use the NuGet.org symbol server when debugging.
 
 An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger, but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project, then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -3,7 +3,7 @@ title: NuGet and .NET libraries
 description: Best practice recommendations for packaging with NuGet for .NET libraries.
 author: jamesnk
 ms.author: mairaw
-ms.date: 10/02/2018
+ms.date: 01/15/2019
 ---
 # NuGet
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -93,7 +93,7 @@ NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbo
 > [!IMPORTANT]
 > The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
 >
-> To use the NuGet.org symbol server when debugging, you must have Visual Studio 2017 15.9 or later.
+> To use the NuGet.org symbol server when debugging into a .NET library developers must have Visual Studio 2017 15.9 or later.
 
 An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger, but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project, then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -93,7 +93,7 @@ NuGet.org hosts its own [symbols server repository](/nuget/create-packages/symbo
 > [!IMPORTANT]
 > The NuGet.org symbol server only supports the new [portable symbol files](https://github.com/dotnet/core/blob/master/Documentation/diagnostics/portable_pdb.md) (`*.pdb`) created by SDK-style projects.
 >
-> To use the NuGet.org symbol server when debugging into a .NET library developers must have Visual Studio 2017 15.9 or later.
+> To use the NuGet.org symbol server when debugging a .NET library, developers must have Visual Studio 2017 15.9 or later.
 
 An alternative to creating a symbol package is embedding symbol files in the main NuGet package. The main NuGet package will be larger, but the embedded symbol files means developers don't need to configure the NuGet.org symbol server. If you're building your NuGet package using an SDK-style project, then you can embed symbol files by setting the `AllowedOutputExtensionsInPackageBuildOutputFolder` property:
 


### PR DESCRIPTION
Fixes #9970
