### PR TITLE
fix wrong word choice in feature description

### DIFF
--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -45,7 +45,7 @@ unsafe struct S
 }
 ```
 
-In earlier versions of C#, you needed to pin a variable to access one of the integers that are part of `myFixedField`. Now, the following code compiles in a safe context:
+In earlier versions of C#, you needed to pin a variable to access one of the integers that are part of `myFixedField`. Now, the following code compiles without pinning the variable `p` inside a separate `fixed` statement:
 
 ```csharp
 class C


### PR DESCRIPTION
The description of accessing a field of a fixed structure was incorrect. This is still legal *only* in an unsafe context. However, it does not require a separate `fixed` statement.

Fixes #9737
