### PR TITLE
Update AppWithPlugin tutorial to link to example.

### DIFF
--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -239,7 +239,7 @@ Almost all plugins are more complex than a simple "Hello World", and many plugin
 
 ## Other plugin examples in the sample
 
-The `AssemblyDependencyResolver` object can also resolve native libraries included in NuGet packages as well as localized satellite assemblies. The `UVPlugin` and `FrenchPlugin` demonstrate these scenarios respectively.
+There is a completed sample of this tutorial can be found in [the dotnet/samples repository](https://github.com/dotnet/samples/tree/master/core/extensions/AppWithPlugin). The completed sample includes a few other examples of `AssemblyDependencyResolver` behavior. For example, the `AssemblyDependencyResolver` object can also resolve native libraries included in NuGet packages as well as localized satellite assemblies. The `UVPlugin` and `FrenchPlugin` in the samples repository demonstrate these scenarios respectively.
 
 ## How to reference a plugin interface assembly defined in a NuGet package
 

--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -239,7 +239,7 @@ Almost all plugins are more complex than a simple "Hello World", and many plugin
 
 ## Other plugin examples in the sample
 
-There is a completed sample of this tutorial can be found in [the dotnet/samples repository](https://github.com/dotnet/samples/tree/master/core/extensions/AppWithPlugin). The completed sample includes a few other examples of `AssemblyDependencyResolver` behavior. For example, the `AssemblyDependencyResolver` object can also resolve native libraries included in NuGet packages as well as localized satellite assemblies. The `UVPlugin` and `FrenchPlugin` in the samples repository demonstrate these scenarios respectively.
+The complete source code for this tutorial can be found in [the dotnet/samples repository](https://github.com/dotnet/samples/tree/master/core/extensions/AppWithPlugin). The completed sample includes a few other examples of `AssemblyDependencyResolver` behavior. For example, the `AssemblyDependencyResolver` object can also resolve native libraries as well as localized satellite assemblies included in NuGet packages. The `UVPlugin` and `FrenchPlugin` in the samples repository demonstrate these scenarios.
 
 ## How to reference a plugin interface assembly defined in a NuGet package
 


### PR DESCRIPTION
The tutorial never actually linked to the samples repository. Since the tutorial mentions two plugins that are only in the samples repository, we should link directly to the sample so users can find these two plugins.

Fixes #10938 
