### PR TITLE
Add one more example of reducing null checks.

### DIFF
--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -33,6 +33,24 @@ If customers IsNot Nothing Then
 End If
 ```
 
+Sometimes you need to take an action on an object that may be null, based on the value of a boolean member on that object (like the boolean property `IsAllowedFreeShipping` in the code below):
+
+```vb
+  Dim customer = FindCustomerByID(123) 'customer will be Nothing if not found.
+  
+  If customer IsNot Nothing AndAlso customer.IsAllowedFreeShipping Then
+   ApplyFreeShippingToOrders(customer)
+  End If
+```
+
+You can shorten your code and avoid manually checking for null by using the null-conditional operator as follows:
+
+```vb
+ Dim customer = FindCustomerByID(123) 'customer will be Nothing if not found.
+ 
+ If customer?.IsAllowedFreeShipping Then ApplyFreeShippingToOrders(customer)
+```
+
 The null-conditional operators are short-circuiting.  If one operation in a chain of conditional member access and index operations returns `Nothing`, the rest of the chain’s execution stops.  In the following example, `C(E)` isn't evaluated if `A`, `B`, or `C` evaluates to `Nothing`.
 
 ```vb

--- a/docs/visual-basic/language-reference/operators/null-conditional-operators.md
+++ b/docs/visual-basic/language-reference/operators/null-conditional-operators.md
@@ -33,7 +33,7 @@ If customers IsNot Nothing Then
 End If
 ```
 
-Sometimes you need to take an action on an object that may be null, based on the value of a boolean member on that object (like the boolean property `IsAllowedFreeShipping` in the code below):
+Sometimes you need to take an action on an object that may be null, based on the value of a Boolean member on that object (like the Boolean property `IsAllowedFreeShipping` in the following example):
 
 ```vb
   Dim customer = FindCustomerByID(123) 'customer will be Nothing if not found.


### PR DESCRIPTION
Added an example of using the null-conditional operator to avoid checking for null when referencing a possibly-null object in an `If` statement (see discussion on #9208).

I wasn't sure where to slot in the extra example, hopefully the current position flows well with the rest of the page. 

PS: since this is the first doc change I have made that isn't a simple typo/grammar fix, I am very much open to the submission being further edited for "flow" or "tone". Much respect to the docs team, it's surprising how difficult it can be to write docs that are both thorough and easy to understand!

Fixes #9208