### PR TITLE
Add missing embed flags to csc commandline arguments documentation

### DIFF
--- a/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
+++ b/docs/csharp/language-reference/compiler-options/listed-alphabetically.md
@@ -30,6 +30,8 @@ The following compiler options are sorted alphabetically. For a categorical list
 |[-delaysign](delaysign-compiler-option.md)|Delay-signs the assembly by using only the public part of the strong name key.|
 |[-deterministic](deterministic-compiler-option.md)|Causes the compiler to output an assembly whose binary content is identical across compilations if inputs are identical.|
 |[-doc](doc-compiler-option.md)|Specifies an XML Documentation file to generate.|
+|-embed|Embed all source files in the PDB.|
+|-embed:\<file list>|Embed specific files in the PDB.|
 |[-errorreport](errorreport-compiler-option.md)|Specifies how to handle internal compiler errors: prompt, send, or none. The default is none.|
 |[-filealign](filealign-compiler-option.md)|Specifies the alignment used for output file sections.|
 |[-fullpaths](fullpaths-compiler-option.md)|Causes the compiler to generate fully qualified paths.|

--- a/docs/csharp/language-reference/compiler-options/listed-by-category.md
+++ b/docs/csharp/language-reference/compiler-options/listed-by-category.md
@@ -48,7 +48,8 @@ The following compiler options are sorted by category. For an alphabetical list,
 |[-reference](reference-compiler-option.md)|Imports metadata from a file that contains an assembly.|
 |-analyzer|Run the analyzers from this assembly (Short form: /a)|
 |-additionalfile|Names additional files that don't directly affect code generation but may be used by analyzers for producing errors or warnings.|
-
+|-embed|Embed all source files in the PDB.|
+|-embed:\<file list>|Embed specific files in the PDB.|
 ## Debugging/Error Checking
 
 |Option|Purpose|


### PR DESCRIPTION
## Summary

The compiler option documentation didn't list the embed flags from proposal #12625.
Text is grabbed from `csc.exe /?` version `3.0.0-beta3-final`. 
I verified that the text has been identical since `2.9.0`.

The second `/embed:<file list>` option is lacking a dot at the end of the sentence in `csc /?`. 
I've added it here and have submitted a separate [pr](https://github.com/dotnet/roslyn/pull/33437) to add it in the roslyn repo.

