### PR TITLE
C76762: Removing all "\" at the end of lines and adding two spaces in…

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/issuerchannelbehaviors-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuerchannelbehaviors-element.md
@@ -8,13 +8,15 @@ ms.assetid: f7378673-8e9b-45b2-98d1-cf5dccdd8c40
 
 Contains a collection of Windows Communication Foundation (WCF) client endpoint behaviors (defined in the configuration) to be used when communicating with the specified Service Token Services. The defined behaviors cannot include any [\<clientCredentials>](../../../../../docs/framework/configure-apps/file-schema/wcf/clientcredentials.md) elements.
 
-\<system.ServiceModel>  
-\<behaviors>  
-endpointBehaviors section  
-\<behavior>  
-\<clientCredentials>  
-\<issuedToken>  
-\<issuerChannelBehaviors>  
+```
+<system.ServiceModel>
+  <behaviors>
+    <endpointBehaviors>
+      <behavior>
+        <clientCredentials>
+          <issuedToken>
+            <issuerChannelBehaviors>
+```
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/issuerchannelbehaviors-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuerchannelbehaviors-element.md
@@ -8,7 +8,7 @@ ms.assetid: f7378673-8e9b-45b2-98d1-cf5dccdd8c40
 
 Contains a collection of Windows Communication Foundation (WCF) client endpoint behaviors (defined in the configuration) to be used when communicating with the specified Service Token Services. The defined behaviors cannot include any [\<clientCredentials>](../../../../../docs/framework/configure-apps/file-schema/wcf/clientcredentials.md) elements.
 
-```
+```xml
 <system.ServiceModel>
   <behaviors>
     <endpointBehaviors>

--- a/docs/framework/configure-apps/file-schema/wcf/issuerchannelbehaviors-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuerchannelbehaviors-element.md
@@ -8,13 +8,13 @@ ms.assetid: f7378673-8e9b-45b2-98d1-cf5dccdd8c40
 
 Contains a collection of Windows Communication Foundation (WCF) client endpoint behaviors (defined in the configuration) to be used when communicating with the specified Service Token Services. The defined behaviors cannot include any [\<clientCredentials>](../../../../../docs/framework/configure-apps/file-schema/wcf/clientcredentials.md) elements.
 
-\<system.ServiceModel>\
-\<behaviors>\
-endpointBehaviors section\
-\<behavior>\
-\<clientCredentials>\
-\<issuedToken>\
-\<issuerChannelBehaviors>
+\<system.ServiceModel>  
+\<behaviors>  
+endpointBehaviors section  
+\<behavior>  
+\<clientCredentials>  
+\<issuedToken>  
+\<issuerChannelBehaviors>  
 
 ## Syntax
 


### PR DESCRIPTION
…stead

Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
