### PR TITLE
Update LoadAndCompleteInstance method

### DIFF
--- a/docs/framework/windows-workflow-foundation/pausing-and-resuming-a-workflow.md
+++ b/docs/framework/windows-workflow-foundation/pausing-and-resuming-a-workflow.md
@@ -64,7 +64,7 @@ static void LoadAndCompleteInstance(Guid id)
     Console.WriteLine("Press <enter> to load the persisted workflow");  
     Console.ReadLine();  
     AutoResetEvent waitHandler = new AutoResetEvent(false);  
-    WorkflowApplication wfApp = new WorkflowApplication(new Workflow1());  
+    WorkflowApplication wfApp = new WorkflowApplication(GetDelayedWF());  
     wfApp.InstanceStore =  
         new SqlWorkflowInstanceStore(ConfigurationManager.AppSettings["SqlWF4PersistenceConnectionString"].ToString());  
     wfApp.Completed = (workflowApplicationCompletedEventArgs) => {  


### PR DESCRIPTION
Activity contents should be the same.

## Summary

WorkflowApplication has to be loaded with the same activity so that changed the line of creating a new instance of WorkflowApplication.

##Fixes 
"Pausing and Resuming a Workflow" example
