### PR TITLE
Addressed language differences for null conditional operator

### DIFF
--- a/docs/csharp/language-reference/operators/null-conditional-operators.md
+++ b/docs/csharp/language-reference/operators/null-conditional-operators.md
@@ -8,7 +8,7 @@ helpviewer_keywords:
   - "?[] operator [C#]"
 ms.assetid: 9c7b2c8f-a785-44ca-836c-407bfb6d27f5
 ---
-# ?. and ?[] null-conditional operators (C# and Visual Basic)
+# ?. and ?[] null-conditional operators (C# Reference)
 
 Tests the value of the left-hand operand for null before performing a member access (`?.`) or index (`?[]`) operation; returns `null` if the left-hand operand evaluates to `null`.
 

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -9,14 +9,19 @@ helpviewer_keywords:
 ---
 # ?. and ?() null-conditional operators (Visual Basic)
 
-Tests the value of the left-hand operand for null (`Nothing`) before performing a member access (`?.`) or index (`?()`) operation; returns `Nothing` if the left-hand operand evaluates to `Nothing`. Note that, in the expressions that would ordinarily return value types, the null-conditional operator returns a <xref:System.Nullable%601>.
+Tests the value of the left-hand operand for null (`Nothing`) before performing a member access (`?.`) or index (`?()`) operation; returns `Nothing` if the left-hand operand evaluates to `Nothing`. Note that in expressions that ordinarily return value types, the null-conditional operator returns a <xref:System.Nullable%601>.
 
 These operators help you write less code to handle null checks, especially when descending into data structures. For example:
 
 ```vb
-Dim length As Integer? = customers?.Length  ' Nothing if customers is Nothing  
-Dim first As Customer = customers?(0)  ' Nothing if customers is Nothing  
-Dim count As Integer? = customers?(0)?.Orders?.Count()  ' Nothing if customers, the first customer, or Orders is Nothing  
+' Nothing if customers is Nothing  
+Dim length As Integer? = customers?.Length  
+
+' Nothing if customers is Nothing
+Dim first As Customer = customers?(0)
+
+' Nothing if customers, the first customer, or Orders is Nothing
+Dim count As Integer? = customers?(0)?.Orders?.Count()   
 ```
 
 For comparison, the alternative code for the first of these expressions without a null-conditional operator is:
@@ -28,27 +33,58 @@ If customers IsNot Nothing Then
 End If
 ```
 
-The null-conditional operators are short-circuiting.  If one operation in a chain of conditional member access and index operations returns Nothing, the rest of the chain’s execution stops.  In the following example, C(E) isn't evaluated if `A`, `B`, or `C` evaluates to Nothing.
+The null-conditional operators are short-circuiting.  If one operation in a chain of conditional member access and index operations returns `Nothing`, the rest of the chain’s execution stops.  In the following example, `C(E)` isn't evaluated if `A`, `B`, or `C` evaluates to `Nothing`.
 
 ```vb
 A?.B?.C?(E);
 ```
 
-Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The old way requires code like the following:  
+Another use for null-conditional member access is to invoke delegates in a thread-safe way with much less code.  The following example defines two types, a `NewsBroadcaster` and a `NewsReceiver`. News items are sent to the receiver by the `NewsBroadcaster.SendNews` delegate.
+
+```vb
+Public Module NewsBroadcaster
+   Dim SendNews As Action(Of String) 
+
+   Public Sub Main()
+      Dim rec As New NewsReceiver()
+      Dim rec2 As New NewsReceiver()
+      SendNews?.Invoke("Just in: A newsworthy item...")
+   End Sub
+
+   Public Sub Register(client As Action(Of String))
+      SendNews = SendNews.Combine({SendNews, client})
+   End Sub
+End Module
+
+Public Class NewsReceiver
+   Public Sub New()
+      NewsBroadcaster.Register(AddressOf Me.DisplayNews)
+   End Sub
+
+   Public Sub DisplayNews(newsItem As String)
+      Console.WriteLine(newsItem)
+   End Sub
+End Class
+```
+
+If there are no elements in the `SendNews` invocation list, the `SendNews` delegate throws a <xref:System.NullReferenceException>. Before 
+null conditional operators, code like the following ensured that the delegate invocation list was not `Nothing`:
 
 ```vb  
-Dim handler = AddressOf(Me.PropertyChanged)  
-If handler IsNot Nothing  
-    Call handler(…)  
+SendNews = SendNews.Combine({SendNews, client})  
+If SendNews IsNot Nothing Then 
+   SendNews("Just in...")
+End If
 ```
 
 The new way is much simpler:  
 
 ```vb
-PropertyChanged?.Invoke(…)
+SendNews = SendNews.Combine({SendNews, client})  
+SendNew?.Invoke("Just in...")
 ```
 
-The new way is thread-safe because the compiler generates code to evaluate `PropertyChanged` one time only, keeping the result in a temporary variable. You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `PropertyChanged?(e)`.  
+The new way is thread-safe because the compiler generates code to evaluate `SendNews` one time only, keeping the result in a temporary variable. You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `SendNews?(String)`.  
 
 ## See also
 

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -81,7 +81,7 @@ The new way is much simpler:
 
 ```vb
 SendNews = SendNews.Combine({SendNews, client})  
-SendNew?.Invoke("Just in...")
+SendNews?.Invoke("Just in...")
 ```
 
 The new way is thread-safe because the compiler generates code to evaluate `SendNews` one time only, keeping the result in a temporary variable. You need to explicitly call the `Invoke` method because there is no null-conditional delegate invocation syntax `SendNews?(String)`.  


### PR DESCRIPTION
## Addressed language differences for null conditional operator

The title of the C# article indicated that it applied to Visual Basic as well, reflecting the time that there was a combined C#/VB language reference. This PR corrects the title.

The VB article used `PropertyChanged` as its delegate invocation example. `PropertyChanged` is most commonly an event (though that wasn't actually clear from the VB code, which lacked context). However, Visual Basic (unlike C#) doesn't throw an exception if no invocation list is present when an event is raised. On the other hand, a non-event delegate with an empty invocation list does throw a NullReferenceException. To eliminate confusion, I've replaced `PropertyChanged` with `SendNews`, a delegate of type `Action<String>`. 

