### PR TITLE
Rename SourceLink to Source Link

### DIFF
--- a/docs/standard/library-guidance/get-started.md
+++ b/docs/standard/library-guidance/get-started.md
@@ -23,9 +23,9 @@ The best way to create NuGet packages for open-source .NET libraries, including 
 
 NuGet makes it easy to use existing packages when building a .NET library. Learn about NuGet dependencies' common sources of friction and how to avoid them.
 
-### [SourceLink](./sourcelink.md)
+### [Source Link](./sourcelink.md)
 
-SourceLink is a great tool that allows users of your .NET library to step into its source code while debugging. This article is an overview of what SourceLink is and why you should use it.
+Source Link is a great tool that allows users of your .NET library to step into its source code while debugging. This article is an overview of what Source Link is and why you should use it.
 
 ### [Publishing](./publish-nuget-package.md)
 

--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -63,9 +63,9 @@ A NuGet package supports many [metadata properties](/nuget/reference/nuspec). Th
 
 **✔️ DO** use a package icon image that is 64x64 and has a transparent background for best viewing results.
 
-**✔️ CONSIDER** setting up [SourceLink](./sourcelink.md) to add source control metadata to your assemblies and NuGet package.
+**✔️ CONSIDER** setting up [Source Link](./sourcelink.md) to add source control metadata to your assemblies and NuGet package.
 
-> SourceLink automatically adds `RepositoryUrl` and `RepositoryType` metadata to the NuGet package. SourceLink also adds information about the exact source code the package was built from. For example, a package created from a Git repository will have the commit hash added as metadata.
+> Source Link automatically adds `RepositoryUrl` and `RepositoryType` metadata to the NuGet package. Source Link also adds information about the exact source code the package was built from. For example, a package created from a Git repository will have the commit hash added as metadata.
 
 ## Pre-release packages
 

--- a/docs/standard/library-guidance/sourcelink.md
+++ b/docs/standard/library-guidance/sourcelink.md
@@ -1,27 +1,27 @@
 ---
-title: SourceLink and .NET libraries
-description: Best practice recommendations for using SourceLink to improve debugging for .NET libraries.
+title: Source Link and .NET libraries
+description: Best practice recommendations for using Source Link to improve debugging for .NET libraries.
 author: jamesnk
 ms.author: mairaw
 ms.date: 01/15/2019
 ---
-# SourceLink
+# Source Link
 
-SourceLink is a technology that enables source code debugging of .NET assemblies from NuGet by developers. SourceLink executes when creating the NuGet package and embeds source control metadata inside assemblies and the package. Developers who download the package and have SourceLink enabled in Visual Studio can step into its source code. SourceLink provides source control metadata to create a great debugging experience.
+Source Link is a technology that enables source code debugging of .NET assemblies from NuGet by developers. Source Link executes when creating the NuGet package and embeds source control metadata inside assemblies and the package. Developers who download the package and have Source Link enabled in Visual Studio can step into its source code. Source Link provides source control metadata to create a great debugging experience.
 
-## SourceLink demo
+## Source Link demo
 
 > [!VIDEO https://www.youtube.com/embed/gyRGhCQPkB4?start=61]
 
-## Using SourceLink
+## Using Source Link
 
-Instructions for using SourceLink can be found on the [dotnet/sourceLink](https://github.com/dotnet/sourcelink/blob/master/README.md) GitHub repository.
+Instructions for using Source Link can be found on the [dotnet/sourcelink](https://github.com/dotnet/sourcelink/blob/master/README.md) GitHub repository.
 
-You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer) to confirm that the SourceLink metadata has been successfully embedded in the package. Check the `Repository` metadata is present with a comment identifier and that .pdb files are located with each target's .dll.
+You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer) to confirm that the Source Link metadata has been successfully embedded in the package. Check the `Repository` metadata is present with a comment identifier and that .pdb files are located with each target's .dll.
 
-![SourceLink in NuGet Package Explorer](./media/sourcelink/nuget-package-explorer-sourcelink.png "SourceLink in NuGet Package Explorer")
+![Source Link in NuGet Package Explorer](./media/sourcelink/nuget-package-explorer-sourcelink.png "Source Link in NuGet Package Explorer")
 
-**✔️ CONSIDER** using SourceLink to add source control metadata to your assemblies and NuGet packages.
+**✔️ CONSIDER** using Source Link to add source control metadata to your assemblies and NuGet packages.
 
 > [!TIP]
 > You can further enhance a developer's debugging experience by adding debugger attributes to your types.
@@ -31,7 +31,7 @@ You can use [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuG
 
 **✔️ CONSIDER** publishing symbol files (`*.pdb`).
 
-> For more information about symbol files and symbol packages, see [Symbol packages](./nuget.md#symbol-packages).
+> For the best debugging experience your library should pubish symbol files as well as use Source Link. For more information about symbol files and symbol packages, see [Symbol packages](./nuget.md#symbol-packages).
 
 >[!div class="step-by-step"]
 >[Previous](dependencies.md)

--- a/docs/standard/library-guidance/toc.md
+++ b/docs/standard/library-guidance/toc.md
@@ -4,7 +4,7 @@
 ## [Strong naming](strong-naming.md)
 ## [NuGet](nuget.md)
 ### [Dependencies](dependencies.md)
-### [SourceLink](sourcelink.md)
+### [Source Link](sourcelink.md)
 ### [Publishing](publish-nuget-package.md)
 ## [Versioning](versioning.md)
 ### [Breaking changes](breaking-changes.md)

--- a/docs/standard/library-guidance/versioning.md
+++ b/docs/standard/library-guidance/versioning.md
@@ -81,7 +81,7 @@ The assembly file version is used to display a file version in Windows and has n
 
 ### Assembly informational version
 
-The assembly informational version is used to record additional version information and has no effect on runtime behavior. Setting this version is optional. If you're using SourceLink, this version will be set on build with the NuGet package version plus a source control version. For example, `1.0.0-beta1+204ff0a` includes the commit hash of the source code the assembly was built from. For more information, see [SourceLink](./sourcelink.md).
+The assembly informational version is used to record additional version information and has no effect on runtime behavior. Setting this version is optional. If you're using Source Link, this version will be set on build with the NuGet package version plus a source control version. For example, `1.0.0-beta1+204ff0a` includes the commit hash of the source code the assembly was built from. For more information, see [Source Link](./sourcelink.md).
 
 ```xml
 <AssemblyInformationalVersion>The quick brown fox jumped over the lazy dog.</AssemblyInformationalVersion>


### PR DESCRIPTION
To be consistent with how Source Link refers to itself

See https://github.com/dotnet/sourcelink/issues/195