### PR TITLE
Replace NullableReferenceTypes w/ NullableContextOptions

### DIFF
--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -49,7 +49,7 @@ You can add the preceding pragma anywhere in a source file, and the nullable ref
 You can also turn on **nullable reference types** for an entire project by adding the following element to your .csproj file, for example, immediately following the `LangVersion` element that enabled C# 8.0:
 
 ```xml
-<NullableReferenceTypes>true</NullableReferenceTypes>
+<NullableContextOptions>enable</NullableContextOptions>
 ```
 
 ### Design the types for the application


### PR DESCRIPTION
With Visual Studio 16 Preview 2 NullableReferenceTypes has been replaced by NullableContextOptions

See: https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-reference-types.md
