### PR TITLE
Escape \ in table

### DIFF
--- a/docs/standard/base-types/custom-date-and-time-format-strings.md
+++ b/docs/standard/base-types/custom-date-and-time-format-strings.md
@@ -626,7 +626,7 @@ The following characters in a custom date and time format string are reserved an
 |F|H|K|M|d|
 |f|g|h|m|s|
 |t|y|z|%|:|
-|/|"|'|\||
+|/|"|'|&#92;||
 
 All other characters are always interpreted as character literals and, in a formatting operation, are included in the result string unchanged.  In a parsing operation, they must match the characters in the input string exactly; the comparison is case-sensitive.
 


### PR DESCRIPTION
Correctly escapes the `\` character in a table. (It seems `\\` doesn't work, at least in GitHub preview.)

To verify that this is actually supposed to be `\` (and not `|`, as is currently shown), I looked at [the relevant source code](https://github.com/dotnet/coreclr/blob/9a465e4/src/System.Private.CoreLib/shared/System/Globalization/DateTimeFormat.cs#L449) and it indeed handles `\` in a special way, but does not have any code for `|`.