### PR TITLE
Explain the `==` operator earlier in the tutorial.

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -96,17 +96,19 @@ You can test more complicated conditions. Add the following code in your `Main` 
 
 ```csharp
 int c = 4;
-if ((a + b + c > 10) && (a > b))
+if ((a + b + c > 10) && (a == b))
 {
     Console.WriteLine("The answer is greater than 10");
-    Console.WriteLine("And the first number is greater than the second");
+    Console.WriteLine("And the first number is equal to the second");
 }
 else
 {
     Console.WriteLine("The answer is not greater than 10");
-    Console.WriteLine("Or the first number is not greater than the second");
+    Console.WriteLine("Or the first number is not equal to the second");
 }
 ```
+
+The `==` symbol tests *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
 
 The `&&` represents "and". It means both conditions must be true to execute
 the statement in the true branch.  These examples also show that you can have multiple
@@ -115,17 +117,19 @@ statements in each conditional branch, provided you enclose them in `{` and `}`.
 You can also use  `||` to represent "or". Add the following code after what you've written so far:
 
 ```csharp
-if ((a + b + c > 10) || (a > b))
+if ((a + b + c > 10) || (a == b))
 {
     Console.WriteLine("The answer is greater than 10");
-    Console.WriteLine("Or the first number is greater than the second");
+    Console.WriteLine("Or the first number is equal to the second");
 }
 else
 {
     Console.WriteLine("The answer is not greater than 10");
-    Console.WriteLine("And the first number is not greater than the second");
+    Console.WriteLine("And the first number is not equal to the second");
 }
 ```
+
+Modify the values of `a`, `b`, and `c` and switch between `&&` and `||` to explore. You'll gain more understanding of how the `&&` and `||` operators work.
 
 You've finished the first step. Before you start the next section, let's move the current code into a separate method. That makes it easier to start working with a new example. Rename your `Main` method to `ExploreIf` and write a new `Main` method that calls `ExploreIf`. When you have finished, your code should look like this:
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -108,7 +108,7 @@ else
 }
 ```
 
-The `==` symbol tests *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
+The `==` symbol tests for *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
 
 The `&&` represents "and". It means both conditions must be true to execute
 the statement in the true branch.  These examples also show that you can have multiple

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -117,7 +117,7 @@ items:
     }
     ```
 
-    The `==` symbol tests *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
+    The `==` symbol tests for *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
 
     The `&&` represents "and". It means both conditions must be true to execute
     the statement in the true branch.  These examples also show that you can have multiple

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -105,17 +105,19 @@ items:
     int a = 5;
     int b = 3;
     int c = 4;
-    if ((a + b + c > 10) && (a > b))
+    if ((a + b + c > 10) && (a == b))
     {
         Console.WriteLine("The answer is greater than 10");
-        Console.WriteLine("And the first number is greater than the second");
+        Console.WriteLine("And the first number is equal to the second");
     }
     else
     {
         Console.WriteLine("The answer is not greater than 10");
-        Console.WriteLine("Or the first number is not greater than the second");
+        Console.WriteLine("Or the first number is not equal to the second");
     }
     ```
+
+    The `==` symbol tests *equality*. Using `==` distinguishes the test for equality from assignment, which you saw in `a = 5`.
 
     The `&&` represents "and". It means both conditions must be true to execute
     the statement in the true branch.  These examples also show that you can have multiple
@@ -127,17 +129,19 @@ items:
     int a = 5;
     int b = 3;
     int c = 4;
-    if ((a + b + c > 10) || (a > b))
+    if ((a + b + c > 10) || (a == b))
     {
         Console.WriteLine("The answer is greater than 10");
-        Console.WriteLine("Or the first number is greater than the second");
+        Console.WriteLine("Or the first number is equal to the second");
     }
     else
     {
         Console.WriteLine("The answer is not greater than 10");
-        Console.WriteLine("And the first number is not greater than the second");
+        Console.WriteLine("And the first number is not equal to the second");
     }
     ```
+
+    Modify the values of `a`, `b`, and `c` and switch between `&&` and `||` to explore. You'll gain more understanding of how the `&&` and `||` operators work.
 
     > [!NOTE]
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).


### PR DESCRIPTION
It's needed to make sure readers understand how to test for equality before the challenge (which uses it).

Fixes #10582
