### PR TITLE
Fix platform invoke data types

### DIFF
--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -19,7 +19,7 @@ To call functions exported from an unmanaged library, a .NET Framework applicati
 
 - Substitute managed data types for unmanaged data types.
 
-You can use the documentation supplied with an unmanaged function to construct an equivalent managed prototype by applying the attribute with its optional fields and substituting managed data types for unmanaged types. For instructions about how to apply the **DllImportAttribute**, see [Consuming Unmanaged DLL Functions](../../../docs/framework/interop/consuming-unmanaged-dll-functions.md).
+You can use the documentation supplied with an unmanaged function to construct an equivalent managed prototype by applying the attribute with its optional fields and substituting managed data types for unmanaged types. For instructions about how to apply the `DllImportAttribute`, see [Consuming Unmanaged DLL Functions](../../../docs/framework/interop/consuming-unmanaged-dll-functions.md).
 
 This section provides samples that demonstrate how to create managed function prototypes for passing arguments to and receiving return values from functions exported by unmanaged libraries. The samples also demonstrate when to use the <xref:System.Runtime.InteropServices.MarshalAsAttribute> attribute and the <xref:System.Runtime.InteropServices.Marshal> class to explicitly marshal data.
 
@@ -29,25 +29,25 @@ The following table lists data types used in the Win32 API (listed in Wtypes.h) 
 
 |Unmanaged type in Win32 APIs|Unmanaged C language type|Managed type|Description|
 |--------------------------------|-------------------------------|------------------------|-----------------|
-|**VOID**|**void**|<xref:System.Void?displayProperty=nameWithType>|Applied to a function that does not return a value.|
-|**HANDLE**|**void \***|<xref:System.IntPtr?displayProperty=nameWithType> or <xref:System.UIntPtr?displayProperty=nameWithType>|32 bits on 32-bit Windows operating systems, 64 bits on 64-bit Windows operating systems.|
-|**BYTE**|**unsigned char**|<xref:System.Byte?displayProperty=nameWithType>|8 bits|
-|**SHORT**|**short**|<xref:System.Int16?displayProperty=nameWithType>|16 bits|
-|**WORD**|**unsigned short**|<xref:System.UInt16?displayProperty=nameWithType>|16 bits|
-|**INT**|**int**|<xref:System.Int32?displayProperty=nameWithType>|32 bits|
-|**UINT**|**unsigned int**|<xref:System.UInt32?displayProperty=nameWithType>|32 bits|
-|**LONG**|**long**|<xref:System.Int32?displayProperty=nameWithType>|32 bits|
-|**BOOL**|**long**|<xref:System.Boolean?displayProperty=nameWithType> or <xref:System.Int32?displayProperty=nameWithType>|32 bits|
-|**DWORD**|**unsigned long**|<xref:System.UInt32?displayProperty=nameWithType>|32 bits|
-|**ULONG**|**unsigned long**|<xref:System.UInt32?displayProperty=nameWithType>|32 bits|
-|**CHAR**|**char**|<xref:System.Char?displayProperty=nameWithType>|Decorate with ANSI.|
-|**WCHAR**|**wchar_t**|<xref:System.Char?displayProperty=nameWithType>|Decorate with Unicode.|
-|**LPSTR**|**char &ast;**|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with ANSI.|
-|**LPCSTR**|**const char &ast;**|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with ANSI.|
-|**LPWSTR**|**wchar_t &ast;**|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with Unicode.|
-|**LPCWSTR**|**const wchar_t &ast;**|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with Unicode.|
-|**FLOAT**|**float**|<xref:System.Single?displayProperty=nameWithType>|32 bits|
-|**DOUBLE**|**double**|<xref:System.Double?displayProperty=nameWithType>|64 bits|
+|`VOID`|`void`|<xref:System.Void?displayProperty=nameWithType>|Applied to a function that does not return a value.|
+|`HANDLE`|`void *`|<xref:System.IntPtr?displayProperty=nameWithType> or <xref:System.UIntPtr?displayProperty=nameWithType>|32 bits on 32-bit Windows operating systems, 64 bits on 64-bit Windows operating systems.|
+|`BYTE`|`unsigned char`|<xref:System.Byte?displayProperty=nameWithType>|8 bits|
+|`SHORT`|`short`|<xref:System.Int16?displayProperty=nameWithType>|16 bits|
+|`WORD`|`unsigned short`|<xref:System.UInt16?displayProperty=nameWithType>|16 bits|
+|`INT`|`int`|<xref:System.Int32?displayProperty=nameWithType>|32 bits|
+|`UINT`|`unsigned int`|<xref:System.UInt32?displayProperty=nameWithType>|32 bits|
+|`LONG`|`long`|<xref:System.Int32?displayProperty=nameWithType>|32 bits|
+|`BOOL`|`long`|<xref:System.Boolean?displayProperty=nameWithType> or <xref:System.Int32?displayProperty=nameWithType>|32 bits|
+|`DWORD`|`unsigned long`|<xref:System.UInt32?displayProperty=nameWithType>|32 bits|
+|`ULONG`|`unsigned long`|<xref:System.UInt32?displayProperty=nameWithType>|32 bits|
+|`CHAR`|`char`|<xref:System.Char?displayProperty=nameWithType>|Decorate with ANSI.|
+|`WCHAR`|`wchar_t`|<xref:System.Char?displayProperty=nameWithType>|Decorate with Unicode.|
+|`LPSTR`|`char *`|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with ANSI.|
+|`LPCSTR`|`const char *`|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with ANSI.|
+|`LPWSTR`|`wchar_t *`|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with Unicode.|
+|`LPCWSTR`|`const wchar_t *`|<xref:System.String?displayProperty=nameWithType> or <xref:System.Text.StringBuilder?displayProperty=nameWithType>|Decorate with Unicode.|
+|`FLOAT`|`float`|<xref:System.Single?displayProperty=nameWithType>|32 bits|
+|`DOUBLE`|`double`|<xref:System.Double?displayProperty=nameWithType>|64 bits|
 
 For corresponding types in [!INCLUDE[vbprvblong](../../../includes/vbprvblong-md.md)], C#, and C++, see the [Introduction to the .NET Framework Class Library](../../../docs/standard/class-library-overview.md).
 

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -19,7 +19,7 @@ To call functions exported from an unmanaged library, a .NET Framework applicati
 
 - Substitute managed data types for unmanaged data types.
 
-You can use the documentation supplied with an unmanaged function to construct an equivalent managed prototype by applying the attribute with its optional fields and substituting managed data types for unmanaged types. For instructions about how to apply the `DllImportAttribute`, see [Consuming Unmanaged DLL Functions](../../../docs/framework/interop/consuming-unmanaged-dll-functions.md).
+You can use the documentation supplied with an unmanaged function to construct an equivalent managed prototype by applying the attribute with its optional fields and substituting managed data types for unmanaged types. For instructions about how to apply the <xref:System.Runtime,.InteropServices.DllImportAttribute>, see [Consuming Unmanaged DLL Functions](../../../docs/framework/interop/consuming-unmanaged-dll-functions.md).
 
 This section provides samples that demonstrate how to create managed function prototypes for passing arguments to and receiving return values from functions exported by unmanaged libraries. The samples also demonstrate when to use the <xref:System.Runtime.InteropServices.MarshalAsAttribute> attribute and the <xref:System.Runtime.InteropServices.Marshal> class to explicitly marshal data.
 

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -25,9 +25,9 @@ This section provides samples that demonstrate how to create managed function pr
 
 ## Platform invoke data types
 
-The following table lists data types used in the Win32 API (listed in Wtypes.h) and C-style functions. Many unmanaged libraries contain functions that pass these data types as parameters and return values. The third column lists the corresponding .NET Framework built-in value type or class that you use in managed code. In some cases, you can substitute a type of the same size for the type listed in the table.
+The following table lists data types used in the Windows APIs and C-style functions. Many unmanaged libraries contain functions that pass these data types as parameters and return values. The third column lists the corresponding .NET Framework built-in value type or class that you use in managed code. In some cases, you can substitute a type of the same size for the type listed in the table.
 
-|Unmanaged type in Win32 APIs|Unmanaged C language type|Managed type|Description|
+|Unmanaged type in Windows APIs|Unmanaged C language type|Managed type|Description|
 |--------------------------------|-------------------------------|------------------------|-----------------|
 |`VOID`|`void`|<xref:System.Void?displayProperty=nameWithType>|Applied to a function that does not return a value.|
 |`HANDLE`|`void *`|<xref:System.IntPtr?displayProperty=nameWithType> or <xref:System.UIntPtr?displayProperty=nameWithType>|32 bits on 32-bit Windows operating systems, 64 bits on 64-bit Windows operating systems.|

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -49,7 +49,7 @@ The following table lists data types used in the Windows APIs and C-style functi
 |`FLOAT`|`float`|<xref:System.Single?displayProperty=nameWithType>|32 bits|
 |`DOUBLE`|`double`|<xref:System.Double?displayProperty=nameWithType>|64 bits|
 
-For corresponding types in [!INCLUDE[vbprvblong](../../../includes/vbprvblong-md.md)], C#, and C++, see the [Introduction to the .NET Framework Class Library](../../../docs/standard/class-library-overview.md).
+For corresponding types in Visual Basic, C#, and C++, see the [Introduction to the .NET Framework Class Library](../../standard/class-library-overview.md#system-namespace).
 
 ## PinvokeLib.dll
 

--- a/docs/framework/interop/marshaling-data-with-platform-invoke.md
+++ b/docs/framework/interop/marshaling-data-with-platform-invoke.md
@@ -27,7 +27,7 @@ This section provides samples that demonstrate how to create managed function pr
 
 The following table lists data types used in the Win32 API (listed in Wtypes.h) and C-style functions. Many unmanaged libraries contain functions that pass these data types as parameters and return values. The third column lists the corresponding .NET Framework built-in value type or class that you use in managed code. In some cases, you can substitute a type of the same size for the type listed in the table.
 
-|Unmanaged type in Wtypes.h|Unmanaged C language type|Managed type name|Description|
+|Unmanaged type in Win32 APIs|Unmanaged C language type|Managed type|Description|
 |--------------------------------|-------------------------------|------------------------|-----------------|
 |**VOID**|**void**|<xref:System.Void?displayProperty=nameWithType>|Applied to a function that does not return a value.|
 |**HANDLE**|**void \***|<xref:System.IntPtr?displayProperty=nameWithType> or <xref:System.UIntPtr?displayProperty=nameWithType>|32 bits on 32-bit Windows operating systems, 64 bits on 64-bit Windows operating systems.|

--- a/docs/standard/native-interop/best-practices.md
+++ b/docs/standard/native-interop/best-practices.md
@@ -156,7 +156,7 @@ Don't forget that `GCHandle` needs to be explicitly freed to avoid memory leaks.
 
 ## Common Windows data types
 
-Here is a list of data types commonly used in Win32 APIs and which C# types to use when calling into the Win32 code.
+Here is a list of data types commonly used in Windows APIs and which C# types to use when calling into the Windows code.
 
 The following types are the same size on 32-bit and 64-bit Windows, despite their names.
 


### PR DESCRIPTION
Contributes to #11396

*wtypes.h* is for Win16 only. These types are defined in either *winnt.h* or *minwindef.h*.