### PR TITLE
Implicit numeric conversions: fix remarks

### DIFF
--- a/docs/csharp/language-reference/keywords/implicit-numeric-conversions-table.md
+++ b/docs/csharp/language-reference/keywords/implicit-numeric-conversions-table.md
@@ -33,9 +33,9 @@ The following table shows the predefined implicit conversions between .NET numer
 
 - Precision but not magnitude might be lost in the conversions from `int`, `uint`, `long`, or `ulong` to `float` and from `long` or `ulong` to `double`.  
   
-- There are no implicit conversions to the `char`, `byte` and `sbyte` types.  
+- There are no implicit conversions to the `char`, `byte`, and `sbyte` types.  
 
-- There are no implicit conversions from the `char`, `double` and `decimal` types.
+- There are no implicit conversions from the `double` and `decimal` types.
   
 - There are no implicit conversions between the `decimal` type and the `float` or `double` types.  
   


### PR DESCRIPTION
There are implicit conversions from `char`: the third row of the [table](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/implicit-numeric-conversions-table) is about that.
