### PR TITLE
Remove mini-TOCs

### DIFF
--- a/docs/framework/interop/default-marshaling-behavior.md
+++ b/docs/framework/interop/default-marshaling-behavior.md
@@ -160,11 +160,11 @@ internal class DelegateTest {
   
  This topic provides the follow information on formatted value types:  
   
--   [Value Types Used in Platform Invoke](#cpcondefaultmarshalingforvaluetypesanchor2)  
+-   [Value Types Used in Platform Invoke](#value-types-used-in-platform-invoke)  
   
--   [Value Types Used in COM Interop](#cpcondefaultmarshalingforvaluetypesanchor3)  
+-   [Value Types Used in COM Interop](#value-types-used-in-com-interop)  
   
- In addition to describing formatted types, this topic identifies [System Value Types](#cpcondefaultmarshalingforvaluetypesanchor1) that have unusual marshaling behavior.  
+ In addition to describing formatted types, this topic identifies [System Value Types](#system-value-types) that have unusual marshaling behavior.  
   
  A formatted type is a complex type that contains information that explicitly controls the layout of its members in memory. The member layout information is provided using the <xref:System.Runtime.InteropServices.StructLayoutAttribute> attribute. The layout can be one of the following <xref:System.Runtime.InteropServices.LayoutKind> enumeration values:  
   
@@ -180,7 +180,6 @@ internal class DelegateTest {
   
      Indicates that the members are laid out according to the <xref:System.Runtime.InteropServices.FieldOffsetAttribute> supplied with each field.  
   
-<a name="cpcondefaultmarshalingforvaluetypesanchor2"></a>   
 ### Value Types Used in Platform Invoke  
  In the following example the `Point` and `Rect` types provide member layout information using the **StructLayoutAttribute**.  
   
@@ -323,7 +322,6 @@ public class Point {
 }  
 ```  
   
-<a name="cpcondefaultmarshalingforvaluetypesanchor3"></a>   
 ### Value Types Used in COM Interop  
  Formatted types can also be passed to COM interop method calls. In fact, when exported to a type library, value types are automatically converted to structures. As the following example shows, the `Point` value type becomes a type definition (typedef) with the name `Point`. All references to the `Point` value type elsewhere in the type library are replaced with the `Point` typedef.  
   
@@ -347,7 +345,6 @@ interface _Graphics {
 > [!NOTE]
 >  Structures having the <xref:System.Runtime.InteropServices.LayoutKind> enumeration value set to **Explicit** cannot be used in COM interop because the exported type library cannot express an explicit layout.  
   
-<a name="cpcondefaultmarshalingforvaluetypesanchor1"></a>   
 ### System Value Types  
  The <xref:System> namespace has several value types that represent the boxed form of the runtime primitive types. For example, the value type <xref:System.Int32?displayProperty=nameWithType> structure represents the boxed form of **ELEMENT_TYPE_I4**. Instead of marshaling these types as structures, as other formatted types are, you marshal them in the same way as the primitive types they box. **System.Int32** is therefore marshaled as **ELEMENT_TYPE_I4** instead of as a structure containing a single member of type **long**. The following table contains a list of the value types in the **System** namespace that are boxed representations of primitive types.  
   

--- a/docs/framework/interop/default-marshaling-behavior.md
+++ b/docs/framework/interop/default-marshaling-behavior.md
@@ -158,7 +158,7 @@ internal class DelegateTest {
 ## Default marshaling for value types  
  Most value types, such as integers and floating-point numbers, are [blittable](blittable-and-non-blittable-types.md) and do not require marshaling. Other [non-blittable](blittable-and-non-blittable-types.md) types have dissimilar representations in managed and unmanaged memory and do require marshaling. Still other types require explicit formatting across the interoperation boundary.  
   
- This topic provides the follow information on formatted value types:  
+ This section provides information on the following formatted value types:  
   
 -   [Value Types Used in Platform Invoke](#value-types-used-in-platform-invoke)  
   

--- a/docs/framework/interop/default-marshaling-for-arrays.md
+++ b/docs/framework/interop/default-marshaling-for-arrays.md
@@ -16,17 +16,8 @@ In an application consisting entirely of managed code, the common language runti
   
  With [pinning optimization](copying-and-pinning.md), a blittable array can appear to operate as an In/Out parameter when interacting with objects in the same apartment. However, if you later export the code to a type library used to generate the cross-machine proxy, and that library is used to marshal your calls across apartments, the calls can revert to true In parameter behavior.  
   
- Arrays are complex by nature, and the distinctions between managed and unmanaged arrays warrant more information than other non-blittable types. This topic provides the following information on marshaling arrays:  
+ Arrays are complex by nature, and the distinctions between managed and unmanaged arrays warrant more information than other non-blittable types.  
   
--   [Managed Arrays](#cpcondefaultmarshalingforarraysanchor1)  
-  
--   [Unmanaged Arrays](#cpcondefaultmarshalingforarraysanchor2)  
-  
--   [Passing Array Parameters to .NET Code](#cpcondefaultmarshalingforarraysanchor3)  
-  
--   [Passing Arrays to COM](#cpcondefaultmarshalingforarraysanchor4)  
-  
-<a name="cpcondefaultmarshalingforarraysanchor1"></a>   
 ## Managed Arrays  
  Managed array types can vary; however, the <xref:System.Array?displayProperty=nameWithType> class is the base class of all array types. The **System.Array** class has properties for determining the rank, length, and lower and upper bounds of an array, as well as methods for accessing, sorting, searching, copying, and creating arrays.  
   
@@ -40,11 +31,9 @@ In an application consisting entirely of managed code, the common language runti
 |**ELEMENT_TYPE_CLASS**|Unknown|Unknown|Unknown|**System.Array**|  
 |**ELEMENT_TYPE_SZARRAY**|Specified by type.|1|0|*type* **[** *n* **]**|  
   
-<a name="cpcondefaultmarshalingforarraysanchor2"></a>   
 ## Unmanaged Arrays  
  Unmanaged arrays are either COM-style safe arrays or C-style arrays with fixed or variable length. Safe arrays are self-describing arrays that carry the type, rank, and bounds of the associated array data. C-style arrays are one-dimensional typed arrays with a fixed lower bound of 0. The marshaling service has limited support for both types of arrays.  
   
-<a name="cpcondefaultmarshalingforarraysanchor3"></a>   
 ## Passing Array Parameters to .NET Code  
  Both C-style arrays and safe arrays can be passed to .NET code from unmanaged code as either a safe array or a C-style array. The following table shows the unmanaged type value and the imported type.  
   
@@ -184,7 +173,6 @@ void New3(ref String ar);
   
  The interop marshaler uses the **CoTaskMemAlloc** and **CoTaskMemFree** methods to allocate and retrieve memory. Memory allocation performed by unmanaged code must also use these methods.  
   
-<a name="cpcondefaultmarshalingforarraysanchor4"></a>   
 ## Passing Arrays to COM  
  All managed array types can be passed to unmanaged code from managed code. Depending on the managed type and the attributes applied to it, the array can be accessed as a safe array or a C-style array, as shown in the following table.  
   

--- a/docs/framework/interop/default-marshaling-for-objects.md
+++ b/docs/framework/interop/default-marshaling-for-objects.md
@@ -20,19 +20,6 @@ Parameters and fields typed as <xref:System.Object?displayProperty=nameWithType>
   
  Only COM interop supports marshaling for object types. The default behavior is to marshal objects to COM variants. These rules apply only to the type **Object** and do not apply to strongly typed objects that derive from the **Object** class.  
   
- This topic provides the following additional information about marshaling object types:  
-  
--   [Marshaling Options](#cpcondefaultmarshalingforobjectsanchor7)  
-  
--   [Marshaling Object to Interface](#cpcondefaultmarshalingforobjectsanchor2)  
-  
--   [Marshaling Object to Variant](#cpcondefaultmarshalingforobjectsanchor3)  
-  
--   [Marshaling Variant to Object](#cpcondefaultmarshalingforobjectsanchor4)  
-  
--   [Marshaling ByRef Variants](#cpcondefaultmarshalingforobjectsanchor6)  
-  
-<a name="cpcondefaultmarshalingforobjectsanchor7"></a>   
 ## Marshaling Options  
  The following table shows the marshaling options for the **Object** data type. The <xref:System.Runtime.InteropServices.MarshalAsAttribute> attribute provides several <xref:System.Runtime.InteropServices.UnmanagedType> enumeration values to marshal objects.  
   
@@ -121,11 +108,9 @@ struct ObjectHolder {
 }  
 ```  
   
-<a name="cpcondefaultmarshalingforobjectsanchor2"></a>   
 ## Marshaling Object to Interface  
  When an object is exposed to COM as an interface, that interface is the class interface for the managed type <xref:System.Object> (the **_Object** interface). This interface is typed as an **IDispatch** (<xref:System.Runtime.InteropServices.UnmanagedType>) or an **IUnknown** (**UnmanagedType.IUnknown**) in the resulting type library. COM clients can dynamically invoke the members of the managed class or any members implemented by its derived classes through the **_Object** interface. The client can also call **QueryInterface** to obtain any other interface explicitly implemented by the managed type.  
   
-<a name="cpcondefaultmarshalingforobjectsanchor3"></a>   
 ## Marshaling Object to Variant  
  When an object is marshaled to a variant, the internal variant type is determined at run time, based on the following rules:  
   
@@ -249,7 +234,6 @@ mo.SetVariant(new CurrencyWrapper(new Decimal(5.25)));
   
  The value of the COM variant is determined by calling the **IConvertible.To** *Type* interface, where **To** *Type* is the conversion routine that corresponds to the type that was returned from **IConvertible.GetTypeCode**. For example, an object that returns **TypeCode.Double** from **IConvertible.GetTypeCode** is marshaled as a COM variant of type **VT_R8**. You can obtain the value of the variant (stored in the **dblVal** field of the COM variant) by casting to the **IConvertible** interface and calling the <xref:System.IConvertible.ToDouble%2A> method.  
   
-<a name="cpcondefaultmarshalingforobjectsanchor4"></a>   
 ## Marshaling Variant to Object  
  When marshaling a variant to an object, the type, and sometimes the value, of the marshaled variant determines the type of object produced. The following table identifies each variant type and the corresponding object type that the marshaler creates when a variant is passed from COM to the .NET Framework.  
   
@@ -283,7 +267,6 @@ mo.SetVariant(new CurrencyWrapper(new Decimal(5.25)));
   
  Variant types passed from COM to managed code and then back to COM might not retain the same variant type for the duration of the call. Consider what happens when a variant of type **VT_DISPATCH** is passed from COM to the .NET Framework. During marshaling, the variant is converted to a <xref:System.Object?displayProperty=nameWithType>. If the **Object** is then passed back to COM, it is marshaled back to a variant of type **VT_UNKNOWN**. There is no guarantee that the variant produced when an object is marshaled from managed code to COM will be the same type as the variant initially used to produce the object.  
   
-<a name="cpcondefaultmarshalingforobjectsanchor6"></a>   
 ## Marshaling ByRef Variants  
  Although variants themselves can be passed by value or by reference, the **VT_BYREF** flag can also be used with any variant type to indicate that the contents of the variant are being passed by reference instead of by value. The difference between marshaling variants by reference and marshaling a variant with the **VT_BYREF** flag set can be confusing. The following illustration clarifies the differences.  
   
@@ -292,9 +275,9 @@ Variants passed by value and by reference
   
  **Default behavior for marshaling objects and variants by value**  
   
--   When passing objects from managed code to COM, the contents of the object are copied into a new variant created by the marshaler, using the rules defined in [Marshaling Object to Variant](#cpcondefaultmarshalingforobjectsanchor3). Changes made to the variant on the unmanaged side are not propagated back to the original object on return from the call.  
+-   When passing objects from managed code to COM, the contents of the object are copied into a new variant created by the marshaler, using the rules defined in [Marshaling Object to Variant](#marshaling-object-to-variant). Changes made to the variant on the unmanaged side are not propagated back to the original object on return from the call.  
   
--   When passing variants from COM to managed code, the contents of the variant are copied to a newly created object, using the rules defined in [Marshaling Variant to Object](#cpcondefaultmarshalingforobjectsanchor4). Changes made to the object on the managed side are not propagated back to the original variant on return from the call.  
+-   When passing variants from COM to managed code, the contents of the variant are copied to a newly created object, using the rules defined in [Marshaling Variant to Object](#marshaling-variant-to-object). Changes made to the object on the managed side are not propagated back to the original variant on return from the call.  
   
  **Default behavior for marshaling objects and variants by reference**  
   

--- a/docs/standard/base-types/regular-expression-language-quick-reference.md
+++ b/docs/standard/base-types/regular-expression-language-quick-reference.md
@@ -18,27 +18,15 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # Regular Expression Language - Quick Reference
-<a name="top"></a> A regular expression is a pattern that the regular expression engine attempts to match in input text. A pattern consists of one or more character literals, operators, or constructs.  For a brief introduction, see [.NET Regular Expressions](../../../docs/standard/base-types/regular-expressions.md).  
+ A regular expression is a pattern that the regular expression engine attempts to match in input text. A pattern consists of one or more character literals, operators, or constructs.  For a brief introduction, see [.NET Regular Expressions](../../../docs/standard/base-types/regular-expressions.md).  
   
- Each section in this quick reference lists a particular category of characters, operators, and constructs that you can use to define regular expressions:  
-  
- [Character escapes](#character_escapes)  
- [Character classes](#character_classes)  
- [Anchors](#anchors)  
- [Grouping constructs](#grouping_constructs)  
- [Quantifiers](#quantifiers)  
- [Backreference constructs](#backreference_constructs)  
- [Alternation constructs](#alternation_constructs)  
- [Substitutions](#substitutions)  
- [Regular expression options](#options)  
- [Miscellaneous constructs](#miscellaneous_constructs)  
+ Each section in this quick reference lists a particular category of characters, operators, and constructs that you can use to define regular expressions.  
   
  We’ve also provided this information in two formats that you can download and print for easy reference:  
   
  [Download in Word (.docx) format](https://download.microsoft.com/download/D/2/4/D240EBF6-A9BA-4E4F-A63F-AEB6DA0B921C/Regular%20expressions%20quick%20reference.docx)  
  [Download in PDF (.pdf) format](https://download.microsoft.com/download/D/2/4/D240EBF6-A9BA-4E4F-A63F-AEB6DA0B921C/Regular%20expressions%20quick%20reference.pdf)  
   
-<a name="character_escapes"></a>   
 ## Character Escapes  
  The backslash character (\\) in a regular expression indicates that the character that follows it either is a special character (as shown in the following table), or should be interpreted literally. For more information, see [Character Escapes](../../../docs/standard/base-types/character-escapes-in-regular-expressions.md).  
   
@@ -60,7 +48,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="character_classes"></a>   
 ## Character Classes  
  A character class matches any one of a set of characters. Character classes include the language elements listed in the following table. For more information, see [Character Classes](../../../docs/standard/base-types/character-classes-in-regular-expressions.md).  
   
@@ -97,7 +84,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="grouping_constructs"></a>   
 ## Grouping Constructs  
  Grouping constructs delineate subexpressions of a regular expression and typically capture substrings of an input string. Grouping constructs include the language elements listed in the following table. For more information, see [Grouping Constructs](grouping-constructs-in-regular-expressions.md).  
   
@@ -116,7 +102,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="quantifiers"></a>   
 ## Quantifiers  
  A quantifier specifies how many instances of the previous element (which can be a character, a group, or a character class) must be present in the input string for a match to occur. Quantifiers include the language elements listed in the following table. For more information, see [Quantifiers](quantifiers-in-regular-expressions.md).  
   
@@ -137,7 +122,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="backreference_constructs"></a>   
 ## Backreference Constructs  
  A backreference allows a previously matched subexpression to be identified subsequently in the same regular expression. The following table lists the backreference constructs supported by regular expressions in .NET. For more information, see [Backreference Constructs](backreference-constructs-in-regular-expressions.md).  
   
@@ -148,7 +132,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="alternation_constructs"></a>   
 ## Alternation Constructs  
  Alternation constructs modify a regular expression to enable either/or matching. These constructs include the language elements listed in the following table. For more information, see [Alternation Constructs](alternation-constructs-in-regular-expressions.md).  
   
@@ -160,7 +143,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="substitutions"></a>   
 ## Substitutions  
  Substitutions are regular expression language elements that are supported in replacement patterns. For more information, see [Substitutions](substitutions-in-regular-expressions.md). The metacharacters listed in the following table are atomic zero-width assertions.  
   
@@ -177,7 +159,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="options"></a>   
 ## Regular Expression Options  
  You can specify options that control how the regular expression engine interprets a regular expression pattern. Many of these options can be specified either inline (in the regular expression pattern) or as one or more <xref:System.Text.RegularExpressions.RegexOptions> constants. This quick reference lists only inline options. For more information about inline and <xref:System.Text.RegularExpressions.RegexOptions> options, see the article [Regular Expression Options](regular-expression-options.md).  
   
@@ -199,7 +180,6 @@ ms.author: "ronpet"
   
  [Back to top](#top)  
   
-<a name="miscellaneous_constructs"></a>   
 ## Miscellaneous Constructs  
  Miscellaneous constructs either modify a regular expression pattern or provide information about it. The following table lists the miscellaneous constructs supported by .NET. For more information, see [Miscellaneous Constructs](miscellaneous-constructs-in-regular-expressions.md).  
   


### PR DESCRIPTION
As well as remove meaningless anchors.

Since there is an **In this article** column on the right.