### PR TITLE
update lang version docs

### DIFF
--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -26,7 +26,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
 |Option|Meaning|  
 |------------|-------------|  
-|Preview|The compiler accepts all valid language syntax from the latest preview version that it can support.|
+|preview|The compiler accepts all valid language syntax from the latest preview version that it can support.|
 |latest|The compiler accepts all valid language syntax from the latest version (including minor releases) that it can support.|
 |latestMajor|The compiler accepts all valid language syntax from the latest major version that it can support.|
 |8.0|The compiler accepts only syntax that is included in C# 8.0 or lower <sup id="TCS80">[CS80](#FCS80)</sup>|

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -74,14 +74,14 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 
 ### Minimum compiler version needed to support all language features
 
-[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET Core 3.0
-[↩](#TCS73)<a name="FCS73">CS73</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7
-[↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5
-[↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3
-[↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017
-[↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015
-[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler
-[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler
-[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler
-[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler
-[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler
+[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET Core 3.0  
+[↩](#TCS73)<a name="FCS73">CS73</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7  
+[↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5  
+[↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3  
+[↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017  
+[↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015  
+[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler  
+[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler  
+[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler  
+[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler  
+[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler  

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -74,7 +74,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 
 ### Minimum compiler version needed to support all language features
 
-[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET Core 3.0
+[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET Core SDK 3.0
 [↩](#TCS73)<a name="FCS73">CS73</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7
 [↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5
 [↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -66,11 +66,11 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |-------|----|-----------|
 |C# 7.0 and later||not currently available|
 |C# 6.0|[Link](../language-specification/index.md)|C# Language Specification Version 6 - Unofficial Draft: .NET Foundation|
-|C# 5.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf)|Standard ECMA-334 5th Edition|
+|C# 5.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-334.pdf)|Standard ECMA-334 5th Edition|
 |C# 3.0|[Download DOC](https://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc)|C# Language Specification Version 3.0: Microsoft Corporation|
-|C# 2.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/Ecma-334%204th%20edition%20June%202006.pdf)|Standard ECMA-334 4th Edition|
-|C# 1.2|[Download DOC](https://download.microsoft.com/download/5/e/5/5e58be0a-b02b-41ac-a4a3-7a22286214ff/csharp%20language%20specification%20v1.2.doc)|C# Language Specification Version 1.2: Microsoft Corporation|
-|C# 1.0|[Download DOC](https://download.microsoft.com/download/a/9/e/a9e229b9-fee5-4c3e-8476-917dee385062/csharp%20language%20specification%20v1.0.doc)|C# Language Specification Version 1.0: Microsoft Corporation|
+|C# 2.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-334%204th%20edition%20June%202006.pdf)|Standard ECMA-334 4th Edition|
+|C# 1.2|[Download DOC](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-334%202nd%20edition%20December%202002.pdf)|C# Language Specification Version 1.2: Microsoft Corporation|
+|C# 1.0|[Download DOC](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-334%201st%20edition%20December%202001.pdf)|C# Language Specification Version 1.0: Microsoft Corporation|
 
 ### Minimum compiler version needed to support all language features
 
@@ -81,7 +81,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 [↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017  
 [↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015  
 [↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .NET Framework 4.5 compiler  
-[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler  
-[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler  
-[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler  
-[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler  
+[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .NET Framework 4.0 compiler  
+[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .NET Framework 3.5 compiler  
+[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .NET Framework 2.0 compiler  
+[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .N Framework 1.0 compiler  

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -29,7 +29,7 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 |preview|The compiler accepts all valid language syntax from the latest preview version that it can support.|
 |latest|The compiler accepts all valid language syntax from the latest version (including minor releases) that it can support.|
 |latestMajor|The compiler accepts all valid language syntax from the latest major version that it can support.|
-|8.0|The compiler accepts only syntax that is included in C# 8.0 or lower <sup id="TCS80">[CS80](#FCS80)</sup>|
+|8.0|The compiler accepts only syntax that is included in C# 8.0 or lower. <sup id="TCS80">[CS80](#FCS80)</sup>|
 |7.3|The compiler accepts only syntax that is included in C# 7.3 or lower <sup id="TCS73">[CS73](#FCS73)</sup>|
 |7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS72">[CS72](#FCS72)</sup>|
 |7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
@@ -74,13 +74,13 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 
 ### Minimum compiler version needed to support all language features
 
-[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET SDK Core 3.0  
+[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET Core 3.0 SDK
 [↩](#TCS73)<a name="FCS73">CS73</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7  
 [↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5  
 [↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3  
 [↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017  
 [↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015  
-[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler  
+[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .NET Framework 4.5 compiler  
 [↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler  
 [↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler  
 [↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler  

--- a/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/langversion-compiler-option.md
@@ -26,22 +26,20 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
   
 |Option|Meaning|  
 |------------|-------------|  
-|default|The compiler accepts all valid language syntax from the latest major version that it can support.|
-|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2) <sup id="TISO1">[ISO1](#FISO1)</sup>|  
-|ISO-2|The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0) <sup id="TISO2">[ISO2](#FISO2)</sup>|
-|3|The compiler accepts only syntax that is included in C# 3.0 or lower <sup id="TCS3">[CS3](#FCS3)</sup>|
-|4|The compiler accepts only syntax that is included in C# 4.0 or lower <sup id="TCS4">[CS4](#FCS4)</sup>|
-|5|The compiler accepts only syntax that is included in C# 5.0 or lower <sup id="TCS5">[CS5](#FCS5)</sup>|
-|6|The compiler accepts only syntax that is included in C# 6.0 or lower <sup id="TCS6">[CS6](#FCS6)</sup>|
-|7|The compiler accepts only syntax that is included in C# 7.0 or lower <sup id="TCS7">[CS7](#FCS7)</sup>|
-|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
-|7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS72">[CS72](#FCS72)</sup>|
+|Preview|The compiler accepts all valid language syntax from the latest preview version that it can support.|
+|latest|The compiler accepts all valid language syntax from the latest version (including minor releases) that it can support.|
+|latestMajor|The compiler accepts all valid language syntax from the latest major version that it can support.|
+|8.0|The compiler accepts only syntax that is included in C# 8.0 or lower <sup id="TCS80">[CS80](#FCS80)</sup>|
 |7.3|The compiler accepts only syntax that is included in C# 7.3 or lower <sup id="TCS73">[CS73](#FCS73)</sup>|
-|latest|The compiler accepts all valid language syntax that it can support.|
-
-<!--- Uncomment and move these above
-|8|The compiler accepts only syntax that is included in C# 8 or lower <sup id="TCS8">[CS8](#FCS8)</sup>|
--->
+|7.2|The compiler accepts only syntax that is included in C# 7.2 or lower <sup id="TCS72">[CS72](#FCS72)</sup>|
+|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower <sup id="TCS71">[CS71](#FCS71)</sup>|
+|7|The compiler accepts only syntax that is included in C# 7.0 or lower <sup id="TCS7">[CS7](#FCS7)</sup>|
+|6|The compiler accepts only syntax that is included in C# 6.0 or lower <sup id="TCS6">[CS6](#FCS6)</sup>|
+|5|The compiler accepts only syntax that is included in C# 5.0 or lower <sup id="TCS5">[CS5](#FCS5)</sup>|
+|4|The compiler accepts only syntax that is included in C# 4.0 or lower <sup id="TCS4">[CS4](#FCS4)</sup>|
+|3|The compiler accepts only syntax that is included in C# 3.0 or lower <sup id="TCS3">[CS3](#FCS3)</sup>|
+|ISO-2|The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0) <sup id="TISO2">[ISO2](#FISO2)</sup>|
+|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2) <sup id="TISO1">[ISO1](#FISO1)</sup>|  
 
 ## Remarks
 
@@ -66,27 +64,24 @@ Causes the compiler to accept only syntax that is included in the chosen C# lang
 
 |Version|Link|Description|
 |-------|----|-----------|
-|C# 1.0|[Download DOC](https://download.microsoft.com/download/a/9/e/a9e229b9-fee5-4c3e-8476-917dee385062/csharp%20language%20specification%20v1.0.doc)|C# Language Specification Version 1.0: Microsoft Corporation|
-|C# 1.2|[Download DOC](https://download.microsoft.com/download/5/e/5/5e58be0a-b02b-41ac-a4a3-7a22286214ff/csharp%20language%20specification%20v1.2.doc)|C# Language Specification Version 1.2: Microsoft Corporation|
-|C# 2.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/Ecma-334%204th%20edition%20June%202006.pdf)|Standard ECMA-334 4th Edition|
-|C# 3.0|[Download DOC](https://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc)|C# Language Specification Version 3.0: Microsoft Corporation|
-|C# 5.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf)|Standard ECMA-334 5th Edition|
-|C# 6.0|[Link](../language-specification/index.md)|C# Language Specification Version 6 - Unofficial Draft: .NET Foundation|
 |C# 7.0 and later||not currently available|
+|C# 6.0|[Link](../language-specification/index.md)|C# Language Specification Version 6 - Unofficial Draft: .NET Foundation|
+|C# 5.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-334.pdf)|Standard ECMA-334 5th Edition|
+|C# 3.0|[Download DOC](https://download.microsoft.com/download/3/8/8/388e7205-bc10-4226-b2a8-75351c669b09/CSharp%20Language%20Specification.doc)|C# Language Specification Version 3.0: Microsoft Corporation|
+|C# 2.0|[Download PDF](https://www.ecma-international.org/publications/files/ECMA-ST-ARCH/Ecma-334%204th%20edition%20June%202006.pdf)|Standard ECMA-334 4th Edition|
+|C# 1.2|[Download DOC](https://download.microsoft.com/download/5/e/5/5e58be0a-b02b-41ac-a4a3-7a22286214ff/csharp%20language%20specification%20v1.2.doc)|C# Language Specification Version 1.2: Microsoft Corporation|
+|C# 1.0|[Download DOC](https://download.microsoft.com/download/a/9/e/a9e229b9-fee5-4c3e-8476-917dee385062/csharp%20language%20specification%20v1.0.doc)|C# Language Specification Version 1.0: Microsoft Corporation|
 
 ### Minimum compiler version needed to support all language features
 
-[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler
-[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler
-[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler
-[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler
-[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler
-[↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015
-[↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017
-[↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3
-[↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5
+[↩](#TCS80)<a name="FCS80">CS80</a>: Microsoft Visual Studio/Build Tools 2019, version 16, or .NET Core 3.0
 [↩](#TCS73)<a name="FCS73">CS73</a>: Microsoft Visual Studio/Build Tools 2017, version 15.7
-
-<!--- Uncomment and add to the above when they become officially released
-[↩](#TCS8)<a name="FCS8">CS8</a>: Microsoft Visual Studio/Build Tools 20??    
--->
+[↩](#TCS72)<a name="FCS72">CS72</a>: Microsoft Visual Studio/Build Tools 2017, version 15.5
+[↩](#TCS71)<a name="FCS71">CS71</a>: Microsoft Visual Studio/Build Tools 2017, version 15.3
+[↩](#TCS7)<a name="FCS7">CS7</a>: Microsoft Visual Studio/Build Tools 2017
+[↩](#TCS6)<a name="FCS6">CS6</a>: Microsoft Visual Studio/Build Tools 2015
+[↩](#TCS5)<a name="FCS5">CS5</a>: Microsoft Visual Studio/Build Tools 2012 or bundled .Net Framework 4.5 compiler
+[↩](#TCS4)<a name="FCS4">CS4</a>: Microsoft Visual Studio/Build Tools 2010 or bundled .Net Framework 4.0 compiler
+[↩](#TCS3)<a name="FCS3">CS3</a>: Microsoft Visual Studio/Build Tools 2008 or bundled .Net Framework 3.5 compiler
+[↩](#TISO2)<a name="FISO2">ISO2</a>: Microsoft Visual Studio/Build Tools 2005 or bundled .Net Framework 2.0 compiler
+[↩](#TISO1)<a name="FISO1">ISO1</a>: Microsoft Visual Studio/Build Tools .Net 2002 or bundled .Net Framework 1.0 compiler

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -8,7 +8,7 @@ ms.date: 02/28/2019
 
 The C# compiler determines a default language version based on your project's target framework or frameworks. When your project targets a preview framework that has a corresponding preview language version, the language version used is the preview language version. When your project doesn't target a preview framework, the language version used is the latest minor version.
 
-For example, during the preview period for .NET Core 3.0, any project that targets `netcoreapp3.0` or `netstandard2.1` (both in preview), the C# 8.0 language (in preview) will be used. Projects targeting any released version will use C# 7.3 (the latest released version). This behavior means that any project targeting .NET Framework will use latest (C# 7.3). 
+For example, during the preview period for .NET Core 3.0, any project that targets `netcoreapp3.0` or `netstandard2.1` (both in preview) will use the C# 8.0 language (also in preview). Projects targeting any released version will use C# 7.3 (the latest released version). This behavior means that any project targeting .NET Framework will use latest (C# 7.3). 
 
 This capability decouples the decision to install new versions of the SDK and tools in your development environment from the decision to incorporate new language features in a project. You can install the latest SDK and tools on your build machine. Each project can be configured to use a specific version of the language for its build. The default behavior means that any language features that rely on new types or new CLR behavior are enabled only when projects target those frameworks.
 

--- a/docs/csharp/language-reference/configure-language-version.md
+++ b/docs/csharp/language-reference/configure-language-version.md
@@ -1,16 +1,18 @@
 ---
 title: Select the C# language version - C# Guide
 description: Configure the compiler to perform syntax validation using a specific compiler version
-ms.date: 05/24/2018
+ms.date: 02/28/2019
 ---
 
 # Select the C# language version
 
-The C# compiler defaults to the latest major version of the language that has been released. You may choose to compile any project using a new point release of the language. Choosing a newer version of the language enables your project to make use of the latest language features. In other scenarios, you may need to validate that a project compiles cleanly when using an older version of the language.
+The C# compiler determines a default language version based on your project's target framework or frameworks. When your project targets a preview framework that has a corresponding preview language version, the language version used is the preview language version. When your project doesn't target a preview framework, the language version used is the latest minor version.
 
-This capability decouples the decision to install new versions of the SDK and tools in your development environment from the decision to incorporate new language features in a project. You can install the latest SDK and tools on your build machine. Each project can be configured to use a specific version of the language for its build.
+For example, during the preview period for .NET Core 3.0, any project that targets `netcoreapp3.0` or `netstandard2.1` (both in preview), the C# 8.0 language (in preview) will be used. Projects targeting any released version will use C# 7.3 (the latest released version). This behavior means that any project targeting .NET Framework will use latest (C# 7.3). 
 
-There are several ways to set the language version:
+This capability decouples the decision to install new versions of the SDK and tools in your development environment from the decision to incorporate new language features in a project. You can install the latest SDK and tools on your build machine. Each project can be configured to use a specific version of the language for its build. The default behavior means that any language features that rely on new types or new CLR behavior are enabled only when projects target those frameworks.
+
+You can override the default behavior by specifying a language version. There are several ways to set the language version:
 
 - Rely on a [Visual Studio quick action](#visual-studio-quick-action).
 - Set the language version in the [Visual Studio UI](#set-the-language-version-in-visual-studio).
@@ -60,21 +62,20 @@ The value `latest` uses the latest minor version of the C# language. Valid value
 
 |Value|Meaning|
 |------------|-------------|
-|default|The compiler accepts all valid language syntax from the latest major version that it can support.|
-|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2) |
-|ISO-2|The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0) |
-|3|The compiler accepts only syntax that is included in C# 3.0 or lower.|
-|4|The compiler accepts only syntax that is included in C# 4.0 or lower.|
-|5|The compiler accepts only syntax that is included in C# 5.0 or lower.|
-|6|The compiler accepts only syntax that is included in C# 6.0 or lower.|
-|7|The compiler accepts only syntax that is included in C# 7.0 or lower.|
-|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower.|
-|7.2|The compiler accepts only syntax that is included in C# 7.2 or lower.|
+|preview|The compiler accepts all valid language syntax from the latest preview version.|
+|latest|The compiler accepts syntax from the latest released version of the compiler (including minor version).|
+|latestMajor|The compiler accepts syntax from the latest released major version of the compiler.|
+|8.0|The compiler accepts only syntax that is included in C# 8.0 or lower.|
 |7.3|The compiler accepts only syntax that is included in C# 7.3 or lower.|
-|latest|The compiler accepts all valid language syntax that it can support.|
-
-The special strings `default` and `latest` resolve to the latest major (C# 7.0)
-and minor (C# 7.3) language versions installed on the build machine, respectively.
+|7.2|The compiler accepts only syntax that is included in C# 7.2 or lower.|
+|7.1|The compiler accepts only syntax that is included in C# 7.1 or lower.|
+|7|The compiler accepts only syntax that is included in C# 7.0 or lower.|
+|6|The compiler accepts only syntax that is included in C# 6.0 or lower.|
+|5|The compiler accepts only syntax that is included in C# 5.0 or lower.|
+|4|The compiler accepts only syntax that is included in C# 4.0 or lower.|
+|3|The compiler accepts only syntax that is included in C# 3.0 or lower.|
+|ISO-2|The compiler accepts only syntax that is included in ISO/IEC 23270:2006 C# (2.0) |
+|ISO-1|The compiler accepts only syntax that is included in ISO/IEC 23270:2003 C# (1.0/1.2) |
 
 ## Configure multiple projects
 


### PR DESCRIPTION
Fixes #10782

The details are in the blog post referenced in that issue.

Summary:
- The default behavior is different in that if you are working with a preview SDK and libraries, you'll also opt in to preview langauge features.
- Latest and LatestMajor keys enable selection between those releases.
- 8.0 is now a thing.

I also rearranged the ordered lists to go from most recent to oldest versions to make it easier for readers to find pertinent information faster.

/cc @agocke 

[Internal review link - configuring language version](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version?branch=pr-en-us-10825)

[Internal review link - language version compiler option](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version?branch=pr-en-us-10825)