### PR TITLE
Add mnemonic device to C# ?: operator docs

### DIFF
--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -38,7 +38,7 @@ is evaluated as
 a ? b : (c ? d : e)
 ```
 
-A handy [mnemonic device](https://www.google.com/search?q=mnemonic+device&rlz=1C1CHBF_enUS811US811&oq=mnemonic+device&aqs=chrome..69i57j69i61j0l4.2439j0j7&sourceid=chrome&ie=UTF-8) you can use to remember how this operator evaluates is by asking: `is this cond true ? yes : no`, with the ? part of the operator acting as a question mark for the previous statement, and the consequent acting as the logical response to this question.
+A handy mnemonic device you can use to remember how this operator evaluates is by asking: `is this cond true ? yes : no`, with the ? part of the operator acting as a question mark for the previous statement, and the consequent acting as the logical response to this question.
 
 The following example demonstrates the usage of the conditional operator:
 

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -38,7 +38,11 @@ is evaluated as
 a ? b : (c ? d : e)
 ```
 
-A handy mnemonic device you can use to remember how this operator evaluates is by asking: `is this cond true ? yes : no`, with the ? part of the operator acting as a question mark for the previous statement, and the consequent acting as the logical response to this question.
+A handy mnemonic device you can use to remember how this operator evaluates is by asking: 
+```
+is this condition true ? yes : no
+```
+with the ? part of the operator acting as a question mark for the previous statement, and the consequent acting as the logical response to this question.
 
 The following example demonstrates the usage of the conditional operator:
 

--- a/docs/csharp/language-reference/operators/conditional-operator.md
+++ b/docs/csharp/language-reference/operators/conditional-operator.md
@@ -38,6 +38,8 @@ is evaluated as
 a ? b : (c ? d : e)
 ```
 
+A handy [mnemonic device](https://www.google.com/search?q=mnemonic+device&rlz=1C1CHBF_enUS811US811&oq=mnemonic+device&aqs=chrome..69i57j69i61j0l4.2439j0j7&sourceid=chrome&ie=UTF-8) you can use to remember how this operator evaluates is by asking: `is this cond true ? yes : no`, with the ? part of the operator acting as a question mark for the previous statement, and the consequent acting as the logical response to this question.
+
 The following example demonstrates the usage of the conditional operator:
 
 [!code-csharp[non ref conditional](~/samples/snippets/csharp/language-reference/operators/ConditionalExamples.cs#ConditionalValue)]


### PR DESCRIPTION
## Summary

Added a mnemonic device to help retention of how the C# ?: operator evaluates. The language could use some refining as it is quite informal, but I figured it would be best to get input from others on this instead of trying to struggle through it myself.

Fixes #11802, Here's the PR @BillWagner 
