### PR TITLE
Fixed variable name in printString code snippet

### DIFF
--- a/docs/fsharp/introduction-to-functional-programming/index.md
+++ b/docs/fsharp/introduction-to-functional-programming/index.md
@@ -94,7 +94,7 @@ There is a special type, `unit`, that is used when there is nothing to return. F
 
 ```fsharp
 let printString (str: string) =
-    printfn "String is: %s" s
+    printfn "String is: %s" str
 ```
 
 The signature looks like this:


### PR DESCRIPTION
## Summary

The `printString` code snippet function has a parameter name of `str` but the snippet used the non-existent variable `s`. Changed `s` to match parameter name `str`.
