### PR TITLE
fix: docs/framework/unmanaged-api/debugging/efn-getmanagedexcepstack-function.md

### DIFF
--- a/docs/framework/unmanaged-api/debugging/efn-getmanagedexcepstack-function.md
+++ b/docs/framework/unmanaged-api/debugging/efn-getmanagedexcepstack-function.md
@@ -1,58 +1,64 @@
 ---
 title: "_EFN_GetManagedExcepStack Function"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "_EFN_GetManagedExcepStack"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "_EFN_GetManagedExcepStack"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "_EFN_GetManagedExcepStack function [.NET Framework debugging]"
 ms.assetid: 21ceed9e-62b2-4024-b027-6d095109955a
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
+
 # _EFN_GetManagedExcepStack Function
-Given a managed exception object address, returns a string version of the stack trace contained inside.  
-  
-## Syntax  
-  
-```  
-HRESULT _EFN_GetManagedExcepStack(  
-    [in]  PDEBUG_CLIENT Client,  
-    [in]  ULONG64       StackObjAddr,  
-    [out] __out_ecount(cbString) PSTR szStackString,  
-    [out] ULONG         cbString  
-);  
-```  
-  
-#### Parameters  
- `Client`  
- [in] The client being debugged.  
-  
- `StackObjAddr`  
- [in] A managed object pointer, derived from <xref:System.Exception>.  
-  
- szStackString  
- [out] The returned string.  
-  
- `cbString`  
- [out] The number of characters available in the string buffer.  
-  
-## Remarks  
- If there is no managed code on the thread currently in context, the function returns HRESULT SOS_E_NOMANAGEDCODE with a facility value of 0xa0 and an error code of 0x1000.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** SOS_Stacktrace.h  
-  
- **.NET Framework Version:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]  
-  
+
+Given a managed exception object address, returns a string version of the stack trace contained inside.
+
+## Syntax
+
+```cpp
+HRESULT _EFN_GetManagedExcepStack(
+    [in]  PDEBUG_CLIENT Client,
+    [in]  ULONG64       StackObjAddr,
+    [out] PSTR szStackString,
+    [out] ULONG         cbString
+);
+```
+
+#### Parameters
+
+`Client`
+[in] The client being debugged.
+
+`StackObjAddr`
+[in] A managed object pointer, derived from <xref:System.Exception>.
+
+szStackString
+[out] The returned string.
+
+`cbString`
+[out] The number of characters available in the string buffer.
+
+## Remarks
+
+If there is no managed code on the thread currently in context, the function returns HRESULT SOS_E_NOMANAGEDCODE with a facility value of 0xa0 and an error code of 0x1000.
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+
+**Header:** SOS_Stacktrace.h
+
+**.NET Framework Version:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]
+
 ## See also
+
 - [Debugging Global Static Functions](../../../../docs/framework/unmanaged-api/debugging/debugging-global-static-functions.md)


### PR DESCRIPTION

- Remove "__out_ecount(cbString)". May have been parsing issue with source generation