### PR TITLE
Fixed wrong link for "What's Machine Learning?"

### DIFF
--- a/docs/machine-learning/index.yml
+++ b/docs/machine-learning/index.yml
@@ -19,7 +19,7 @@ sections:
 - title: Get Started
   items:
   - type: paragraph
-    text: 'If you are new to machine learning, get an overview from <a href="dotnet/machine-learning/what-is-machine-learning">What is machine learning</a>? To understand how an ML.NET application is built, read <a href="dotnet/machine-learning/how-does-mldotnet-work">How does ML.NET work</a>? Or get started by adding the <b>Microsoft.ML</b> nuget package to your application.'
+    text: 'If you are new to machine learning, get an overview from <a href="/dotnet/machine-learning/what-is-machine-learning">What is machine learning</a>? To understand how an ML.NET application is built, read <a href="dotnet/machine-learning/how-does-mldotnet-work">How does ML.NET work</a>? Or get started by adding the <b>Microsoft.ML</b> nuget package to your application.'
 - title: Step-by-Step Tutorials
   items:
   - type: paragraph


### PR DESCRIPTION
Fixed wrong link for "What's Machine Learning?" page. A slash was missing.

## Summary

Added a slash (/) to the begining of the existing URL (/dotnet/...)

Fixes #Issue_Number (if available)
