### PR TITLE
Nit: mark #line as code fragment

### DIFF
--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
@@ -12,7 +12,7 @@ ms.assetid: 6439e525-5dd5-4acb-b8ea-efabb32ff95b
 # #line (C# Reference)
 `#line` lets you modify the compiler's line numbering and (optionally) the file name output for errors and warnings.
 
-The following example shows how to report two warnings associated with line numbers. The `#line 200` directive forces the next line's number to be 200 (although the default is #6) and until the next `#line` directive, the filename will be reported as "Special". The `#line default` directive returns the line numbering to its default numbering, which counts the lines that were renumbered by the previous directive.  
+The following example shows how to report two warnings associated with line numbers. The `#line 200` directive forces the next line's number to be 200 (although the default is #6), and until the next `#line` directive, the filename will be reported as "Special". The `#line default` directive returns the line numbering to its default numbering, which counts the lines that were renumbered by the previous directive.  
   
 ```csharp
 class MainClass  

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
@@ -12,7 +12,7 @@ ms.assetid: 6439e525-5dd5-4acb-b8ea-efabb32ff95b
 # #line (C# Reference)
 `#line` lets you modify the compiler's line numbering and (optionally) the file name output for errors and warnings.
 
-The following example shows how to report two warnings associated with line numbers. The `#line 200` directive forces the next line's number to be 200 (although the default is #6) and until the next #line directive, the filename will be reported as "Special". The #line default directive returns the line numbering to its default numbering, which counts the lines that were renumbered by the previous directive.  
+The following example shows how to report two warnings associated with line numbers. The `#line 200` directive forces the next line's number to be 200 (although the default is #6) and until the next `#line` directive, the filename will be reported as "Special". The `#line default` directive returns the line numbering to its default numbering, which counts the lines that were renumbered by the previous directive.  
   
 ```csharp
 class MainClass  


### PR DESCRIPTION
## Summary

Minor formatting change to more consistently mark `#line ...` as a code fragment.
