### PR TITLE
Remove unnecessary "<T>"

### DIFF
--- a/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
+++ b/docs/standard/memory-and-spans/memory-t-usage-guidelines.md
@@ -240,7 +240,7 @@ Any component that transfers ownership of the <xref:System.Buffers.IMemoryOwner%
 
 **Rule #9: If you're wrapping a synchronous p/invoke method, your API should accept Span\<T> as a parameter.**
 
-According to Rule #1, <xref:System.Span%601> is generally the correct type to use for synchronous APIs. You can pin <xref:System.Span%601>\<T> instances via the [`fixed`](~/docs/csharp/language-reference/keywords/fixed-statement.md) keyword, as in the following example.
+According to Rule #1, <xref:System.Span%601> is generally the correct type to use for synchronous APIs. You can pin <xref:System.Span%601> instances via the [`fixed`](~/docs/csharp/language-reference/keywords/fixed-statement.md) keyword, as in the following example.
 
 ```csharp
 using System.Runtime.InteropServices;


### PR DESCRIPTION
## Summary

Remove unnecessary trailing `<T>`.

Screenshot:
![image](https://user-images.githubusercontent.com/29521868/57026633-381e6400-6c75-11e9-998f-d03369408f67.png)


