### PR TITLE
Expression body definitions for property accessors are from C# 7.0

### DIFF
--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -44,7 +44,7 @@ For more information, see [Methods (C# Programming Guide)](../classes-and-struct
 Starting with C# 6, you can use expression body definition to implement a read-only property. To do that, use the following syntax:
 
 ```csharp
-PropertyName => expression;
+PropertyType PropertyName => expression;
 ```
 
 The following example defines a `Location` class whose read-only `Name` property is implemented as an expression body definition that returns the value of the private `locationName` field:

--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -1,7 +1,7 @@
 ---
 title: "Expression-bodied members - C# Programming Guide"
 ms.custom: seodec18
-ms.date: 07/20/2015
+ms.date: 02/06/2019
 helpviewer_keywords: 
   - "expression-bodied members[C#]"
   - "C# language, expresion-bodied members"
@@ -9,38 +9,61 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # Expression-bodied members (C# programming guide)
+
 Expression body definitions let you provide a member's implementation in a very concise, readable form. You can use an expression body definition whenever the logic for any supported member, such as a method or property, consists of a single expression. An expression body definition has the following general syntax:
 
 ```csharp
 member => expression;
 ```
 
-where *expression* is a valid expression. 
+where *expression* is a valid expression.
 
-Support for expression body definitions was introduced for methods and property get accessors in C# 6 and was expanded in C# 7.0. Expression body definitions can be used with the type members listed in the following table: 
+Support for expression body definitions was introduced for methods and read-only properties in C# 6 and was expanded in C# 7.0. Expression body definitions can be used with the type members listed in the following table:
 
 |Member  |Supported as of... |
 |---------|---------|
 |[Method](#methods)  |C# 6 |
+|[Read-only property](#read-only-properties)   |C# 6  |
+|[Property](#properties)  |C# 7.0 |
 |[Constructor](#constructors)   |C# 7.0 |
 |[Finalizer](#finalizers)     |C# 7.0 |
-|[Property Get](#property-get-statements)  |C# 6 |
-|[Property Set](#property-set-statements)  |C# 7.0 |
 |[Indexer](#indexers)       |C# 7.0 |
 
 ## Methods
 
-An expression-bodied method consists of a single expression that returns a value whose type matches the method's return type, or, for methods that return `void`, that performs some operation. For example, types that override the <xref:System.Object.ToString%2A> method typically include a single expression that returns the string representation of the current object. 
+An expression-bodied method consists of a single expression that returns a value whose type matches the method's return type, or, for methods that return `void`, that performs some operation. For example, types that override the <xref:System.Object.ToString%2A> method typically include a single expression that returns the string representation of the current object.
 
 The following example defines a `Person` class that overrides the <xref:System.Object.ToString%2A> method with an expression body definition. It also defines a `DisplayName` method that displays a name to the console. Note that the `return` keyword is not used in the `ToString` expression body definition.
 
 [!code-csharp[expression-bodied-methods](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-methods.cs)]  
 
 For more information, see [Methods (C# Programming Guide)](../classes-and-structs/methods.md).
- 
+
+## Read-only properties
+
+Starting with C# 6, you can use expression body definition to implement a read-only property. To do that, use the following syntax:
+
+```csharp
+PropertyName => expression;
+```
+
+The following example defines a `Location` class whose read-only `Name` property is implemented as an expression body definition that returns the value of the private `locationName` field:
+
+[!code-csharp[expression-bodied-constructor](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-readonly.cs#1)]  
+
+For more information about properties, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
+
+## Properties
+
+Starting with C# 7.0, you can use expression body definitions to implement property `get` and `set` accessors. The following example demonstrates how to do that:
+
+[!code-csharp[expression-bodied-property-getter](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]
+
+For more information about properties, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
+
 ## Constructors
 
-An expression body definition for a constructor typically consists of a single assignment expression or a method call that handles the constructor's arguments or initializes instance state. 
+An expression body definition for a constructor typically consists of a single assignment expression or a method call that handles the constructor's arguments or initializes instance state.
 
 The following example defines a `Location` class whose constructor has a single string parameter named *name*. The expression body definition assigns the argument to the `Name` property.
 
@@ -58,43 +81,12 @@ The following example defines a finalizer that uses an expression body definitio
 
 For more information, see [Finalizers (C# Programming Guide)](../classes-and-structs/destructors.md).
 
-## Property get statements
-
-If you choose to implement a property get accessor yourself, you can use an expression body definition for single expressions that simply return the property value. Note that the `return` statement isn't used.
-
-The following example defines a `Location.Name` property whose property get accessor returns the value of the private `locationName` field that backs the property. 
-
-[!code-csharp[expression-bodied-property-getter](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]  
-
-Read-only properties that use an expression body definition can be implemented without an explicit `set` statement. The syntax is:
-
-```csharp
-PropertyName => returnValue;
-```
-
-The following example defines a `Location` class whose read-only `Name` property is implemented as an expression body definition that returns the value of the private `locationName` field.
-
-[!code-csharp[expression-bodied-constructor](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-readonly.cs#1)]  
-
-For more information, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
-
-## Property set statements
-
-If you choose to implement a property set accessor yourself, you can use an expression body definition for a single-line expression that assigns a value to the field that backs the property.
-
-The following example defines a `Location.Name` property whose property set statement assigns its input argument to the private `locationName` field that backs the property.
-
-[!code-csharp[expression-bodied-property-setter](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]  
-
-For more information, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
-
 ## Indexers
 
 Like properties, an indexer's get and set accessors consist of expression body definitions if the get accessor consists of a single statement that returns a value or the set accessor performs a simple assignment.
 
 The following example defines a class named `Sports` that includes an internal <xref:System.String> array that contains the names of a number of sports. Both the indexer's get and set accessors are implemented as expression body definitions.
 
-[!code-csharp[expression-bodied-indexer](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-indexers.cs#1)] 
+[!code-csharp[expression-bodied-indexer](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-indexers.cs#1)]
 
 For more information, see [Indexers (C# Programming Guide)](../indexers/index.md).
-

--- a/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md
@@ -49,7 +49,7 @@ PropertyName => expression;
 
 The following example defines a `Location` class whose read-only `Name` property is implemented as an expression body definition that returns the value of the private `locationName` field:
 
-[!code-csharp[expression-bodied-constructor](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-readonly.cs#1)]  
+[!code-csharp[expression-bodied-read-only-property](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-readonly.cs#1)]  
 
 For more information about properties, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
 
@@ -57,7 +57,7 @@ For more information about properties, see [Properties (C# Programming Guide)](.
 
 Starting with C# 7.0, you can use expression body definitions to implement property `get` and `set` accessors. The following example demonstrates how to do that:
 
-[!code-csharp[expression-bodied-property-getter](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]
+[!code-csharp[expression-bodied-property-get-set](../../../../samples/snippets/csharp/programming-guide/classes-and-structs/expr-bodied-ctor.cs#1)]
 
 For more information about properties, see [Properties (C# Programming Guide)](../classes-and-structs/properties.md).
 


### PR DESCRIPTION
Fixes #10076
Snippets from the [current version](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/statements-expressions-operators/expression-bodied-members) were fine to still use.

Rich diff makes it easier to review.
