### PR TITLE
Tour of C#: link operator reference

### DIFF
--- a/docs/csharp/language-reference/keywords/operator.md
+++ b/docs/csharp/language-reference/keywords/operator.md
@@ -1,7 +1,6 @@
 ---
 title: "operator keyword - C# Reference"
 ms.custom: seodec18
-
 description: "Learn how to overload a built-in C# operator"
 ms.date: 08/27/2018
 f1_keywords: 

--- a/docs/csharp/tour-of-csharp/expressions.md
+++ b/docs/csharp/tour-of-csharp/expressions.md
@@ -1,10 +1,9 @@
 ---
 title: C# Expressions - A tour of the C# language
-description: expressions, operands, and operators are building blocks of the C# language
-ms.date: 11/06/2016
+description: Expressions, operands, and operators are building blocks of the C# language
+ms.date: 04/25/2019
 ms.assetid: 20d5eb10-7381-47b9-ad90-f1cc895aa27e
 ---
-
 # Expressions
 
 *Expressions* are constructed from *operands* and *operators*. The operators of an expression indicate which operations to apply to the operands. Examples of operators include `+`, `-`, `*`, `/`, and `new`. Examples of operands include literals, fields, local variables, and expressions.
@@ -18,73 +17,11 @@ When an operand occurs between two operators with the same precedence, the *asso
 
 Precedence and associativity can be controlled using parentheses. For example, `x + y * z` first multiplies `y` by `z` and then adds the result to `x`, but `(x + y) * z` first adds `x` and `y` and then multiplies the result by `z`.
 
-Most operators can be *overloaded*. Operator overloading permits user-defined operator implementations to be specified for operations where one or both of the operands are of a user-defined class or struct type.
+Most operators can be [*overloaded*](../language-reference/keywords/operator.md). Operator overloading permits user-defined operator implementations to be specified for operations where one or both of the operands are of a user-defined class or struct type.
 
-The following summarizes C#’s operators, listing the operator categories in order of precedence from highest to lowest. Operators in the same category have equal precedence. Under each category is a list of expressions in that category along with the description of that expression type.
+C# provides a number of operators to perform [arithmetic](../language-reference/operators/arithmetic-operators.md), [logical](../language-reference/operators/boolean-logical-operators.md), [bitwise and shift](../language-reference/operators/bitwise-and-shift-operators.md) operations and [equality](../language-reference/operators/equality-operators.md) and [order](../language-reference/operators/comparison-operators.md) comparisons.
 
-* Primary
-  - `x.m`: Member access
-  - `x(...)`: Method and delegate invocation
-  - `x[...]`: Array and indexer access
-  - `x++`: Post-increment
-  - `x--`: Post-decrement
-  - `new T(...)`: Object and delegate creation
-  - `new T(...){...}`: Object creation with initializer
-  - `new {...}`:  Anonymous object initializer
-  - `new T[...]`: Array creation
-  - `typeof(T)`: Obtain <xref:System.Type> object for `T`
-  - `checked(x)`: Evaluate expression in checked context
-  - `unchecked(x)`: Evaluate expression in unchecked context
-  - `default(T)`: Obtain default value of type `T`
-  - `delegate {...}`: Anonymous function (anonymous method)
-* Unary
-  - `+x`: Identity
-  - `-x`: Negation
-  - `!x`: Logical negation
-  - `~x`: Bitwise negation
-  - `++x`: Pre-increment
-  - `--x`: Pre-decrement
-  - `(T)x`: Explicitly convert `x` to type `T`
-  - `await x`: Asynchronously wait for `x` to complete
-* Multiplicative
-  - `x * y`: Multiplication
-  - `x / y`: Division
-  - `x % y`: Remainder
-* Additive
-  - `x + y`: Addition, string concatenation, delegate combination
-  - `x – y`: Subtraction, delegate removal
-* Shift
-  - `x << y`: Shift left
-  - `x >> y`: Shift right
-* Relational and type testing
-  - `x < y`: Less than
-  - `x > y`: Greater than
-  - `x <= y`: Less than or equal
-  - `x >= y`: Greater than or equal
-  - `x is T`: Return `true` if `x` is a `T`, `false` otherwise
-  - `x as T`: Return `x` typed as `T`, or `null` if `x` is not a `T`
-* Equality
-  - `x == y`: Equal
-  - `x != y`: Not equal
-* Logical AND
-  - `x & y`: Integer bitwise AND, boolean logical AND
-* Logical XOR
-  - `x ^ y`: Integer bitwise XOR, boolean logical XOR
-* Logical OR
-  - `x | y`: Integer bitwise OR, boolean logical OR
-* Conditional AND
-  - `x && y`: Evaluates `y` only if `x` is not `false`
-* Conditional OR
-  - `x || y`: Evaluates `y` only if `x` is not `true`
-* Null coalescing
-  - `x ?? y`: Evaluates to `y` if `x` is null, to `x` otherwise
-* Conditional
-  - `x ? y : z`: Evaluates `y` if `x` is `true`, `z` if `x` is `false`
-* Assignment or anonymous function
-  - `x = y`: Assignment
-  - `x op= y`: Compound assignment; supported operators are
-    - `*=`   `/=`   `%=`   `+=`   `-=`   `<<=`   `>>=`   `&=`  `^=`  `|=`
-  - `(T x) => y`: Anonymous function (lambda expression)
+For the complete list of C# operators ordered by precedence level, see [C# operators](../language-reference/operators/index.md).
 
 > [!div class="step-by-step"]
 > [Previous](types-and-variables.md)


### PR DESCRIPTION
Fixes #9907

Rather than provide the duplicate description of all the operators, let's link the operators index page. Also, now we can link operator overviews as well.
