### PR TITLE
comment out non-existing entries

### DIFF
--- a/docs/csharp/roslyn-sdk/toc.yml
+++ b/docs/csharp/roslyn-sdk/toc.yml
@@ -23,19 +23,22 @@
     items:
     - name: Build your first analyzer and code fix
       href: tutorials/how-to-write-csharp-analyzer-code-fix.md
-    - name: Get started writing custom analyzers and code fixes
-  - name: Tutorials
-    items:
-    - name: Build your first analyzer
-    - name: Build your first code fix
-    - name: Deploy your analyzer as a VSIX
-    - name: Deploy your analyzer as a NuGet package
-- name: Samples
-  items:
-    - name: Async packages
-    - name: Console classifier
-    - name: Convert to auto property
-    - name: Format solution
-    - name: Implement notify property changed
-    - name: Make const
-    - name: How to guides
+# Taken from https://github.com/dotnet/roslyn/wiki/Samples-and-Walkthroughs
+#    - name: Get started writing custom analyzers and code fixes
+#  - name: Tutorials
+#    items:
+#    - name: Build your first analyzer
+#    - name: Build your first code fix
+#    - name: Deploy your analyzer as a VSIX
+#    - name: Deploy your analyzer as a NuGet package
+#- name: Samples
+# Taken from https://github.com/dotnet/roslyn/wiki/Samples-and-Walkthroughs
+#  items:
+#    - name: Async packages
+#    - name: Console classifier
+#    - name: Convert to auto property
+#    - name: Format solution
+#    - name: Implement notify property changed
+#    - name: Make const
+#    - name: How to guides
+# Look at the samples, and determine which are "How To" vs. Samples.


### PR DESCRIPTION
Fixes #11827 

To match what we had before the TOC migration from md to yml:
https://raw.githubusercontent.com/dotnet/docs/33388f53749f9557de8736572ec0dbe0abf234ae/docs/csharp/roslyn-sdk/toc.md