### PR TITLE
Fix ML.NET ms.topic metadata

### DIFF
--- a/docs/machine-learning/how-to-guides/prepare-data-ml-net.md
+++ b/docs/machine-learning/how-to-guides/prepare-data-ml-net.md
@@ -4,7 +4,6 @@ description: Learn how to use transforms in ML.NET to manipulate and prepare dat
 author: luisquintanilla
 ms.author: luquinta
 ms.date: 04/26/2019
-ms.topic: how-to
 ms.custom: mvc
 #Customer intent: As a developer, I want to know how I can transform and prepare data with ML.NET using transforms
 ---

--- a/docs/machine-learning/how-to-guides/train-machine-learning-model-ml-net.md
+++ b/docs/machine-learning/how-to-guides/train-machine-learning-model-ml-net.md
@@ -4,7 +4,6 @@ description: Learn how to train and evaluate machine learning models in ML.NET
 ms.date: 04/17/2019
 author: luisquintanilla
 ms.author: luquinta
-ms.topic: how-to
 ms.custom: mvc
 #Customer intent: As a developer I want to know how to train and evaluate a machine learning model with ML.NET
 ---


### PR DESCRIPTION
Those hits were showing up in CATS

how-to is not a valid ms.topic value (https://review.docs.microsoft.com/en-us/help/contribute/metadata-attributes?branch=master#mstopic-quick-reference) - even though I'd love to have that added

Default ms.topic is conceptual but let me know if you'd like something different:
https://github.com/dotnet/docs/blob/staging/docfx.json#L111