### PR TITLE
Replace absolute links to specs / proposals to relative links

### DIFF
--- a/docs/csharp/language-reference/operators/assignment-operator.md
+++ b/docs/csharp/language-reference/operators/assignment-operator.md
@@ -37,7 +37,7 @@ Beginning with C# 7.3, you can use the ref assignment operator `= ref` to reassi
 
 In the case of the ref assignment operator, the type of the left operand and the right operand must be the same.
 
-For more information, see the [feature proposal note](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.3/ref-local-reassignment.md).
+For more information, see the [feature proposal note](../../../../_csharplang/proposals/csharp-7.3/ref-local-reassignment.md).
 
 ## Operator overloadability
 

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -60,7 +60,7 @@ The following example demonstrates the usage of the conditional ref expression:
 
 [!code-csharp[conditional ref](~/samples/snippets/csharp/language-reference/operators/ConditionalExamples.cs#ConditionalRef)]
 
-For more information, see the [feature proposal note](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.2/conditional-ref.md).
+For more information, see the [feature proposal note](../../../../_csharplang/proposals/csharp-7.2/conditional-ref.md).
 
 ## Conditional operator and an `if..else` statement
 

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -35,7 +35,7 @@ The compiler uses static analysis to determine if a nullable reference is known 
 name!.Length;
 ```
 
-You can read details about this operator in the [draft nullable reference types](https://github.com/dotnet/csharplang/blob/master/proposals/csharp-8.0/nullable-reference-types-specification.md#the-null-forgiving-operator) specification proposal on GitHub.
+You can read details about this operator in the [draft nullable reference types](../../_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md#the-null-forgiving-operator) specification proposal on GitHub.
 
 ## Nullability of types
 


### PR DESCRIPTION
Now that we publish the C# specs and proposals on docs, these links should point to the content published on docs rather than the GitHub source.

Relies on #11190 

There will be 1 warning until that PR is merged.