### PR TITLE
Fixed inconsistent list format

### DIFF
--- a/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
+++ b/docs/framework/wcf/feature-details/how-to-create-temporary-certificates-for-use-during-development.md
@@ -72,7 +72,7 @@ Once you have set up the temporary certificates, you can use them to develop WCF
 
 ### To specify a certificate as the client credential type
 
-- In the configuration file for a service, use the following XML to set the security mode to message, and the client credential type to certificate.
+1. In the configuration file for a service, use the following XML to set the security mode to message, and the client credential type to certificate.
 
     ```xml
     <bindings>
@@ -86,19 +86,19 @@ Once you have set up the temporary certificates, you can use them to develop WCF
     </bindings>
     ```
 
-In the configuration file for a client, use the following XML to specify that the certificate is found in the user’s store, and can be found by searching the SubjectName field for the value "CohoWinery."
+2. In the configuration file for a client, use the following XML to specify that the certificate is found in the user’s store, and can be found by searching the SubjectName field for the value "CohoWinery."
 
-```xml
-<behaviors>
-  <endpointBehaviors>
-    <behavior name="CertForClient">
-      <clientCredentials>
-        <clientCertificate findValue="CohoWinery" x509FindType="FindBySubjectName" />
-       </clientCredentials>
-     </behavior>
-   </endpointBehaviors>
-</behaviors>
-```
+    ```xml
+    <behaviors>
+      <endpointBehaviors>
+        <behavior name="CertForClient">
+          <clientCredentials>
+            <clientCertificate findValue="CohoWinery" x509FindType="FindBySubjectName" />
+          </clientCredentials>
+        </behavior>
+      </endpointBehaviors>
+    </behaviors>
+    ```
 
 For more information about using certificates in WCF, see [Working with Certificates](working-with-certificates.md).
 


### PR DESCRIPTION
## Summary

There are two steps when specifying a certificate as the client credential type. Because of that, the current styling of that section of the document is confusing (the first part is an unordered list, the second part is outside the list). I think there are three options to fix it:

1. Numbered list (1 & 2)
2. Unordered list (dots)
3. No list at all

As far as I've seen in other documents, the first option seems to be the most fitting.

Also, the second code sample had a small problem with the indentation of the closing tags.
