### PR TITLE
Allow elmish style tuples

### DIFF
--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -274,7 +274,7 @@ It is also commonly accepted to omit parentheses if the tuple is the return valu
 
 ```fsharp
 // OK
-let f model msg =
+let update model msg =
     match msg with
     | 1 -> model + 1, []
     | _ -> model, [ msg ]

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -270,7 +270,7 @@ match x, y with
 | x, y -> 1
 ```
 
-It is qlso accepted to omit parentheses if the tuple is the return value of a function:
+It is also commonly accepted to omit parentheses if the tuple is the return value of a function:
 
 ```fsharp
 // OK

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -279,7 +279,7 @@ let f model msg =
     | 1 -> model + 1, []
     | _ -> model, [ msg ]
 ```
-
+In summary, prefer parenthesized tuple instantiations, but when using tuples for pattern matching or a return value, it is considered fine to avoid parentheses.
 
 ## Formatting discriminated union declarations
 

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -270,6 +270,17 @@ match x, y with
 | x, y -> 1
 ```
 
+It is qlso accepted to omit parentheses if the tuple is the return value of a function:
+
+```fsharp
+// OK
+let f model msg =
+    match msg with
+    | 1 -> model + 1, []
+    | _ -> model, [ msg ]
+```
+
+
 ## Formatting discriminated union declarations
 
 Indent `|` in type definition by 4 spaces:


### PR DESCRIPTION
Since Fsharplint is using this styleguide as source and ionide is using fsharplint, it seems this guide is going to be the canonical styleguide. In general I think this is a good thing and I try to be not too opionated here (which is hard).
Anyway, I'd like to suggest a small change to the very restrictive tuple instantiation. The new fsharplint is complaining on thousands of lines in our elmish update functions. Stuff that we as community suggested to use for everyone in safe stack. Basically all samples and all existing safe stack code is now considered as bad.
I'm not sure if my wording here is good, but I want to open up the discussion.