### PR TITLE
Update Enumeration and CardType classes

### DIFF
--- a/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
+++ b/docs/standard/microservices-architecture/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types.md
@@ -24,9 +24,6 @@ public abstract class Enumeration : IComparable
 
     public int Id { get; private set; }
 
-    protected Enumeration()
-    { }
-
     protected Enumeration(int id, string name) 
     {
         Id = id; 
@@ -68,30 +65,13 @@ You can use this class as a type in any entity or value object, as for the follo
 ```csharp
 public abstract class CardType : Enumeration
 {
-    public static CardType Amex = new AmexCardType();
-    public static CardType Visa = new VisaCardType();
-    public static CardType MasterCard = new MasterCardType();
+    public static CardType Amex = new CardType(1, "Amex");
+    public static CardType Visa = new CardType(2, "Visa");
+    public static CardType MasterCard = new CardType(3, "MasterCard");
 
-    protected CardType(int id, string name)
+    public CardType(int id, string name)
         : base(id, name)
-    { }
-
-    private class AmexCardType : CardType
     {
-        public AmexCardType(): base(1, "Amex")
-        { }
-    }
-    
-    private class VisaCardType : CardType
-    {
-        public VisaCardType(): base(2, "Visa")
-        { }
-    }
-    
-    private class MasterCardType : CardType
-    {
-        public MasterCardType(): base(3, "MasterCard")
-        { }
     }
 }
 ```


### PR DESCRIPTION
## Summary

Partially applied changes proposed by @svick in https://github.com/dotnet-architecture/eShopOnContainers/pull/704 although the changes were done in https://github.com/dotnet-architecture/eShopOnContainers/pull/980

Note. the `Name` and `Id` properties can't be read-only because both EF Core and object deserialization fail, so they have to be kept private set.

Closes https://github.com/dotnet/docs/pull/6967
Closes https://github.com/dotnet/docs/issues/6812
