### PR TITLE
Update how-to-create-temporary-certificates-for-use-during-developmen…

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
+++ b/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
@@ -64,7 +64,7 @@ Once a self-signed certificate is created, you can install it in the Trusted Roo
 
 4. Right-click the **Certificates** folder and click **All Tasks**, then click **Import**.
 
-5. Follow the on-screen wizard instructions to import the TempCa.cer into the store.
+5. Follow the on-screen wizard instructions to import the RootCA.pfx into the store.
 
 ## Using certificates With WCF
 


### PR DESCRIPTION
…t.md

I believe the filename TempCA.cer is incorrect here.  Given the examples above where the self-signed certificate was exported as RootCA.pfx, the instructions here should be changed to use that file.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
