### PR TITLE
Fix Warning in explicit val keyword

### DIFF
--- a/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
+++ b/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
@@ -34,7 +34,7 @@ For example, an immutable field called `someField` has a backing field in the .N
 For a mutable field, the .NET compiled representation is a .NET field.
 
 >[!WARNING]
-`Note` The .NET Framework namespace `System.ComponentModel` contains an attribute that has the same name. For information about this attribute, see `System.ComponentModel.DefaultValueAttribute`.
+>Note The .NET Framework namespace `System.ComponentModel` contains an attribute that has the same name. For information about this >attribute, see `System.ComponentModel.DefaultValueAttribute`.
 
 The following code shows the use of explicit fields and, for comparison, a `let` binding in a class that has a primary constructor. Note that the `let`-bound field `myInt1` is private. When the `let`-bound field `myInt1` is referenced from a member method, the self identifier `this` is not required. But when you are referencing the explicit fields `myInt2` and `myString`, the self identifier is required.
 

--- a/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
+++ b/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
@@ -34,7 +34,7 @@ For example, an immutable field called `someField` has a backing field in the .N
 For a mutable field, the .NET compiled representation is a .NET field.
 
 >[!WARNING]
->Note The .NET Framework namespace `System.ComponentModel` contains an attribute that has the same name. For information about this attribute, see `System.ComponentModel.DefaultValueAttribute`.
+>The .NET Framework namespace `System.ComponentModel` contains an attribute that has the same name. For information about this attribute, see `System.ComponentModel.DefaultValueAttribute`.
 
 The following code shows the use of explicit fields and, for comparison, a `let` binding in a class that has a primary constructor. Note that the `let`-bound field `myInt1` is private. When the `let`-bound field `myInt1` is referenced from a member method, the self identifier `this` is not required. But when you are referencing the explicit fields `myInt2` and `myString`, the self identifier is required.
 

--- a/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
+++ b/docs/fsharp/language-reference/members/explicit-fields-the-val-keyword.md
@@ -34,7 +34,7 @@ For example, an immutable field called `someField` has a backing field in the .N
 For a mutable field, the .NET compiled representation is a .NET field.
 
 >[!WARNING]
->Note The .NET Framework namespace `System.ComponentModel` contains an attribute that has the same name. For information about this >attribute, see `System.ComponentModel.DefaultValueAttribute`.
+>Note The .NET Framework namespace `System.ComponentModel` contains an attribute that has the same name. For information about this attribute, see `System.ComponentModel.DefaultValueAttribute`.
 
 The following code shows the use of explicit fields and, for comparison, a `let` binding in a class that has a primary constructor. Note that the `let`-bound field `myInt1` is private. When the `let`-bound field `myInt1` is referenced from a member method, the self identifier `this` is not required. But when you are referencing the explicit fields `myInt2` and `myString`, the self identifier is required.
 


### PR DESCRIPTION
## Summary

Removed the `Note` that broke the warning block.

Fixes #11538 
