### PR TITLE
Move https://docs.microsoft.com/dotnet links to relative links.

### DIFF
--- a/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/docker-apps-inner-loop-workflow.md
+++ b/docs/standard/containerized-lifecycle-architecture/design-develop-containerized-apps/docker-apps-inner-loop-workflow.md
@@ -114,7 +114,7 @@ In the DockerFile, you also need to instruct Docker to listen to the TCP port th
 
 There are other lines of configuration that you can add in the DockerFile depending on the language/framework you are using, so Docker knows how to run the app. For instance, you need the ENTRYPOINT line with \["dotnet", "MyCustomMicroservice.dll"\] to run a .NET Core app, although you can have multiple variants depending on the approach to build and run your service. If you're using the SDK and dotnet CLI to build and run the .NET app, it would be slightly different. The bottom line is that the ENTRYPOINT line plus additional lines will be different depending on the language/platform you choose for your application.
 
-**More info** For information about building Docker images for .NET Core applications, go to <https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images>.
+**More info** For information about building Docker images for .NET Core applications, go to [https://docs.microsoft.com/dotnet/core/docker/building-net-docker-images](../../../core/docker/building-net-docker-images.md).
 
 To learn more about building your own images, go to [https://docs.docker.com/engine/\
 tutorials/dockerimages/](https://docs.docker.com/engine/tutorials/dockerimages/).

--- a/docs/standard/containerized-lifecycle-architecture/road-to-modern-applications-based-on-containers.md
+++ b/docs/standard/containerized-lifecycle-architecture/road-to-modern-applications-based-on-containers.md
@@ -18,10 +18,10 @@ This book belongs to a Microsoft suite of guides that cover many of the needs an
 You can find additional Microsoft e-books related to Docker containers in the list below:
 
 - **.NET Microservices: Architecture for Containerized .NET Applications** \
-  [*https://docs.microsoft.com/dotnet/standard/microservices-architecture/*](https://docs.microsoft.com/dotnet/standard/microservices-architecture/)
+  [*https://docs.microsoft.com/dotnet/standard/microservices-architecture/*](../microservices-architecture/index.md)
 
 - **Modernize existing .NET applications with Azure cloud and Windows Containers** \
-  [*https://docs.microsoft.com/dotnet/standard/modernize-with-azure-and-containers/*](https://docs.microsoft.com/dotnet/standard/modernize-with-azure-and-containers/)
+  [*https://docs.microsoft.com/dotnet/standard/modernize-with-azure-and-containers/*](../modernize-with-azure-and-containers/index.md)
 
 >[!div class="step-by-step"]
 >[Previous](docker-containers-images-and-registries.md)

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/multi-container-applications-docker-compose.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/multi-container-applications-docker-compose.md
@@ -452,7 +452,7 @@ To achieve this, the .NET team is providing three basic variants in [microsoft/d
 
 1.  **sdk**: for the development and build scenarios.
 2.  **runtime**: for the production scenario and
-3.  **runtime-deps**: for the production scenario of [self-contained applications](https://docs.microsoft.com/dotnet/core/deploying/index#self-contained-deployments-scd).
+3.  **runtime-deps**: for the production scenario of [self-contained applications](../../../core/deploying/index.md#self-contained-deployments-scd).
 
 Runtime images also provides automatic setting of aspnetcore\_urls to port 80 and the pre-ngend cache of assemblies; to help in getting faster startup.
 
@@ -462,7 +462,7 @@ Runtime images also provides automatic setting of aspnetcore\_urls to port 80 an
     [*https://blogs.msdn.microsoft.com/stevelasker/2016/09/29/building-optimized-docker-images-with-asp-net-core/*](https://blogs.msdn.microsoft.com/stevelasker/2016/09/29/building-optimized-docker-images-with-asp-net-core/)
 
 -   **Building Docker Images for .NET Core Applications** <br/>
-    [*https://docs.microsoft.com/en-us/dotnet/core/docker/building-net-docker-images*](https://docs.microsoft.com/en-us/dotnet/core/docker/building-net-docker-images)
+    [*https://docs.microsoft.com/en-us/dotnet/core/docker/building-net-docker-images*](../../../core/docker/building-net-docker-images.md)
 
 >[!div class="step-by-step"]
 >[Previous](data-driven-crud-microservice.md)

--- a/docs/standard/modern-web-apps-azure-architecture/index.md
+++ b/docs/standard/modern-web-apps-azure-architecture/index.md
@@ -102,7 +102,7 @@ Feel free to forward this guide to your team to help ensure a common understandi
 ## References
 
 - **Choosing between .NET Core and .NET Framework for server apps**  
-  <https://docs.microsoft.com/dotnet/standard/choosing-core-framework-server>
+  [https://docs.microsoft.com/dotnet/standard/choosing-core-framework-server](../choosing-core-framework-server.md)
 
 >[!div class="step-by-step"]
 >[Next](modern-web-applications-characteristics.md)


### PR DESCRIPTION
Changed absolute https://docs.microsoft.com/dotnet links to relative links.

Contributes to #8364 