### PR TITLE
Invalid dockerfile

### DIFF
--- a/docs/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow.md
+++ b/docs/standard/microservices-architecture/docker-application-development-process/docker-app-development-workflow.md
@@ -187,14 +187,14 @@ The initial Dockerfile might look something like this:
 17  RUN dotnet restore src/Services/Catalog/Catalog.API/Catalog.API.csproj
 18  COPY . .
 19  WORKDIR /src/src/Services/Catalog/Catalog.API
-20  RUN dotnet build Catalog.API.csproj -c Release -0 /app
+20  RUN dotnet build Catalog.API.csproj -c Release -o /app
 21
 22  FROM build AS publish
-23  RUN dotnet publish Catalog.API.csproj -c Release -0 /app
+23  RUN dotnet publish Catalog.API.csproj -c Release -o /app
 24
 25  FROM base AS final
 26  WORKDIR /app
-27  COPY --from=publish /app
+27  COPY --from=publish /app .
 28  ENTRYPOINT ["dotnet", "Catalog.API.dll"]
 ```
 


### PR DESCRIPTION
When reading a part of this document I noticed that the dockerfile example appears to be invalid.

I believe -0 is meant to be -o to define the output directory for the build and publish steps.

Also, the final stage copy should include the destination for the copy.

## Summary
This PR includes fixes for these points.

NOTE: I incorrectly stated dockercompose in the commit, it should be dockerfile!