### PR TITLE
Fix method name references in documentation.

### DIFF
--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -303,11 +303,11 @@ Since we want to load the model from the zip file we saved, we'll create the `Fi
 
 [!code-csharp[LoadTheModel](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#21 "Load the model")]
 
-While the `model` is a `transformer` that operates on many rows of data, a very common production scenario is a need for predictions on individual examples. The <xref:Microsoft.ML.PredictionEngine%602> is a wrapper that is returned from the `CreatePredictionEngine` method. Let's add the following code to create the `PredictionEngine` as the first line in the `Predict` Method:
+While the `model` is a `transformer` that operates on many rows of data, a very common production scenario is a need for predictions on individual examples. The <xref:Microsoft.ML.PredictionEngine%602> is a wrapper that is returned from the `CreatePredictionEngine` method. Let's add the following code to create the `PredictionEngine` as the next line in the `TestSinglePrediction` Method:
 
 [!code-csharp[MakePredictionEngine](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#22 "Create the PredictionFunction")]
   
-This tutorial uses one test trip within this class. Later you can add other scenarios to experiment with the model. Add a trip to test the trained model's prediction of cost in the `Predict` method by creating an instance of `TaxiTrip`:
+This tutorial uses one test trip within this class. Later you can add other scenarios to experiment with the model. Add a trip to test the trained model's prediction of cost in the `TestSinglePrediction` method by creating an instance of `TaxiTrip`:
 
 [!code-csharp[PredictionData](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#23 "Create test data for single prediction")]
 
@@ -315,7 +315,7 @@ This tutorial uses one test trip within this class. Later you can add other scen
 
 [!code-csharp[Predict](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#24 "Create a prediction of taxi fare")]
 
-To display the predicted fare of the specified trip, add the following code into the `Main` method:
+To display the predicted fare of the specified trip, add the following code into the `TestSinglePrediction` method:
 
 [!code-csharp[Predict](../../../samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#25 "Display the prediction.")]
 


### PR DESCRIPTION
## Summary

The corrections are based on the code in the repo at https://github.com/dotnet/samples/blob/master/machine-learning/tutorials/TaxiFarePrediction/Program.cs, and on my own experience implementing the code in the tutorial.