### PR TITLE
Added links to sections about floating-point representation

### DIFF
--- a/docs/csharp/language-reference/operators/arithmetic-operators.md
+++ b/docs/csharp/language-reference/operators/arithmetic-operators.md
@@ -229,6 +229,8 @@ Because of general limitations of the floating-point representation of real numb
 
 [!code-csharp-interactive[round-off errors](~/samples/snippets/csharp/language-reference/operators/ArithmeticOperators.cs#RoundOffErrors)]
 
+For more information, see remarks at [System.Double](/dotnet/api/system.double#remarks), [System.Single](/dotnet/api/system.single#remarks), or [System.Decimal](/dotnet/api/system.decimal#remarks) reference pages.
+
 ## Operator overloadability
 
 User-defined types can [overload](../keywords/operator.md) the unary (`++`, `--`, `+`, and `-`) and binary (`*`, `/`, `%`, `+`, and `-`) arithmetic operators. When a binary operator is overloaded, the corresponding compound assignment operator is also implicitly overloaded. A user-defined type cannot explicitly overload a compound assignment operator.


### PR DESCRIPTION
Provides escapes to the minds that are curious about the origin of round-off errors.
