### PR TITLE
Update using-a-data-contract-resolver.md

### DIFF
--- a/docs/framework/wcf/feature-details/using-a-data-contract-resolver.md
+++ b/docs/framework/wcf/feature-details/using-a-data-contract-resolver.md
@@ -49,7 +49,7 @@ public class MyCustomerResolver : DataContractResolver
 XmlObjectSerializer serializer = new DataContractSerializer(typeof(Customer), null, Int32.MaxValue, false, false, null, new MyCustomerResolver());  
 ```  
   
- You can specify a <xref:System.Runtime.Serialization.DataContractResolver> in a call to the <xref:System.Runtime.Serialization.DataContractSerializer.ReadObject%2A?displayProperty=nameWithType> or <xref:System.Runtime.Serialization.DataContractSerializer.WriteObject%2A>displayProperty=nameWithType> methods, as shown in the following example.  
+ You can specify a <xref:System.Runtime.Serialization.DataContractResolver> in a call to the <xref:System.Runtime.Serialization.DataContractSerializer.ReadObject%2A?displayProperty=nameWithType> or <xref:System.Runtime.Serialization.DataContractSerializer.WriteObject%2A?displayProperty=nameWithType> methods, as shown in the following example.  
   
 ```  
 MemoryStream ms = new MemoryStream();  

--- a/docs/framework/wcf/feature-details/using-a-data-contract-resolver.md
+++ b/docs/framework/wcf/feature-details/using-a-data-contract-resolver.md
@@ -49,7 +49,7 @@ public class MyCustomerResolver : DataContractResolver
 XmlObjectSerializer serializer = new DataContractSerializer(typeof(Customer), null, Int32.MaxValue, false, false, null, new MyCustomerResolver());  
 ```  
   
- You can specify a <xref:System.Runtime.Serialization.DataContractSerializer> in a call to the <xref:System.Runtime.Serialization.DataContractSerializer.ReadObject%2A> or <xref:System.Runtime.Serialization.DataContractSerializer.WriteObject%2A> methods, as shown in the following example.  
+ You can specify a <xref:System.Runtime.Serialization.DataContractResolver> in a call to the <xref:System.Runtime.Serialization.DataContractSerializer.ReadObject%2A> or <xref:System.Runtime.Serialization.DataContractSerializer.WriteObject%2A> methods, as shown in the following example.  
   
 ```  
 MemoryStream ms = new MemoryStream();  

--- a/docs/framework/wcf/feature-details/using-a-data-contract-resolver.md
+++ b/docs/framework/wcf/feature-details/using-a-data-contract-resolver.md
@@ -49,7 +49,7 @@ public class MyCustomerResolver : DataContractResolver
 XmlObjectSerializer serializer = new DataContractSerializer(typeof(Customer), null, Int32.MaxValue, false, false, null, new MyCustomerResolver());  
 ```  
   
- You can specify a <xref:System.Runtime.Serialization.DataContractResolver> in a call to the <xref:System.Runtime.Serialization.DataContractSerializer.ReadObject%2A> or <xref:System.Runtime.Serialization.DataContractSerializer.WriteObject%2A> methods, as shown in the following example.  
+ You can specify a <xref:System.Runtime.Serialization.DataContractResolver> in a call to the <xref:System.Runtime.Serialization.DataContractSerializer.ReadObject%2A?displayProperty=nameWithType> or <xref:System.Runtime.Serialization.DataContractSerializer.WriteObject%2A>displayProperty=nameWithType> methods, as shown in the following example.  
   
 ```  
 MemoryStream ms = new MemoryStream();  


### PR DESCRIPTION
An instance of DataContractResolver can be passed into WriteObject and ReadObject calls, not DataContractSerializer.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
