### PR TITLE
The URL for downloading .NET Framework 4.7.2 is not working

### DIFF
--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # Install the .NET Framework on Windows 10 and Windows Server 2016
 
-The .NET Framework is required to run many applications on Windows. The instructions in this article should help you install the .NET Framework versions that you need. The [.NET Framework 4.7.2](https://go.microsoft.com/fwlink/?LinkID=863255) is the latest available version.
+The .NET Framework is required to run many applications on Windows. The instructions in this article should help you install the .NET Framework versions that you need. The [.NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral) is the latest available version.
 
 You may have arrived on this page after trying to run an application and seeing a dialog on your machine similar to the following one:
 
@@ -25,9 +25,9 @@ The .NET Framework 4.7.2 is included with:
 > [!div class="button"]
 > [Download .NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral)
 
-The [.NET Framework 4.7.2](https://go.microsoft.com/fwlink/?LinkID=863255) can be used to run applications built for the .NET Framework 4.0 through 4.7.1.
+The [.NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral) can be used to run applications built for the .NET Framework 4.0 through 4.7.1.
 
-You can install the [.NET Framework 4.7.2](https://go.microsoft.com/fwlink/?LinkID=863255) on:
+You can install the [.NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral) on:
 
 * Windows 10 Fall Creators Update (version 1709)
 * Windows 10 Creators Update (version 1703)

--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -8,7 +8,7 @@ ms.custom: "updateeachrelease"
 ---
 # Install the .NET Framework on Windows 10 and Windows Server 2016
 
-The .NET Framework is required to run many applications on Windows. The instructions in this article should help you install the .NET Framework versions that you need. The [.NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral) is the latest available version.
+The .NET Framework is required to run many applications on Windows. The instructions in this article should help you install the .NET Framework versions that you need. The [.NET Framework 4.7.2](https://dotnet.microsoft.com/download/dotnet-framework-runtime/net472) is the latest available version.
 
 You may have arrived on this page after trying to run an application and seeing a dialog on your machine similar to the following one:
 
@@ -23,11 +23,11 @@ The .NET Framework 4.7.2 is included with:
 * [Windows 10 April 2018 Update](https://www.microsoft.com/software-download/windows10)
 
 > [!div class="button"]
-> [Download .NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral)
+> [Download .NET Framework 4.7.2](https://dotnet.microsoft.com/download/dotnet-framework-runtime/net472)
 
-The [.NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral) can be used to run applications built for the .NET Framework 4.0 through 4.7.1.
+The [.NET Framework 4.7.2](https://dotnet.microsoft.com/download/dotnet-framework-runtime/net472) can be used to run applications built for the .NET Framework 4.0 through 4.7.1.
 
-You can install the [.NET Framework 4.7.2](https://www.microsoft.com/net/download/thank-you/net472?utm_source=ms-docs&utm_medium=referral) on:
+You can install the [.NET Framework 4.7.2](https://dotnet.microsoft.com/download/dotnet-framework-runtime/net472) on:
 
 * Windows 10 Fall Creators Update (version 1709)
 * Windows 10 Creators Update (version 1703)


### PR DESCRIPTION
The URL https://go.microsoft.com/fwlink/?LinkID=863255 for downloading .NET Framework 4.7.2 is not working. This URL is being used in:
   - Line 11
   - Line 28
   - Line 30

I changed all .NET download URLs equal to the URL of the line 26.

Other URL:
 - https://www.microsoft.com/net/download?utm_source=ms-docs&utm_medium=referral (used on line 26)
 - https://dotnet.microsoft.com/download/dotnet-framework-runtime

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
