### PR TITLE
Move P/Invokes to NativeMethods class

### DIFF
--- a/docs/framework/interop/creating-prototypes-in-managed-code.md
+++ b/docs/framework/interop/creating-prototypes-in-managed-code.md
@@ -43,7 +43,7 @@ Friend Class NativeMethods
 End Class
 ```
   
- To apply the <xref:System.Runtime.InteropServices.DllImportAttribute.BestFitMapping>, <xref:System.Runtime.InteropServices.DllImportAttribute.CallingConvention>, <xref:System.Runtime.InteropServices.DllImportAttribute.ExactSpelling>, <xref:System.Runtime.InteropServices.DllImportAttribute.PreserveSig>, <xref:System.Runtime.InteropServices.DllImportAttribute.SetLastError>, or <xref:System.Runtime.InteropServices.DllImportAttribute.ThrowOnUnmappableChar> fields to a [!INCLUDE[vbprvbext](../../../includes/vbprvbext-md.md)] declaration, you must use the <xref:System.Runtime.InteropServices.DllImportAttribute> attribute instead of the `Declare` statement.  
+ To apply the <xref:System.Runtime.InteropServices.DllImportAttribute.BestFitMapping?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.CallingConvention?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.ExactSpelling?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.PreserveSig?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.SetLastError?displayProperty=nameWithtype>, or <xref:System.Runtime.InteropServices.DllImportAttribute.ThrowOnUnmappableChar?displayProperty=nameWithtype> fields to a Visual Basic declaration, you must use the <xref:System.Runtime.InteropServices.DllImportAttribute> attribute instead of the `Declare` statement.  
   
 ```vb
 Imports System
@@ -105,9 +105,9 @@ extern "C" int MessageBox(
 ### Platform Invoke Examples  
  The platform invoke samples in this section illustrate the use of the `RegistryPermission` attribute with the stack walk modifiers.  
   
- In the following code example, the <xref:System.Security.Permissions.SecurityAction>`Assert`, `Deny`, and `PermitOnly` modifiers are ignored.  
+ In the following example, the <xref:System.Security.Permissions.SecurityAction>`Assert`, `Deny`, and `PermitOnly` modifiers are ignored.  
   
-```  
+```csharp  
 [DllImport("MyClass.dll", EntryPoint = "CallRegistryPermission")]  
 [RegistryPermission(SecurityAction.Assert, Unrestricted = true)]  
     private static extern bool CallRegistryPermissionAssert();  
@@ -123,7 +123,7 @@ extern "C" int MessageBox(
   
  However, the `Demand` modifier in the following example is accepted.  
   
-```  
+```csharp
 [DllImport("MyClass.dll", EntryPoint = "CallRegistryPermission")]  
 [RegistryPermission(SecurityAction.Demand, Unrestricted = true)]  
     private static extern bool CallRegistryPermissionDeny();  

--- a/docs/framework/interop/creating-prototypes-in-managed-code.md
+++ b/docs/framework/interop/creating-prototypes-in-managed-code.md
@@ -32,10 +32,8 @@ This topic describes how to access unmanaged functions and introduces several at
  Managed definitions to unmanaged functions are language-dependent, as you can see in the following examples. For more complete code examples, see [Platform Invoke Examples](platform-invoke-examples.md).  
   
 ```vb
-Imports System
-
 Friend Class NativeMethods
-    Friend Shared Declare Auto Function MessageBox Lib "user32.dll" (
+    Friend Declare Auto Function MessageBox Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
         ByVal lpCaption As String,
@@ -46,7 +44,6 @@ End Class
  To apply the <xref:System.Runtime.InteropServices.DllImportAttribute.BestFitMapping?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.CallingConvention?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.ExactSpelling?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.PreserveSig?displayProperty=nameWithtype>, <xref:System.Runtime.InteropServices.DllImportAttribute.SetLastError?displayProperty=nameWithtype>, or <xref:System.Runtime.InteropServices.DllImportAttribute.ThrowOnUnmappableChar?displayProperty=nameWithtype> fields to a Visual Basic declaration, you must use the <xref:System.Runtime.InteropServices.DllImportAttribute> attribute instead of the `Declare` statement.  
   
 ```vb
-Imports System
 Imports System.Runtime.InteropServices
 
 Friend Class NativeMethods

--- a/docs/framework/interop/creating-prototypes-in-managed-code.md
+++ b/docs/framework/interop/creating-prototypes-in-managed-code.md
@@ -34,7 +34,7 @@ This topic describes how to access unmanaged functions and introduces several at
 ```vb
 Imports System
 
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Auto Function MessageBox Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
@@ -49,7 +49,7 @@ End Class
 Imports System
 Imports System.Runtime.InteropServices
 
-Friend Class WindowsAPI
+Friend Class NativeMethods
     <DllImport("user32.dll", CharSet:=CharSet.Auto)>
     Friend Shared Function MessageBox(
         ByVal hWnd As IntPtr,
@@ -64,7 +64,7 @@ End Class
 using System;
 using System.Runtime.InteropServices;
 
-internal static class WindowsAPI
+internal static class NativeMethods
 {
     [DllImport("user32.dll")]
     internal static extern int MessageBox(

--- a/docs/framework/interop/default-marshaling-behavior.md
+++ b/docs/framework/interop/default-marshaling-behavior.md
@@ -224,7 +224,7 @@ BOOL PtInRect(const RECT *lprc, POINT pt);
   
 ```vb
 Friend Class NativeMethods
-    Friend Shared Declare Auto Function PtInRect Lib "User32.dll" (
+    Friend Declare Auto Function PtInRect Lib "User32.dll" (
         ByRef r As Rect, p As Point) As Boolean
 End Class
 ```
@@ -286,7 +286,7 @@ void GetSystemTime(SYSTEMTIME* SystemTime);
   
 ```vb
 Friend Class NativeMethods
-    Friend Shared Declare Auto Sub GetSystemTime Lib "Kernel32.dll" (
+    Friend Declare Auto Sub GetSystemTime Lib "Kernel32.dll" (
         ByVal sysTime As SystemTime)
 End Class
 ```

--- a/docs/framework/interop/default-marshaling-behavior.md
+++ b/docs/framework/interop/default-marshaling-behavior.md
@@ -223,14 +223,14 @@ BOOL PtInRect(const RECT *lprc, POINT pt);
  You can pass structures using the following platform invoke definition:  
   
 ```vb
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Auto Function PtInRect Lib "User32.dll" (
         ByRef r As Rect, p As Point) As Boolean
 End Class
 ```
   
 ```csharp
-internal static class WindowsAPI
+internal static class NativeMethods
 {
    [DllImport("User32.dll")]
    internal static extern bool PtInRect(ref Rect r, Point p);
@@ -285,14 +285,14 @@ void GetSystemTime(SYSTEMTIME* SystemTime);
  The equivalent platform invoke definition for **GetSystemTime** is as follows:  
   
 ```vb
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Auto Sub GetSystemTime Lib "Kernel32.dll" (
         ByVal sysTime As SystemTime)
 End Class
 ```
   
 ```csharp
-internal static class WindowsAPI
+internal static class NativeMethods
 {
    [DllImport("Kernel32.dll", CharSet = CharSet.Auto)]
    internal static extern void GetSystemTime(SystemTime st);

--- a/docs/framework/interop/default-marshaling-for-strings.md
+++ b/docs/framework/interop/default-marshaling-for-strings.md
@@ -241,6 +241,10 @@ int GetWindowText(
 A `StringBuilder` can be dereferenced and modified by the callee, provided it does not exceed the capacity of the `StringBuilder`. The following code example demonstrates how `StringBuilder` can be initialized to a fixed length.
 
 ```csharp
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
 internal static class NativeMethods
 {
     [DllImport("User32.dll")]
@@ -260,8 +264,10 @@ public class Window
 ```
 
 ```vb
+Imports System.Text
+
 Friend Class NativeMethods
-    Friend Shared Declare Auto Sub GetWindowText Lib "User32.dll" _
+    Friend Declare Auto Sub GetWindowText Lib "User32.dll" _
         (hWnd As IntPtr, lpString As StringBuilder, nMaxCount As Integer)
 End Class
 

--- a/docs/framework/interop/default-marshaling-for-strings.md
+++ b/docs/framework/interop/default-marshaling-for-strings.md
@@ -241,7 +241,7 @@ int GetWindowText(
 A `StringBuilder` can be dereferenced and modified by the callee, provided it does not exceed the capacity of the `StringBuilder`. The following code example demonstrates how `StringBuilder` can be initialized to a fixed length.
 
 ```csharp
-internal static class WindowsAPI
+internal static class NativeMethods
 {
     [DllImport("User32.dll")]
     internal static extern void GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
@@ -253,14 +253,14 @@ public class Window
     public String GetText()
     {
         StringBuilder sb = new StringBuilder(256);
-        WindowsAPI.GetWindowText(h, sb, sb.Capacity + 1);
+        NativeMethods.GetWindowText(h, sb, sb.Capacity + 1);
         return sb.ToString();
     }
 }
 ```
 
 ```vb
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Auto Sub GetWindowText Lib "User32.dll" _
         (hWnd As IntPtr, lpString As StringBuilder, nMaxCount As Integer)
 End Class
@@ -269,7 +269,7 @@ Public Class Window
     Friend h As IntPtr ' Friend handle to Window.
     Public Function GetText() As String
         Dim sb As New StringBuilder(256)
-        WindowsAPI.GetWindowText(h, sb, sb.Capacity + 1)
+        NativeMethods.GetWindowText(h, sb, sb.Capacity + 1)
         Return sb.ToString()
    End Function
 End Class

--- a/docs/framework/interop/passing-structures.md
+++ b/docs/framework/interop/passing-structures.md
@@ -93,9 +93,7 @@ void GetSystemTime(SYSTEMTIME* SystemTime);
  Unlike value types, classes always have at least one level of indirection.  
   
 ```vb  
-Imports System  
 Imports System.Runtime.InteropServices  
-Imports Microsoft.VisualBasic  
   
 <StructLayout(LayoutKind.Sequential)> Public Class MySystemTime  
     Public wYear As Short  
@@ -109,9 +107,9 @@ Imports Microsoft.VisualBasic
 End Class  
   
 Friend Class NativeMethods  
-    Friend Shared Declare Auto Sub GetSystemTime Lib "Kernel32.dll" (
+    Friend Declare Auto Sub GetSystemTime Lib "Kernel32.dll" (
         sysTime As MySystemTime)  
-    Friend Shared Declare Auto Function MessageBox Lib "User32.dll" (
+    Friend Declare Auto Function MessageBox Lib "User32.dll" (
         hWnd As IntPtr, lpText As String, lpCaption As String, uType As UInteger) As Integer  
 End Class  
   

--- a/docs/framework/interop/passing-structures.md
+++ b/docs/framework/interop/passing-structures.md
@@ -53,7 +53,7 @@ Public Structure <StructLayout(LayoutKind.Explicit)> Rect
     <FieldOffset(12)> Public bottom As Integer  
 End Structure  
   
-Friend Class WindowsAPI      
+Friend Class NativeMethods      
     Friend Shared Declare Auto Function PtInRect Lib "user32.dll" (
         ByRef r As Rect, p As Point) As Boolean  
 End Class  
@@ -76,7 +76,7 @@ public struct Rect {
     [FieldOffset(12)] public int bottom;  
 }     
   
-internal static class WindowsAPI
+internal static class NativeMethods
 {  
     [DllImport("User32.dll")]  
     internal static extern bool PtInRect(ref Rect r, Point p);  
@@ -108,7 +108,7 @@ Imports Microsoft.VisualBasic
     Public wMiliseconds As Short  
 End Class  
   
-Friend Class WindowsAPI  
+Friend Class NativeMethods  
     Friend Shared Declare Auto Sub GetSystemTime Lib "Kernel32.dll" (
         sysTime As MySystemTime)  
     Friend Shared Declare Auto Function MessageBox Lib "User32.dll" (
@@ -118,7 +118,7 @@ End Class
 Public Class TestPlatformInvoke      
     Public Shared Sub Main()  
         Dim sysTime As New MySystemTime()  
-        WindowsAPI.GetSystemTime(sysTime)  
+        NativeMethods.GetSystemTime(sysTime)  
   
         Dim dt As String  
         dt = "System time is:" & ControlChars.CrLf & _  
@@ -126,7 +126,7 @@ Public Class TestPlatformInvoke
               ControlChars.CrLf & "Month: " & sysTime.wMonth & _  
               ControlChars.CrLf & "DayOfWeek: " & sysTime.wDayOfWeek & _  
               ControlChars.CrLf & "Day: " & sysTime.wDay  
-        WindowsAPI.MessageBox(IntPtr.Zero, dt, "Platform Invoke Sample", 0)        
+        NativeMethods.MessageBox(IntPtr.Zero, dt, "Platform Invoke Sample", 0)        
     End Sub  
 End Class  
 ```  
@@ -143,7 +143,7 @@ public class MySystemTime {
     public ushort wSecond;   
     public ushort wMilliseconds;   
 }  
-internal static class WindowsAPI
+internal static class NativeMethods
 {  
     [DllImport("Kernel32.dll")]  
     internal static extern void GetSystemTime(MySystemTime st);  
@@ -158,7 +158,7 @@ public class TestPlatformInvoke
     public static void Main()  
     {  
         MySystemTime sysTime = new MySystemTime();  
-        WindowsAPI.GetSystemTime(sysTime);  
+        NativeMethods.GetSystemTime(sysTime);  
   
         string dt;  
         dt = "System time is: \n" +  
@@ -166,7 +166,7 @@ public class TestPlatformInvoke
               "Month: " + sysTime.wMonth + "\n" +  
               "DayOfWeek: " + sysTime.wDayOfWeek + "\n" +  
               "Day: " + sysTime.wDay;  
-        WindowsAPI.MessageBox(IntPtr.Zero, dt, "Platform Invoke Sample", 0);  
+        NativeMethods.MessageBox(IntPtr.Zero, dt, "Platform Invoke Sample", 0);  
     }  
 }  
 ```  

--- a/docs/framework/interop/passing-structures.md
+++ b/docs/framework/interop/passing-structures.md
@@ -54,7 +54,7 @@ Public Structure <StructLayout(LayoutKind.Explicit)> Rect
 End Structure  
   
 Friend Class NativeMethods      
-    Friend Shared Declare Auto Function PtInRect Lib "user32.dll" (
+    Friend Declare Auto Function PtInRect Lib "user32.dll" (
         ByRef r As Rect, p As Point) As Boolean  
 End Class  
 ```  

--- a/docs/framework/interop/specifying-a-character-set.md
+++ b/docs/framework/interop/specifying-a-character-set.md
@@ -64,19 +64,19 @@ The <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet?displayPrope
   
 ```vb
 Friend Class NativeMethods
-    Friend Shared Declare Function MessageBoxA Lib "user32.dll" (
+    Friend Declare Function MessageBoxA Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
         ByVal lpCaption As String,
         ByVal uType As UInteger) As Integer
 
-    Friend Shared Declare Unicode Function MessageBoxW Lib "user32.dll" (
+    Friend Declare Unicode Function MessageBoxW Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
         ByVal lpCaption As String,
         ByVal uType As UInteger) As Integer
 
-    Friend Shared Declare Auto Function MessageBox Lib "user32.dll" (
+    Friend Declare Auto Function MessageBox Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
         ByVal lpCaption As String,

--- a/docs/framework/interop/specifying-a-character-set.md
+++ b/docs/framework/interop/specifying-a-character-set.md
@@ -65,7 +65,7 @@ The <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet?displayPrope
 ```vb
 Imports System
 
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Function MessageBoxA Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
@@ -107,7 +107,7 @@ End Class
 using System;
 using System.Runtime.InteropServices;
 
-internal static class WindowsAPI
+internal static class NativeMethods
 {
     [DllImport("user32.dll")]
     internal static extern int MessageBoxA(

--- a/docs/framework/interop/specifying-a-character-set.md
+++ b/docs/framework/interop/specifying-a-character-set.md
@@ -63,8 +63,6 @@ The <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet?displayPrope
  If you omit the character-set keyword, as is done in the first declaration statement, the <xref:System.Runtime.InteropServices.DllImportAttribute.CharSet?displayProperty=nameWithType> field defaults to the ANSI character set. The second and third statements in the example explicitly specify a character set with a keyword.  
   
 ```vb
-Imports System
-
 Friend Class NativeMethods
     Friend Shared Declare Function MessageBoxA Lib "user32.dll" (
         ByVal hWnd As IntPtr,

--- a/docs/framework/interop/specifying-an-entry-point.md
+++ b/docs/framework/interop/specifying-an-entry-point.md
@@ -30,7 +30,7 @@ An entry point identifies the location of a function in a DLL. Within a managed 
 ```vb
 Imports System
 
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Auto Function MessageBox Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
@@ -44,7 +44,7 @@ End Class
 ```vb
 Imports System
 
-Friend Class WindowsAPI
+Friend Class NativeMethods
     Friend Shared Declare Auto Function MsgBox _
         Lib "user32.dll" Alias "MessageBox" (
         ByVal hWnd As IntPtr,
@@ -70,7 +70,7 @@ End Class
 using System;
 using System.Runtime.InteropServices;
 
-internal static class WindowsAPI
+internal static class NativeMethods
 {
     [DllImport("user32.dll", EntryPoint = "MessageBoxA")]
     internal static extern int MessageBox(

--- a/docs/framework/interop/specifying-an-entry-point.md
+++ b/docs/framework/interop/specifying-an-entry-point.md
@@ -29,7 +29,7 @@ An entry point identifies the location of a function in a DLL. Within a managed 
   
 ```vb
 Friend Class NativeMethods
-    Friend Shared Declare Auto Function MessageBox Lib "user32.dll" (
+    Friend Declare Auto Function MessageBox Lib "user32.dll" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,
         ByVal lpCaption As String,
@@ -41,7 +41,7 @@ End Class
   
 ```vb
 Friend Class NativeMethods
-    Friend Shared Declare Auto Function MsgBox _
+    Friend Declare Auto Function MsgBox _
         Lib "user32.dll" Alias "MessageBox" (
         ByVal hWnd As IntPtr,
         ByVal lpText As String,

--- a/docs/framework/interop/specifying-an-entry-point.md
+++ b/docs/framework/interop/specifying-an-entry-point.md
@@ -28,8 +28,6 @@ An entry point identifies the location of a function in a DLL. Within a managed 
  Visual Basic uses the **Function** keyword in the **Declare** statement to set the <xref:System.Runtime.InteropServices.DllImportAttribute.EntryPoint?displayProperty=nameWithType> field. The following example shows a basic declaration.  
   
 ```vb
-Imports System
-
 Friend Class NativeMethods
     Friend Shared Declare Auto Function MessageBox Lib "user32.dll" (
         ByVal hWnd As IntPtr,
@@ -42,8 +40,6 @@ End Class
  You can replace the **MessageBox** entry point with **MsgBox** by including the **Alias** keyword in your definition, as shown in the following example. In both examples the **Auto** keyword eliminates the need to specify the character-set version of the entry point. For more information about selecting a character set, see [Specifying a Character Set](../../../docs/framework/interop/specifying-a-character-set.md).  
   
 ```vb
-Imports System
-
 Friend Class NativeMethods
     Friend Shared Declare Auto Function MsgBox _
         Lib "user32.dll" Alias "MessageBox" (


### PR DESCRIPTION
Contributes to #11396 

In .NET Framework Guide.

[CA1060: Move P/Invokes to NativeMethods class](https://docs.microsoft.com/visualstudio/code-quality/ca1060-move-p-invokes-to-nativemethods-class)