### PR TITLE
updates for bounce rate

### DIFF
--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -6,11 +6,12 @@ helpviewer_keywords:
   - "getting started, Visual C#"
 author: rpetrusha
 ms.author: ronpet
-ms.date: 08/23/2017
+ms.date: 04/05/2019
+ms.custom: seoapril2019
 ---
 # Get started with C\#
 
-This section provides short, simple tutorials that let you quickly build an application using C# and .NET Core. There are getting started topics for Visual Studio 2017 and Visual Studio Code. You can build either a simple Hello World application or, if you have Visual Studio 2017, a simple class library that can be used by other applications.
+This section provides short, simple tutorials that let you quickly build an application using C# and .NET Core. There are getting started topics for Visual Studio 2017 and Visual Studio Code. These articles assume some programming experience. If C# is your first experience, try our [introduction to C#](../tutorials/intro-to-csharp/index.md) interactive tutorials.
 
 The following topics are available:
 

--- a/docs/csharp/getting-started/index.md
+++ b/docs/csharp/getting-started/index.md
@@ -11,7 +11,7 @@ ms.custom: seoapril2019
 ---
 # Get started with C\#
 
-This section provides short, simple tutorials that let you quickly build an application using C# and .NET Core. There are getting started topics for Visual Studio 2017 and Visual Studio Code. These articles assume some programming experience. If C# is your first experience, try our [introduction to C#](../tutorials/intro-to-csharp/index.md) interactive tutorials.
+This section provides short, simple tutorials that let you quickly build an application using C# and .NET Core. There are getting started topics for Visual Studio 2017 and Visual Studio Code. These articles assume some programming experience. If your are new to programming, try our [introduction to C#](../tutorials/intro-to-csharp/index.md) interactive tutorials.
 
 The following topics are available:
 

--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -13,7 +13,9 @@ ms.assetid: 14c48aaa-7d35-4058-a1a4-f53353050579
 
 # default (C# Reference)
 
-The `default` keyword can be used in the [`switch` statement](switch.md) to specify the default label, or in a [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type.
+The `default` keyword can be used in two ways:
+- The [`switch` statement](switch.md) to specify the default label.
+- A [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -13,7 +13,7 @@ ms.assetid: 14c48aaa-7d35-4058-a1a4-f53353050579
 
 # default (C# Reference)
 
-The `default` keyword can be used in the [`switch` statement](switch.md) to specify the default label,  or in a [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type.
+The `default` keyword can be used in the [`switch` statement](switch.md) to specify the default label, or in a [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/default.md
+++ b/docs/csharp/language-reference/keywords/default.md
@@ -13,11 +13,7 @@ ms.assetid: 14c48aaa-7d35-4058-a1a4-f53353050579
 
 # default (C# Reference)
 
-The `default` keyword can be used in the `switch` statement or in a default value expression:
-
-- [The switch statement](switch.md): Specifies the default label.
-
-- [Default value expressions](../../programming-guide/statements-expressions-operators/default-value-expressions.md): Produces the default value of a type.
+The `default` keyword can be used in the [`switch` statement](switch.md) to specify the default label,  or in a [default value expression](../../programming-guide/statements-expressions-operators/default-value-expressions.md) to produce the default value of a type.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/namespace.md
+++ b/docs/csharp/language-reference/keywords/namespace.md
@@ -1,6 +1,6 @@
 ---
 title: "namespace keyword - C# Reference"
-ms.custom: seodec18
+ms.custom: seoapril2019
 
 ms.date: 07/20/2015
 f1_keywords: 
@@ -67,4 +67,5 @@ For more information about using namespaces, see the following topics:
 - [C# Programming Guide](../../programming-guide/index.md)
 - [C# Keywords](index.md)
 - [Namespace Keywords](namespace-keywords.md)
-- [using](using.md)
+- [using](using-directive.md)
+- [using static](using-static.md)

--- a/docs/csharp/language-reference/keywords/using.md
+++ b/docs/csharp/language-reference/keywords/using.md
@@ -11,7 +11,10 @@ ms.assetid: 124e1a63-2a4b-4132-b269-3b6d8d3ef72d
 ---
 # using (C# Reference)
 
-The `using` keyword has two major uses. The [using statement](using-statement.md) defines a scope at the end of which an object will be disposed. The using [directive](using-directive.md) creates an alias for a namespace or imports types defined in other namespaces. The related [using static directive](using-static.md) imports the members of a single class.
+The `using` keyword has three major uses:
+- The [using statement](using-statement.md) defines a scope at the end of which an object will be disposed. 
+- The using [directive](using-directive.md) creates an alias for a namespace or imports types defined in other namespaces. 
+- The [using static directive](using-static.md) imports the members of a single class.
 
 ## See also
 

--- a/docs/csharp/language-reference/keywords/using.md
+++ b/docs/csharp/language-reference/keywords/using.md
@@ -1,7 +1,7 @@
 ---
 title: "using keyword - C# Reference"
-ms.custom: seodec18
-ms.date: 07/20/2015
+ms.custom: seoapril2019
+ms.date: 04/05/2019
 f1_keywords: 
   - "using_CSharpKeyword"
   - "using"
@@ -11,13 +11,7 @@ ms.assetid: 124e1a63-2a4b-4132-b269-3b6d8d3ef72d
 ---
 # using (C# Reference)
 
-The `using` keyword has two major uses:
-
-- As a directive, when it is used to create an alias for a namespace or to import types defined in other namespaces. See [using directive](using-directive.md).
-
-- As a statement, when it defines a scope at the end of which an object will be disposed. See [using statement](using-statement.md).
-
-In addition, the [using static](using-static.md) directive lets you define a type whose static members you can access without specifying a type name.
+The `using` keyword has two major uses. The [using statement](using-statement.md) defines a scope at the end of which an object will be disposed. The using [directive](using-directive.md) creates an alias for a namespace or imports types defined in other namespaces. The related [using static directive](using-static.md) imports the members of a single class.
 
 ## See also
 

--- a/docs/csharp/tour-of-csharp/index.md
+++ b/docs/csharp/tour-of-csharp/index.md
@@ -1,13 +1,13 @@
 ---
 title: A Tour of C# - C# Guide
 description: New to C#? Learn the basics of the language.
-ms.date: 08/10/2016
-ms.assetid: ebc727cd-8112-42e7-b59c-3c2873ad661c
+ms.date: 04/05/2019
+ms.custom: seoapril2019
 ---
 
 # A Tour of the C# Language
 
-C# (pronounced "See Sharp") is a simple, modern, object-oriented, and type-safe programming language. C# has its roots in the C family of languages and will be immediately familiar to C, C++, Java, and JavaScript programmers.
+C# (pronounced "See Sharp") is a simple, modern, object-oriented, and type-safe programming language. C# has its roots in the C family of languages and will be immediately familiar to C, C++, Java, and JavaScript programmers. This tour provides an overview of the major components of the language. If you want to explore the language through interactive examples, try our [introduction to C#](../tutorials/intro-to-csharp/index.md) tutorials.
 
 C# is an object-oriented language, but C# further includes support for ***component-oriented*** programming. Contemporary software design increasingly relies on software components in the form of self-contained and self-describing packages of functionality. Key to such components is that they present a programming model with properties, methods, and events; they have attributes that provide declarative information about the component; and they incorporate their own documentation. C# provides language constructs to support directly these concepts, making C# a very natural language in which to create and use software components.
 


### PR DESCRIPTION
- The "tour" and the "getting-started" were seeing bounce because beginning programmers saw both as day 0 content. Add links to the interactive tutorials.
- The keyword pages for a couple keywords that have multiple uses were bouncing. Update the opening to get the appropriate links in the introductory paragraph.
- Some other links drove traffic to these disambiguating pages, rather than a pasrticular use of the keyword.
