### PR TITLE
Follow naming conventions for public members

### DIFF
--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -77,7 +77,7 @@ There are several syntax improvements here:
 Contrast that with the equivalent code using the classic `switch` statement:
 
 ```csharp
-public static RGBColor fromRainbowClassic(Rainbow colorBand)
+public static RGBColor FromRainbowClassic(Rainbow colorBand)
 {
     switch (colorBand)
     {


### PR DESCRIPTION
Fix camel cased fromRainbowClassic method name to pascal cased FromRainbowClassic