### PR TITLE
Updated GitHub Issue Classification Tutorial to v0.11

### DIFF
--- a/docs/machine-learning/tutorials/github-issue-classification.md
+++ b/docs/machine-learning/tutorials/github-issue-classification.md
@@ -1,7 +1,7 @@
 ---
 title: Use ML.NET in a GitHub issue multiclass classification scenario
 description: Discover how to use ML.NET in a multiclass classification scenario to classify GitHub issues to assign them to a given area.
-ms.date: 02/20/2019
+ms.date: 03/12/2019
 ms.topic: tutorial
 ms.custom: mvc
 #Customer intent: As a developer, I want to use ML.NET to apply a multiclass classification learning algorithm so that I can understand how to classify GitHGub issues to assign them to a given area.
@@ -201,7 +201,7 @@ You defined the data schema previously when you created the `GitHubIssue` class.
 * the third column `Title` (GitHub issue title) is the first [feature](../resources/glossary.md##feature)  used for predicting the `Area`
 * the fourth column  `Description` is the second feature used for predicting the `Area`
 
-The second part of the line  (`.Read(_trainDataPath)`) uses <xref:Microsoft.ML.Data.TextLoader.Read%2A> method to load the training text file using `_trainDataPath` into the `IDataView` (`_trainingDataView`) global variable.  
+The second part of the line  (`.Load(_trainDataPath)`) uses <xref:Microsoft.ML.Data.TextLoader.Load%2A> method to load the training text file using `_trainDataPath` into the `IDataView` (`_trainingDataView`) global variable.  
 
 To initialize and load the `_trainingDataView` global variable in order to use it for the pipeline, add the following code after the  `mlContext` initialization:
 
@@ -220,7 +220,7 @@ The `ProcessData` method executes the following tasks:
 Create the `ProcessData` method, just after the `Main` method, using the following code:
 
 ```csharp
-public static EstimatorChain<ITransformer> ProcessData()
+public static EstimatorChain<ColumnConcatenatingTransformer> ProcessData()
 {
 
 }
@@ -279,7 +279,7 @@ The `BuildAndTrainModel` method executes the following tasks:
 Create the `BuildAndTrainModel` method, just after the `Main` method, using the following code:
 
 ```csharp
-public static EstimatorChain<KeyToValueMappingTransformer> BuildAndTrainModel(IDataView trainingDataView, EstimatorChain<ITransformer> pipeline)
+public static EstimatorChain<KeyToValueMappingTransformer> BuildAndTrainModel(IDataView trainingDataView, EstimatorChain<ColumnConcatenatingTransformer> pipeline)
 {
 
 }

--- a/docs/machine-learning/tutorials/github-issue-classification.md
+++ b/docs/machine-learning/tutorials/github-issue-classification.md
@@ -24,7 +24,7 @@ In this tutorial, you learn how to:
 > [!NOTE]
 > This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit [the ML.NET introduction](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet).
 
-This tutorial and related sample are currently using **ML.NET version 0.10**. For more information, see the release notes at the [dotnet/machinelearning github repo](https://github.com/dotnet/machinelearning/tree/master/docs/release-notes).
+This tutorial and related sample are currently using **ML.NET version 0.11**. For more information, see the release notes at the [dotnet/machinelearning github repo](https://github.com/dotnet/machinelearning/tree/master/docs/release-notes).
 
 ## GitHub issue sample overview
 

--- a/docs/machine-learning/tutorials/github-issue-classification.md
+++ b/docs/machine-learning/tutorials/github-issue-classification.md
@@ -192,7 +192,8 @@ In ML.NET, data is similar to a `SQL view`. It is lazily evaluated, schematized,
 
 Since your previously created `GitHubIssue` data model type matches the dataset schema, you can combine the initialization, mapping, and dataset loading into one line of code.
 
-The first part of the line (`CreateTextLoader<GitHubIssue>(hasHeader: true)`) creates a <xref:Microsoft.ML.Data.TextLoader> by inferring the dataset schema from the `GitHubIssue` data model type and using the dataset header.
+Load the data using the `MLContext.Data.LoadFromTextFile` wrapper for the [LoadFromTextFile method](xref:Microsoft.ML.TextLoaderSaverCatalog.LoadFromTextFile%60%601%28Microsoft.ML.DataOperationsCatalog,System.String,System.Char,System.Boolean,System.Boolean,System.Boolean,System.Boolean%29). It returns a
+<xref:Microsoft.Data.DataView.IDataView> which infers the dataset schema from the `GitHubIssue` data model type and uses the dataset header. 
 
 You defined the data schema previously when you created the `GitHubIssue` class. For your schema:
 
@@ -201,12 +202,9 @@ You defined the data schema previously when you created the `GitHubIssue` class.
 * the third column `Title` (GitHub issue title) is the first [feature](../resources/glossary.md##feature)  used for predicting the `Area`
 * the fourth column  `Description` is the second feature used for predicting the `Area`
 
-The second part of the line  (`.Load(_trainDataPath)`) uses <xref:Microsoft.ML.Data.TextLoader.Load%2A> method to load the training text file using `_trainDataPath` into the `IDataView` (`_trainingDataView`) global variable.  
-
 To initialize and load the `_trainingDataView` global variable in order to use it for the pipeline, add the following code after the  `mlContext` initialization:
 
 [!code-csharp[LoadTrainData](../../../samples/machine-learning/tutorials/GitHubIssueClassification/Program.cs#LoadTrainData)]
-
 
 Add the following as the next line of code in the `Main` method:
 
@@ -220,7 +218,7 @@ The `ProcessData` method executes the following tasks:
 Create the `ProcessData` method, just after the `Main` method, using the following code:
 
 ```csharp
-public static EstimatorChain<ColumnConcatenatingTransformer> ProcessData()
+public static IEstimator<ITransformer> ProcessData()
 {
 
 }
@@ -279,13 +277,13 @@ The `BuildAndTrainModel` method executes the following tasks:
 Create the `BuildAndTrainModel` method, just after the `Main` method, using the following code:
 
 ```csharp
-public static EstimatorChain<KeyToValueMappingTransformer> BuildAndTrainModel(IDataView trainingDataView, EstimatorChain<ColumnConcatenatingTransformer> pipeline)
+public static IEstimator<ITransformer> BuildAndTrainModel(IDataView trainingDataView, IEstimator<ITransformer> pipeline)
 {
 
 }
 ```
 
-Notice that two parameters are passed into the BuildAndTrainModel method; an `IDataView` for the training dataset (`trainingDataView`), and a <xref:Microsoft.ML.Data.EstimatorChain%601> for the processing pipeline created in ProcessData (`pipeline`).
+Notice that two parameters are passed into the BuildAndTrainModel method; an `IDataView` for the training dataset (`trainingDataView`), and a <xref:Microsoft.ML.EstimatorChain%601> for the processing pipeline created in ProcessData (`pipeline`).
 
  Add the following code as the first line of the `BuildAndTrainModel` method:
 


### PR DESCRIPTION
Updated GitHub Issue Classification Tutorial to v0.11

[Internal Review Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/tutorials/github-issue-classification?branch=pr-en-us-11280)
[Code Sample PR](https://github.com/dotnet/samples/pull/706)