### PR TITLE
C76692: Adding break-lines (two spaces) at the end of rows

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
@@ -8,12 +8,12 @@ ms.assetid: 6ebf0240-d7be-4493-b0fe-f00fd5989d77
 
 Defines the SOAP message security settings on this `netMsmqBinding` binding.
 
-\<system.ServiceModel>\
-\<bindings>\
-\<netMsmqBinding>\
-\<binding>\
-\<security>\
-\<message>
+\<system.ServiceModel>\  
+\<bindings>\  
+\<netMsmqBinding>\  
+\<binding>\  
+\<security>\  
+\<message>  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
@@ -8,12 +8,14 @@ ms.assetid: 6ebf0240-d7be-4493-b0fe-f00fd5989d77
 
 Defines the SOAP message security settings on this `netMsmqBinding` binding.
 
-\<system.ServiceModel>\  
-\<bindings>\  
-\<netMsmqBinding>\  
-\<binding>\  
-\<security>\  
-\<message>  
+```
+<system.ServiceModel>
+  <bindings>
+    <netMsmqBinding>
+      <binding>
+        <security>
+          <message>
+```
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
@@ -8,7 +8,7 @@ ms.assetid: 6ebf0240-d7be-4493-b0fe-f00fd5989d77
 
 Defines the SOAP message security settings on this `netMsmqBinding` binding.
 
-```
+```xml
 <system.ServiceModel>
   <bindings>
     <netMsmqBinding>


### PR DESCRIPTION
Hello, @BillWagner,
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Missing break lines at the end of the spotted lines are preventing to show the content in one line instead of one line for every string

Please review and merge the proposed file change to fix to target versions. If you make related fix in another PR  then share your PR number so we can confirm and close this PR.
Many thanks in advance.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
