### PR TITLE
Sync thread cancellation references with TOC

### DIFF
--- a/docs/standard/threading/managed-threading-basics.md
+++ b/docs/standard/threading/managed-threading-basics.md
@@ -40,9 +40,6 @@ The first five topics of this section are designed to help you determine when to
  [Thread Local Storage: Thread-Relative Static Fields and Data Slots](../../../docs/standard/threading/thread-local-storage-thread-relative-static-fields-and-data-slots.md)  
  Describes thread-relative storage mechanisms.  
   
- [Cancellation in Managed Threads](../../../docs/standard/threading/cancellation-in-managed-threads.md)  
- Describes how asynchronous or long-running synchronous operations can be canceled by using a cancellation token.  
-  
 ## Reference
 
  <xref:System.Threading.Thread>  

--- a/docs/standard/threading/toc.yml
+++ b/docs/standard/threading/toc.yml
@@ -27,7 +27,7 @@
       href: destroying-threads.md
     - name: Scheduling threads
       href: scheduling-threads.md
-    - name: Cancellation in Managed Threads
+    - name: Cancellation in managed threads
       href: cancellation-in-managed-threads.md
       items:
       - name: Canceling threads cooperatively

--- a/docs/standard/threading/using-threads-and-threading.md
+++ b/docs/standard/threading/using-threads-and-threading.md
@@ -26,7 +26,7 @@ You create a new thread by creating a new instance of the <xref:System.Threading
 
 To terminate the execution of a thread, use the <xref:System.Threading.Thread.Abort%2A?displayProperty=nameWithType> method. That method raises a <xref:System.Threading.ThreadAbortException> on the thread on which it's invoked. For more information, see [Destroying threads](destroying-threads.md).
 
-Beginning with the .NET Framework 4, you can use the <xref:System.Threading.CancellationToken?displayProperty=nameWithType> to cancel a thread cooperatively. For more information, see [Canceling threads cooperatively](canceling-threads-cooperatively.md).
+Beginning with the .NET Framework 4, you can use the <xref:System.Threading.CancellationToken?displayProperty=nameWithType> to cancel a thread cooperatively. For more information, see [Cancellation in managed threads](cancellation-in-managed-threads.md).
 
 Use the <xref:System.Threading.Thread.Join%2A?displayProperty=nameWithType> method to make the calling thread wait for the termination of the thread on which the method is invoked.
 


### PR DESCRIPTION
PR #9860 consolidated thread cancellation TOC, but that was not reflected in articles. This PR fixes that.
