### PR TITLE
CCI6636: Replacing HTML entities by characters

### DIFF
--- a/docs/visual-basic/language-reference/xmldoc/value.md
+++ b/docs/visual-basic/language-reference/xmldoc/value.md
@@ -6,7 +6,7 @@ helpviewer_keywords:
   - "value XML tag"
 ms.assetid: 0b84b02e-9e6d-41b5-a926-0d5dc76dacb5
 ---
-# <value> (Visual Basic)
+# \<value> (Visual Basic)
 Specifies the description of a property.  
   
 ## Syntax  

--- a/docs/visual-basic/language-reference/xmldoc/value.md
+++ b/docs/visual-basic/language-reference/xmldoc/value.md
@@ -1,12 +1,12 @@
 ---
-title: "&lt;value&gt; (Visual Basic)"
+title: "<value> (Visual Basic)"
 ms.date: 07/20/2015
 helpviewer_keywords: 
   - "<value> XML tag"
   - "value XML tag"
 ms.assetid: 0b84b02e-9e6d-41b5-a926-0d5dc76dacb5
 ---
-# &lt;value&gt; (Visual Basic)
+# <value> (Visual Basic)
 Specifies the description of a property.  
   
 ## Syntax  


### PR DESCRIPTION
Hello, @mairaw ,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: HTML entities are not rendering properties in Metadata. Also we suggest to change the entities in Title for consistency.

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

Link to page: [\<value> (Visual Basic)](https://review.docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/xmldoc/value?branch=pr-en-us-10115)