### PR TITLE
Corrected a grammatical error

### DIFF
--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -70,7 +70,7 @@ The .NET Framework 4.7.2 features a large number of cryptographic enhancements, 
 
 **New overloads of RSA.Create and DSA.Create**
 
-The <xref:System.Security.Cryptography.DSA.Create(System.Security.Cryptography.DSAParameters)?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.Create(System.Security.Cryptography.RSAParameters)?displayProperty=nameWithType> methods let you supply key parameters when instantiated a new <xref:System.Security.Cryptography.DSA> or <xref:System.Security.Cryptography.RSA> key. They allow you to replace code like the following:
+The <xref:System.Security.Cryptography.DSA.Create(System.Security.Cryptography.DSAParameters)?displayProperty=nameWithType> and <xref:System.Security.Cryptography.RSA.Create(System.Security.Cryptography.RSAParameters)?displayProperty=nameWithType> methods let you supply key parameters when instantiating a new <xref:System.Security.Cryptography.DSA> or <xref:System.Security.Cryptography.RSA> key. They allow you to replace code like the following:
 
 ```csharp
 // Before .NET Framework 4.7.2


### PR DESCRIPTION
Corrected a grammatical error in New overloads of RSA.Create and DSA.Create at
"key parameters when instantiating a new"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
