### PR TITLE
"fix" TOC

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -44,7 +44,7 @@
 ### [Parallel Programming](standard/parallel-programming/)
 ### [Threading](standard/threading/)
 ## [Memory and span-related types](standard/memory-and-spans/index.md)
-### [Memory\<T> and Span\<T> usage guidelines](standard/memory-and-spans/memory-t-usage-guidelines.md)
+### [Memory<T> and Span<T> usage guidelines](standard/memory-and-spans/memory-t-usage-guidelines.md)
 ## [Native interoperability](standard/native-interop/index.md)
 ### [P/Invoke](standard/native-interop/pinvoke.md)
 ### [Type marshalling](standard/native-interop/type-marshalling.md)


### PR DESCRIPTION
The escape characters are being rendered on the TOC
![image](https://user-images.githubusercontent.com/12971179/51626169-cdca8a80-1ef3-11e9-8e88-f32889888fc6.png)

This change should fix the problem. I believe this is probably a bug on the parser. I'm checking with the engineering team.
