### PR TITLE
Update sharedlisteners-element.md

### DIFF
--- a/docs/framework/configure-apps/file-schema/trace-debug/sharedlisteners-element.md
+++ b/docs/framework/configure-apps/file-schema/trace-debug/sharedlisteners-element.md
@@ -79,7 +79,7 @@ Contains listeners that any source or trace element can reference.  These listen
       </listeners>  
     </trace>  
   </system.diagnostics>  
-</configuration></system.diagnostics>   
+</configuration>
 ```  
   
 ## See also


### PR DESCRIPTION
removed duplicated close of system.diagnostics tag

## Summary

i found that example of configuration is invalid and removed duplicated close of system.diagnostics tag

Fixes #Issue_Number (if available)
