### PR TITLE
Add COM server sample link

### DIFF
--- a/docs/samples-and-tutorials/index.md
+++ b/docs/samples-and-tutorials/index.md
@@ -56,6 +56,10 @@ This sample demonstrates many of the problems that can be solved by using Expres
 
 This series of samples demonstrate many of the features of Language Integrated Query (LINQ). The [completed sample](https://github.com/dotnet/samples/tree/master/core/linq/csharp) is available in the dotnet/samples repository on GitHub.
 
+** Managed COM server Sample **
+
+The [COM server](https://github.com/dotnet/samples/tree/master/core/extensions/COMServerDemo) sample demonstrates the creation of a managed COM server and how it can be globally registered.
+
 **Microsoft Office PIA Sample**
 
 The [ExcelDemo](https://github.com/dotnet/samples/tree/master/core/extensions/ExcelDemo) sample demonstrates the consumption of [Microsoft Office PIAs](/visualstudio/vsto/office-primary-interop-assemblies) in .NET Core.


### PR DESCRIPTION
@rpetrusha It seems I targeted the "staging" branch for https://github.com/dotnet/samples/pull/857 instead of "master". I have defined the link above to the master branch because I _think_ that is where it should be. Did i make a mistake here or will "staging" flow to "master" at some point?

## Summary

Provide link to official managed COM server sample.
