### PR TITLE
Fix broken link for ResilientHttpClient

### DIFF
--- a/docs/standard/microservices-architecture/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
+++ b/docs/standard/microservices-architecture/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
@@ -12,7 +12,7 @@ The recommended approach for retries with exponential backoff is to take advanta
 
 Polly is a .NET library that provides resilience and transient-fault handling capabilities. You can implement those capabilities by applying Polly policies such as Retry, Circuit Breaker, Bulkhead Isolation, Timeout, and Fallback. Polly targets .NET 4.x and the .NET Standard Library 1.0 (which supports .NET Core).
 
-However, using Polly’s library with your own custom code with HttpClient can be significantly complex. In the original version of eShopOnContainers, there was a [ResilientHttpClient building-block](https://github.com/dotnet-architecture/eShopOnContainers/blob/master/src/BuildingBlocks/Resilience/Resilience.Http/ResilientHttpClient.cs) based on Polly. But with the release of HttpClientFactory, resilient Http communication has become much simpler to implement, so that building-block was deprecated from eShopOnContainers. 
+However, using Polly’s library with your own custom code with HttpClient can be significantly complex. In the original version of eShopOnContainers, there was a [ResilientHttpClient building-block](https://github.com/dotnet-architecture/eShopOnContainers/commit/0c317d56f3c8937f6823cf1b45f5683397274815#diff-e6532e623eb606a0f8568663403e3a10) based on Polly. But with the release of [HttpClientFactory](https://docs.microsoft.com/en-us/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests), resilient Http communication has become much simpler to implement, so that building-block was deprecated from eShopOnContainers. 
 
 The following steps show how you can use Http retries with Polly integrated into HttpClientFactory, which is explained in the previous section.
 


### PR DESCRIPTION
## Summary
Fix the broken link for ResilientHttpClient and add a link to the documentation for HttpClientFactory
