### PR TITLE
ML.NET landing page: fix broken links

### DIFF
--- a/docs/machine-learning/index.yml
+++ b/docs/machine-learning/index.yml
@@ -23,16 +23,16 @@ sections:
   - type: list
     style: unordered
     items:
-    - html: <a href="/machine-learning/tutorials/sentiment-analysis">Analyze sentiment using binary classification</a>
-    - html: <a href="/machine-learning/tutorials/github-issue-classification">Categorize GitHub issues using multiclass classification</a></li>
-    - html: <a href="/machine-learning/tutorials/taxi-fare">Predict NYC taxi fares using regresssion</a>
-    - html: <a href="/machine-learning/tutorials/iris-clustering">Categorize flowers by characteristics using clustering</a>
-    - html: <a href="/machine-learning/tutorials/movie-recommmendation">Create a movie recommender with matrix factorization</a>
-    - html: <a href="/machine-learning/tutorials/image-classification">Build a custom image classifier with TensorFlow</a>
+    - html: <a href="/dotnet/machine-learning/tutorials/sentiment-analysis">Analyze sentiment using binary classification</a>
+    - html: <a href="/dotnet/machine-learning/tutorials/github-issue-classification">Categorize GitHub issues using multiclass classification</a></li>
+    - html: <a href="/dotnet/machine-learning/tutorials/taxi-fare">Predict NYC taxi fares using regresssion</a>
+    - html: <a href="/dotnet/machine-learning/tutorials/iris-clustering">Categorize flowers by characteristics using clustering</a>
+    - html: <a href="/dotnet/machine-learning/tutorials/movie-recommmendation">Create a movie recommender with matrix factorization</a>
+    - html: <a href="/dotnet/machine-learning/tutorials/image-classification">Build a custom image classifier with TensorFlow</a>
 - title: Reference and Resources
   items:
   - type: list
     style: unordered
     items:
-    - html: '<a href="/api/?view=ml-dotnet">ML.NET API</a>'
+    - html: '<a href="/dotnet/api/?view=ml-dotnet">ML.NET API</a>'
     - html: '<a href="https://github.com/dotnet/machinelearning-samples/blob/master/README.md">ML.NET samples: C# and F#</a>'


### PR DESCRIPTION
/cc @JRAlexander  @cjgronlund 

On this page:
https://docs.microsoft.com/en-us/dotnet/machine-learning/

the link to the first tutorial (and all other links):
https://docs.microsoft.com/en-us/machine-learning/tutorials/sentiment-analysis

misses `dotnet`:
`.../en-us/machine-learning/...`