### PR TITLE
Publish the speclets for C# 7.2

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -411,8 +411,12 @@
             "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-7.1/async-main"
         },
         {
+            "source_path": "docs/csharp/language-reference/proposals/csharp-7.2/index.md",
+            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-7.2/async-main"
+        },
+        {
             "source_path": "docs/csharp/language-reference/proposals/index.md",
-            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-7.1/async-main"
+            "redirect_url": "/dotnet/csharp/language-reference/proposals/csharp-7.2/readonly-ref"
         },
         {
             "source_path": "docs/csharp/language-reference/operators/modulus-assignment-operator.md",

--- a/docfx.json
+++ b/docfx.json
@@ -37,6 +37,7 @@
           "records.md",
           "csharp-7.0/*.md",
           "csharp-7.1/*.md",
+          "csharp-7.2/*.md",
           "csharp-8.0/patterns.md"
         ],
         "src": "_csharplang/proposals",
@@ -186,6 +187,8 @@
       "ms.date": {
         "_csharplang/spec/*.md": "07/01/2017",
         "_csharplang/proposals/csharp-7.0/*.md": "08/13/2018",
+        "_csharplang/proposals/csharp-7.1/*.md": "02/16/2018",
+        "_csharplang/proposals/csharp-7.2/*.md": "01/19/2019",
         "_vblang/spec/*.md": "07/21/2017"
       },
       "ms.technology": {
@@ -220,6 +223,8 @@
       "titleSuffix": {
         "_csharplang/spec/*.md": "C# language specification",
         "_csharplang/proposals/csharp-7.0/*.md": "C# 7.0 language proposals",
+        "_csharplang/proposals/csharp-7.1/*.md": "C# 7.1 language proposals",
+        "_csharplang/proposals/csharp-7.2/*.md": "C# 7.2 language proposals",
         "docs/fsharp/tutorials/**/**.md": "F#",
         "docs/fsharp/language-reference/**/**.md": "F#",
         "docs/core/additional-tools/**.md": ".NET Core",

--- a/docs/csharp/language-reference/toc.md
+++ b/docs/csharp/language-reference/toc.md
@@ -39,3 +39,10 @@
 ### [Default expressions](../../../_csharplang/proposals/csharp-7.1/target-typed-default.md)
 ### [Infer tuple names](../../../_csharplang/proposals/csharp-7.1/infer-tuple-names.md)
 ### [Pattern matching with generics](../../../_csharplang/proposals/csharp-7.1/generics-pattern-match.md)
+## C# 7.2 language proposals
+### [Readonly references](../../../_csharplang/proposals/csharp-7.2/readonly-ref.md)
+### [Compile time safety for ref-like types](../../../_csharplang/proposals/csharp-7.2/span-safety.md)
+### [Non-trailing named arguments](../../../_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md)
+### [Private protected](../../../_csharplang/proposals/csharp-7.2/private protected.md)
+### [Conditional ref](../../../_csharplang/proposals/csharp-7.2/conditional-ref.md)
+### [Leading digit separator](../../../_csharplang/proposals/csharp-7.2/leading-separator.md)

--- a/docs/csharp/language-reference/toc.md
+++ b/docs/csharp/language-reference/toc.md
@@ -43,6 +43,6 @@
 ### [Readonly references](../../../_csharplang/proposals/csharp-7.2/readonly-ref.md)
 ### [Compile time safety for ref-like types](../../../_csharplang/proposals/csharp-7.2/span-safety.md)
 ### [Non-trailing named arguments](../../../_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md)
-### [Private protected](../../../_csharplang/proposals/csharp-7.2/private protected.md)
+### [Private protected](../../../_csharplang/proposals/csharp-7.2/private-protected.md)
 ### [Conditional ref](../../../_csharplang/proposals/csharp-7.2/conditional-ref.md)
 ### [Leading digit separator](../../../_csharplang/proposals/csharp-7.2/leading-separator.md)

--- a/toc.yml
+++ b/toc.yml
@@ -506,6 +506,9 @@
         - name: C# 7.1 language proposals
           tocHref: /dotnet/csharp/language-reference/proposals/csharp-7.1/
           topicHref: /dotnet/csharp/language-reference/proposals/csharp-7.1/index
+        - name: C# 7.2 language proposals
+          tocHref: /dotnet/csharp/language-reference/proposals/csharp-7.2/
+          topicHref: /dotnet/csharp/language-reference/proposals/csharp-7.2/index
     - name: F# Guide
       tocHref: /dotnet/fsharp/
       topicHref: /dotnet/fsharp/index


### PR DESCRIPTION
Fixes #10723

Internal review links:

[readonly references](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/readonly-ref?branch=pr-en-us-11121)
[compile time safety for ref-like types](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/span-safety?branch=pr-en-us-11121)
[non-trailing named arguments](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/leading-separator?branch=pr-en-us-11121)
[private protected](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/private-protected?branch=pr-en-us-11121)
[conditional ref](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/conditional-ref?branch=pr-en-us-11121)
[leading digit separators](https://review.docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/leading-separator?branch=pr-en-us-11121)
