### PR TITLE
Update configuring-http-and-https.md

### DIFF
--- a/docs/framework/wcf/feature-details/configuring-http-and-https.md
+++ b/docs/framework/wcf/feature-details/configuring-http-and-https.md
@@ -27,7 +27,7 @@ WCF services and clients can communicate over HTTP and HTTPS. The HTTP/HTTPS set
  The following shows the syntax of the Httpcfg command with the `set urlacl` option  
   
 ```console  
-httpcfg set urlacl /u {http://URL:Port/ | https://URL:Port/} /aACL  
+httpcfg set urlacl /u {http://URL:Port/ | https://URL:Port/} /a ACL  
 ```  
   
  The `/u` parameter is required when using `set urlacl`. It takes a string that contains a fully-qualified URL that serves as the record key for the reservation being made.  


### PR DESCRIPTION
There is a space between /a and the ACL (see https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc781601(v=ws.10))

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
