### PR TITLE
fix: MD031/blanks-around-fences

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,7 +14,6 @@
     "MD028": false,
     "MD029": false,
     "MD030": false,
-    "MD031": false,
     "MD032": false,
     "MD033": {
         "allowed_elements": [

--- a/docs/core/additional-tools/dotnet-svcutil-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil-guide.md
@@ -60,6 +60,7 @@ dotnet new web
 
 3. Install the [`dotnet-svcutil` NuGet package](https://nuget.org/packages/dotnet-svcutil) as a CLI tool:
 # [dotnet-svcutil 2.x](#tab/dotnetsvcutil2x)
+
 ```console
 dotnet tool install --global dotnet-svcutil
 ```
@@ -83,14 +84,17 @@ dotnet restore
 
 4. Run the _dotnet-svcutil_ command to generate the web service reference file as follows:
 # [dotnet-svcutil 2.x](#tab/dotnetsvcutil2x)
+
 ```console
 dotnet-svcutil http://contoso.com/SayHello.svc
 ```
 
 # [dotnet-svcutil 1.x](#tab/dotnetsvcutil1x)
+
 ```console
 dotnet svcutil http://contoso.com/SayHello.svc
 ```
+
 ---
 
 The generated file is saved as _HelloSvcutil/ServiceReference/Reference.cs_. The _dotnet-svcutil_ tool also adds to the project the appropriate WCF packages required by the proxy code as package references.
@@ -144,14 +148,17 @@ You should see the following output:
 
 For a detailed description of the `dotnet-svcutil` tool parameters, invoke the tool passing the help parameter as follows:
 # [dotnet-svcutil 2.x](#tab/dotnetsvcutil2x)
+
 ```console
 dotnet-svcutil --help
 ```
 
 # [dotnet-svcutil 1.x](#tab/dotnetsvcutil1x)
+
 ```console
 dotnet svcutil --help
 ```
+
 ---
 
 ## Feedback & questions

--- a/docs/core/tools/dependencies.md
+++ b/docs/core/tools/dependencies.md
@@ -40,6 +40,7 @@ In this example we will use the default template that is dropped by `dotnet new 
 ```xml
 <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
 ```
+
 After this, we save the project and run the `dotnet restore` command to install the dependency. 
 
 [!INCLUDE[DotNet Restore Note](~/includes/dotnet-restore-note.md)]

--- a/docs/core/tools/dotnet-build.md
+++ b/docs/core/tools/dotnet-build.md
@@ -14,19 +14,23 @@ ms.date: 12/04/2018
 ## Synopsis
 
 # [.NET Core 2.x](#tab/netcore2x)
+
 ```
 dotnet build [<PROJECT>|<SOLUTION>] [-c|--configuration] [-f|--framework] [--force] [--no-dependencies] [--no-incremental]
     [--no-restore] [-o|--output] [-r|--runtime] [-v|--verbosity] [--version-suffix]
 
 dotnet build [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet build [<PROJECT>|<SOLUTION>] [-c|--configuration] [-f|--framework] [--no-dependencies] [--no-incremental] [-o|--output]
     [-r|--runtime] [-v|--verbosity] [--version-suffix]
 
 dotnet build [-h|--help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet-nuget-delete.md
+++ b/docs/core/tools/dotnet-nuget-delete.md
@@ -15,17 +15,21 @@ ms.date: 12/04/2018
 ## Synopsis
 
 # [.NET Core 2.x](#tab/netcore2x)
+
 ```
 dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [--interactive] [-k|--api-key] [--no-service-endpoint]
     [--non-interactive] [-s|--source]
 dotnet nuget delete [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet nuget delete [<PACKAGE_NAME> <PACKAGE_VERSION>] [--force-english-output] [-k|--api-key] [--non-interactive]
     [-s|--source]
 dotnet nuget delete [-h|--help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet-nuget-push.md
+++ b/docs/core/tools/dotnet-nuget-push.md
@@ -15,17 +15,21 @@ ms.date: 12/04/2018
 ## Synopsis
 
 # [.NET Core 2.x](#tab/netcore2x)
+
 ```
 dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [--interactive] [-k|--api-key] [-n|--no-symbols]
     [--no-service-endpoint] [-s|--source] [-sk|--symbol-api-key] [-ss|--symbol-source] [-t|--timeout]
 dotnet nuget push [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet nuget push [<ROOT>] [-d|--disable-buffering] [--force-english-output] [-k|--api-key] [-n|--no-symbols]
     [-s|--source] [-sk|--symbol-api-key] [-ss|--symbol-source] [-t|--timeout]
 dotnet nuget push [-h|--help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet-pack.md
+++ b/docs/core/tools/dotnet-pack.md
@@ -14,17 +14,21 @@ ms.date: 12/04/2018
 ## Synopsis
 
 # [.NET Core 2.x](#tab/netcore2x)
+
 ```
 dotnet pack [<PROJECT>] [-c|--configuration] [--force] [--include-source] [--include-symbols] [--no-build] [--no-dependencies]
     [--no-restore] [-o|--output] [--runtime] [-s|--serviceable] [-v|--verbosity] [--version-suffix]
 dotnet pack [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet pack [<PROJECT>] [-c|--configuration] [--include-source] [--include-symbols] [--no-build] [-o|--output]
     [-s|--serviceable] [-v|--verbosity] [--version-suffix]
 dotnet pack [-h|--help]
 ```
+
 ---
 
 ## Description
@@ -103,6 +107,7 @@ You can provide MSBuild properties to the `dotnet pack` command for the packing 
 
 > [!NOTE]
 > Web projects aren't packable by default. To override the default behavior, add the following property to your *.csproj* file:
+>
 > ```xml
 > <PropertyGroup>
 >    <IsPackable>true</IsPackable>

--- a/docs/core/tools/dotnet-publish.md
+++ b/docs/core/tools/dotnet-publish.md
@@ -14,23 +14,29 @@ ms.date: 05/29/2018
 ## Synopsis
 
 # [.NET Core 2.1](#tab/netcore21)
+
 ```
 dotnet publish [<PROJECT>] [-c|--configuration] [-f|--framework] [--force] [--manifest] [--no-build] [--no-dependencies]
     [--no-restore] [-o|--output] [-r|--runtime] [--self-contained] [-v|--verbosity] [--version-suffix]
 dotnet publish [-h|--help]
 ```
+
 # [.NET Core 2.0](#tab/netcore20)
+
 ```
 dotnet publish [<PROJECT>] [-c|--configuration] [-f|--framework] [--force] [--manifest] [--no-dependencies]
     [--no-restore] [-o|--output] [-r|--runtime] [--self-contained] [-v|--verbosity] [--version-suffix]
 dotnet publish [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet publish [<PROJECT>] [-c|--configuration] [-f|--framework] [-o|--output] [-r|--runtime] [-v|--verbosity]
     [--version-suffix]
 dotnet publish [-h|--help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet-restore.md
+++ b/docs/core/tools/dotnet-restore.md
@@ -14,17 +14,21 @@ ms.date: 05/29/2018
 ## Synopsis
 
 # [.NET Core 2.x](#tab/netcore2x)
+
 ```
 dotnet restore [<ROOT>] [--configfile] [--disable-parallel] [--force] [--ignore-failed-sources] [--no-cache]
     [--no-dependencies] [--packages] [-r|--runtime] [-s|--source] [-v|--verbosity] [--interactive]
 dotnet restore [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet restore [<ROOT>] [--configfile] [--disable-parallel] [--ignore-failed-sources] [--no-cache]
     [--no-dependencies] [--packages] [-r|--runtime] [-s|--source] [-v|--verbosity]
 dotnet restore [-h|--help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet-run.md
+++ b/docs/core/tools/dotnet-run.md
@@ -14,22 +14,28 @@ ms.date: 05/29/2018
 ## Synopsis
 
 # [.NET Core 2.1](#tab/netcore21)
+
 ```
 dotnet run [-c|--configuration] [-f|--framework] [--force] [--launch-profile] [--no-build] [--no-dependencies]
     [--no-launch-profile] [--no-restore] [-p|--project] [--runtime] [-v|--verbosity] [[--] [application arguments]]
 dotnet run [-h|--help]
 ```
+
 # [.NET Core 2.0](#tab/netcore20)
+
 ```
 dotnet run [-c|--configuration] [-f|--framework] [--force] [--launch-profile] [--no-build] [--no-dependencies]
     [--no-launch-profile] [--no-restore] [-p|--project] [--runtime] [[--] [application arguments]]
 dotnet run [-h|--help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet run [-c|--configuration] [-f|--framework] [-p|--project] [[--] [application arguments]]
 dotnet run [-h|--help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet-vstest.md
+++ b/docs/core/tools/dotnet-vstest.md
@@ -15,24 +15,30 @@ ms.date: 05/30/2018
 ## Synopsis
 
 # [.NET Core 2.1](#tab/netcore21)
+
 ```
 dotnet vstest [<TEST_FILE_NAMES>] [--Settings|/Settings] [--Tests|/Tests] [--TestAdapterPath|/TestAdapterPath]
     [--Platform|/Platform] [--Framework|/Framework] [--Parallel|/Parallel] [--TestCaseFilter|/TestCaseFilter] [--logger|/logger]
     [-lt|--ListTests|/lt|/ListTests] [--ParentProcessId|/ParentProcessId] [--Port|/Port] [--Diag|/Diag] [--Blame|/Blame] [--InIsolation|/InIsolation]
     [[--] <args>...]] [-?|--Help|/?|/Help]
 ```
+
 # [.NET Core 2.0](#tab/netcore20)
+
 ```
 dotnet vstest [<TEST_FILE_NAMES>] [--Settings|/Settings] [--Tests|/Tests] [--TestAdapterPath|/TestAdapterPath] 
     [--Platform|/Platform] [--Framework|/Framework] [--Parallel|/Parallel] [--TestCaseFilter|/TestCaseFilter] [--logger|/logger]
     [-lt|--ListTests|/lt|/ListTests] [--ParentProcessId|/ParentProcessId] [--Port|/Port] [--Diag|/Diag] [[--] <args>...]] [-?|--Help|/?|/Help]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet vstest [<TEST_FILE_NAMES>] [--Settings|/Settings] [--Tests|/Tests] [--TestAdapterPath|/TestAdapterPath]
     [--Platform|/Platform] [--Framework|/Framework] [--Parallel|/Parallel] [--TestCaseFilter|/TestCaseFilter] [--logger|/logger] 
     [-lt|--ListTests|/lt|/ListTests] [--ParentProcessId|/ParentProcessId] [--Port|/Port] [--Diag|/Diag] [[--] <args>...]] [-?|--Help|/?|/Help]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -14,20 +14,26 @@ ms.date: 06/04/2018
 ## Synopsis
 
 # [.NET Core 2.1](#tab/netcore21)
+
 ```
 dotnet [command] [arguments] [--additional-deps] [--additionalprobingpath] [-d|--diagnostics] [--fx-version]
     [-h|--help] [--info] [--list-runtimes] [--list-sdks] [--roll-forward-on-no-candidate-fx] [-v|--verbosity] [--version]
 ```
+
 # [.NET Core 2.0](#tab/netcore20)
+
 ```
 dotnet [command] [arguments] [--additional-deps] [--additionalprobingpath] [-d|--diagnostics]
     [--fx-version] [-h|--help] [--info] [--roll-forward-on-no-candidate-fx] [-v|--verbosity] [--version]
 ```
+
 # [.NET Core 1.x](#tab/netcore1x)
+
 ```
 dotnet [command] [arguments] [--additionalprobingpath] [-d|--diagnostics] [--fx-version]
     [-h|--help] [--info] [-v|--verbosity] [--version]
 ```
+
 ---
 
 ## Description

--- a/docs/core/tutorials/debugging-with-visual-studio.md
+++ b/docs/core/tutorials/debugging-with-visual-studio.md
@@ -148,6 +148,7 @@ To set a conditional breakpoint and test what happens when the user fails to ent
    ```vb
    ? String.IsNullOrEmpty(name)
    ```
+
   ![Immediate Window returning a value of true after the statement is executed - Visual Basic](./media/debugging-with-visual-studio/vb-immediate-window-output.png)
 
 1. Select the **Continue** button on the toolbar to continue program execution.

--- a/docs/core/tutorials/testing-library-with-visual-studio.md
+++ b/docs/core/tutorials/testing-library-with-visual-studio.md
@@ -144,11 +144,13 @@ Your test run had no failures, but change it slightly so that one of the test me
    string[] words = { "alphabet", "Error", "zebra", "abc", "αυτοκινητοβιομηχανία", "государство",
                       "1234", ".", ";", " " };
    ```
+
    ```vb
    Dim words() As String = { "alphabet", "Error", "zebra", "abc", "αυτοκινητοβιομηχανία", "государство",
                       "1234", ".", ";", " " }
 
    ```
+
 1. Run the test by selecting **Test** > **Run** > **All Tests** from the menu bar. The **Test Explorer** window indicates that two tests succeeded and one failed.
 
    ![Test Explorer window with failing tests](./media/testing-library-with-visual-studio/failed-test-window.png)

--- a/docs/core/tutorials/vb-with-visual-studio.md
+++ b/docs/core/tutorials/vb-with-visual-studio.md
@@ -4,7 +4,7 @@ description: Learn how to build a simple .NET Core console application with Visu
 author: rpetrusha
 ms.author: ronpet
 ms.date: 08/07/2017
-dev_langs: 
+dev_langs:
   - "vb"
 ms.custom: "vs-dotnet, seodec18"
 ---
@@ -25,7 +25,7 @@ Begin by creating a simple "Hello World" console application. Follow these steps
 1. Launch Visual Studio 2017. Select **File** > **New** > **Project** from the menu bar. In the *New Project** dialog, select the **Visual Basic** node followed by the **.NET Core** node. Then select the **Console App (.NET Core)** project template. In the **Name** text box, type "HelloWorld". Select the **OK** button.
 
    ![New Project dialog with Console App selected](./media/vb-with-visual-studio/visual-studio-new-project.png)
-   
+
 1. Visual Studio uses the template to create your project. The Visual Basic Console Application template for .NET Core automatically defines a class, `Program`, with a single method, `Main`, that takes a <xref:System.String> array as an argument. `Main` is the application entry point, the method that's called automatically by the runtime when it launches the application. Any command-line arguments supplied when the application is launched are available in the *args* array.
 
    ![Visual Studio and the new HelloWorld project](./media/vb-with-visual-studio/visual-studio-main-window.png)
@@ -38,6 +38,7 @@ Begin by creating a simple "Hello World" console application. Follow these steps
    Console.Write("Press any key to continue...")
    Console.ReadKey(true)
    ```
+
    This code prompts the user to press any key and then pauses the program until a key is pressed.
 
 1. On the menu bar, select **Build** > **Build Solution**. This compiles your program into an intermediate language (IL) that's converted into binary code by a just-in-time (JIT) compiler.

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -87,6 +87,7 @@ You can also watch a short video tutorial for further setup help on [Windows](ht
 1. To add a new class right-click in the VSCode Explorer and select **New File**. This adds a new file to the folder you have open in VSCode.
 2. Name your file `MyClass.cs`. You must save it with a `.cs` extension at the end for it to be recognized as a csharp file.
 3. Add the code below to create your first class. Make sure to include the correct namespace so you can reference it from your `Program.cs` file.
+
 ``` csharp
 using System;
 
@@ -121,6 +122,7 @@ namespace HelloWorld
 ```
 
 5. Save your changes and run your program again. The new message should appear with the appended string.
+
 ```console
 > dotnet run
 Hello World! Happy coding!

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -23,7 +23,7 @@ Begin by creating a simple "Hello World" console application. Follow these steps
 1. Launch Visual Studio 2017. Select **File** > **New** > **Project** from the menu bar. In the *New Project** dialog, select the **Visual C#** node followed by the **.NET Core** node. Then select the **Console App (.NET Core)** project template. In the **Name** text box, type "HelloWorld". Select the **OK** button.
 
    ![New Project dialog with Console App selected](./media/with-visual-studio/visual-studio-new-project.png)
-   
+
 1. Visual Studio uses the template to create your project. The C# Console Application template for .NET Core automatically defines a class, `Program`, with a single method, `Main`, that takes a <xref:System.String> array as an argument. `Main` is the application entry point, the method that's called automatically by the runtime when it launches the application. Any command-line arguments supplied when the application is launched are available in the *args* array.
 
    ![Visual Studio and the new HelloWorld project](./media/with-visual-studio/visual-studio-main-window.png)
@@ -36,6 +36,7 @@ Begin by creating a simple "Hello World" console application. Follow these steps
    Console.Write("Press any key to continue...");
    Console.ReadKey(true);
    ```
+
    This code prompts the user to press any key and then pauses the program until a key is pressed.
 
 1. On the menu bar, select **Build** > **Build Solution**. This compiles your program into an intermediate language (IL) that's converted into binary code by a just-in-time (JIT) compiler.

--- a/docs/core/whats-new/dotnet-core-3-0.md
+++ b/docs/core/whats-new/dotnet-core-3-0.md
@@ -1,7 +1,7 @@
 ---
 title: What's new in .NET Core 3.0
 description: Learn about the new features found in .NET Core 3.0.
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
 author: thraka
@@ -58,7 +58,7 @@ async IAsyncEnumerable<int> GetBigResultsAsync()
 {
     await foreach (var result in GetResultsAsync())
     {
-        if (result > 20) yield return result; 
+        if (result > 20) yield return result;
     }
 }
 ```
@@ -161,20 +161,20 @@ During `dotnet build` or `dotnet publish`, an executable is created provided tha
 
 ## Build copies dependencies
 
-`dotnet build` now copies NuGet dependencies for your application from the NuGet cache to the build output folder. Previously, dependencies were only copied as part of `dotnet publish`. 
+`dotnet build` now copies NuGet dependencies for your application from the NuGet cache to the build output folder. Previously, dependencies were only copied as part of `dotnet publish`.
 
 There are some operations, like linking and razor page publishing that will still require publishing.
 
 ## Local dotnet tools
 
->[!WARNING]
->There was a change in .NET Core Local Tools between .NET Core 3.0 Preview 1 and .NET Core 3.0 Preview 2.  If you tried out local tools in Preview 1 by running a command like `dotnet tool restore` or `dotnet tool install`, you need to delete your local tools cache folder before local tools will work correctly in Preview 2. This folder is located at:
+> [!WARNING]
+> There was a change in .NET Core Local Tools between .NET Core 3.0 Preview 1 and .NET Core 3.0 Preview 2.  If you tried out local tools in Preview 1 by running a command like `dotnet tool restore` or `dotnet tool install`, you need to delete your local tools cache folder before local tools will work correctly in Preview 2. This folder is located at:
 >
->On mac, Linux: `rm -r $HOME/.dotnet/toolResolverCache`
+> On mac, Linux: `rm -r $HOME/.dotnet/toolResolverCache`
 >
->On Windows: `rmdir /s %USERPROFILE%\.dotnet\toolResolverCache`
+> On Windows: `rmdir /s %USERPROFILE%\.dotnet\toolResolverCache`
 >
->If you do not delete this folder, you will receive an error.
+> If you do not delete this folder, you will receive an error.
 
 While .NET Core 2.1 supported global tools, .NET Core 3.0 now has local tools. Local tools are similar to global tools but are associated with a particular location on disk. This enables per-project and per-repository tooling. Any tool installed locally isn't available globally. Tools are distributed as NuGet packages.
 
@@ -304,10 +304,12 @@ Please share your feedback on the [dotnet/winforms](https://github.com/dotnet/wi
 
 The [Windows Application Packaging Project](https://docs.microsoft.com/windows/uwp/porting/desktop-to-uwp-packaging-dot-net), available in Visual Studio 2019, allows you to create MSIX packages with [self-contained](../deploying/index.md#self-contained-deployments-scd) .NET Core applications.
 
->Note: The .NET Core project file must specify the supported runtimes in the `<RuntimeIdentifiers>` property:
-```xml
-<RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
-```
+> [!NOTE]
+> The .NET Core project file must specify the supported runtimes in the `<RuntimeIdentifiers>` property:
+>
+> ```xml
+> <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+> ```
 
 ## Fast built-in JSON support
 
@@ -461,7 +463,7 @@ Assembly unloadability is a new capability of `AssemblyLoadContext`. This new fe
 
 This new capability can be used for scenarios similar to:
 
-* Plugin scenarios where dynamic plugin loading and unloading is required. 
+* Plugin scenarios where dynamic plugin loading and unloading is required.
 * Dynamically compiling, running and then flushing code. Useful for web sites, scripting engines, etc.
 * Loading assemblies for introspection (like ReflectionOnlyLoad), although [MetadataLoadContext](#type-metadataloadcontext) (released in Preview 1) will be a better choice in many cases.
 
@@ -479,7 +481,7 @@ You can see an example of using COM with the [Excel Demo source code](https://gi
 
 ## Type: SequenceReader
 
-In .NET Core 3.0, `System.Buffers.SequenceReader` has been added which can be used as a reader for `ReadOnlySequence<T>`. This allows easy, high performance, low allocation parsing of `System.IO.Pipelines` data that can cross multiple backing buffers. 
+In .NET Core 3.0, `System.Buffers.SequenceReader` has been added which can be used as a reader for `ReadOnlySequence<T>`. This allows easy, high performance, low allocation parsing of `System.IO.Pipelines` data that can cross multiple backing buffers.
 
 The following example breaks an input `Sequence` into valid `CR/LF` delimited lines:
 
@@ -658,7 +660,7 @@ namespace rsakeyprint
             {
                 byte[] keyBytes = File.ReadAllBytes(args[0]);
                 rsa.ImportRSAPrivateKey(keyBytes, out int bytesRead);
- 
+
                 Console.WriteLine($"Read {bytesRead} bytes, {keyBytes.Length-bytesRead} extra byte(s) in file.");
                 RSAParameters rsaParameters = rsa.ExportParameters(true);
                 Console.WriteLine(BitConverter.ToString(rsaParameters.D));
@@ -704,7 +706,7 @@ Previously, .NET Core only supported using the `SerialPort` type on Windows.
 
 ## More BCL Improvements
 
-The `Span<T>`, `Memory<T>`, and related types that were introduced in .NET Core 2.1, have been optimized in .NET Core 3.0. Common operations such as span construction, slicing, parsing, and formatting now perform better. 
+The `Span<T>`, `Memory<T>`, and related types that were introduced in .NET Core 2.1, have been optimized in .NET Core 3.0. Common operations such as span construction, slicing, parsing, and formatting now perform better.
 
 Additionally, types like `String` have seen under-the-cover improvements to make them more efficient when used as keys with `Dictionary<TKey, TValue>` and other collections. No code changes are required to benefit from these improvements.
 
@@ -746,7 +748,7 @@ After configuring Snap on your system, run the following command to install the 
 ```console
 sudo snap install dotnet-sdk --beta --classic
 ```
- 
+
 When .NET Core in installed using the Snap package, the default .NET Core command is `dotnet-sdk.dotnet`, as opposed to just `dotnet`. The benefit of the namespaced command is that it will not conflict with a globally installed .NET Core version you may have. This command can be aliased to `dotnet` with:
 
 ```console

--- a/docs/csharp/expression-trees-explained.md
+++ b/docs/csharp/expression-trees-explained.md
@@ -25,6 +25,7 @@ Here's a line of code:
 ```csharp
 var sum = 1 + 2;
 ```
+
 If you were to analyze this as an expression tree, the tree contains several nodes.
 The outermost node is a variable declaration statement with assignment (`var sum = 1 + 2;`)
 That outermost node contains several child nodes: a variable declaration, an assignment operator, and an

--- a/docs/csharp/iterators.md
+++ b/docs/csharp/iterators.md
@@ -9,7 +9,7 @@ ms.assetid: 5cf36f45-f91a-4fca-a0b7-87f233e108e9
 
 Almost every program you write will have some need to iterate
 over a collection. You'll write code that examines every item in
-a collection. 
+a collection.
 
 You'll also create iterator methods which are methods that produces an
 iterator for the elements of that class. These can be used for:
@@ -31,7 +31,7 @@ This tutorial has multiple steps. After each step, you can run the application a
 Enumerating a collection is simple: The `foreach` keyword enumerates
 a collection, executing the embedded statement once for each element
 in the collection:
- 
+
 ```csharp
 foreach (var item in collection)
 {
@@ -45,7 +45,7 @@ though. It relies on two generic interfaces defined in the .NET core library in 
 to generate the code necessary to iterate a collection: `IEnumerable<T>` and
 `IEnumerator<T>`. This mechanism is explained in more detail below.
 
-Both of these interfaces also have non-generic counterparts: `IEnumerable` and 
+Both of these interfaces also have non-generic counterparts: `IEnumerable` and
 `IEnumerator`. The [generic](programming-guide/generics/index.md) versions are preferred for modern code.
 
 ## Enumeration sources with iterator methods
@@ -53,7 +53,7 @@ Both of these interfaces also have non-generic counterparts: `IEnumerable` and
 Another great feature of the C# language enables you to build methods that create
 a source for an enumeration. These are referred to as *iterator methods*. An iterator
 method defines how to generate the objects in a sequence when requested. You
-use the `yield return` contextual keywords to define an iterator method. 
+use the `yield return` contextual keywords to define an iterator method.
 
 You could write this method to produce the sequence of integers from 0 through 9:
 
@@ -97,9 +97,9 @@ public IEnumerable<int> GetSingleDigitNumbers()
     int index = 0;
     while (index++ < 10)
         yield return index;
-        
+
     yield return 50;
-    
+
     index = 100;
     while (index++ < 110)
         yield return index;
@@ -134,12 +134,12 @@ public IEnumerable<int> GetSingleDigitNumbers()
     int index = 0;
     while (index++ < 10)
         yield return index;
-        
+
     yield return 50;
-   
-    // generates a compile time error: 
+
+    // generates a compile time error:
     var items = new int[] {100, 101, 102, 103, 104, 105, 106, 107, 108, 109 };
-    return items;  
+    return items;
 }
 ```
 
@@ -155,15 +155,15 @@ public IEnumerable<int> GetSingleDigitNumbers()
     int index = 0;
     while (index++ < 10)
         yield return index;
-        
+
     yield return 50;
-   
+
     var items = new int[] {100, 101, 102, 103, 104, 105, 106, 107, 108, 109 };
     foreach (var item in items)
         yield return item;
 }
 ```
- 
+
 Sometimes, the right answer is to split an iterator method into two different
 methods. One that uses `return`, and a second that uses `yield return`. Consider
 a situation where you might want to return an empty collection, or the first 5
@@ -187,7 +187,7 @@ private IEnumerable<int> IteratorMethod()
             yield return index;
 }
 ```
- 
+
 Look at the methods above. The first uses the standard `return` statement to return
 either an empty collection, or the iterator created by the second method. The second
 method uses the `yield return` statement to create the requested sequence.
@@ -197,7 +197,7 @@ method uses the `yield return` statement to create the requested sequence.
 The `foreach` statement expands into a standard idiom that uses the
 `IEnumerable<T>` and `IEnumerator<T>` interfaces to iterate across all
 elements of a collection. It also  minimizes errors developers make
-by not properly managing resources. 
+by not properly managing resources.
 
 The compiler translates the `foreach` loop shown in the first
 example into something similar to this construct:
@@ -235,14 +235,14 @@ the `IDisposable` interface. The full expansion generates code more like this:
 ```csharp
 {
     var enumerator = collection.GetEnumerator();
-    try 
+    try
     {
         while (enumerator.MoveNext())
         {
             var item = enumerator.Current;
             Console.WriteLine(item.ToString());
         }
-    } finally 
+    } finally
     {
         // dispose of enumerator.
     }
@@ -253,31 +253,32 @@ The manner in which the enumerator is disposed of depends on the characteristics
 the type of `enumerator`. In the general case, the `finally` clause expands to:
 
 ```csharp
-finally 
+finally
 {
    (enumerator as IDisposable)?.Dispose();
-} 
+}
 ```
 
 However, if the type of `enumerator` is a sealed type and there is no implicit
 conversion from the type of `enumerator` to `IDisposable`, the `finally` clause
 expands to an empty block:
+
 ```csharp
-finally 
+finally
 {
-} 
+}
 ```
 
 If there is an implicit conversion from the type of `enumerator` to `IDisposable`,
 and `enumerator` is a non-nullable value type, the `finally` clause expands to:
 
 ```csharp
-finally 
+finally
 {
    ((IDisposable)enumerator).Dispose();
-} 
+}
 ```
 
 Thankfully, you don't need to remember all these details. The `foreach` statement
 handles all those nuances for you. The compiler will generate the correct code for
-any of these constructs. 
+any of these constructs.

--- a/docs/csharp/language-reference/compiler-messages/cs1029.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1029.md
@@ -1,29 +1,31 @@
 ---
 title: "Compiler Error CS1029"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS1029"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS1029"
 ms.assetid: 61bd4d44-9bfc-42bb-a9f0-a0683da53640
 ---
 # Compiler Error CS1029
-\#error: 'text'  
-  
- Displays the text of an error defined with the [#error](../../../csharp/language-reference/preprocessor-directives/preprocessor-error.md) directive.  
-  
- The following sample shows how to create a user-defined error:  
-  
-```csharp  
-// CS1029.cs  
-class Sample  
-{  
-   static void Main()  
-   {  
-      #error Let's give an error here   // CS1029  
-   }  
-}  
+
+\#error: 'text'
+
+Displays the text of an error defined with the [#error](../../../csharp/language-reference/preprocessor-directives/preprocessor-error.md) directive.
+
+The following sample shows how to create a user-defined error:
+
+```csharp
+// CS1029.cs
+class Sample
+{
+   static void Main()
+   {
+      #error Let's give an error here   // CS1029
+   }
+}
 ```
+
 Compilation produces the following output:
 
 ```console

--- a/docs/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
+++ b/docs/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
@@ -1,9 +1,9 @@
 ---
 title: "How to: Set Environment Variables for the Visual Studio Command Line"
 ms.date: "09/29/2017"
-f1_keywords: 
+f1_keywords:
   - "cs.build.commandline"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "csc.exe, command-line builds"
   - "Visual C#, command-line builds"
   - "command-line compilers, Visual C#"
@@ -22,23 +22,24 @@ The VsDevCmd.bat file sets the appropriate environment variables to enable comma
 
 > [!NOTE]
 > The VsDevCmd.bat file is a new file delivered with Visual Studio 2017. Visual Studio 2015 and earlier versions used VSVARS32.bat for the same purpose. This file was stored in \Program Files\Microsoft Visual Studio\\*Version*\Common7\Tools or Program Files (x86)\Microsoft Visual Studio\\*Version*\Common7\Tools.
-  
+
 If the current version of Visual Studio is installed on a computer that also has an earlier version of Visual Studio, you should not run VsDevCmd.bat and VSVARS32.BAT from different versions in the same Command Prompt window. Instead, you should run the command for each version in its own window.
-  
-### To run VsDevCmd.BAT  
-  
+
+### To run VsDevCmd.BAT
+
 1. From the **Start** menu, open the **Developer Command Prompt for VS 2017**.  It's in the **Visual Studio 2017** folder.
-  
+
 2. Change to the \Program Files\Microsoft Visual Studio\\*Version*\\*Offering*\Common7\Tools or \Program Files (x86)\Microsoft Visual Studio\\*Version*\\*Offering*\Common7\Tools subdirectory of your installation.  (*Version* is *2017* for the current version. *Offering* is one of *Enterprise*, *Professional* or *Community*.)
-  
-3. Run VsDevCmd.bat by typing **VsDevCmd**.  
-  
+
+3. Run VsDevCmd.bat by typing **VsDevCmd**.
+
     > [!CAUTION]
-    >  VsDevCmd.bat can vary from computer to computer. Do not replace a missing or damaged VsDevCmd.bat file with a VsDevCmd.bat from another computer. Instead, rerun setup to replace the missing file.  
+    > VsDevCmd.bat can vary from computer to computer. Do not replace a missing or damaged VsDevCmd.bat file with a VsDevCmd.bat from another computer. Instead, rerun setup to replace the missing file.
 
 ### Available options for VsDevCmd.BAT
 
 To see the available options for VsDevCmd.BAT, run the command with the `-help` option:
+
 ```console
 VsDevCmd.bat -help
 ```

--- a/docs/csharp/language-reference/keywords/long.md
+++ b/docs/csharp/language-reference/keywords/long.md
@@ -60,6 +60,7 @@ The `L` suffix guarantees that the correct overload is called:
 SampleMethod(5);    // Calls the method with the int parameter
 SampleMethod(5L);   // Calls the method with the long parameter
 ```
+
 If an integer literal has no suffix, its type is the first of the following types in which its value can be represented:
 
 1. [int](int.md)

--- a/docs/csharp/language-reference/keywords/nameof.md
+++ b/docs/csharp/language-reference/keywords/nameof.md
@@ -3,133 +3,145 @@ title: "nameof  - C# Reference"
 ms.custom: seodec18
 
 ms.date: 06/16/2017
-f1_keywords: 
+f1_keywords:
   - "nameof_CSharpKeyword"
   - "nameof"
 ms.assetid: 33601bf3-cc2c-4496-846d-f9679bccf2a7
 ---
 # nameof (C# Reference)
 
-Used to obtain the simple (unqualified) string name of a variable, type, or member.  
+Used to obtain the simple (unqualified) string name of a variable, type, or member.
 
-When reporting errors in code, hooking up model-view-controller (MVC) links, firing property changed events, etc., you often want to capture the string name of a method.  Using `nameof` helps keep your code valid when renaming definitions.  Before, you had to use string literals to refer to definitions, which is brittle when renaming code elements because tools do not know to check these string literals.  
-  
- A `nameof` expression has this form:  
-  
-```csharp  
-if (x == null) throw new ArgumentNullException(nameof(x));  
-WriteLine(nameof(person.Address.ZipCode)); // prints "ZipCode"  
-```  
-  
-## Key Use Cases  
- These examples show the key use cases for `nameof`.  
-  
- Validate parameters:  
- ```csharp  
-void f(string s) {  
-    if (s == null) throw new ArgumentNullException(nameof(s));  
-}  
-```  
-  
- MVC Action links:  
- ```html  
-<%= Html.ActionLink("Sign up",  
-             @typeof(UserController),  
-             @nameof(UserController.SignUp))  
-%>  
-```  
-  
- INotifyPropertyChanged:  
- ```csharp  
-int p {  
-    get { return this.p; }  
-    set { this.p = value; PropertyChanged(this, new PropertyChangedEventArgs(nameof(this.p)); } // nameof(p) works too  
-}  
-```  
-  
- XAML dependency property:  
- ```csharp  
-public static DependencyProperty AgeProperty = DependencyProperty.Register(nameof(Age), typeof(int), typeof(C));  
-```  
-  
- Logging:  
- ```csharp  
-void f(int i) {  
-    Log(nameof(f), "method entry");  
-}  
-```  
-  
- Attributes:  
- ```csharp  
-[DebuggerDisplay("={" + nameof(GetString) + "()}")]  
-class C {  
-    string GetString() { }  
-}  
-```  
-  
-## Examples  
- Some C# examples:  
-  
-```csharp  
-using Stuff = Some.Cool.Functionality  
-class C {  
-    static int Method1 (string x, int y) {}  
-    static int Method1 (string x, string y) {}  
-    int Method2 (int z) {}  
-    string f<T>() => nameof(T);  
-}  
-  
-var c = new C()  
-  
-class Test {  
-    static void Main (string[] args) {  
-        Console.WriteLine(nameof(C)); // -> "C"  
-        Console.WriteLine(nameof(C.Method1)); // -> "Method1"   
-        Console.WriteLine(nameof(C.Method2)); // -> "Method2"  
-        Console.WriteLine(nameof(c.Method1)); // -> "Method1"   
-        Console.WriteLine(nameof(c.Method2)); // -> "Method2"  
-        // Console.WriteLine(nameof(z)); -> "z" [inside of Method2 ok, inside Method1 is a compiler error]  
-        Console.WriteLine(nameof(Stuff)); // -> "Stuff"  
-        // Console.WriteLine(nameof(T)); -> "T" [works inside of method but not in attributes on the method]  
-        Console.WriteLine(nameof(f)); // -> "f"  
-        // Console.WriteLine(nameof(f<T>)); -> [syntax error]  
-        // Console.WriteLine(nameof(f<>)); -> [syntax error]  
-        // Console.WriteLine(nameof(Method2())); -> [error "This expression does not have a name"]  
-    }
+When reporting errors in code, hooking up model-view-controller (MVC) links, firing property changed events, etc., you often want to capture the string name of a method.  Using `nameof` helps keep your code valid when renaming definitions.  Before, you had to use string literals to refer to definitions, which is brittle when renaming code elements because tools do not know to check these string literals.
+
+A `nameof` expression has this form:
+
+```csharp
+if (x == null) throw new ArgumentNullException(nameof(x));
+WriteLine(nameof(person.Address.ZipCode)); // prints "ZipCode"
+```
+
+## Key Use Cases
+
+These examples show the key use cases for `nameof`.
+
+Validate parameters:
+
+ ```csharp
+void f(string s) {
+    if (s == null) throw new ArgumentNullException(nameof(s));
 }
-```  
-  
-## Remarks  
- The argument to `nameof` must be a simple name, qualified name, member access, base access with a specified member, or this access with a specified member.  The argument expression identifies a code definition, but it is never evaluated.  
-  
- Because the argument needs to be an expression syntactically, there are many things disallowed that are not useful to list.  The following are worth mentioning that produce errors: predefined types (for example, `int` or `void`), nullable types (`Point?`), array types (`Customer[,]`), pointer types (`Buffer*`), qualified alias (`A::B`), and unbound generic types (`Dictionary<,>`), preprocessing symbols (`DEBUG`), and labels (`loop:`).  
-  
- If you need to get the fully-qualified name, you can use the `typeof` expression along with `nameof`.  For example:
-```csharp  
+```
+
+MVC Action links:
+
+```html
+<%= Html.ActionLink("Sign up",
+             @typeof(UserController),
+             @nameof(UserController.SignUp))
+%>
+```
+
+INotifyPropertyChanged:
+
+```csharp
+int p {
+    get { return this.p; }
+    set { this.p = value; PropertyChanged(this, new PropertyChangedEventArgs(nameof(this.p)); } // nameof(p) works too
+}
+```
+
+XAML dependency property:
+
+```csharp
+public static DependencyProperty AgeProperty = DependencyProperty.Register(nameof(Age), typeof(int), typeof(C));
+```
+
+Logging:
+
+```csharp
+void f(int i) {
+    Log(nameof(f), "method entry");
+}
+```
+
+Attributes:
+
+```csharp
+[DebuggerDisplay("={" + nameof(GetString) + "()}")]
 class C {
-    void f(int i) {  
-        Log($"{typeof(C)}.{nameof(f)}", "method entry");  
+    string GetString() { }
+}
+```
+
+## Examples
+
+Some C# examples:
+
+```csharp
+using Stuff = Some.Cool.Functionality
+class C {
+    static int Method1 (string x, int y) {}
+    static int Method1 (string x, string y) {}
+    int Method2 (int z) {}
+    string f<T>() => nameof(T);
+}
+
+var c = new C()
+
+class Test {
+    static void Main (string[] args) {
+        Console.WriteLine(nameof(C)); // -> "C"
+        Console.WriteLine(nameof(C.Method1)); // -> "Method1"
+        Console.WriteLine(nameof(C.Method2)); // -> "Method2"
+        Console.WriteLine(nameof(c.Method1)); // -> "Method1"
+        Console.WriteLine(nameof(c.Method2)); // -> "Method2"
+        // Console.WriteLine(nameof(z)); -> "z" [inside of Method2 ok, inside Method1 is a compiler error]
+        Console.WriteLine(nameof(Stuff)); // -> "Stuff"
+        // Console.WriteLine(nameof(T)); -> "T" [works inside of method but not in attributes on the method]
+        Console.WriteLine(nameof(f)); // -> "f"
+        // Console.WriteLine(nameof(f<T>)); -> [syntax error]
+        // Console.WriteLine(nameof(f<>)); -> [syntax error]
+        // Console.WriteLine(nameof(Method2())); -> [error "This expression does not have a name"]
     }
 }
-``` 
+```
 
- Unfortunately `typeof` is not a constant expression like `nameof`, so `typeof` cannot be used in conjunction with `nameof` in all the same places as `nameof`.  For example, the following would cause a CS0182 compile error:
- ```csharp  
-[DebuggerDisplay("={" + typeof(C) + nameof(GetString) + "()}")]  
-class C {  
-    string GetString() { }  
-}  
-```    
- In the examples you see that you can use a type name and access an instance method name.  You do not need to have an instance of the type, as required in evaluated expressions.  Using the type name can be very convenient in some situations, and since you are just referring to the name and not using instance data, you do not need to contrive an instance variable or expression.  
-  
- You can reference the members of a class in attribute expressions on the class.  
-  
- There is no way to get a signatures information such as "`Method1 (str, str)`".  One way to do that is to use an Expression, `Expression e = () => A.B.Method1("s1", "s2")`, and pull the MemberInfo from the resulting expression tree.  
-  
-## Language Specifications  
+## Remarks
+
+The argument to `nameof` must be a simple name, qualified name, member access, base access with a specified member, or this access with a specified member.  The argument expression identifies a code definition, but it is never evaluated.
+
+Because the argument needs to be an expression syntactically, there are many things disallowed that are not useful to list.  The following are worth mentioning that produce errors: predefined types (for example, `int` or `void`), nullable types (`Point?`), array types (`Customer[,]`), pointer types (`Buffer*`), qualified alias (`A::B`), and unbound generic types (`Dictionary<,>`), preprocessing symbols (`DEBUG`), and labels (`loop:`).
+
+If you need to get the fully-qualified name, you can use the `typeof` expression along with `nameof`.  For example:
+
+```csharp
+class C {
+    void f(int i) {
+        Log($"{typeof(C)}.{nameof(f)}", "method entry");
+    }
+}
+```
+
+Unfortunately `typeof` is not a constant expression like `nameof`, so `typeof` cannot be used in conjunction with `nameof` in all the same places as `nameof`.  For example, the following would cause a CS0182 compile error:
+
+```csharp
+[DebuggerDisplay("={" + typeof(C) + nameof(GetString) + "()}")]
+class C {
+    string GetString() { }
+}
+```
+
+In the examples you see that you can use a type name and access an instance method name.  You do not need to have an instance of the type, as required in evaluated expressions.  Using the type name can be very convenient in some situations, and since you are just referring to the name and not using instance data, you do not need to contrive an instance variable or expression.
+
+You can reference the members of a class in attribute expressions on the class.
+
+There is no way to get a signatures information such as "`Method1 (str, str)`".  One way to do that is to use an Expression, `Expression e = () => A.B.Method1("s1", "s2")`, and pull the MemberInfo from the resulting expression tree.
+
+## Language Specifications
 
 For more information, see [Nameof expressions](~/_csharplang/spec/expressions.md#nameof-expressions) in the [C# Language Specification](../language-specification/index.md). The language specification is the definitive source for C# syntax and usage.
- 
+
 ## See also
 
 - [C# Reference](../../../csharp/language-reference/index.md)

--- a/docs/csharp/language-reference/keywords/protected-internal.md
+++ b/docs/csharp/language-reference/keywords/protected-internal.md
@@ -50,6 +50,7 @@ class DerivedClass : BaseClass
     }
 }
 ```
+
 This example contains two files, `Assembly1.cs` and `Assembly2.cs`.
 The first file contains a public base class, `BaseClass`, and another class, `TestAccess`. `BaseClass` owns a protected internal member, `myValue`, which is accessed by the `TestAccess` type.
 In the second file, an attempt to access `myValue` through an instance of `BaseClass` will produce an error, while an access to this member through an instance of a derived class, `DerivedClass` will succeed.

--- a/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
+++ b/docs/csharp/language-reference/preprocessor-directives/preprocessor-line.md
@@ -3,34 +3,36 @@ title: "#line - C# Reference"
 ms.custom: seodec18
 
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "#line"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "#line directive [C#]"
 ms.assetid: 6439e525-5dd5-4acb-b8ea-efabb32ff95b
 ---
 # #line (C# Reference)
+
 `#line` lets you modify the compiler's line numbering and (optionally) the file name output for errors and warnings.
 
-The following example shows how to report two warnings associated with line numbers. The `#line 200` directive forces the next line's number to be 200 (although the default is #6), and until the next `#line` directive, the filename will be reported as "Special". The `#line default` directive returns the line numbering to its default numbering, which counts the lines that were renumbered by the previous directive.  
-  
+The following example shows how to report two warnings associated with line numbers. The `#line 200` directive forces the next line's number to be 200 (although the default is #6), and until the next `#line` directive, the filename will be reported as "Special". The `#line default` directive returns the line numbering to its default numbering, which counts the lines that were renumbered by the previous directive.
+
 ```csharp
-class MainClass  
-{  
-    static void Main()  
-    {  
-#line 200 "Special"  
+class MainClass
+{
+    static void Main()
+    {
+#line 200 "Special"
         int i;
         int j;
-#line default  
+#line default
         char c;
         float f;
-#line hidden // numbering not affected  
-        string s;   
+#line hidden // numbering not affected
+        string s;
         double d;
-    }  
-}  
-```  
+    }
+}
+```
+
 Compilation produces the following output:
 
 ```console
@@ -42,36 +44,38 @@ MainClass.cs(12,16): warning CS0168: The variable 's' is declared but never used
 MainClass.cs(13,16): warning CS0168: The variable 'd' is declared but never used
 ```
 
-## Remarks  
- The `#line` directive might be used in an automated, intermediate step in the build process. For example, if lines were removed from the original source code file, but you still wanted the compiler to generate output based on the original line numbering in the file, you could remove lines and then simulate the original line numbering with `#line`.  
-  
- The `#line hidden` directive hides the successive lines from the debugger, such that when the developer steps through the code, any lines between a `#line hidden` and the next `#line` directive (assuming that it is not another `#line hidden` directive) will be stepped over. This option can also be used to allow ASP.NET to differentiate between user-defined and machine-generated code. Although ASP.NET is the primary consumer of this feature, it is likely that more source generators will make use of it.  
-  
- A `#line hidden` directive does not affect file names or line numbers in error reporting. That is, if an error is encountered in a hidden block, the compiler will report the current file name and line number of the error.  
-  
- The `#line filename` directive specifies the file name you want to appear in the compiler output. By default, the actual name of the source code file is used. The file name must be in double quotation marks ("") and must be preceded by a line number.  
-  
- A source code file can have any number of `#line` directives.  
-  
-## Example 1  
- The following example shows how the debugger ignores the hidden lines in the code. When you run the example, it will display three lines of text. However, when you set a break point, as shown in the example, and hit F10 to step through the code, you will notice that the debugger ignores the hidden line. Notice also that even if you set a break point at the hidden line, the debugger will still ignore it.  
-  
+## Remarks
+
+The `#line` directive might be used in an automated, intermediate step in the build process. For example, if lines were removed from the original source code file, but you still wanted the compiler to generate output based on the original line numbering in the file, you could remove lines and then simulate the original line numbering with `#line`.
+
+The `#line hidden` directive hides the successive lines from the debugger, such that when the developer steps through the code, any lines between a `#line hidden` and the next `#line` directive (assuming that it is not another `#line hidden` directive) will be stepped over. This option can also be used to allow ASP.NET to differentiate between user-defined and machine-generated code. Although ASP.NET is the primary consumer of this feature, it is likely that more source generators will make use of it.
+
+A `#line hidden` directive does not affect file names or line numbers in error reporting. That is, if an error is encountered in a hidden block, the compiler will report the current file name and line number of the error.
+
+The `#line filename` directive specifies the file name you want to appear in the compiler output. By default, the actual name of the source code file is used. The file name must be in double quotation marks ("") and must be preceded by a line number.
+
+A source code file can have any number of `#line` directives.
+
+## Example 1
+
+The following example shows how the debugger ignores the hidden lines in the code. When you run the example, it will display three lines of text. However, when you set a break point, as shown in the example, and hit F10 to step through the code, you will notice that the debugger ignores the hidden line. Notice also that even if you set a break point at the hidden line, the debugger will still ignore it.
+
 ```csharp
-// preprocessor_linehidden.cs  
-using System;  
-class MainClass   
-{  
-    static void Main()   
-    {  
-        Console.WriteLine("Normal line #1."); // Set break point here.  
-#line hidden  
-        Console.WriteLine("Hidden line.");  
-#line default  
-        Console.WriteLine("Normal line #2.");  
-    }  
-}  
-```  
-  
+// preprocessor_linehidden.cs
+using System;
+class MainClass
+{
+    static void Main()
+    {
+        Console.WriteLine("Normal line #1."); // Set break point here.
+#line hidden
+        Console.WriteLine("Hidden line.");
+#line default
+        Console.WriteLine("Normal line #2.");
+    }
+}
+```
+
 ## See also
 
 - [C# Reference](../../../csharp/language-reference/index.md)

--- a/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
@@ -4,201 +4,210 @@ ms.date: 07/20/2015
 ms.assetid: 1a500f60-2e10-49fb-8b2a-d8d08e4817cb
 ---
 # How to: Add Custom Methods for LINQ Queries (C#)
-You can extend the set of methods that you can use for LINQ queries by adding extension methods to the <xref:System.Collections.Generic.IEnumerable%601> interface. For example, in addition to the standard average or maximum operations, you can create a custom aggregate method to compute a single value from a sequence of values. You can also create a method that works as a custom filter or a specific data transform for a sequence of values and returns a new sequence. Examples of such methods are <xref:System.Linq.Enumerable.Distinct%2A>, <xref:System.Linq.Enumerable.Skip%2A>, and <xref:System.Linq.Enumerable.Reverse%2A>.  
-  
- When you extend the <xref:System.Collections.Generic.IEnumerable%601> interface, you can apply your custom methods to any enumerable collection. For more information, see [Extension Methods](../../../../csharp/programming-guide/classes-and-structs/extension-methods.md).  
-  
-## Adding an Aggregate Method  
- An aggregate method computes a single value from a set of values. LINQ provides several aggregate methods, including <xref:System.Linq.Enumerable.Average%2A>, <xref:System.Linq.Enumerable.Min%2A>, and <xref:System.Linq.Enumerable.Max%2A>. You can create your own aggregate method by adding an extension method to the <xref:System.Collections.Generic.IEnumerable%601> interface.  
-  
- The following code example shows how to create an extension method called `Median` to compute a median for a sequence of numbers of type `double`.  
-  
-```csharp  
-public static class LINQExtension  
-{  
-    public static double Median(this IEnumerable<double> source)  
-    {  
-        if (source.Count() == 0)  
-        {  
-            throw new InvalidOperationException("Cannot compute median for an empty set.");  
-        }  
-  
-        var sortedList = from number in source  
-                         orderby number  
-                         select number;  
-  
-        int itemIndex = (int)sortedList.Count() / 2;  
-  
-        if (sortedList.Count() % 2 == 0)  
-        {  
-            // Even number of items.  
-            return (sortedList.ElementAt(itemIndex) + sortedList.ElementAt(itemIndex - 1)) / 2;  
-        }  
-        else  
-        {  
-            // Odd number of items.  
-            return sortedList.ElementAt(itemIndex);  
-        }  
-    }  
-}  
-```  
-  
- You call this extension method for any enumerable collection in the same way you call other aggregate methods from the <xref:System.Collections.Generic.IEnumerable%601> interface.  
-  
- The following code example shows how to use the `Median` method for an array of type `double`.  
-  
-```csharp  
-double[] numbers1 = { 1.9, 2, 8, 4, 5.7, 6, 7.2, 0 };  
-  
-var query1 = numbers1.Median();  
-  
-Console.WriteLine("double: Median = " + query1);  
-```  
 
-```csharp  
-/*  
- This code produces the following output:  
-  
- Double: Median = 4.85  
-*/  
-```  
-  
-### Overloading an Aggregate Method to Accept Various Types  
- You can overload your aggregate method so that it accepts sequences of various types. The standard approach is to create an overload for each type. Another approach is to create an overload that will take a generic type and convert it to a specific type by using a delegate. You can also combine both approaches.  
-  
-#### To create an overload for each type  
- You can create a specific overload for each type that you want to support. The following code example shows an overload of the `Median` method for the `integer` type.  
-  
-```csharp  
-//int overload  
-  
-public static double Median(this IEnumerable<int> source)  
-{  
-    return (from num in source select (double)num).Median();  
-}  
-```   
- You can now call the `Median` overloads for both `integer` and `double` types, as shown in the following code:  
-  
-```csharp  
-double[] numbers1 = { 1.9, 2, 8, 4, 5.7, 6, 7.2, 0 };  
-  
-var query1 = numbers1.Median();  
-  
-Console.WriteLine("double: Median = " + query1);  
-```  
-  
-```csharp  
-int[] numbers2 = { 1, 2, 3, 4, 5 };  
-  
-var query2 = numbers2.Median();  
-  
-Console.WriteLine("int: Median = " + query2);  
-```  
-  
-```csharp  
-/*  
- This code produces the following output:  
-  
- Double: Median = 4.85  
- Integer: Median = 3  
-*/  
-```  
+You can extend the set of methods that you can use for LINQ queries by adding extension methods to the <xref:System.Collections.Generic.IEnumerable%601> interface. For example, in addition to the standard average or maximum operations, you can create a custom aggregate method to compute a single value from a sequence of values. You can also create a method that works as a custom filter or a specific data transform for a sequence of values and returns a new sequence. Examples of such methods are <xref:System.Linq.Enumerable.Distinct%2A>, <xref:System.Linq.Enumerable.Skip%2A>, and <xref:System.Linq.Enumerable.Reverse%2A>.
 
-#### To create a generic overload  
- You can also create an overload that accepts a sequence of generic objects. This overload takes a delegate as a parameter and uses it to convert a sequence of objects of a generic type to a specific type.  
-  
- The following code shows an overload of the `Median` method that takes the <xref:System.Func%602> delegate as a parameter. This delegate takes an object of generic type T and returns an object of type `double`.  
-  
-```csharp  
-// Generic overload.  
-  
-public static double Median<T>(this IEnumerable<T> numbers,  
-                       Func<T, double> selector)  
-{  
-    return (from num in numbers select selector(num)).Median();  
-}  
-```  
-  
- You can now call the `Median` method for a sequence of objects of any type. If the type does not have its own method overload, you have to pass a delegate parameter. In C#, you can use a lambda expression for this purpose. Also, in Visual Basic only, if you use the `Aggregate` or `Group By` clause instead of the method call, you can pass any value or expression that is in the scope this clause.  
-  
- The following example code shows how to call the `Median` method for an array of integers and an array of strings. For strings, the median for the lengths of strings in the array is calculated. The example shows how to pass the <xref:System.Func%602> delegate parameter to the `Median` method for each case.  
-  
-```csharp  
-int[] numbers3 = { 1, 2, 3, 4, 5 };  
-  
-/*   
-  You can use the num=>num lambda expression as a parameter for the Median method   
-  so that the compiler will implicitly convert its value to double.  
-  If there is no implicit conversion, the compiler will display an error message.            
-*/  
-  
-var query3 = numbers3.Median(num => num);  
-  
-Console.WriteLine("int: Median = " + query3);  
-  
-string[] numbers4 = { "one", "two", "three", "four", "five" };  
-  
-// With the generic overload, you can also use numeric properties of objects.  
-  
-var query4 = numbers4.Median(str => str.Length);  
-  
-Console.WriteLine("String: Median = " + query4);  
-  
-/*  
- This code produces the following output:  
-  
- Integer: Median = 3  
- String: Median = 4  
-*/  
-```   
-## Adding a Method That Returns a Collection  
- You can extend the <xref:System.Collections.Generic.IEnumerable%601> interface with a custom query method that returns a sequence of values. In this case, the method must return a collection of type <xref:System.Collections.Generic.IEnumerable%601>. Such methods can be used to apply filters or data transforms to a sequence of values.  
-  
- The following example shows how to create an extension method named `AlternateElements` that returns every other element in a collection, starting from the first element.  
-  
-```csharp  
-// Extension method for the IEnumerable<T> interface.   
-// The method returns every other element of a sequence.  
-  
-public static IEnumerable<T> AlternateElements<T>(this IEnumerable<T> source)  
-{  
-    List<T> list = new List<T>();  
-  
-    int i = 0;  
-  
-    foreach (var element in source)  
-    {  
-        if (i % 2 == 0)  
-        {  
-            list.Add(element);  
-        }  
-  
-        i++;  
-    }  
-  
-    return list;  
-}  
-```  
- You can call this extension method for any enumerable collection just as you would call other methods from the <xref:System.Collections.Generic.IEnumerable%601> interface, as shown in the following code:  
-  
-```csharp  
-string[] strings = { "a", "b", "c", "d", "e" };  
-  
-var query = strings.AlternateElements();  
-  
-foreach (var element in query)  
-{  
-    Console.WriteLine(element);  
-}  
-/*  
- This code produces the following output:  
-  
- a  
- c  
- e  
-*/  
-```  
-  
+When you extend the <xref:System.Collections.Generic.IEnumerable%601> interface, you can apply your custom methods to any enumerable collection. For more information, see [Extension Methods](../../../../csharp/programming-guide/classes-and-structs/extension-methods.md).
+
+## Adding an Aggregate Method
+
+An aggregate method computes a single value from a set of values. LINQ provides several aggregate methods, including <xref:System.Linq.Enumerable.Average%2A>, <xref:System.Linq.Enumerable.Min%2A>, and <xref:System.Linq.Enumerable.Max%2A>. You can create your own aggregate method by adding an extension method to the <xref:System.Collections.Generic.IEnumerable%601> interface.
+
+The following code example shows how to create an extension method called `Median` to compute a median for a sequence of numbers of type `double`.
+
+```csharp
+public static class LINQExtension
+{
+    public static double Median(this IEnumerable<double> source)
+    {
+        if (source.Count() == 0)
+        {
+            throw new InvalidOperationException("Cannot compute median for an empty set.");
+        }
+
+        var sortedList = from number in source
+                         orderby number
+                         select number;
+
+        int itemIndex = (int)sortedList.Count() / 2;
+
+        if (sortedList.Count() % 2 == 0)
+        {
+            // Even number of items.
+            return (sortedList.ElementAt(itemIndex) + sortedList.ElementAt(itemIndex - 1)) / 2;
+        }
+        else
+        {
+            // Odd number of items.
+            return sortedList.ElementAt(itemIndex);
+        }
+    }
+}
+```
+
+You call this extension method for any enumerable collection in the same way you call other aggregate methods from the <xref:System.Collections.Generic.IEnumerable%601> interface.
+
+The following code example shows how to use the `Median` method for an array of type `double`.
+
+```csharp
+double[] numbers1 = { 1.9, 2, 8, 4, 5.7, 6, 7.2, 0 };
+
+var query1 = numbers1.Median();
+
+Console.WriteLine("double: Median = " + query1);
+```
+
+```csharp
+/*
+ This code produces the following output:
+
+ Double: Median = 4.85
+*/
+```
+
+### Overloading an Aggregate Method to Accept Various Types
+
+You can overload your aggregate method so that it accepts sequences of various types. The standard approach is to create an overload for each type. Another approach is to create an overload that will take a generic type and convert it to a specific type by using a delegate. You can also combine both approaches.
+
+#### To create an overload for each type
+
+You can create a specific overload for each type that you want to support. The following code example shows an overload of the `Median` method for the `integer` type.
+
+```csharp
+//int overload
+
+public static double Median(this IEnumerable<int> source)
+{
+    return (from num in source select (double)num).Median();
+}
+```
+
+You can now call the `Median` overloads for both `integer` and `double` types, as shown in the following code:
+
+```csharp
+double[] numbers1 = { 1.9, 2, 8, 4, 5.7, 6, 7.2, 0 };
+
+var query1 = numbers1.Median();
+
+Console.WriteLine("double: Median = " + query1);
+```
+
+```csharp
+int[] numbers2 = { 1, 2, 3, 4, 5 };
+
+var query2 = numbers2.Median();
+
+Console.WriteLine("int: Median = " + query2);
+```
+
+```csharp
+/*
+ This code produces the following output:
+
+ Double: Median = 4.85
+ Integer: Median = 3
+*/
+```
+
+#### To create a generic overload
+
+You can also create an overload that accepts a sequence of generic objects. This overload takes a delegate as a parameter and uses it to convert a sequence of objects of a generic type to a specific type.
+
+The following code shows an overload of the `Median` method that takes the <xref:System.Func%602> delegate as a parameter. This delegate takes an object of generic type T and returns an object of type `double`.
+
+```csharp
+// Generic overload.
+
+public static double Median<T>(this IEnumerable<T> numbers,
+                       Func<T, double> selector)
+{
+    return (from num in numbers select selector(num)).Median();
+}
+```
+
+You can now call the `Median` method for a sequence of objects of any type. If the type does not have its own method overload, you have to pass a delegate parameter. In C#, you can use a lambda expression for this purpose. Also, in Visual Basic only, if you use the `Aggregate` or `Group By` clause instead of the method call, you can pass any value or expression that is in the scope this clause.
+
+The following example code shows how to call the `Median` method for an array of integers and an array of strings. For strings, the median for the lengths of strings in the array is calculated. The example shows how to pass the <xref:System.Func%602> delegate parameter to the `Median` method for each case.
+
+```csharp
+int[] numbers3 = { 1, 2, 3, 4, 5 };
+
+/*
+  You can use the num=>num lambda expression as a parameter for the Median method
+  so that the compiler will implicitly convert its value to double.
+  If there is no implicit conversion, the compiler will display an error message.
+*/
+
+var query3 = numbers3.Median(num => num);
+
+Console.WriteLine("int: Median = " + query3);
+
+string[] numbers4 = { "one", "two", "three", "four", "five" };
+
+// With the generic overload, you can also use numeric properties of objects.
+
+var query4 = numbers4.Median(str => str.Length);
+
+Console.WriteLine("String: Median = " + query4);
+
+/*
+ This code produces the following output:
+
+ Integer: Median = 3
+ String: Median = 4
+*/
+```
+
+## Adding a Method That Returns a Collection
+
+You can extend the <xref:System.Collections.Generic.IEnumerable%601> interface with a custom query method that returns a sequence of values. In this case, the method must return a collection of type <xref:System.Collections.Generic.IEnumerable%601>. Such methods can be used to apply filters or data transforms to a sequence of values.
+
+The following example shows how to create an extension method named `AlternateElements` that returns every other element in a collection, starting from the first element.
+
+```csharp
+// Extension method for the IEnumerable<T> interface.
+// The method returns every other element of a sequence.
+
+public static IEnumerable<T> AlternateElements<T>(this IEnumerable<T> source)
+{
+    List<T> list = new List<T>();
+
+    int i = 0;
+
+    foreach (var element in source)
+    {
+        if (i % 2 == 0)
+        {
+            list.Add(element);
+        }
+
+        i++;
+    }
+
+    return list;
+}
+```
+
+You can call this extension method for any enumerable collection just as you would call other methods from the <xref:System.Collections.Generic.IEnumerable%601> interface, as shown in the following code:
+
+```csharp
+string[] strings = { "a", "b", "c", "d", "e" };
+
+var query = strings.AlternateElements();
+
+foreach (var element in query)
+{
+    Console.WriteLine(element);
+}
+/*
+ This code produces the following output:
+
+ a
+ c
+ e
+*/
+```
+
 ## See also
 
 - <xref:System.Collections.Generic.IEnumerable%601>

--- a/docs/csharp/programming-guide/concepts/linq/linq-to-xml-overview.md
+++ b/docs/csharp/programming-guide/concepts/linq/linq-to-xml-overview.md
@@ -4,26 +4,29 @@ ms.date: 10/30/2018
 ms.assetid: 716b94d3-0091-4de1-8e05-41bc069fa9dd
 ---
 # LINQ to XML Overview (C#)
-XML has been widely adopted as a way to format data in many contexts. For example, you can find XML on the Web, in configuration files, in Microsoft Office Word files, and in databases.  
-  
- [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is an up-to-date, redesigned approach to programming with XML. It provides the in-memory document modification capabilities of the Document Object Model (DOM), and supports [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query expressions. Although these query expressions are syntactically different from XPath, they provide similar functionality.  
-  
-## LINQ to XML Developers  
- [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] targets a variety of developers. For an average developer who just wants to get something done, [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] makes XML easier by providing a query experience that is similar to SQL. With just a bit of study, programmers can learn to write succinct and powerful queries in their programming language of choice.  
-  
- Professional developers can use [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] to greatly increase their productivity. With [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)], they can write less code that is more expressive, more compact, and more powerful. They can use query expressions from multiple data domains at the same time.  
-  
-## What Is LINQ to XML?  
- [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is a LINQ-enabled, in-memory XML programming interface that enables you to work with XML from within the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)] programming languages.  
-  
- [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is like the Document Object Model (DOM) in that it brings the XML document into memory. You can query and modify the document, and after you modify it you can save it to a file or serialize it and send it over the Internet. However, [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] differs from DOM: It provides a new object model that is lighter weight and easier to work with, and that takes advantage of language features in C#.  
-  
- The most important advantage of [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is its integration with [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)]. This integration enables you to write queries on the in-memory XML document to retrieve collections of elements and attributes. The query capability of [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is comparable in functionality (although not in syntax) to XPath and XQuery. The integration of [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] in C# provides stronger typing, compile-time checking, and improved debugger support.  
-  
- Another advantage of [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is the ability to use query results as parameters to <xref:System.Xml.Linq.XElement> and <xref:System.Xml.Linq.XAttribute> object constructors enables a powerful approach to creating XML trees. This approach, called *functional construction*, enables developers to easily transform XML trees from one shape to another.  
-  
- For example, you might have a typical XML purchase order as described in [Sample XML File: Typical Purchase Order (LINQ to XML)](sample-xml-file-typical-purchase-order-linq-to-xml-1.md). By using [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)], you could run the following query to obtain the part number attribute value for every item element in the purchase order:  
-  
+
+XML has been widely adopted as a way to format data in many contexts. For example, you can find XML on the Web, in configuration files, in Microsoft Office Word files, and in databases.
+
+[!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is an up-to-date, redesigned approach to programming with XML. It provides the in-memory document modification capabilities of the Document Object Model (DOM), and supports [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] query expressions. Although these query expressions are syntactically different from XPath, they provide similar functionality.
+
+## LINQ to XML Developers
+
+[!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] targets a variety of developers. For an average developer who just wants to get something done, [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] makes XML easier by providing a query experience that is similar to SQL. With just a bit of study, programmers can learn to write succinct and powerful queries in their programming language of choice.
+
+Professional developers can use [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] to greatly increase their productivity. With [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)], they can write less code that is more expressive, more compact, and more powerful. They can use query expressions from multiple data domains at the same time.
+
+## What Is LINQ to XML?
+
+[!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is a LINQ-enabled, in-memory XML programming interface that enables you to work with XML from within the [!INCLUDE[dnprdnshort](~/includes/dnprdnshort-md.md)] programming languages.
+
+[!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is like the Document Object Model (DOM) in that it brings the XML document into memory. You can query and modify the document, and after you modify it you can save it to a file or serialize it and send it over the Internet. However, [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] differs from DOM: It provides a new object model that is lighter weight and easier to work with, and that takes advantage of language features in C#.
+
+The most important advantage of [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is its integration with [!INCLUDE[vbteclinqext](~/includes/vbteclinqext-md.md)]. This integration enables you to write queries on the in-memory XML document to retrieve collections of elements and attributes. The query capability of [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is comparable in functionality (although not in syntax) to XPath and XQuery. The integration of [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] in C# provides stronger typing, compile-time checking, and improved debugger support.
+
+Another advantage of [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is the ability to use query results as parameters to <xref:System.Xml.Linq.XElement> and <xref:System.Xml.Linq.XAttribute> object constructors enables a powerful approach to creating XML trees. This approach, called *functional construction*, enables developers to easily transform XML trees from one shape to another.
+
+For example, you might have a typical XML purchase order as described in [Sample XML File: Typical Purchase Order (LINQ to XML)](sample-xml-file-typical-purchase-order-linq-to-xml-1.md). By using [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)], you could run the following query to obtain the part number attribute value for every item element in the purchase order:
+
 ```csharp
 // Load the XML file from our project directory containing the purchase orders
 var filename = "PurchaseOrder.xml";
@@ -32,18 +35,19 @@ var purchaseOrderFilepath = Path.Combine(currentDirectory, filename);
 
 XElement purchaseOrder = XElement.Load($"{purchaseOrderFilepath}");
 
-IEnumerable<string> partNos =  from item in purchaseOrder.Descendants("Item")  
-                               select (string) item.Attribute("PartNumber");  
-``` 
+IEnumerable<string> partNos =  from item in purchaseOrder.Descendants("Item")
+                               select (string) item.Attribute("PartNumber");
+```
+
 This can be rewritten in method syntax form:
 
 ```csharp
 IEnumerable<string> partNos = purchaseOrder.Descendants("Item").Select(x => (string) x.Attribute("PartNumber"));
 ```
 
-As another example, you might want a list, sorted by part number, of the items with a value greater than $100. To obtain this information, you could run the following query:  
-  
-```csharp 
+As another example, you might want a list, sorted by part number, of the items with a value greater than $100. To obtain this information, you could run the following query:
+
+```csharp
 // Load the XML file from our project directory containing the purchase orders
 var filename = "PurchaseOrder.xml";
 var currentDirectory = Directory.GetCurrentDirectory();
@@ -51,11 +55,11 @@ var purchaseOrderFilepath = Path.Combine(currentDirectory, filename);
 
 XElement purchaseOrder = XElement.Load($"{purchaseOrderFilepath}");
 
-IEnumerable<XElement> pricesByPartNos =  from item in purchaseOrder.Descendants("Item")  
-                                 where (int) item.Element("Quantity") * (decimal) item.Element("USPrice") > 100  
-                                 orderby (string)item.Element("PartNumber")  
-                                 select item;  
-```  
+IEnumerable<XElement> pricesByPartNos =  from item in purchaseOrder.Descendants("Item")
+                                 where (int) item.Element("Quantity") * (decimal) item.Element("USPrice") > 100
+                                 orderby (string)item.Element("PartNumber")
+                                 select item;
+```
 
 Again, this can be rewritten in method syntax form:
 
@@ -65,46 +69,47 @@ IEnumerable<XElement> pricesByPartNos = purchaseOrder.Descendants("Item")
                                         .OrderBy(order => order.Element("PartNumber"));
 ```
 
- In addition to these [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] capabilities, [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] provides an improved XML programming interface. Using [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)], you can:  
-  
--   Load XML from [files](how-to-load-xml-from-a-file.md) or [streams](how-to-stream-xml-fragments-from-an-xmlreader.md).  
-  
--   Serialize XML to files or streams.  
-  
--   Create XML from scratch by using functional construction.  
-  
--   Query XML using XPath-like axes.  
-  
--   Manipulate the in-memory XML tree by using methods such as <xref:System.Xml.Linq.XContainer.Add%2A>, <xref:System.Xml.Linq.XNode.Remove%2A>, <xref:System.Xml.Linq.XNode.ReplaceWith%2A>, and <xref:System.Xml.Linq.XElement.SetValue%2A>.  
-  
--   Validate XML trees using XSD.  
-  
--   Use a combination of these features to transform XML trees from one shape into another.  
-  
-## Creating XML Trees  
- One of the most significant advantages of programming with [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is that it is easy to create XML trees. For example, to create a small XML tree, you can write code as follows:  
-  
-```csharp  
-XElement contacts =  
-new XElement("Contacts",  
-    new XElement("Contact",  
-        new XElement("Name", "Patrick Hines"),  
-        new XElement("Phone", "206-555-0144",   
-            new XAttribute("Type", "Home")),  
-        new XElement("phone", "425-555-0145",  
-            new XAttribute("Type", "Work")),  
-        new XElement("Address",  
-            new XElement("Street1", "123 Main St"),  
-            new XElement("City", "Mercer Island"),  
-            new XElement("State", "WA"),  
-            new XElement("Postal", "68042")  
-        )  
-    )  
-);  
-```  
-  
- For more information, see [Creating XML Trees (C#)](../../../../csharp/programming-guide/concepts/linq/creating-xml-trees.md).  
-  
+In addition to these [!INCLUDE[vbteclinq](~/includes/vbteclinq-md.md)] capabilities, [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] provides an improved XML programming interface. Using [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)], you can:
+
+- Load XML from [files](how-to-load-xml-from-a-file.md) or [streams](how-to-stream-xml-fragments-from-an-xmlreader.md).
+
+- Serialize XML to files or streams.
+
+- Create XML from scratch by using functional construction.
+
+- Query XML using XPath-like axes.
+
+- Manipulate the in-memory XML tree by using methods such as <xref:System.Xml.Linq.XContainer.Add%2A>, <xref:System.Xml.Linq.XNode.Remove%2A>, <xref:System.Xml.Linq.XNode.ReplaceWith%2A>, and <xref:System.Xml.Linq.XElement.SetValue%2A>.
+
+- Validate XML trees using XSD.
+
+- Use a combination of these features to transform XML trees from one shape into another.
+
+## Creating XML Trees
+
+One of the most significant advantages of programming with [!INCLUDE[sqltecxlinq](~/includes/sqltecxlinq-md.md)] is that it is easy to create XML trees. For example, to create a small XML tree, you can write code as follows:
+
+```csharp
+XElement contacts =
+new XElement("Contacts",
+    new XElement("Contact",
+        new XElement("Name", "Patrick Hines"),
+        new XElement("Phone", "206-555-0144",
+            new XAttribute("Type", "Home")),
+        new XElement("phone", "425-555-0145",
+            new XAttribute("Type", "Work")),
+        new XElement("Address",
+            new XElement("Street1", "123 Main St"),
+            new XElement("City", "Mercer Island"),
+            new XElement("State", "WA"),
+            new XElement("Postal", "68042")
+        )
+    )
+);
+```
+
+For more information, see [Creating XML Trees (C#)](../../../../csharp/programming-guide/concepts/linq/creating-xml-trees.md).
+
 ## See also
 
 - <xref:System.Xml.Linq>

--- a/docs/csharp/programming-guide/types/index.md
+++ b/docs/csharp/programming-guide/types/index.md
@@ -2,7 +2,7 @@
 title: "Types - C# Programming Guide"
 ms.custom: seodec18
 ms.date: 07/20/2015
-helpviewer_keywords: 
+helpviewer_keywords:
   - "value types [C#]"
   - "reference types [C#]"
   - "types [C#]"
@@ -14,171 +14,186 @@ helpviewer_keywords:
 ms.assetid: f782d7cc-035e-4500-b1b1-36a9881130ad
 ---
 # Types (C# Programming Guide)
-## Types, Variables, and Values  
- C# is a strongly-typed language. Every variable and constant has a type, as does every expression that evaluates to a value. Every method signature specifies a type for each input parameter and for the return value. The .NET class library defines a set of built-in numeric types as well as more complex types that represent a wide variety of logical constructs, such as the file system, network connections, collections and arrays of objects, and dates. A typical C# program uses types from the class library as well as user-defined types that model the concepts that are specific to the program's problem domain.  
-  
- The information stored in a type can include the following:  
-  
--   The storage space that a variable of the type requires.  
-  
--   The maximum and minimum values that it can represent.  
-  
--   The members (methods, fields, events, and so on) that it contains.  
-  
--   The base type it inherits from.  
-  
--   The location where the memory for variables will be allocated at run time.  
-  
--   The kinds of operations that are permitted.  
-  
- The compiler uses type information to make sure that all operations that are performed in your code are *type safe*. For example, if you declare a variable of type [int](../../../csharp/language-reference/keywords/int.md), the compiler allows you to use the variable in addition and subtraction operations. If you try to perform those same operations on a variable of type [bool](../../../csharp/language-reference/keywords/bool.md), the compiler generates an error, as shown in the following example:  
-  
- [!code-csharp[csProgGuideTypes#42](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#42)]  
-  
-> [!NOTE]
->  C and C++ developers, notice that in C#, [bool](../../../csharp/language-reference/keywords/bool.md) is not convertible to [int](../../../csharp/language-reference/keywords/int.md).  
-  
- The compiler embeds the type information into the executable file as metadata. The common language runtime (CLR) uses that metadata at run time to further guarantee type safety when it allocates and reclaims memory.  
-  
-### Specifying Types in Variable Declarations  
- When you declare a variable or constant in a program, you must either specify its type or use the [var](../../../csharp/language-reference/keywords/var.md) keyword to let the compiler infer the type. The following example shows some variable declarations that use both built-in numeric types and complex user-defined types:  
-  
- [!code-csharp[csProgGuideTypes#36](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#36)]  
-  
- The types of method parameters and return values are specified in the method signature. The following signature shows a method that requires an [int](../../../csharp/language-reference/keywords/int.md) as an input argument and returns a string:  
-  
- [!code-csharp[csProgGuideTypes#35](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#35)]  
-  
- After a variable is declared, it cannot be re-declared with a new type, and it cannot be assigned a value that is not compatible with its declared type. For example, you cannot declare an [int](../../../csharp/language-reference/keywords/int.md) and then assign it a Boolean value of [true](../../../csharp/language-reference/keywords/true-literal.md). However, values can be converted to other types, for example when they are assigned to new variables or passed as method arguments. A *type conversion* that does not cause data loss is performed automatically by the compiler. A conversion that might cause data loss requires a *cast* in the source code.  
-  
- For more information, see [Casting and Type Conversions](../../../csharp/programming-guide/types/casting-and-type-conversions.md).  
-  
-## Built-in Types  
- C# provides a standard set of built-in numeric types to represent integers, floating point values, Boolean expressions, text characters, decimal values, and other types of data. There are also built-in `string` and `object` types. These are available for you to use in any C# program. For more information about the built-in types, see [Reference Tables for Types](../../../csharp/language-reference/keywords/reference-tables-for-types.md).  
-  
-## Custom Types  
- You use the [struct](../../../csharp/language-reference/keywords/struct.md), [class](../../../csharp/language-reference/keywords/class.md), [interface](../../../csharp/language-reference/keywords/interface.md), and [enum](../../../csharp/language-reference/keywords/enum.md) constructs to create your own custom types. The .NET class library itself is a collection of custom types provided by Microsoft that you can use in your own applications. By default, the most frequently used types in the class library are available in any C# program. Others become available only when you explicitly add a project reference to the assembly in which they are defined. After the compiler has a reference to the assembly, you can declare variables (and constants) of the types declared in that assembly in source code. For more information, see [.NET Class Library](../../../standard/class-library-overview.md).  
-  
-## The Common Type System  
- It is important to understand two fundamental points about the type system in .NET:  
-  
--   It supports the principle of inheritance. Types can derive from other types, called *base types*. The derived type inherits (with some restrictions) the methods, properties, and other members of the base type. The base type can in turn derive from some other type, in which case the derived type inherits the members of both base types in its inheritance hierarchy. All types, including built-in numeric types such as <xref:System.Int32?displayProperty=nameWithType> (C# keyword: [int](../../../csharp/language-reference/keywords/int.md)), derive ultimately from a single base type, which is <xref:System.Object?displayProperty=nameWithType> (C# keyword: [object](../../../csharp/language-reference/keywords/object.md)). This unified type hierarchy is called the [Common Type System](../../../standard/base-types/common-type-system.md) (CTS). For more information about inheritance in C#, see [Inheritance](../../../csharp/programming-guide/classes-and-structs/inheritance.md).  
-  
--   Each type in the CTS is defined as either a *value type* or a *reference type*. This includes all custom types in the .NET class library and also your own user-defined types. Types that you define by using the [struct](../../../csharp/language-reference/keywords/struct.md) keyword are value types; all the built-in numeric types are `structs`. Types that you define by using the [class](../../../csharp/language-reference/keywords/class.md) keyword are reference types. Reference types and value types have different compile-time rules, and different run-time behavior.  
-  
- The following illustration shows the relationship between value types and reference types in the CTS.
 
- The following image shows value types and reference types in the CTS: 
+## Types, Variables, and Values
 
- ![Screenshot that shows CTS value types and reference types.](./media/index/value-reference-types-common-type-system.png)  
-  
+C# is a strongly-typed language. Every variable and constant has a type, as does every expression that evaluates to a value. Every method signature specifies a type for each input parameter and for the return value. The .NET class library defines a set of built-in numeric types as well as more complex types that represent a wide variety of logical constructs, such as the file system, network connections, collections and arrays of objects, and dates. A typical C# program uses types from the class library as well as user-defined types that model the concepts that are specific to the program's problem domain.
+
+The information stored in a type can include the following:
+
+- The storage space that a variable of the type requires.
+
+- The maximum and minimum values that it can represent.
+
+- The members (methods, fields, events, and so on) that it contains.
+
+- The base type it inherits from.
+
+- The location where the memory for variables will be allocated at run time.
+
+- The kinds of operations that are permitted.
+
+The compiler uses type information to make sure that all operations that are performed in your code are *type safe*. For example, if you declare a variable of type [int](../../../csharp/language-reference/keywords/int.md), the compiler allows you to use the variable in addition and subtraction operations. If you try to perform those same operations on a variable of type [bool](../../../csharp/language-reference/keywords/bool.md), the compiler generates an error, as shown in the following example:
+
+[!code-csharp[csProgGuideTypes#42](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#42)]
+
 > [!NOTE]
->  You can see that the most commonly used types are all organized in the <xref:System> namespace. However, the namespace in which a type is contained has no relation to whether it is a value type or reference type.  
-  
-### Value Types  
- Value types derive from <xref:System.ValueType?displayProperty=nameWithType>, which derives from <xref:System.Object?displayProperty=nameWithType>. Types that derive from <xref:System.ValueType?displayProperty=nameWithType> have special behavior in the CLR. Value type variables directly contain their values, which means that the memory is allocated inline in whatever context the variable is declared. There is no separate heap allocation or garbage collection overhead for value-type variables.  
-  
- There are two categories of value types: [struct](../../../csharp/language-reference/keywords/struct.md) and [enum](../../../csharp/language-reference/keywords/enum.md).  
-  
- The built-in numeric types are structs, and they have properties and methods that you can access:  
-  
-```csharp  
-// Static method on type byte.  
+> C and C++ developers, notice that in C#, [bool](../../../csharp/language-reference/keywords/bool.md) is not convertible to [int](../../../csharp/language-reference/keywords/int.md).
+
+The compiler embeds the type information into the executable file as metadata. The common language runtime (CLR) uses that metadata at run time to further guarantee type safety when it allocates and reclaims memory.
+
+### Specifying Types in Variable Declarations
+
+When you declare a variable or constant in a program, you must either specify its type or use the [var](../../../csharp/language-reference/keywords/var.md) keyword to let the compiler infer the type. The following example shows some variable declarations that use both built-in numeric types and complex user-defined types:
+
+[!code-csharp[csProgGuideTypes#36](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#36)]
+
+The types of method parameters and return values are specified in the method signature. The following signature shows a method that requires an [int](../../../csharp/language-reference/keywords/int.md) as an input argument and returns a string:
+
+[!code-csharp[csProgGuideTypes#35](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#35)]
+
+After a variable is declared, it cannot be re-declared with a new type, and it cannot be assigned a value that is not compatible with its declared type. For example, you cannot declare an [int](../../../csharp/language-reference/keywords/int.md) and then assign it a Boolean value of [true](../../../csharp/language-reference/keywords/true-literal.md). However, values can be converted to other types, for example when they are assigned to new variables or passed as method arguments. A *type conversion* that does not cause data loss is performed automatically by the compiler. A conversion that might cause data loss requires a *cast* in the source code.
+
+For more information, see [Casting and Type Conversions](../../../csharp/programming-guide/types/casting-and-type-conversions.md).
+
+## Built-in Types
+
+C# provides a standard set of built-in numeric types to represent integers, floating point values, Boolean expressions, text characters, decimal values, and other types of data. There are also built-in `string` and `object` types. These are available for you to use in any C# program. For more information about the built-in types, see [Reference Tables for Types](../../../csharp/language-reference/keywords/reference-tables-for-types.md).
+
+## Custom Types
+
+You use the [struct](../../../csharp/language-reference/keywords/struct.md), [class](../../../csharp/language-reference/keywords/class.md), [interface](../../../csharp/language-reference/keywords/interface.md), and [enum](../../../csharp/language-reference/keywords/enum.md) constructs to create your own custom types. The .NET class library itself is a collection of custom types provided by Microsoft that you can use in your own applications. By default, the most frequently used types in the class library are available in any C# program. Others become available only when you explicitly add a project reference to the assembly in which they are defined. After the compiler has a reference to the assembly, you can declare variables (and constants) of the types declared in that assembly in source code. For more information, see [.NET Class Library](../../../standard/class-library-overview.md).
+
+## The Common Type System
+
+It is important to understand two fundamental points about the type system in .NET:
+
+- It supports the principle of inheritance. Types can derive from other types, called *base types*. The derived type inherits (with some restrictions) the methods, properties, and other members of the base type. The base type can in turn derive from some other type, in which case the derived type inherits the members of both base types in its inheritance hierarchy. All types, including built-in numeric types such as <xref:System.Int32?displayProperty=nameWithType> (C# keyword: [int](../../../csharp/language-reference/keywords/int.md)), derive ultimately from a single base type, which is <xref:System.Object?displayProperty=nameWithType> (C# keyword: [object](../../../csharp/language-reference/keywords/object.md)). This unified type hierarchy is called the [Common Type System](../../../standard/base-types/common-type-system.md) (CTS). For more information about inheritance in C#, see [Inheritance](../../../csharp/programming-guide/classes-and-structs/inheritance.md).
+
+- Each type in the CTS is defined as either a *value type* or a *reference type*. This includes all custom types in the .NET class library and also your own user-defined types. Types that you define by using the [struct](../../../csharp/language-reference/keywords/struct.md) keyword are value types; all the built-in numeric types are `structs`. Types that you define by using the [class](../../../csharp/language-reference/keywords/class.md) keyword are reference types. Reference types and value types have different compile-time rules, and different run-time behavior.
+
+The following illustration shows the relationship between value types and reference types in the CTS.
+
+The following image shows value types and reference types in the CTS:
+
+![Screenshot that shows CTS value types and reference types.](./media/index/value-reference-types-common-type-system.png)
+
+> [!NOTE]
+> You can see that the most commonly used types are all organized in the <xref:System> namespace. However, the namespace in which a type is contained has no relation to whether it is a value type or reference type.
+
+### Value Types
+
+Value types derive from <xref:System.ValueType?displayProperty=nameWithType>, which derives from <xref:System.Object?displayProperty=nameWithType>. Types that derive from <xref:System.ValueType?displayProperty=nameWithType> have special behavior in the CLR. Value type variables directly contain their values, which means that the memory is allocated inline in whatever context the variable is declared. There is no separate heap allocation or garbage collection overhead for value-type variables.
+
+There are two categories of value types: [struct](../../../csharp/language-reference/keywords/struct.md) and [enum](../../../csharp/language-reference/keywords/enum.md).
+
+The built-in numeric types are structs, and they have properties and methods that you can access:
+
+```csharp
+// Static method on type byte.
 byte b = byte.MaxValue;
-```  
-  
- But you declare and assign values to them as if they were simple non-aggregate types:  
-  
-```csharp  
-byte num = 0xA;  
-int i = 5;  
-char c = 'Z';  
-```  
-  
- Value types are *sealed*, which means, for example, that you cannot derive a type from <xref:System.Int32?displayProperty=nameWithType>, and you cannot define a struct to inherit from any user-defined class or struct because a struct can only inherit from <xref:System.ValueType?displayProperty=nameWithType>. However, a struct can implement one or more interfaces. You can cast a struct type to any interface type that it implements; this causes a *boxing* operation to wrap the struct inside a reference type object on the managed heap. Boxing operations occur when you pass a value type to a method that takes a <xref:System.Object?displayProperty=nameWithType> or any interface type as an input parameter. For more information, see [Boxing and Unboxing](../../../csharp/programming-guide/types/boxing-and-unboxing.md).  
-  
- You use the [struct](../../../csharp/language-reference/keywords/struct.md) keyword to create your own custom value types. Typically, a struct is used as a container for a small set of related variables, as shown in the following example:  
-  
- [!code-csharp[csProgGuideObjects#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs#1)]  
-  
- For more information about structs, see [Structs](../../../csharp/programming-guide/classes-and-structs/structs.md). For more information about value types in .NET, see [Value Types](../../../csharp/language-reference/keywords/value-types.md).  
-  
- The other category of value types is [enum](../../../csharp/language-reference/keywords/enum.md). An enum defines a set of named integral constants. For example, the <xref:System.IO.FileMode?displayProperty=nameWithType> enumeration in the .NET class library contains a set of named constant integers that specify how a file should be opened. It is defined as shown in the following example:  
- 
- [!code-csharp[csProgGuideTypes#44](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#44)]  
-  
- The `System.IO.FileMode.Create` constant has a value of 2. However, the name is much more meaningful for humans reading the source code, and for that reason it is better to use enumerations instead of constant literal numbers. For more information, see <xref:System.IO.FileMode?displayProperty=nameWithType>.  
-  
- All enums inherit from <xref:System.Enum?displayProperty=nameWithType>, which inherits from <xref:System.ValueType?displayProperty=nameWithType>. All the rules that apply to structs also apply to enums. For more information about enums, see [Enumeration Types](../../../csharp/programming-guide/enumeration-types.md).  
-  
-### Reference Types  
- A type that is defined as a [class](../../../csharp/language-reference/keywords/class.md), [delegate](../../../csharp/language-reference/keywords/delegate.md), array, or [interface](../../../csharp/language-reference/keywords/interface.md) is a *reference type*. At run time, when you declare a variable of a reference type, the variable contains the value [null](../../../csharp/language-reference/keywords/null.md) until you explicitly create an object by using the [new](../../../csharp/language-reference/keywords/new.md) operator, or assign it an object that has been created elsewhere by using `new`, as shown in the following example:
-  
-```csharp  
-MyClass mc = new MyClass();  
-MyClass mc2 = mc;  
-```  
-   An interface must be initialized together with a class object that implements it. If `MyClass` implements `IMyInterface`, you create an instance of `IMyInterface` as shown in the following example:  
-  
-```csharp  
-IMyInterface iface = new MyClass();  
-```  
-  
- When the object is created, the memory is allocated on the managed heap, and the variable holds only a reference to the location of the object. Types on the managed heap require overhead both when they are allocated and when they are reclaimed by the automatic memory management functionality of the CLR, which is known as *garbage collection*. However, garbage collection is also highly optimized, and in most scenarios it does not create a performance issue. For more information about garbage collection, see [Automatic Memory Management](../../../standard/automatic-memory-management.md).  
-  
- All arrays are reference types, even if their elements are value types. Arrays implicitly derive from the <xref:System.Array?displayProperty=nameWithType> class, but you declare and use them with the simplified syntax that is provided by C#, as shown in the following example:  
-  
- [!code-csharp[csProgGuideTypes#45](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#45)]  
-  
- Reference types fully support inheritance. When you create a class, you can inherit from any other interface or class that is not defined as [sealed](../../../csharp/language-reference/keywords/sealed.md), and other classes can inherit from your class and override your virtual methods. For more information about how to create your own classes, see [Classes and Structs](../../../csharp/programming-guide/classes-and-structs/index.md). For more information about inheritance and virtual methods, see [Inheritance](../../../csharp/programming-guide/classes-and-structs/inheritance.md).  
-  
-## Types of Literal Values  
- In C#, literal values receive a type from the compiler. You can specify how a numeric literal should be typed by appending a letter to the end of the number. For example, to specify that the value 4.56 should be treated as a float, append an "f" or "F" after the number: `4.56f`. If no letter is appended, the compiler will infer a type for the literal. For more information about which types can be specified with letter suffixes, see the reference pages for individual types in [Value Types](../../../csharp/language-reference/keywords/value-types.md).  
-  
- Because literals are typed, and all types derive ultimately from <xref:System.Object?displayProperty=nameWithType>, you can write and compile code such as the following:  
-  
- [!code-csharp[csProgGuideTypes#37](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#37)]  
-  
-## Generic Types  
- A type can be declared with one or more *type parameters* that serve as a placeholder for the actual type (the *concrete type*) that client code will provide when it creates an instance of the type. Such types are called *generic types*. For example, the .NET type <xref:System.Collections.Generic.List%601?displayProperty=nameWithType> has one type parameter that by convention is given the name *T*. When you create an instance of the type, you specify the type of the objects that the list will contain, for example, string:  
- 
+```
+
+But you declare and assign values to them as if they were simple non-aggregate types:
+
+```csharp
+byte num = 0xA;
+int i = 5;
+char c = 'Z';
+```
+
+Value types are *sealed*, which means, for example, that you cannot derive a type from <xref:System.Int32?displayProperty=nameWithType>, and you cannot define a struct to inherit from any user-defined class or struct because a struct can only inherit from <xref:System.ValueType?displayProperty=nameWithType>. However, a struct can implement one or more interfaces. You can cast a struct type to any interface type that it implements; this causes a *boxing* operation to wrap the struct inside a reference type object on the managed heap. Boxing operations occur when you pass a value type to a method that takes a <xref:System.Object?displayProperty=nameWithType> or any interface type as an input parameter. For more information, see [Boxing and Unboxing](../../../csharp/programming-guide/types/boxing-and-unboxing.md).
+
+You use the [struct](../../../csharp/language-reference/keywords/struct.md) keyword to create your own custom value types. Typically, a struct is used as a container for a small set of related variables, as shown in the following example:
+
+[!code-csharp[csProgGuideObjects#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideObjects/CS/Objects.cs#1)]
+
+For more information about structs, see [Structs](../../../csharp/programming-guide/classes-and-structs/structs.md). For more information about value types in .NET, see [Value Types](../../../csharp/language-reference/keywords/value-types.md).
+
+The other category of value types is [enum](../../../csharp/language-reference/keywords/enum.md). An enum defines a set of named integral constants. For example, the <xref:System.IO.FileMode?displayProperty=nameWithType> enumeration in the .NET class library contains a set of named constant integers that specify how a file should be opened. It is defined as shown in the following example:
+
+[!code-csharp[csProgGuideTypes#44](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#44)]
+
+The `System.IO.FileMode.Create` constant has a value of 2. However, the name is much more meaningful for humans reading the source code, and for that reason it is better to use enumerations instead of constant literal numbers. For more information, see <xref:System.IO.FileMode?displayProperty=nameWithType>.
+
+All enums inherit from <xref:System.Enum?displayProperty=nameWithType>, which inherits from <xref:System.ValueType?displayProperty=nameWithType>. All the rules that apply to structs also apply to enums. For more information about enums, see [Enumeration Types](../../../csharp/programming-guide/enumeration-types.md).
+
+### Reference Types
+
+A type that is defined as a [class](../../../csharp/language-reference/keywords/class.md), [delegate](../../../csharp/language-reference/keywords/delegate.md), array, or [interface](../../../csharp/language-reference/keywords/interface.md) is a *reference type*. At run time, when you declare a variable of a reference type, the variable contains the value [null](../../../csharp/language-reference/keywords/null.md) until you explicitly create an object by using the [new](../../../csharp/language-reference/keywords/new.md) operator, or assign it an object that has been created elsewhere by using `new`, as shown in the following example:
+
+```csharp
+MyClass mc = new MyClass();
+MyClass mc2 = mc;
+```
+
+An interface must be initialized together with a class object that implements it. If `MyClass` implements `IMyInterface`, you create an instance of `IMyInterface` as shown in the following example:
+
+```csharp
+IMyInterface iface = new MyClass();
+```
+
+When the object is created, the memory is allocated on the managed heap, and the variable holds only a reference to the location of the object. Types on the managed heap require overhead both when they are allocated and when they are reclaimed by the automatic memory management functionality of the CLR, which is known as *garbage collection*. However, garbage collection is also highly optimized, and in most scenarios it does not create a performance issue. For more information about garbage collection, see [Automatic Memory Management](../../../standard/automatic-memory-management.md).
+
+All arrays are reference types, even if their elements are value types. Arrays implicitly derive from the <xref:System.Array?displayProperty=nameWithType> class, but you declare and use them with the simplified syntax that is provided by C#, as shown in the following example:
+
+[!code-csharp[csProgGuideTypes#45](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#45)]
+
+Reference types fully support inheritance. When you create a class, you can inherit from any other interface or class that is not defined as [sealed](../../../csharp/language-reference/keywords/sealed.md), and other classes can inherit from your class and override your virtual methods. For more information about how to create your own classes, see [Classes and Structs](../../../csharp/programming-guide/classes-and-structs/index.md). For more information about inheritance and virtual methods, see [Inheritance](../../../csharp/programming-guide/classes-and-structs/inheritance.md).
+
+## Types of Literal Values
+
+In C#, literal values receive a type from the compiler. You can specify how a numeric literal should be typed by appending a letter to the end of the number. For example, to specify that the value 4.56 should be treated as a float, append an "f" or "F" after the number: `4.56f`. If no letter is appended, the compiler will infer a type for the literal. For more information about which types can be specified with letter suffixes, see the reference pages for individual types in [Value Types](../../../csharp/language-reference/keywords/value-types.md).
+
+Because literals are typed, and all types derive ultimately from <xref:System.Object?displayProperty=nameWithType>, you can write and compile code such as the following:
+
+[!code-csharp[csProgGuideTypes#37](~/samples/snippets/csharp/VS_Snippets_VBCSharp/CsProgGuideTypes/CS/Class1.cs#37)]
+
+## Generic Types
+
+A type can be declared with one or more *type parameters* that serve as a placeholder for the actual type (the *concrete type*) that client code will provide when it creates an instance of the type. Such types are called *generic types*. For example, the .NET type <xref:System.Collections.Generic.List%601?displayProperty=nameWithType> has one type parameter that by convention is given the name *T*. When you create an instance of the type, you specify the type of the objects that the list will contain, for example, string:
+
 ```csharp
 List<string> stringList = new List<string>();
 stringList.Add("String example");
 // compile time error adding a type other than a string:
 stringList.Add(4);
 ```
- The use of the type parameter makes it possible to reuse the same class to hold any type of element, without having to convert each element to [object](../../../csharp/language-reference/keywords/object.md). Generic collection classes are called *strongly-typed collections* because the compiler knows the specific type of the collection's elements and can raise an error at compile-time if, for example, you try to add an integer to the `stringList` object in the previous example. For more information, see [Generics](../../../csharp/programming-guide/generics/index.md).  
-  
-## Implicit Types, Anonymous Types, and Nullable Types  
- As stated previously, you can implicitly type a local variable (but not class members) by using the [var](../../../csharp/language-reference/keywords/var.md) keyword. The variable still receives a type at compile time, but the type is provided by the compiler. For more information, see [Implicitly Typed Local Variables](../../../csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md).  
-  
- In some cases, it is inconvenient to create a named type for simple sets of related values that you do not intend to store or pass outside method boundaries. You can create *anonymous types* for this purpose. For more information, see [Anonymous Types](../../../csharp/programming-guide/classes-and-structs/anonymous-types.md).  
-  
- Ordinary value types cannot have a value of [null](../../../csharp/language-reference/keywords/null.md). However, you can create nullable value types by affixing a `?` after the type. For example, `int?` is an `int` type that can also have the value [null](../../../csharp/language-reference/keywords/null.md). In the CTS, nullable types are instances of the generic struct type <xref:System.Nullable%601?displayProperty=nameWithType>. Nullable types are especially useful when you are passing data to and from databases in which numeric values might be null. For more information, see [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md).  
-  
-## Related Sections  
- For more information, see the following topics:  
-  
--   [Casting and Type Conversions](../../../csharp/programming-guide/types/casting-and-type-conversions.md)  
-  
--   [Boxing and Unboxing](../../../csharp/programming-guide/types/boxing-and-unboxing.md)  
-  
--   [Using Type dynamic](../../../csharp/programming-guide/types/using-type-dynamic.md)  
-  
--   [Value Types](../../../csharp/language-reference/keywords/value-types.md)  
-  
--   [Reference Types](../../../csharp/language-reference/keywords/reference-types.md)  
-  
--   [Classes and Structs](../../../csharp/programming-guide/classes-and-structs/index.md)  
-  
--   [Anonymous Types](../../../csharp/programming-guide/classes-and-structs/anonymous-types.md)  
-  
--   [Generics](../../../csharp/programming-guide/generics/index.md)  
 
-## C# Language Specification  
- [!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]  
-  
+The use of the type parameter makes it possible to reuse the same class to hold any type of element, without having to convert each element to [object](../../../csharp/language-reference/keywords/object.md). Generic collection classes are called *strongly-typed collections* because the compiler knows the specific type of the collection's elements and can raise an error at compile-time if, for example, you try to add an integer to the `stringList` object in the previous example. For more information, see [Generics](../../../csharp/programming-guide/generics/index.md).
+
+## Implicit Types, Anonymous Types, and Nullable Types
+
+As stated previously, you can implicitly type a local variable (but not class members) by using the [var](../../../csharp/language-reference/keywords/var.md) keyword. The variable still receives a type at compile time, but the type is provided by the compiler. For more information, see [Implicitly Typed Local Variables](../../../csharp/programming-guide/classes-and-structs/implicitly-typed-local-variables.md).
+
+In some cases, it is inconvenient to create a named type for simple sets of related values that you do not intend to store or pass outside method boundaries. You can create *anonymous types* for this purpose. For more information, see [Anonymous Types](../../../csharp/programming-guide/classes-and-structs/anonymous-types.md).
+
+Ordinary value types cannot have a value of [null](../../../csharp/language-reference/keywords/null.md). However, you can create nullable value types by affixing a `?` after the type. For example, `int?` is an `int` type that can also have the value [null](../../../csharp/language-reference/keywords/null.md). In the CTS, nullable types are instances of the generic struct type <xref:System.Nullable%601?displayProperty=nameWithType>. Nullable types are especially useful when you are passing data to and from databases in which numeric values might be null. For more information, see [Nullable Types](../../../csharp/programming-guide/nullable-types/index.md).
+
+## Related Sections
+
+For more information, see the following topics:
+
+- [Casting and Type Conversions](../../../csharp/programming-guide/types/casting-and-type-conversions.md)
+
+- [Boxing and Unboxing](../../../csharp/programming-guide/types/boxing-and-unboxing.md)
+
+- [Using Type dynamic](../../../csharp/programming-guide/types/using-type-dynamic.md)
+
+- [Value Types](../../../csharp/language-reference/keywords/value-types.md)
+
+- [Reference Types](../../../csharp/language-reference/keywords/reference-types.md)
+
+- [Classes and Structs](../../../csharp/programming-guide/classes-and-structs/index.md)
+
+- [Anonymous Types](../../../csharp/programming-guide/classes-and-structs/anonymous-types.md)
+
+- [Generics](../../../csharp/programming-guide/generics/index.md)
+
+## C# Language Specification
+
+[!INCLUDE[CSharplangspec](~/includes/csharplangspec-md.md)]
+
 ## See also
 
 - [C# Reference](../../../csharp/language-reference/index.md)

--- a/docs/csharp/roslyn-sdk/get-started/semantic-analysis.md
+++ b/docs/csharp/roslyn-sdk/get-started/semantic-analysis.md
@@ -51,7 +51,7 @@ Next, build a <xref:Microsoft.CodeAnalysis.CSharp.CSharpCompilation> from the tr
 
 [!code-csharp[Create the compilation](../../../../samples/csharp/roslyn-sdk/SemanticQuickStart/Program.cs#3 "Create the compilation for the semantic model")]
 
-The <xref:Microsoft.CodeAnalysis.CSharp.CSharpCompilation.AddReferences%2A?displayProperty=nameWithType> method adds references to the compilation. The <xref:Microsoft.CodeAnalysis.MetadataReference.CreateFromFile%2A?displayProperty=nameWithType> method loads an assembly as a reference. 
+The <xref:Microsoft.CodeAnalysis.CSharp.CSharpCompilation.AddReferences%2A?displayProperty=nameWithType> method adds references to the compilation. The <xref:Microsoft.CodeAnalysis.MetadataReference.CreateFromFile%2A?displayProperty=nameWithType> method loads an assembly as a reference.
 
 ## Querying the semantic model
 
@@ -154,4 +154,5 @@ Intern
 IsInterned
 Press any key to continue . . .
 ```
+
 You've used the Semantic API to find and display information about the symbols that are part of this program.

--- a/docs/framework/additional-apis/adodb.eventreasonenum.md
+++ b/docs/framework/additional-apis/adodb.eventreasonenum.md
@@ -16,6 +16,7 @@ api_type:
 [GuidAttribute("00000531-0000-0010-8000-00AA006D2EA4")]
 public enum EventReasonEnum
 ```
+
 ## Members
 
 | Member name  | Description  |

--- a/docs/framework/additional-apis/adodb.eventstatusenum.md
+++ b/docs/framework/additional-apis/adodb.eventstatusenum.md
@@ -16,6 +16,7 @@ api_type:
 [GuidAttribute("00000530-0000-0010-8000-00AA006D2EA4")]
 public enum EventStatusEnum
 ```
+
 ## Members
 
 | Member name  | Description  |

--- a/docs/framework/docker/console.md
+++ b/docs/framework/docker/console.md
@@ -21,22 +21,24 @@ The [complete example](https://github.com/dotnet/samples/tree/master/framework/d
 You need to be familiar with some Docker terms before you begin working
 on moving your application to a container.
 
+> [!NOTE]
 > A *Docker image* is a read-only template that defines the environment
 > for a running container, including the operating system (OS), system components, and application(s).
 
 One important feature of Docker images is that images are composed from a
 base image. Each new image adds a small set of features to an existing
-image. 
+image.
 
-> A *Docker container* is a running instance of an image. 
+> [!NOTE]
+> A *Docker container* is a running instance of an image.
 
 You scale an application by running the same image in many containers.
 Conceptually, this is similar to running the same application in multiple
 hosts.
 
-You can learn more about the Docker architecture by reading the 
+You can learn more about the Docker architecture by reading the
 [Docker Overview](https://docs.docker.com/engine/understanding-docker/)
-on the Docker site. 
+on the Docker site.
 
 Moving your console application is a matter of a few steps.
 
@@ -45,7 +47,8 @@ Moving your console application is a matter of a few steps.
 1. [Process to build and run the Docker container](#creating-the-image)
 
 ## Prerequisites
-Windows containers are supported on [Windows 10 Anniversary Update](https://www.microsoft.com/en-us/software-download/windows10/) or 
+
+Windows containers are supported on [Windows 10 Anniversary Update](https://www.microsoft.com/en-us/software-download/windows10/) or
 [Windows Server 2016](https://www.microsoft.com/en-us/cloud-platform/windows-server).
 
 > [!NOTE]
@@ -56,13 +59,14 @@ You need to have Docker for Windows, version 1.12 Beta 26 or higher to support W
 ![Screenshot of the Windows container menu option.](./media/console/windows-container-option.png)
 
 ## Building the application
+
 Typically console applications are distributed through an installer, FTP, or File Share deployment. When deploying to a container, the assets need to be compiled and staged to a location that can be used when the Docker image is created.
 
 Here is the sample application: [ConsoleRandomAnswerGenerator](https://github.com/dotnet/samples/tree/master/framework/docker/ConsoleRandomAnswerGenerator)
 
 In *build.ps1*<sup>[[source]](https://github.com/dotnet/samples/blob/master/framework/docker/ConsoleRandomAnswerGenerator/ConsoleRandomAnswerGenerator/build.ps1)</sup>, the script uses [MSBuild](/visualstudio/msbuild/msbuild) to compile the application to complete the task of building the assets. There are a few parameters passed to MSBuild to finalize the needed assets. The name of the project file or solution to be compiled, the location for the output and finally the configuration (Release or Debug).
 
-In the call to `Invoke-MSBuild` the `OutputPath` is set to **publish** and  `Configuration` set to **Release**. 
+In the call to `Invoke-MSBuild` the `OutputPath` is set to **publish** and  `Configuration` set to **Release**.
 
 ```powershell
 function Invoke-MSBuild ([string]$MSBuildPath, [string]$MSBuildParameters) {
@@ -75,14 +79,16 @@ Invoke-MSBuild -MSBuildPath "MSBuild.exe" -MSBuildParameters ".\ConsoleRandomAns
 ## Creating the Dockerfile
 The base image used for a console .NET Framework application is `microsoft/windowsservercore`, publicly available on [Docker Hub](https://hub.docker.com/r/microsoft/windowsservercore/). The base image contains a minimal installation of Windows Server 2016, .NET Framework 4.6.2 and serves as the base OS image for Windows Containers.
 
-```
+```Dockerfile
 FROM microsoft/windowsservercore
 ADD publish/ /
 ENTRYPOINT ConsoleRandomAnswerGenerator.exe
 ```
-The first line in the Dockerfile designates the base image using the [`FROM`](https://docs.docker.com/engine/reference/builder/#/from) instruction. Next, [`ADD`](https://docs.docker.com/engine/reference/builder/#/add) in the file copies the application assets from the **publish** folder to root folder of the container and last; setting the [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#/entrypoint) of the image states that this is the command or application that will run when the container starts. 
+
+The first line in the Dockerfile designates the base image using the [`FROM`](https://docs.docker.com/engine/reference/builder/#/from) instruction. Next, [`ADD`](https://docs.docker.com/engine/reference/builder/#/add) in the file copies the application assets from the **publish** folder to root folder of the container and last; setting the [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#/entrypoint) of the image states that this is the command or application that will run when the container starts.
 
 ## Creating the image
+
 In order to create the Docker image, the following code is added to the *build.ps1* script. When the script is run, the `console-random-answer-generator` image is created using the assets compiled from MSBuild defined in the [Building the application](#building-the-application) section.
 
 ```powershell
@@ -106,6 +112,7 @@ console-random-answer-generator   latest              8f7c807db1b5        8 seco
 ```
 
 ## Running the container
+
 You can start the container from the command line using the Docker commands.
 
 ```
@@ -121,8 +128,8 @@ The answer to your question: 'Are you a square container?' is Concentrate and as
 If you run the `docker ps -a` command from PowerShell, you can see that the container still exists.
 
 ```
-CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS                          
-70c3d48f4343        console-random-answer-generator   "cmd /S /C ConsoleRan"   2 minutes ago       Exited (0) About a minute ago      
+CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS
+70c3d48f4343        console-random-answer-generator   "cmd /S /C ConsoleRan"   2 minutes ago       Exited (0) About a minute ago
 ```
 
 The STATUS column shows at "About a minute ago", the application was complete and could be shut down. If the command was run a hundred times, there would be a hundred containers left static with no work to do. In the beginning scenario the ideal operation was to do the work and shutdown or cleanup. To accomplish that workflow, adding the `--rm` option to the `docker run` command will remove the container as soon as the `Exited` signal is received.
@@ -134,6 +141,7 @@ docker run --rm console-random-answer-generator "Are you a square container?"
 Running the command with this option and then looking at the output of `docker ps -a` command; notice that the container id (the `Environment.MachineName`) is not in the list.
 
 ### Running the container using PowerShell
+
 In the sample project files there is also a *run.ps1* which is an example of how to use PowerShell to run the application accepting the arguments.
 
 To run, open PowerShell and use the following command:
@@ -143,4 +151,5 @@ To run, open PowerShell and use the following command:
 ```
 
 ## Summary
+
 Just by adding a Dockerfile and publishing the application, you can containerize your .NET Framework console applications and now take the advantage of running multiple instances, clean start and stop and more Windows Server 2016 capabilities without making any changes to the application code at all.

--- a/docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md
+++ b/docs/framework/reflection-and-codedom/specifying-fully-qualified-type-names.md
@@ -181,6 +181,7 @@ com.microsoft.crypto, Culture="", PublicKeyToken=a5d015c7d5a0b012
 com.microsoft.crypto, Culture=en, PublicKeyToken=a5d015c7d5a0b012,
     Version=1.0.0.0
 ```
+
 ## Specifying generic types
 
 SimpleTypeSpec\`NUMBER represents an open generic type with from 1 to *n* generic type parameters. For example, to get reference to the open generic type List\<T> or the closed generic type List\<String>, use ``Type.GetType("System.Collections.Generic.List`1")`` To get a reference to the generic type Dictionary\<TKey,TValue>, use ``Type.GetType("System.Collections.Generic.Dictionary`2")``.

--- a/docs/framework/resources/packaging-and-deploying-resources-in-desktop-apps.md
+++ b/docs/framework/resources/packaging-and-deploying-resources-in-desktop-apps.md
@@ -221,6 +221,7 @@ When you run the example from a system whose language is anything other than Rus
 ```
 Bon jour!
 ```
+
 ## Suggested Packaging Alternative
 
 Time or budget constraints might prevent you from creating a set of resources for every subculture that your application supports. Instead, you can create a single satellite assembly for a parent culture that all related subcultures can use. For example, you can provide a single English satellite assembly (en) that is retrieved by users who request region-specific English resources, and a single German satellite assembly (de) for users who request region-specific German resources. For example, requests for German as spoken in Germany (de-DE), Austria (de-AT), and Switzerland (de-CH) would fall back to the German satellite assembly (de). The default resources are the final fallback and therefore should be the resources that will be requested by the majority of your application's users, so choose these resources carefully. This approach deploys resources that are less culturally specific, but can significantly reduce your application's localization costs.

--- a/docs/framework/tools/gacutil-exe-gac-tool.md
+++ b/docs/framework/tools/gacutil-exe-gac-tool.md
@@ -1,7 +1,7 @@
 ---
 title: "Gacutil.exe (Global Assembly Cache Tool)"
 ms.date: "03/30/2017"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "assemblies [.NET Framework], global assembly cache"
   - "global assembly cache, viewing contents"
   - "viewing assemblies in global assembly cache"
@@ -21,78 +21,81 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # Gacutil.exe (Global Assembly Cache Tool)
-The Global Assembly Cache tool allows you to view and manipulate the contents of the global assembly cache and download cache.  
-  
- This tool is automatically installed with Visual Studio. To run the tool, use the Developer Command Prompt for Visual Studio (or the Visual Studio Command Prompt in Windows 7). For more information, see [Command Prompts](../../../docs/framework/tools/developer-command-prompt-for-vs.md).  
-  
- At the command prompt, type the following:  
-  
-## Syntax  
-  
-```  
-gacutil [options] [assemblyName | assemblyPath | assemblyListFile]  
-```  
-  
-## Parameters  
-  
-|Argument|Description|  
-|--------------|-----------------|  
-|*assemblyName*|The name of an assembly. You can supply either a partially specified assembly name such as `myAssembly` or a fully specified assembly name such as `myAssembly, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0038abc9deabfle5`.|  
-|*assemblyPath*|The name of a file that contains an assembly manifest.|  
-|*assemblyListFile*|The path to an ANSI text file that lists assemblies to install or uninstall. To use a text file to install assemblies, specify the path to each assembly on a separate line in the file. The tool interprets relative paths, relative to the location of the *assemblyListFile*. To use a text file to uninstall assemblies, specify the fully qualified assembly name for each assembly on a separate line in the file. See the *assemblyListFile* contents examples later in this topic.|  
-  
-|Option|Description|  
-|------------|-----------------|  
-|**/cdl**|Deletes the contents of the download cache.|  
-|**/f**|Specify this option with the **/i** or **/il** options to force an assembly to reinstall. If an assembly with the same name already exists in the global assembly cache, the tool overwrites it.|  
-|**/h**[**elp**]|Displays command syntax and options for the tool.|  
-|**/i** *assemblyPath*|Installs an assembly into the global assembly cache.|  
-|**/if**  *assemblyPath*|Installs an assembly into the global assembly cache. If an assembly with the same name already exists in the global assembly cache, the tool overwrites it.<br /><br /> Specifying this option is equivalent to specifying the **/i** and **/f** options together.|  
-|**/il** *assemblyListFile*|Installs one or more assemblies specified in *assemblyListFile* into the global assembly cache.|  
-|**/ir**  *assemblyPath*<br /><br /> *scheme*<br /><br /> *id*<br /><br /> *description*|Installs an assembly into the global assembly cache and adds a reference to count the assembly. You must specify the *assemblyPath*, *scheme*, *id*,and *description* parameters with this option. For a description of the valid values you can specify for these parameters, see the **/r** option.<br /><br /> Specifying this option is equivalent to specifying the **/i** and **/r** options together.|  
-|**/l** [*assemblyName*]|Lists the contents of the global assembly cache. If you specify the *assemblyName* parameter, the tool lists only the assemblies matching that name.|  
-|**/ldl**|Lists the contents of the downloaded files cache.|  
-|**/lr** [*assemblyName*]|Lists all assemblies and their corresponding reference counts. If you specify the *assemblyName* parameter, the tool lists only the assemblies matching that name and their corresponding reference counts.|  
-|**/nologo**|Suppresses the Microsoft startup banner display.|  
-|**/r** [*assemblyName &#124; assemblyPath*]<br /><br /> *scheme*<br /><br /> *id*<br /><br /> *description*|Specifies a traced reference to an assembly or assemblies to install or uninstall. Specify this option with the **/i**, **/il**, **/u**, or **/ul** options.<br /><br /> To install an assembly, specify the *assemblyPath*, *scheme*, *id*,and *description* parameters with this option. To uninstall an assembly, specify the *assemblyName*, *scheme*, *id*,and *description* parameters.<br /><br /> To remove a reference to an assembly, you must specify the same *scheme*, *id*, and *description* parameters that were specified with the **/i** and **/r** (or **/ir**) options when the assembly was installed. If you are uninstalling an assembly, the tool also removes the assembly from the global assembly cache if it is the last reference to remove and if Windows Installer has no outstanding references to the assembly.<br /><br /> The *scheme* parameter specifies the type of installation scheme. You can specify one of the following values:<br /><br /> -   UNINSTALL_KEY: Specify this value if the installer adds the application to Add/Remove Programs in Microsoft Windows. Applications add themselves to Add/Remove Programs by adding a registry key to HKLM\Software\Microsoft\Windows\CurrentVersion.<br />-   FILEPATH: Specify this value if the installer does not add the application to Add/Remove Programs.<br />-   OPAQUE: Specify this value if supplying a registry key or file path does not apply to your installation scenario. This value allows you to specify custom information for the *id* parameter.<br /><br /> The value to specify for the *id* parameter depends on the value specified for the *scheme* parameter:<br /><br /> -   If you specify UNINSTALL_KEY for the *scheme* parameter, specify the name of the application set in the HKLM\Software\Microsoft\Windows\CurrentVersion registry key. For example, if the registry key is HKLM\Software\Microsoft\Windows\CurrentVersion\MyApp, specify MyApp for the *id* parameter.<br />-   If you specify FILEPATH for the *scheme* parameter, specify the full path to the executable file that installs the assembly as the *id* parameter.<br />-   If you specify OPAQUE for the *scheme* parameter, you can supply any piece of data as the *id* parameter. The data you specify must be enclosed in quotation marks ("").<br /><br /> The *description* parameter allows you to specify descriptive text about the application to install. This information is displayed when references are enumerated.|  
-|**/silent**|Suppresses the display of all output.|  
-|**/u**  *assemblyName*|Uninstalls an assembly from the global assembly cache.|  
-|**/uf**  *assemblyName*|Forces a specified assembly to uninstall by removing all references to the assembly.<br /><br /> Specifying this option is equivalent to specifying the **/u** and **/f** options together. **Note:**  You cannot use this option to remove an assembly that was installed using Microsoft Windows Installer. If you attempt this operation, the tool displays an error message.|  
-|**/ul** *assemblyListFile*|Uninstalls one or more assemblies specified in *assemblyListFile* from the global assembly cache.|  
-|**/u**[**ngen**] *assemblyName*|Uninstalls a specified assembly from the global assembly cache. If the specified assembly has existing reference counts, the tool displays the reference counts and does not remove the assembly from the global assembly cache. **Note:**  In the .NET Framework version 2.0, `/ungen` is not supported. Instead, use the `uninstall` command of the [Ngen.exe (Native Image Generator)](../../../docs/framework/tools/ngen-exe-native-image-generator.md). <br /><br /> In the .NET Framework versions 1.0 and 1.1, specifying **/ungen** causes Gacutil.exe to remove the assembly from the native image cache. This cache stores the native images for assemblies that have been created using the [Ngen.exe (Native Image Generator)](../../../docs/framework/tools/ngen-exe-native-image-generator.md).|  
-|**/ur**  *assemblyName*<br /><br /> *scheme*<br /><br /> *id*<br /><br /> *description*|Uninstalls a reference to a specified assembly from the global assembly cache. To remove a reference to an assembly, you must specify the same *scheme*, *id*, and *description* parameters that were specified with the **/i** and **/r** (or **/ir)** options when the assembly was installed. For a description of the valid values you can specify for these parameters, see the **/r** option.<br /><br /> Specifying this option is equivalent to specifying the **/u** and **/r** options together.|  
-|**/?**|Displays command syntax and options for the tool.|  
-  
-## Remarks  
-  
-> [!NOTE]
->  You must have administrator privileges to use Gacutil.exe.  
-  
- Specifically, Gacutil.exe allows you to install assemblies into the cache, remove them from the cache, and list the contents of the cache.  
-  
- Gacutil.exe provides options that support reference counting similar to the reference counting scheme supported by Windows Installer. You can use Gacutil.exe to install two applications that install the same assembly; the tool keeps track of the number of references to the assembly. As a result, the assembly will remain on the computer until both applications are uninstalled. If you are using Gacutil.exe for actual product installations, use the options that support reference counting. Use the **/i** and **/r** options together to install an assembly and add a reference to count it. Use the **/u** and **/r** options together to remove a reference count for an assembly. Be aware that using the **/i** and **/u** options alone does not support reference counting. These options are appropriate for use during product development but not for actual product installations.  
-  
- Use the **/il** or **/ul** options to install or uninstall a list of assemblies stored in an ANSI text file. The contents of the text file must be formatted correctly. To use a text file to install assemblies, specify the path to each assembly on a separate line in the file. The following example demonstrates the contents of a file containing assemblies to install.  
-  
-```  
-myAssembly1.dll  
-myAssembly2.dll  
-myAssembly3.dll  
-```  
-  
- To use a text file to uninstall assemblies, specify the fully qualified assembly name for each assembly on a separate line in the file. The following example demonstrates the contents of a file containing assemblies to uninstall.  
-  
-```  
-myAssembly1,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab  
-myAssembly2,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab  
-myAssembly3,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab  
-```  
+
+The Global Assembly Cache tool allows you to view and manipulate the contents of the global assembly cache and download cache.
+
+This tool is automatically installed with Visual Studio. To run the tool, use the Developer Command Prompt for Visual Studio (or the Visual Studio Command Prompt in Windows 7). For more information, see [Command Prompts](../../../docs/framework/tools/developer-command-prompt-for-vs.md).
+
+At the command prompt, type the following:
+
+## Syntax
+
+```
+gacutil [options] [assemblyName | assemblyPath | assemblyListFile]
+```
+
+## Parameters
+
+|Argument|Description|
+|--------------|-----------------|
+|*assemblyName*|The name of an assembly. You can supply either a partially specified assembly name such as `myAssembly` or a fully specified assembly name such as `myAssembly, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0038abc9deabfle5`.|
+|*assemblyPath*|The name of a file that contains an assembly manifest.|
+|*assemblyListFile*|The path to an ANSI text file that lists assemblies to install or uninstall. To use a text file to install assemblies, specify the path to each assembly on a separate line in the file. The tool interprets relative paths, relative to the location of the *assemblyListFile*. To use a text file to uninstall assemblies, specify the fully qualified assembly name for each assembly on a separate line in the file. See the *assemblyListFile* contents examples later in this topic.|
+
+|Option|Description|
+|------------|-----------------|
+|**/cdl**|Deletes the contents of the download cache.|
+|**/f**|Specify this option with the **/i** or **/il** options to force an assembly to reinstall. If an assembly with the same name already exists in the global assembly cache, the tool overwrites it.|
+|**/h**[**elp**]|Displays command syntax and options for the tool.|
+|**/i** *assemblyPath*|Installs an assembly into the global assembly cache.|
+|**/if**  *assemblyPath*|Installs an assembly into the global assembly cache. If an assembly with the same name already exists in the global assembly cache, the tool overwrites it.<br /><br /> Specifying this option is equivalent to specifying the **/i** and **/f** options together.|
+|**/il** *assemblyListFile*|Installs one or more assemblies specified in *assemblyListFile* into the global assembly cache.|
+|**/ir**  *assemblyPath*<br /><br /> *scheme*<br /><br /> *id*<br /><br /> *description*|Installs an assembly into the global assembly cache and adds a reference to count the assembly. You must specify the *assemblyPath*, *scheme*, *id*,and *description* parameters with this option. For a description of the valid values you can specify for these parameters, see the **/r** option.<br /><br /> Specifying this option is equivalent to specifying the **/i** and **/r** options together.|
+|**/l** [*assemblyName*]|Lists the contents of the global assembly cache. If you specify the *assemblyName* parameter, the tool lists only the assemblies matching that name.|
+|**/ldl**|Lists the contents of the downloaded files cache.|
+|**/lr** [*assemblyName*]|Lists all assemblies and their corresponding reference counts. If you specify the *assemblyName* parameter, the tool lists only the assemblies matching that name and their corresponding reference counts.|
+|**/nologo**|Suppresses the Microsoft startup banner display.|
+|**/r** [*assemblyName &#124; assemblyPath*]<br /><br /> *scheme*<br /><br /> *id*<br /><br /> *description*|Specifies a traced reference to an assembly or assemblies to install or uninstall. Specify this option with the **/i**, **/il**, **/u**, or **/ul** options.<br /><br /> To install an assembly, specify the *assemblyPath*, *scheme*, *id*,and *description* parameters with this option. To uninstall an assembly, specify the *assemblyName*, *scheme*, *id*,and *description* parameters.<br /><br /> To remove a reference to an assembly, you must specify the same *scheme*, *id*, and *description* parameters that were specified with the **/i** and **/r** (or **/ir**) options when the assembly was installed. If you are uninstalling an assembly, the tool also removes the assembly from the global assembly cache if it is the last reference to remove and if Windows Installer has no outstanding references to the assembly.<br /><br /> The *scheme* parameter specifies the type of installation scheme. You can specify one of the following values:<br /><br /> - UNINSTALL_KEY: Specify this value if the installer adds the application to Add/Remove Programs in Microsoft Windows. Applications add themselves to Add/Remove Programs by adding a registry key to HKLM\Software\Microsoft\Windows\CurrentVersion.<br />- FILEPATH: Specify this value if the installer does not add the application to Add/Remove Programs.<br />- OPAQUE: Specify this value if supplying a registry key or file path does not apply to your installation scenario. This value allows you to specify custom information for the *id* parameter.<br /><br /> The value to specify for the *id* parameter depends on the value specified for the *scheme* parameter:<br /><br /> - If you specify UNINSTALL_KEY for the *scheme* parameter, specify the name of the application set in the HKLM\Software\Microsoft\Windows\CurrentVersion registry key. For example, if the registry key is HKLM\Software\Microsoft\Windows\CurrentVersion\MyApp, specify MyApp for the *id* parameter.<br />- If you specify FILEPATH for the *scheme* parameter, specify the full path to the executable file that installs the assembly as the *id* parameter.<br />- If you specify OPAQUE for the *scheme* parameter, you can supply any piece of data as the *id* parameter. The data you specify must be enclosed in quotation marks ("").<br /><br /> The *description* parameter allows you to specify descriptive text about the application to install. This information is displayed when references are enumerated.|
+|**/silent**|Suppresses the display of all output.|
+|**/u**  *assemblyName*|Uninstalls an assembly from the global assembly cache.|
+|**/uf**  *assemblyName*|Forces a specified assembly to uninstall by removing all references to the assembly.<br /><br /> Specifying this option is equivalent to specifying the **/u** and **/f** options together. **Note:**  You cannot use this option to remove an assembly that was installed using Microsoft Windows Installer. If you attempt this operation, the tool displays an error message.|
+|**/ul** *assemblyListFile*|Uninstalls one or more assemblies specified in *assemblyListFile* from the global assembly cache.|
+|**/u**[**ngen**] *assemblyName*|Uninstalls a specified assembly from the global assembly cache. If the specified assembly has existing reference counts, the tool displays the reference counts and does not remove the assembly from the global assembly cache. **Note:**  In the .NET Framework version 2.0, `/ungen` is not supported. Instead, use the `uninstall` command of the [Ngen.exe (Native Image Generator)](../../../docs/framework/tools/ngen-exe-native-image-generator.md). <br /><br /> In the .NET Framework versions 1.0 and 1.1, specifying **/ungen** causes Gacutil.exe to remove the assembly from the native image cache. This cache stores the native images for assemblies that have been created using the [Ngen.exe (Native Image Generator)](../../../docs/framework/tools/ngen-exe-native-image-generator.md).|
+|**/ur**  *assemblyName*<br /><br /> *scheme*<br /><br /> *id*<br /><br /> *description*|Uninstalls a reference to a specified assembly from the global assembly cache. To remove a reference to an assembly, you must specify the same *scheme*, *id*, and *description* parameters that were specified with the **/i** and **/r** (or **/ir)** options when the assembly was installed. For a description of the valid values you can specify for these parameters, see the **/r** option.<br /><br /> Specifying this option is equivalent to specifying the **/u** and **/r** options together.|
+|**/?**|Displays command syntax and options for the tool.|
+
+## Remarks
 
 > [!NOTE]
->  Attempting to install an assembly with a filename longer than between 79 and 91 characters (excluding the file extension) can result in the following error:
+> You must have administrator privileges to use Gacutil.exe.
+
+Specifically, Gacutil.exe allows you to install assemblies into the cache, remove them from the cache, and list the contents of the cache.
+
+Gacutil.exe provides options that support reference counting similar to the reference counting scheme supported by Windows Installer. You can use Gacutil.exe to install two applications that install the same assembly; the tool keeps track of the number of references to the assembly. As a result, the assembly will remain on the computer until both applications are uninstalled. If you are using Gacutil.exe for actual product installations, use the options that support reference counting. Use the **/i** and **/r** options together to install an assembly and add a reference to count it. Use the **/u** and **/r** options together to remove a reference count for an assembly. Be aware that using the **/i** and **/u** options alone does not support reference counting. These options are appropriate for use during product development but not for actual product installations.
+
+Use the **/il** or **/ul** options to install or uninstall a list of assemblies stored in an ANSI text file. The contents of the text file must be formatted correctly. To use a text file to install assemblies, specify the path to each assembly on a separate line in the file. The following example demonstrates the contents of a file containing assemblies to install.
+
+```
+myAssembly1.dll
+myAssembly2.dll
+myAssembly3.dll
+```
+
+To use a text file to uninstall assemblies, specify the fully qualified assembly name for each assembly on a separate line in the file. The following example demonstrates the contents of a file containing assemblies to uninstall.
+
+```
+myAssembly1,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
+myAssembly2,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
+myAssembly3,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
+```
+
+> [!NOTE]
+> Attempting to install an assembly with a filename longer than between 79 and 91 characters (excluding the file extension) can result in the following error:
+>
 > ```
 > Failure adding assembly to the cache:   The file name is too long.
 > ```
+>
 > This is because internally Gacutil.exe constructs a path of up to MAX_PATH characters that consists of the following elements:
 > - GAC Root - 34 chars (ie. `C:\Windows\Microsoft.NET\assembly\`)
 > - Architecture - 7 or 9 chars (ie. `GAC_32\`, `GAC_64\`, `GAC_MSIL`)
@@ -104,61 +107,70 @@ myAssembly3,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
 >   - PublicKey - 17 chars (eg. `31bf3856ad364e35\`)
 > - DllFileName - Up to 91 + 4 chars (ie. `<AssemblyName>.dll`)
 
-## Examples  
- The following command installs the assembly `mydll.dll` into the global assembly cache.  
-  
-```  
-gacutil /i mydll.dll  
-```  
-  
- The following command removes the assembly `hello` from the global assembly cache as long as no reference counts exist for the assembly.  
-  
-```  
-gacutil /u hello  
-```  
-  
- Note that the previous command might remove more than one assembly from the assembly cache because the assembly name is not fully specified. For example, if both version 1.0.0.0 and 3.2.2.1 of `hello` are installed in the cache, the command `gacutil /u hello` removes both of the assemblies.  
-  
- Use the following example to avoid removing more than one assembly. This command removes only the `hello` assembly that matches the fully specified version number, culture, and public key.  
-  
-```  
-gacutil /u hello, Version=1.0.0.1, Culture="de",PublicKeyToken=45e343aae32233ca  
-```  
-  
- The following command installs the assemblies specified in the file `assemblyList.txt` into the global assembly cache.  
-  
- `gacutil /il assemblyList.txt`  
-  
- The following command removes the assemblies specified in the file `assemblyList.txt` from the global assembly cache.  
-  
- `gacutil /ul assemblyList.txt`  
-  
- The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The assembly `myDll.dll` is used by the application `MyApp`. The `UNINSTALL_KEY MyApp` parameter specifies the registry key that adds `MyApp` to Add/Remove Programs in Windows. The description parameter is specified as `My Application Description`.  
-  
-```  
-gacutil /i /r myDll.dll UNINSTALL_KEY MyApp "My Application Description"  
-```  
-  
- The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The scheme parameter, `FILEPATH`, and the id parameter, `c:\applications\myApp\myApp.exe`, specify the path to the application that is installing `myDll.dll.` The description parameter is specified as `MyApp`.  
-  
- `gacutil /i /r myDll.dll FILEPATH c:\applications\myApp\myApp.exe MyApp`  
-  
- The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The scheme parameter, `OPAQUE`, allows you to customize the id and description parameters.  
-  
-```  
-gacutil /i /r mydll.dll OPAQUE "Insert custom application details here" "Insert Custom description information here"  
-```  
-  
- The following command removes the reference to `myDll.dll` by the application `myApp`. If this is the last reference to the assembly, it will also remove the assembly from the global assembly cache.  
-  
- `gacutil /u /r myDll.dll FILEPATH c:\applications\myApp\myApp.exe MyApp`  
-  
- The following command lists the contents of the global assembly cache.  
-  
-```  
-gacutil /l  
-```  
-  
+## Examples
+
+The following command installs the assembly `mydll.dll` into the global assembly cache.
+
+```
+gacutil /i mydll.dll
+```
+
+The following command removes the assembly `hello` from the global assembly cache as long as no reference counts exist for the assembly.
+
+```
+gacutil /u hello
+```
+
+Note that the previous command might remove more than one assembly from the assembly cache because the assembly name is not fully specified. For example, if both version 1.0.0.0 and 3.2.2.1 of `hello` are installed in the cache, the command `gacutil /u hello` removes both of the assemblies.
+
+Use the following example to avoid removing more than one assembly. This command removes only the `hello` assembly that matches the fully specified version number, culture, and public key.
+
+```
+gacutil /u hello, Version=1.0.0.1, Culture="de",PublicKeyToken=45e343aae32233ca
+```
+
+The following command installs the assemblies specified in the file `assemblyList.txt` into the global assembly cache.
+
+```
+gacutil /il assemblyList.txt
+```
+
+The following command removes the assemblies specified in the file `assemblyList.txt` from the global assembly cache.
+
+```
+gacutil /ul assemblyList.txt
+```
+
+The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The assembly `myDll.dll` is used by the application `MyApp`. The `UNINSTALL_KEY MyApp` parameter specifies the registry key that adds `MyApp` to Add/Remove Programs in Windows. The description parameter is specified as `My Application Description`.
+
+```
+gacutil /i /r myDll.dll UNINSTALL_KEY MyApp "My Application Description"
+```
+
+The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The scheme parameter, `FILEPATH`, and the id parameter, `c:\applications\myApp\myApp.exe`, specify the path to the application that is installing `myDll.dll.` The description parameter is specified as `MyApp`.
+
+```
+gacutil /i /r myDll.dll FILEPATH c:\applications\myApp\myApp.exe MyApp
+```
+
+The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The scheme parameter, `OPAQUE`, allows you to customize the id and description parameters.
+
+```
+gacutil /i /r mydll.dll OPAQUE "Insert custom application details here" "Insert Custom description information here"
+```
+
+The following command removes the reference to `myDll.dll` by the application `myApp`. If this is the last reference to the assembly, it will also remove the assembly from the global assembly cache.
+
+```
+gacutil /u /r myDll.dll FILEPATH c:\applications\myApp\myApp.exe MyApp
+```
+
+The following command lists the contents of the global assembly cache.
+
+```
+gacutil /l
+```
+
 ## See also
 
 - [Tools](../../../docs/framework/tools/index.md)

--- a/docs/framework/unmanaged-api/debugging/ixclrdatamodule-request-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdatamodule-request-method.md
@@ -23,7 +23,8 @@ Requests to populate the buffer given with the module's data.
 [!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
 
 ## Syntax
-```
+
+```cpp
 HRESULT Request([in] ULONG32 reqCode,
     [in] ULONG32 inBufferSize,
     [in, size_is(inBufferSize)] BYTE* inBuffer,
@@ -54,10 +55,10 @@ The provided method is part of the `IXCLRDataModule` interface and corresponds t
 
 ## Requirements
 
-**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-**Header:** None   
-**Library:** None  
-**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+**Header:** None
+**Library:** None
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-endenummodules-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-endenummodules-method.md
@@ -23,7 +23,8 @@ Releases the resources used by internal iterators used during module enumeration
 [!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
 
 ## Syntax
-```
+
+```cpp
 HRESULT EndEnumModules(
     [in] CLRDATA_ENUM handle
 );
@@ -40,10 +41,10 @@ The provided method is part of the `IXCLRDataProcess` interface and corresponds 
 
 ## Requirements
 
-**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).   
-**Header:** None   
-**Library:** None   
-**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]   
+**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+**Header:** None
+**Library:** None
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/debugging/ixclrdataprocess-getappdomainbyuniqueid-method.md
+++ b/docs/framework/unmanaged-api/debugging/ixclrdataprocess-getappdomainbyuniqueid-method.md
@@ -23,7 +23,8 @@ Gets an `AppDomain` in a process based on its unique identifier.
 [!INCLUDE[debugging-api-recommended-note](../../../../includes/debugging-api-recommended-note.md)]
 
 ## Syntax
-```
+
+```cpp
 HRESULT GetAppDomainByUniqueID(
     [in] ULONG64               id,
     [out] IXCLRDataAppDomain **appDomain
@@ -43,10 +44,11 @@ HRESULT GetAppDomainByUniqueID(
 The provided method is part of the `IXCLRDataProcess` interface and corresponds to the 20th slot of the virtual method table. The `IXCLRDataAppDomain*` returned is used for interaction with other APIs.
 
 ## Requirements
-**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-**Header:** None  
-**Library:** None  
-**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]  
+
+**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+**Header:** None
+**Library:** None
+**.NET Framework Versions:** [!INCLUDE[net_current_v47plus](../../../../includes/net-current-v47plus.md)]
 
 ## See also
 

--- a/docs/framework/unmanaged-api/wmi/connectserverwmi.md
+++ b/docs/framework/unmanaged-api/wmi/connectserverwmi.md
@@ -2,29 +2,30 @@
 title: ConnectServerWmi function (Unmanaged API Reference)
 description: The ConnectServerWmi function uses DCOM to create a connection to a WMI namespace.
 ms.date: "11/06/2017"
-api_name: 
+api_name:
   - "ConnectServerWmi"
-api_location: 
+api_location:
   - "WMINet_Utils.dll"
-api_type: 
+api_type:
   - "DLLExport"
-f1_keywords: 
+f1_keywords:
   - "ConnectServerWmi"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ConnectServerWmi function [.NET WMI and performance counters]"
-topic_type: 
+topic_type:
   - "Reference"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ConnectServerWmi function
+
 Creates a connection through DCOM to a WMI namespace on a specified computer.
 
 [!INCLUDE[internalonly-unmanaged](../../../../includes/internalonly-unmanaged.md)]
 
 ## Syntax
 
-```
+```cpp
 HRESULT ConnectServerWmi (
    [in] BSTR               strNetworkResource,
    [in] BSTR               strUser,
@@ -34,10 +35,11 @@ HRESULT ConnectServerWmi (
    [in] BSTR               strAuthority,
    [in] IWbemContext*      pCtx,
    [out] IWbemServices**   ppNamespace,
-   [in] DWORD              impLevel, 
+   [in] DWORD              impLevel,
    [in] DWORD              authLevel
 );
 ```
+
 ## Parameters
 
 `strNetworkResource`\
@@ -50,8 +52,8 @@ HRESULT ConnectServerWmi (
 [in] A pointer to a valid `BSTR` that contains the password. A `null` indicates the current security context. An empty string ("") indicates a valid zero-length password.
 
 `strLocale`\
-[in] A pointer to a valid `BSTR` that indicates the correct locale for information retrieval. For Microsoft locale identifiers, the format of the string is "MS\_*xxx*", where *xxx* is a string in hexadecimal form that indicates the locale identifier (LCID). If an invalid locale is specified, the method returns `WBEM_E_INVALID_PARAMETER` except on Windows 7, where the default locale of the server is used instead. If `null1, the current locale is used. 
- 
+[in] A pointer to a valid `BSTR` that indicates the correct locale for information retrieval. For Microsoft locale identifiers, the format of the string is "MS\_*xxx*", where *xxx* is a string in hexadecimal form that indicates the locale identifier (LCID). If an invalid locale is specified, the method returns `WBEM_E_INVALID_PARAMETER` except on Windows 7, where the default locale of the server is used instead. If `null1, the current locale is used.
+
 `lSecurityFlags`\
 [in] Flags to pass to the `ConnectServerWmi` method. A value of zero (0) for this parameter results in the call to `ConnectServerWmi` returning only after a connection to the server is established. This could result in an application not responding indefinitely if the server is broken. The other valid values are:
 
@@ -70,7 +72,7 @@ HRESULT ConnectServerWmi (
 | NTLMDOMAIN:*domain name* | NT LAN Manager authentication is used, and this parameter contains an NTLM domain name. |
 
 `pCtx`\
-[in] Typically, this parameter is `null`. Otherwise, it is a pointer to an [IWbemContext](/windows/desktop/api/wbemcli/nn-wbemcli-iwbemcontext) object required by one or more dynamic class providers. 
+[in] Typically, this parameter is `null`. Otherwise, it is a pointer to an [IWbemContext](/windows/desktop/api/wbemcli/nn-wbemcli-iwbemcontext) object required by one or more dynamic class providers.
 
 `ppNamespace`\
 [out] When the function returns, receives a pointer to an [IWbemServices](/windows/desktop/api/wbemcli/nn-wbemcli-iwbemservices) object bound to the specified namespace. It is set to point to `null` when there is an error.

--- a/docs/framework/unmanaged-api/wmi/initialize.md
+++ b/docs/framework/unmanaged-api/wmi/initialize.md
@@ -2,48 +2,53 @@
 title: Initialize function (Unmanaged API Reference)
 description: The Initialize function performs WMI initialization.
 ms.date: "11/06/2017"
-api_name: 
+api_name:
   - "Initialize"
-api_location: 
+api_location:
   - "WMINet_Utils.dll"
-api_type: 
+api_type:
   - "DLLExport"
-f1_keywords: 
+f1_keywords:
   - "Initialize"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Initialize function [.NET WMI and performance counters]"
-topic_type: 
+topic_type:
   - "Reference"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # Initialize function
-Performs WMI initialization.  
-  
+
+Performs WMI initialization.
+
 [!INCLUDE[internalonly-unmanaged](../../../../includes/internalonly-unmanaged.md)]
-  
-## Syntax 
-```  
+
+## Syntax
+
+```cpp
 HRESULT Initialize(
    [in] boolean bAllowIManagementObjectQI
-); 
-```  
+);
+```
+
 ## Parameters
 
-`bAllowIManagementObjectQI`   
+`bAllowIManagementObjectQI`
+
 [in] `true` to indicate that calls to QueryInterface on WMI objects are allowed; `false` otherwise.
 
 ## Return value
 
 The function always returns `S_OK` (0).
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** WMINet_Utils.def  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v472plus](../../../../includes/net-current-v472plus.md)]  
-  
+
+## Requirements
+
+**Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+
+**Header:** WMINet_Utils.def
+
+**.NET Framework Versions:** [!INCLUDE[net_current_v472plus](../../../../includes/net-current-v472plus.md)]
+
 ## See also
 
 - [WMI and Performance Counters (Unmanaged API Reference)](index.md)

--- a/docs/framework/wcf/diagnostics/wmi/messageencodingbindingelement.md
+++ b/docs/framework/wcf/diagnostics/wmi/messageencodingbindingelement.md
@@ -4,35 +4,40 @@ ms.date: "03/30/2017"
 ms.assetid: 7f750742-b96b-498f-bf5e-05933a1a5961
 ---
 # MessageEncodingBindingElement
-MessageEncodingBindingElement  
-  
-## Syntax  
+
+MessageEncodingBindingElement
+
+## Syntax
+
 ```csharp
 class MessageEncodingBindingElement : BindingElement
 {
-    string MessageVersion;  
-};  
- ```
-  
-## Methods  
- The MessageEncodingBindingElement class does not define any methods.  
-  
-## Properties  
- The MessageEncodingBindingElement class has the following property:  
-  
-### MessageVersion  
- Data type: string  
-  
- Access type: Read-only  
-  
- The SOAP version of the messages sent using the binding.  
-  
-## Requirements  
-  
-|MOF|Declared in Servicemodel.mof.|  
-|---------|-----------------------------------|  
-|Namespace|Defined in root\ServiceModel|  
-  
+    string MessageVersion;
+};
+```
+
+## Methods
+
+The MessageEncodingBindingElement class does not define any methods.
+
+## Properties
+
+The MessageEncodingBindingElement class has the following property:
+
+### MessageVersion
+
+Data type: string
+
+Access type: Read-only
+
+The SOAP version of the messages sent using the binding.
+
+## Requirements
+
+|MOF|Declared in Servicemodel.mof.|
+|---------|-----------------------------------|
+|Namespace|Defined in root\ServiceModel|
+
 ## See also
 
 - <xref:System.ServiceModel.Channels.MessageEncodingBindingElement>

--- a/docs/framework/wcf/diagnostics/wmi/peercustomresolverbindingelement.md
+++ b/docs/framework/wcf/diagnostics/wmi/peercustomresolverbindingelement.md
@@ -4,43 +4,49 @@ ms.date: "03/30/2017"
 ms.assetid: 9ccc2770-a20e-4dff-9970-f56ad8aec2b5
 ---
 # PeerCustomResolverBindingElement
-PeerCustomResolverBindingElement  
-  
-## Syntax  
+
+PeerCustomResolverBindingElement
+
+## Syntax
+
 ```csharp
 class PeerCustomResolverBindingElement : PeerResolverBindingElement
-{  
+{
     string Address;
     string Binding;
 };
-```  
-  
-## Methods  
- The PeerCustomResolverBindingElement class does not define any methods.  
-  
-## Properties  
- The PeerCustomResolverBindingElement class has the following properties:  
-  
-### Address  
- Data type: string  
-  
- Access type: Read-only  
-  
- The address of the peer custom resolver.  
-  
-### Binding  
- Data type: string  
-  
- Access type: Read-only  
-  
- The configuration name of the binding.  
-  
-## Requirements  
-  
-|MOF|Declared in Servicemodel.mof.|  
-|---------|-----------------------------------|  
-|Namespace|Defined in root\ServiceModel|  
-  
+```
+
+## Methods
+
+The PeerCustomResolverBindingElement class does not define any methods.
+
+## Properties
+
+ The PeerCustomResolverBindingElement class has the following properties:
+
+### Address
+
+Data type: string
+
+Access type: Read-only
+
+The address of the peer custom resolver.
+
+### Binding
+
+Data type: string
+
+Access type: Read-only
+
+The configuration name of the binding.
+
+## Requirements
+
+|MOF|Declared in Servicemodel.mof.|
+|---------|-----------------------------------|
+|Namespace|Defined in root\ServiceModel|
+
 ## See also
 
 - <xref:System.ServiceModel.Channels.PeerCustomResolverBindingElement>

--- a/docs/framework/wcf/diagnostics/wmi/pnrppeerresolverbindingelement.md
+++ b/docs/framework/wcf/diagnostics/wmi/pnrppeerresolverbindingelement.md
@@ -4,24 +4,27 @@ ms.date: "03/30/2017"
 ms.assetid: 050f24bf-dc23-4181-ad1e-a4cce1dc89fb
 ---
 # PnrpPeerResolverBindingElement
-PnrpPeerResolverBindingElement  
-  
-## Syntax 
-```csharp 
+
+PnrpPeerResolverBindingElement
+
+## Syntax
+
+```csharp
 class PnrpPeerResolverBindingElement : PeerResolverBindingElement
-{ 
+{
 };
-```  
-  
-## Methods  
- The PnrpPeerResolverBindingElement class inherits from PeerResolverBindingElement but does not define additional methods or properties.  
-  
-## Requirements  
-  
-|MOF|Declared in Servicemodel.mof.|  
-|---------|-----------------------------------|  
-|Namespace|Defined in root\ServiceModel|  
-  
+```
+
+## Methods
+
+The PnrpPeerResolverBindingElement class inherits from PeerResolverBindingElement but does not define additional methods or properties.
+
+## Requirements
+
+|MOF|Declared in Servicemodel.mof.|
+|---------|-----------------------------------|
+|Namespace|Defined in root\ServiceModel|
+
 ## See also
 
 - <xref:System.ServiceModel.Channels.PnrpPeerResolverBindingElement>

--- a/docs/framework/wcf/feature-details/duplex-services.md
+++ b/docs/framework/wcf/feature-details/duplex-services.md
@@ -1,86 +1,88 @@
 ---
 title: "Duplex Services"
 ms.date: "05/09/2018"
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
 ms.assetid: 396b875a-d203-4ebe-a3a1-6a330d962e95
 ---
 # Duplex Services
-A duplex service contract is a message exchange pattern in which both endpoints can send messages to the other independently. A duplex service, therefore, can send messages back to the client endpoint, providing event-like behavior. Duplex communication occurs when a client connects to a service and provides the service with a channel on which the service can send messages back to the client. Note that the event-like behavior of duplex services only works within a session.  
-  
- To create a duplex contract you create a pair of interfaces. The first is the service contract interface that describes the operations that a client can invoke. That service contract must specify a *callback contract* in the <xref:System.ServiceModel.ServiceContractAttribute.CallbackContract%2A?displayProperty=nameWithType> property. The callback contract is the interface that defines the operations that the service can call on the client endpoint. A duplex contract does not require a session, although the system-provided duplex bindings make use of them.  
-  
- The following is an example of a duplex contract.  
-  
- [!code-csharp[c_DuplexServices#0](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/service.cs#0)]
- [!code-vb[c_DuplexServices#0](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/service.vb#0)]  
-  
- The `CalculatorService` class implements the primary `ICalculatorDuplex` interface. The service uses the <xref:System.ServiceModel.InstanceContextMode.PerSession> instance mode to maintain the result for each session. A private property named `Callback` accesses the callback channel to the client. The service uses the callback for sending messages back to the client through the callback interface, as shown in the following sample code.  
-  
- [!code-csharp[c_DuplexServices#1](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/service.cs#1)]
- [!code-vb[c_DuplexServices#1](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/service.vb#1)]  
-  
- The client must provide a class that implements the callback interface of the duplex contract, for receiving messages from the service. The following sample code shows a `CallbackHandler` class that implements the `ICalculatorDuplexCallback` interface.  
-  
- [!code-csharp[c_DuplexServices#2](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/client.cs#2)]
- [!code-vb[c_DuplexServices#2](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/client.vb#2)]  
-  
- The WCF client that is generated for a duplex contract requires a <xref:System.ServiceModel.InstanceContext> class to be provided upon construction. This <xref:System.ServiceModel.InstanceContext> class is used as the site for an object that implements the callback interface and handles messages that are sent back from the service. An <xref:System.ServiceModel.InstanceContext> class is constructed with an instance of the `CallbackHandler` class. This object handles messages sent from the service to the client on the callback interface.  
-  
- [!code-csharp[c_DuplexServices#3](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/client.cs#3)]
- [!code-vb[c_DuplexServices#3](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/client.vb#3)]  
-  
- The configuration for the service must be set up to provide a binding that supports both session communication and duplex communication. The `wsDualHttpBinding` element supports session communication and allows duplex communication by providing dual HTTP connections, one for each direction.  
-  
- On the client, you must configure an address that the server can use to connect to the client, as shown in the following sample configuration.  
+
+A duplex service contract is a message exchange pattern in which both endpoints can send messages to the other independently. A duplex service, therefore, can send messages back to the client endpoint, providing event-like behavior. Duplex communication occurs when a client connects to a service and provides the service with a channel on which the service can send messages back to the client. Note that the event-like behavior of duplex services only works within a session.
+
+To create a duplex contract you create a pair of interfaces. The first is the service contract interface that describes the operations that a client can invoke. That service contract must specify a *callback contract* in the <xref:System.ServiceModel.ServiceContractAttribute.CallbackContract%2A?displayProperty=nameWithType> property. The callback contract is the interface that defines the operations that the service can call on the client endpoint. A duplex contract does not require a session, although the system-provided duplex bindings make use of them.
+
+The following is an example of a duplex contract.
+
+[!code-csharp[c_DuplexServices#0](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/service.cs#0)]
+[!code-vb[c_DuplexServices#0](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/service.vb#0)]
+
+The `CalculatorService` class implements the primary `ICalculatorDuplex` interface. The service uses the <xref:System.ServiceModel.InstanceContextMode.PerSession> instance mode to maintain the result for each session. A private property named `Callback` accesses the callback channel to the client. The service uses the callback for sending messages back to the client through the callback interface, as shown in the following sample code.
+
+[!code-csharp[c_DuplexServices#1](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/service.cs#1)]
+[!code-vb[c_DuplexServices#1](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/service.vb#1)]
+
+The client must provide a class that implements the callback interface of the duplex contract, for receiving messages from the service. The following sample code shows a `CallbackHandler` class that implements the `ICalculatorDuplexCallback` interface.
+
+[!code-csharp[c_DuplexServices#2](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/client.cs#2)]
+[!code-vb[c_DuplexServices#2](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/client.vb#2)]
+
+The WCF client that is generated for a duplex contract requires a <xref:System.ServiceModel.InstanceContext> class to be provided upon construction. This <xref:System.ServiceModel.InstanceContext> class is used as the site for an object that implements the callback interface and handles messages that are sent back from the service. An <xref:System.ServiceModel.InstanceContext> class is constructed with an instance of the `CallbackHandler` class. This object handles messages sent from the service to the client on the callback interface.
+
+[!code-csharp[c_DuplexServices#3](../../../../samples/snippets/csharp/VS_Snippets_CFX/c_duplexservices/cs/client.cs#3)]
+[!code-vb[c_DuplexServices#3](../../../../samples/snippets/visualbasic/VS_Snippets_CFX/c_duplexservices/vb/client.vb#3)]
+
+The configuration for the service must be set up to provide a binding that supports both session communication and duplex communication. The `wsDualHttpBinding` element supports session communication and allows duplex communication by providing dual HTTP connections, one for each direction.
+
+On the client, you must configure an address that the server can use to connect to the client, as shown in the following sample configuration.
 
 > [!NOTE]
->  Non-duplex clients that fail to authenticate using a secure conversation typically throw a <xref:System.ServiceModel.Security.MessageSecurityException>. However, if a duplex client that uses a secure conversation fails to authenticate, the client receives a <xref:System.TimeoutException> instead.  
-  
- If you create a client/service using the `WSHttpBinding` element and you do not include the client callback endpoint, you will receive the following error.  
-  
-```  
-HTTP could not register URL  
-htp://+:80/Temporary_Listen_Addresses/<guid> because TCP port 80 is being used by another application.  
-```  
-  
- The following sample code shows how to specify the client endpoint address programmatically.
-  
-```csharp  
-WSDualHttpBinding binding = new WSDualHttpBinding();  
-EndpointAddress endptadr = new EndpointAddress("http://localhost:12000/DuplexTestUsingCode/Server");  
-binding.ClientBaseAddress = new Uri("http://localhost:8000/DuplexTestUsingCode/Client/");  
-```  
+> Non-duplex clients that fail to authenticate using a secure conversation typically throw a <xref:System.ServiceModel.Security.MessageSecurityException>. However, if a duplex client that uses a secure conversation fails to authenticate, the client receives a <xref:System.TimeoutException> instead.
+
+If you create a client/service using the `WSHttpBinding` element and you do not include the client callback endpoint, you will receive the following error.
+
+```
+HTTP could not register URL
+htp://+:80/Temporary_Listen_Addresses/<guid> because TCP port 80 is being used by another application.
+```
+
+The following sample code shows how to specify the client endpoint address programmatically.
+
+```csharp
+WSDualHttpBinding binding = new WSDualHttpBinding();
+EndpointAddress endptadr = new EndpointAddress("http://localhost:12000/DuplexTestUsingCode/Server");
+binding.ClientBaseAddress = new Uri("http://localhost:8000/DuplexTestUsingCode/Client/");
+```
+
 ```vb
 Dim binding As New WSDualHttpBinding()
 Dim endptadr As New EndpointAddress("http://localhost:12000/DuplexTestUsingCode/Server")
-binding.ClientBaseAddress = New Uri("http://localhost:8000/DuplexTestUsingCode/Client/")  
+binding.ClientBaseAddress = New Uri("http://localhost:8000/DuplexTestUsingCode/Client/")
 ```
 
- The following sample code shows how to specify the client endpoint address in configuration.  
-  
-```xml  
-<client>  
-    <endpoint name ="ServerEndpoint"   
-          address="http://localhost:12000/DuplexTestUsingConfig/Server"  
-          bindingConfiguration="WSDualHttpBinding_IDuplexTest"   
-            binding="wsDualHttpBinding"  
-           contract="IDuplexTest" />  
-</client>  
-<bindings>  
-    <wsDualHttpBinding>  
-        <binding name="WSDualHttpBinding_IDuplexTest"    
-          clientBaseAddress="http://localhost:8000/myClient/" >  
-            <security mode="None"/>  
-         </binding>  
-    </wsDualHttpBinding>  
-</bindings>  
-```  
-  
+The following sample code shows how to specify the client endpoint address in configuration.
+
+```xml
+<client>
+    <endpoint name ="ServerEndpoint"
+          address="http://localhost:12000/DuplexTestUsingConfig/Server"
+          bindingConfiguration="WSDualHttpBinding_IDuplexTest"
+            binding="wsDualHttpBinding"
+           contract="IDuplexTest" />
+</client>
+<bindings>
+    <wsDualHttpBinding>
+        <binding name="WSDualHttpBinding_IDuplexTest"
+          clientBaseAddress="http://localhost:8000/myClient/" >
+            <security mode="None"/>
+         </binding>
+    </wsDualHttpBinding>
+</bindings>
+```
+
 > [!WARNING]
->  The duplex model does not automatically detect when a service or client closes its channel. So if a client unexpectedly terminates, by default the service will not be notified, or if a client unexpectedly terminates, the service will not be notified. Clients and services can implement their own protocol to notify each other if they so choose.  
-  
+> The duplex model does not automatically detect when a service or client closes its channel. So if a client unexpectedly terminates, by default the service will not be notified, or if a client unexpectedly terminates, the service will not be notified. Clients and services can implement their own protocol to notify each other if they so choose.
+
 ## See also
 
 - [Duplex](../../../../docs/framework/wcf/samples/duplex.md)

--- a/docs/framework/wcf/samples/iis-hosting-using-inline-code.md
+++ b/docs/framework/wcf/samples/iis-hosting-using-inline-code.md
@@ -1,93 +1,95 @@
 ---
 title: "IIS Hosting Using Inline Code"
 ms.date: "03/30/2017"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Web hosted service"
   - "IIS Hosting Using Inline Code Sample [Windows Communication Foundation]"
 ms.assetid: 56fe3687-a34b-4661-8e30-b33770f413fa
 ---
 # IIS Hosting Using Inline Code
-This sample demonstrates how to implement a service hosted by Internet Information Services (IIS), where the service code is contained in-line in a .svc file and is compiled on demand. Service code can also be implemented directly in source code files located in the application's \App_Code directory, or compiled into assembly deployed in \bin. This sample does not demonstrate these techniques.  
-  
+
+This sample demonstrates how to implement a service hosted by Internet Information Services (IIS), where the service code is contained in-line in a .svc file and is compiled on demand. Service code can also be implemented directly in source code files located in the application's \App_Code directory, or compiled into assembly deployed in \bin. This sample does not demonstrate these techniques.
+
 > [!NOTE]
->  The set-up procedure and build instructions for this sample are located at the end of this topic.  
-  
+> The set-up procedure and build instructions for this sample are located at the end of this topic.
+
 > [!IMPORTANT]
->  The samples may already be installed on your computer. Check for the following (default) directory before continuing.  
->   
->  `<InstallDrive>:\WF_WCF_Samples`  
->   
->  If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.  
->   
->  `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Services\Hosting\WebHost\InlineCode`  
-  
- The sample demonstrates a typical service that implements a contract that defines a request-reply communication pattern. The service is hosted in IIS and the service code is entirely contained in the Service.svc file. The service is host-activated and compiled on-demand by the first message sent to the service. There is no pre-compilation necessary. The service implements an `ICalculator` contract as defined in the following code:  
-  
+> The samples may already be installed on your computer. Check for the following (default) directory before continuing.
+>
+> `<InstallDrive>:\WF_WCF_Samples`
+>
+> If this directory does not exist, go to [Windows Communication Foundation (WCF) and Windows Workflow Foundation (WF) Samples for .NET Framework 4](https://go.microsoft.com/fwlink/?LinkId=150780) to download all Windows Communication Foundation (WCF) and [!INCLUDE[wf1](../../../../includes/wf1-md.md)] samples. This sample is located in the following directory.
+>
+> `<InstallDrive>:\WF_WCF_Samples\WCF\Basic\Services\Hosting\WebHost\InlineCode`
+
+The sample demonstrates a typical service that implements a contract that defines a request-reply communication pattern. The service is hosted in IIS and the service code is entirely contained in the Service.svc file. The service is host-activated and compiled on-demand by the first message sent to the service. There is no pre-compilation necessary. The service implements an `ICalculator` contract as defined in the following code:
+
 ```csharp
-// Define a service contract.  
-[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]  
-    public interface ICalculator  
-{  
-    [OperationContract]  
-    double Add(double n1, double n2);  
-    [OperationContract]  
-    double Subtract(double n1, double n2);  
-    [OperationContract]  
-    double Multiply(double n1, double n2);  
-    [OperationContract]  
-    double Divide(double n1, double n2);  
-}  
-```  
-  
- The service implementation calculates and returns the appropriate result.  
-  
-```svc
-<%@ServiceHost language=c# Debug="true" Service="Microsoft.ServiceModel.Samples.CalculatorService" %>   
+// Define a service contract.
+[ServiceContract(Namespace="http://Microsoft.ServiceModel.Samples")]
+    public interface ICalculator
+{
+    [OperationContract]
+    double Add(double n1, double n2);
+    [OperationContract]
+    double Subtract(double n1, double n2);
+    [OperationContract]
+    double Multiply(double n1, double n2);
+    [OperationContract]
+    double Divide(double n1, double n2);
+}
 ```
+
+The service implementation calculates and returns the appropriate result.
+
+```svc
+<%@ServiceHost language=c# Debug="true" Service="Microsoft.ServiceModel.Samples.CalculatorService" %>
+```
+
 ```csharp
-// Service class that implements the service contract.  
-public class CalculatorService : ICalculator  
-{  
-    public double Add(double n1, double n2)  
-    {  
-        return n1 + n2;  
-    }  
-    public double Subtract(double n1, double n2)  
-    {  
-        return n1 - n2;  
-    }  
-    public double Multiply(double n1, double n2)  
-    {  
-        return n1 * n2;  
-    }  
-    public double Divide(double n1, double n2)  
-    {  
-        return n1 / n2;  
-    }  
-}  
-```  
-  
- When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.  
-  
-```console  
-Add(100,15.99) = 115.99  
-Subtract(145,76.54) = 68.46  
-Multiply(9,81.25) = 731.25  
-Divide(22,7) = 3.14285714285714  
-  
-Press <ENTER> to terminate client.  
-```  
-  
-### To set up, build, and run the sample  
-  
-1. Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).  
-  
-2. To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).  
-  
-3. After the solution has been built, run setup.bat to set up the ServiceModelSamples Application in [!INCLUDE[iisver](../../../../includes/iisver-md.md)]. The ServiceModelSamples directory should now appear as an [!INCLUDE[iisver](../../../../includes/iisver-md.md)] Application.  
-  
-4. To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md). For an example on how to create a client application that can call this service, see [How to: Create a Client](../../../../docs/framework/wcf/how-to-create-a-wcf-client.md).  
-  
+// Service class that implements the service contract.
+public class CalculatorService : ICalculator
+{
+    public double Add(double n1, double n2)
+    {
+        return n1 + n2;
+    }
+    public double Subtract(double n1, double n2)
+    {
+        return n1 - n2;
+    }
+    public double Multiply(double n1, double n2)
+    {
+        return n1 * n2;
+    }
+    public double Divide(double n1, double n2)
+    {
+        return n1 / n2;
+    }
+}
+```
+
+When you run the sample, the operation requests and responses are displayed in the client console window. Press ENTER in the client window to shut down the client.
+
+```console
+Add(100,15.99) = 115.99
+Subtract(145,76.54) = 68.46
+Multiply(9,81.25) = 731.25
+Divide(22,7) = 3.14285714285714
+
+Press <ENTER> to terminate client.
+```
+
+### To set up, build, and run the sample
+
+1. Ensure that you have performed the [One-Time Setup Procedure for the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/one-time-setup-procedure-for-the-wcf-samples.md).
+
+2. To build the C# or Visual Basic .NET edition of the solution, follow the instructions in [Building the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/building-the-samples.md).
+
+3. After the solution has been built, run setup.bat to set up the ServiceModelSamples Application in [!INCLUDE[iisver](../../../../includes/iisver-md.md)]. The ServiceModelSamples directory should now appear as an [!INCLUDE[iisver](../../../../includes/iisver-md.md)] Application.
+
+4. To run the sample in a single- or cross-computer configuration, follow the instructions in [Running the Windows Communication Foundation Samples](../../../../docs/framework/wcf/samples/running-the-samples.md). For an example on how to create a client application that can call this service, see [How to: Create a Client](../../../../docs/framework/wcf/how-to-create-a-wcf-client.md).
+
 ## See also
 
 - [AppFabric Hosting and Persistence Samples](https://go.microsoft.com/fwlink/?LinkId=193961)

--- a/docs/framework/whats-new/index.md
+++ b/docs/framework/whats-new/index.md
@@ -88,7 +88,9 @@ Using rsa = RSA.Create()
    ' Other code to execute using the rsa instance.
 End Using
 ```
+
 with code like this:
+
 ```csharp
 // Starting with .NET Framework 4.7.2
 using (RSA rsa = RSA.Create(rsaParameters))
@@ -96,6 +98,7 @@ using (RSA rsa = RSA.Create(rsaParameters))
    // Other code to execute using the rsa instance.
 }
 ```
+
 ```vb
 ' Starting with .NET Framework 4.7.2
 Using rsa = RSA.Create(rsaParameters)
@@ -261,6 +264,7 @@ c.SameSite = SameSiteMode.Lax;
 Dim c As New HttpCookie("secureCookie", "same origin")
 c.SameSite = SameSiteMode.Lax
 ```
+
 You can also configure SameSite cookies at the application level by modifying the web.config file:
 
 ```xml
@@ -268,6 +272,7 @@ You can also configure SameSite cookies at the application level by modifying th
    <httpCookies sameSite="Strict" />
 </system.web>
 ```
+
 You can add SameSite for <xref:System.Web.Security.FormsAuthentication> and <xref:System.Web.SessionState> cookies by modifying the web config file:
 
 ```xml

--- a/docs/framework/whats-new/whats-new-in-accessibility.md
+++ b/docs/framework/whats-new/whats-new-in-accessibility.md
@@ -200,6 +200,7 @@ var peer = FrameworkElementAutomationPeer.FromElement(myTextBlock);
 
 peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged);
 ```
+
 ```vb
 Dim peer = FrameworkElementAutomationPeer.FromElement(myTextBlock)
 peer.RaiseAutomationEvent(AutomationEvents.LiveRegionChanged)

--- a/docs/framework/windows-workflow-foundation/using-activity-delegates.md
+++ b/docs/framework/windows-workflow-foundation/using-activity-delegates.md
@@ -4,48 +4,52 @@ ms.date: "03/30/2017"
 ms.assetid: e33cf876-8979-440b-9b23-4a12d1139960
 ---
 # Using Activity Delegates
-Activity delegates enable activity authors to expose callbacks with specific signatures, for which users of the activity can provide activity-based handlers. Two types of activity delegates are available: <xref:System.Activities.ActivityAction%601> is used to define activity delegates that do not have a return value, and <xref:System.Activities.ActivityFunc%601> is used to define activity delegates that do have a return value.  
-  
- Activity delegates are useful in scenarios where a child activity must be constrained to having a certain signature. For example, a <xref:System.Activities.Statements.While> activity can contain any type of child activity with no constraints, but the body of a <xref:System.Activities.Statements.ForEach%601> activity is an <xref:System.Activities.ActivityAction%601>, and the child activity that is ultimately executed by <xref:System.Activities.Statements.ForEach%601> must have an <xref:System.Activities.InArgument%601> that is the same type of the members of the collection that the <xref:System.Activities.Statements.ForEach%601> enumerates.  
-  
-## Using ActivityAction  
- Several [!INCLUDE[netfx_current_short](../../../includes/netfx-current-short-md.md)] activities use activity actions, such as the <xref:System.Activities.Statements.Catch> activity and the <xref:System.Activities.Statements.ForEach%601> activity. In each case, the activity action represents a location where the workflow author specifies an activity to provide the desired behavior when composing a workflow using one of these activities. In the following example, a <xref:System.Activities.Statements.ForEach%601> activity is used to display text to the console window. The body of the <xref:System.Activities.Statements.ForEach%601> is specified by using an <xref:System.Activities.ActivityAction%601> that matches the type of the <xref:System.Activities.Statements.ForEach%601> which is string. The <xref:System.Activities.Statements.WriteLine> activity specified in the <xref:System.Activities.ActivityDelegate.Handler%2A> has its <xref:System.Activities.Statements.WriteLine.Text%2A> argument bound to the string values in the collection that the <xref:System.Activities.Statements.ForEach%601> activity iterates.  
-  
- [!code-csharp[CFX_ActivityExample#6](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#6)]  
-  
- The actionArgument is used to flow the individual items in the collection to the WriteLine. When the workflow is invoked, the following output is displayed to the console.  
- ``` 
- HelloWorld.
- ```  
-The examples in this topic use object initialization syntax. Object initialization syntax can be a useful way to create workflow definitions in code because it provides a hierarchical view of the activities in the workflow and shows the relationship between the activities. There is no requirement to use object initialization syntax when you programmatically create workflows. The following example is functionally equivalent to the previous example.  
-  
- [!code-csharp[CFX_ActivityExample#7](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#7)]  
-  
- For more information about object initializers, see [How to: Initialize Objects without Calling a Constructor (C# Programming Guide)](https://go.microsoft.com/fwlink/?LinkId=161015) and [How to: Declare an Object by Using an Object Initializer](https://go.microsoft.com/fwlink/?LinkId=161016).  
-  
- In the following example, a <xref:System.Activities.Statements.TryCatch> activity is used in a workflow. An <xref:System.ApplicationException> is thrown by the workflow, and is handled by a <xref:System.Activities.Statements.Catch%601> activity. The handler for the <xref:System.Activities.Statements.Catch%601> activity's activity action is a <xref:System.Activities.Statements.WriteLine> activity, and the exception detail is flowed through to it using the `ex` <xref:System.Activities.DelegateInArgument%601>.  
-  
- [!code-csharp[CFX_WorkflowApplicationExample#33](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#33)]  
-  
- When creating a custom activity that defines an <xref:System.Activities.ActivityAction%601>, use an <xref:System.Activities.Statements.InvokeAction%601> to model the invocation of that <xref:System.Activities.ActivityAction%601>. In this example, a custom `WriteLineWithNotification` activity is defined. This activity is composed of a <xref:System.Activities.Statements.Sequence> that contains a <xref:System.Activities.Statements.WriteLine> activity followed by an <xref:System.Activities.Statements.InvokeAction%601> that invokes an <xref:System.Activities.ActivityAction%601> that takes one string argument.  
-  
- [!code-csharp[CFX_ActivityExample#1](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#1)]  
-  
- When a workflow is created by using the `WriteLineWithNotification` activity, the workflow author specifies the desired custom logic in the activity action’s <xref:System.Activities.ActivityDelegate.Handler%2A>. In this example, a workflow is created that use the `WriteLineWithNotification` activity, and a <xref:System.Activities.Statements.WriteLine> activity is used as the <xref:System.Activities.ActivityDelegate.Handler%2A>.  
-  
- [!code-csharp[CFX_ActivityExample#2](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#2)]  
-  
- There are multiple generic versions of <xref:System.Activities.Statements.InvokeAction%601> and <xref:System.Activities.ActivityAction%601> provided for passing one or more arguments.  
-  
-## Using ActivityFunc  
- <xref:System.Activities.ActivityAction%601> is useful when there is no result value from the activity, and <xref:System.Activities.ActivityFunc%601> is used when a result value is returned. When creating a custom activity that defines an <xref:System.Activities.ActivityFunc%601>, use an <xref:System.Activities.Expressions.InvokeFunc%601> to model the invocation of that <xref:System.Activities.ActivityFunc%601>. In the following example, a `WriteFillerText` activity is defined. To supply the filler text, an <xref:System.Activities.Expressions.InvokeFunc%601> is specified that takes an integer argument and has a string result. Once the filler text is retrieved, it is displayed to the console using a <xref:System.Activities.Statements.WriteLine> activity.  
-  
- [!code-csharp[CFX_ActivityExample#3](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#3)]  
-  
- To supply the text, an activity must be used that takes one `int` argument and has a string result. This example shows a `TextGenerator` activity that meets these requirements.  
-  
- [!code-csharp[CFX_ActivityExample#4](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#4)]  
-  
- To use the `TextGenerator` activity with the `WriteFillerText` activity, specify it as the <xref:System.Activities.ActivityDelegate.Handler%2A>.  
-  
- [!code-csharp[CFX_ActivityExample#5](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#5)]
+Activity delegates enable activity authors to expose callbacks with specific signatures, for which users of the activity can provide activity-based handlers. Two types of activity delegates are available: <xref:System.Activities.ActivityAction%601> is used to define activity delegates that do not have a return value, and <xref:System.Activities.ActivityFunc%601> is used to define activity delegates that do have a return value.
+
+Activity delegates are useful in scenarios where a child activity must be constrained to having a certain signature. For example, a <xref:System.Activities.Statements.While> activity can contain any type of child activity with no constraints, but the body of a <xref:System.Activities.Statements.ForEach%601> activity is an <xref:System.Activities.ActivityAction%601>, and the child activity that is ultimately executed by <xref:System.Activities.Statements.ForEach%601> must have an <xref:System.Activities.InArgument%601> that is the same type of the members of the collection that the <xref:System.Activities.Statements.ForEach%601> enumerates.
+
+## Using ActivityAction
+
+Several [!INCLUDE[netfx_current_short](../../../includes/netfx-current-short-md.md)] activities use activity actions, such as the <xref:System.Activities.Statements.Catch> activity and the <xref:System.Activities.Statements.ForEach%601> activity. In each case, the activity action represents a location where the workflow author specifies an activity to provide the desired behavior when composing a workflow using one of these activities. In the following example, a <xref:System.Activities.Statements.ForEach%601> activity is used to display text to the console window. The body of the <xref:System.Activities.Statements.ForEach%601> is specified by using an <xref:System.Activities.ActivityAction%601> that matches the type of the <xref:System.Activities.Statements.ForEach%601> which is string. The <xref:System.Activities.Statements.WriteLine> activity specified in the <xref:System.Activities.ActivityDelegate.Handler%2A> has its <xref:System.Activities.Statements.WriteLine.Text%2A> argument bound to the string values in the collection that the <xref:System.Activities.Statements.ForEach%601> activity iterates.
+
+[!code-csharp[CFX_ActivityExample#6](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#6)]
+
+The actionArgument is used to flow the individual items in the collection to the WriteLine. When the workflow is invoked, the following output is displayed to the console.
+
+```
+HelloWorld.
+```
+
+The examples in this topic use object initialization syntax. Object initialization syntax can be a useful way to create workflow definitions in code because it provides a hierarchical view of the activities in the workflow and shows the relationship between the activities. There is no requirement to use object initialization syntax when you programmatically create workflows. The following example is functionally equivalent to the previous example.
+
+[!code-csharp[CFX_ActivityExample#7](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#7)]
+
+For more information about object initializers, see [How to: Initialize Objects without Calling a Constructor (C# Programming Guide)](https://go.microsoft.com/fwlink/?LinkId=161015) and [How to: Declare an Object by Using an Object Initializer](https://go.microsoft.com/fwlink/?LinkId=161016).
+
+In the following example, a <xref:System.Activities.Statements.TryCatch> activity is used in a workflow. An <xref:System.ApplicationException> is thrown by the workflow, and is handled by a <xref:System.Activities.Statements.Catch%601> activity. The handler for the <xref:System.Activities.Statements.Catch%601> activity's activity action is a <xref:System.Activities.Statements.WriteLine> activity, and the exception detail is flowed through to it using the `ex` <xref:System.Activities.DelegateInArgument%601>.
+
+[!code-csharp[CFX_WorkflowApplicationExample#33](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#33)]
+
+When creating a custom activity that defines an <xref:System.Activities.ActivityAction%601>, use an <xref:System.Activities.Statements.InvokeAction%601> to model the invocation of that <xref:System.Activities.ActivityAction%601>. In this example, a custom `WriteLineWithNotification` activity is defined. This activity is composed of a <xref:System.Activities.Statements.Sequence> that contains a <xref:System.Activities.Statements.WriteLine> activity followed by an <xref:System.Activities.Statements.InvokeAction%601> that invokes an <xref:System.Activities.ActivityAction%601> that takes one string argument.
+
+[!code-csharp[CFX_ActivityExample#1](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#1)]
+
+When a workflow is created by using the `WriteLineWithNotification` activity, the workflow author specifies the desired custom logic in the activity action’s <xref:System.Activities.ActivityDelegate.Handler%2A>. In this example, a workflow is created that use the `WriteLineWithNotification` activity, and a <xref:System.Activities.Statements.WriteLine> activity is used as the <xref:System.Activities.ActivityDelegate.Handler%2A>.
+
+[!code-csharp[CFX_ActivityExample#2](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#2)]
+
+There are multiple generic versions of <xref:System.Activities.Statements.InvokeAction%601> and <xref:System.Activities.ActivityAction%601> provided for passing one or more arguments.
+
+## Using ActivityFunc
+
+<xref:System.Activities.ActivityAction%601> is useful when there is no result value from the activity, and <xref:System.Activities.ActivityFunc%601> is used when a result value is returned. When creating a custom activity that defines an <xref:System.Activities.ActivityFunc%601>, use an <xref:System.Activities.Expressions.InvokeFunc%601> to model the invocation of that <xref:System.Activities.ActivityFunc%601>. In the following example, a `WriteFillerText` activity is defined. To supply the filler text, an <xref:System.Activities.Expressions.InvokeFunc%601> is specified that takes an integer argument and has a string result. Once the filler text is retrieved, it is displayed to the console using a <xref:System.Activities.Statements.WriteLine> activity.
+
+[!code-csharp[CFX_ActivityExample#3](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#3)]
+
+To supply the text, an activity must be used that takes one `int` argument and has a string result. This example shows a `TextGenerator` activity that meets these requirements.
+
+[!code-csharp[CFX_ActivityExample#4](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#4)]
+
+To use the `TextGenerator` activity with the `WriteFillerText` activity, specify it as the <xref:System.Activities.ActivityDelegate.Handler%2A>.
+
+[!code-csharp[CFX_ActivityExample#5](~/samples/snippets/csharp/VS_Snippets_CFX/CFX_ActivityExample/cs/Program.cs#5)]

--- a/docs/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms.md
+++ b/docs/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms.md
@@ -1,29 +1,31 @@
 ---
 title: "PrintPreviewDialog Control Overview (Windows Forms)"
 ms.date: "01/08/2018"
-f1_keywords: 
+f1_keywords:
   - "PrintPreviewDialog"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "PrintPreviewDialog control (using designer), about PrintPreviewDialog"
 ms.assetid: efd4ee8d-6edd-47ec-88e4-4a4759bd2384
 author: rpetrusha
 ms.author: ronpet
 ---
 # PrintPreviewDialog control overview (Windows Forms)
-The Windows Forms <xref:System.Windows.Forms.PrintPreviewDialog> control is a pre-configured dialog box used to display how a [PrintDocument](printdocument-component-windows-forms.md) will appear when printed. Use it within your Windows-based application as a simple solution instead of configuring your own dialog box. The control contains buttons for printing, zooming in, displaying one or multiple pages, and closing the dialog box.  
-  
-## Key properties and methods  
- The control's key property is <xref:System.Windows.Forms.PrintPreviewDialog.Document%2A>, which sets the document to be previewed. The document must be a <xref:System.Drawing.Printing.PrintDocument> object. In order to display the dialog box, you must call its <xref:System.Windows.Forms.Form.ShowDialog%2A> method. Anti-aliasing can make the text appear smoother, but it can also make the display slower; to use it, set the <xref:System.Windows.Forms.PrintPreviewDialog.UseAntiAlias%2A> property to `true`.  
-  
- Certain properties are available through the <xref:System.Windows.Forms.PrintPreviewControl> that the <xref:System.Windows.Forms.PrintPreviewDialog> contains. (You do not have to add this <xref:System.Windows.Forms.PrintPreviewControl> to the form; it is automatically contained within the <xref:System.Windows.Forms.PrintPreviewDialog> when you add the dialog to your form.) Examples of properties available through the <xref:System.Windows.Forms.PrintPreviewControl> are the <xref:System.Windows.Forms.PrintPreviewControl.Columns%2A> and <xref:System.Windows.Forms.PrintPreviewControl.Rows%2A> properties, which determine the number of pages displayed horizontally and vertically on the control. You can access the <xref:System.Windows.Forms.PrintPreviewControl.Columns%2A> property as `PrintPreviewDialog1.PrintPreviewControl.Columns` in Visual Basic, `printPreviewDialog1.PrintPreviewControl.Columns` in Visual C#, or `printPreviewDialog1->PrintPreviewControl->Columns` in [!INCLUDE[vcprvc](../../../../includes/vcprvc-md.md)].  
-  
+
+The Windows Forms <xref:System.Windows.Forms.PrintPreviewDialog> control is a pre-configured dialog box used to display how a [PrintDocument](printdocument-component-windows-forms.md) will appear when printed. Use it within your Windows-based application as a simple solution instead of configuring your own dialog box. The control contains buttons for printing, zooming in, displaying one or multiple pages, and closing the dialog box.
+
+## Key properties and methods
+
+The control's key property is <xref:System.Windows.Forms.PrintPreviewDialog.Document%2A>, which sets the document to be previewed. The document must be a <xref:System.Drawing.Printing.PrintDocument> object. In order to display the dialog box, you must call its <xref:System.Windows.Forms.Form.ShowDialog%2A> method. Anti-aliasing can make the text appear smoother, but it can also make the display slower; to use it, set the <xref:System.Windows.Forms.PrintPreviewDialog.UseAntiAlias%2A> property to `true`.
+
+Certain properties are available through the <xref:System.Windows.Forms.PrintPreviewControl> that the <xref:System.Windows.Forms.PrintPreviewDialog> contains. (You do not have to add this <xref:System.Windows.Forms.PrintPreviewControl> to the form; it is automatically contained within the <xref:System.Windows.Forms.PrintPreviewDialog> when you add the dialog to your form.) Examples of properties available through the <xref:System.Windows.Forms.PrintPreviewControl> are the <xref:System.Windows.Forms.PrintPreviewControl.Columns%2A> and <xref:System.Windows.Forms.PrintPreviewControl.Rows%2A> properties, which determine the number of pages displayed horizontally and vertically on the control. You can access the <xref:System.Windows.Forms.PrintPreviewControl.Columns%2A> property as `PrintPreviewDialog1.PrintPreviewControl.Columns` in Visual Basic, `printPreviewDialog1.PrintPreviewControl.Columns` in Visual C#, or `printPreviewDialog1->PrintPreviewControl->Columns` in [!INCLUDE[vcprvc](../../../../includes/vcprvc-md.md)].
+
 ## PrintPreviewDialog performance
 
 Under the following conditions, the <xref:System.Windows.Forms.PrintPreviewDialog> control initializes very slowly:
 
 - A network printer is used.
 - User preferences for this printer, such as duplex settings, are modified.
-  
+
 For apps running on the .NET Framework 4.5.2, you can add the following key to the \<appSettings> section of your configuration file to improve the performance of <xref:System.Windows.Forms.PrintPreviewDialog> control initialization:
 
 ```xml
@@ -31,6 +33,7 @@ For apps running on the .NET Framework 4.5.2, you can add the following key to t
    <add key="EnablePrintPreviewOptimization" value="true" />
 </appSettings>
 ```
+
 If the `EnablePrintPreviewOptimization` key is set to any other value, or if the key is not present, the optimization is not applied.
 
 For apps running on the .NET Framework 4.6 or later versions, you can add the following switch to the [\<AppContextSwitchOverrides>](../../configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md) element in the [\<runtime>](../../configure-apps/file-schema/runtime/index.md) section of your app config file:
@@ -40,10 +43,11 @@ For apps running on the .NET Framework 4.6 or later versions, you can add the fo
    <!-- AppContextSwitchOverrides values are in the form of 'key1=true|false;key2=true|false -->
    <AppContextSwitchOverrides value = "Switch.System.Drawing.Printing.OptimizePrintPreview=true" />
 </runtime >
-``` 
-If the switch is not present or if it is set to any other value, the optimization is not applied. 
+```
 
-If you use the <xref:System.Drawing.Printing.PrintDocument.QueryPageSettings> event to modify printer settings, the performance of the <xref:System.Windows.Forms.PrintPreviewDialog> control will not improve even if an optimization configuration switch is set.  
+If the switch is not present or if it is set to any other value, the optimization is not applied.
+
+If you use the <xref:System.Drawing.Printing.PrintDocument.QueryPageSettings> event to modify printer settings, the performance of the <xref:System.Windows.Forms.PrintPreviewDialog> control will not improve even if an optimization configuration switch is set.
 
 ## See also
 

--- a/docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
+++ b/docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
@@ -1,11 +1,11 @@
 ---
 title: "Walkthrough: Serializing Collections of Standard Types with the DesignerSerializationVisibilityAttribute"
 ms.date: "03/30/2017"
-dev_langs: 
+dev_langs:
   - "csharp"
   - "vb"
   - "cpp"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "serialization [Windows Forms], collections"
   - "standard types [Windows Forms], collections"
   - "collections [Windows Forms], serializing"
@@ -13,124 +13,128 @@ helpviewer_keywords:
 ms.assetid: 020c9df4-fdc5-4dae-815a-963ecae5668c
 ---
 # Walkthrough: Serializing Collections of Standard Types with the DesignerSerializationVisibilityAttribute
-Your custom controls will sometimes expose a collection as a property. This walkthrough demonstrates how to use the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute> class to control how a collection is serialized at design time. Applying the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute.Content> value to your collection property ensures that the property will be serialized.  
-  
- To copy the code in this topic as a single listing, see [How to: Serialize Collections of Standard Types with the DesignerSerializationVisibilityAttribute](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2013/ms171833(v=vs.120)).  
-  
+
+Your custom controls will sometimes expose a collection as a property. This walkthrough demonstrates how to use the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute> class to control how a collection is serialized at design time. Applying the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute.Content> value to your collection property ensures that the property will be serialized.
+
+ To copy the code in this topic as a single listing, see [How to: Serialize Collections of Standard Types with the DesignerSerializationVisibilityAttribute](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2013/ms171833(v=vs.120)).
+
 > [!NOTE]
->  The dialog boxes and menu commands you see might differ from those described in Help depending on your active settings or edition. To change your settings, choose **Import and Export Settings** on the **Tools** menu. For more information, see [Personalize the Visual Studio IDE](/visualstudio/ide/personalizing-the-visual-studio-ide).  
-  
-## Prerequisites  
- In order to complete this walkthrough, you will need:  
-  
--   Sufficient permissions to be able to create and run Windows Forms application projects on the computer where Visual Studio is installed.  
-  
-## Creating a Control That Has a Serializable Collection  
- The first step is to create a control that has a serializable collection as a property. You can edit the contents of this collection using the **Collection Editor**, which you can access from the **Properties** window.  
-  
-#### To create a control with a serializable collection  
-  
-1. Create a Windows Control Library project called `SerializationDemoControlLib`. For more information, see [Windows Control Library Template](https://docs.microsoft.com/previous-versions/kxczf775(v=vs.100)).  
-  
-2. Rename `UserControl1` to `SerializationDemoControl`. For more information, see [Rename a code symbol refactoring](/visualstudio/ide/reference/rename).  
-  
-3. In the **Properties** window, set the value of the <xref:System.Windows.Forms.Padding.All%2A?displayProperty=nameWithType> property to `10`.  
-  
-4. Place a <xref:System.Windows.Forms.TextBox> control in the `SerializationDemoControl`.  
-  
-5. Select the <xref:System.Windows.Forms.TextBox> control. In the **Properties** window, set the following properties.  
-  
-    |Property|Change to|  
-    |--------------|---------------|  
-    |**Multiline**|`true`|  
-    |**Dock**|<xref:System.Windows.Forms.DockStyle.Fill>|  
-    |**ScrollBars**|<xref:System.Windows.Forms.ScrollBars.Vertical>|  
-    |**ReadOnly**|`true`|  
-  
-6. In the **Code Editor**, declare a string array field named `stringsValue` in `SerializationDemoControl`.  
-  
+> The dialog boxes and menu commands you see might differ from those described in Help depending on your active settings or edition. To change your settings, choose **Import and Export Settings** on the **Tools** menu. For more information, see [Personalize the Visual Studio IDE](/visualstudio/ide/personalizing-the-visual-studio-ide).
+
+## Prerequisites
+ In order to complete this walkthrough, you will need:
+
+- Sufficient permissions to be able to create and run Windows Forms application projects on the computer where Visual Studio is installed.
+
+## Creating a Control That Has a Serializable Collection
+ The first step is to create a control that has a serializable collection as a property. You can edit the contents of this collection using the **Collection Editor**, which you can access from the **Properties** window.
+
+#### To create a control with a serializable collection
+
+1. Create a Windows Control Library project called `SerializationDemoControlLib`. For more information, see [Windows Control Library Template](https://docs.microsoft.com/previous-versions/kxczf775(v=vs.100)).
+
+2. Rename `UserControl1` to `SerializationDemoControl`. For more information, see [Rename a code symbol refactoring](/visualstudio/ide/reference/rename).
+
+3. In the **Properties** window, set the value of the <xref:System.Windows.Forms.Padding.All%2A?displayProperty=nameWithType> property to `10`.
+
+4. Place a <xref:System.Windows.Forms.TextBox> control in the `SerializationDemoControl`.
+
+5. Select the <xref:System.Windows.Forms.TextBox> control. In the **Properties** window, set the following properties.
+
+    |Property|Change to|
+    |--------------|---------------|
+    |**Multiline**|`true`|
+    |**Dock**|<xref:System.Windows.Forms.DockStyle.Fill>|
+    |**ScrollBars**|<xref:System.Windows.Forms.ScrollBars.Vertical>|
+    |**ReadOnly**|`true`|
+
+6. In the **Code Editor**, declare a string array field named `stringsValue` in `SerializationDemoControl`.
+
      [!code-cpp[System.ComponentModel.DesignerSerializationVisibilityAttribute#4](~/samples/snippets/cpp/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/cpp/form1.cpp#4)]
      [!code-csharp[System.ComponentModel.DesignerSerializationVisibilityAttribute#4](~/samples/snippets/csharp/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/CS/form1.cs#4)]
-     [!code-vb[System.ComponentModel.DesignerSerializationVisibilityAttribute#4](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/VB/form1.vb#4)]  
-  
-7. Define the `Strings` property on the `SerializationDemoControl`.  
-  
+     [!code-vb[System.ComponentModel.DesignerSerializationVisibilityAttribute#4](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/VB/form1.vb#4)]
+
+7. Define the `Strings` property on the `SerializationDemoControl`.
+
 > [!NOTE]
->  The <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute.Content> value is used to enable serialization of the collection.  
-  
+> The <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute.Content> value is used to enable serialization of the collection.
+
  [!code-cpp[System.ComponentModel.DesignerSerializationVisibilityAttribute#5](~/samples/snippets/cpp/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/cpp/form1.cpp#5)]
  [!code-csharp[System.ComponentModel.DesignerSerializationVisibilityAttribute#5](~/samples/snippets/csharp/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/CS/form1.cs#5)]
- [!code-vb[System.ComponentModel.DesignerSerializationVisibilityAttribute#5](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/VB/form1.vb#5)]  
-  
-1. Press F5 to build the project and run your control in the **UserControl Test Container**.  
-  
-2. Find the `Strings` property in the <xref:System.Windows.Forms.PropertyGrid> of the **UserControl Test Container**. Click the `Strings` property, then click the ellipsis (![VisualStudioEllipsesButton screenshot](../media/vbellipsesbutton.png "vbEllipsesButton")) button to open the **String Collection Editor**.  
-  
-3. Enter several strings in the **String Collection Editor**. Separate them by pressing the ENTER key at the end of each string. Click **OK** when you are finished entering strings.  
-  
+ [!code-vb[System.ComponentModel.DesignerSerializationVisibilityAttribute#5](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.ComponentModel.DesignerSerializationVisibilityAttribute/VB/form1.vb#5)]
+
+1. Press F5 to build the project and run your control in the **UserControl Test Container**.
+
+2. Find the `Strings` property in the <xref:System.Windows.Forms.PropertyGrid> of the **UserControl Test Container**. Click the `Strings` property, then click the ellipsis (![VisualStudioEllipsesButton screenshot](../media/vbellipsesbutton.png "vbEllipsesButton")) button to open the **String Collection Editor**.
+
+3. Enter several strings in the **String Collection Editor**. Separate them by pressing the ENTER key at the end of each string. Click **OK** when you are finished entering strings.
+
 > [!NOTE]
->  The strings you typed appear in the <xref:System.Windows.Forms.TextBox> of the `SerializationDemoControl`.  
-  
-## Serializing a Collection Property  
- To test the serialization behavior of your control, you will place it on a form and change the contents of the collection with the **Collection Editor**. You can see the serialized collection state by looking at a special designer file, into which the **Windows Forms Designer** emits code.  
-  
-#### To serialize a collection  
-  
-1. Add a Windows Application project to the solution. Name the project `SerializationDemoControlTest`.  
-  
-2. In the **Toolbox**, find the tab named **SerializationDemoControlLib Components**. In this tab, you will find the `SerializationDemoControl`. For more information, see [Walkthrough: Automatically Populating the Toolbox with Custom Components](walkthrough-automatically-populating-the-toolbox-with-custom-components.md).  
-  
-3. Place a `SerializationDemoControl` on your form.  
-  
-4. Find the `Strings` property in the **Properties** window. Click the `Strings` property, then click the ellipsis (![VisualStudioEllipsesButton screenshot](../media/vbellipsesbutton.png "vbEllipsesButton")) button to open the **String Collection Editor**.  
-  
-5. Type several strings in the **String Collection Editor**. Separate them by pressing the ENTER key at the end of each string. Click **OK** when you are finished entering strings.  
-  
+> The strings you typed appear in the <xref:System.Windows.Forms.TextBox> of the `SerializationDemoControl`.
+
+## Serializing a Collection Property
+
+To test the serialization behavior of your control, you will place it on a form and change the contents of the collection with the **Collection Editor**. You can see the serialized collection state by looking at a special designer file, into which the **Windows Forms Designer** emits code.
+
+#### To serialize a collection
+
+1. Add a Windows Application project to the solution. Name the project `SerializationDemoControlTest`.
+
+2. In the **Toolbox**, find the tab named **SerializationDemoControlLib Components**. In this tab, you will find the `SerializationDemoControl`. For more information, see [Walkthrough: Automatically Populating the Toolbox with Custom Components](walkthrough-automatically-populating-the-toolbox-with-custom-components.md).
+
+3. Place a `SerializationDemoControl` on your form.
+
+4. Find the `Strings` property in the **Properties** window. Click the `Strings` property, then click the ellipsis (![VisualStudioEllipsesButton screenshot](../media/vbellipsesbutton.png "vbEllipsesButton")) button to open the **String Collection Editor**.
+
+5. Type several strings in the **String Collection Editor**. Separate them by pressing the ENTER key at the end of each string. Click **OK** when you are finished entering strings.
+
 > [!NOTE]
->  The strings you typed appear in the <xref:System.Windows.Forms.TextBox> of the `SerializationDemoControl`.  
-  
-1. In **Solution Explorer**, click the **Show All Files** button.  
-  
-2. Open the **Form1** node. Beneath it is a file called **Form1.Designer.cs** or **Form1.Designer.vb**. This is the file into which the **Windows Forms Designer** emits code representing the design-time state of your form and its child controls. Open this file in the **Code Editor**.  
-  
-3. Open the region called **Windows Form Designer generated code** and find the section labeled **serializationDemoControl1**. Beneath this label is the code representing the serialized state of your control. The strings you typed in step 5 appear in an assignment to the `Strings` property. The following code examples in C# and Visual Basic, show code similar to what you will see if you typed the strings "red", "orange", and "yellow".  
-  
-    ```csharp  
-    this.serializationDemoControl1.Strings = new string[] {  
-            "red",  
-            "orange",  
-            "yellow"};  
-    ```  
-    
-    ```vb  
-    Me.serializationDemoControl1.Strings = New String() {"red", "orange", "yellow"}  
+> The strings you typed appear in the <xref:System.Windows.Forms.TextBox> of the `SerializationDemoControl`.
+
+1. In **Solution Explorer**, click the **Show All Files** button.
+
+2. Open the **Form1** node. Beneath it is a file called **Form1.Designer.cs** or **Form1.Designer.vb**. This is the file into which the **Windows Forms Designer** emits code representing the design-time state of your form and its child controls. Open this file in the **Code Editor**.
+
+3. Open the region called **Windows Form Designer generated code** and find the section labeled **serializationDemoControl1**. Beneath this label is the code representing the serialized state of your control. The strings you typed in step 5 appear in an assignment to the `Strings` property. The following code examples in C# and Visual Basic, show code similar to what you will see if you typed the strings "red", "orange", and "yellow".
+
+    ```csharp
+    this.serializationDemoControl1.Strings = new string[] {
+            "red",
+            "orange",
+            "yellow"};
     ```
-  
-4. In the **Code Editor**, change the value of the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute> on the `Strings` property to <xref:System.ComponentModel.DesignerSerializationVisibility.Hidden>.  
-  
-    ```csharp  
-    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]  
-    ```  
-    ```vb  
-    <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _  
-    ```  
-  
-5. Rebuild the solution and repeat steps 3 and 4.  
-  
+
+    ```vb
+    Me.serializationDemoControl1.Strings = New String() {"red", "orange", "yellow"}
+    ```
+
+4. In the **Code Editor**, change the value of the <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute> on the `Strings` property to <xref:System.ComponentModel.DesignerSerializationVisibility.Hidden>.
+
+    ```csharp
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+    ```
+
+    ```vb
+    <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)> _
+    ```
+
+5. Rebuild the solution and repeat steps 3 and 4.
+
 > [!NOTE]
->  In this case, the **Windows Forms Designer** emits no assignment to the `Strings` property.  
-  
-## Next Steps  
- Once you know how to serialize a collection of standard types, consider integrating your custom controls more deeply into the design-time environment. The following topics describe how to enhance the design-time integration of your custom controls:  
-  
--   [Design-Time Architecture](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2013/c5z9s1h4(v=vs.120))  
-  
--   [Attributes in Windows Forms Controls](attributes-in-windows-forms-controls.md)  
-  
--   [Designer Serialization Overview](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2013/ms171834(v=vs.120))  
-  
--   [Walkthrough: Creating a Windows Forms Control That Takes Advantage of Visual Studio Design-Time Features](creating-a-wf-control-design-time-features.md)  
-  
+> In this case, the **Windows Forms Designer** emits no assignment to the `Strings` property.
+
+## Next Steps
+
+Once you know how to serialize a collection of standard types, consider integrating your custom controls more deeply into the design-time environment. The following topics describe how to enhance the design-time integration of your custom controls:
+
+- [Design-Time Architecture](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2013/c5z9s1h4(v=vs.120))
+
+- [Attributes in Windows Forms Controls](attributes-in-windows-forms-controls.md)
+
+- [Designer Serialization Overview](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2013/ms171834(v=vs.120))
+
+- [Walkthrough: Creating a Windows Forms Control That Takes Advantage of Visual Studio Design-Time Features](creating-a-wf-control-design-time-features.md)
+
 ## See also
 
 - <xref:System.ComponentModel.DesignerSerializationVisibilityAttribute>

--- a/docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
+++ b/docs/framework/winforms/controls/serializing-collections-designerserializationvisibilityattribute.md
@@ -29,7 +29,7 @@ Your custom controls will sometimes expose a collection as a property. This walk
 ## Creating a Control That Has a Serializable Collection
  The first step is to create a control that has a serializable collection as a property. You can edit the contents of this collection using the **Collection Editor**, which you can access from the **Properties** window.
 
-#### To create a control with a serializable collection
+### To create a control with a serializable collection
 
 1. Create a Windows Control Library project called `SerializationDemoControlLib`. For more information, see [Windows Control Library Template](https://docs.microsoft.com/previous-versions/kxczf775(v=vs.100)).
 
@@ -76,7 +76,7 @@ Your custom controls will sometimes expose a collection as a property. This walk
 
 To test the serialization behavior of your control, you will place it on a form and change the contents of the collection with the **Collection Editor**. You can see the serialized collection state by looking at a special designer file, into which the **Windows Forms Designer** emits code.
 
-#### To serialize a collection
+### To serialize a collection
 
 1. Add a Windows Application project to the solution. Name the project `SerializationDemoControlTest`.
 

--- a/docs/fsharp/get-started/get-started-vscode.md
+++ b/docs/fsharp/get-started/get-started-vscode.md
@@ -147,6 +147,7 @@ Next, open the `Script.fsx` file again, and delete the entire `toPigLatin` funct
 #load "ClassLibraryDemo.fs"
 open ClassLibraryDemo
 ```
+
 Select both lines of text and press Alt+Enter to execute these lines in FSI. These will load the contents of the Pig Latin library into the FSI process and `open` the `ClassLibraryDemo` namespace so that you have access to the functionality.
 
 Next, in the FSI window, call the function with the `PigLatin` module that you defined earlier:

--- a/docs/fsharp/language-reference/arrays.md
+++ b/docs/fsharp/language-reference/arrays.md
@@ -103,6 +103,7 @@ The output shows that the subarray starts at element 5 and contains 10 elements.
 ```
 [|5; 6; 7; 8; 9; 10; 11; 12; 13; 14|]
 ```
+
 [`Array.append`](https://msdn.microsoft.com/library/08836310-5036-4474-b9a2-2c73e2293911) creates a new array by combining two existing arrays.
 
 The following code demonstrates **Array.append**.
@@ -158,7 +159,7 @@ The output of the preceding code is as follows.
 
 [`Array.rev`](https://msdn.microsoft.com/library/1bbf822c-763b-4794-af21-97d2e48ef709) generates a new array by reversing the order of an existing array. The following code demonstrates `Array.rev`.
 
-[!code-fsharp[Main](../../../samples/snippets/fsharp/arrays/snippet18.fs)]  
+[!code-fsharp[Main](../../../samples/snippets/fsharp/arrays/snippet18.fs)]
 
 The output of the preceding code is as follows.
 
@@ -199,7 +200,7 @@ Only a subset of the functions available for one-dimensional arrays is also avai
 In a two-dimensional array (a matrix), you can extract a sub-matrix by specifying ranges and using a wildcard (`*`) character to specify whole rows or columns.
 
 ```fsharp
-/ Get rows 1 to N from an NxM matrix (returns a matrix):
+// Get rows 1 to N from an NxM matrix (returns a matrix):
 matrix.[1.., *]
 
 // Get rows 1 to 3 from a matrix (returns a matrix):
@@ -233,7 +234,7 @@ type Matrix<'T>(N: int, M: int) =
         and set(a: int, b: int) (value:'T) = internalArray.[a, b] <- value
 
     member this.GetSlice(rowStart: int option, rowFinish : int option, colStart: int option, colFinish : int option) =
-        let rowStart = 
+        let rowStart =
             match rowStart with
             | Some(v) -> v
             | None -> 0
@@ -241,33 +242,33 @@ type Matrix<'T>(N: int, M: int) =
             match rowFinish with
             | Some(v) -> v
             | None -> internalArray.GetLength(0) - 1
-        let colStart = 
+        let colStart =
             match colStart with
             | Some(v) -> v
             | None -> 0
-        let colFinish = 
+        let colFinish =
             match colFinish with
             | Some(v) -> v
             | None -> internalArray.GetLength(1) - 1
         internalArray.[rowStart..rowFinish, colStart..colFinish]
 
     member this.GetSlice(row: int, colStart: int option, colFinish: int option) =
-        let colStart = 
+        let colStart =
             match colStart with
             | Some(v) -> v
             | None -> 0
-        let colFinish = 
+        let colFinish =
             match colFinish with
             | Some(v) -> v
             | None -> internalArray.GetLength(1) - 1
         internalArray.[row, colStart..colFinish]
 
     member this.GetSlice(rowStart: int option, rowFinish: int option, col: int) =
-        let rowStart = 
+        let rowStart =
             match rowStart with
             | Some(v) -> v
             | None -> 0
-        let rowFinish = 
+        let rowFinish =
             match rowFinish with
             | Some(v) -> v
             | None -> internalArray.GetLength(0) - 1

--- a/docs/fsharp/language-reference/verbose-syntax.md
+++ b/docs/fsharp/language-reference/verbose-syntax.md
@@ -27,6 +27,7 @@ compound expressions
 <expression1>
 <expression2>
 ```
+
 </td><td>
 
 ```fsharp
@@ -78,6 +79,7 @@ begin
     <expression2>;
 end
 ```
+
 </td>
 </tr>
 <tr><td>
@@ -238,7 +240,7 @@ type <union-name> =
     ...
     with
         <value-or-member-definitions>
-    end    
+    end
 ```
 
 </td>
@@ -249,6 +251,7 @@ type <union-name> =
 type <interface-name> =
     ...
 ```
+
 </td><td>
 
 ```fsharp

--- a/docs/fsharp/style-guide/formatting.md
+++ b/docs/fsharp/style-guide/formatting.md
@@ -279,6 +279,7 @@ let update model msg =
     | 1 -> model + 1, []
     | _ -> model, [ msg ]
 ```
+
 In summary, prefer parenthesized tuple instantiations, but when using tuples for pattern matching or a return value, it is considered fine to avoid parentheses.
 
 ## Formatting discriminated union declarations
@@ -338,10 +339,10 @@ type PostalAddress =
     City: string
     Zip: string }
     member x.ZipAndCity = sprintf "%s %s" x.Zip x.City
-    
+
 // Unusual in F#
 type PostalAddress =
-    { 
+    {
         Address: string
         City: string
         Zip: string
@@ -353,13 +354,13 @@ Placing the opening token on a new line and the closing token on a new line is p
 ```fsharp
 // Declaring additional members on PostalAddress
 type PostalAddress =
-    { 
+    {
         Address: string
         City: string
         Zip: string
     } with
     member x.ZipAndCity = sprintf "%s %s" x.Zip x.City
-    
+
 type MyRecord =
     {
         SomeField: int
@@ -401,7 +402,7 @@ let rainbow =
         Boss8 = "Jeffrey"
         Lackeys = ["Zippy"; "George"; "Bungle"]
     }
-    
+
 type MyRecord =
     {
         SomeField: int
@@ -439,12 +440,12 @@ let rainbow2 =
 
 And as with the record guidance, you may want to dedicate separate lines for the braces and indent one scope to the right with the expression. Note that in some special cases, such as wrapping a value with an optional without parentheses, you may need to keep a brace on one line:
 
-```fsharp    
+```fsharp
 type S = { F1: int; F2: string }
 type State = { F:  S option }
 
 let state = { F = Some { F1 = 1; F2 = "Hello" } }
-let newState = 
+let newState =
     {
         state with
             F = Some {

--- a/docs/machine-learning/tutorials/movie-recommmendation.md
+++ b/docs/machine-learning/tutorials/movie-recommmendation.md
@@ -198,7 +198,7 @@ public static ITransformer BuildAndTrainModel(MLContext mlContext, IDataView tra
 > This method will give you an error until you add a return statement in the following steps.
 
 Define the data transformations by adding the following code to `BuildAndTrainModel()`:
-   
+
 [!code-csharp[DataTransformations](~/samples/machine-learning/tutorials/MovieRecommendation/Program.cs#DataTransformations "Define data transformations")]
 
 Since `userId` and `movieId` represent users and movie titles, not real values, you use the [MapValueToKey()](xref:Microsoft.ML.ConversionsExtensionsCatalog.MapValueToKey%2A) method to transform each `userId` and each `movieId` into a numeric key type `Feature` column (a format accepted by recommendation algorithms) and add them as new dataset columns:
@@ -213,7 +213,7 @@ Choose the machine learning algorithm and append it to the data transformation d
 
 [!code-csharp[AddAlgorithm](~/samples/machine-learning/tutorials/MovieRecommendation/Program.cs#AddAlgorithm "Add the training algorithm with options")]
 
-The [MatrixFactorizationTrainer](xref:Microsoft.ML.RecommendationCatalog.RecommendationTrainers.MatrixFactorization%28Microsoft.ML.Trainers.MatrixFactorizationTrainer.Options%29) is your recommendation training algorithm.  [Matrix Factorization](https://en.wikipedia.org/wiki/Matrix_factorization_(recommender_systems)) is a common approach to recommendation when you have data on how users have rated products in the past, which is the case for the datasets in this tutorial. There are other recommendation algorithms for when you have different data available (see the [Other recommendation algorithms](#other-recommendation-algorithms) section below to learn more). 
+The [MatrixFactorizationTrainer](xref:Microsoft.ML.RecommendationCatalog.RecommendationTrainers.MatrixFactorization%28Microsoft.ML.Trainers.MatrixFactorizationTrainer.Options%29) is your recommendation training algorithm.  [Matrix Factorization](https://en.wikipedia.org/wiki/Matrix_factorization_(recommender_systems)) is a common approach to recommendation when you have data on how users have rated products in the past, which is the case for the datasets in this tutorial. There are other recommendation algorithms for when you have different data available (see the [Other recommendation algorithms](#other-recommendation-algorithms) section below to learn more).
 
 In this case, the `Matrix Factorization` algorithm uses a method called "collaborative filtering", which assumes that if User 1 has the same opinion as User 2 on a certain issue, then User 1 is more likely to feel the same way as User 2 about a different issue.
 
@@ -238,7 +238,7 @@ Add the following as the next line of code in the `Main()` method to call your `
 
 ## Evaluate your model
 
-Once you have trained your model, use your test data to evaluate how your model is performing. 
+Once you have trained your model, use your test data to evaluate how your model is performing.
 
 Create the `EvaluateModel()` method, just after the `BuildAndTrainModel()` method, using the following code:
 
@@ -311,6 +311,7 @@ Building successful models is an iterative process. This model has initial lower
 Now you can use your trained model to make predictions on new data.
 
 Create the `UseModelForSinglePrediction()` method, just after the `EvaluateModel()` method, using the following code:
+
 ```csharp
 public static void UseModelForSinglePrediction(MLContext mlContext, ITransformer model)
 {
@@ -423,9 +424,9 @@ Adding more training data that has enough samples for each user and movie id can
 
 ### Features
 
-In this tutorial, you only use the three `Features` (`user id`, `movie id`, and `rating`) that are provided by the dataset. 
+In this tutorial, you only use the three `Features` (`user id`, `movie id`, and `rating`) that are provided by the dataset.
 
-While this is a good start, in reality you might want to add other attributes or `Features` (for example, age, gender, geo-location, etc.) if they are included in the dataset. Adding more relevant `Features` can help improve the performance of your recommendation model. 
+While this is a good start, in reality you might want to add other attributes or `Features` (for example, age, gender, geo-location, etc.) if they are included in the dataset. Adding more relevant `Features` can help improve the performance of your recommendation model.
 
 If you are unsure about which `Features` might be the most relevant for your machine learning task, you can also make use of Feature Contribution Calculation (FCC) and [Feature Permutation Importance](../how-to-guides/determine-global-feature-importance-in-model.md), which ML.NET provides to discover the most influential `Features`.
 
@@ -441,7 +442,7 @@ For instance, in this tutorial the algorithm options are:
 var options = new MatrixFactorizationTrainer.Options
 {
     MatrixColumnIndexColumnName = "userIdEncoded",
-    MatrixRowIndexColumnName = "movieIdEncoded", 
+    MatrixRowIndexColumnName = "movieIdEncoded",
     LabelColumnName = "Label",
     NumberOfIterations = 20,
     ApproximationRank = 100

--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -28,7 +28,7 @@ In this tutorial, you learn how to:
 
 ## Sentiment analysis sample overview
 
-The sample is a console app that uses ML.NET to train a model that classifies and predicts sentiment as either positive or negative. The Yelp sentiment dataset is from University of California, Irvine (UCI), which is split into a train dataset and a test dataset. The sample evaluates the model with the test dataset for quality analysis. 
+The sample is a console app that uses ML.NET to train a model that classifies and predicts sentiment as either positive or negative. The Yelp sentiment dataset is from University of California, Irvine (UCI), which is split into a train dataset and a test dataset. The sample evaluates the model with the test dataset for quality analysis.
 
 You can find the source code for this tutorial at the [dotnet/samples](https://github.com/dotnet/samples/tree/master/machine-learning/tutorials/SentimentAnalysis) repository.
 
@@ -48,7 +48,7 @@ The workflow phases are as follows:
 2. **Prepare your data**
    * **Load the data**
    * **Extract features (Transform your data)**
-3. **Build and train** 
+3. **Build and train**
    * **Train the model**
    * **Evaluate the model**
 4. **Deploy Model**
@@ -91,7 +91,7 @@ Classification algorithms are frequently one of the following types:
 * Binary: either A or B.
 * Multiclass: multiple categories that can be predicted by using a single model.
 
-Because the website comments need to be classified as either positive or negative, you use the Binary Classification algorithm. 
+Because the website comments need to be classified as either positive or negative, you use the Binary Classification algorithm.
 
 ## Create a console application
 
@@ -173,22 +173,23 @@ public static TrainCatalogBase.TrainTestData LoadData(MLContext mlContext)
 
 }
 ```
+
 ## Load the data
 
 Since your previously created `SentimentData` data model type matches the dataset schema, you can combine the initialization, mapping, and dataset loading into one line of code using the `MLContext.Data.LoadFromTextFile` wrapper for the [LoadFromTextFile method](xref:Microsoft.ML.TextLoaderSaverCatalog.LoadFromTextFile%60%601%28Microsoft.ML.DataOperationsCatalog,System.String,System.Char,System.Boolean,System.Boolean,System.Boolean,System.Boolean%29). It returns a
-<xref:Microsoft.Data.DataView.IDataView>. 
+<xref:Microsoft.Data.DataView.IDataView>.
 
- As the input and output of `Transforms`, a `DataView` is the fundamental data pipeline type, comparable to `IEnumerable` for `LINQ`.
+As the input and output of `Transforms`, a `DataView` is the fundamental data pipeline type, comparable to `IEnumerable` for `LINQ`.
 
 In ML.NET, data is similar to a SQL view. It is lazily evaluated, schematized, and heterogenous. The object is the first part of the pipeline, and loads the data. For this tutorial, it loads a dataset with comments and corresponding toxic or non toxic sentiment. This is used to create the model, and train it.
 
- Add the following code as the first line of the `LoadData` method:
+Add the following code as the first line of the `LoadData` method:
 
 [!code-csharp[LoadData](~/samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#LoadData "loading dataset")]
 
 ### Split the dataset for model training and testing
 
-Next, you need both a training dataset to train the model and a test dataset to evaluate the model. Use the `MLContext.BinaryClassification.TrainTestSplit` which wraps <xref:Microsoft.ML.StaticPipe.TrainingStaticExtensions.TrainTestSplit%2A> to split the loaded dataset into train and test datasets and return them inside of a <xref:Microsoft.ML.TrainCatalogBase.TrainTestData>. You can specify the fraction of data for the test set with the `testFraction`parameter. The default is 10% but you use 20% in this case to use more data for the evaluation.  
+Next, you need both a training dataset to train the model and a test dataset to evaluate the model. Use the `MLContext.BinaryClassification.TrainTestSplit` which wraps <xref:Microsoft.ML.StaticPipe.TrainingStaticExtensions.TrainTestSplit%2A> to split the loaded dataset into train and test datasets and return them inside of a <xref:Microsoft.ML.TrainCatalogBase.TrainTestData>. You can specify the fraction of data for the test set with the `testFraction`parameter. The default is 10% but you use 20% in this case to use more data for the evaluation.
 
 To split the loaded data into the needed datasets, add the following code as the next line in the `LoadData` method:
 
@@ -220,7 +221,7 @@ public static ITransformer BuildAndTrainModel(MLContext mlContext, IDataView spl
 }
 ```
 
-Notice that two parameters are passed into the Train method; a `MLContext` for the context (`mlContext`), and an `IDataView`for the training dataset (`splitTrainSet`). 
+Notice that two parameters are passed into the Train method; a `MLContext` for the context (`mlContext`), and an `IDataView`for the training dataset (`splitTrainSet`).
 
 ## Extract and transform the data
 
@@ -349,7 +350,7 @@ Add a call to the new method from the `Main` method, right under the `Evaluate` 
 While the `model` is a `transformer` that operates on many rows of data, a very common production scenario is a need for predictions on individual examples. The <xref:Microsoft.ML.PredictionEngine%602> is a wrapper that is returned from the `CreatePredictionEngine` method. Let's add the following code to create the `PredictionEngine` as the first line in the `Predict` Method:
 
 [!code-csharp[CreatePredictionEngine](~/samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#CreatePredictionEngine1 "Create the PredictionEngine")]
-  
+
 Add a comment to test the trained model's prediction in the `Predict` method by creating an instance of `SentimentData`:
 
 [!code-csharp[PredictionData](~/samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#CreateTestIssue1 "Create test data for single prediction")]
@@ -446,7 +447,7 @@ Press any key to continue . . .
 
 ```
 
-Congratulations! You've now successfully built a machine learning model for classifying and predicting messages sentiment. 
+Congratulations! You've now successfully built a machine learning model for classifying and predicting messages sentiment.
 
 Building successful models is an iterative process. This model has initial lower quality as the tutorial uses small datasets to provide quick model training. If you aren't satisfied with the model quality, you can try to improve it by providing larger training datasets or by choosing different training algorithms with different hyper-parameters for each algorithm.
 
@@ -455,6 +456,7 @@ You can find the source code for this tutorial at the [dotnet/samples](https://g
 ## Next steps
 
 In this tutorial, you learned how to:
+
 > [!div class="checklist"]
 > * Understand the problem
 > * Select the appropriate machine learning algorithm
@@ -466,5 +468,6 @@ In this tutorial, you learned how to:
 > * Deploy and Predict with a loaded model
 
 Advance to the next tutorial to learn more
+
 > [!div class="nextstepaction"]
 > [Issue Classification](github-issue-classification.md)

--- a/docs/machine-learning/tutorials/taxi-fare.md
+++ b/docs/machine-learning/tutorials/taxi-fare.md
@@ -144,7 +144,7 @@ We are passing two parameters into the `Train` method; an `MLContext` for the co
 ## Load and transform data
 
 Load the data using the `MLContext.Data.LoadFromTextFile` wrapper for the [LoadFromTextFile method](xref:Microsoft.ML.TextLoaderSaverCatalog.LoadFromTextFile%60%601%28Microsoft.ML.DataOperationsCatalog,System.String,System.Char,System.Boolean,System.Boolean,System.Boolean,System.Boolean%29). It returns a
-<xref:Microsoft.Data.DataView.IDataView>. 
+<xref:Microsoft.Data.DataView.IDataView>.
 
 As the input and output of `Transforms`, a `DataView` is the fundamental data pipeline type, comparable to `IEnumerable` for `LINQ`.
 
@@ -227,6 +227,7 @@ private static void Evaluate(MLContext mlContext, ITransformer model)
 
 }
 ```
+
 The `Evaluate` method executes the following tasks:
 
 * Loads the test dataset.
@@ -298,12 +299,12 @@ Since we want to load the model from the zip file we saved, we'll create the `Fi
 While the `model` is a `transformer` that operates on many rows of data, a very common production scenario is a need for predictions on individual examples. The <xref:Microsoft.ML.PredictionEngine%602> is a wrapper that is returned from the `CreatePredictionEngine` method. Let's add the following code to create the `PredictionEngine` as the next line in the `TestSinglePrediction` Method:
 
 [!code-csharp[MakePredictionEngine](~/samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#22 "Create the PredictionFunction")]
-  
+
 This tutorial uses one test trip within this class. Later you can add other scenarios to experiment with the model. Add a trip to test the trained model's prediction of cost in the `TestSinglePrediction` method by creating an instance of `TaxiTrip`:
 
 [!code-csharp[PredictionData](~/samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#23 "Create test data for single prediction")]
 
- We can use that to predict the fare based on a single instance of the taxi trip data. To get a prediction, use <xref:Microsoft.ML.PredictionEngine%602.Predict%2A> on the data. Note that the input data is a string and the model includes the featurization. Your pipeline is in sync during training and prediction. You didn’t have to write preprocessing/featurization code specifically for predictions, and the same API takes care of both batch and one-time predictions.
+We can use that to predict the fare based on a single instance of the taxi trip data. To get a prediction, use <xref:Microsoft.ML.PredictionEngine%602.Predict%2A> on the data. Note that the input data is a string and the model includes the featurization. Your pipeline is in sync during training and prediction. You didn’t have to write preprocessing/featurization code specifically for predictions, and the same API takes care of both batch and one-time predictions.
 
 [!code-csharp[Predict](~/samples/machine-learning/tutorials/TaxiFarePrediction/Program.cs#24 "Create a prediction of taxi fare")]
 
@@ -318,6 +319,7 @@ Congratulations! You've now successfully built a machine learning model for pred
 ## Next steps
 
 In this tutorial, you learned how to:
+
 > [!div class="checklist"]
 > * Understand the problem
 > * Select the appropriate machine learning task
@@ -330,5 +332,6 @@ In this tutorial, you learned how to:
 > * Use the model for predictions
 
 Advance to the next tutorial to learn more.
+
 > [!div class="nextstepaction"]
 > [Iris clustering](iris-clustering.md)

--- a/docs/standard/assembly/friend-assemblies.md
+++ b/docs/standard/assembly/friend-assemblies.md
@@ -3,90 +3,95 @@ title: "Friend Assemblies (C#)"
 ms.date: 03/03/2019
 ms.assetid: b65ea7de-0801-477a-a39c-e914c2cc107c
 ---
-# Friend assemblies 
-A *friend assembly* is an assembly that can access another assembly's [internal](../../csharp/language-reference/keywords/internal.md) (in C# or [Friend](../../visual-basic/language-reference/modifiers/friend.md) in Visual Basic) types and members. If you identify an assembly as a friend assembly, you no longer have to mark types and members as public in order for them to be accessed by other assemblies. This is especially convenient in the following scenarios:  
-  
--   During unit testing, when test code runs in a separate assembly but requires access to members in the assembly being tested that are marked as `internal` in C# or `Friend` in Visual Basic.  
-  
--   When you are developing a class library and additions to the library are contained in separate assemblies but require access to members in existing assemblies that are marked as `internal` in C# or `Friend` in Visual Basic. 
-  
-## Remarks  
- You can use the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute to identify one or more friend assemblies for a given assembly. The following example uses the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute in assembly A and specifies assembly `AssemblyB` as a friend assembly. This gives assembly `AssemblyB` access to all types and members in assembly A that are marked as `internal` in C# or `Friend` in Visual Basic.
-  
-> [!NOTE]
->  When you compile an assembly (assembly `AssemblyB`) that will access internal types or internal members of another assembly (assembly *A*), you must explicitly specify the name of the output file (.exe or .dll) by using the **/out** compiler option. This is required because the compiler has not yet generated the name for the assembly it is building at the time it is binding to external references. For more information, see [/out (C#)](../../csharp/language-reference/compiler-options/out-compiler-option.md) or [/out (Visual Basic)](../../visual-basic/reference/command-line-compiler/out.md).  
+# Friend assemblies
 
-# [C#](#tab/csharp) 
-```csharp  
-using System.Runtime.CompilerServices;  
-using System;  
-  
-[assembly: InternalsVisibleTo("AssemblyB")]  
-  
-// The class is internal by default.  
-class FriendClass  
-{  
-    public void Test()  
-    {  
-        Console.WriteLine("Sample Class");  
-    }  
-}  
-  
-// Public class that has an internal method.  
-public class ClassWithFriendMethod  
-{  
-    internal void Test()  
-    {  
-        Console.WriteLine("Sample Method");  
-    }  
-  
-}  
-```  
-  
+A *friend assembly* is an assembly that can access another assembly's [internal](../../csharp/language-reference/keywords/internal.md) (in C# or [Friend](../../visual-basic/language-reference/modifiers/friend.md) in Visual Basic) types and members. If you identify an assembly as a friend assembly, you no longer have to mark types and members as public in order for them to be accessed by other assemblies. This is especially convenient in the following scenarios:
+
+- During unit testing, when test code runs in a separate assembly but requires access to members in the assembly being tested that are marked as `internal` in C# or `Friend` in Visual Basic.
+
+- When you are developing a class library and additions to the library are contained in separate assemblies but require access to members in existing assemblies that are marked as `internal` in C# or `Friend` in Visual Basic.
+
+## Remarks
+
+You can use the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute to identify one or more friend assemblies for a given assembly. The following example uses the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute in assembly A and specifies assembly `AssemblyB` as a friend assembly. This gives assembly `AssemblyB` access to all types and members in assembly A that are marked as `internal` in C# or `Friend` in Visual Basic.
+
+> [!NOTE]
+> When you compile an assembly (assembly `AssemblyB`) that will access internal types or internal members of another assembly (assembly *A*), you must explicitly specify the name of the output file (.exe or .dll) by using the **/out** compiler option. This is required because the compiler has not yet generated the name for the assembly it is building at the time it is binding to external references. For more information, see [/out (C#)](../../csharp/language-reference/compiler-options/out-compiler-option.md) or [/out (Visual Basic)](../../visual-basic/reference/command-line-compiler/out.md).
+
+# [C#](#tab/csharp)
+
+```csharp
+using System.Runtime.CompilerServices;
+using System;
+
+[assembly: InternalsVisibleTo("AssemblyB")]
+
+// The class is internal by default.
+class FriendClass
+{
+    public void Test()
+    {
+        Console.WriteLine("Sample Class");
+    }
+}
+
+// Public class that has an internal method.
+public class ClassWithFriendMethod
+{
+    internal void Test()
+    {
+        Console.WriteLine("Sample Method");
+    }
+
+}
+```
+
 # [Visual Basic](#tab/vb)
-```vb  
-Imports System.Runtime.CompilerServices  
-Imports System  
-<Assembly: InternalsVisibleTo("AssemblyB")>   
-  
-' Friend class.  
-Friend Class FriendClass  
-    Public Sub Test()  
-        Console.WriteLine("Sample Class")  
-    End Sub  
-End Class  
-  
-' Public class with a Friend method.  
-Public Class ClassWithFriendMethod  
-    Friend Sub Test()  
-        Console.WriteLine("Sample Method")  
-    End Sub  
-End Class  
-```  
+
+```vb
+Imports System.Runtime.CompilerServices
+Imports System
+<Assembly: InternalsVisibleTo("AssemblyB")>
+
+' Friend class.
+Friend Class FriendClass
+    Public Sub Test()
+        Console.WriteLine("Sample Class")
+    End Sub
+End Class
+
+' Public class with a Friend method.
+Public Class ClassWithFriendMethod
+    Friend Sub Test()
+        Console.WriteLine("Sample Method")
+    End Sub
+End Class
+```
+
 ---
 
- Only assemblies that you explicitly specify as friends can access `internal` (in C# or `Friend` in Visual Basic) types and members. For example, if assembly B is a friend of assembly A and assembly C references assembly B, C does not have access to `internal` (in C# or `Friend` in Visual Basic) types in A.  
-  
- The compiler performs some basic validation of the friend assembly name passed to the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute. If assembly *A* declares *B* as a friend assembly, the validation rules are as follows:  
-  
--   If assembly *A* is strong named, assembly *B* must also be strong named. The friend assembly name that is passed to the attribute must consist of the assembly name and the public key of the strong-name key that is used to sign assembly *B*.  
-  
-     The friend assembly name that is passed to the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute cannot be the strong name of assembly *B*: do not include the assembly version, culture, architecture, or public key token.  
-  
--   If assembly *A* is not strong named, the friend assembly name should consist of only the assembly name. For more information, see [How to: Create Unsigned Friend Assemblies (C#)](../../csharp/programming-guide/concepts/assemblies-gac/how-to-create-unsigned-friend-assemblies.md) or [How to: Create Unsigned Friend Assemblies (Visual Basic)](../../visual-basic/programming-guide/concepts/assemblies-gac/how-to-create-unsigned-friend-assemblies.md).  
-  
--   If assembly *B* is strong named, you must specify the strong-name key for assembly *B* by using the project setting or the command-line `/keyfile` compiler option. For more information, see [How to: Create Signed Friend Assemblies (C#)](../../csharp/programming-guide/concepts/assemblies-gac/how-to-create-signed-friend-assemblies.md) or [How to: Create Signed Friend Assemblies (Visual Basic)](../../visual-basic/programming-guide/concepts/assemblies-gac/how-to-create-signed-friend-assemblies.md).  
-  
- The <xref:System.Security.Permissions.StrongNameIdentityPermission> class also provides the ability to share types, with the following differences:  
-  
--   <xref:System.Security.Permissions.StrongNameIdentityPermission> applies to an individual type, while a friend assembly applies to the whole assembly.  
-  
--   If there are hundreds of types in assembly *A* that you want to share with assembly *B*, you have to add <xref:System.Security.Permissions.StrongNameIdentityPermission> to all of them. If you use a friend assembly, you only need to declare the friend relationship once.  
-  
--   If you use <xref:System.Security.Permissions.StrongNameIdentityPermission>, the types you want to share have to be declared as public. If you use a friend assembly, the shared types are declared as `internal` (in C# or `Friend` in Visual Basic).  
-  
- For information about how to access an assembly's `internal` (in C# or `Friend` in Visual Basic) types and methods from a module file (a file with the .netmodule extension), see [/moduleassemblyname (C#)](../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md) or [/moduleassemblyname (Visual Basic)](../../visual-basic/reference/command-line-compiler/moduleassemblyname.md).  
-  
+Only assemblies that you explicitly specify as friends can access `internal` (in C# or `Friend` in Visual Basic) types and members. For example, if assembly B is a friend of assembly A and assembly C references assembly B, C does not have access to `internal` (in C# or `Friend` in Visual Basic) types in A.
+
+The compiler performs some basic validation of the friend assembly name passed to the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute. If assembly *A* declares *B* as a friend assembly, the validation rules are as follows:
+
+- If assembly *A* is strong named, assembly *B* must also be strong named. The friend assembly name that is passed to the attribute must consist of the assembly name and the public key of the strong-name key that is used to sign assembly *B*.
+
+     The friend assembly name that is passed to the <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute> attribute cannot be the strong name of assembly *B*: do not include the assembly version, culture, architecture, or public key token.
+
+- If assembly *A* is not strong named, the friend assembly name should consist of only the assembly name. For more information, see [How to: Create Unsigned Friend Assemblies (C#)](../../csharp/programming-guide/concepts/assemblies-gac/how-to-create-unsigned-friend-assemblies.md) or [How to: Create Unsigned Friend Assemblies (Visual Basic)](../../visual-basic/programming-guide/concepts/assemblies-gac/how-to-create-unsigned-friend-assemblies.md).
+
+- If assembly *B* is strong named, you must specify the strong-name key for assembly *B* by using the project setting or the command-line `/keyfile` compiler option. For more information, see [How to: Create Signed Friend Assemblies (C#)](../../csharp/programming-guide/concepts/assemblies-gac/how-to-create-signed-friend-assemblies.md) or [How to: Create Signed Friend Assemblies (Visual Basic)](../../visual-basic/programming-guide/concepts/assemblies-gac/how-to-create-signed-friend-assemblies.md).
+
+ The <xref:System.Security.Permissions.StrongNameIdentityPermission> class also provides the ability to share types, with the following differences:
+
+- <xref:System.Security.Permissions.StrongNameIdentityPermission> applies to an individual type, while a friend assembly applies to the whole assembly.
+
+- If there are hundreds of types in assembly *A* that you want to share with assembly *B*, you have to add <xref:System.Security.Permissions.StrongNameIdentityPermission> to all of them. If you use a friend assembly, you only need to declare the friend relationship once.
+
+- If you use <xref:System.Security.Permissions.StrongNameIdentityPermission>, the types you want to share have to be declared as public. If you use a friend assembly, the shared types are declared as `internal` (in C# or `Friend` in Visual Basic).
+
+For information about how to access an assembly's `internal` (in C# or `Friend` in Visual Basic) types and methods from a module file (a file with the .netmodule extension), see [/moduleassemblyname (C#)](../../csharp/language-reference/compiler-options/moduleassemblyname-compiler-option.md) or [/moduleassemblyname (Visual Basic)](../../visual-basic/reference/command-line-compiler/moduleassemblyname.md).
+
 ## See also
 
 - <xref:System.Runtime.CompilerServices.InternalsVisibleToAttribute>

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
@@ -17,35 +17,35 @@ Since .NET Core 2.0, the framework provides a new interface named <xref:Microsof
 
 **Figure 6-26**. Using IHostedService in a WebHost vs. a Host
 
-Note the difference made between `WebHost` and `Host`. 
+Note the difference made between `WebHost` and `Host`.
 
 A `WebHost` (base class implementing `IWebHost`) in ASP.NET Core 2.0 is the infrastructure artifact you use to provide HTTP server features to your process, such as if you are implementing an MVC web app or Web API service. It provides all the new infrastructure goodness in ASP.NET Core, enabling you to use dependency injection, insert middlewares in the request pipeline, etc. and precisely use these `IHostedServices` for background tasks.
 
 A `Host` (base class implementing `IHost`) was introduced in .NET Core 2.1. Basically, a `Host` allows you to have a similar infrastructure than what you have with `WebHost` (dependency injection, hosted services, etc.), but in this case, you just want to have a simple and lighter process as the host, with nothing related to MVC, Web API or HTTP server features.
 
-Therefore, you can choose and either create a specialized host-process with IHost to handle the hosted services and nothing else, such a microservice made just for hosting the `IHostedServices`, or you can alternatively extend an existing ASP.NET Core `WebHost`, such as an existing ASP.NET Core Web API or MVC app. 
+Therefore, you can choose and either create a specialized host-process with IHost to handle the hosted services and nothing else, such a microservice made just for hosting the `IHostedServices`, or you can alternatively extend an existing ASP.NET Core `WebHost`, such as an existing ASP.NET Core Web API or MVC app.
 
 Each approach has pros and cons depending on your business and scalability needs. The bottom line is basically that if your background tasks have nothing to do with HTTP (IWebHost) you should use IHost.
 
 ## Registering hosted services in your WebHost or Host
 
-Let’s drill down further on the `IHostedService` interface since its usage is pretty similar in a `WebHost` or in a `Host`. 
+Let’s drill down further on the `IHostedService` interface since its usage is pretty similar in a `WebHost` or in a `Host`.
 
 SignalR is one example of an artifact using hosted services, but you can also use it for much simpler things like:
 
--   A background task polling a database looking for changes.
--   A scheduled task updating some cache periodically.
--   An implementation of QueueBackgroundWorkItem that allows a task to be executed on a background thread.
--   Processing messages from a message queue in the background of a web app while sharing common services such as `ILogger`.
--   A background task started with `Task.Run()`.
+- A background task polling a database looking for changes.
+- A scheduled task updating some cache periodically.
+- An implementation of QueueBackgroundWorkItem that allows a task to be executed on a background thread.
+- Processing messages from a message queue in the background of a web app while sharing common services such as `ILogger`.
+- A background task started with `Task.Run()`.
 
 You can basically offload any of those actions to a background task based on IHostedService.
 
-The way you add one or multiple `IHostedServices` into your `WebHost` or `Host` is by registering them up through the standard DI (dependency injection) in an ASP.NET Core `WebHost` (or in a `Host` in .NET Core 2.1 and above). Basically, you have to register the hosted services within the familiar `ConfigureServices()` method of the `Startup` class, as in the following code from a typical ASP.NET WebHost. 
+The way you add one or multiple `IHostedServices` into your `WebHost` or `Host` is by registering them up through the standard DI (dependency injection) in an ASP.NET Core `WebHost` (or in a `Host` in .NET Core 2.1 and above). Basically, you have to register the hosted services within the familiar `ConfigureServices()` method of the `Startup` class, as in the following code from a typical ASP.NET WebHost.
 
 ```csharp
 public IServiceProvider ConfigureServices(IServiceCollection services)
-{            
+{
     //Other DI registrations;
 
     // Register Hosted Services
@@ -87,13 +87,14 @@ namespace Microsoft.Extensions.Hosting
     }
 }
 ```
+
 As you can imagine, you can create multiple implementations of IHostedService and register them at the `ConfigureService()` method into the DI container, as shown previously. All those hosted services will be started and stopped along with the application/microservice.
 
 As a developer, you are responsible for handling the stopping action or your services when `StopAsync()` method is triggered by the host.
 
 ## Implementing IHostedService with a custom hosted service class deriving from the BackgroundService base class
 
-You could go ahead and create your custom hosted service class from scratch and implement the `IHostedService`, as you need to do when using .NET Core 2.0. 
+You could go ahead and create your custom hosted service class from scratch and implement the `IHostedService`, as you need to do when using .NET Core 2.0.
 
 However, since most background tasks will have similar needs in regard to the cancellation tokens management and other typical operations, there is a convenient abstract base class you can derive from, named `BackgroundService` (available since .NET Core 2.1).
 
@@ -102,14 +103,14 @@ That class provides the main work needed to set up the background task.
 The next code is the abstract BackgroundService base class as implemented in .NET Core.
 
 ```csharp
-// Copyright (c) .NET Foundation. Licensed under the Apache License, Version 2.0. 
+// Copyright (c) .NET Foundation. Licensed under the Apache License, Version 2.0.
 /// <summary>
 /// Base class for implementing a long running <see cref="IHostedService"/>.
 /// </summary>
 public abstract class BackgroundService : IHostedService, IDisposable
 {
     private Task _executingTask;
-    private readonly CancellationTokenSource _stoppingCts = 
+    private readonly CancellationTokenSource _stoppingCts =
                                                    new CancellationTokenSource();
 
     protected abstract Task ExecuteAsync(CancellationToken stoppingToken);
@@ -119,7 +120,7 @@ public abstract class BackgroundService : IHostedService, IDisposable
         // Store the task we're executing
         _executingTask = ExecuteAsync(_stoppingCts.Token);
 
-        // If the task is completed then return it, 
+        // If the task is completed then return it,
         // this will bubble cancellation and failure to the caller
         if (_executingTask.IsCompleted)
         {
@@ -129,7 +130,7 @@ public abstract class BackgroundService : IHostedService, IDisposable
         // Otherwise it's running
         return Task.CompletedTask;
     }
-    
+
     public virtual async Task StopAsync(CancellationToken cancellationToken)
     {
         // Stop called without start
@@ -163,7 +164,7 @@ When deriving from the previous abstract base class, thanks to that inherited im
 
 ```csharp
 public class GracePeriodManagerService : BackgroundService
-{        
+{
     private readonly ILogger<GracePeriodManagerService> _logger;
     private readonly OrderingBackgroundSettings _settings;
 
@@ -173,27 +174,27 @@ public class GracePeriodManagerService : BackgroundService
                                      IEventBus eventBus,
                                      ILogger<GracePeriodManagerService> logger)
     {
-        //Constructor’s parameters validations...       
+        //Constructor’s parameters validations...
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogDebug($"GracePeriodManagerService is starting.");
 
-        stoppingToken.Register(() => 
+        stoppingToken.Register(() =>
             _logger.LogDebug($" GracePeriod background task is stopping."));
 
         while (!stoppingToken.IsCancellationRequested)
         {
             _logger.LogDebug($"GracePeriod task doing background work.");
 
-            // This eShopOnContainers method is querying a database table 
+            // This eShopOnContainers method is querying a database table
             // and publishing events into the Event Bus (RabbitMS / ServiceBus)
             CheckConfirmedGracePeriodOrders();
 
             await Task.Delay(_settings.CheckUpdateTime, stoppingToken);
         }
-            
+
         _logger.LogDebug($"GracePeriod background task is stopping.");
     }
 
@@ -218,7 +219,7 @@ WebHost.CreateDefaultBuilder(args)
 ### Summary class diagram
 
 The following image shows a visual summary of the classes and interfaced involved when implementing IHostedServices.
- 
+
 ![Class diagram: IWebHost and IHost can host many services, which inherit from BackgroundService, which implements IHostedService.](./media/image27.png)
 
 **Figure 6-27**. Class diagram showing the multiple classes and interfaces related to IHostedService
@@ -233,13 +234,13 @@ The `IHostedService` interface provides a convenient way to start background tas
 
 #### Additional resources
 
--   **Building a scheduled task in ASP.NET Core/Standard 2.0** <br/>
+- **Building a scheduled task in ASP.NET Core/Standard 2.0** <br/>
     [https://blog.maartenballiauw.be/post/2017/08/01/building-a-scheduled-cache-updater-in-aspnet-core-2.html](https://blog.maartenballiauw.be/post/2017/08/01/building-a-scheduled-cache-updater-in-aspnet-core-2.html)
 
--   **Implementing IHostedService in ASP.NET Core 2.0** <br/>
+- **Implementing IHostedService in ASP.NET Core 2.0** <br/>
     [https://www.stevejgordon.co.uk/asp-net-core-2-ihostedservice](https://www.stevejgordon.co.uk/asp-net-core-2-ihostedservice)
 
--   **GenericHost Sample using ASP.NET Core 2.1** <br/>
+- **GenericHost Sample using ASP.NET Core 2.1** <br/>
     [https://github.com/aspnet/Hosting/tree/release/2.1/samples/GenericHostSample](https://github.com/aspnet/Hosting/tree/release/2.1/samples/GenericHostSample)
 
 >[!div class="step-by-step"]

--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/implement-api-gateways-with-ocelot.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/implement-api-gateways-with-ocelot.md
@@ -80,6 +80,7 @@ public async Task<IActionResult> GetItemById(int id)
     return NotFound();
 }
 ```
+
 The HTTP request will end up running that kind of C# code accessing the microservice database and any additional required action.
 
 Regarding the microservice URL, when the containers are deployed in your local development PC (local Docker host), each microservice’s container has always an internal port (usually port 80) specified in its dockerfile, as in the following dockerfile:

--- a/docs/visual-basic/getting-started/whats-new.md
+++ b/docs/visual-basic/getting-started/whats-new.md
@@ -1,9 +1,9 @@
 ---
 title: "What's new for Visual Basic"
 ms.date: 10/24/2018
-f1_keywords: 
+f1_keywords:
   - "VB.StartPage.WhatsNew"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "new features, Visual Basic"
   - "what's new [Visual Basic]"
   - "Visual Basic, what's new"
@@ -12,45 +12,45 @@ ms.assetid: d7e97396-7f42-4873-a81c-4ebcc4b6ca02
 # What's new for Visual Basic
 
 This topic lists key feature names for each version of Visual Basic, with detailed descriptions of the new and enhanced features in the latest versions of the language.
-  
+
 ## Current version
 
-Visual Basic 15.8 / Visual Studio 2017 Version 15.8  
+Visual Basic 15.8 / Visual Studio 2017 Version 15.8
 For new features, see [Visual Basic 15.8](#visual-basic-158)
 
 ## Previous versions
 
-Visual Basic 15.5 / Visual Studio 2017 Version 15.5  
+Visual Basic 15.5 / Visual Studio 2017 Version 15.5
 For new features, see [Visual Basic 15.5](#visual-basic-155)
 
-Visual Basic 15.3 / Visual Studio 2017 Version 15.3  
+Visual Basic 15.3 / Visual Studio 2017 Version 15.3
 For new features, see [Visual Basic 15.3](#visual-basic-153)
 
-Visual Basic 2017 / Visual Studio 2017  
+Visual Basic 2017 / Visual Studio 2017
 For new features, see [Visual Basic 2017](#visual-basic-2017)
 
-Visual Basic / Visual Studio 2015   
+Visual Basic / Visual Studio 2015
 For new features, see [Visual Basic 14](#visual-basic-14)
 
-Visual Basic / Visual Studio 2013  
+Visual Basic / Visual Studio 2013
 Technology previews of the .NET Compiler Platform (“Roslyn”)
 
-Visual Basic / Visual Studio 2012   
+Visual Basic / Visual Studio 2012
 `Async` and `await` keywords, iterators, caller info attributes
 
-Visual Basic, Visual Studio 2010   
+Visual Basic, Visual Studio 2010
 Auto-implemented properties, collection initializers, implicit line continuation, dynamic, generic co/contra variance, global namespace access
 
-Visual Basic / Visual Studio 2008   
-Language Integrated Query (LINQ), XML literals, local type inference, object initializers, anonymous types, extension methods, local `var` type inference, lambda expressions, `if` operator, partial methods, nullable value types  
+Visual Basic / Visual Studio 2008
+Language Integrated Query (LINQ), XML literals, local type inference, object initializers, anonymous types, extension methods, local `var` type inference, lambda expressions, `if` operator, partial methods, nullable value types
 
-Visual Basic / Visual Studio 2005   
+Visual Basic / Visual Studio 2005
 The `My` type and helper types (access to app, computer, files system, network)
 
-Visual Basic / Visual Studio .NET 2003   
+Visual Basic / Visual Studio .NET 2003
 Bit-shift operators, loop variable declaration
 
-Visual Basic / Visual Studio .NET 2002   
+Visual Basic / Visual Studio .NET 2002
 The first release of Visual Basic .NET
 
 ## Visual Basic 15.8
@@ -74,7 +74,7 @@ This optimization allows code to run faster -- up to twice as fast for code that
 
 ```vb
 Dim s As Single = 173.7619
-Dim d As Double = s 
+Dim d As Double = s
 
 Dim i1 As Integer = CInt(Fix(s))               ' Result: 173
 Dim b1 As Byte = CByte(Int(d))                 ' Result: 173
@@ -108,7 +108,8 @@ Visual Basic 2017 added support for the underscore character (`_`) as a digit se
 
 ```vb
 Dim number As Integer = &H_C305_F860
-``` 
+```
+
 To use the underscore character as a leading separator, you must add the following element to your Visual Basic project (\*.vbproj) file:
 
 ```xml
@@ -125,7 +126,7 @@ When you assign the value of tuple elements from variables, Visual Basic infers 
 
 [!code-vb[Inferred tuple names](../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/named-tuples/program.vb#2)]
 
-**Additional compiler switches**  
+**Additional compiler switches**
 
 The Visual Basic command-line compiler now supports the [**-refout**](../reference/command-line-compiler/refout-compiler-option.md) and [**-refonly**](../reference/command-line-compiler/refonly-compiler-option.md) compiler options to control the output of reference assemblies. **-refout** defines the output directory of the reference assembly, and **-refonly** specifies that only a reference assembly is to be output by compilation.
 
@@ -138,14 +139,14 @@ Tuples are a lightweight data structure that most commonly is used to return mul
 - Define a custom type (a `Class` or a `Structure`). This is a heavyweight solution.
 
 - Define one or more `ByRef` parameters, in addition to returning a value from the method.
- 
+
 Visual Basic's support for tuples lets you quickly define a tuple, optionally assign semantic names to its values, and quickly retrieve its values. The following example wraps a call to the <xref:System.Int32.TryParse%2A> method and returns a tuple.
 
 [!code-vb[Tuple](../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb#2)]
 
 You can then call the method and handle the returned tuple with code like the following.
 
-[!code-vb[ReturnTuple](../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb#3)] 
+[!code-vb[ReturnTuple](../../../samples/snippets/visualbasic/programming-guide/language-features/data-types/tuple-returns.vb#3)]
 
 **Binary literals and digit separators**
 
@@ -179,73 +180,89 @@ For more information, see [Reference Return Values](../programming-guide/languag
 
 ## Visual Basic 14
 
-[Nameof](../../csharp/language-reference/keywords/nameof.md)  
- You can get the unqualified string name of a type or member for use in an error message without hard coding a string.  This allows your code to remain correct when refactoring.  This feature is also useful for hooking up model-view-controller MVC links and firing property changed events.  
-  
-[String interpolation](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md)  
- You can use string interpolation expressions to construct strings.  An interpolated string expression looks like a template string that contains expressions.  An interpolated string is easier to understand with respect to arguments than [Composite Formatting](../../standard/base-types/composite-format.md).  
-  
-[Null-conditional member access and indexing](../language-reference/operators/null-conditional-operators.md)  
-You can test for null in a very light syntactic way before performing a member access (`?.`) or index (`?[]`) operation.  These operators help you write less code to handle null checks, especially for descending into data structures.  If the left operand or object reference is null, the operations returns null.  
-  
-[Multi-line string literals](../../visual-basic/programming-guide/language-features/strings/string-basics.md)  
- String literals can contain newline sequences.  You no longer need the old work around of using `<xml><![CDATA[...text with newlines...]]></xml>.Value`  
-  
-**Comments**  
-You can put comments after implicit line continuations, inside initializer expressions, and among LINQ expression terms.  
-  
-**Smarter fully-qualified name resolution**  
- Given code such as `Threading.Thread.Sleep(1000)`, Visual Basic used to look up the namespace "Threading", discover it was ambiguous between System.Threading and System.Windows.Threading, and then report an error.  Visual Basic now considers both possible namespaces together.  If you show the completion list, the Visual Studio editor lists members from both types in the completion list.  
-  
- **Year-first date literals**  
- You can have date literals in yyyy-mm-dd format, `#2015-03-17 16:10 PM#`.  
-  
- **Readonly interface properties**  
- You can implement readonly interface properties using a readwrite property.  The interface guarantees minimum functionality, and it does not stop an implementing class from allowing the property to be set.  
-  
- [TypeOf \<expr> IsNot \<type>](../../visual-basic/language-reference/operators/typeof-operator.md)  
- For more readability of your code, you can now use `TypeOf` with `IsNot`.  
-  
- [#Disable Warning \<ID> and #Enable Warning \<ID>](../../visual-basic/language-reference/directives/index.md)  
- You can disable and enable specific warnings for regions within a source file.  
-  
- **XML doc comment improvements**  
- When writing doc comments, you get smart editor and build support for validating parameter names, proper handling of `crefs` (generics, operators, etc.), colorizing, and refactoring.  
-  
- [Partial module and interface definitions](../../visual-basic/language-reference/modifiers/partial.md)  
- In addition to classes and structs, you can declare partial modules and interfaces.  
-  
- [#Region directives inside method bodies](../../visual-basic/language-reference/directives/region-directive.md)  
- You can put #Region…#End Region delimiters anywhere in a file, inside functions, and even spanning across function bodies.  
-  
- [Overrides definitions are implicitly overloads](../../visual-basic/language-reference/modifiers/overrides.md)  
- If you add the `Overrides` modifier to a definition, the compiler implicitly adds `Overloads` so that you can type less code in common cases.  
-  
- **CObj allowed in attributes arguments**  
- The compiler used to give an error that CObj(…) was not a constant when used in attribute constructions.  
-  
- **Declaring and consuming ambiguous methods from different interfaces**  
- Previously the following code yielded errors that prevented you from declaring `IMock` or from calling `GetDetails` (if these had been declared in C#):  
-  
-```vb  
-Interface ICustomer  
-  Sub GetDetails(x As Integer)  
-End Interface  
-  
-Interface ITime  
-  Sub GetDetails(x As String)  
-End Interface  
-  
-Interface IMock : Inherits ICustomer, ITime  
-  Overloads Sub GetDetails(x As Char)  
-End Interface  
-  
-Interface IMock2 : Inherits ICustomer, ITime  
-End Interface  
-```  
-  
- Now the compiler will use normal overload resolution rules to choose the most appropriate `GetDetails` to call, and you can declare interface relationships in Visual Basic like those shown in the sample.  
-  
+[Nameof](../../csharp/language-reference/keywords/nameof.md)
+
+You can get the unqualified string name of a type or member for use in an error message without hard coding a string.  This allows your code to remain correct when refactoring.  This feature is also useful for hooking up model-view-controller MVC links and firing property changed events.
+
+[String interpolation](../../visual-basic/programming-guide/language-features/strings/interpolated-strings.md)
+
+You can use string interpolation expressions to construct strings.  An interpolated string expression looks like a template string that contains expressions.  An interpolated string is easier to understand with respect to arguments than [Composite Formatting](../../standard/base-types/composite-format.md).
+
+[Null-conditional member access and indexing](../language-reference/operators/null-conditional-operators.md)
+
+You can test for null in a very light syntactic way before performing a member access (`?.`) or index (`?[]`) operation.  These operators help you write less code to handle null checks, especially for descending into data structures.  If the left operand or object reference is null, the operations returns null.
+
+[Multi-line string literals](../../visual-basic/programming-guide/language-features/strings/string-basics.md)
+
+String literals can contain newline sequences.  You no longer need the old work around of using `<xml><![CDATA[...text with newlines...]]></xml>.Value`
+
+**Comments**
+
+You can put comments after implicit line continuations, inside initializer expressions, and among LINQ expression terms.
+
+**Smarter fully-qualified name resolution**
+
+Given code such as `Threading.Thread.Sleep(1000)`, Visual Basic used to look up the namespace "Threading", discover it was ambiguous between System.Threading and System.Windows.Threading, and then report an error.  Visual Basic now considers both possible namespaces together.  If you show the completion list, the Visual Studio editor lists members from both types in the completion list.
+
+**Year-first date literals**
+
+You can have date literals in yyyy-mm-dd format, `#2015-03-17 16:10 PM#`.
+
+**Readonly interface properties**
+
+You can implement readonly interface properties using a readwrite property.  The interface guarantees minimum functionality, and it does not stop an implementing class from allowing the property to be set.
+
+[TypeOf \<expr> IsNot \<type>](../../visual-basic/language-reference/operators/typeof-operator.md)
+
+For more readability of your code, you can now use `TypeOf` with `IsNot`.
+
+[#Disable Warning \<ID> and #Enable Warning \<ID>](../../visual-basic/language-reference/directives/index.md)
+
+You can disable and enable specific warnings for regions within a source file.
+
+**XML doc comment improvements**
+
+When writing doc comments, you get smart editor and build support for validating parameter names, proper handling of `crefs` (generics, operators, etc.), colorizing, and refactoring.
+
+[Partial module and interface definitions](../../visual-basic/language-reference/modifiers/partial.md)
+
+In addition to classes and structs, you can declare partial modules and interfaces.
+
+[#Region directives inside method bodies](../../visual-basic/language-reference/directives/region-directive.md)
+
+You can put #Region…#End Region delimiters anywhere in a file, inside functions, and even spanning across function bodies.
+
+[Overrides definitions are implicitly overloads](../../visual-basic/language-reference/modifiers/overrides.md)
+
+If you add the `Overrides` modifier to a definition, the compiler implicitly adds `Overloads` so that you can type less code in common cases.
+
+**CObj allowed in attributes arguments**
+
+The compiler used to give an error that CObj(…) was not a constant when used in attribute constructions.
+
+**Declaring and consuming ambiguous methods from different interfaces**
+
+Previously the following code yielded errors that prevented you from declaring `IMock` or from calling `GetDetails` (if these had been declared in C#):
+
+```vb
+Interface ICustomer
+  Sub GetDetails(x As Integer)
+End Interface
+
+Interface ITime
+  Sub GetDetails(x As String)
+End Interface
+
+Interface IMock : Inherits ICustomer, ITime
+  Overloads Sub GetDetails(x As Char)
+End Interface
+
+Interface IMock2 : Inherits ICustomer, ITime
+End Interface
+```
+
+Now the compiler will use normal overload resolution rules to choose the most appropriate `GetDetails` to call, and you can declare interface relationships in Visual Basic like those shown in the sample.
+
 ## See also
 
 - [What's New in Visual Studio 2017](/visualstudio/ide/whats-new-in-visual-studio)

--- a/docs/visual-basic/misc/bc30568.md
+++ b/docs/visual-basic/misc/bc30568.md
@@ -1,32 +1,34 @@
 ---
 title: "Array initializer has <number> too many elements"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "bc30568"
   - "vbc30568"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "BC30568"
 ms.assetid: 5d81f73d-1ce1-42a0-8cf5-f564d6094617
 ---
 # Array initializer has \<number> too many elements
-Your array initializer contains too many elements.  
-  
- **Error ID:** BC30568  
-  
-## To correct this error  
-  
+
+Your array initializer contains too many elements.
+
+**Error ID:** BC30568
+
+## To correct this error
+
 - If you are using nested array literals to create a jagged array, enclose each subarray in parentheses. For example, if your jagged array definition is:
- 
+
   ```vb
   Dim jaggedValues =  {{1, 2}, {2, 3, 4}}
   ```
+
   you can change it to:
 
   ```vb
   Dim valuesjagged = {({1, 2}), ({2, 3, 4})}
-  ```    
+  ```
 
--   Use `ReDim` to change the size of the array.  
+- Use `ReDim` to change the size of the array.
 
 ## See also
 

--- a/docs/visual-basic/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
+++ b/docs/visual-basic/programming-guide/concepts/linq/how-to-add-custom-methods-for-linq-queries.md
@@ -4,191 +4,200 @@ ms.date: 07/20/2015
 ms.assetid: 099b2e2a-83cd-45c6-aa4d-01b398b5faaf
 ---
 # How to: Add Custom Methods for LINQ Queries (Visual Basic)
-You can extend the set of methods that you can use for LINQ queries by adding extension methods to the <xref:System.Collections.Generic.IEnumerable%601> interface. For example, in addition to the standard average or maximum operations, you can create a custom aggregate method to compute a single value from a sequence of values. You can also create a method that works as a custom filter or a specific data transform for a sequence of values and returns a new sequence. Examples of such methods are <xref:System.Linq.Enumerable.Distinct%2A>, <xref:System.Linq.Enumerable.Skip%2A>, and <xref:System.Linq.Enumerable.Reverse%2A>.  
-  
- When you extend the <xref:System.Collections.Generic.IEnumerable%601> interface, you can apply your custom methods to any enumerable collection. For more information, see [Extension Methods](../../../../visual-basic/programming-guide/language-features/procedures/extension-methods.md).  
-  
-## Adding an Aggregate Method  
- An aggregate method computes a single value from a set of values. LINQ provides several aggregate methods, including <xref:System.Linq.Enumerable.Average%2A>, <xref:System.Linq.Enumerable.Min%2A>, and <xref:System.Linq.Enumerable.Max%2A>. You can create your own aggregate method by adding an extension method to the <xref:System.Collections.Generic.IEnumerable%601> interface.  
-  
- The following code example shows how to create an extension method called `Median` to compute a median for a sequence of numbers of type `double`.  
-  
-```vb  
-Imports System.Runtime.CompilerServices  
-  
-Module LINQExtension  
-  
-    ' Extension method for the IEnumerable(of T) interface.   
-    ' The method accepts only values of the Double type.  
-    <Extension()>   
-    Function Median(ByVal source As IEnumerable(Of Double)) As Double  
-        If source.Count = 0 Then  
-            Throw New InvalidOperationException("Cannot compute median for an empty set.")  
-        End If  
-  
-        Dim sortedSource = From number In source   
-                           Order By number  
-  
-        Dim itemIndex = sortedSource.Count \ 2  
-  
-        If sortedSource.Count Mod 2 = 0 Then  
-            ' Even number of items in list.  
-            Return (sortedSource(itemIndex) + sortedSource(itemIndex - 1)) / 2  
-        Else  
-            ' Odd number of items in list.  
-            Return sortedSource(itemIndex)  
-        End If  
-    End Function  
-End Module  
-```  
-  
- You call this extension method for any enumerable collection in the same way you call other aggregate methods from the <xref:System.Collections.Generic.IEnumerable%601> interface.  
-  
+
+You can extend the set of methods that you can use for LINQ queries by adding extension methods to the <xref:System.Collections.Generic.IEnumerable%601> interface. For example, in addition to the standard average or maximum operations, you can create a custom aggregate method to compute a single value from a sequence of values. You can also create a method that works as a custom filter or a specific data transform for a sequence of values and returns a new sequence. Examples of such methods are <xref:System.Linq.Enumerable.Distinct%2A>, <xref:System.Linq.Enumerable.Skip%2A>, and <xref:System.Linq.Enumerable.Reverse%2A>.
+
+When you extend the <xref:System.Collections.Generic.IEnumerable%601> interface, you can apply your custom methods to any enumerable collection. For more information, see [Extension Methods](../../../../visual-basic/programming-guide/language-features/procedures/extension-methods.md).
+
+## Adding an Aggregate Method
+
+An aggregate method computes a single value from a set of values. LINQ provides several aggregate methods, including <xref:System.Linq.Enumerable.Average%2A>, <xref:System.Linq.Enumerable.Min%2A>, and <xref:System.Linq.Enumerable.Max%2A>. You can create your own aggregate method by adding an extension method to the <xref:System.Collections.Generic.IEnumerable%601> interface.
+
+The following code example shows how to create an extension method called `Median` to compute a median for a sequence of numbers of type `double`.
+
+```vb
+Imports System.Runtime.CompilerServices
+
+Module LINQExtension
+
+    ' Extension method for the IEnumerable(of T) interface.
+    ' The method accepts only values of the Double type.
+    <Extension()>
+    Function Median(ByVal source As IEnumerable(Of Double)) As Double
+        If source.Count = 0 Then
+            Throw New InvalidOperationException("Cannot compute median for an empty set.")
+        End If
+
+        Dim sortedSource = From number In source
+                           Order By number
+
+        Dim itemIndex = sortedSource.Count \ 2
+
+        If sortedSource.Count Mod 2 = 0 Then
+            ' Even number of items in list.
+            Return (sortedSource(itemIndex) + sortedSource(itemIndex - 1)) / 2
+        Else
+            ' Odd number of items in list.
+            Return sortedSource(itemIndex)
+        End If
+    End Function
+End Module
+```
+
+You call this extension method for any enumerable collection in the same way you call other aggregate methods from the <xref:System.Collections.Generic.IEnumerable%601> interface.
+
 > [!NOTE]
->  In Visual Basic, you can either use a method call or standard query syntax for the `Aggregate` or `Group By` clause. For more information, see [Aggregate Clause](../../../../visual-basic/language-reference/queries/aggregate-clause.md) and [Group By Clause](../../../../visual-basic/language-reference/queries/group-by-clause.md).  
-  
- The following code example shows how to use the `Median` method for an array of type `double`.  
-  
-```vb  
-Dim numbers1() As Double = {1.9, 2, 8, 4, 5.7, 6, 7.2, 0}  
-  
-Dim query1 = Aggregate num In numbers1 Into Median()  
-  
-Console.WriteLine("Double: Median = " & query1)  
-```  
-  
-```vb  
-' This code produces the following output:  
-'  
-' Double: Median = 4.85  
-```  
+> In Visual Basic, you can either use a method call or standard query syntax for the `Aggregate` or `Group By` clause. For more information, see [Aggregate Clause](../../../../visual-basic/language-reference/queries/aggregate-clause.md) and [Group By Clause](../../../../visual-basic/language-reference/queries/group-by-clause.md).
 
-### Overloading an Aggregate Method to Accept Various Types  
- You can overload your aggregate method so that it accepts sequences of various types. The standard approach is to create an overload for each type. Another approach is to create an overload that will take a generic type and convert it to a specific type by using a delegate. You can also combine both approaches.  
-  
-#### To create an overload for each type  
- You can create a specific overload for each type that you want to support. The following code example shows an overload of the `Median` method for the `integer` type.  
-  
-```vb  
-' Integer overload  
-  
-<Extension()>   
-Function Median(ByVal source As IEnumerable(Of Integer)) As Double  
-    Return Aggregate num In source Select CDbl(num) Into med = Median()  
-End Function  
-```  
- You can now call the `Median` overloads for both `integer` and `double` types, as shown in the following code:  
-  
-```vb  
-Dim numbers1() As Double = {1.9, 2, 8, 4, 5.7, 6, 7.2, 0}  
-  
-Dim query1 = Aggregate num In numbers1 Into Median()  
-  
-Console.WriteLine("Double: Median = " & query1)  
-```  
-  
-```vb  
-Dim numbers2() As Integer = {1, 2, 3, 4, 5}  
-  
-Dim query2 = Aggregate num In numbers2 Into Median()  
-  
-Console.WriteLine("Integer: Median = " & query2)  
-```  
-  
-```vb  
-' This code produces the following output:  
-'  
-' Double: Median = 4.85  
-' Integer: Median = 3  
-```  
+The following code example shows how to use the `Median` method for an array of type `double`.
 
-#### To create a generic overload  
- You can also create an overload that accepts a sequence of generic objects. This overload takes a delegate as a parameter and uses it to convert a sequence of objects of a generic type to a specific type.  
-  
- The following code shows an overload of the `Median` method that takes the <xref:System.Func%602> delegate as a parameter. This delegate takes an object of generic type T and returns an object of type `double`.  
-  
-```vb  
-' Generic overload.  
-  
-<Extension()>   
-Function Median(Of T)(ByVal source As IEnumerable(Of T),   
-                      ByVal selector As Func(Of T, Double)) As Double  
-    Return Aggregate num In source Select selector(num) Into med = Median()  
-End Function  
-```  
-  
- You can now call the `Median` method for a sequence of objects of any type. If the type does not have its own method overload, you have to pass a delegate parameter. In Visual Basic, you can use a lambda expression for this purpose. Also, if you use the `Aggregate` or `Group By` clause instead of the method call, you can pass any value or expression that is in the scope this clause.  
-  
- The following example code shows how to call the `Median` method for an array of integers and an array of strings. For strings, the median for the lengths of strings in the array is calculated. The example shows how to pass the <xref:System.Func%602> delegate parameter to the `Median` method for each case.  
-  
-```vb  
-Dim numbers3() As Integer = {1, 2, 3, 4, 5}  
-  
-' You can use num as a parameter for the Median method   
-' so that the compiler will implicitly convert its value to double.  
-' If there is no implicit conversion, the compiler will  
-' display an error message.  
-  
-Dim query3 = Aggregate num In numbers3 Into Median(num)  
-  
-Console.WriteLine("Integer: Median = " & query3)  
-  
-Dim numbers4() As String = {"one", "two", "three", "four", "five"}  
-  
-' With the generic overload, you can also use numeric properties of objects.  
-  
-Dim query4 = Aggregate str In numbers4 Into Median(str.Length)  
-  
-Console.WriteLine("String: Median = " & query4)  
-  
-' This code produces the following output:  
-'  
-' Integer: Median = 3  
-' String: Median = 4  
-```  
-## Adding a Method That Returns a Collection  
- You can extend the <xref:System.Collections.Generic.IEnumerable%601> interface with a custom query method that returns a sequence of values. In this case, the method must return a collection of type <xref:System.Collections.Generic.IEnumerable%601>. Such methods can be used to apply filters or data transforms to a sequence of values.  
-  
- The following example shows how to create an extension method named `AlternateElements` that returns every other element in a collection, starting from the first element.  
-  
-```vb  
-' Extension method for the IEnumerable(of T) interface.   
-' The method returns every other element of a sequence.  
-  
-<Extension()>   
-Function AlternateElements(Of T)(  
-    ByVal source As IEnumerable(Of T)  
-    ) As IEnumerable(Of T)  
-  
-    Dim list As New List(Of T)  
-    Dim i = 0  
-    For Each element In source  
-        If (i Mod 2 = 0) Then  
-            list.Add(element)  
-        End If  
-        i = i + 1  
-    Next  
-    Return list  
-End Function  
-```  
- You can call this extension method for any enumerable collection just as you would call other methods from the <xref:System.Collections.Generic.IEnumerable%601> interface, as shown in the following code:  
-  
-```vb  
-Dim strings() As String = {"a", "b", "c", "d", "e"}  
-  
-Dim query = strings.AlternateElements()  
-  
-For Each element In query  
-    Console.WriteLine(element)  
-Next  
-  
-' This code produces the following output:  
-'  
-' a  
-' c  
-' e  
-```  
-  
+```vb
+Dim numbers1() As Double = {1.9, 2, 8, 4, 5.7, 6, 7.2, 0}
+
+Dim query1 = Aggregate num In numbers1 Into Median()
+
+Console.WriteLine("Double: Median = " & query1)
+```
+
+```vb
+' This code produces the following output:
+'
+' Double: Median = 4.85
+```
+
+### Overloading an Aggregate Method to Accept Various Types
+
+You can overload your aggregate method so that it accepts sequences of various types. The standard approach is to create an overload for each type. Another approach is to create an overload that will take a generic type and convert it to a specific type by using a delegate. You can also combine both approaches.
+
+#### To create an overload for each type
+
+You can create a specific overload for each type that you want to support. The following code example shows an overload of the `Median` method for the `integer` type.
+
+```vb
+' Integer overload
+
+<Extension()>
+Function Median(ByVal source As IEnumerable(Of Integer)) As Double
+    Return Aggregate num In source Select CDbl(num) Into med = Median()
+End Function
+```
+
+You can now call the `Median` overloads for both `integer` and `double` types, as shown in the following code:
+
+```vb
+Dim numbers1() As Double = {1.9, 2, 8, 4, 5.7, 6, 7.2, 0}
+
+Dim query1 = Aggregate num In numbers1 Into Median()
+
+Console.WriteLine("Double: Median = " & query1)
+```
+
+```vb
+Dim numbers2() As Integer = {1, 2, 3, 4, 5}
+
+Dim query2 = Aggregate num In numbers2 Into Median()
+
+Console.WriteLine("Integer: Median = " & query2)
+```
+
+```vb
+' This code produces the following output:
+'
+' Double: Median = 4.85
+' Integer: Median = 3
+```
+
+#### To create a generic overload
+
+You can also create an overload that accepts a sequence of generic objects. This overload takes a delegate as a parameter and uses it to convert a sequence of objects of a generic type to a specific type.
+
+The following code shows an overload of the `Median` method that takes the <xref:System.Func%602> delegate as a parameter. This delegate takes an object of generic type T and returns an object of type `double`.
+
+```vb
+' Generic overload.
+
+<Extension()>
+Function Median(Of T)(ByVal source As IEnumerable(Of T),
+                      ByVal selector As Func(Of T, Double)) As Double
+    Return Aggregate num In source Select selector(num) Into med = Median()
+End Function
+```
+
+You can now call the `Median` method for a sequence of objects of any type. If the type does not have its own method overload, you have to pass a delegate parameter. In Visual Basic, you can use a lambda expression for this purpose. Also, if you use the `Aggregate` or `Group By` clause instead of the method call, you can pass any value or expression that is in the scope this clause.
+
+The following example code shows how to call the `Median` method for an array of integers and an array of strings. For strings, the median for the lengths of strings in the array is calculated. The example shows how to pass the <xref:System.Func%602> delegate parameter to the `Median` method for each case.
+
+```vb
+Dim numbers3() As Integer = {1, 2, 3, 4, 5}
+
+' You can use num as a parameter for the Median method
+' so that the compiler will implicitly convert its value to double.
+' If there is no implicit conversion, the compiler will
+' display an error message.
+
+Dim query3 = Aggregate num In numbers3 Into Median(num)
+
+Console.WriteLine("Integer: Median = " & query3)
+
+Dim numbers4() As String = {"one", "two", "three", "four", "five"}
+
+' With the generic overload, you can also use numeric properties of objects.
+
+Dim query4 = Aggregate str In numbers4 Into Median(str.Length)
+
+Console.WriteLine("String: Median = " & query4)
+
+' This code produces the following output:
+'
+' Integer: Median = 3
+' String: Median = 4
+```
+
+## Adding a Method That Returns a Collection
+
+You can extend the <xref:System.Collections.Generic.IEnumerable%601> interface with a custom query method that returns a sequence of values. In this case, the method must return a collection of type <xref:System.Collections.Generic.IEnumerable%601>. Such methods can be used to apply filters or data transforms to a sequence of values.
+
+The following example shows how to create an extension method named `AlternateElements` that returns every other element in a collection, starting from the first element.
+
+```vb
+' Extension method for the IEnumerable(of T) interface.
+' The method returns every other element of a sequence.
+
+<Extension()>
+Function AlternateElements(Of T)(
+    ByVal source As IEnumerable(Of T)
+    ) As IEnumerable(Of T)
+
+    Dim list As New List(Of T)
+    Dim i = 0
+    For Each element In source
+        If (i Mod 2 = 0) Then
+            list.Add(element)
+        End If
+        i = i + 1
+    Next
+    Return list
+End Function
+```
+
+You can call this extension method for any enumerable collection just as you would call other methods from the <xref:System.Collections.Generic.IEnumerable%601> interface, as shown in the following code:
+
+```vb
+Dim strings() As String = {"a", "b", "c", "d", "e"}
+
+Dim query = strings.AlternateElements()
+
+For Each element In query
+    Console.WriteLine(element)
+Next
+
+' This code produces the following output:
+'
+' a
+' c
+' e
+```
+
 ## See also
 
 - <xref:System.Collections.Generic.IEnumerable%601>

--- a/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md
+++ b/docs/visual-basic/programming-guide/language-features/strings/interpolated-strings.md
@@ -6,69 +6,70 @@ ms.date: "10/31/2017"
 
 Used to construct strings.  An interpolated string looks like a template string that contains *interpolated expressions*.  An interpolated string returns a string that replaces the interpolated expressions that it contains with their string representations. This feature is available in Visual Basic 14 and later versions.
 
-The arguments of an interpolated string are easier to understand than a [composite format string](../../../../standard/base-types/composite-formatting.md#composite-format-string).  For example, the interpolated string  
-  
-```vb  
+The arguments of an interpolated string are easier to understand than a [composite format string](../../../../standard/base-types/composite-formatting.md#composite-format-string).  For example, the interpolated string
+
+```vb
 Console.WriteLine($"Name = {name}, hours = {hours:hh}")
-```  
+```
+
 contains two interpolated expressions, '{name}' and '{hours:hh}'. The equivalent composite format string is:
 
 ```vb
-Console.WriteLine("Name = {0}, hours = {1:hh}", name, hours); 
-```  
+Console.WriteLine("Name = {0}, hours = {1:hh}", name, hours);
+```
 
-The structure of an interpolated string is:  
-  
-```vb  
-$"<text> {<interpolated-expression> [,<field-width>] [:<format-string>] } <text> ..."  
-```  
+The structure of an interpolated string is:
 
-where: 
+```vb
+$"<text> {<interpolated-expression> [,<field-width>] [:<format-string>] } <text> ..."
+```
 
-- *field-width* is a signed integer that indicates the number of characters in the field. If it is positive, the field is right-aligned; if negative, left-aligned. 
+where:
+
+- *field-width* is a signed integer that indicates the number of characters in the field. If it is positive, the field is right-aligned; if negative, left-aligned.
 
 - *format-string* is a format string appropriate for the type of object being formatted. For example, for a <xref:System.DateTime> value, it could be a [standard date and time format string](~/docs/standard/base-types/standard-date-and-time-format-strings.md) such as "D" or "d".
 
 > [!IMPORTANT]
 > You cannot have any white space between the `$` and the `"` that starts the string. Doing so causes a compiler error.
 
- You can use an interpolated string anywhere you can use a string literal.  The interpolated string is evaluated each time the code with the interpolated string executes. This allows you to separate the definition and evaluation of an interpolated string.  
-  
- To include a curly brace ("{" or "}") in an interpolated string, use two curly braces, "{{" or "}}".  See the Implicit Conversions section for more details.  
+You can use an interpolated string anywhere you can use a string literal.  The interpolated string is evaluated each time the code with the interpolated string executes. This allows you to separate the definition and evaluation of an interpolated string.
+
+To include a curly brace ("{" or "}") in an interpolated string, use two curly braces, "{{" or "}}".  See the Implicit Conversions section for more details.
 
 If the interpolated string contains other characters with special meaning in an interpolated string, such as the quotation mark ("), colon (:), or comma (,), they should be escaped if they occur in literal text, or they should be included in an expression delimited by parentheses if they are language elements included in an interpolated expression. The following example escapes quotation marks to include them in the result string, and it uses parentheses to delimit the expression `(age == 1 ? "" : "s")` so that the colon is not interpreted as beginning a format string.
 
-[!code-vb[interpolated-strings](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings4.vb)]  
+[!code-vb[interpolated-strings](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings4.vb)]
 
-## Implicit Conversions  
+## Implicit Conversions
 
-There are three implicit type conversions from an interpolated string:  
+There are three implicit type conversions from an interpolated string:
 
 1. Conversion of an interpolated string to a <xref:System.String>. The following example returns a string whose interpolated string expressions have been replaced with their string representations. For example:
 
-   [!code-vb[interpolated-strings1](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings1.vb)]  
+   [!code-vb[interpolated-strings1](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings1.vb)]
 
-   This is the final result of a string interpretation. All occurrences of double curly braces ("{{" and "}}") are converted to a single curly brace. 
+   This is the final result of a string interpretation. All occurrences of double curly braces ("{{" and "}}") are converted to a single curly brace.
 
-2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the <xref:System.Object.ToString> method.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
+2. Conversion of an interpolated string to an <xref:System.IFormattable> variable that allows you create multiple result strings with culture-specific content from a single <xref:System.IFormattable> instance. This is useful for including such things as the correct numeric and date formats for individual cultures.  All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format the string by explicitly or implicitly calling the <xref:System.Object.ToString> method.  All contained interpolation expressions are converted to {0}, {1}, and so on.
 
    The following example uses reflection to display the members as well as the field and property values of an <xref:System.IFormattable> variable that is created from an interpolated string. It also passes the <xref:System.IFormattable> variable to the <xref:System.Console.WriteLine(System.String)?displayProperty=nameWithType> method.
 
-   [!code-vb[interpolated-strings2](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings2.vb)]  
+   [!code-vb[interpolated-strings2](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings2.vb)]
 
-   Note that the interpolated string can be inspected only by using reflection. If it is passed to a string formatting method, such as <xref:System.Console.WriteLine(System.String)>, its format items are resolved and the result string returned. 
+   Note that the interpolated string can be inspected only by using reflection. If it is passed to a string formatting method, such as <xref:System.Console.WriteLine(System.String)>, its format items are resolved and the result string returned.
 
 3. Conversion of an interpolated string to a <xref:System.FormattableString> variable that represents a composite format string. Inspecting the composite format string and how it renders as a result string might, for example, help you protect against an injection attack if you were building a query. A <xref:System.FormattableString> also includes:
 
       - A <xref:System.FormattableString.ToString> overload that produces a result string for the <xref:System.Globalization.CultureInfo.CurrentCulture>.
-      
-      - A <xref:System.FormattableString.Invariant%2A> method that produces a string for the <xref:System.Globalization.CultureInfo.InvariantCulture>.
-      
-      - A <xref:System.FormattableString.ToString(System.IFormatProvider)> method that produces a result string for a specified culture. 
-  
-    All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format.  All contained interpolation expressions are converted to {0}, {1}, and so on.  
 
-   [!code-vb[interpolated-strings3](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings3.vb)]  
+      - A <xref:System.FormattableString.Invariant%2A> method that produces a string for the <xref:System.Globalization.CultureInfo.InvariantCulture>.
+
+      - A <xref:System.FormattableString.ToString(System.IFormatProvider)> method that produces a result string for a specified culture.
+
+    All occurrences of double curly braces ("{{" and "}}") remain as double curly braces until you format.  All contained interpolation expressions are converted to {0}, {1}, and so on.
+
+   [!code-vb[interpolated-strings3](../../../../../samples/snippets/visualbasic/programming-guide/language-features/strings/interpolated-strings3.vb)]
 
 ## See also
 

--- a/docs/visual-basic/reference/command-line-compiler/quiet.md
+++ b/docs/visual-basic/reference/command-line-compiler/quiet.md
@@ -1,59 +1,65 @@
 ---
 title: "-quiet"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "-quiet"
   - "quiet"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "-quiet compiler option [Visual Basic]"
   - "/quiet compiler option [Visual Basic]"
   - "quiet compiler option [Visual Basic]"
 ms.assetid: 5d77fa23-4c50-4708-8535-649912b098e8
 ---
 # -quiet
-Prevents the compiler from displaying code for syntax-related errors and warnings.  
-  
-## Syntax  
-  
-```  
--quiet  
-```  
-  
-## Remarks  
- By default, `-quiet` is not in effect. When the compiler reports a syntax-related error or warning, it also outputs the line from source code. For applications that parse compiler output, it may be more convenient for the compiler to output only the text of the diagnostic.  
-  
- In the following example, `Module1` outputs an error that includes source code when compiled without `-quiet`.  
-  
-```vb  
-Module Module1  
-    Sub Main()  
-        x()  
-    End Sub  
-End Module  
-```  
-  
- Output:  
- 
+
+Prevents the compiler from displaying code for syntax-related errors and warnings.
+
+## Syntax
+
+```
+-quiet
+```
+
+## Remarks
+
+By default, `-quiet` is not in effect. When the compiler reports a syntax-related error or warning, it also outputs the line from source code. For applications that parse compiler output, it may be more convenient for the compiler to output only the text of the diagnostic.
+
+In the following example, `Module1` outputs an error that includes source code when compiled without `-quiet`.
+
+```vb
+Module Module1
+    Sub Main()
+        x()
+    End Sub
+End Module
+```
+
+Output:
+
 ```console
 C:\projects\vb2.vb(3) : error BC30451: 'x' is not declared. It may be inaccessible due to its protection level.
 
         x()
         ~
-``` 
- Compiled with `-quiet`, the compiler outputs only the following:  
-  
- `E:\test\t2.vb(3) : error BC30451: Name 'x' is not declared.`  
-  
+```
+
+Compiled with `-quiet`, the compiler outputs only the following:
+
+```
+E:\test\t2.vb(3) : error BC30451: Name 'x' is not declared.
+```
+
 > [!NOTE]
->  The `-quiet` option is not available from within the Visual Studio development environment; it is available only when compiling from the command line.  
-  
-## Example  
- The following code compiles `T2.vb` and does not display code for syntax-related compiler diagnostics:  
-  
-```  
-vbc -quiet t2.vb  
-```  
-  
+> The `-quiet` option is not available from within the Visual Studio development environment; it is available only when compiling from the command line.
+
+## Example
+
+The following code compiles `T2.vb` and does not display code for syntax-related compiler diagnostics:
+
+```
+vbc -quiet t2.vb
+```
+
 ## See also
 
 - [Visual Basic Command-Line Compiler](../../../visual-basic/reference/command-line-compiler/index.md)


### PR DESCRIPTION

- Fenced code blocks should be surrounded by blank lines
- Trim trailing leading spaces
- Space around headers
- Code fence languages