### PR TITLE
Tiny bug in .gitignore, should be just .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ _dependentPackages/
 !/xml/System.Net.Cache/
 
 # Visual Studio Code
-.vscode/*
+.vscode/
 !.vscode/extensions.json
 
 # Visual Studio 2019


### PR DESCRIPTION
## Summary

Change .gitignore from `.vscode/*` to `.vscode/` b/c some local vscode settings where not being ignored