### PR TITLE
Noting what members it returns

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
@@ -33,7 +33,7 @@ HRESULT EnumMembers (
 );  
 ```  
   
-### Parameters  
+## Parameters  
  `phEnum`  
  [in, out] A pointer to the enumerator.  
   

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
@@ -57,7 +57,9 @@ HRESULT EnumMembers (
 |`S_FALSE`|There are no MemberDef tokens to enumerate. In that case, `pcTokens` is zero.|  
   
 ## Remarks  
- When enumerating collections of members for a class, `EnumMembers` returns only members defined directly on the class. It does not return any members that the class inherits, even if the class provides an implementation for those inherited members. To enumerate inherited members, the caller must explicitly walk the inheritance chain. Note that the rules for the inheritance chain may vary depending on the language or compiler that emitted the original metadata.  
+ When enumerating collections of members for a class, `EnumMembers` returns only members (fields and methods, but **not** properties or events) defined directly on the class. It does not return any members that the class inherits, even if the class provides an implementation for those inherited members. To enumerate inherited members, the caller must explicitly walk the inheritance chain. Note that the rules for the inheritance chain may vary depending on the language or compiler that emitted the original metadata.
+ 
+ Properties and events are not enumerated by **EnumMembers**. In order to enumerate those use **EnumProperties** or **EnumEvents**.
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
@@ -33,7 +33,7 @@ HRESULT EnumMembers (
 );  
 ```  
   
-#### Parameters  
+### Parameters  
  `phEnum`  
  [in, out] A pointer to the enumerator.  
   
@@ -59,7 +59,7 @@ HRESULT EnumMembers (
 ## Remarks  
  When enumerating collections of members for a class, `EnumMembers` returns only members (fields and methods, but **not** properties or events) defined directly on the class. It does not return any members that the class inherits, even if the class provides an implementation for those inherited members. To enumerate inherited members, the caller must explicitly walk the inheritance chain. Note that the rules for the inheritance chain may vary depending on the language or compiler that emitted the original metadata.
  
- Properties and events are not enumerated by **EnumMembers**. In order to enumerate those use **EnumProperties** or **EnumEvents**.
+ Properties and events are not enumerated by `EnumMembers`. To enumerate those, use `EnumProperties` or `EnumEvents`.
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-enummembers-method.md
@@ -59,7 +59,7 @@ HRESULT EnumMembers (
 ## Remarks  
  When enumerating collections of members for a class, `EnumMembers` returns only members (fields and methods, but **not** properties or events) defined directly on the class. It does not return any members that the class inherits, even if the class provides an implementation for those inherited members. To enumerate inherited members, the caller must explicitly walk the inheritance chain. Note that the rules for the inheritance chain may vary depending on the language or compiler that emitted the original metadata.
  
- Properties and events are not enumerated by `EnumMembers`. To enumerate those, use `EnumProperties` or `EnumEvents`.
+ Properties and events are not enumerated by `EnumMembers`. To enumerate those, use [EnumProperties](imetadataimport-enumproperties-method.md) or [EnumEvents](imetadataimport-enumevents-method.md).
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  


### PR DESCRIPTION
EnumMembers only returns fields and methods, and does not return properties or events.

## Summary

EnumMembers only emumerates certain items:

- **Methods**: Yes
- **Fields**: Yes
- **Properties**: No
- **Events**: No

From the 2001 Unmanaged Metadata API documentation:

> Enumerates all members (fields and methods, but **not** properties or events) defined
by the class specified by _cl_. This does not include any members inherited by that
class; even in the case where this TypeDef actually implements an inherited method.
