### PR TITLE
chore: Remove BOM from Markdown files

### DIFF
--- a/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
+++ b/docs/csharp/misc/sorry-we-don-t-have-specifics-on-this-csharp-error.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Sorry, we don't have specifics on this C# error"
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/framework/configure-apps/file-schema/wcf/activitystatequery-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/activitystatequery-of-wcf.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<activityStateQuery> of WCF"
 ms.date: "03/30/2017"
 ms.assetid: d6cdc04b-6f3a-4097-a623-ee4a1be3b5c4

--- a/docs/framework/configure-apps/file-schema/wcf/add-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/add-of-wcf.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<add> of WCF"
 ms.date: "03/30/2017"
 ms.assetid: c196f6d7-77f6-4266-973c-305b2b4dd8a2

--- a/docs/framework/configure-apps/file-schema/wcf/certificate-of-clientcertificate-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/certificate-of-clientcertificate-element.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<certificate> of <clientCertificate> Element"
 ms.date: "03/30/2017"
 ms.assetid: 00297efb-a7f2-4e03-bc2b-943d545610fc

--- a/docs/framework/configure-apps/file-schema/wcf/certificatereference-for-identity.md
+++ b/docs/framework/configure-apps/file-schema/wcf/certificatereference-for-identity.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<certificateReference> for <identity>"
 ms.date: "03/30/2017"
 ms.assetid: ac359c65-c22d-42d2-97de-db53b77cebdb

--- a/docs/framework/configure-apps/file-schema/wcf/claimtyperequirements-for-message.md
+++ b/docs/framework/configure-apps/file-schema/wcf/claimtyperequirements-for-message.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<claimTypeRequirements> for <message>"
 ms.date: "03/30/2017"
 ms.assetid: f95c5ecd-abb6-4b77-a6d7-a38727f4a142

--- a/docs/framework/configure-apps/file-schema/wcf/contracttypenames.md
+++ b/docs/framework/configure-apps/file-schema/wcf/contracttypenames.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<contractTypeNames>"
 ms.date: "03/30/2017"
 ms.assetid: 5ec5efc6-87f8-4160-9be0-dcd2e01df3df

--- a/docs/framework/configure-apps/file-schema/wcf/discoveryclient.md
+++ b/docs/framework/configure-apps/file-schema/wcf/discoveryclient.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<discoveryClient>"
 ms.date: "03/30/2017"
 ms.assetid: a78f74c3-1152-4149-ab29-3f12d316caeb

--- a/docs/framework/configure-apps/file-schema/wcf/discoveryclientsettings.md
+++ b/docs/framework/configure-apps/file-schema/wcf/discoveryclientsettings.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<discoveryClientSettings>"
 ms.date: "03/30/2017"
 ms.assetid: 02e1b823-a8bb-4074-90d5-8599f71e8f9d

--- a/docs/framework/configure-apps/file-schema/wcf/discoveryendpoint.md
+++ b/docs/framework/configure-apps/file-schema/wcf/discoveryendpoint.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<discoveryEndpoint>"
 ms.date: "03/30/2017"
 ms.assetid: fae2f48b-a635-4e4b-859d-a1432ac37e1c

--- a/docs/framework/configure-apps/file-schema/wcf/dns.md
+++ b/docs/framework/configure-apps/file-schema/wcf/dns.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<dns>"
 ms.date: "03/30/2017"
 ms.assetid: 81819dae-4825-43b7-bccd-f16d2d3d2f06

--- a/docs/framework/configure-apps/file-schema/wcf/endpoint-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/endpoint-element.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<endpoint> element"
 ms.date: "03/30/2017"
 ms.assetid: 2fc8fedc-78d0-4e87-8142-fbfd26c15a4e

--- a/docs/framework/configure-apps/file-schema/wcf/endpointdiscovery.md
+++ b/docs/framework/configure-apps/file-schema/wcf/endpointdiscovery.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<endpointDiscovery>"
 ms.date: "03/30/2017"
 ms.assetid: 70812717-888a-4748-9640-0df6715ff029

--- a/docs/framework/configure-apps/file-schema/wcf/findcriteria.md
+++ b/docs/framework/configure-apps/file-schema/wcf/findcriteria.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<findCriteria>"
 ms.date: "03/30/2017"
 ms.assetid: 5454cd19-6bf5-4ba8-94d1-f58d10dc1917

--- a/docs/framework/configure-apps/file-schema/wcf/msmqintegrationbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/msmqintegrationbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<msmqIntegrationBinding>"
 ms.date: "03/30/2017"
 helpviewer_keywords: 

--- a/docs/framework/configure-apps/file-schema/wcf/participants-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/participants-of-wcf.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<participants> of WCF"
 ms.date: "03/30/2017"
 ms.assetid: d99dbddc-0057-4e18-8e42-f91411d39970

--- a/docs/framework/configure-apps/file-schema/wcf/routing-of-servicebehavior.md
+++ b/docs/framework/configure-apps/file-schema/wcf/routing-of-servicebehavior.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<routing> of <serviceBehavior>"
 ms.date: "03/30/2017"
 ms.assetid: d8f9c844-4629-4a45-9599-856dc8f01794

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-webhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-webhttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<security> of <webHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 727cf3d2-6f56-48ad-a59f-ba423edb9c83

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-ws2007httpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-ws2007httpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<security> of <ws2007HttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: fdda0ff7-b462-4e26-af52-e87ddab71945

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-wshttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<security> of <wsHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 8658b162-2ddf-4162-a869-aa517a42288a

--- a/docs/framework/configure-apps/file-schema/wcf/servicecertificate-of-servicecredentials.md
+++ b/docs/framework/configure-apps/file-schema/wcf/servicecertificate-of-servicecredentials.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<serviceCertificate> of <serviceCredentials>"
 ms.date: "03/30/2017"
 ms.assetid: 597ae6d5-4938-4950-9f5e-b2280e816182

--- a/docs/framework/configure-apps/file-schema/wcf/servicediscovery.md
+++ b/docs/framework/configure-apps/file-schema/wcf/servicediscovery.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<serviceDiscovery>"
 ms.date: "03/30/2017"
 ms.assetid: a3c68a4a-fc95-43c5-aacb-785936c0cf39

--- a/docs/framework/configure-apps/file-schema/wcf/servicehostingenvironment.md
+++ b/docs/framework/configure-apps/file-schema/wcf/servicehostingenvironment.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<serviceHostingEnvironment>"
 ms.date: "03/30/2017"
 ms.assetid: 4f8a7c4f-e735-4987-979a-b74fcdae2652

--- a/docs/framework/configure-apps/file-schema/wcf/servicemetadata.md
+++ b/docs/framework/configure-apps/file-schema/wcf/servicemetadata.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<serviceMetadata>"
 ms.date: "03/30/2017"
 ms.assetid: 2b4c3b4c-31d4-4908-a9b7-5bb411c221f2

--- a/docs/framework/configure-apps/file-schema/wcf/transactionflow.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transactionflow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<transactionFlow>"
 ms.date: "03/30/2017"
 ms.assetid: 8c7b4c5b-ace3-4fe3-89ff-7b13c9aacd13

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-basichttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-basichttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<transport> of <basicHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 4c5ba293-3d7e-47a6-b84e-e9022857b7e5

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-nethttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-nethttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<transport> of <netHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 3b180006-1661-43bf-a699-96fd3da469af

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-nettcpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<transport> of <netTcpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 49462e0a-66e1-463f-b3e1-c83a441673c6

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-webhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-webhttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<transport> of <webHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: f150fb19-7de1-44af-81f4-86cad881cd05

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-wshttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<transport> of <wsHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 21e38acf-450a-4bda-82b6-de305e1f7cd8

--- a/docs/framework/configure-apps/file-schema/wcf/webhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/webhttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<webHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 84179d77-825d-44b9-895a-ab08e7aa044d

--- a/docs/framework/configure-apps/file-schema/wcf/workflow-of-wcf.md
+++ b/docs/framework/configure-apps/file-schema/wcf/workflow-of-wcf.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<workflow> of WCF"
 ms.date: "03/30/2017"
 ms.assetid: c0443eba-d3b4-4fae-886e-9878daf77691

--- a/docs/framework/configure-apps/file-schema/wcf/ws2007federationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/ws2007federationhttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<ws2007FederationHttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 9af4ec79-cdef-457e-9dca-09d5eb821594

--- a/docs/framework/configure-apps/file-schema/wcf/ws2007httpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/ws2007httpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<ws2007HttpBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 8586ecc9-bdaa-44d6-8d4d-7038e4ea1741

--- a/docs/framework/configure-apps/file-schema/wcf/wsdualhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wsdualhttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<wsDualHttpBinding>"
 ms.date: "03/30/2017"
 helpviewer_keywords: 

--- a/docs/framework/configure-apps/file-schema/wcf/wsfederationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wsfederationhttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<wsFederationHttpBinding>"
 ms.date: "03/30/2017"
 helpviewer_keywords: 

--- a/docs/framework/configure-apps/file-schema/wcf/wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wshttpbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<wsHttpBinding>"
 ms.date: "03/30/2017"
 helpviewer_keywords: 

--- a/docs/framework/configure-apps/file-schema/wcf/wshttpcontextbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wshttpcontextbinding.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<wsHttpContextBinding>"
 ms.date: "03/30/2017"
 ms.assetid: 1e40b5c9-0df2-4d66-afc5-a99d0e4ae7a4

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/cookiehandler.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/cookiehandler.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<cookieHandler>"
 ms.date: "03/30/2017"
 ms.assetid: bfdc127f-8d94-4566-8bef-f583c6ae7398

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/issuernameregistry.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/issuernameregistry.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<issuerNameRegistry>"
 ms.date: "03/30/2017"
 ms.assetid: 58b39d12-c953-40c4-88af-d7eb3343ca28

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/securitytokenhandlerconfiguration.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/securitytokenhandlerconfiguration.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<securityTokenHandlerConfiguration>"
 ms.date: "03/30/2017"
 ms.assetid: 28724cc6-020c-4a06-9a1f-d7594f315019

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel-services.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel-services.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<system.identityModel.services>"
 ms.date: "03/30/2017"
 ms.assetid: fa1624dd-2d74-4ae3-942e-498cee261ac5

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/system-identitymodel.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<system.identityModel>"
 ms.date: "03/30/2017"
 ms.assetid: 210ce7e9-d07b-400c-800f-5f525dcf95e8

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/trustedissuers.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/trustedissuers.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<trustedIssuers>"
 ms.date: "03/30/2017"
 ms.assetid: d818c917-07b4-40db-9801-8676561859fd

--- a/docs/framework/configure-apps/file-schema/windows-identity-foundation/wsfederation.md
+++ b/docs/framework/configure-apps/file-schema/windows-identity-foundation/wsfederation.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<wsFederation>"
 ms.date: "03/30/2017"
 ms.assetid: c537f770-68bd-4f82-96ad-6424ad91369f

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/activitystatequery.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<activityStateQuery>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/add-of-participants.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/add-of-participants.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<add> of <participants>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/argument.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/argument.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<argument>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/arguments.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/arguments.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<arguments>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/etwtracking.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/etwtracking.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<etwTracking>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/participants.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/participants.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<participants>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/state-of-states.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/state-of-states.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<state> of <states>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/states-of-activitystatequery.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/states-of-activitystatequery.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<states> of <activityStateQuery>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/variable.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/variable.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<variable>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/configure-apps/file-schema/windows-workflow-foundation/variables.md
+++ b/docs/framework/configure-apps/file-schema/windows-workflow-foundation/variables.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "<variables>"
 ms.date: "03/30/2017"
 ms.topic: "reference"

--- a/docs/framework/data/adonet/implement-copytodatatable-where-type-not-a-datarow.md
+++ b/docs/framework/data/adonet/implement-copytodatatable-where-type-not-a-datarow.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "How to: Implement CopyToDataTable<T> Where the Generic Type T Is Not a DataRow"
 ms.date: "03/30/2017"
 dev_langs: 

--- a/docs/framework/data/adonet/whats-new.md
+++ b/docs/framework/data/adonet/whats-new.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "What's New in ADO.NET"
 ms.date: "03/30/2017"
 ms.assetid: 3bb65d38-cce2-46f5-b979-e5c505e95e10

--- a/docs/framework/security/whats-new-in-wif.md
+++ b/docs/framework/security/whats-new-in-wif.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "What's New in Windows Identity Foundation 4.5"
 ms.date: "03/30/2017"
 ms.assetid: 3b381f04-593b-471f-bd33-0362be1aade5

--- a/docs/framework/wcf/whats-new.md
+++ b/docs/framework/wcf/whats-new.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "What's New in Windows Communication Foundation 4.5"
 ms.date: "03/30/2017"
 helpviewer_keywords:

--- a/docs/framework/wpf/getting-started/whats-new.md
+++ b/docs/framework/wpf/getting-started/whats-new.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "What's New in WPF Version 4.5"
 ms.date: "03/30/2017"
 helpviewer_keywords: 

--- a/docs/standard/async-in-depth.md
+++ b/docs/standard/async-in-depth.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Async in depth
 description: Learn how writing I/O-bound and CPU-bound asynchronous code is straightforward using the .NET Task-based async model.
 author: cartermp

--- a/docs/visual-basic/language-reference/error-messages/event-eventname1-cannot-implement-event-eventname2-on-interface.md
+++ b/docs/visual-basic/language-reference/error-messages/event-eventname1-cannot-implement-event-eventname2-on-interface.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Event '<eventname1>' cannot implement event '<eventname2>' on interface '<interface>' because their delegate types '<delegate1>' and '<delegate2>' do not match"
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/visual-basic/language-reference/error-messages/first-statement-of-this-sub-new-must-be-a-call-to-mybase-new-or-myclass-new.md
+++ b/docs/visual-basic/language-reference/error-messages/first-statement-of-this-sub-new-must-be-a-call-to-mybase-new-or-myclass-new.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "First statement of this 'Sub New' must be a call to 'MyBase.New' or 'MyClass.New' (No Accessible Constructor Without Parameters)"
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/visual-basic/language-reference/error-messages/type-of-variablename-cannot-be-inferred.md
+++ b/docs/visual-basic/language-reference/error-messages/type-of-variablename-cannot-be-inferred.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Type of '<variablename>' cannot be inferred because the loop bounds and the step variable do not widen to the same type"
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/visual-basic/misc/bc2009.md
+++ b/docs/visual-basic/misc/bc2009.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "option <optionname> can be followed only by '+' or '-'"
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/visual-basic/misc/bc31538.md
+++ b/docs/visual-basic/misc/bc31538.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Member <member> cannot override member <baseMember> defined in another assembly-project because the access modifier 'Protected Friend' expands accessibility. Use 'Protected' instead."
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/visual-basic/misc/bc42316.md
+++ b/docs/visual-basic/misc/bc42316.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "XML documentation parse error: Start tag '<tag>' doesn't have a matching end tag"
 ms.date: 07/20/2015
 f1_keywords: 

--- a/docs/visual-basic/misc/field-fieldname-of-type-typename-is-readonly.md
+++ b/docs/visual-basic/misc/field-fieldname-of-type-typename-is-readonly.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Field '<fieldname>' of type '<typename>' is 'ReadOnly'"
 ms.date: 07/20/2015
 f1_keywords: 


### PR DESCRIPTION
Just ran a script from https://ngeor.wordpress.com/2017/08/02/strip-the-bom/ to strip the BOM character from the MD files because they YAML frontmater doesn't render on GH when the BOM is included in the file. It also causes false positives for the validation service
```
find . -type f -iname "*.md" -exec node -e "var f = process.argv[1]; var contents = fs.readFileSync(f, 'utf8'); if (contents.charCodeAt(0) === 0xFEFF) { fs.writeFileSync(f, contents.slice(1), 'utf8'); } " \{\} \;
```
Feel free to run this internally instead if easier.