### PR TITLE
Noting that it returns mdInterfaceImpl tokens

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataimport-enuminterfaceimpls-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-enuminterfaceimpls-method.md
@@ -19,7 +19,7 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # IMetaDataImport::EnumInterfaceImpls Method
-Enumerates all interfaces implemented by the specified TypeDef. 
+Enumerates all interfaces implemented by the specified `TypeDef`. 
   
 ## Syntax  
   
@@ -33,7 +33,7 @@ HRESULT EnumInterfaceImpls (
 );  
 ```  
   
-#### Parameters  
+## Parameters  
  `phEnum`  
  [in, out] A pointer to the enumerator.  
   
@@ -58,7 +58,7 @@ HRESULT EnumInterfaceImpls (
 
 ## Remarks
 
-The enumeration returns a collection of `mdInterfaceImpl` tokens for each interface implemented by the specified **TypeDef**. Interface tokens will be returned in the order the interfaces were specified (through **DefineTypeDef** or **SetTypeDefProps**). Properties of the returned `mdInterfaceImpl` tokens can be queried using **GetInterfaceImplProps**.
+The enumeration returns a collection of `mdInterfaceImpl` tokens for each interface implemented by the specified `TypeDef`. Interface tokens are returned in the order the interfaces were specified (through `DefineTypeDef` or `SetTypeDefProps`). Properties of the returned `mdInterfaceImpl` tokens can be queried using [GetInterfaceImplProps](imetadataimport-getinterfaceimplprops-method.md).
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-enuminterfaceimpls-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-enuminterfaceimpls-method.md
@@ -19,7 +19,7 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # IMetaDataImport::EnumInterfaceImpls Method
-Enumerates MethodDef tokens representing interface implementations.  
+Enumerates all interfaces implemented by the specified TypeDef. 
   
 ## Syntax  
   
@@ -55,6 +55,10 @@ HRESULT EnumInterfaceImpls (
 |-------------|-----------------|  
 |`S_OK`|`EnumInterfaceImpls` returned successfully.|  
 |`S_FALSE`|There are no MethodDef tokens to enumerate. In that case, `pcImpls` is set to zero.|  
+
+## Remarks
+
+The enumeration returns a collection of `mdInterfaceImpl` tokens for each interface implemented by the specified **TypeDef**. Interface tokens will be returned in the order the interfaces were specified (through **DefineTypeDef** or **SetTypeDefProps**). Properties of the returned `mdInterfaceImpl` tokens can be queried using **GetInterfaceImplProps**.
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  


### PR DESCRIPTION
- it returns mdInterfaceImpl tokens
- properties of the interface implementations can be queries with GetInterfaceImplProps

From the 2001 Microsoft document "Metadata Unmanaged API":

> ### 4.1.6 EnumInterfaceImpls
> 
>     HRESULT EnumInterfaceImpls(HCORENUM *phEnum, mdTypeDef td,
>             mdInterfaceImpl rTokens[], ULONG cTokens, ULONG *pcTokens)
> 
> Enumerates all interfaces implemented by the specified TypeDef. Tokens will be returned in the order the interfaces were specified (through *DefineTypeDef* or *SetTypeDefProps*).
> 
> [See GetInterfaceImplProps for more detail of how this method works]
> 
> | in/out | Parameter | Description | Required? |
> |---------|-----------|--------------|-----------------|
> | inout | phEnum | Enumeration handle. Must be 0 on first call | yes |
> | in | td | Token specifying the TypeDef whose InterfaceImpls are required | yes |
> | out | rTokens [] | Array to hold returned tokens | |
> | in | cTokens | Size of rTokens [] array | yes |
> | out | pcTokens | Number of tokens actually returned | |