### PR TITLE
Fixed broken link

### DIFF
--- a/docs/machine-learning/tutorials/index.md
+++ b/docs/machine-learning/tutorials/index.md
@@ -12,7 +12,7 @@ The following tutorials enable you to understand how to use [ML.NET](../index.md
 - [GitHub issue classification](github-issue-classification.md): demonstrates how to apply a **multiclass classification** task using ML.NET.
 - [Price predictor](taxi-fare.md): demonstrates how to apply a **regression** task using ML.NET.
 - [Iris clustering](iris-clustering.md): demonstrates how to apply a **clustering** task using ML.NET.
-- [Recommendation](movie-recommendation.md): generate movie **recommendations** based on previous user ratings
+- [Recommendation](movie-recommmendation.md): generate movie **recommendations** based on previous user ratings
 - [Image classification](image-classification.md): demonstrates how to retrain an existing Tensorflow model to create a custom image classifier using ML.NET.
 
 ## Next Steps


### PR DESCRIPTION
Fixed broken link in tutorials landing page

[Internal Review URL](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/tutorials/index?branch=pr-en-us-11752)