### PR TITLE
BOM required to override computer codepage

### DIFF
--- a/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
@@ -23,10 +23,8 @@ This option specifies which codepage to use during compilation if the required p
  The id of the code page to use for all source code files in the compilation.  
   
 ## Remarks  
- If you compile one or more source code files that were not created to use the default code page on your computer, you can use the **-codepage** option to specify which code page should be used. **-codepage** applies to all source code files in your compilation.  
-  
- If the source code files were created with the same codepage that is in effect on your computer or if the source code files are encoded as Unicode (e.g. UTF-8) with a Byte Order Mark (BOM), you need not use **-codepage**.  
-  
+ The compiler will first attempt to intrept all source files as UTF-8. If your source code files are in an encoding other than UTF-8 and use characters other than 7-bit ASCII characters, use the **-codepage** option to specify which code page should be used. **-codepage** applies to all source code files in your compilation.  
+    
  See [GetCPInfo](/windows/desktop/api/winnls/nf-winnls-getcpinfo) for information on how to find which code pages are supported on your system.  
   
  This compiler option is unavailable in Visual Studio and cannot be changed programmatically.  

--- a/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
@@ -25,7 +25,7 @@ This option specifies which codepage to use during compilation if the required p
 ## Remarks  
  If you compile one or more source code files that were not created to use the default code page on your computer, you can use the **-codepage** option to specify which code page should be used. **-codepage** applies to all source code files in your compilation.  
   
- If the source code files were created with the same codepage that is in effect on your computer or if the source code files were created with UNICODE or UTF-8, you need not use **-codepage**.  
+ If the source code files were created with the same codepage that is in effect on your computer or if the source code files are encoded as Unicode (e.g. UTF-8) with a Byte Order Mark (BOM), you need not use **-codepage**.  
   
  See [GetCPInfo](/windows/desktop/api/winnls/nf-winnls-getcpinfo) for information on how to find which code pages are supported on your system.  
   

--- a/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/codepage-compiler-option.md
@@ -23,7 +23,7 @@ This option specifies which codepage to use during compilation if the required p
  The id of the code page to use for all source code files in the compilation.  
   
 ## Remarks  
- The compiler will first attempt to intrept all source files as UTF-8. If your source code files are in an encoding other than UTF-8 and use characters other than 7-bit ASCII characters, use the **-codepage** option to specify which code page should be used. **-codepage** applies to all source code files in your compilation.  
+ The compiler will first attempt to interpret all source files as UTF-8. If your source code files are in an encoding other than UTF-8 and use characters other than 7-bit ASCII characters, use the **-codepage** option to specify which code page should be used. **-codepage** applies to all source code files in your compilation.  
     
  See [GetCPInfo](/windows/desktop/api/winnls/nf-winnls-getcpinfo) for information on how to find which code pages are supported on your system.  
   


### PR DESCRIPTION
This page said that **-codepage** is not needed for source code files created with UNICODE or UTF-8. If that's true, then if I have a .cs file encoded in UTF-8 with no Byte Order Mark, csc.exe will interpret it as UTF-8 regardless of the codepage in effect on the computer. That doesn't seem possible, however, since csc.exe can't know whether the file is encoded as UTF-8 or the computer's codepage.

This change corrects the text to indicate that if the source file indicates that uses a Unicode encoding by including a byte order mark, then the computer's codepage is ignored.