### PR TITLE
Update the dotnet vstest doc

### DIFF
--- a/docs/core/tools/dotnet-vstest.md
+++ b/docs/core/tools/dotnet-vstest.md
@@ -37,7 +37,7 @@ dotnet vstest [<TEST_FILE_NAMES>] [--Settings|/Settings] [--Tests|/Tests] [--Tes
 
 ## Description
 
-The `dotnet-vstest` command runs the `VSTest.Console` command-line application to run automated unit and coded UI application tests.
+The `dotnet-vstest` command runs the `VSTest.Console` command-line application to run automated unit tests.
 
 ## Arguments
 
@@ -67,11 +67,11 @@ Target platform architecture used for test execution. Valid values are `x86`, `x
 
 `--Framework|/Framework:<Framework Version>`
 
-Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework35`, `Framework40`, `Framework45`, `FrameworkCore10`, and `FrameworkUap10`.
+Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework40`, `Framework45`, `FrameworkCore10`, and `FrameworkUap10`.
 
 `--Parallel|/Parallel`
 
-Execute tests in parallel. By default, all available cores on the machine are available for use. Set an explicit number of cores with a settings file.
+Execute tests in parallel. By default, all available cores on the machine are available for use. Specify explicit number of cores by setting MaxCpuCount property under the RunConfiguration node in the runsettings file.
 
 `--TestCaseFilter|/TestCaseFilter:<Expression>`
 
@@ -156,11 +156,11 @@ Target platform architecture used for test execution. Valid values are `x86`, `x
 
 `--Framework|/Framework:<Framework Version>`
 
-Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework35`, `Framework40`, `Framework45`, and `FrameworkCore10`.
+Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework40`, `Framework45`, and `FrameworkCore10`.
 
 `--Parallel|/Parallel`
 
-Execute tests in parallel. By default, all available cores on the machine are available for use. Set an explicit number of cores with a settings file.
+Execute tests in parallel. By default, all available cores on the machine are available for use. Specify explicit number of cores by setting MaxCpuCount property under the RunConfiguration node in the runsettings file.
 
 `--TestCaseFilter|/TestCaseFilter:<Expression>`
 
@@ -232,11 +232,11 @@ Target platform architecture used for test execution. Valid values are `x86`, `x
 
 `--Framework|/Framework:<Framework Version>`
 
-Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework35`, `Framework40`, `Framework45`, and `FrameworkCore10`.
+Target .NET Framework version used for test execution. Examples of valid values are `.NETFramework,Version=v4.6` or `.NETCoreApp,Version=v1.0`. Other supported values are `Framework40`, `Framework45`, and `FrameworkCore10`.
 
 `--Parallel|/Parallel`
 
-Execute tests in parallel. By default, all available cores on the machine are available for use. Set an explicit number of cores with a settings file.
+Execute tests in parallel. By default, all available cores on the machine are available for use. Specify explicit number of cores by setting MaxCpuCount property under the RunConfiguration node in the runsettings file.
 
 `--TestCaseFilter|/TestCaseFilter:<Expression>`
 

--- a/docs/core/tools/dotnet-vstest.md
+++ b/docs/core/tools/dotnet-vstest.md
@@ -71,7 +71,7 @@ Target .NET Framework version used for test execution. Examples of valid values 
 
 `--Parallel|/Parallel`
 
-Execute tests in parallel. By default, all available cores on the machine are available for use. Specify explicit number of cores by setting MaxCpuCount property under the RunConfiguration node in the runsettings file.
+Execute tests in parallel. By default, all available cores on the machine are available for use. Specify an explicit number of cores by setting the MaxCpuCount property under the RunConfiguration node in the runsettings file.
 
 `--TestCaseFilter|/TestCaseFilter:<Expression>`
 
@@ -160,7 +160,7 @@ Target .NET Framework version used for test execution. Examples of valid values 
 
 `--Parallel|/Parallel`
 
-Execute tests in parallel. By default, all available cores on the machine are available for use. Specify explicit number of cores by setting MaxCpuCount property under the RunConfiguration node in the runsettings file.
+Execute tests in parallel. By default, all available cores on the machine are available for use. Specify an explicit number of cores by setting the MaxCpuCount property under the RunConfiguration node in the runsettings file.
 
 `--TestCaseFilter|/TestCaseFilter:<Expression>`
 
@@ -236,7 +236,7 @@ Target .NET Framework version used for test execution. Examples of valid values 
 
 `--Parallel|/Parallel`
 
-Execute tests in parallel. By default, all available cores on the machine are available for use. Specify explicit number of cores by setting MaxCpuCount property under the RunConfiguration node in the runsettings file.
+Execute tests in parallel. By default, all available cores on the machine are available for use. Specify an explicit number of cores by setting the MaxCpuCount property under the RunConfiguration node in the runsettings file.
 
 `--TestCaseFilter|/TestCaseFilter:<Expression>`
 


### PR DESCRIPTION
Removed the reference to coded ui.
Fixed the message for parallel.
Removed Framework35 from the supported frameworks.
