### PR TITLE
C76806: Missing spaces prevent italics tags rendering

### DIFF
--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -45,7 +45,7 @@ In Visual Studio, there are Visual Basic and C# console application templates fo
 
 From the command line, you can use either .NET Core and its CLI tools (for example, `dotnet new console` or `dotnet new console -lang vb`), or you can create the file and use the command-line compiler for a .NET Framework application.
 
-For a .NET Core project, you must reference the **System.Drawing.Common** NuGet package. In Visual Studio, use the NuGet Package Manager to install the package. Alternatively, you can add a reference to the package in your *.* csproj\* or *.* vbproj\* file:
+For a .NET Core project, you must reference the **System.Drawing.Common** NuGet package. In Visual Studio, use the NuGet Package Manager to install the package. Alternatively, you can add a reference to the package in your \*.csproj or \*.vbproj file:
  
 ```xml
 <ItemGroup>

--- a/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
+++ b/docs/standard/parallel-programming/how-to-write-a-simple-parallel-foreach-loop.md
@@ -45,7 +45,7 @@ In Visual Studio, there are Visual Basic and C# console application templates fo
 
 From the command line, you can use either .NET Core and its CLI tools (for example, `dotnet new console` or `dotnet new console -lang vb`), or you can create the file and use the command-line compiler for a .NET Framework application.
 
-For a .NET Core project, you must reference the **System.Drawing.Common** NuGet package. In Visual Studio, use the NuGet Package Manager to install the package. Alternatively, you can add a reference to the package in your *.*csproj* or *.*vbproj* file:
+For a .NET Core project, you must reference the **System.Drawing.Common** NuGet package. In Visual Studio, use the NuGet Package Manager to install the package. Alternatively, you can add a reference to the package in your *.* csproj\* or *.* vbproj\* file:
  
 ```xml
 <ItemGroup>


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.