### PR TITLE
fix: MD003/heading-style/header-style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Your topic will also contain links to the sample. Link directly to the sample's 
 
 For more information, see the [Samples Readme](https://github.com/dotnet/samples/blob/master/README.md).
 
-## The C# interactive experience #
+## The C# interactive experience
 
 Short code samples in C# can use the `csharp-interactive` language tag to
 specify a C# sample that runs in the browser. (Inline code samples use the

--- a/docs/csharp/language-reference/keywords/is.md
+++ b/docs/csharp/language-reference/keywords/is.md
@@ -10,11 +10,11 @@ helpviewer_keywords:
   - "is keyword [C#]"
 ms.assetid: bc62316a-d41f-4f90-8300-c6f4f0556e43
 ---
-# is (C# Reference) #
+# is (C# Reference)
 
 Checks if an object is compatible with a given type, or (starting with C# 7.0) tests an expression against a pattern.
 
-## Testing for type compatibility ##
+## Testing for type compatibility
 
 The `is` keyword evaluates type compatibility at runtime. It determines whether an object instance or the result of an expression can be converted to a specified type. It has the syntax
 
@@ -51,7 +51,7 @@ The `is` keyword generates a compile-time warning if the expression is known to 
 
 Starting with C# 7.0, you can use pattern matching with the [type pattern](#type) to write more concise code that uses the `is` statement.
 
-## Pattern matching with `is` ##
+## Pattern matching with `is`
 
 Starting with C# 7.0, the `is` and [switch](../../../csharp/language-reference/keywords/switch.md) statements support pattern matching. The `is` keyword supports the following patterns:
 
@@ -99,7 +99,7 @@ The equivalent code without pattern matching requires a separate assignment that
 
 [!code-csharp[is#10](../../../../samples/snippets/csharp/language-reference/keywords/is/is-type-pattern10.cs#10)]
 
-### <a name="constant" /> Constant pattern ###
+### <a name="constant" /> Constant pattern
 
 When performing pattern matching with the constant pattern, `is` tests whether an expression equals a specified constant. In C# 6 and earlier versions, the constant pattern is supported by the [switch](switch.md) statement. Starting with C# 7.0, it is supported by the `is` statement as well. Its syntax is:
 

--- a/docs/csharp/linq/linq-in-csharp.md
+++ b/docs/csharp/linq/linq-in-csharp.md
@@ -4,7 +4,7 @@ description: Links to topics that provide more detailed information about LINQ i
 ms.date: 11/30/2016
 ms.assetid: 8eb3284f-0ab9-4cad-9216-2da58d9761a5
 ---
-# LINQ in C# #
+# LINQ in C\#
 
 This section contains links to topics that provide more detailed information about LINQ.
 

--- a/docs/csharp/linq/write-linq-queries.md
+++ b/docs/csharp/linq/write-linq-queries.md
@@ -4,7 +4,7 @@ description: Learn how to write LINQ queries in C#.
 ms.date: 12/01/2016
 ms.assetid: 30703f79-cf3a-4d02-b892-c95d58a1d9ed
 ---
-# Write LINQ queries in C# #
+# Write LINQ queries in C\#
 
 This article shows the three ways in which you can write a LINQ query in C#:
 

--- a/docs/csharp/pattern-matching.md
+++ b/docs/csharp/pattern-matching.md
@@ -5,7 +5,7 @@ ms.date: 01/24/2017
 ms.assetid: 1e575c32-2e2b-4425-9dca-7d118f3ed15b
 ---
 
-# Pattern Matching #
+# Pattern Matching
 
 Patterns test that a value has a certain *shape*, and can *extract*
 information from the value when it has the matching shape. Pattern

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-define-constants.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-define-constants.md
@@ -6,7 +6,7 @@ helpviewer_keywords:
   - "constants [C#]"
 ms.assetid: 43f511be-346c-4b8a-995e-aded94542ece
 ---
-# How to: Define Constants in C#
+# How to: Define Constants in C\#
 Constants are fields whose values are set at compile time and can never be changed. Use constants to provide meaningful names instead of numeric literals ("magic numbers") for special values.  
   
 > [!NOTE]

--- a/docs/csharp/programming-guide/concepts/linq/getting-started-with-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/getting-started-with-linq.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
   - "queries [LINQ], LINQ in C#"
 ms.assetid: b8700c1f-05c9-4380-b6eb-e34c4da38e54
 ---
-# Getting Started with LINQ in C#
+# Getting Started with LINQ in C\#
 This section contains basic background information that will help you understand the rest of the LINQ documentation and samples.  
   
 ## In This Section  

--- a/docs/csharp/programming-guide/concepts/linq/scope-of-default-namespaces.md
+++ b/docs/csharp/programming-guide/concepts/linq/scope-of-default-namespaces.md
@@ -3,7 +3,7 @@ title: "Scope of Default Namespaces in C#1"
 ms.date: 07/20/2015
 ms.assetid: fe826236-830f-457a-9027-7ad62c909fae
 ---
-# Scope of Default Namespaces in C#
+# Scope of Default Namespaces in C\#
 Default namespaces as represented in the XML tree are not in scope for queries. If you have XML that is in a default namespace, you still must declare an <xref:System.Xml.Linq.XNamespace> variable, and combine it with the local name to make a qualified name to be used in the query.  
   
  One of the most common problems when querying XML trees is that if the XML tree has a default namespace, the developer sometimes writes the query as though the XML were not in a namespace.  

--- a/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
+++ b/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
@@ -2,7 +2,7 @@
 title: "Walkthrough: Persisting an Object using C#"
 ms.date: 04/26/2018
 ---
-# Walkthrough: persisting an object using C# #
+# Walkthrough: persisting an object using C\#
 
 You can use serialization to persist an object's data between instances, which enables you to store values and retrieve them the next time that the object is instantiated.
 

--- a/docs/csharp/programming-guide/interop/interoperability-overview.md
+++ b/docs/csharp/programming-guide/interop/interoperability-overview.md
@@ -24,7 +24,7 @@ The topic describes methods to enable interoperability between C# managed code a
 ## C++ Interop  
  You can use C++ interop, also known as It Just Works (IJW), to wrap a native C++ class so that it can be consumed by code that is authored in C# or another .NET Framework language. To do this, you write C++ code to wrap a native DLL or COM component. Unlike other .NET Framework languages, [!INCLUDE[vcprvc](~/includes/vcprvc-md.md)] has interoperability support that enables managed and unmanaged code to be located in the same application and even in the same file. You then build the C++ code by using the **/clr** compiler switch to produce a managed assembly. Finally, you add a reference to the assembly in your C# project and use the wrapped objects just as you would use other managed classes.  
   
-## Exposing COM Components to C#  
+## Exposing COM Components to C\#
  You can consume a COM component from a C# project. The general steps are as follows:  
   
 1.  Locate a COM component to use and register it. Use regsvr32.exe to register or un–register a COM DLL.  

--- a/docs/csharp/programming-guide/statements-expressions-operators/anonymous-functions.md
+++ b/docs/csharp/programming-guide/statements-expressions-operators/anonymous-functions.md
@@ -20,7 +20,7 @@ An anonymous function is an "inline" statement or expression that can be used wh
     > [!NOTE]
     >  Lambda expressions can be bound to expression trees and also to delegates.  
   
-## The Evolution of Delegates in C#  
+## The Evolution of Delegates in C\#
  In C# 1.0, you created an instance of a delegate by explicitly initializing it with a method that was defined elsewhere in the code. C# 2.0 introduced the concept of anonymous methods as a way to write unnamed inline statement blocks that can be executed in a delegate invocation. C# 3.0 introduced lambda expressions, which are similar in concept to anonymous methods but more expressive and concise. These two features are known collectively as *anonymous functions*. In general, applications that target version 3.5 and later of the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)] should use lambda expressions.  
   
  The following example demonstrates the evolution of delegate creation from C# 1.0 to C# 3.0:  

--- a/docs/csharp/tuples.md
+++ b/docs/csharp/tuples.md
@@ -4,7 +4,7 @@ description: Learn about unnamed and named tuple types in C#
 ms.date: 05/15/2018
 ms.assetid: ee8bf7c3-aa3e-4c9e-a5c6-e05cc6138baa
 ---
-# C# tuple types #
+# C# tuple types
 
 C# tuples are types that you define using a lightweight syntax. The advantages
 include a simpler syntax, rules for conversions based on number (referred to as cardinality)

--- a/docs/csharp/tutorials/attributes.md
+++ b/docs/csharp/tutorials/attributes.md
@@ -6,7 +6,7 @@ ms.date: 03/06/2017
 ms.assetid: b152cf36-76e4-43a5-b805-1a1952e53b79
 ---
 
-# Using Attributes in C# #
+# Using Attributes in C\#
 
 Attributes provide a way of associating information with code in a declarative way. They can also provide a reusable element that can be applied to a variety of targets.
 

--- a/docs/csharp/tutorials/index.md
+++ b/docs/csharp/tutorials/index.md
@@ -7,7 +7,7 @@ ms.date: 10/25/2018
 
 Welcome to the C# tutorials. These start with interactive lessons that you can run in your browser. Later tutorials, and more advanced tutorials help you work with the .NET development tools to create C# programs on your machine.
 
-## Introduction to C# interactive tutorials #
+## Introduction to C# interactive tutorials
 
 The first lessons explain C# concepts using small snippets of code. You'll
 learn the basics of C# syntax and how to work with data types like strings,
@@ -60,7 +60,7 @@ with the next lesson online or on your own machine. There are links
 to help you setup your environment and continue with the next tutorial
 on your machine.
 
-## Explore new features in C# #
+## Explore new features in C\#
 
 Try new features in [C# 6](../whats-new/csharp-6.md) in this [interactive exploration](exploration/csharp-6.yml).
 

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -4,7 +4,7 @@ description: Learn C# in your browser, and get started with your own development
 ms.date: 01/30/2018
 ms.custom: mvc
 ---
-# Introduction to C# #
+# Introduction to C\#
 
 Welcome to the introduction to C# tutorials. These start with interactive lessons
 that you can run in your browser.

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
@@ -4,7 +4,7 @@ description: Learn C# by exploring numeric types, their properties and methods.
 ms.date: 10/31/2017
 ms.custom: mvc
 ---
-# Manipulate integral and floating point numbers in C# #
+# Manipulate integral and floating point numbers in C\#
 
 This tutorial teaches you about the numeric types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 

--- a/docs/csharp/tutorials/string-interpolation.md
+++ b/docs/csharp/tutorials/string-interpolation.md
@@ -4,7 +4,7 @@ description: Learn how to include formatted expression results in a result strin
 author: pkulikov
 ms.date: 05/09/2018
 ---
-# String interpolation in C# #
+# String interpolation in C\#
 
 This tutorial shows you how to use [string interpolation](../language-reference/tokens/interpolated.md) to format and include expression results in a result string. The examples assume that you are familiar with basic C# concepts and .NET type formatting. If you are new to string interpolation or .NET type formatting, check out the [interactive string interpolation tutorial](../tutorials/intro-to-csharp/interpolated-strings.yml) first. For more information about formatting types in .NET, see the [Formatting Types in .NET](../../standard/base-types/formatting-types.md) topic.
 

--- a/docs/csharp/versioning.md
+++ b/docs/csharp/versioning.md
@@ -5,7 +5,7 @@ ms.date: 01/08/2017
 ms.assetid: aa8732d7-5cd0-46e1-994a-78017f20d861
 ---
 
-# Versioning in C# #
+# Versioning in C\#
 
 In this tutorial you'll learn what versioning means in .NET. You'll also learn the factors to consider when versioning your library as well as upgrading
 to a new version of a library.

--- a/docs/csharp/whats-new/csharp-version-history.md
+++ b/docs/csharp/whats-new/csharp-version-history.md
@@ -5,7 +5,7 @@ author: erikdietrich
 ms.date: 09/20/2017
 ---
 
-# The history of C# #
+# The history of C\#
 
 This article provides a history of each major release of the C# language. The C# team is continuing to innovate and add new features. Detailed language feature status, including features considered for upcoming releases can be found [on the dotnet/roslyn repository](https://github.com/dotnet/roslyn/blob/master/docs/Language%20Feature%20Status.md) on GitHub.
 

--- a/docs/framework/data/adonet/sql/linq/how-to-generate-the-object-model-in-visual-basic-or-csharp.md
+++ b/docs/framework/data/adonet/sql/linq/how-to-generate-the-object-model-in-visual-basic-or-csharp.md
@@ -3,7 +3,7 @@ title: "How to: Generate the Object Model in Visual Basic or C#"
 ms.date: "03/30/2017"
 ms.assetid: a0c73b33-5650-420c-b9dc-f49310c201ee
 ---
-# How to: Generate the Object Model in Visual Basic or C# #
+# How to: Generate the Object Model in Visual Basic or C\#
 In [!INCLUDE[vbtecdlinq](../../../../../../includes/vbtecdlinq-md.md)], an object model in your own programming language is mapped to a relational database. Two tools are available for automatically generating a Visual Basic or C# model from the metadata of an existing database.  
   
 -   If you are using Visual Studio, you can use the [!INCLUDE[vs_ordesigner_long](../../../../../../includes/vs-ordesigner-long-md.md)] to generate an object model. The [!INCLUDE[vs_ordesigner_short](../../../../../../includes/vs-ordesigner-short-md.md)] provides a rich user interface to help you generate a [!INCLUDE[vbtecdlinq](../../../../../../includes/vbtecdlinq-md.md)] object model. For more information see, [Linq to SQL Tools in Visual Studio](https://docs.microsoft.com/visualstudio/data-tools/linq-to-sql-tools-in-visual-studio2).

--- a/docs/framework/winforms/advanced/how-to-add-multiple-sets-of-settings-to-your-application-in-csharp.md
+++ b/docs/framework/winforms/advanced/how-to-add-multiple-sets-of-settings-to-your-application-in-csharp.md
@@ -6,7 +6,7 @@ helpviewer_keywords:
   - "application settings [Windows Forms], C#"
 ms.assetid: 45007ac6-cf07-4be7-bc38-3f0ef962faf9
 ---
-# How To: Add Multiple Sets of Settings To Your Application in C# #
+# How To: Add Multiple Sets of Settings To Your Application in C\#
 In some cases, you might want to have multiple sets of settings in an application. For example, if you are developing an application where a particular group of settings is expected to change frequently, it might be wise to separate them all into a single file so that the file can be replaced wholesale, leaving other settings unaffected. Visual Studio allows you to add multiple sets of settings to your project. Additional sets of settings can be accessed via the Properties.Settings object.  
   
 ### To Add an Additional Set of Setting to your Application  

--- a/docs/framework/winforms/advanced/how-to-change-the-value-of-an-existing-setting-at-design-time.md
+++ b/docs/framework/winforms/advanced/how-to-change-the-value-of-an-existing-setting-at-design-time.md
@@ -9,7 +9,7 @@ ms.assetid: 5da91272-ad7e-49e7-9d1f-eb64439a1e4d
 # How To: Change the Value of an Existing Setting at Design Time
 You can use Visual Studio to edit the values of existing settings in your project.  
   
-### To Change the Value of an Existing Setting at Design Time in C#  
+### To Change the Value of an Existing Setting at Design Time in C\#
   
 1.  In **Solution Explorer**, expand the **Properties** node of your project.  
   

--- a/docs/framework/winforms/advanced/how-to-create-a-new-setting-at-design-time.md
+++ b/docs/framework/winforms/advanced/how-to-create-a-new-setting-at-design-time.md
@@ -9,7 +9,7 @@ ms.assetid: c5d60a66-6507-462f-a81f-e3bc0a804e16
 # How To: Create a New Setting at Design Time
 You can create a new setting at design time by using the Settings designer. The Settings designer is a grid-style interface that allows you to create new settings and specify properties for those settings. You must specify Name, Value, Type and Scope for your new settings. Once a setting is created, it is accessible in code.  
   
-### To create a new setting at design time in C#  
+### To create a new setting at design time in C\#
   
 1.  In **Solution Explorer**, expand the **Properties** node of your project.  
   

--- a/docs/framework/winforms/advanced/how-to-read-settings-at-run-time-with-csharp.md
+++ b/docs/framework/winforms/advanced/how-to-read-settings-at-run-time-with-csharp.md
@@ -7,10 +7,10 @@ helpviewer_keywords:
   - "application settings [Windows Forms], C#"
 ms.assetid: dbe8bf09-5e1c-49da-9192-154033d7240b
 ---
-# How To: Read Settings at Run Time With C# #
+# How To: Read Settings at Run Time With C\#
 You can read both Application-scoped and User-scoped settings at run time via the Properties object. The Properties object exposes all of the default settings for the project via the Properties.Settings.Default member.  
   
-### To Read Settings at Run Time with C#  
+### To Read Settings at Run Time with C\#
   
 -   Access the appropriate setting via the Properties.Settings.Default member. The following example shows how to assign a setting named `myColor` to a BackColor property. It requires you to have previously created a Settings file containing a setting named `myColor` of type `System.Drawing.Color`. For information about creating a Settings file, see [How To: Create a New Setting at Design Time](../../../../docs/framework/winforms/advanced/how-to-create-a-new-setting-at-design-time.md).  
   

--- a/docs/framework/winforms/advanced/how-to-read-settings-at-run-time-with-csharp.md
+++ b/docs/framework/winforms/advanced/how-to-read-settings-at-run-time-with-csharp.md
@@ -10,7 +10,7 @@ ms.assetid: dbe8bf09-5e1c-49da-9192-154033d7240b
 # How To: Read Settings at Run Time With C\#
 You can read both Application-scoped and User-scoped settings at run time via the Properties object. The Properties object exposes all of the default settings for the project via the Properties.Settings.Default member.  
   
-### To Read Settings at Run Time with C\#
+## To Read Settings at Run Time with C\#
   
 -   Access the appropriate setting via the Properties.Settings.Default member. The following example shows how to assign a setting named `myColor` to a BackColor property. It requires you to have previously created a Settings file containing a setting named `myColor` of type `System.Drawing.Color`. For information about creating a Settings file, see [How To: Create a New Setting at Design Time](../../../../docs/framework/winforms/advanced/how-to-create-a-new-setting-at-design-time.md).  
   

--- a/docs/framework/winforms/advanced/how-to-write-user-settings-at-run-time-with-csharp.md
+++ b/docs/framework/winforms/advanced/how-to-write-user-settings-at-run-time-with-csharp.md
@@ -10,7 +10,7 @@ ms.assetid: 9d061c7d-b33b-470f-a36d-edccb1d6f9a3
 # How To: Write User Settings at Run Time with C\#
 Settings that are application-scoped are read-only, and can only be changed at design time or by altering the .config file in between application sessions. Settings that are user-scoped, however, can be written at run time just as you would change any property value. The new value persists for the duration of the application session. You can persist the changes to the settings between application sessions by calling the Save method.  
   
-### How To: Write and Persist User Settings at Run Time with C\#
+## How To: Write and Persist User Settings at Run Time with C\#
   
 1.  Access the setting and assign it a new value as shown in this example:  
   

--- a/docs/framework/winforms/advanced/how-to-write-user-settings-at-run-time-with-csharp.md
+++ b/docs/framework/winforms/advanced/how-to-write-user-settings-at-run-time-with-csharp.md
@@ -7,10 +7,10 @@ helpviewer_keywords:
   - "application settings [Windows Forms], C#"
 ms.assetid: 9d061c7d-b33b-470f-a36d-edccb1d6f9a3
 ---
-# How To: Write User Settings at Run Time with C# #
+# How To: Write User Settings at Run Time with C\#
 Settings that are application-scoped are read-only, and can only be changed at design time or by altering the .config file in between application sessions. Settings that are user-scoped, however, can be written at run time just as you would change any property value. The new value persists for the duration of the application session. You can persist the changes to the settings between application sessions by calling the Save method.  
   
-### How To: Write and Persist User Settings at Run Time with C#  
+### How To: Write and Persist User Settings at Run Time with C\#
   
 1.  Access the setting and assign it a new value as shown in this example:  
   

--- a/docs/framework/winforms/controls/walkthrough-authoring-a-composite-control-with-visual-csharp.md
+++ b/docs/framework/winforms/controls/walkthrough-authoring-a-composite-control-with-visual-csharp.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
   - "custom controls [Windows Forms], creating"
 ms.assetid: f88481a8-c746-4a36-9479-374ce5f2e91f
 ---
-# Walkthrough: Authoring a Composite Control with Visual C# #
+# Walkthrough: Authoring a Composite Control with Visual C\#
 Composite controls provide a means by which custom graphical interfaces can be created and reused. A composite control is essentially a component with a visual representation. As such, it might consist of one or more Windows Forms controls, components, or blocks of code that can extend functionality by validating user input, modifying display properties, or performing other tasks required by the author. Composite controls can be placed on Windows Forms in the same manner as other controls. In the first part of this walkthrough, you create a simple composite control called `ctlClock`. In the second part of the walkthrough, you extend the functionality of `ctlClock` through inheritance.  
   
 > [!NOTE]

--- a/docs/framework/winforms/controls/walkthrough-inheriting-from-a-windows-forms-control-with-visual-csharp.md
+++ b/docs/framework/winforms/controls/walkthrough-inheriting-from-a-windows-forms-control-with-visual-csharp.md
@@ -9,7 +9,7 @@ helpviewer_keywords:
   - "custom controls [Windows Forms], inheritance"
 ms.assetid: 09476da0-8d4c-4a4c-b969-649519dfb438
 ---
-# Walkthrough: Inheriting from a Windows Forms Control with Visual C# #
+# Walkthrough: Inheriting from a Windows Forms Control with Visual C\#
 With [!INCLUDE[csprcslong](../../../../includes/csprcslong-md.md)], you can create powerful custom controls through *inheritance*. Through inheritance you are able to create controls that retain all of the inherent functionality of standard Windows Forms controls but also incorporate custom functionality. In this walkthrough, you will create a simple inherited control called `ValueButton`. This button will inherit functionality from the standard Windows Forms <xref:System.Windows.Forms.Button> control, and will expose a custom property called `ButtonValue`.  
   
 > [!NOTE]

--- a/docs/framework/winforms/how-to-connect-multiple-events-to-a-single-event-handler-in-windows-forms.md
+++ b/docs/framework/winforms/how-to-connect-multiple-events-to-a-single-event-handler-in-windows-forms.md
@@ -40,7 +40,7 @@ In your application design, you may find it necessary to use a single event hand
   
 6.  Add the appropriate code to the event handler.  
   
-### To connect multiple events to a single event handler in C#  
+### To connect multiple events to a single event handler in C\#
   
 1.  Select the control to which you want to connect an event handler.  
   

--- a/docs/fsharp/get-started/index.md
+++ b/docs/fsharp/get-started/index.md
@@ -3,7 +3,7 @@ title: Get started with F#
 description: Find out how to get started with the F# programming language.
 ms.date: 12/08/2018
 ---
-# Get Started with F# #
+# Get Started with F\#
 
 You can get started with F# on your machine or online.
 

--- a/docs/fsharp/get-started/install-fsharp.md
+++ b/docs/fsharp/get-started/install-fsharp.md
@@ -4,7 +4,7 @@ description: Learn how to install F# based on your environment.
 ms.date: 08/28/2018
 ---
 
-# Install F# #
+# Install F\#
 
 You can install F# in multiple ways, depending on your environment.
 

--- a/docs/fsharp/index.md
+++ b/docs/fsharp/index.md
@@ -8,7 +8,7 @@ ms.date: 08/03/2018
 
 The F# guide provides many resources to learn the F# language.
 
-## Learning F# #
+## Learning F\#
 
 [What is F#](what-is-fsharp.md) describes what the F# language is and what programming in it is like, with short code samples. This is recommended if you are new to F#.
 

--- a/docs/fsharp/introduction-to-functional-programming/index.md
+++ b/docs/fsharp/introduction-to-functional-programming/index.md
@@ -4,7 +4,7 @@ description: Learn the fundamentals of functional programming in F#.
 ms.date: 10/29/2018
 ---
 
-# Introduction to Functional Programming in F# #
+# Introduction to Functional Programming in F\#
 
 Functional programming is a style of programming that emphasizes the use of functions and immutable data. Typed functional programming is when functional programming is combined with static types, such as with F#. In general, the following concepts are emphasized in functional programming:
 

--- a/docs/fsharp/language-reference/byrefs.md
+++ b/docs/fsharp/language-reference/byrefs.md
@@ -99,7 +99,7 @@ All of these rules together mean that the holder of an `inref` pointer may not m
 
 The purpose of `outref<'T>` is to indicate that the pointer should only be read from. Unexpectedly, `outref<'T>` permits reading the underlying value despite its name. This is for compatibility purposes. Semantically, `outref<'T>` is no different than `byref<'T>`.
 
-### Interop with C# #
+### Interop with C\#
 
 C# supports the `in ref` and `out ref` keywords, in addition to `ref` returns. The following table shows how F# interprets what C# emits:
 

--- a/docs/fsharp/tour.md
+++ b/docs/fsharp/tour.md
@@ -3,7 +3,7 @@ title: Tour of F#
 description: Examine some of the key features of the F# programming language in this tour with code samples.
 ms.date: 11/06/2018
 ---
-# Tour of F# #
+# Tour of F\#
 
 The best way to learn about F# is to read and write F# code. This article will act as a tour through some of the key features of the F# language and give you some code snippets that you can execute on your machine. To learn about setting up a development environment, check out [Getting Started](tutorials/getting-started/index.md).
 

--- a/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
+++ b/docs/fsharp/tutorials/asynchronous-and-concurrent-programming/async.md
@@ -3,7 +3,7 @@ title: Async Programming
 description: Learn how F# async programming is accomplished via a language-level programming model that is easy to use and natural to the language.
 ms.date: 06/20/2016
 ---
-# Async Programming in F# #
+# Async Programming in F\#
 
 > [!NOTE]
 > Some inaccuracies have been discovered in this article.  It is being rewritten.  See [Issue #666](https://github.com/dotnet/docs/issues/666) to learn about the changes.
@@ -47,7 +47,7 @@ There are a few syntactical constructs which are worth noting:
 
 Additionally, normal `let`, `use`, and `do` keywords can be used alongside the async versions just as they would in a normal function.
 
-## How to start Async Code in F# #
+## How to start Async Code in F\#
 
 As mentioned earlier, async code is a specification of work to be done in another context which needs to be explicitly started. Here are two primary ways to accomplish this:
 
@@ -146,7 +146,7 @@ for html in htmlList do
 
  F#’s compiler is very strict, making it nearly impossible to do something troubling like run "async" code synchronously. If you come across a warning, that’s a sign that the code won’t execute how you think it will. If you can make the compiler happy, your code will most likely execute as expected.
 
-## For the C#/VB Programmer Looking Into F# #
+## For the C#/VB Programmer Looking Into F\#
 
 This section assumes you’re familiar with the async model in C#/VB. If you are not, [Async Programming in C#](../../../csharp/async.md) is a starting point.
 

--- a/docs/fsharp/tutorials/fsharp-interactive/index.md
+++ b/docs/fsharp/tutorials/fsharp-interactive/index.md
@@ -3,7 +3,7 @@ title: F# Interactive (fsi.exe) Reference
 description: Learn how F# Interactive (fsi.exe) is used to run F# code interactively at the console or to execute F# scripts.
 ms.date: 05/16/2016
 ---
-# Interactive Programming with F# #
+# Interactive Programming with F\#
 
 > [!NOTE]
 > This article currently describes the experience for Windows only.  It will be rewritten.
@@ -38,7 +38,7 @@ If you have a project open that references some libraries, you can reference the
 You can control the F# Interactive command line arguments (options) by adjusting the settings. On the **Tools** menu, select **Options...**, and then expand **F# Tools**. The two settings that you can change are the F# Interactive options and the **64-bit F# Interactive** setting, which is relevant only if you are running F# Interactive on a 64-bit machine. This setting determines whether you want to run the dedicated 64-bit version of fsi.exe or fsianycpu.exe, which uses the machine architecture to determine whether to run as a 32-bit or 64-bit process.
 
 
-## Scripting with F# #
+## Scripting with F\#
 Scripts use the file extension **.fsx** or **.fsscript**. Instead of compiling source code and then later running the compiled assembly, you can just run **fsi.exe** and specify the filename of the script of F# source code, and F# interactive reads the code and executes it in real time.
 
 

--- a/docs/fsharp/using-fsharp-on-azure/blob-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/blob-storage.md
@@ -4,7 +4,7 @@ description: Store unstructured data in the cloud with Azure Blob storage.
 author: sylvanc
 ms.date: 09/20/2016
 ---
-# Get started with Azure Blob storage using F# #
+# Get started with Azure Blob storage using F\#
 
 Azure Blob storage is a service that stores unstructured data in the cloud as objects/blobs. Blob storage can store any type of text or binary data, such as a document, media file, or application installer. Blob storage is also referred to as object storage.
 

--- a/docs/fsharp/using-fsharp-on-azure/file-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/file-storage.md
@@ -4,7 +4,7 @@ description: Store file data in the cloud with Azure File storage, and mount you
 author: sylvanc
 ms.date: 09/20/2016
 ---
-# Get started with Azure File storage using F# #
+# Get started with Azure File storage using F\#
 
 Azure File storage is a service that offers file shares in the cloud using the standard [Server Message Block (SMB) Protocol](https://msdn.microsoft.com/library/windows/desktop/aa365233.aspx). Both SMB 2.1 and SMB 3.0 are supported. With Azure File storage, you can migrate legacy applications that rely on file shares to Azure quickly and without costly rewrites. Applications running in Azure virtual machines or cloud services or from on-premises clients can mount a file share in the cloud, just as a desktop application mounts a typical SMB share. Any number of application components can then mount and access the File storage share simultaneously.
 

--- a/docs/fsharp/using-fsharp-on-azure/index.md
+++ b/docs/fsharp/using-fsharp-on-azure/index.md
@@ -13,14 +13,14 @@ In the following sections, you will find resources on how to use a range of Azur
 > [!NOTE]
 > If a particular Azure service isn't in this documentation set, please consult either the Azure Functions or .NET documentation for that service. Some Azure services are language-independent and require no language-specific documentation and are not listed here.
 
-## Using Azure Virtual Machines with F# #
+## Using Azure Virtual Machines with F\#
 
 Azure supports a wide range of virtual machine (VM) configurations, see [Linux and Azure Virtual Machines](https://azure.microsoft.com/services/virtual-machines/).
 
 To install F# on a virtual machine for execution, compilation and/or scripting see [Using F# on Linux](https://fsharp.org/use/linux) and [Using F# on Windows](https://fsharp.org/use/windows).
 
 
-## Using Azure Functions with F# #
+## Using Azure Functions with F\#
 
 [Azure Functions](https://azure.microsoft.com/services/functions/) is a solution for easily running small pieces of code, or "functions," in the cloud. You can write just the code you need for the problem at hand, without worrying about a whole application or the infrastructure to run it. Your functions are connected to events in Azure storage and other cloud-hosted resources. Data flows into your F# functions via function arguments. You can use your development language of choice, trusting Azure to scale as needed.
 
@@ -32,7 +32,7 @@ Other resources for using Azure Functions and F#:
 * [How to create Azure function in F#](https://mnie.github.io/2016-09-08-AzureFunctions/)
 * [Using the Azure Type Provider with Azure Functions](https://compositional-it.com/blog/2017/08-30-using-the-azure-type-provider-with-azure-functions/index.html)
 
-## Using Azure Storage with F# #
+## Using Azure Storage with F\#
 
 Azure Storage is a base layer of storage services for modern applications that rely on durability, availability, and scalability to meet the needs of customers. F# programs can interact directly with Azure storage services, using the techniques described in the following articles.
 
@@ -43,7 +43,7 @@ Azure Storage is a base layer of storage services for modern applications that r
 
 Azure Storage can also be used in conjunction with Azure Functions through declarative configuration rather than explicit API calls. See [Azure Functions triggers and bindings for Azure Storage](/azure/azure-functions/functions-bindings-storage) which includes F# examples.
 
-## Using Azure App Service with F# #
+## Using Azure App Service with F\#
 
 [Azure App Service](https://azure.microsoft.com/services/app-service/) is a cloud platform to build powerful web and mobile apps that connect to data anywhere, in the cloud or on-premises.
 
@@ -57,7 +57,7 @@ Azure Storage can also be used in conjunction with Azure Functions through decla
 * [Implementing Spark Apps in F# using Mobius](https://github.com/Microsoft/Mobius/blob/master/notes/spark-fsharp-mobius.md)
 * [Example F# Spark Apps using Mobius](https://github.com/Microsoft/Mobius/tree/master/examples/fsharp)
 
-## Using Azure Cosmos DB with F# #
+## Using Azure Cosmos DB with F\#
 
 [Azure Cosmos DB](https://azure.microsoft.com/services/cosmos-db) is a NoSQL service for highly available, globally distributed apps.
 
@@ -66,7 +66,7 @@ Azure Cosmos DB can be used with F# in two ways:
 1. Through the creation of F# Azure Functions which react to or cause changes to Azure Cosmos DB collections. See [Azure Cosmos DB bindings for Azure Functions](/azure/azure-functions/functions-bindings-cosmosdb), or
 2. By using the [Azure Cosmos DB .NET SDK for SQL API](/azure/cosmos-db/sql-api-sdk-dotnet). The related samples are in C#.
 
-## Using Azure Event Hubs with F# #
+## Using Azure Event Hubs with F\#
 
 [Azure Event Hubs](https://azure.microsoft.com/services/event-hubs/) provide cloud-scale telemetry ingestion from websites, apps, and devices.
 
@@ -75,7 +75,7 @@ Azure Event Hubs can be used with F# in two ways:
 1. Through the creation of F# Azure Functions which are triggered by events. See [Azure Function triggers for Event Hubs](/azure/azure-functions/functions-bindings-event-hubs), or
 2. By using the [.NET SDK for Azure](/azure/event-hubs/event-hubs-csharp-ephcs-getstarted). Note these examples are in C#.
 
-## Using Azure Notification Hubs with F# #
+## Using Azure Notification Hubs with F\#
 
 [Azure Notification Hubs](/azure/notification-hubs/) are multiplatform, scaled-out push infrastructure that enable you to send mobile push notifications from any backend (in the cloud or on-premises) to any mobile platform.
 
@@ -85,25 +85,25 @@ Azure Notification Hubs can be used with F# in two ways:
 2. By using the [.NET SDK for Azure](https://blogs.msdn.microsoft.com/azuremobile/2014/04/08/push-notifications-using-notification-hub-and-net-backend/). Note these examples are in C#.
 
 
-## Implementing WebHooks on Azure with F# #
+## Implementing WebHooks on Azure with F\#
 
 A [Webhook](https://en.wikipedia.org/wiki/Webhook) is a callback triggered via a web request. Webhooks are used by sites such as GitHub to signal events. 
 
 Webhooks can be implemented in F# and hosted on Azure via an [Azure Function in F# with a Webhook Binding](/azure/azure-functions/functions-bindings-http-webhook).
 
-## Using Webjobs with F# #
+## Using Webjobs with F\#
 
 [Webjobs](/azure/app-service-web/web-sites-create-web-jobs) are programs you can run in your App Service web app in three ways: on demand, continuously, or on a schedule.
 
 [Example F# Webjob](https://github.com/jrr/webjob-project-examples)
 
-## Implementing Timers on Azure with F# #
+## Implementing Timers on Azure with F\#
 
 Timer triggers call functions based on a schedule, one time or recurring.
 
 Timers can be implemented in F# and hosted on Azure via an [Azure Function in F# with a Timer Trigger](/azure/azure-functions/functions-bindings-timer).
 
-## Deploying and Managing Azure Resources with F# Scripts #
+## Deploying and Managing Azure Resources with F# Scripts
 
 Azure VMs may be programmatically deployed and managed from F# scripts by using the Microsoft.Azure.Management packages and APIs. For example, see [Get Started with the Management Libraries for .NET](https://msdn.microsoft.com/library/dn722415.aspx) and [Using Azure Resource Manager](/azure/azure-resource-manager/resource-manager-deployment-model).
 

--- a/docs/fsharp/using-fsharp-on-azure/queue-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/queue-storage.md
@@ -4,7 +4,7 @@ description: Azure Queues provide reliable, asynchronous messaging between appli
 author: sylvanc
 ms.date: 09/20/2016
 ---
-# Get started with Azure Queue storage using F# #
+# Get started with Azure Queue storage using F\#
 
 Azure Queue storage provides cloud messaging between application components. In designing applications for scale, application components are often decoupled, so that they can scale independently. Queue storage delivers asynchronous messaging for communication between application components, whether they are running in the cloud, on the desktop, on an on-premises server, or on a mobile device. Queue storage also supports managing asynchronous tasks and building process work flows.
 

--- a/docs/fsharp/using-fsharp-on-azure/table-storage.md
+++ b/docs/fsharp/using-fsharp-on-azure/table-storage.md
@@ -4,7 +4,7 @@ description: Store structured data in the cloud using Azure Table storage or Azu
 author: sylvanc
 ms.date: 03/26/2018
 ---
-# Get started with Azure Table storage and the Azure Cosmos DB Table API using F# # 
+# Get started with Azure Table storage and the Azure Cosmos DB Table API using F\#
 
 Azure Table storage is a service that stores structured NoSQL data in the cloud. Table storage is a key/attribute store with a schemaless design. Because Table storage is schemaless, it's easy to adapt your data as the needs of your application evolve. Access to data is fast and cost-effective for all kinds of applications. Table storage is typically significantly lower in cost than traditional SQL for similar volumes of data.
 

--- a/docs/fsharp/what-is-fsharp.md
+++ b/docs/fsharp/what-is-fsharp.md
@@ -3,7 +3,7 @@ title: What is F#
 description: Learn about what the F# programming language is and what F# programming is like. Learn about rich data types, functions, and how they fit together.
 ms.date: 08/03/2018
 ---
-# What is F# #
+# What is F\#
 
 F# is a functional programming language that makes it easy to write correct and maintainable code.
 

--- a/docs/standard/asynchronous-programming-patterns/implementing-the-event-based-asynchronous-pattern.md
+++ b/docs/standard/asynchronous-programming-patterns/implementing-the-event-based-asynchronous-pattern.md
@@ -125,7 +125,7 @@ If you are writing a class with some operations that may incur noticeable delays
 |One Async Operation in entire class|`Sub MethodNameAsyncCancel(ByVal userState As Object)`|`Sub MethodNameAsyncCancel()`|  
 |Multiple Async Operations in class|`Sub CancelAsync(ByVal userState As Object)`|`Sub CancelAsync()`|  
   
-### C#  
+### C\#
   
 ||Multiple Simultaneous Operations Supported|Only One Operation at a Time|  
 |------|------------------------------------------------|----------------------------------|  

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -270,7 +270,7 @@
 ## [Tour of C#](csharp/tour-of-csharp/)
 <!-- The "What's New" section is short, and one level
     deep, so leave it in the main TOC -->
-## What's new in C#
+## What's new in C\#
 ### [C# 8.0 - Preview 2](csharp/whats-new/csharp-8.md)
 ### [C# 7.3](csharp/whats-new/csharp-7-3.md)
 ### [C# 7.2](csharp/whats-new/csharp-7-2.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -270,7 +270,7 @@
 ## [Tour of C#](csharp/tour-of-csharp/)
 <!-- The "What's New" section is short, and one level
     deep, so leave it in the main TOC -->
-## What's new in C\#
+## What's new in C#
 ### [C# 8.0 - Preview 2](csharp/whats-new/csharp-8.md)
 ### [C# 7.3](csharp/whats-new/csharp-7-3.md)
 ### [C# 7.2](csharp/whats-new/csharp-7-2.md)


### PR DESCRIPTION

Mostly escaping trailing hashes in headers that can be intepreted as "Closed ATX" style in markdown