### PR TITLE
Update .NET Standard to include disclaimer for .NET Framework

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -14,7 +14,7 @@
 
 <sup>1 The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/master/release-notes/download-archive.md) if you cannot upgrade to Visual Studio 2017.</sup>
 
-<sup>2 The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. While NuGet considers .NET Framework 4.6.1 as supporting .NET Standard 2.0, there are several issues with consuming .NET Standard libraries that were built for .NET Standard 1.5 or higher. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.</sup>
+<sup>2 The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. While NuGet considers .NET Framework 4.6.1 as supporting .NET Standard 1.5 through 2.0, there are several issues with consuming .NET Standard libraries that were built for those versions from .NET Framework 4.6.1 projects. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.</sup>
 
 - The columns represent .NET Standard versions. Each header cell is a link to a document that shows which APIs got added in that version of .NET Standard.
 - The rows represent the different .NET implementations.

--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -1,18 +1,20 @@
-| .NET Standard              | [1.0]  | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]      | [1.6]      | [2.0]      |
-|----------------------------|--------|--------|-------|-------|-------|------------|------------|------------|
-| .NET Core                  | 1.0    | 1.0    | 1.0   | 1.0   | 1.0   | 1.0        | 1.0        | 2.0        |
-| .NET Framework <sup>1</sup>| 4.5    | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1      | 4.6.1      | 4.6.1      |
-| Mono                       | 4.6    | 4.6    | 4.6   | 4.6   | 4.6   | 4.6        | 4.6        | 5.4        |
-| Xamarin.iOS                | 10.0   | 10.0   | 10.0  | 10.0  | 10.0  | 10.0       | 10.0       | 10.14      |
-| Xamarin.Mac                | 3.0    | 3.0    | 3.0   | 3.0   | 3.0   | 3.0        | 3.0        | 3.8        |
-| Xamarin.Android            | 7.0    | 7.0    | 7.0   | 7.0   | 7.0   | 7.0        | 7.0        | 8.0        |
-| Universal Windows Platform | 10.0   | 10.0   | 10.0  | 10.0  | 10.0  | 10.0.16299 | 10.0.16299 | 10.0.16299 |
-| Windows                    | 8.0    | 8.0    | 8.1   |       |       |            |            |            |
-| Windows Phone              | 8.1    | 8.1    | 8.1   |       |       |            |            |            |
-| Windows Phone Silverlight  | 8.0    |        |       |       |       |            |            |            |
-| Unity                      | 2018.1 | 2018.1 | 2018.1| 2018.1| 2018.1| 2018.1     |  2018.1    | 2018.1     |
+| .NET Standard              | [1.0]  | [1.1]  | [1.2] | [1.3] | [1.4] | [1.5]              | [1.6]              | [2.0]               |
+|----------------------------|--------|--------|-------|-------|-------|--------------------|--------------------|---------------------|
+| .NET Core                  | 1.0    | 1.0    | 1.0   | 1.0   | 1.0   | 1.0                | 1.0                | 2.0                 |
+| .NET Framework <sup>1</sup>| 4.5    | 4.5    | 4.5.1 | 4.6   | 4.6.1 | 4.6.1 <sup>2</sup> | 4.6.1 <sup>2</sup> | 4.6.1 <sup>2</sup>  |
+| Mono                       | 4.6    | 4.6    | 4.6   | 4.6   | 4.6   | 4.6                | 4.6                | 5.4                 |
+| Xamarin.iOS                | 10.0   | 10.0   | 10.0  | 10.0  | 10.0  | 10.0               | 10.0               | 10.14               |
+| Xamarin.Mac                | 3.0    | 3.0    | 3.0   | 3.0   | 3.0   | 3.0                | 3.0                | 3.8                 |
+| Xamarin.Android            | 7.0    | 7.0    | 7.0   | 7.0   | 7.0   | 7.0                | 7.0                | 8.0                 |
+| Universal Windows Platform | 10.0   | 10.0   | 10.0  | 10.0  | 10.0  | 10.0.16299         | 10.0.16299         | 10.0.16299          |
+| Windows                    | 8.0    | 8.0    | 8.1   |       |       |                    |                    |                     |
+| Windows Phone              | 8.1    | 8.1    | 8.1   |       |       |                    |                    |                     |
+| Windows Phone Silverlight  | 8.0    |        |       |       |       |                    |                    |                     |
+| Unity                      | 2018.1 | 2018.1 | 2018.1| 2018.1| 2018.1| 2018.1             |  2018.1            | 2018.1              |
 
 <sup>1 The versions listed for .NET Framework apply to .NET Core 2.0 SDK and later versions of the tooling. Older versions used a different mapping for .NET Standard 1.5 and higher. You can [download tooling for .NET Core tools for Visual Studio 2015](https://github.com/dotnet/core/blob/master/release-notes/download-archive.md) if you cannot upgrade to Visual Studio 2017.</sup>
+
+<sup>2 The versions listed here represent the rules that NuGet uses to determine whether a given .NET Standard library is applicable. While NuGet considers .NET Framework 4.6.1 as supporting .NET Standard 2.0, there are several issues with consuming .NET Standard libraries that were built for .NET Standard 1.5 or higher. For .NET Framework projects that need to use such libraries, we recommend that you upgrade the project to target .NET Framework 4.7.2 or higher.</sup>
 
 - The columns represent .NET Standard versions. Each header cell is a link to a document that shows which APIs got added in that version of .NET Standard.
 - The rows represent the different .NET implementations.


### PR DESCRIPTION
This is intended to be a better fix for #10448. We should remain truthful to the applicability rules of NuGet while also calling out that consuming .NET Standard 1.5+ from .NET Framework 4.6.1 really isn't a great experience that that the consumer should upgrade to .NET Framework 4.7.2.

Fixes #7305 

/cc @SimonCropp 