### PR TITLE
Clarify implicit None glob behavior

### DIFF
--- a/docs/core/tools/csproj.md
+++ b/docs/core/tools/csproj.md
@@ -66,7 +66,13 @@ Setting this property to `false` will disable implicit inclusion, reverting to t
 
 This change does not modify the main mechanics of other includes. However, if you wish to specify, for example, some files to get published with your app, you can still use the known mechanisms in *csproj* for that (for example, the `<Content>` element).
 
-`<EnableDefaultCompileItems>` only disables `Compile` globs but doesn't affect other globs, like the implicit `None` glob, which also applies to \*.cs items. Because of that, **Solution Explorer** will continue show \*.cs items as part of the project, included as `None` items. In a similar way, you can use `<EnableDefaultNoneItems>` to disable the implicit `None` glob.
+`<EnableDefaultCompileItems>` only disables `Compile` globs but doesn't affect other globs, like the implicit `None` glob, which also applies to \*.cs items. Because of that, **Solution Explorer** will continue show \*.cs items as part of the project, included as `None` items. In a similar way, you can set `<EnableDefaultNoneItems>` to false to disable the implicit `None` glob, like this:
+
+```xml
+<PropertyGroup>
+    <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
+</PropertyGroup>
+```
 
 To disable **all implicit globs**, you can set the `<EnableDefaultItems>` property to `false` as in the following example:
 


### PR DESCRIPTION
Updated documentation after discussion with @nguerrera and @dsplaisted regarding how to glob all `**\*.sql` files as EmbeddedResource items.

Nick/Daniel, I'll also bring this up to FluentMigrator and EasyMigrator GitHub as a tip on how to use the new .NET SDK.  Sometimes it's best just to slap people over the head with examples.