### PR TITLE
chore: Enable MD003 rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,7 +2,6 @@
     "default": true,
     "MD001": false,
     "MD002": false,
-    "MD003": false,
     "MD004": false,
     "MD005": false,
     "MD006": false,


### PR DESCRIPTION

The one H2 exception was suppressed in a separate PR