### PR TITLE
Fix AMQP acronym

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/domain-events-design-implementation.md
@@ -25,7 +25,7 @@ In short, domain events help you to express, explicitly, the domain rules, based
 
 It's important to ensure that, just like a database transaction, either all the operations related to a domain event finish successfully or none of them do.
 
-Domain events are similar to messaging-style events, with one important difference. With real messaging, message queuing, message brokers, or a service bus using AMPQ, a message is always sent asynchronously and communicated across processes and machines. This is useful for integrating multiple Bounded Contexts, microservices, or even different applications. However, with domain events, you want to raise an event from the domain operation you are currently running, but you want any side effects to occur within the same domain.
+Domain events are similar to messaging-style events, with one important difference. With real messaging, message queuing, message brokers, or a service bus using AMQP, a message is always sent asynchronously and communicated across processes and machines. This is useful for integrating multiple Bounded Contexts, microservices, or even different applications. However, with domain events, you want to raise an event from the domain operation you are currently running, but you want any side effects to occur within the same domain.
 
 The domain events and their side effects (the actions triggered afterwards that are managed by event handlers) should occur almost immediately, usually in-process, and within the same domain. Thus, domain events could be synchronous or asynchronous. Integration events, however, should always be asynchronous.
 


### PR DESCRIPTION
Properly write the AMQP (Advanced Message Queueing Protocol) acronym.

Fixes #10234