### PR TITLE
removed comment-out block from VB .NET Core tutorial

### DIFF
--- a/docs/core/tutorials/vb-with-visual-studio.md
+++ b/docs/core/tutorials/vb-with-visual-studio.md
@@ -78,6 +78,4 @@ You've created and run your application. To develop a professional application, 
 
 ## Related topics
 
-Instead of a console application, you can also build a class library with .NET Core and Visual Studio 2017. For a step-by-step introduction, see [Building a class library with C# and .NET Core in Visual Studio 2017](library-with-visual-studio.md).
-
-You can also develop a .NET Core console app on Mac, Linux, and Windows by using [Visual Studio Code](https://code.visualstudio.com/), a downloadable code editor. For a step-by-step tutorial, see [Getting Started with Visual Studio Code](with-visual-studio-code.md).
+Instead of a console application, you can also build a .NET Standard class library with Visual Basic, .NET Core, and Visual Studio 2017. For a step-by-step introduction, see [Build a .NET Standard library with Visual Basic and .NET Core SDK in Visual Studio 2017](vb-library-with-visual-studio.md).

--- a/docs/core/tutorials/vb-with-visual-studio.md
+++ b/docs/core/tutorials/vb-with-visual-studio.md
@@ -76,9 +76,8 @@ You've created and run your application. To develop a professional application, 
 
 - To publish a distributable version of your application, see [Publish your .NET Core Hello World application with Visual Studio 2017](publishing-with-visual-studio.md).
 
-<!--
 ## Related topics
 
 Instead of a console application, you can also build a class library with .NET Core and Visual Studio 2017. For a step-by-step introduction, see [Building a class library with C# and .NET Core in Visual Studio 2017](library-with-visual-studio.md).
 
-You can also develop a .NET Core console app on Mac, Linux, and Windows by using [Visual Studio Code](https://code.visualstudio.com/), a downloadable code editor. For a step-by-step tutorial, see [Getting Started with Visual Studio Code](with-visual-studio-code.md). -->
+You can also develop a .NET Core console app on Mac, Linux, and Windows by using [Visual Studio Code](https://code.visualstudio.com/), a downloadable code editor. For a step-by-step tutorial, see [Getting Started with Visual Studio Code](with-visual-studio-code.md).


### PR DESCRIPTION
## Removed commented-out block from VB.NET Core tutorial

Fixes #11283 

//cc @NextTurn 

