### PR TITLE
Refer to external example class

### DIFF
--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -52,7 +52,7 @@ public enum Rainbow
 }
 ```
 
-You could convert a `Rainbow` value to its RGB values using the following method containing a switch expression:
+If your application defined an `RGBColor` type that is constructed from the `R`, `G` and `B` components, you could convert a `Rainbow` value to its RGB values using the following method containing a switch expression:
 
 ```csharp
 public static RGBColor FromRainbow(Rainbow colorBand) =>


### PR DESCRIPTION
Fixes #11584 

Add a phrase to clarify that the `RGBColor` class is not part of the displayed snippet.

