### PR TITLE
C67698: Should the link be clickable?

### DIFF
--- a/includes/tlasharptla-wpfxmlnsv1-md.md
+++ b/includes/tlasharptla-wpfxmlnsv1-md.md
@@ -1,1 +1,1 @@
-[http://schemas.microsoft.com/winfx/2006/xaml/presentation](http://schemas.microsoft.com/winfx/2006/xaml/presentation)
+`http://schemas.microsoft.com/winfx/2006/xaml/presentation`

--- a/includes/tlasharptla-wpfxmlnsv1-md.md
+++ b/includes/tlasharptla-wpfxmlnsv1-md.md
@@ -1,1 +1,1 @@
-http://schemas.microsoft.com/winfx/2006/xaml/presentation
+[http://schemas.microsoft.com/winfx/2006/xaml/presentation](http://schemas.microsoft.com/winfx/2006/xaml/presentation)


### PR DESCRIPTION
Hello @yishengjin1413,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description of the source issue:
The link is not being rendered as clickable on LOC pages, while on EN it is. The link is not working though. Should the link be clickable? If link should be clickable then it should be written like this, so it works on LOC pages too.
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
