### PR TITLE
Fix header sizing for consistency in Extensibility doc

### DIFF
--- a/docs/core/tools/extensibility.md
+++ b/docs/core/tools/extensibility.md
@@ -90,7 +90,7 @@ their dependencies.
 You can find richer examples and different combinations of this in the [.NET Core CLI repo](https://github.com/dotnet/cli/tree/release/2.1/TestAssets/TestProjects).
 You can also see the [implementation of tools used](https://github.com/dotnet/cli/tree/release/2.1/TestAssets/TestPackages) in the same repo.
 
-### Custom targets
+## Custom targets
 NuGet has the capability to [package custom MSBuild targets and props files](/nuget/create-packages/creating-a-package#including-msbuild-props-and-targets-in-a-package). With the move of the .NET Core CLI tools to use MSBuild, the same mechanism of extensibility now applies to .NET Core projects. You would use this type of extensibility when you want to extend the build process, or when you want to access any of the artifacts in the build process, such as generated files, or you want to inspect the configuration under which the build is invoked, etc.
 
 In the following example, you can see the target's project file using the `csproj` syntax. This instructs the [`dotnet pack`](dotnet-pack.md) command what to package, placing the targets files as well as the assemblies into the *build* folder inside the package. Notice the `<ItemGroup>` element that has the `Label` property set to `dotnet pack instructions`, and the Target
@@ -149,7 +149,7 @@ Using the custom target depends solely on how you configure it. Since it's an MS
 
 However, if you want to provide a better user experience to your users, you can combine per-project tools and custom targets. In this scenario, the per-project tool would essentially just accept whatever needed parameters and would translate that into the required [`dotnet msbuild`](dotnet-msbuild.md) invocation that would execute the target. You can see a sample of this kind of synergy on the [MVP Summit 2016 Hackathon samples](https://github.com/dotnet/MVPSummitHackathon2016) repo in the [`dotnet-packer`](https://github.com/dotnet/MVPSummitHackathon2016/tree/master/dotnet-packer) project.
 
-### PATH-based extensibility
+## PATH-based extensibility
 PATH-based extensibility is usually used for development machines where you need a tool that conceptually covers more
 than a single project. The main drawback of this extension mechanism is that it's tied to the machine where the
 tool exists. If you need it on another machine, you would have to deploy it.


### PR DESCRIPTION
## Summary

There are three main headings in this doc that should be at the same level:

 - Per-project based extensibility
 - Custom targets
 - PATH-based extensibility

However, the last two were incorrectly a level lower than the first, making the structure confusing.