### PR TITLE
Follow naming conventions in examples on Using Constructors

### DIFF
--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_1.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_1.cs
@@ -1,9 +1,9 @@
     public class Taxi
     {
-        public bool isInitialized;
+        public bool IsInitialized;
         public Taxi()
         {
-            isInitialized = true;
+            IsInitialized = true;
         }
     }
 
@@ -12,6 +12,6 @@
         static void Main()
         {
             Taxi t = new Taxi();
-            Console.WriteLine(t.isInitialized);
+            Console.WriteLine(t.IsInitialized);
         }
     }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_2.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_2.cs
@@ -3,5 +3,5 @@
         // Private Constructor:
         private NLog() { }
 
-        public static double e = Math.E;  //2.71828...
+        public static double E = Math.E;  //2.71828...
     }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_3.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_3.cs
@@ -1,14 +1,14 @@
         public class Employee
         {
-            public int salary;
+            public int Salary;
 
             public Employee(int annualSalary)
             {
-                salary = annualSalary;
+                Salary = annualSalary;
             }
 
             public Employee(int weeklySalary, int numberOfWeeks)
             {
-                salary = weeklySalary * numberOfWeeks;
+                Salary = weeklySalary * numberOfWeeks;
             }
         }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_6.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_6.cs
@@ -1,4 +1,4 @@
-                public Manager(int initialdata)
+                public Manager(int initialData)
                 {
                     //Add further instructions here.
                 }

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_7.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_7.cs
@@ -1,4 +1,4 @@
-                public Manager(int initialdata)
+                public Manager(int initialData)
                     : base()
                 {
                     //Add further instructions here.

--- a/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_9.cs
+++ b/docs/csharp/programming-guide/classes-and-structs/codesnippet/CSharp/using-constructors_9.cs
@@ -1,4 +1,4 @@
             public Employee(int annualSalary)
             {
-                salary = annualSalary;
+                Salary = annualSalary;
             }


### PR DESCRIPTION
## Summary

Changed code examples to follow the naming conventions

Fixes #9915
