### PR TITLE
Snippet use a Human class not a Person class

### DIFF
--- a/docs/standard/language-independence-and-language-independent-components.md
+++ b/docs/standard/language-independence-and-language-independent-components.md
@@ -337,7 +337,7 @@ The .NET Framework is language independent. This means that, as a developer, you
 ### Member accessibility  
  Overriding an inherited member cannot change the accessibility of that member. For example, a public method in a base class cannot be overridden by a private method in a derived class. There is one exception: a `protected internal` (in C#) or `Protected Friend` (in Visual Basic) member in one assembly that is overridden by a type in a different assembly. In that case, the accessibility of the override is `Protected`.  
   
- The following example illustrates the error that is generated when the <xref:System.CLSCompliantAttribute> attribute is set to `true`, and `Person`, which is a class derived from `Animal`, tries to change the accessibility of the `Species` property from public to private. The example compiles successfully if its accessibility is changed to public.  
+ The following example illustrates the error that is generated when the <xref:System.CLSCompliantAttribute> attribute is set to `true`, and `Human`, which is a class derived from `Animal`, tries to change the accessibility of the `Species` property from public to private. The example compiles successfully if its accessibility is changed to public.  
   
  [!code-csharp[Conceptual.CLSCompliant#28](../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.clscompliant/cs/accessibility1.cs#28)]
  [!code-vb[Conceptual.CLSCompliant#28](../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.clscompliant/vb/accessibility1.vb#28)]  


### PR DESCRIPTION
`Public Class Human : Inherits Animal` in VB
and 
`public class Human : Animal` in C#
but
`Person` in documentation.

## Summary

Change `Person` to `Human` to match the referenced snippets.

Fixes #Issue_Number (if available)
