### PR TITLE
Replace incorrect method reference

### DIFF
--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -264,7 +264,7 @@ Use the following code to display the metrics, share the results, and then act o
 
 [!code-csharp[DisplayMetrics](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#15 "Display selected metrics")]
 
-To save your model to a .zip file before returning, add the following code to call the `SaveModelAsFile` method as the next line in `TrainFinalModel`:
+To save your model to a .zip file before returning, add the following code to call the `SaveModelAsFile` method as the next line in `Evaluate`:
 
 [!code-csharp[SaveModel](../../../samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#23 "Save the model")]
 


### PR DESCRIPTION
Replace TrainFinalMethod reference with Evaluate method reference. Fixes #10012.
