### PR TITLE
typo

### DIFF
--- a/docs/csharp/programming-guide/concepts/reflection.md
+++ b/docs/csharp/programming-guide/concepts/reflection.md
@@ -22,7 +22,7 @@ System.Console.WriteLine(type);
  The following example uses reflection to obtain the full name of the loaded assembly.  
   
 ```csharp  
-// Using Reflection to get information from an Assembly:  
+// Using Reflection to get information of an Assembly:  
 System.Reflection.Assembly info = typeof(System.Int32).Assembly;  
 System.Console.WriteLine(info);  
 ```  


### PR DESCRIPTION
Code snippet gets the "information of `System.Int32` Assembly" and not the "information from an Assembly."

## Summary

change `from` to `of`
