### PR TITLE
Update potential-pitfalls-with-plinq.md

### DIFF
--- a/docs/standard/parallel-programming/potential-pitfalls-with-plinq.md
+++ b/docs/standard/parallel-programming/potential-pitfalls-with-plinq.md
@@ -43,12 +43,12 @@ In many cases, PLINQ can provide significant performance improvements over seque
   
 ```vb  
 Dim fs As FileStream = File.OpenWrite(…)  
-a.Where(...).OrderBy(...).Select(...).ForAll(Sub(x) fs.Write(x))  
+a.AsParallel().Where(...).OrderBy(...).Select(...).ForAll(Sub(x) fs.Write(x))  
 ```  
   
 ```csharp  
 FileStream fs = File.OpenWrite(...);  
-a.Where(...).OrderBy(...).Select(...).ForAll(x => fs.Write(x));  
+a.AsParallel().Where(...).OrderBy(...).Select(...).ForAll(x => fs.Write(x));  
 ```  
   
 ## Limit Calls to Thread-Safe Methods  


### PR DESCRIPTION
Changed sample parallel write to file code to explicitly show we're dealing with parallel enumerable for first time readers

## Summary

Describe your changes here.
Added an explicitly call to `AsParallel()`. This way anyone new to C# and PLINQ will get the idea of what is happening. 

Fixes #Issue_Number (if available)
