### PR TITLE
typo in link markdown

### DIFF
--- a/docs/fsharp/get-started/get-started-vscode.md
+++ b/docs/fsharp/get-started/get-started-vscode.md
@@ -10,7 +10,7 @@ You can write F# in [Visual Studio Code](https://code.visualstudio.com) with the
 To begin, ensure that you have [F# and the Ionide plugin correctly installed](install-fsharp.md#install-f-with-visual-studio-code).
 
 > [!NOTE]
-> Ionide will generate .NET Framework F# projects, not dotnet core, which can have cross-platform compatibility issues. If you are running on **Linux** or **OSX**, a simpler way to get started is to use the (command line tools)[https://docs.microsoft.com/en-us/dotnet/fsharp/get-started/get-started-command-line].
+> Ionide will generate .NET Framework F# projects, not dotnet core, which can have cross-platform compatibility issues. If you are running on **Linux** or **OSX**, a simpler way to get started is to use the [command line tools](https://docs.microsoft.com/en-us/dotnet/fsharp/get-started/get-started-command-line).
 
 ## Creating your first project with Ionide
 


### PR DESCRIPTION
@cartermp oops! typo in the markdown - the link to the command line tools page was incorrectly formatted.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
