### PR TITLE
Add variant generic interfaces introduced in 4.5

### DIFF
--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
@@ -8,7 +8,7 @@ ms.assetid: 4828a8f9-48c0-4128-9749-7fcd6bf19a06
 
 .NET Framework 4 introduced variance support for several existing generic interfaces. Variance support enables implicit conversion of classes that implement these interfaces. 
 
-The following interfaces are now variant:
+Staring with .NET Framework 4, the following interfaces are variant:
 
 - <xref:System.Collections.Generic.IEnumerable%601> (T is covariant)
 

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
@@ -6,7 +6,9 @@ ms.assetid: 4828a8f9-48c0-4128-9749-7fcd6bf19a06
 
 # Variance in Generic Interfaces (C#)
 
-.NET Framework 4 introduced variance support for several existing generic interfaces. Variance support enables implicit conversion of classes that implement these interfaces. The following interfaces are now variant:
+.NET Framework 4 introduced variance support for several existing generic interfaces. Variance support enables implicit conversion of classes that implement these interfaces. 
+
+The following interfaces are now variant:
 
 - <xref:System.Collections.Generic.IEnumerable%601> (T is covariant)
 
@@ -21,6 +23,12 @@ ms.assetid: 4828a8f9-48c0-4128-9749-7fcd6bf19a06
 - <xref:System.Collections.Generic.IEqualityComparer%601> (T is contravariant)
 
 - <xref:System.IComparable%601> (T is contravariant)
+
+The following variant interfaces were added in .NET Framework 4.5:
+
+- <xref:System.Collections.Generic.IReadOnlyList%601> (T is contravariant)
+
+- <xref:System.Collections.Generic.IReadOnlyCollection%601> (T is contravariant)
 
 Covariance permits a method to have a more derived return type than that defined by the generic type parameter of the interface. To illustrate the covariance feature, consider these generic interfaces: `IEnumerable<Object>` and `IEnumerable<String>`. The `IEnumerable<String>` interface does not inherit the `IEnumerable<Object>` interface. However, the `String` type does inherit the `Object` type, and in some cases you may want to assign objects of these interfaces to each other. This is shown in the following code example.
 

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Variance in Generic Interfaces (C#)"
-ms.date: 07/20/2015
+ms.date: 04/10/2019
 ms.assetid: 4828a8f9-48c0-4128-9749-7fcd6bf19a06
 ---
 
@@ -37,7 +37,7 @@ IEnumerable<String> strings = new List<String>();
 IEnumerable<Object> objects = strings;
 ```
 
-In earlier versions of the .NET Framework, this code causes a compilation error in C# with `Option Strict On`. But now you can use `strings` instead of `objects`, as shown in the previous example, because the <xref:System.Collections.Generic.IEnumerable%601> interface is covariant.
+In earlier versions of the .NET Framework, this code causes a compilation error in C# and, if `Option Strict` is on, in Visual Basic. But now you can use `strings` instead of `objects`, as shown in the previous example, because the <xref:System.Collections.Generic.IEnumerable%601> interface is covariant.
 
 Contravariance permits a method to have argument types that are less derived than that specified by the generic parameter of the interface. To illustrate contravariance, assume that you have created a `BaseComparer` class to compare instances of the `BaseClass` class. The `BaseComparer` class implements the `IEqualityComparer<BaseClass>` interface. Because the <xref:System.Collections.Generic.IEqualityComparer%601> interface is now contravariant, you can use `BaseComparer` to compare instances of classes that inherit the `BaseClass` class. This is shown in the following code example.
 

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
@@ -24,7 +24,7 @@ Staring with .NET Framework 4, the following interfaces are variant:
 
 - <xref:System.IComparable%601> (T is contravariant)
 
-The following variant interfaces were added in .NET Framework 4.5:
+Starting with .NET Framework 4.5, the following interfaces are variant:
 
 - <xref:System.Collections.Generic.IReadOnlyList%601> (T is contravariant)
 


### PR DESCRIPTION
Many places introduce this page as "For the list of the variant interfaces in the .NET Framework, see Variance in Generic Interfaces (C#)." so I am thinking it would be nice to include the two new ones introduced in .NET Framework 4.5.