### PR TITLE
Add link to xUnit documentation

### DIFF
--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -167,6 +167,5 @@ Continue to iterate by adding more tests, more theories, and more code in the ma
 
 ### Additional resources
 
--   **xUnit.net**. Official site. <br/>
-    [*https://xunit.github.io/*](https://xunit.github.io/)
+- [xUnit.net official site](https://xunit.github.io)
 - [Testing controller logic in ASP.NET Core](/aspnet/core/mvc/controllers/testing)

--- a/docs/core/testing/unit-testing-with-dotnet-test.md
+++ b/docs/core/testing/unit-testing-with-dotnet-test.md
@@ -61,7 +61,7 @@ Next, create the *PrimeService.Tests* directory. The following outline shows the
     /PrimeService.Tests
 ```
 
-Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new xunit`](../tools/dotnet-new.md). This command creates a test project that uses xUnit as the test library. The generated template configures the test runner in the *PrimeServiceTests.csproj* file similar to the following code:
+Make the *PrimeService.Tests* directory the current directory and create a new project using [`dotnet new xunit`](../tools/dotnet-new.md). This command creates a test project that uses [xUnit](https://xunit.github.io/) as the test library. The generated template configures the test runner in the *PrimeServiceTests.csproj* file similar to the following code:
 
 ```xml
 <ItemGroup>
@@ -167,4 +167,6 @@ Continue to iterate by adding more tests, more theories, and more code in the ma
 
 ### Additional resources
 
+-   **xUnit.net**. Official site. <br/>
+    [*https://xunit.github.io/*](https://xunit.github.io/)
 - [Testing controller logic in ASP.NET Core](/aspnet/core/mvc/controllers/testing)


### PR DESCRIPTION
2 links to the official xUnit page where added.

One in the first occurrence of the term xUnit in the document (besides the title), and one in the 'Additional Resources' section.

In this page: [Testing ASP.NET Core services and web apps](https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/multi-container-microservice-net-applications/test-aspnet-core-services-web-apps), which also refers to xUnit, 
this is the approach used so i kept the same for consistency.

Fixes #7962