### PR TITLE
Fix the whats new error about FDE

### DIFF
--- a/docs/core/deploying/index.md
+++ b/docs/core/deploying/index.md
@@ -88,12 +88,7 @@ There are also a few disadvantages:
 
 ## Step-by-step examples
 
-For step-by-step examples of deploying .NET Core apps with CLI tools, see [Deploying .NET Core Apps with CLI Tools](deploy-with-cli.md). For step-by-step examples of deploying .NET Core apps with Visual Studio, see [Deploying .NET Core Apps with Visual Studio](deploy-with-vs.md). Each article includes examples of the following deployments:
-
-- Framework-dependent deployment
-- Framework-dependent deployment with third-party dependencies
-- Self-contained deployment
-- Self-contained deployment with third-party dependencies
+For step-by-step examples of deploying .NET Core apps with CLI tools, see [Deploying .NET Core Apps with CLI Tools](deploy-with-cli.md). For step-by-step examples of deploying .NET Core apps with Visual Studio, see [Deploying .NET Core Apps with Visual Studio](deploy-with-vs.md). 
 
 ## See also
 

--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -25,15 +25,12 @@ For more information, see the [.NET Core 3.0 Preview 1 announcement](https://blo
 
 ## Default executables
 
-.NET Core will now build executables by default. This is new for applications that use a globally installed version of .NET Core. Until now, only [self-contained deployments](../deploying/index.md#self-contained-deployments-scd) had executables.
+.NET Core will now build [framework-dependent executables](../deploying/index.md#framework-dependent-executables-fde) by default. This is new for applications that use a globally installed version of .NET Core. Until now, only [self-contained deployments](../deploying/index.md#self-contained-deployments-scd) would produce an executable.
 
 During `dotnet build` or `dotnet publish`, an executable is created provided that matches the environment and platform of the SDK you are using. You can expect the same things with these executables as you would other native executables, such as:
 
 * You can double-click on the executable.
 * You can launch the application from a command prompt directly, such as `myapp.exe` on Windows, and `./myapp` on Linux and macOS.
-
-> [!NOTE]
-> Specifying a specific runtime with `dotnet publish -r` or `dotnet build -r` arguments for other runtime environments isn't supported.
 
 ## Build copies dependencies
 


### PR DESCRIPTION
## Summary

Whats new for 3.0 incorrectly said -r isn't supported with FDE. Also fix wording around the deployment article's next steps.
