### PR TITLE
Add redirect for moved documentation

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1647,6 +1647,11 @@
             "redirect_url": "/dotnet/standard/index"
         },
         {
+            "source_path": "docs/standard/assembly-format.md",
+            "redirect_url": "/dotnet/standard/assembly/file-format",
+            "redirect_document_id": true
+        },
+        {
             "source_path": "docs/standard/asynchronous-programming-patterns/multithreaded-programming-with-the-event-based-asynchronous-pattern.md",
             "redirect_url": "/dotnet/standard/asynchronous-programming-patterns/event-based-asynchronous-pattern-eap"
         },


### PR DESCRIPTION
## Summary

As mentioned in [this review](https://github.com/dotnet/docs/pull/6404#pullrequestreview-136412539) of #6404  a redirect from `/docs/standard/assembly-format.md` to the new `docs/standard/assembly/file-format.md` file needs to be made. 

Looks like it just got missed.

