### PR TITLE
[repo] Update labeler definition for windows workflow

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -21,6 +21,7 @@
       "(?i).*master\/docs\/framework\/install.*": ":card_file_box: Technology - Installers",
       "(?i).*master\/docs\/framework\/migration-guide.*": ":card_file_box: Technology - AppCompat",
       "(?i).*master\/docs\/framework\/network-programming.*": ":card_file_box: Technology - NCL",
+      "(?i).*master\/docs\/framework\/windows-workflow-foundation.*": ":card_file_box: Technology - WF",
       "(?i).*master\/docs\/framework\/wpf.*": ":card_file_box: Technology - WPF",
       "(?i).*master\/docs\/framework\/wcf.*": ":card_file_box: Technology - WCF",
       "(?i).*master\/docs\/framework\/winforms.*": ":card_file_box: Technology - WinForms",

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ _dependentPackages/
 # Visual Studio Code
 .vscode
 
+# Visual Studio 2019
+.vs
+
 # Windows thumbnail cache files
 Thumbs.db
 ehthumbs.db


### PR DESCRIPTION
## Summary

Saw an issue come in where the tech label for windows workflow could have been applied. 

Also took the chance to add a rule to exclude `.vs` folder generated by visual studio 2019
