### PR TITLE
C67708: Issue with Bookmark

### DIFF
--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -1042,8 +1042,8 @@ For more information on the <xref:System.TimeZoneInfo> structure and time zone a
 
 - Flowchart Activity Designer or other Workflow Activity Designers may display all objects in their default locations as opposed to attached property values.
 
-
-### Clickonce-1
+<a name="clickonce-1" />
+### Clickonce
 
 ClickOnce has been updated to support TLS 1.1 and TLS 1.2 in addition to the 1.0 protocol, which it already supports. ClickOnce automatically detects which protocol is required; no extra steps within the ClickOnce application are required to enable TLS 1.1 and 1.2 support.
 

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -1043,7 +1043,7 @@ For more information on the <xref:System.TimeZoneInfo> structure and time zone a
 - Flowchart Activity Designer or other Workflow Activity Designers may display all objects in their default locations as opposed to attached property values.
 
 
-### ClickOnce
+### Clickonce-1
 
 ClickOnce has been updated to support TLS 1.1 and TLS 1.2 in addition to the 1.0 protocol, which it already supports. ClickOnce automatically detects which protocol is required; no extra steps within the ClickOnce application are required to enable TLS 1.1 and 1.2 support.
 

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -1043,6 +1043,7 @@ For more information on the <xref:System.TimeZoneInfo> structure and time zone a
 - Flowchart Activity Designer or other Workflow Activity Designers may display all objects in their default locations as opposed to attached property values.
 
 <a name="clickonce-1" />
+
 ### Clickonce
 
 ClickOnce has been updated to support TLS 1.1 and TLS 1.2 in addition to the 1.0 protocol, which it already supports. ClickOnce automatically detects which protocol is required; no extra steps within the ClickOnce application are required to enable TLS 1.1 and 1.2 support.


### PR DESCRIPTION
Hello @rpetrusha,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description of the source issue:  Spotted string does not match with bookmark reference, therefore anchor to heading is not rendered. Consider writing heading like this:  Clickonce-1
Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
