### PR TITLE
Updating recommendation for publishing symbols

### DIFF
--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -106,11 +106,14 @@ An alternative to creating a symbol package is embedding symbol files in the mai
 </Project>
 ```
 
-**✔️ CONSIDER** embedding symbol files in the main NuGet package.
-
-> Embedding symbol files in the main NuGet package gives developers a better debugging experience by default. They don't need to find and configure the NuGet symbol server in their IDE to get symbol files.
->
 > The downside to embedded symbol files is they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern, you should publish symbols in a symbol package instead.
+
+**✔️ CONSIDER** publishing symbols as a symbol package (snupkg) to NuGet.org
+
+> Symbol packages (snupkg) provide developers a good on-demand debugging experience without bloating the main package size and impacting restore performance for those who don't intend to debug the NuGet package.
+>
+> The caveat is that they would need to find and configure the NuGet symbol server in their IDE to get symbol files. Visual Studio 2019 plans to provide the NuGet.org symbol server as one of the options out of the box. 
+
 
 >[!div class="step-by-step"]
 >[Previous](strong-naming.md)

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -106,7 +106,7 @@ An alternative to creating a symbol package is embedding symbol files in the mai
 </Project>
 ```
 
-> The downside to embedded symbol files is they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern, you should publish symbols in a symbol package instead.
+The downside of embedding symbol files is that they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern, you should publish symbols in a symbol package instead.
 
 **✔️ CONSIDER** publishing symbols as a symbol package (snupkg) to NuGet.org
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -112,7 +112,7 @@ An alternative to creating a symbol package is embedding symbol files in the mai
 
 > Symbol packages (snupkg) provide developers a good on-demand debugging experience without bloating the main package size and impacting restore performance for those who don't intend to debug the NuGet package.
 >
-> The caveat is that they would need to find and configure the NuGet symbol server in their IDE to get symbol files. Visual Studio 2019 plans to provide the NuGet.org symbol server as one of the options out of the box. 
+> The caveat is that they would need to find and configure the NuGet symbol server in their IDE (as a one-time setup) to get symbol files. Visual Studio 2019 plans to provide the NuGet.org symbol server as one of the options out of the box. 
 
 
 >[!div class="step-by-step"]

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -108,7 +108,7 @@ An alternative to creating a symbol package is embedding symbol files in the mai
 
 The downside of embedding symbol files is that they increase the package size by about 30% for .NET libraries compiled using SDK-style projects. If package size is a concern, you should publish symbols in a symbol package instead.
 
-**✔️ CONSIDER** publishing symbols as a symbol package (snupkg) to NuGet.org
+**✔️ CONSIDER** publishing symbols as a symbol package (`*.snupkg`) to NuGet.org
 
 > Symbol packages (snupkg) provide developers a good on-demand debugging experience without bloating the main package size and impacting restore performance for those who don't intend to debug the NuGet package.
 >

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -110,7 +110,7 @@ The downside of embedding symbol files is that they increase the package size by
 
 **✔️ CONSIDER** publishing symbols as a symbol package (`*.snupkg`) to NuGet.org
 
-> Symbol packages (snupkg) provide developers a good on-demand debugging experience without bloating the main package size and impacting restore performance for those who don't intend to debug the NuGet package.
+> Symbol packages (`*.snupkg`) provide developers a good on-demand debugging experience without bloating the main package size and impacting restore performance for those who don't intend to debug the NuGet package.
 >
 > The caveat is that they would need to find and configure the NuGet symbol server in their IDE (as a one-time setup) to get symbol files. Visual Studio 2019 plans to provide the NuGet.org symbol server as one of the options out of the box. 
 


### PR DESCRIPTION
The Microsoft messaging is developers should publish symbols as a separate symbol package (snupkg). Updating this doc to make this messaging consistent across all customer-facing channels.