### PR TITLE
Moved true and false operators to the unary operators section

### DIFF
--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -85,6 +85,10 @@ These operators have higher precedence than the next section and lower precedenc
 
 [*x](multiplication-operator.md) – dereferencing.
 
+[true operator](../keywords/true-false-operators.md) - returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely true.
+
+[false operator](../keywords/true-false-operators.md) - returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely false.
+
 ## Multiplicative operators
 
 These operators have higher precedence than the next section and lower precedence than the previous section.
@@ -152,14 +156,6 @@ This operator has higher precedence than the next section and lower precedence t
 This operator has higher precedence than the next section and lower precedence than the previous section.
 
 `x | y` – [logical OR](boolean-logical-operators.md#logical-or-operator-) for the `bool` operands or [bitwise logical OR](bitwise-and-shift-operators.md#logical-or-operator-) for the operands of the integral types.
-
-## True operator
-
-The [true](../keywords/true-false-operators.md) operator returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely true. 
-
-## False operator
-
-The [false](../keywords/true-false-operators.md) operator returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely false. 
 
 ## Conditional AND operator
 


### PR DESCRIPTION
Continuation of #11860

My guess is that, when grouped by precedence, the `true` and `false` operators should be in the group of unary operators.

@BillWagner is it a correct guess?

The spec doesn't say anything about precedence of those two operators:
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#operator-precedence-and-associativity

Moreover, that silence is [intentional](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/expressions#operator-overloading) (emphasis mine):

> Although `true` and `false` are not used explicitly in expressions **(and therefore are not included in the precedence table in Operator precedence and associativity)**, they are considered operators because they are invoked in several expression contexts: boolean expressions (Boolean expressions) and expressions involving the conditional (Conditional operator), and conditional logical operators (Conditional logical operators).

/cc: @paulomorgado 
