### PR TITLE
Remove unknown -d parameter to xperf -merge

### DIFF
--- a/docs/framework/performance/clr-etw-providers.md
+++ b/docs/framework/performance/clr-etw-providers.md
@@ -78,7 +78,7 @@ The common language runtime (CLR) has two providers: the runtime provider and th
 4.  Merge the profiles to create one log file:  
   
     ```  
-    xperf -merge -d clr1.etl clr2.etl merged.etl  
+    xperf -merge clr1.etl clr2.etl merged.etl  
     ```  
   
      The merged.etl file will contain the events from the runtime and the rundown provider sessions.  


### PR DESCRIPTION
## Summary
Fix xperf merge example to actually work by removing unknown -d parameter

Describe your changes here.

Fixes #Issue_Number (if available)
