### PR TITLE
make caller info sample work with C#

### DIFF
--- a/docs/fsharp/language-reference/caller-information.md
+++ b/docs/fsharp/language-reference/caller-information.md
@@ -22,24 +22,22 @@ The following example shows how you might use these attributes to trace a caller
 ```fsharp
 open System.Diagnostics
 open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
 
 type Tracer() =
     member __.DoTrace(message: string,
-                      [<CallerMemberName>] ?memberName: string,
-                      [<CallerFilePath>] ?path: string,
-                      [<CallerLineNumber>] ?line: int) =
+                      [<CallerMemberName; Optional; DefaultParameterValue("")>] memberName: string,
+                      [<CallerFilePath; Optional; DefaultParameterValue("")>] path: string,
+                      [<CallerLineNumber; Optional; DefaultParameterValue(0)>] line: int) =
         Trace.WriteLine(sprintf "Message: %s" message)
-        match (memberName, path, line) with
-        | Some m, Some p, Some l ->
-            Trace.WriteLine(sprintf "Member name: %s" m)
-            Trace.WriteLine(sprintf "Source file path: %s" p)
-            Trace.WriteLine(sprintf "Source line number: %d" l)
-        | _,_,_ -> ()
+        Trace.WriteLine(sprintf "Member name: %s" memberName)
+        Trace.WriteLine(sprintf "Source file path: %s" path)
+        Trace.WriteLine(sprintf "Source line number: %d" line)
 ```
 
 ## Remarks
 
-Caller Info attributes can only be applied to optional parameters. You must supply an explicit value for each optional parameter. The Caller Info attributes cause the compiler to write the proper value for each optional parameter decorated with a Caller Info attribute.
+Caller Info attributes can only be applied to optional parameters. The Caller Info attributes cause the compiler to write the proper value for each optional parameter decorated with a Caller Info attribute.
 
 Caller Info values are emitted as literals into the Intermediate Language (IL) at compile time. Unlike the results of the [StackTrace](/dotnet/api/system.diagnostics.stacktrace) property for exceptions, the results aren't affected by obfuscation.
 


### PR DESCRIPTION
## Summary
Make this sample work when called from C#

### TL;DR;
As it is, C# (respectively the C# compiler) does not understand how to handle e.g. parameters of type `option<string>` decorated with some `[CallerInfoX]` attribute. Instead we would need to supply some `FSharpOption<string>`. Marking the `option`al parameter `[<Optional>]` leads to an optional option, which is OK from C# perspective<sup>1</sup> but always `null`, i.e. `None`. I believe, we should have examples that work for F# and C# out-of-the-box. I'm happy to provide two samples including an explanation, if you think different.

<sup>1</sup> maybe the compiler should emit a warning if it encounters a [CallerInfo] attribute on a type it cannot supply?