### PR TITLE
[CLEANUP] Fix method name trimInput

### DIFF
--- a/docs/core/testing/unit-testing-best-practices.md
+++ b/docs/core/testing/unit-testing-best-practices.md
@@ -245,17 +245,17 @@ Consider the following case
 ```csharp
 public string ParseLogLine(string input)
 {
-    var sanitizedInput = trimInput(input);
+    var sanitizedInput = TrimInput(input);
     return sanitizedInput;
 }
 
-private string trimInput(string input)
+private string TrimInput(string input)
 {
     return input.Trim();
 }
 ```
 
-Your first reaction may be to start writing a test for `trimInput` because you want to make sure that the method is working as expected. However, it is entirely possible that `ParseLogLine` manipulates `sanitizedInput` in such a way that you do not expect, rendering a test against `trimInput` useless. 
+Your first reaction may be to start writing a test for `TrimInput` because you want to make sure that the method is working as expected. However, it is entirely possible that `ParseLogLine` manipulates `sanitizedInput` in such a way that you do not expect, rendering a test against `TrimInput` useless. 
 
 The real test should be done against the public facing method `ParseLogLine` because that is what you should ultimately care about. 
 


### PR DESCRIPTION
## Summary

The method 'trimInput' does not follow [Microsoft naming conventions](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions) for method names. This will fix it using PascalCasing convention. 
