### PR TITLE
Noting where the tokens come from

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -45,7 +45,7 @@ HRESULT GetInterfaceImplProps (
 
  You obtain the value for `iImpl` by calling the [EnumInterfaceImpls](imetadataimport-enuminterfaceimpls-method) method.
  
- For example, suppose a class has an mdTypeDef token value of 0x02000007. And suppose it implements three
+ For example, suppose that a class has an `mdTypeDef` token value of 0x02000007 and that it implements three
 interfaces whose types have tokens: 
 
 - 0x02000003 (TypeDef)

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -65,7 +65,7 @@ Conceptually, this information is stored into an interface implementation table 
 Recall, the token is a 4-byte value:
 
 - the lower 3 bytes hold the row number, or RID
-- the upper byte holds the token type – 0x09 for `mdtInterfaceImpl` 
+- The upper byte holds the token type – 0x09 for `mdtInterfaceImpl`.
 
 **GetInterfaceImplProps** will return the information held in the row whose token you provide in the *iImpl* argument. 
   

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -67,7 +67,7 @@ Recall, the token is a 4-byte value:
 - the lower 3 bytes hold the row number, or RID
 - The upper byte holds the token type – 0x09 for `mdtInterfaceImpl`.
 
-**GetInterfaceImplProps** will return the information held in the row whose token you provide in the *iImpl* argument. 
+`GetInterfaceImplProps` returns the information held in the row whose token you provide in the `iImpl` argument. 
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -19,7 +19,7 @@ author: "mairaw"
 ms.author: "mairaw"
 ---
 # IMetaDataImport::GetInterfaceImplProps Method
-Gets a pointer to the metadata tokens for the <xref:System.Type> that implements the specified method, and for the interface that declares that method.  
+Gets a pointer to the metadata tokens for the <xref:System.Type> that implements the specified method, and for the interface that declares that method.
   
 ## Syntax  
   
@@ -40,6 +40,34 @@ HRESULT GetInterfaceImplProps (
   
  `ptkIface`  
  [out] The metadata token representing the interface that defines the implemented method.  
+
+## Remarks
+
+ You obtain the value for *iImpl* by calling the **EnumInterfaceImpls** method.
+ 
+ For example, suppose a class has an mdTypeDef token value of 0x02000007. And suppose it implements three
+interfaces whose types have tokens: 
+
+- 0x02000003 (TypeDef)
+- 0x0100000A (TypeRef)
+- 0x0200001C (TypeDef)
+
+Conceptually, this information is stored into an interface implementation table as:
+
+| Row Number | Class Token | Interface Token |
+|------------|-------------|-----------------|
+| 4          |             |                 |
+| 5          | 02000007    | 02000003        |
+| 6          | 02000007    | 0100000A        |
+| 7          |             |                 |
+| 8          | 02000007    | 0200001C        |
+
+Recall, the token is a 4-byte value:
+
+- the lower 3 bytes hold the row number, or RID
+- the upper byte holds the token type – 0x09 for `mdtInterfaceImpl` 
+
+**GetInterfaceImplProps** will return the information held in the row whose token you provide in the *iImpl* argument. 
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -43,7 +43,7 @@ HRESULT GetInterfaceImplProps (
 
 ## Remarks
 
- You obtain the value for `iImpl` by calling the [EnumInterfaceImpls](imetadataimport-enuminterfaceimpls-method) method.
+ You obtain the value for `iImpl` by calling the [EnumInterfaceImpls](imetadataimport-enuminterfaceimpls-method.md) method.
  
  For example, suppose that a class has an `mdTypeDef` token value of 0x02000007 and that it implements three
 interfaces whose types have tokens: 

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -43,7 +43,7 @@ HRESULT GetInterfaceImplProps (
 
 ## Remarks
 
- You obtain the value for *iImpl* by calling the **EnumInterfaceImpls** method.
+ You obtain the value for `iImpl` by calling the [EnumInterfaceImpls](imetadataimport-enuminterfaceimpls-method) method.
  
  For example, suppose a class has an mdTypeDef token value of 0x02000007. And suppose it implements three
 interfaces whose types have tokens: 

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -64,7 +64,7 @@ Conceptually, this information is stored into an interface implementation table 
 
 Recall, the token is a 4-byte value:
 
-- the lower 3 bytes hold the row number, or RID
+- The lower 3 bytes hold the row number, or RID.
 - The upper byte holds the token type – 0x09 for `mdtInterfaceImpl`.
 
 `GetInterfaceImplProps` returns the information held in the row whose token you provide in the `iImpl` argument. 

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -54,7 +54,7 @@ interfaces whose types have tokens:
 
 Conceptually, this information is stored into an interface implementation table as:
 
-| Row Number | Class Token | Interface Token |
+| Row number | Class token | Interface token |
 |------------|-------------|-----------------|
 | 4          |             |                 |
 | 5          | 02000007    | 02000003        |

--- a/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataimport-getinterfaceimplprops-method.md
@@ -1,6 +1,6 @@
 ---
 title: "IMetaDataImport::GetInterfaceImplProps Method"
-ms.date: "03/30/2017"
+ms.date: "02/25/2019"
 api_name: 
   - "IMetaDataImport.GetInterfaceImplProps"
 api_location: 


### PR DESCRIPTION
The mdInterfaceImpl tokens come from EnumInterfaceImpls

## Summary

Added note that the mdInterfaceImpl tokens from the EnumInterfaceImpls, and describe what you're getting (i.e. you're not getting the Interface propertie)
