### PR TITLE
typo: explosed -> exposed

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/transactedbatching.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transactedbatching.md
@@ -3,46 +3,52 @@ title: "<transactedBatching>"
 ms.date: "03/30/2017"
 ms.assetid: 2f790a0d-8f03-4b86-81b5-ce1bc1a6c575
 ---
+
 # \<transactedBatching>
-Specifies whether transaction batching is supported for receive operations.  
-  
- \<system.ServiceModel>  
-\<behaviors>  
-\<endpointBehaviors>  
-\<behavior>  
-\<transactedBatching>  
-  
-## Syntax  
-  
-```xml  
+
+Specifies whether transaction batching is supported for receive operations.
+
+\<system.ServiceModel>\
+\<behaviors>\
+\<endpointBehaviors>\
+\<behavior>\
+\<transactedBatching>
+
+## Syntax
+
+```xml
 <transactedBatching maxBatchSize="Integer" />
-```  
-  
-## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
-  
-### Attributes  
-  
-|Attribute|Description|  
-|---------------|-----------------|  
-|`maxBatchSize`|An integer that specifies the maximum number of receive operations that can be batched together in one transaction. The default is 0.|  
-  
-### Child Elements  
- None.  
-  
-### Parent Elements  
-  
-|Element|Description|  
-|-------------|-----------------|  
-|[\<behavior>](../../../../../docs/framework/configure-apps/file-schema/wcf/behavior-of-endpointbehaviors.md)|Specifies an endpoint behavior.|  
-  
-## Remarks  
- A transport that is configured with transaction batching attempts to batch several receive operations into one transaction. By doing so, the relatively high cost of creating a transaction and committing it in every receive operation is avoided.  
-  
-## Example  
- The following example shows how to add the transacted batching behavior to a service in a configuration file.  
-  
-```xml  
+```
+
+## Attributes and Elements
+
+The following sections describe attributes, child elements, and parent elements.
+
+### Attributes
+
+|Attribute|Description|
+|---------------|-----------------|
+|`maxBatchSize`|An integer that specifies the maximum number of receive operations that can be batched together in one transaction. The default is 0.|
+
+### Child Elements
+
+None.
+
+### Parent Elements
+
+|Element|Description|
+|-------------|-----------------|
+|[\<behavior>](../../../../../docs/framework/configure-apps/file-schema/wcf/behavior-of-endpointbehaviors.md)|Specifies an endpoint behavior.|
+
+## Remarks
+
+A transport that is configured with transaction batching attempts to batch several receive operations into one transaction. By doing so, the relatively high cost of creating a transaction and committing it in every receive operation is avoided.
+
+## Example
+
+The following example shows how to add the transacted batching behavior to a service in a configuration file.
+
+```xml
 <system.serviceModel>
   <services>
     <service name="Microsoft.ServiceModel.Samples.CalculatorService"
@@ -56,7 +62,7 @@ Specifies whether transaction batching is supported for receive operations.
       <endpoint address="net.msmq://localhost/private/ServiceModelSamples"
                 binding="netMsmqBinding"
                 contract="Microsoft.ServiceModel.Samples.IQueueCalculator" />
-      <!-- the mex endpoint is explosed at http://localhost:8000/ServiceModelSamples/service/mex -->
+      <!-- the mex endpoint is exposed at http://localhost:8000/ServiceModelSamples/service/mex -->
       <endpoint address="mex"
                 binding="mexHttpBinding"
                 contract="IMetadataExchange" />
@@ -75,8 +81,9 @@ Specifies whether transaction batching is supported for receive operations.
     </serviceBehaviors>
   </behaviors>
 </system.serviceModel>
-```  
-  
+```
+
 ## See also
+
 - <xref:System.ServiceModel.Configuration.TransactedBatchingElement>
 - <xref:System.ServiceModel.Description.TransactedBatchingBehavior>

--- a/docs/framework/wcf/samples/getting-started-sample.md
+++ b/docs/framework/wcf/samples/getting-started-sample.md
@@ -1,281 +1,284 @@
 ---
 title: "Getting Started Sample"
 ms.date: "03/30/2017"
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "basic samples [WCF], getting started"
 ms.assetid: 967a3d94-0261-49ff-b85a-20bb07f1af20
 ---
+
 # Getting Started Sample
-The Getting Started sample demonstrates how to implement a typical service and a typical client using Windows Communication Foundation (WCF). This sample is the basis for all other basic technology samples.  
-  
+
+The Getting Started sample demonstrates how to implement a typical service and a typical client using Windows Communication Foundation (WCF). This sample is the basis for all other basic technology samples.
+
 > [!NOTE]
->  The setup procedure and build instructions for this sample are located at the end of this topic.  
-  
+> The setup procedure and build instructions for this sample are located at the end of this topic.
+
 > [!IMPORTANT]
->  The samples may already be installed on your computer. Check for the following (default) directory before continuing.  
->   
->  `<InstallDrive>:\WF_WCF_Samples`  
->   
->  If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.  
->   
->  `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\GettingStarted\GettingStarted`  
-  
- The service describes the operations it performs in a service contract that it exposes publicly as metadata. The service also contains the code to implement the operations.  
-  
- The client contains a definition of the service contract and a proxy class for accessing the service. The proxy code is generated from the service metadata using the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md).  
-  
- On [!INCLUDE[wv](../../../../includes/wv-md.md)], the service is hosted in the Windows Activation Service (WAS). On [!INCLUDE[wxp](../../../../includes/wxp-md.md)] and [!INCLUDE[ws2003](../../../../includes/ws2003-md.md)], it is hosted by Internet Information Services (IIS) and ASP.NET. Hosting a service in IIS or WAS allows the service to be activated automatically when it is accessed for the first time.  
-  
+> The samples may already be installed on your computer. Check for the following (default) directory before continuing.
+>
+> `<InstallDrive>:\WF_WCF_Samples`
+>
+> If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.
+>
+> `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\GettingStarted\GettingStarted`
+
+The service describes the operations it performs in a service contract that it exposes publicly as metadata. The service also contains the code to implement the operations.
+
+The client contains a definition of the service contract and a proxy class for accessing the service. The proxy code is generated from the service metadata using the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md).
+
+On [!INCLUDE[wv](../../../../includes/wv-md.md)], the service is hosted in the Windows Activation Service (WAS). On [!INCLUDE[wxp](../../../../includes/wxp-md.md)] and [!INCLUDE[ws2003](../../../../includes/ws2003-md.md)], it is hosted by Internet Information Services (IIS) and ASP.NET. Hosting a service in IIS or WAS allows the service to be activated automatically when it is accessed for the first time.
+
 > [!NOTE]
->  If you would prefer to get started with a sample that hosts the service in a console application instead of IIS, see the [Self-Host](../../../../docs/framework/wcf/samples/self-host.md) sample.  
-  
- The service and client specify access details in configuration file settings, which provide flexibility at the time of deployment. This includes an endpoint definition that specifies an address, binding, and contract. The binding specifies transport and security details for how the service is to be accessed.  
-  
- The service configures a run-time behavior to publish its metadata.  
-  
- The service implements a contract that defines a request-reply communication pattern. The contract is defined by the `ICalculator` interface, which exposes math operations (add, subtract, multiply, and divide). The client makes requests to a given math operation and the service replies with the result. The service implements an `ICalculator` contract that is defined in the following code.  
-  
-```vb  
-' Define a service contract.  
-    <ServiceContract(Namespace:="http://Microsoft.Samples.GettingStarted")>  
-     Public Interface ICalculator  
-        <OperationContract()>  
-        Function Add(ByVal n1 As Double, ByVal n2 As Double) As Double  
-        <OperationContract()>  
-        Function Subtract(ByVal n1 As Double, ByVal n2 As Double) As Double  
-        <OperationContract()>  
-        Function Multiply(ByVal n1 As Double, ByVal n2 As Double) As Double  
-        <OperationContract()>  
-        Function Divide(ByVal n1 As Double, ByVal n2 As Double) As Double  
-    End Interface  
-```  
-  
-```csharp  
-// Define a service contract.  
-[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]  
-public interface ICalculator  
-{  
-    [OperationContract]  
-    double Add(double n1, double n2);  
-    [OperationContract]  
-    double Subtract(double n1, double n2);  
-    [OperationContract]  
-    double Multiply(double n1, double n2);  
-    [OperationContract]  
-    double Divide(double n1, double n2);  
-}  
-```  
-  
- The service implementation calculates and returns the appropriate result, as shown in the following example code.  
-  
-```vb  
-' Service class which implements the service contract.  
-Public Class CalculatorService  
-Implements ICalculator  
-Public Function Add(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Add  
-Return n1 + n2  
-End Function  
-  
-Public Function Subtract(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Subtract  
-Return n1 - n2  
-End Function  
-  
-Public Function Multiply(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Multiply  
-Return n1 * n2  
-End Function  
-  
-Public Function Divide(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Divide  
-Return n1 / n2  
-End Function  
-End Class  
-```  
-  
-```csharp  
-// Service class that implements the service contract.  
-public class CalculatorService : ICalculator  
-{  
-    public double Add(double n1, double n2)  
-    {  
-        return n1 + n2;  
-    }  
-    public double Subtract(double n1, double n2)  
-    {  
-        return n1 - n2;  
-    }  
-    public double Multiply(double n1, double n2)  
-    {  
-        return n1 * n2;  
-    }  
-    public double Divide(double n1, double n2)  
-    {  
-        return n1 / n2;  
-    }  
-}  
-```  
-  
- The service exposes an endpoint for communicating with the service, defined using a configuration file (Web.config), as shown in the following sample configuration.  
-  
-```xaml  
-<services>  
-    <service   
-        name="Microsoft.ServiceModel.Samples.CalculatorService"  
-        behaviorConfiguration="CalculatorServiceBehavior">  
-        <!-- ICalculator is exposed at the base address provided by  
-         host: http://localhost/servicemodelsamples/service.svc.  -->  
-       <endpoint address=""  
-              binding="wsHttpBinding"  
-              contract="Microsoft.ServiceModel.Samples.ICalculator" />  
-       ...  
-    </service>  
-</services>  
-```  
-  
- The service exposes the endpoint at the base address provided by the IIS or WAS host. The binding is configured with a standard <xref:System.ServiceModel.WSHttpBinding>, which provides HTTP communication and standard Web service protocols for addressing and security. The contract is the `ICalculator` implemented by the service.  
-  
- As configured, the service can be accessed at `http://localhost/servicemodelsamples/service.svc` by a client on the same computer. For clients on remote computers to access the service, a fully-qualified domain name must be specified instead of localhost.  
-  
- The framework does not expose metadata by default. As such, the service turns on the <xref:System.ServiceModel.Description.ServiceMetadataBehavior> and exposes a metadata exchange (MEX) endpoint at `http://localhost/servicemodelsamples/service.svc/mex`. The following configuration demonstrates this.  
-  
-```xaml  
-<system.serviceModel>  
-  <services>  
-    <service   
-        name="Microsoft.ServiceModel.Samples.CalculatorService"  
-        behaviorConfiguration="CalculatorServiceBehavior">  
-      ...  
-      <!-- the mex endpoint is explosed at  
-       http://localhost/servicemodelsamples/service.svc/mex -->  
-      <endpoint address="mex"  
-                binding="mexHttpBinding"  
-                contract="IMetadataExchange" />  
-    </service>  
-  </services>  
-  
-  <!--For debugging purposes set the includeExceptionDetailInFaults  
-   attribute to true-->  
-  <behaviors>  
-    <serviceBehaviors>  
-      <behavior name="CalculatorServiceBehavior">  
-        <serviceMetadata httpGetEnabled="True"/>  
-        <serviceDebug includeExceptionDetailInFaults="False" />  
-      </behavior>  
-    </serviceBehaviors>  
-  </behaviors>  
-</system.serviceModel>  
-```  
-  
- The client communicates using a given contract type by using a client class that is generated by the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md). This generated client is contained in the file generatedClient.cs or generatedClient.vb. This utility retrieves metadata for a given service and generates a client for use by the client application to communicate using a given contract type. The hosted service must be available to generate the client code, because the service is used to retrieve the updated metadata.  
-  
- Run the following command from the SDK command prompt in the client directory to generate the typed proxy:  
-  
-```  
-svcutil.exe /n:"http://Microsoft.ServiceModel.Samples,Microsoft.ServiceModel.Samples" http://localhost/servicemodelsamples/service.svc/mex /out:generatedClient.cs  
-```  
-  
- To generate client in Visual Basic type the following from the SDK command prompt:  
-  
- `Svcutil.exe /n:"http://Microsoft.ServiceModel.Samples,Microsoft.ServiceModel.Samples" http://localhost/servicemodelsamples/service.svc/mex /l:vb /out:generatedClient.vb`  
-  
- By using the generated client, the client can access a given service endpoint by configuring the appropriate address and binding. Like the service, the client uses a configuration file (App.config) to specify the endpoint with which it wants to communicate. The client endpoint configuration consists of an absolute address for the service endpoint, the binding, and the contract, as shown in the following example.  
-  
-```xaml  
-<client>  
-     <endpoint  
-         address="http://localhost/servicemodelsamples/service.svc"   
-         binding="wsHttpBinding"   
-         contract=" Microsoft.ServiceModel.Samples.ICalculator" />  
-</client>  
-```  
-  
- The client implementation instantiates the client and uses the typed interface to begin communicating with the service, as shown in the following example code.  
-  
-```vb  
-' Create a client  
-Dim client As New CalculatorClient()  
-  
-' Call the Add service operation.  
-            Dim value1 = 100.0R  
-            Dim value2 = 15.99R  
-            Dim result = client.Add(value1, value2)  
-Console.WriteLine("Add({0},{1}) = {2}", value1, value2, result)  
-  
-' Call the Subtract service operation.  
-value1 = 145.00R  
-value2 = 76.54R  
-result = client.Subtract(value1, value2)  
-Console.WriteLine("Subtract({0},{1}) = {2}", value1, value2, result)  
-  
-' Call the Multiply service operation.  
-value1 = 9.00R  
-value2 = 81.25R  
-result = client.Multiply(value1, value2)  
-Console.WriteLine("Multiply({0},{1}) = {2}", value1, value2, result)  
-  
-' Call the Divide service operation.  
-value1 = 22.00R  
-value2 = 7.00R  
-result = client.Divide(value1, value2)  
-Console.WriteLine("Divide({0},{1}) = {2}", value1, value2, result)  
-  
-'Closing the client gracefully closes the connection and cleans up resources  
-```  
-  
-```csharp  
-// Create a client.  
-CalculatorClient client = new CalculatorClient();  
-  
-// Call the Add service operation.  
-double value1 = 100.00D;  
-double value2 = 15.99D;  
-double result = client.Add(value1, value2);  
-Console.WriteLine("Add({0},{1}) = {2}", value1, value2, result);  
-  
-// Call the Subtract service operation.  
-value1 = 145.00D;  
-value2 = 76.54D;  
-result = client.Subtract(value1, value2);  
-Console.WriteLine("Subtract({0},{1}) = {2}", value1, value2, result);  
-  
-// Call the Multiply service operation.  
-value1 = 9.00D;  
-value2 = 81.25D;  
-result = client.Multiply(value1, value2);  
-Console.WriteLine("Multiply({0},{1}) = {2}", value1, value2, result);  
-  
-// Call the Divide service operation.  
-value1 = 22.00D;  
-value2 = 7.00D;  
-result = client.Divide(value1, value2);  
-Console.WriteLine("Divide({0},{1}) = {2}", value1, value2, result);  
-  
-//Closing the client releases all communication resources.  
-client.Close();  
-```  
-  
- When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.  
-  
-```  
-Add(100,15.99) = 115.99  
-Subtract(145,76.54) = 68.46  
-Multiply(9,81.25) = 731.25  
-Divide(22,7) = 3.14285714285714  
-  
-Press <ENTER> to terminate client.  
-```  
-  
- The Getting Started sample shows the standard way to create a service and client. The other [Basic](../../../../docs/framework/wcf/samples/basic-sample.md) build on this sample to demonstrate specific product features.  
-  
-### To set up, build, and run the sample  
-  
-1.  Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).  
-  
-2.  To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).  
-  
-3.  To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).  
-  
+> If you would prefer to get started with a sample that hosts the service in a console application instead of IIS, see the [Self-Host](../../../../docs/framework/wcf/samples/self-host.md) sample.
+
+The service and client specify access details in configuration file settings, which provide flexibility at the time of deployment. This includes an endpoint definition that specifies an address, binding, and contract. The binding specifies transport and security details for how the service is to be accessed.
+
+The service configures a run-time behavior to publish its metadata.
+
+The service implements a contract that defines a request-reply communication pattern. The contract is defined by the `ICalculator` interface, which exposes math operations (add, subtract, multiply, and divide). The client makes requests to a given math operation and the service replies with the result. The service implements an `ICalculator` contract that is defined in the following code.
+
+```vb
+' Define a service contract.
+    <ServiceContract(Namespace:="http://Microsoft.Samples.GettingStarted")>
+     Public Interface ICalculator
+        <OperationContract()>
+        Function Add(ByVal n1 As Double, ByVal n2 As Double) As Double
+        <OperationContract()>
+        Function Subtract(ByVal n1 As Double, ByVal n2 As Double) As Double
+        <OperationContract()>
+        Function Multiply(ByVal n1 As Double, ByVal n2 As Double) As Double
+        <OperationContract()>
+        Function Divide(ByVal n1 As Double, ByVal n2 As Double) As Double
+    End Interface
+```
+
+```csharp
+// Define a service contract.
+[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]
+public interface ICalculator
+{
+    [OperationContract]
+    double Add(double n1, double n2);
+    [OperationContract]
+    double Subtract(double n1, double n2);
+    [OperationContract]
+    double Multiply(double n1, double n2);
+    [OperationContract]
+    double Divide(double n1, double n2);
+}
+```
+
+The service implementation calculates and returns the appropriate result, as shown in the following example code.
+
+```vb
+' Service class which implements the service contract.
+Public Class CalculatorService
+Implements ICalculator
+Public Function Add(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Add
+Return n1 + n2
+End Function
+
+Public Function Subtract(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Subtract
+Return n1 - n2
+End Function
+
+Public Function Multiply(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Multiply
+Return n1 * n2
+End Function
+
+Public Function Divide(ByVal n1 As Double, ByVal n2 As Double) As Double Implements ICalculator.Divide
+Return n1 / n2
+End Function
+End Class
+```
+
+```csharp
+// Service class that implements the service contract.
+public class CalculatorService : ICalculator
+{
+    public double Add(double n1, double n2)
+    {
+        return n1 + n2;
+    }
+    public double Subtract(double n1, double n2)
+    {
+        return n1 - n2;
+    }
+    public double Multiply(double n1, double n2)
+    {
+        return n1 * n2;
+    }
+    public double Divide(double n1, double n2)
+    {
+        return n1 / n2;
+    }
+}
+```
+
+The service exposes an endpoint for communicating with the service, defined using a configuration file (Web.config), as shown in the following sample configuration.
+
+```xaml
+<services>
+    <service
+        name="Microsoft.ServiceModel.Samples.CalculatorService"
+        behaviorConfiguration="CalculatorServiceBehavior">
+        <!-- ICalculator is exposed at the base address provided by
+         host: http://localhost/servicemodelsamples/service.svc.  -->
+       <endpoint address=""
+              binding="wsHttpBinding"
+              contract="Microsoft.ServiceModel.Samples.ICalculator" />
+       ...
+    </service>
+</services>
+```
+
+The service exposes the endpoint at the base address provided by the IIS or WAS host. The binding is configured with a standard <xref:System.ServiceModel.WSHttpBinding>, which provides HTTP communication and standard Web service protocols for addressing and security. The contract is the `ICalculator` implemented by the service.
+
+As configured, the service can be accessed at `http://localhost/servicemodelsamples/service.svc` by a client on the same computer. For clients on remote computers to access the service, a fully-qualified domain name must be specified instead of localhost.
+
+The framework does not expose metadata by default. As such, the service turns on the <xref:System.ServiceModel.Description.ServiceMetadataBehavior> and exposes a metadata exchange (MEX) endpoint at `http://localhost/servicemodelsamples/service.svc/mex`. The following configuration demonstrates this.
+
+```xaml
+<system.serviceModel>
+  <services>
+    <service
+        name="Microsoft.ServiceModel.Samples.CalculatorService"
+        behaviorConfiguration="CalculatorServiceBehavior">
+      ...
+      <!-- the mex endpoint is exposed at
+       http://localhost/servicemodelsamples/service.svc/mex -->
+      <endpoint address="mex"
+                binding="mexHttpBinding"
+                contract="IMetadataExchange" />
+    </service>
+  </services>
+
+  <!--For debugging purposes set the includeExceptionDetailInFaults
+   attribute to true-->
+  <behaviors>
+    <serviceBehaviors>
+      <behavior name="CalculatorServiceBehavior">
+        <serviceMetadata httpGetEnabled="True"/>
+        <serviceDebug includeExceptionDetailInFaults="False" />
+      </behavior>
+    </serviceBehaviors>
+  </behaviors>
+</system.serviceModel>
+```
+
+The client communicates using a given contract type by using a client class that is generated by the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md). This generated client is contained in the file generatedClient.cs or generatedClient.vb. This utility retrieves metadata for a given service and generates a client for use by the client application to communicate using a given contract type. The hosted service must be available to generate the client code, because the service is used to retrieve the updated metadata.
+
+ Run the following command from the SDK command prompt in the client directory to generate the typed proxy:
+
+```
+svcutil.exe /n:"http://Microsoft.ServiceModel.Samples,Microsoft.ServiceModel.Samples" http://localhost/servicemodelsamples/service.svc/mex /out:generatedClient.cs
+```
+
+To generate client in Visual Basic type the following from the SDK command prompt:
+
+`Svcutil.exe /n:"http://Microsoft.ServiceModel.Samples,Microsoft.ServiceModel.Samples" http://localhost/servicemodelsamples/service.svc/mex /l:vb /out:generatedClient.vb`
+
+By using the generated client, the client can access a given service endpoint by configuring the appropriate address and binding. Like the service, the client uses a configuration file (App.config) to specify the endpoint with which it wants to communicate. The client endpoint configuration consists of an absolute address for the service endpoint, the binding, and the contract, as shown in the following example.
+
+```xaml
+<client>
+     <endpoint
+         address="http://localhost/servicemodelsamples/service.svc"
+         binding="wsHttpBinding"
+         contract=" Microsoft.ServiceModel.Samples.ICalculator" />
+</client>
+```
+
+The client implementation instantiates the client and uses the typed interface to begin communicating with the service, as shown in the following example code.
+
+```vb
+' Create a client
+Dim client As New CalculatorClient()
+
+' Call the Add service operation.
+            Dim value1 = 100.0R
+            Dim value2 = 15.99R
+            Dim result = client.Add(value1, value2)
+Console.WriteLine("Add({0},{1}) = {2}", value1, value2, result)
+
+' Call the Subtract service operation.
+value1 = 145.00R
+value2 = 76.54R
+result = client.Subtract(value1, value2)
+Console.WriteLine("Subtract({0},{1}) = {2}", value1, value2, result)
+
+' Call the Multiply service operation.
+value1 = 9.00R
+value2 = 81.25R
+result = client.Multiply(value1, value2)
+Console.WriteLine("Multiply({0},{1}) = {2}", value1, value2, result)
+
+' Call the Divide service operation.
+value1 = 22.00R
+value2 = 7.00R
+result = client.Divide(value1, value2)
+Console.WriteLine("Divide({0},{1}) = {2}", value1, value2, result)
+
+'Closing the client gracefully closes the connection and cleans up resources
+```
+
+```csharp
+// Create a client.
+CalculatorClient client = new CalculatorClient();
+
+// Call the Add service operation.
+double value1 = 100.00D;
+double value2 = 15.99D;
+double result = client.Add(value1, value2);
+Console.WriteLine("Add({0},{1}) = {2}", value1, value2, result);
+
+// Call the Subtract service operation.
+value1 = 145.00D;
+value2 = 76.54D;
+result = client.Subtract(value1, value2);
+Console.WriteLine("Subtract({0},{1}) = {2}", value1, value2, result);
+
+// Call the Multiply service operation.
+value1 = 9.00D;
+value2 = 81.25D;
+result = client.Multiply(value1, value2);
+Console.WriteLine("Multiply({0},{1}) = {2}", value1, value2, result);
+
+// Call the Divide service operation.
+value1 = 22.00D;
+value2 = 7.00D;
+result = client.Divide(value1, value2);
+Console.WriteLine("Divide({0},{1}) = {2}", value1, value2, result);
+
+//Closing the client releases all communication resources.
+client.Close();
+```
+
+When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.
+
+```
+Add(100,15.99) = 115.99
+Subtract(145,76.54) = 68.46
+Multiply(9,81.25) = 731.25
+Divide(22,7) = 3.14285714285714
+
+Press <ENTER> to terminate client.
+```
+
+The Getting Started sample shows the standard way to create a service and client. The other [Basic](../../../../docs/framework/wcf/samples/basic-sample.md) build on this sample to demonstrate specific product features.
+
+### To set up, build, and run the sample
+
+1.  Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
+
+2.  To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
+
+3.  To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).
+
 ## See also
+
 - [How to: Host a WCF Service in a Managed Application](../../../../docs/framework/wcf/how-to-host-a-wcf-service-in-a-managed-application.md)
 - [How to: Host a WCF Service in IIS](../../../../docs/framework/wcf/feature-details/how-to-host-a-wcf-service-in-iis.md)

--- a/docs/framework/wcf/samples/namedpipe-activation.md
+++ b/docs/framework/wcf/samples/namedpipe-activation.md
@@ -3,219 +3,222 @@ title: "NamedPipe Activation"
 ms.date: "03/30/2017"
 ms.assetid: f3c0437d-006c-442e-bfb0-6b29216e4e29
 ---
+
 # NamedPipe Activation
-This sample demonstrates hosting a service that uses Windows Process Activation Service (WAS) to activate a service that communicates over names pipes. This sample is based on the [Getting Started](../../../../docs/framework/wcf/samples/getting-started-sample.md) and requires [!INCLUDE[wv](../../../../includes/wv-md.md)] to run.  
-  
+
+This sample demonstrates hosting a service that uses Windows Process Activation Service (WAS) to activate a service that communicates over names pipes. This sample is based on the [Getting Started](../../../../docs/framework/wcf/samples/getting-started-sample.md) and requires [!INCLUDE[wv](../../../../includes/wv-md.md)] to run.
+
 > [!NOTE]
->  The set-up procedure and build instructions for this sample are located at the end of this topic.  
-  
+> The set-up procedure and build instructions for this sample are located at the end of this topic.
+
 > [!IMPORTANT]
->  The samples may already be installed on your computer. Check for the following (default) directory before continuing.  
->   
->  `<InstallDrive>:\WF_WCF_Samples`  
->   
->  If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.  
->   
->  `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Services\Hosting\WASHost\NamedPipeActivation`  
-  
-## Sample Details  
- The sample consists of a client console program (.exe) and a service library (.dll) hosted in a worker process activated by the Windows Process Activation Services (WAS). Client activity is visible in the console window.  
-  
- The service implements a contract that defines a request-reply communication pattern. The contract is defined by the `ICalculator` interface, which exposes math operations (Add, Subtract, Multiply, and Divide), as shown in the following sample code.  
-  
+> The samples may already be installed on your computer. Check for the following (default) directory before continuing.
+>
+> `<InstallDrive>:\WF_WCF_Samples`
+>
+> If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.
+>
+> `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Services\Hosting\WASHost\NamedPipeActivation`
+
+## Sample Details
+
+The sample consists of a client console program (.exe) and a service library (.dll) hosted in a worker process activated by the Windows Process Activation Services (WAS). Client activity is visible in the console window.
+
+The service implements a contract that defines a request-reply communication pattern. The contract is defined by the `ICalculator` interface, which exposes math operations (Add, Subtract, Multiply, and Divide), as shown in the following sample code.
+
 ```csharp
-[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]  
-public interface ICalculator  
-{  
-    [OperationContract]  
-    double Add(double n1, double n2);  
-    [OperationContract]  
-    double Subtract(double n1, double n2);  
-    [OperationContract]  
-    double Multiply(double n1, double n2);  
-    [OperationContract]  
-    double Divide(double n1, double n2);  
-}  
-```  
-  
- The client makes synchronous requests to a given math operation and the service implementation calculates and returns the appropriate result.  
-  
+[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]
+public interface ICalculator
+{
+    [OperationContract]
+    double Add(double n1, double n2);
+    [OperationContract]
+    double Subtract(double n1, double n2);
+    [OperationContract]
+    double Multiply(double n1, double n2);
+    [OperationContract]
+    double Divide(double n1, double n2);
+}
+```
+
+The client makes synchronous requests to a given math operation and the service implementation calculates and returns the appropriate result.
+
 ```csharp
-// Service class that implements the service contract.  
-public class CalculatorService : ICalculator  
-{  
-    public double Add(double n1, double n2)  
-    {  
-        return n1 + n2;  
-    }  
-    public double Subtract(double n1, double n2)  
-    {  
-        return n1 - n2;  
-    }  
-    public double Multiply(double n1, double n2)  
-    {  
-        return n1 * n2;  
-    }  
-    public double Divide(double n1, double n2)  
-    {  
-        return n1 / n2;  
-    }  
-}  
-```  
-  
- The sample uses a modified `netNamedPipeBinding` binding with no security. The binding is specified in the configuration files for the client and service. The binding type for the service is specified in the endpoint element’s `binding` attribute as shown in the following sample configuration.  
-  
- If you want use a secured named pipe binding, change the server's security mode to the desired security setting and run svcutil.exe again on the client to obtain an updated client configuration file.  
-  
-```xml  
-<system.serviceModel>  
-        <services>  
-            <service name="Microsoft.ServiceModel.Samples.CalculatorService"  
-               behaviorConfiguration="CalculatorServiceBehavior">  
-  
-        <!-- This endpoint is exposed at the base address provided by host: net.pipe://localhost/servicemodelsamples/service.svc  -->  
-        <endpoint address=""   
-                  binding="netNamedPipeBinding"  
-                  bindingConfiguration="Binding1"   
-                  contract="Microsoft.ServiceModel.Samples.ICalculator" />  
-        <!-- the mex endpoint is explosed at net.pipe://localhost/servicemodelsamples/service.svc/mex -->  
-        <endpoint address="mex"  
-                  binding="mexNamedPipeBinding"  
-                  contract="IMetadataExchange" />  
-      </service>  
-        </services>      
-        <bindings>  
-            <netNamedPipeBinding>  
-                <binding name="Binding1" >  
-                    <security mode = "None">  
-                    </security>  
-                </binding >  
-            </netNamedPipeBinding>  
-        </bindings>  
-  
-    <!--For debugging purposes set the includeExceptionDetailInFaults attribute to true-->  
-    <behaviors>  
-      <serviceBehaviors>  
-        <behavior name="CalculatorServiceBehavior">  
-          <serviceMetadata />  
-          <serviceDebug includeExceptionDetailInFaults="False" />  
-        </behavior>  
-      </serviceBehaviors>  
-    </behaviors>  
-  
-  </system.serviceModel>  
-```  
-  
- The client’s endpoint information is configured as shown in the following sample code.  
-  
-```xml  
-<system.serviceModel>  
-  
-    <client>  
-      <endpoint name=""  
-                          address="net.pipe://localhost/servicemodelsamples/service.svc"   
-                          binding="netNamedPipeBinding"   
-                          bindingConfiguration="Binding1"   
-                          contract="Microsoft.ServiceModel.Samples.ICalculator" />  
-    </client>  
-  
-    <bindings>  
-  
-      <!--  Following is the expanded configuration section for a NetNamedPipeBinding.  
-            Each property is configured with the default value.   -->  
-  
-      <netNamedPipeBinding>  
-        <binding name="Binding1"   
-                         maxBufferSize="65536"  
-                         maxConnections="10">  
-          <security mode = "None">  
-          </security>  
-        </binding >  
-  
-      </netNamedPipeBinding>  
-    </bindings>  
-  
-  </system.serviceModel>  
-```  
-  
- When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.  
-  
+// Service class that implements the service contract.
+public class CalculatorService : ICalculator
+{
+    public double Add(double n1, double n2)
+    {
+        return n1 + n2;
+    }
+    public double Subtract(double n1, double n2)
+    {
+        return n1 - n2;
+    }
+    public double Multiply(double n1, double n2)
+    {
+        return n1 * n2;
+    }
+    public double Divide(double n1, double n2)
+    {
+        return n1 / n2;
+    }
+}
+```
+
+The sample uses a modified `netNamedPipeBinding` binding with no security. The binding is specified in the configuration files for the client and service. The binding type for the service is specified in the endpoint element’s `binding` attribute as shown in the following sample configuration.
+
+If you want use a secured named pipe binding, change the server's security mode to the desired security setting and run svcutil.exe again on the client to obtain an updated client configuration file.
+
+```xml
+<system.serviceModel>
+        <services>
+            <service name="Microsoft.ServiceModel.Samples.CalculatorService"
+               behaviorConfiguration="CalculatorServiceBehavior">
+
+        <!-- This endpoint is exposed at the base address provided by host: net.pipe://localhost/servicemodelsamples/service.svc  -->
+        <endpoint address=""
+                  binding="netNamedPipeBinding"
+                  bindingConfiguration="Binding1"
+                  contract="Microsoft.ServiceModel.Samples.ICalculator" />
+        <!-- the mex endpoint is exposed at net.pipe://localhost/servicemodelsamples/service.svc/mex -->
+        <endpoint address="mex"
+                  binding="mexNamedPipeBinding"
+                  contract="IMetadataExchange" />
+      </service>
+        </services>
+        <bindings>
+            <netNamedPipeBinding>
+                <binding name="Binding1" >
+                    <security mode = "None">
+                    </security>
+                </binding >
+            </netNamedPipeBinding>
+        </bindings>
+
+    <!--For debugging purposes set the includeExceptionDetailInFaults attribute to true-->
+    <behaviors>
+      <serviceBehaviors>
+        <behavior name="CalculatorServiceBehavior">
+          <serviceMetadata />
+          <serviceDebug includeExceptionDetailInFaults="False" />
+        </behavior>
+      </serviceBehaviors>
+    </behaviors>
+
+  </system.serviceModel>
+```
+
+The client’s endpoint information is configured as shown in the following sample code.
+
+```xml
+<system.serviceModel>
+
+    <client>
+      <endpoint name=""
+                          address="net.pipe://localhost/servicemodelsamples/service.svc"
+                          binding="netNamedPipeBinding"
+                          bindingConfiguration="Binding1"
+                          contract="Microsoft.ServiceModel.Samples.ICalculator" />
+    </client>
+
+    <bindings>
+
+      <!--  Following is the expanded configuration section for a NetNamedPipeBinding.
+            Each property is configured with the default value. -->
+
+      <netNamedPipeBinding>
+        <binding name="Binding1"
+                         maxBufferSize="65536"
+                         maxConnections="10">
+          <security mode = "None">
+          </security>
+        </binding >
+
+      </netNamedPipeBinding>
+    </bindings>
+
+  </system.serviceModel>
+```
+
+When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.
+
 ```console
-Add(100,15.99) = 115.99  
-Subtract(145,76.54) = 68.46  
-Multiply(9,81.25) = 731.25  
-Divide(22,7) = 3.14285714285714  
-  
-Press <ENTER> to terminate client.  
-```  
-  
-### To set up, build, and run the sample  
-  
-1.  Ensure that [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is installed. [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is required for WAS activation.  
-  
-2.  Ensure you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).  
-  
-     In addition, you must install the WCF non-HTTP activation components:  
-  
-    1.  From the **Start** menu, choose **Control Panel**.  
-  
-    2.  Select **Programs and Features**.  
-  
-    3.  Click **Turn Windows Components on or Off**.  
-  
-    4.  Expand the **Microsoft .NET Framework 3.0** node and check the **Windows Communication Foundation Non-HTTP Activation** feature.  
-  
-3.  Configure the Windows Process Activation Service (WAS) to support named pipe activation.  
-  
-     As a convenience, the following two steps are implemented in a batch file called AddNetPipeSiteBinding.cmd located in the sample directory.  
-  
-    1.  To support net.pipe activation, the default Web site must first be bound to the net.pipe protocol. This can be done using appcmd.exe, which is installed with the IIS 7.0 management toolset. From an elevated (administrator) command prompt, run the following command.  
-  
-        ```  
-        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site"   
-        -+bindings.[protocol='net.pipe',bindingInformation='*']  
-        ```  
-  
+Add(100,15.99) = 115.99
+Subtract(145,76.54) = 68.46
+Multiply(9,81.25) = 731.25
+Divide(22,7) = 3.14285714285714
+
+Press <ENTER> to terminate client.
+```
+
+### To set up, build, and run the sample
+
+1. Ensure that [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is installed. [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is required for WAS activation.
+
+2. Ensure you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
+
+    In addition, you must install the WCF non-HTTP activation components:
+
+    1. From the **Start** menu, choose **Control Panel**.
+
+    2. Select **Programs and Features**.
+
+    3. Click **Turn Windows Components on or Off**.
+
+    4. Expand the **Microsoft .NET Framework 3.0** node and check the **Windows Communication Foundation Non-HTTP Activation** feature.
+
+3. Configure the Windows Process Activation Service (WAS) to support named pipe activation.
+
+    As a convenience, the following two steps are implemented in a batch file called AddNetPipeSiteBinding.cmd located in the sample directory.
+
+    1. To support net.pipe activation, the default Web site must first be bound to the net.pipe protocol. This can be done using appcmd.exe, which is installed with the IIS 7.0 management toolset. From an elevated (administrator) command prompt, run the following command.
+
+        ```
+        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site"
+        -+bindings.[protocol='net.pipe',bindingInformation='*']
+        ```
+
         > [!NOTE]
-        >  This command is a single line of text.  
-  
-         This command adds a net.pipe site binding to the default Web site.  
-  
-    2.  Although all applications within a site share a common net.pipe binding, each application can enable net.pipe support individually. To enable net.pipe for the /servicemodelsamples application, run the following command from an elevated command prompt.  
-  
-        ```  
-        %windir%\system32\inetsrv\appcmd.exe set app "Default Web Site/servicemodelsamples" /enabledProtocols:http,net.pipe  
-        ```  
-  
+        > This command is a single line of text.
+
+        This command adds a net.pipe site binding to the default Web site.
+
+    2. Although all applications within a site share a common net.pipe binding, each application can enable net.pipe support individually. To enable net.pipe for the /servicemodelsamples application, run the following command from an elevated command prompt.
+
+        ```
+        %windir%\system32\inetsrv\appcmd.exe set app "Default Web Site/servicemodelsamples" /enabledProtocols:http,net.pipe
+        ```
+
         > [!NOTE]
-        >  This command is a single line of text.  
-  
-         This command enables the /servicemodelsamples application to be accessed using both `http://localhost/servicemodelsamples` and `net.tcp://localhost/servicemodelsamples`.  
-  
-4.  To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).  
-  
-5.  Remove the net.pipe site binding you added for this sample.  
-  
-     As a convenience, the following two steps are implemented in a batch file called RemoveNetPipeSiteBinding.cmd located in the sample directory:  
-  
-    1.  Remove net.tcp from the list of enabled protocols by running the following command from an elevated command prompt.  
-  
-        ```  
-        %windir%\system32\inetsrv\appcmd.exe set app "Default Web Site/servicemodelsamples" /enabledProtocols:http  
-        ```  
-  
+        > This command is a single line of text.
+
+        This command enables the /servicemodelsamples application to be accessed using both `http://localhost/servicemodelsamples` and `net.tcp://localhost/servicemodelsamples`.
+
+4. To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
+
+5. Remove the net.pipe site binding you added for this sample.
+
+    As a convenience, the following two steps are implemented in a batch file called RemoveNetPipeSiteBinding.cmd located in the sample directory:
+
+    1. Remove net.tcp from the list of enabled protocols by running the following command from an elevated command prompt.
+
+        ```
+        %windir%\system32\inetsrv\appcmd.exe set app "Default Web Site/servicemodelsamples" /enabledProtocols:http
+        ```
+
         > [!NOTE]
-        >  This command must be entered as a single line of text.  
-  
-    2.  Remove the net.tcp site binding by running the following command from an elevated command prompt.  
-  
-        ```  
-        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site" --bindings.[protocol='net.pipe',bindingInformation='*']  
-        ```  
-  
+        > This command must be entered as a single line of text.
+
+    2. Remove the net.tcp site binding by running the following command from an elevated command prompt.
+
+        ```
+        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site" --bindings.[protocol='net.pipe',bindingInformation='*']
+        ```
+
         > [!NOTE]
-        >  This command must be typed in as a single line of text.  
-  
+        > This command must be typed in as a single line of text.
+
 ## See also
 
 - [AppFabric Hosting and Persistence Samples](https://docs.microsoft.com/previous-versions/appfabric/ff383418(v=azure.10))

--- a/docs/framework/wcf/samples/tcp-activation.md
+++ b/docs/framework/wcf/samples/tcp-activation.md
@@ -3,201 +3,204 @@ title: "TCP Activation"
 ms.date: "03/30/2017"
 ms.assetid: bf8c215c-0228-4f4f-85c2-e33794ec09a7
 ---
+
 # TCP Activation
-This sample demonstrates hosting a service that uses Windows Process Activation Services (WAS) to activate a service that communicates over the net.tcp protocol. This sample is based on the [Getting Started](../../../../docs/framework/wcf/samples/getting-started-sample.md).  
-  
+
+This sample demonstrates hosting a service that uses Windows Process Activation Services (WAS) to activate a service that communicates over the net.tcp protocol. This sample is based on the [Getting Started](../../../../docs/framework/wcf/samples/getting-started-sample.md).
+
 > [!NOTE]
->  The setup procedure and build instructions for this sample are located at the end of this topic.  
-  
+> The setup procedure and build instructions for this sample are located at the end of this topic.
+
 > [!IMPORTANT]
->  The samples may already be installed on your computer. Check for the following (default) directory before continuing.  
->   
->  `<InstallDrive>:\WF_WCF_Samples`  
->   
->  If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.  
->   
->  `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Services\Hosting\WASHost\TCPActivation`  
-  
- The sample consists of a client console program (.exe) and a service library (.dll) hosted in a worker process activated by WAS. Client activity is visible in the console window.  
-  
- The service implements a contract that defines a request-reply communication pattern. The contract is defined by the `ICalculator` interface, which exposes math operations (Add, Subtract, Multiply, and Divide), as shown in the following sample code:  
-  
+> The samples may already be installed on your computer. Check for the following (default) directory before continuing.
+>
+> `<InstallDrive>:\WF_WCF_Samples`
+>
+> If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.
+>
+> `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Services\Hosting\WASHost\TCPActivation`
+
+The sample consists of a client console program (.exe) and a service library (.dll) hosted in a worker process activated by WAS. Client activity is visible in the console window.
+
+The service implements a contract that defines a request-reply communication pattern. The contract is defined by the `ICalculator` interface, which exposes math operations (Add, Subtract, Multiply, and Divide), as shown in the following sample code:
+
 ```csharp
-[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]  
-public interface ICalculator  
-{  
-    [OperationContract]  
-    double Add(double n1, double n2);  
-    [OperationContract]  
-    double Subtract(double n1, double n2);  
-    [OperationContract]  
-    double Multiply(double n1, double n2);  
-    [OperationContract]  
-    double Divide(double n1, double n2);  
-}  
-```  
-  
- The service implementation calculates and returns the appropriate result:  
-  
+[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]
+public interface ICalculator
+{
+    [OperationContract]
+    double Add(double n1, double n2);
+    [OperationContract]
+    double Subtract(double n1, double n2);
+    [OperationContract]
+    double Multiply(double n1, double n2);
+    [OperationContract]
+    double Divide(double n1, double n2);
+}
+```
+
+The service implementation calculates and returns the appropriate result:
+
 ```csharp
-// Service class that implements the service contract.  
-public class CalculatorService : ICalculator  
-{  
-    public double Add(double n1, double n2)  
-    {  
-        return n1 + n2;  
-    }  
-    public double Subtract(double n1, double n2)  
-    {  
-        return n1 - n2;  
-    }  
-    public double Multiply(double n1, double n2)  
-    {  
-        return n1 * n2;  
-    }  
-    public double Divide(double n1, double n2)  
-    {  
-        return n1 / n2;  
-    }  
-}  
-```  
-  
- The sample uses a variant of the net.tcp binding with TCP port sharing enabled and security turned off. If you want to use a secured TCP binding, change the server's security mode to the desired setting and re-run Svcutil.exe on the client to generate an update client configuration file.  
-  
- The following sample shows the configuration for the service:  
-  
-```xml  
-<system.serviceModel>  
-  
-    <services>  
-      <service name="Microsoft.ServiceModel.Samples.CalculatorService"  
-               behaviorConfiguration="CalculatorServiceBehavior">  
-        <!-- This endpoint is exposed at the base address provided by host: net.tcp://localhost/servicemodelsamples/service.svc  -->  
-        <endpoint binding="netTcpBinding" bindingConfiguration="PortSharingBinding"  
-          contract="Microsoft.ServiceModel.Samples.ICalculator" />  
-        <!-- the mex endpoint is explosed at net.tcp://localhost/servicemodelsamples/service.svc/mex -->  
-        <endpoint address="mex"  
-                  binding="mexTcpBinding"  
-                  contract="IMetadataExchange" />  
-      </service>  
-    </services>  
-    <bindings>  
-      <netTcpBinding>  
-        <binding name="PortSharingBinding" portSharingEnabled="true">  
-          <security mode="None" />  
-        </binding>  
-      </netTcpBinding>  
-    </bindings>  
-  
-    <!--For debugging purposes set the includeExceptionDetailInFaults attribute to true-->  
-    <behaviors>  
-      <serviceBehaviors>  
-        <behavior name="CalculatorServiceBehavior">  
-          <serviceMetadata />  
-          <serviceDebug includeExceptionDetailInFaults="False" />  
-        </behavior>  
-      </serviceBehaviors>  
-    </behaviors>  
-  
-  </system.serviceModel>  
-```  
-  
- The client's endpoint is configured as shown in the following sample code:  
-  
-```xml  
-<system.serviceModel>  
-    <bindings>  
-        <netTcpBinding>  
-          <binding name="NetTcpBinding_ICalculator">  
-            <security mode="None"/>  
-          </binding>  
-        </netTcpBinding>  
-    </bindings>  
-    <client>  
-        <endpoint address="net.tcp://localhost/servicemodelsamples/service.svc"  
-            binding="netTcpBinding" bindingConfiguration="NetTcpBinding_ICalculator"  
-            contract="Microsoft.ServiceModel.Samples.ICalculator" name="NetTcpBinding_ICalculator" />  
-    </client>  
-</system.serviceModel>  
-```  
-  
- When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.  
-  
-```console  
-Add(100,15.99) = 115.99  
-Subtract(145,76.54) = 68.46  
-Multiply(9,81.25) = 731.25  
-Divide(22,7) = 3.14285714285714  
-  
-Press <ENTER> to terminate client.  
-```  
-  
-### To set up, build, and run the sample  
-  
-1.  Ensure that [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is installed. [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is required for WAS activation.  
-  
-2.  Be sure you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).  
-  
-     In addition, you must install the WCF non-HTTP activation components:  
-  
-    1.  From the **Start** menu, choose **Control Panel**.  
-  
-    2.  Select **Programs and Features**.  
-  
-    3.  Click **Turn Windows Components on or Off**.  
-  
-    4.  Expand the **Microsoft .NET Framework 3.0** node and check the **Windows Communication Foundation Non-HTTP Activation** feature.  
-  
-3.  Configure WAS to support TCP activation.  
-  
-     As a convenience, the following two steps are implemented in a batch file called AddNetTcpSiteBinding.cmd located in the sample directory.  
-  
-    1.  To support net.tcp activation, the default Web site must first be bound to a net.tcp port. This can be done using Appcmd.exe, which is installed with the Internet Information Services 7.0 (IIS) management toolset. From an administrator-level command prompt, run the following command:  
-  
-        ```console  
-        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site" -+bindings.[protocol='net.tcp',bindingInformation='808:*']  
-        ```  
-  
+// Service class that implements the service contract.
+public class CalculatorService : ICalculator
+{
+    public double Add(double n1, double n2)
+    {
+        return n1 + n2;
+    }
+    public double Subtract(double n1, double n2)
+    {
+        return n1 - n2;
+    }
+    public double Multiply(double n1, double n2)
+    {
+        return n1 * n2;
+    }
+    public double Divide(double n1, double n2)
+    {
+        return n1 / n2;
+    }
+}
+```
+
+The sample uses a variant of the net.tcp binding with TCP port sharing enabled and security turned off. If you want to use a secured TCP binding, change the server's security mode to the desired setting and re-run Svcutil.exe on the client to generate an update client configuration file.
+
+The following sample shows the configuration for the service:
+
+```xml
+<system.serviceModel>
+
+    <services>
+      <service name="Microsoft.ServiceModel.Samples.CalculatorService"
+               behaviorConfiguration="CalculatorServiceBehavior">
+        <!-- This endpoint is exposed at the base address provided by host: net.tcp://localhost/servicemodelsamples/service.svc  -->
+        <endpoint binding="netTcpBinding" bindingConfiguration="PortSharingBinding"
+          contract="Microsoft.ServiceModel.Samples.ICalculator" />
+        <!-- the mex endpoint is exposed at net.tcp://localhost/servicemodelsamples/service.svc/mex -->
+        <endpoint address="mex"
+                  binding="mexTcpBinding"
+                  contract="IMetadataExchange" />
+      </service>
+    </services>
+    <bindings>
+      <netTcpBinding>
+        <binding name="PortSharingBinding" portSharingEnabled="true">
+          <security mode="None" />
+        </binding>
+      </netTcpBinding>
+    </bindings>
+
+    <!--For debugging purposes set the includeExceptionDetailInFaults attribute to true-->
+    <behaviors>
+      <serviceBehaviors>
+        <behavior name="CalculatorServiceBehavior">
+          <serviceMetadata />
+          <serviceDebug includeExceptionDetailInFaults="False" />
+        </behavior>
+      </serviceBehaviors>
+    </behaviors>
+
+  </system.serviceModel>
+```
+
+The client's endpoint is configured as shown in the following sample code:
+
+```xml
+<system.serviceModel>
+    <bindings>
+        <netTcpBinding>
+          <binding name="NetTcpBinding_ICalculator">
+            <security mode="None"/>
+          </binding>
+        </netTcpBinding>
+    </bindings>
+    <client>
+        <endpoint address="net.tcp://localhost/servicemodelsamples/service.svc"
+            binding="netTcpBinding" bindingConfiguration="NetTcpBinding_ICalculator"
+            contract="Microsoft.ServiceModel.Samples.ICalculator" name="NetTcpBinding_ICalculator" />
+    </client>
+</system.serviceModel>
+```
+
+When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.
+
+```console
+Add(100,15.99) = 115.99
+Subtract(145,76.54) = 68.46
+Multiply(9,81.25) = 731.25
+Divide(22,7) = 3.14285714285714
+
+Press <ENTER> to terminate client.
+```
+
+### To set up, build, and run the sample
+
+1. Ensure that [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is installed. [!INCLUDE[iisver](../../../../includes/iisver-md.md)] is required for WAS activation.
+
+2. Be sure you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
+
+    In addition, you must install the WCF non-HTTP activation components:
+
+    1. From the **Start** menu, choose **Control Panel**.
+
+    2. Select **Programs and Features**.
+
+    3. Click **Turn Windows Components on or Off**.
+
+    4. Expand the **Microsoft .NET Framework 3.0** node and check the **Windows Communication Foundation Non-HTTP Activation** feature.
+
+3. Configure WAS to support TCP activation.
+
+    As a convenience, the following two steps are implemented in a batch file called AddNetTcpSiteBinding.cmd located in the sample directory.
+
+    1. To support net.tcp activation, the default Web site must first be bound to a net.tcp port. This can be done using Appcmd.exe, which is installed with the Internet Information Services 7.0 (IIS) management toolset. From an administrator-level command prompt, run the following command:
+
+        ```console
+        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site" -+bindings.[protocol='net.tcp',bindingInformation='808:*']
+        ```
+
         > [!TIP]
-        >  This command is a single line of text. This command adds a net.tcp site binding to the default Web site listening on TCP port 808 with any hostname.  
-  
-    2.  Although all applications within a site share a common net.tcp binding, each application can enable net.tcp support individually. To enable net.tcp for the /servicemodelsamples application, run the following command from an administrator-level command prompt:  
-  
-        ```console  
-        %windir%\system32\inetsrv\appcmd.exe set app   
-        "Default Web Site/servicemodelsamples" /enabledProtocols:http,net.tcp  
-        ```  
-  
+        > This command is a single line of text. This command adds a net.tcp site binding to the default Web site listening on TCP port 808 with any hostname.
+
+    2. Although all applications within a site share a common net.tcp binding, each application can enable net.tcp support individually. To enable net.tcp for the /servicemodelsamples application, run the following command from an administrator-level command prompt:
+
+        ```console
+        %windir%\system32\inetsrv\appcmd.exe set app
+        "Default Web Site/servicemodelsamples" /enabledProtocols:http,net.tcp
+        ```
+
         > [!NOTE]
-        > This command is a single line of text. This command enables the /servicemodelsamples application to be accessed using both `http://localhost/servicemodelsamples` and `net.tcp://localhost/servicemodelsamples`.  
-  
-4.  To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).  
-  
-5.  To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).  
-  
-     Remove the net.tcp site binding you added for this sample.  
-  
-     As a convenience, the following two steps are implemented in a batch file called RemoveNetTcpSiteBinding.cmd located in the sample directory.  
-  
-    1.  Remove net.tcp from the list of enabled protocols by running the following command from an administrator-level command prompt:  
-  
-        ```console  
-        %windir%\system32\inetsrv\appcmd.exe set app   
-        "Default Web Site/servicemodelsamples" /enabledProtocols:http  
-        ```  
-  
+        > This command is a single line of text. This command enables the /servicemodelsamples application to be accessed using both `http://localhost/servicemodelsamples` and `net.tcp://localhost/servicemodelsamples`.
+
+4. To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
+
+5. To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).
+
+    Remove the net.tcp site binding you added for this sample.
+
+    As a convenience, the following two steps are implemented in a batch file called RemoveNetTcpSiteBinding.cmd located in the sample directory.
+
+    1. Remove net.tcp from the list of enabled protocols by running the following command from an administrator-level command prompt:
+
+        ```console
+        %windir%\system32\inetsrv\appcmd.exe set app
+        "Default Web Site/servicemodelsamples" /enabledProtocols:http
+        ```
+
         > [!NOTE]
-        >  This command must be entered as a single line of text.  
-  
-    2.  Remove the net.tcp site binding by running the following command from an administrator-level command prompt:  
-  
-        ```console  
-        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site"   
-        --bindings.[protocol='net.tcp',bindingInformation='808:*']  
-        ```  
-  
+        > This command must be entered as a single line of text.
+
+    2. Remove the net.tcp site binding by running the following command from an administrator-level command prompt:
+
+        ```console
+        %windir%\system32\inetsrv\appcmd.exe set site "Default Web Site"
+        --bindings.[protocol='net.tcp',bindingInformation='808:*']
+        ```
+
         > [!NOTE]
-        >  This command must be typed in as a single line of text.  
-  
+        > This command must be typed in as a single line of text.
+
 ## See also
+
 - [AppFabric Hosting and Persistence Samples](https://go.microsoft.com/fwlink/?LinkId=193961)

--- a/docs/framework/wcf/samples/transacted-msmq-binding.md
+++ b/docs/framework/wcf/samples/transacted-msmq-binding.md
@@ -3,19 +3,21 @@ title: "Transacted MSMQ Binding"
 ms.date: "03/30/2017"
 ms.assetid: 71f5cb8d-f1df-4e1e-b8a2-98e734a75c37
 ---
+
 # Transacted MSMQ Binding
+
 This sample demonstrates how to perform transacted queued communication by using Message Queuing (MSMQ).
 
 > [!NOTE]
->  The setup procedure and build instructions for this sample are located at the end of this topic.
+> The setup procedure and build instructions for this sample are located at the end of this topic.
 
- In queued communication, the client communicates to the service using a queue. More precisely, the client sends messages to a queue. The service receives messages from the queue. The service and client, therefore, do not have to be running at the same time to communicate using a queue.
+In queued communication, the client communicates to the service using a queue. More precisely, the client sends messages to a queue. The service receives messages from the queue. The service and client, therefore, do not have to be running at the same time to communicate using a queue.
 
- When transactions are used to send and receive messages, there are actually two separate transactions. When the client sends messages within the scope of a transaction, the transaction is local to the client and the client queue manager. When the service receives messages within the scope of the transaction, the transaction is local to the service and the receiving queue manager. It is very important to remember that the client and the service are not participating in the same transaction; rather, they are using different transactions when performing their operations (such as send and receive) with the queue.
+When transactions are used to send and receive messages, there are actually two separate transactions. When the client sends messages within the scope of a transaction, the transaction is local to the client and the client queue manager. When the service receives messages within the scope of the transaction, the transaction is local to the service and the receiving queue manager. It is very important to remember that the client and the service are not participating in the same transaction; rather, they are using different transactions when performing their operations (such as send and receive) with the queue.
 
- In this sample, the client sends a batch of messages to the service from within the scope of a transaction. The messages sent to the queue are then received by the service within the transaction scope defined by the service.
+In this sample, the client sends a batch of messages to the service from within the scope of a transaction. The messages sent to the queue are then received by the service within the transaction scope defined by the service.
 
- The service contract is `IOrderProcessor`, as shown in the following sample code. The interface defines a one-way service that is suitable for use with queues.
+The service contract is `IOrderProcessor`, as shown in the following sample code. The interface defines a one-way service that is suitable for use with queues.
 
 ```csharp
 [ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]
@@ -26,7 +28,7 @@ public interface IOrderProcessor
 }
 ```
 
- The service behavior defines an operation behavior with `TransactionScopeRequired` set to `true`. This ensures that the same transaction scope that is used to retrieve the message from the queue is used by any resource managers accessed by the method. It also guarantees that if the method throws an exception, the message is returned to the queue. Without setting this operation behavior, a queued channel creates a transaction to read the message from the queue and commits it automatically before dispatch such that if the operation fails, the message is lost. The most common scenario is for service operations to enlist in the transaction that is used to read the message from the queue, as demonstrated in the following code.
+The service behavior defines an operation behavior with `TransactionScopeRequired` set to `true`. This ensures that the same transaction scope that is used to retrieve the message from the queue is used by any resource managers accessed by the method. It also guarantees that if the method throws an exception, the message is returned to the queue. Without setting this operation behavior, a queued channel creates a transaction to read the message from the queue and commits it automatically before dispatch such that if the operation fails, the message is lost. The most common scenario is for service operations to enlist in the transaction that is used to read the message from the queue, as demonstrated in the following code.
 
 ```csharp
  // This service class that implements the service contract.
@@ -43,7 +45,7 @@ public interface IOrderProcessor
 }
 ```
 
- The service is self hosted. When using the MSMQ transport, the queue used must be created in advance. This can be done manually or through code. In this sample, the service contains code to check for the existence of the queue and create the queue if it does not exist. The queue name is read from the configuration file. The base address is used by the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md) to generate the proxy to the service.
+The service is self hosted. When using the MSMQ transport, the queue used must be created in advance. This can be done manually or through code. In this sample, the service contains code to check for the existence of the queue and create the queue if it does not exist. The queue name is read from the configuration file. The base address is used by the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md) to generate the proxy to the service.
 
 ```csharp
 // Host the service within this EXE console application.
@@ -74,7 +76,7 @@ public static void Main()
 }
 ```
 
- The MSMQ queue name is specified in an appSettings section of the configuration file, as shown in the following sample configuration.
+The MSMQ queue name is specified in an appSettings section of the configuration file, as shown in the following sample configuration.
 
 ```xml
 <appSettings>
@@ -83,9 +85,9 @@ public static void Main()
 ```
 
 > [!NOTE]
->  The queue name uses a dot (.) for the local computer and backslash separators in its path when creating the queue using <xref:System.Messaging>. The Windows Communication Foundation (WCF) endpoint uses the queue address with net.msmq scheme, uses "localhost" to denote the local computer, and uses forward slashes in its path.
+> The queue name uses a dot (.) for the local computer and backslash separators in its path when creating the queue using <xref:System.Messaging>. The Windows Communication Foundation (WCF) endpoint uses the queue address with net.msmq scheme, uses "localhost" to denote the local computer, and uses forward slashes in its path.
 
- The client creates a transaction scope. Communication with the queue takes place within the scope of the transaction, causing it to be treated as an atomic unit where all messages are sent to the queue or none of the messages are sent to the queue. The transaction is committed by calling <xref:System.Transactions.TransactionScope.Complete%2A> on the transaction scope.
+The client creates a transaction scope. Communication with the queue takes place within the scope of the transaction, causing it to be treated as an atomic unit where all messages are sent to the queue or none of the messages are sent to the queue. The transaction is committed by calling <xref:System.Transactions.TransactionScope.Complete%2A> on the transaction scope.
 
 ```csharp
 // Create a client.
@@ -127,15 +129,15 @@ Console.WriteLine("Press <ENTER> to terminate client.");
 Console.ReadLine();
 ```
 
- To verify that transactions are working, modify the client by commenting the transaction scope as shown in the following sample code, rebuild the solution, and run the client.
+To verify that transactions are working, modify the client by commenting the transaction scope as shown in the following sample code, rebuild the solution, and run the client.
 
 ```csharp
 //scope.Complete();
 ```
 
- Because the transaction is not completed, the messages are not sent to the queue.
+Because the transaction is not completed, the messages are not sent to the queue.
 
- When you run the sample, the client and service activities are displayed in both the service and client console windows. You can see the service receive messages from the client. Press ENTER in each console window to shut down the service and client. Note that because queuing is in use, the client and service do not have to be up and running at the same time. You can run the client, shut it down, and then start up the service and it still receives the messages.
+When you run the sample, the client and service activities are displayed in both the service and client console windows. You can see the service receive messages from the client. Press ENTER in each console window to shut down the service and client. Note that because queuing is in use, the client and service do not have to be up and running at the same time. You can run the client, shut it down, and then start up the service and it still receives the messages.
 
 ```
 The service is ready.
@@ -152,29 +154,29 @@ Processing Purchase Order: 7b31ce51-ae7c-4def-9b8b-617e4288eafd
 
 ### To set up, build, and run the sample
 
-1.  Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
+1. Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
 
-2.  If the service is run first, it will check to ensure that the queue is present. If the queue is not present, the service will create one. You can run the service first to create the queue, or you can create one via the MSMQ Queue Manager. Follow these steps to create a queue in Windows 2008.
+2. If the service is run first, it will check to ensure that the queue is present. If the queue is not present, the service will create one. You can run the service first to create the queue, or you can create one via the MSMQ Queue Manager. Follow these steps to create a queue in Windows 2008.
 
-    1.  Open Server Manager in Visual Studio 2012.
+    1. Open Server Manager in Visual Studio 2012.
 
-    2.  Expand the **Features** tab.
+    2. Expand the **Features** tab.
 
-    3.  Right-click **Private Message Queues**, and select **New**, **Private Queue**.
+    3. Right-click **Private Message Queues**, and select **New**, **Private Queue**.
 
-    4.  Check the **Transactional** box.
+    4. Check the **Transactional** box.
 
-    5.  Enter `ServiceModelSamplesTransacted` as the name of the new queue.
+    5. Enter `ServiceModelSamplesTransacted` as the name of the new queue.
 
-3.  To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
+3. To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
 
-4.  To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).
+4. To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).
 
- By default with the <xref:System.ServiceModel.NetMsmqBinding>, transport security is enabled. There are two relevant properties for MSMQ transport security, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A> and <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>. By default, the authentication mode is set to `Windows` and the protection level is set to `Sign`. For MSMQ to provide the authentication and signing feature, it must be part of a domain and the Active Directory integration option for MSMQ must be installed. If you run this sample on a computer that does not satisfy these criteria, you receive an error.
+By default with the <xref:System.ServiceModel.NetMsmqBinding>, transport security is enabled. There are two relevant properties for MSMQ transport security, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A> and <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>. By default, the authentication mode is set to `Windows` and the protection level is set to `Sign`. For MSMQ to provide the authentication and signing feature, it must be part of a domain and the Active Directory integration option for MSMQ must be installed. If you run this sample on a computer that does not satisfy these criteria, you receive an error.
 
 ### To run the sample on a computer joined to a workgroup or without Active Directory integration
 
-1.  If your computer is not part of a domain or does not have Active Directory integration installed, turn off transport security by setting the authentication mode and protection level to `None` as shown in the following sample configuration code.
+1. If your computer is not part of a domain or does not have Active Directory integration installed, turn off transport security by setting the authentication mode and protection level to `None` as shown in the following sample configuration code.
 
     ```xml
     <system.serviceModel>
@@ -192,7 +194,7 @@ Processing Purchase Order: 7b31ce51-ae7c-4def-9b8b-617e4288eafd
               binding="netMsmqBinding"
               bindingConfiguration="Binding1"
            contract="Microsoft.ServiceModel.Samples.IOrderProcessor" />
-          <!-- The mex endpoint is explosed at http://localhost:8000/ServiceModelSamples/service/mex. -->
+          <!-- The mex endpoint is exposed at http://localhost:8000/ServiceModelSamples/service/mex. -->
           <endpoint address="mex"
                     binding="mexHttpBinding"
                     contract="IMetadataExchange" />
@@ -218,18 +220,16 @@ Processing Purchase Order: 7b31ce51-ae7c-4def-9b8b-617e4288eafd
       </system.serviceModel>
     ```
 
-2.  Ensure that you change the configuration on both the server and the client before you run the sample.
+2. Ensure that you change the configuration on both the server and the client before you run the sample.
 
     > [!NOTE]
-    >  Setting `security mode` to `None` is equivalent to setting <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A>, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>, and `Message` security to `None`.
+    > Setting `security mode` to `None` is equivalent to setting <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A>, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>, and `Message` security to `None`.
 
 > [!IMPORTANT]
->  The samples may already be installed on your computer. Check for the following (default) directory before continuing.  
->   
->  `<InstallDrive>:\WF_WCF_Samples`  
->   
->  If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.  
->   
->  `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Binding\Net\MSMQ\Transacted`  
-  
-## See also
+> The samples may already be installed on your computer. Check for the following (default) directory before continuing.
+>
+> `<InstallDrive>:\WF_WCF_Samples`
+>
+> If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.
+>
+> `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Binding\Net\MSMQ\Transacted`

--- a/docs/framework/wcf/samples/volatile-queued-communication.md
+++ b/docs/framework/wcf/samples/volatile-queued-communication.md
@@ -3,222 +3,222 @@ title: "Volatile Queued Communication"
 ms.date: "03/30/2017"
 ms.assetid: 0d012f64-51c7-41d0-8e18-c756f658ee3d
 ---
+
 # Volatile Queued Communication
-This sample demonstrates how to perform volatile queued communication over the Message Queuing (MSMQ) transport. This sample uses <xref:System.ServiceModel.NetMsmqBinding>. The service in this case is a self-hosted console application to enable you to observe the service receiving queued messages.  
-  
+
+This sample demonstrates how to perform volatile queued communication over the Message Queuing (MSMQ) transport. This sample uses <xref:System.ServiceModel.NetMsmqBinding>. The service in this case is a self-hosted console application to enable you to observe the service receiving queued messages.
+
 > [!NOTE]
->  The setup procedure and build instructions for this sample are located at the end of this topic.  
-  
- In queued communication, the client communicates to the service using a queue. More precisely, the client sends messages to a queue. The service receives messages from the queue. The service and client therefore, do not have to be running at the same time to communicate using a queue.  
-  
- When you send a message with no assurances, MSMQ only makes a best effort to deliver the message, unlike with Exactly Once assurances where MSMQ ensures that the message gets delivered or, if it cannot be delivered, lets you know that the message cannot be delivered.  
-  
- In certain scenarios, you may want to send a volatile message with no assurances over a queue, when timely delivery is more important than losing messages. Volatile messages do not survive queue manager crashes. Therefore if the queue manager crashes, the non-transactional queue used to store volatile messages survives but the messages themselves do not because the messages are not stored on the disk.  
-  
+> The setup procedure and build instructions for this sample are located at the end of this topic.
+
+In queued communication, the client communicates to the service using a queue. More precisely, the client sends messages to a queue. The service receives messages from the queue. The service and client therefore, do not have to be running at the same time to communicate using a queue.
+
+When you send a message with no assurances, MSMQ only makes a best effort to deliver the message, unlike with Exactly Once assurances where MSMQ ensures that the message gets delivered or, if it cannot be delivered, lets you know that the message cannot be delivered.
+
+In certain scenarios, you may want to send a volatile message with no assurances over a queue, when timely delivery is more important than losing messages. Volatile messages do not survive queue manager crashes. Therefore if the queue manager crashes, the non-transactional queue used to store volatile messages survives but the messages themselves do not because the messages are not stored on the disk.
+
 > [!NOTE]
->  You cannot send volatile messages with no assurances within the scope of a transaction using MSMQ. You also must create a non-transactional queue to send volatile messages.  
-  
- The service contract in this sample is `IStockTicker` that defines one-way services that are best suited for use with queuing.  
+> You cannot send volatile messages with no assurances within the scope of a transaction using MSMQ. You also must create a non-transactional queue to send volatile messages.
+
+The service contract in this sample is `IStockTicker` that defines one-way services that are best suited for use with queuing.
 
 ```csharp
-[ServiceContract(Namespace = "http://Microsoft.ServiceModel.Samples")]  
-public interface IStockTicker  
-{  
-    [OperationContract(IsOneWay = true)]  
-    void StockTick(string symbol, float price);  
-}  
+[ServiceContract(Namespace = "http://Microsoft.ServiceModel.Samples")]
+public interface IStockTicker
+{
+    [OperationContract(IsOneWay = true)]
+    void StockTick(string symbol, float price);
+}
 ```
 
- The service operation displays the stock ticker symbol and price, as shown in the following sample code:  
-  
-```csharp
-public class StockTickerService : IStockTicker  
-{  
-    public void StockTick(string symbol, float price)  
-    {  
-        Console.WriteLine("Stock Tick {0}:{1} ", symbol, price);  
-     }  
-     …  
-}  
-```  
-  
- The service is self hosted. When using the MSMQ transport, the queue used must be created in advance. This can be done manually or through code. In this sample, the service contains code to check for the existence of the queue and create it if required. The queue name is read from the configuration file. The base address is used by the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md) to generate the proxy for the service.  
+The service operation displays the stock ticker symbol and price, as shown in the following sample code:
 
 ```csharp
-// Host the service within this EXE console application.  
-public static void Main()  
-{  
-    // Get MSMQ queue name from app settings in configuration.  
-    string queueName = ConfigurationManager.AppSettings["queueName"];  
-  
-    // Create the transacted MSMQ queue if necessary.  
-    if (!MessageQueue.Exists(queueName))  
-        MessageQueue.Create(queueName);  
-  
-    // Create a ServiceHost for the StockTickerService type.  
-    using (ServiceHost serviceHost = new ServiceHost(typeof(StockTickerService)))  
-    {  
-        // Open the ServiceHost to create listeners and start listening for messages.  
-        serviceHost.Open();  
-  
-        // The service can now be accessed.  
-        Console.WriteLine("The service is ready.");  
-        Console.WriteLine("Press <ENTER> to terminate service.");  
-        Console.WriteLine();  
-        Console.ReadLine();  
-  
-        // Close the ServiceHost to shutdown the service.  
-        serviceHost.Close();  
-    }  
-}  
+public class StockTickerService : IStockTicker
+{
+    public void StockTick(string symbol, float price)
+    {
+        Console.WriteLine("Stock Tick {0}:{1} ", symbol, price);
+     }
+     …
+}
 ```
 
- The MSMQ queue name is specified in the appSettings section of the configuration file. The endpoint for the service is defined in the system.serviceModel section of the configuration file and specifies the `netMsmqBinding` binding.  
-  
+The service is self hosted. When using the MSMQ transport, the queue used must be created in advance. This can be done manually or through code. In this sample, the service contains code to check for the existence of the queue and create it if required. The queue name is read from the configuration file. The base address is used by the [ServiceModel Metadata Utility Tool (Svcutil.exe)](../../../../docs/framework/wcf/servicemodel-metadata-utility-tool-svcutil-exe.md) to generate the proxy for the service.
+
+```csharp
+// Host the service within this EXE console application.
+public static void Main()
+{
+    // Get MSMQ queue name from app settings in configuration.
+    string queueName = ConfigurationManager.AppSettings["queueName"];
+
+    // Create the transacted MSMQ queue if necessary.
+    if (!MessageQueue.Exists(queueName))
+        MessageQueue.Create(queueName);
+
+    // Create a ServiceHost for the StockTickerService type.
+    using (ServiceHost serviceHost = new ServiceHost(typeof(StockTickerService)))
+    {
+        // Open the ServiceHost to create listeners and start listening for messages.
+        serviceHost.Open();
+
+        // The service can now be accessed.
+        Console.WriteLine("The service is ready.");
+        Console.WriteLine("Press <ENTER> to terminate service.");
+        Console.WriteLine();
+        Console.ReadLine();
+
+        // Close the ServiceHost to shutdown the service.
+        serviceHost.Close();
+    }
+}
+```
+
+The MSMQ queue name is specified in the appSettings section of the configuration file. The endpoint for the service is defined in the system.serviceModel section of the configuration file and specifies the `netMsmqBinding` binding.
+
 > [!NOTE]
->  The queue name uses a dot (.) for the local machine and backslash separators in its path when creating a queue using <xref:System.Messaging>. The Windows Communication Foundation (WCF) endpoint address specifies a net.msmq: scheme, uses "localhost" for the local machine and forward slashes in its path.  
-  
- The assurances and durability or volatility of messages are also specified in the configuration.  
-  
-```xml  
-<appSettings>  
-  <!-- use appSetting to configure MSMQ queue name -->  
-  <add key="queueName" value=".\private$\ServiceModelSamplesVolatile" />  
-</appSettings>  
-  
-<system.serviceModel>  
-  <services>  
-    <service name="Microsoft.ServiceModel.Samples.StockTickerService"  
-             behaviorConfiguration="CalculatorServiceBehavior">  
-    ...  
-      <!-- Define NetMsmqEndpoint -->  
-      <endpoint address="net.msmq://localhost/private/ServiceModelSamplesVolatile"  
-                binding="netMsmqBinding"  
-                bindingConfiguration="volatileBinding"   
-                contract="Microsoft.ServiceModel.Samples.IStockTicker" />  
-    ...  
-    </service>  
-  </services>  
-  
-  <bindings>  
-    <netMsmqBinding>  
-      <binding name="volatileBinding"   
-             durable="false"  
-           exactlyOnce="false"/>  
-    </netMsmqBinding>  
-  </bindings>  
-  ...  
-</system.serviceModel>  
-```  
-  
- Because the sample sends queued messages by using a non-transactional queue, transacted messages cannot be sent to the queue.  
+> The queue name uses a dot (.) for the local machine and backslash separators in its path when creating a queue using <xref:System.Messaging>. The Windows Communication Foundation (WCF) endpoint address specifies a net.msmq: scheme, uses "localhost" for the local machine and forward slashes in its path.
 
-```csharp
-// Create a client.  
-Random r = new Random(137);  
-  
-StockTickerClient client = new StockTickerClient();  
-  
-float price = 43.23F;  
-for (int i = 0; i < 10; i++)  
-{  
-    float increment = 0.01f * (r.Next(10));  
-    client.StockTick("zzz" + i, price + increment);  
-}  
-  
-//Closing the client gracefully cleans up resources.  
-client.Close();  
+The assurances and durability or volatility of messages are also specified in the configuration.
+
+```xml
+<appSettings>
+  <!-- use appSetting to configure MSMQ queue name -->
+  <add key="queueName" value=".\private$\ServiceModelSamplesVolatile" />
+</appSettings>
+
+<system.serviceModel>
+  <services>
+    <service name="Microsoft.ServiceModel.Samples.StockTickerService"
+             behaviorConfiguration="CalculatorServiceBehavior">
+    ...
+      <!-- Define NetMsmqEndpoint -->
+      <endpoint address="net.msmq://localhost/private/ServiceModelSamplesVolatile"
+                binding="netMsmqBinding"
+                bindingConfiguration="volatileBinding"
+                contract="Microsoft.ServiceModel.Samples.IStockTicker" />
+    ...
+    </service>
+  </services>
+
+  <bindings>
+    <netMsmqBinding>
+      <binding name="volatileBinding"
+             durable="false"
+           exactlyOnce="false"/>
+    </netMsmqBinding>
+  </bindings>
+  ...
+</system.serviceModel>
 ```
 
- When you run the sample, the client and service activities are displayed in both the service and client console windows. You can see the service receive messages from the client. Press ENTER in each console window to shut down the service and client. Note that because queuing is in use, the client and service do not have to be up and running at the same time. You can run the client, shut it down, and then start up the service and it still receives its messages.  
-  
-```  
-The service is ready.  
-Press <ENTER> to terminate service.  
-  
-Stock Tick zzz0:43.25  
-Stock Tick zzz1:43.23  
-Stock Tick zzz2:43.28  
-Stock Tick zzz3:43.3  
-Stock Tick zzz4:43.23  
-Stock Tick zzz5:43.25  
-Stock Tick zzz6:43.25  
-Stock Tick zzz7:43.24  
-Stock Tick zzz8:43.32  
-Stock Tick zzz9:43.3  
-```  
-  
-### To set up, build, and run the sample  
-  
-1.  Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).  
-  
-2.  To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).  
-  
-3.  To run the sample in a single- or cross-machine configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).  
-  
- By default with the <xref:System.ServiceModel.NetMsmqBinding>, transport security is enabled. There are two pertinent properties for MSMQ transport security, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A> and <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>`.` By default, the authentication mode is set to `Windows` and the protection level is set to `Sign`. For MSMQ to provide the authentication and signing feature, it must be part of a domain and the active directory integration option for MSMQ must be installed. If you run this sample on a computer that does not satisfy these criteria you receive an error.  
-  
-### To run the sample on a computer joined to a workgroup or without active directory integration  
-  
-1.  If your computer is not part of a domain or does not have active directory integration installed, turn off transport security by setting the authentication mode and protection level to `None` as shown in the following sample configuration code:  
-  
-    ```xml  
-    <system.serviceModel>  
-        <services>  
-          <service name="Microsoft.ServiceModel.Samples.StockTickerService"  
-                   behaviorConfiguration="StockTickerServiceBehavior">  
-            <host>  
-              <baseAddresses>  
-                <add baseAddress="http://localhost:8000/ServiceModelSamples/service"/>  
-              </baseAddresses>  
-            </host>  
-  
-            <!-- Define NetMsmqEndpoint -->  
-            <endpoint address="net.msmq://localhost/private/ServiceModelSamplesVolatile"  
-                      binding="netMsmqBinding"  
-                      bindingConfiguration="volatileBinding"   
-                      contract="Microsoft.ServiceModel.Samples.IStockTicker" />  
-            <!-- the mex endpoint is explosed at http://localhost:8000/ServiceModelSamples/service/mex -->  
-            <endpoint address="mex"  
-                      binding="mexHttpBinding"  
-                      contract="IMetadataExchange" />  
-  
-          </service>  
-        </services>  
-  
-        <bindings>  
-          <netMsmqBinding>  
-            <binding name="volatileBinding"   
-                  durable="false"  
-                  exactlyOnce="false">  
-              <security mode="None" />  
-            </binding>  
-          </netMsmqBinding>  
-        </bindings>  
-  
-        <behaviors>  
-          <serviceBehaviors>  
-            <behavior name="StockTickerServiceBehavior">  
-              <serviceMetadata httpGetEnabled="True"/>  
-            </behavior>  
-          </serviceBehaviors>  
-        </behaviors>  
-  
-      </system.serviceModel>  
-    ```  
-  
-2.  Ensure that you change the configuration on both the server and the client before you run the sample.  
-  
+Because the sample sends queued messages by using a non-transactional queue, transacted messages cannot be sent to the queue.
+
+```csharp
+// Create a client.
+Random r = new Random(137);
+
+StockTickerClient client = new StockTickerClient();
+
+float price = 43.23F;
+for (int i = 0; i < 10; i++)
+{
+    float increment = 0.01f * (r.Next(10));
+    client.StockTick("zzz" + i, price + increment);
+}
+
+//Closing the client gracefully cleans up resources.
+client.Close();
+```
+
+When you run the sample, the client and service activities are displayed in both the service and client console windows. You can see the service receive messages from the client. Press ENTER in each console window to shut down the service and client. Note that because queuing is in use, the client and service do not have to be up and running at the same time. You can run the client, shut it down, and then start up the service and it still receives its messages.
+
+```
+The service is ready.
+Press <ENTER> to terminate service.
+
+Stock Tick zzz0:43.25
+Stock Tick zzz1:43.23
+Stock Tick zzz2:43.28
+Stock Tick zzz3:43.3
+Stock Tick zzz4:43.23
+Stock Tick zzz5:43.25
+Stock Tick zzz6:43.25
+Stock Tick zzz7:43.24
+Stock Tick zzz8:43.32
+Stock Tick zzz9:43.3
+```
+
+### To set up, build, and run the sample
+
+1. Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
+
+2. To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
+
+3. To run the sample in a single- or cross-machine configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md).
+
+By default with the <xref:System.ServiceModel.NetMsmqBinding>, transport security is enabled. There are two pertinent properties for MSMQ transport security, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A> and <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>`.` By default, the authentication mode is set to `Windows` and the protection level is set to `Sign`. For MSMQ to provide the authentication and signing feature, it must be part of a domain and the active directory integration option for MSMQ must be installed. If you run this sample on a computer that does not satisfy these criteria you receive an error.
+
+### To run the sample on a computer joined to a workgroup or without active directory integration
+
+1. If your computer is not part of a domain or does not have active directory integration installed, turn off transport security by setting the authentication mode and protection level to `None` as shown in the following sample configuration code:
+
+    ```xml
+    <system.serviceModel>
+        <services>
+          <service name="Microsoft.ServiceModel.Samples.StockTickerService"
+                   behaviorConfiguration="StockTickerServiceBehavior">
+            <host>
+              <baseAddresses>
+                <add baseAddress="http://localhost:8000/ServiceModelSamples/service"/>
+              </baseAddresses>
+            </host>
+
+            <!-- Define NetMsmqEndpoint -->
+            <endpoint address="net.msmq://localhost/private/ServiceModelSamplesVolatile"
+                      binding="netMsmqBinding"
+                      bindingConfiguration="volatileBinding"
+                      contract="Microsoft.ServiceModel.Samples.IStockTicker" />
+            <!-- the mex endpoint is exposed at http://localhost:8000/ServiceModelSamples/service/mex -->
+            <endpoint address="mex"
+                      binding="mexHttpBinding"
+                      contract="IMetadataExchange" />
+
+          </service>
+        </services>
+
+        <bindings>
+          <netMsmqBinding>
+            <binding name="volatileBinding"
+                  durable="false"
+                  exactlyOnce="false">
+              <security mode="None" />
+            </binding>
+          </netMsmqBinding>
+        </bindings>
+
+        <behaviors>
+          <serviceBehaviors>
+            <behavior name="StockTickerServiceBehavior">
+              <serviceMetadata httpGetEnabled="True"/>
+            </behavior>
+          </serviceBehaviors>
+        </behaviors>
+
+      </system.serviceModel>
+    ```
+
+2. Ensure that you change the configuration on both the server and the client before you run the sample.
+
     > [!NOTE]
-    >  Setting `security mode` to `None` is equivalent to setting <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A>, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>, and `Message` security to `None`.  
-  
+    > Setting `security mode` to `None` is equivalent to setting <xref:System.ServiceModel.MsmqTransportSecurity.MsmqAuthenticationMode%2A>, <xref:System.ServiceModel.MsmqTransportSecurity.MsmqProtectionLevel%2A>, and `Message` security to `None`.
+
 > [!IMPORTANT]
->  The samples may already be installed on your computer. Check for the following (default) directory before continuing.  
->   
->  `<InstallDrive>:\WF_WCF_Samples`  
->   
->  If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.  
->   
->  `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Binding\Net\MSMQ\Volatile`  
-  
-## See also
+> The samples may already be installed on your computer. Check for the following (default) directory before continuing.
+>
+> `<InstallDrive>:\WF_WCF_Samples`
+>
+> If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.
+>
+> `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Binding\Net\MSMQ\Volatile`


### PR DESCRIPTION

- Trim trailing/leading spaces
- Removed empty "See aslo" headings