### PR TITLE
Update charset.md for changes in .NET Core 3.0

### DIFF
--- a/docs/standard/native-interop/charset.md
+++ b/docs/standard/native-interop/charset.md
@@ -12,7 +12,7 @@ The way `char` values, `string` objects, and `System.Text.StringBuilder` objects
 
 The following table shows a mapping between each charset and how a character or string is represented when marshalled with that charset:
 
-| CharSet | Windows            | Unix (.NET Core before 3.0) | Mono and .NET Core 3.0 and later on Unix |
+| CharSet | Windows            | Unix on .NET Core 2.2 and earlier | Mono and Unix on .NET Core 3.0 and later |
 |---------|--------------------|-----------------------------|------------------------------------------|
 | Ansi    | `char` (ANSI)      | `char` (UTF-8)              | `char` (UTF-8)                           |
 | Unicode | `wchar_t` (UTF-16) | `char16_t` (UTF-16)         | `char16_t` (UTF-16)                      |

--- a/docs/standard/native-interop/charset.md
+++ b/docs/standard/native-interop/charset.md
@@ -12,10 +12,10 @@ The way `char` values, `string` objects, and `System.Text.StringBuilder` objects
 
 The following table shows a mapping between each charset and how a character or string is represented when marshalled with that charset:
 
-| CharSet | Windows            | Unix                                   | Mono on Unix        |
-|---------|--------------------|----------------------------------------|---------------------|
-| Ansi    | `char` (ANSI)      | `char` (ANSI on macOS, UTF-8 on Linux) | `char` (UTF-8)      |
-| Unicode | `wchar_t` (UTF-16) | `char16_t` (UTF-16)                    | `char16_t` (UTF-16) |
-| Auto    | `wchar_t` (UTF-16) | `char16_t` (UTF-16)                    | `char` (UTF-8)      |
+| CharSet | Windows            | Unix (.NET Core before 3.0) | Mono and .NET Core 3.0 and later on Unix |
+|---------|--------------------|-----------------------------|------------------------------------------|
+| Ansi    | `char` (ANSI)      | `char` (UTF-8)              | `char` (UTF-8)                           |
+| Unicode | `wchar_t` (UTF-16) | `char16_t` (UTF-16)         | `char16_t` (UTF-16)                      |
+| Auto    | `wchar_t` (UTF-16) | `char16_t` (UTF-16)         | `char` (UTF-8)                           |
 
 Make sure you know what representation your native representation expects when picking your charset.


### PR DESCRIPTION
In .NET Core 3.0, we have changed the meaning of `CharSet.Auto` to match Mono's behavior cross-platform. This PR updates the docs to reflect that behavior change.