### PR TITLE
GetMemberProps is a helper

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getmemberprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getmemberprops-method.md
@@ -19,7 +19,7 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # IMetaDataImport::GetMemberProps Method
-Gets metadata information, including the name, binary signature, and relative virtual address, of the <xref:System.Type> member referenced by the specified metadata token.  
+Gets information stored in the metadata for a specified member definition, including the name, binary signature, and relative virtual address, of the <xref:System.Type> member referenced by the specified metadata token. This is a simple helper method: if *mb* is a MethodDef, then **GetMethodProps** is called; if *mb* is a FieldDef, then **GetFieldProps** is called. See these other methods for details. 
   
 ## Syntax  
   
@@ -73,7 +73,7 @@ HRESULT GetMemberProps (
  [out] Any method implementation flags associated with the member.  
   
  `pdwCPlusTypeFlag`  
- [out] A flag that marks a <xref:System.ValueType>.  
+ [out] A flag that marks a <xref:System.ValueType>. It is one of the `ELEMENT_TYPE_*` values.
   
  `ppValue`  
  [out] A constant string value returned by this member.  


### PR DESCRIPTION
Pointing out that GetMemberProps is a helper, and it will call GetMethodProps or GetFieldProps based on the type of token being passed.

## Summary

From the 2001 Unamanged Metadata API documentation:

> Gets the information stored in metadata for a specified member definition. This is a
simple helper method: if _md_ is a MethodDef, then we call _GetMethodProps_; if _md_ is a
FieldDef, then we call _GetFieldProps_. See these other methods for details. 
