### PR TITLE
Operators overview: link sections from the introduction

### DIFF
--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -32,8 +32,8 @@ helpviewer_keywords:
 
 The following operators perform arithmetic operations with numeric types:
 
-- Unary `++` (increment), `--` (decrement), `+` (plus), and `-` (minus) operators.
-- Binary `*` (multiplication), `/` (division), `%` (remainder), `+` (addition), and `-` (subtraction) operators.
+- Unary [`++` (increment)](#increment-operator-), [`--` (decrement)](#decrement-operator---), [`+` (plus)](#unary-plus-and-minus-operators), and [`-` (minus)](#unary-plus-and-minus-operators) operators.
+- Binary [`*` (multiplication)](#multiplication-operator-), [`/` (division)](#division-operator-), [`%` (remainder)](#remainder-operator-), [`+` (addition)](#addition-operator-), and [`-` (subtraction)](#subtraction-operator-) operators.
 
 Those operators support all [integral](../keywords/integral-types-table.md) and [floating-point](../keywords/floating-point-types-table.md) numeric types.
 

--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -15,7 +15,7 @@ helpviewer_keywords:
 ---
 # Equality operators (C# Reference)
 
-The `==` (equality) and `!=` (inequality) operators check if their operands are equal or not.
+The [`==` (equality)](#equality-operator-) and [`!=` (inequality)](#inequality-operator-) operators check if their operands are equal or not.
 
 ## Equality operator ==
 


### PR DESCRIPTION
So, the article went live and I've made an experiment:
- In Visual Studio, navigate with the mouse cursor to the `/` operator usage
- Press `F1`
- End up in the browser on the "Arithmetic operators" page a little bit puzzled: introduction mentions the `/` operator but no way to navigate to its definition fast; the navigation at right doesn't jump into eyes immediately. 

And then, I've noticed related feedback on Twitter.
So, adding links to the individual operator sections to the introduction.
