### PR TITLE
Fixed grammar and simplified language

### DIFF
--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -85,7 +85,7 @@ If you are new to string interpolation, see the [String interpolation in C#](../
 
 ## Compilation of interpolated strings
 
-If an interpolated string has the type `string`, it's typically transformed into a <xref:System.String.Format%2A?displayProperty=nameWithType> method call. The compiler may substitute <xref:System.String.Format%2A?displayProperty=nameWithType> for <xref:System.String.Concat%2A?displayProperty=nameWithType> if the analyzed behavior would be equivalent to concatenation.
+If an interpolated string has the type `string`, it's typically transformed into a <xref:System.String.Format%2A?displayProperty=nameWithType> method call. The compiler may replace <xref:System.String.Format%2A?displayProperty=nameWithType> with <xref:System.String.Concat%2A?displayProperty=nameWithType> if the analyzed behavior would be equivalent to concatenation.
 
 If an interpolated string has the type <xref:System.IFormattable> or <xref:System.FormattableString>, the compiler generates a call to the <xref:System.Runtime.CompilerServices.FormattableStringFactory.Create%2A?displayProperty=nameWithType> method.
 


### PR DESCRIPTION
Original version was: 
> substitute `string.Format` for `string.Concat`

That was incorrect, because it is `string.Format` that is replaced with `string.Concat`. So, the correct version would be
>substitute `string.Concat` for `string.Format`

However, I think using "replace" verb makes sentence easier to understand.
