### PR TITLE
Fix Infer.NET location in TOC

### DIFF
--- a/docs/machine-learning/how-to-guides/matchup-app-infer-net.md
+++ b/docs/machine-learning/how-to-guides/matchup-app-infer-net.md
@@ -1,17 +1,12 @@
 ---
 title: Create a game match up list app with Infer.NET and probabilistic programming
 description: Discover how to use probabilistic programming with Infer.NET to create a game matchup list app based on a simplified version of TrueSkill.
-ms.date: 03/05/2019
+ms.date: 05/06/2019
 ms.custom: mvc,how-to
 #Customer intent: As a developer, I want to use probabilistic programming with Infer.NET to create a game matchup list app based on a simplified version of TrueSkill.
 ---
 
 # Create a game match up list app with Infer.NET and probabilistic programming
-
-> [!NOTE]
-> This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit [the ML.NET introduction](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet).
-
-This how-to and related sample are currently using **ML.NET version 0.10**. For more information, see the release notes at the [dotnet/machinelearning GitHub repo](https://github.com/dotnet/machinelearning/tree/master/docs/release-notes).
 
 This how-to guide teaches you about probabilistic programming using Infer.NET. Probabilistic programming is a machine learning approach where custom models are expressed as computer programs. It allows for incorporating domain knowledge in the models and makes the machine learning system more interpretable. It also supports online inference – the process of learning as new data arrives. Infer.NET is used in various products at Microsoft in Azure, Xbox, and Bing.
 

--- a/docs/machine-learning/toc.yml
+++ b/docs/machine-learning/toc.yml
@@ -97,4 +97,4 @@
     - name: Use the automated ML API
       href: how-to-guides/how-to-use-the-automl-api.md
     - name: API reference
-      href: https://docs.microsoft.com/en-us/dotnet/api/index?view=automl-dotnet
+      href: https://docs.microsoft.com/dotnet/api/index?view=automl-dotnet

--- a/docs/machine-learning/toc.yml
+++ b/docs/machine-learning/toc.yml
@@ -51,10 +51,10 @@
       href: how-to-guides/serve-model-serverless-azure-functions-ml-net.md
     - name: Deploy a model to a web API
       href: how-to-guides/serve-model-web-api-ml-net.md
-    - name: Infer.NET
-      items:
-      - name: Probabilistic programming with Infer.NET
-        href: how-to-guides/matchup-app-infer-net.md
+  - name: Infer.NET
+    items:
+    - name: Probabilistic programming with Infer.NET
+      href: how-to-guides/matchup-app-infer-net.md
 - name: Reference
   items:
   - name: API Reference


### PR DESCRIPTION
Fix Infer.NET location in TOC

[Internal Review Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/how-to-guides/matchup-app-infer-net?branch=pr-en-us-12199)