### PR TITLE
Clarified introduction about the abstract keyword

### DIFF
--- a/docs/csharp/language-reference/keywords/abstract.md
+++ b/docs/csharp/language-reference/keywords/abstract.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 ms.assetid: b0797770-c1f3-4b4d-9441-b9122602a6bb
 ---
 # abstract (C# Reference)
-The `abstract` modifier indicates that the thing being modified has a missing or incomplete implementation. The abstract modifier can be used with classes, methods, properties, indexers, and events. Use the `abstract` modifier in a class declaration to indicate that a class is intended only to be a base class of other classes. Members marked as abstract, or included in an abstract class, must be implemented by classes that derive from the abstract class.  
+The `abstract` modifier indicates that the thing being modified has a missing or incomplete implementation. The abstract modifier can be used with classes, methods, properties, indexers, and events. Use the `abstract` modifier in a class declaration to indicate that a class is intended only to be a base class of other classes, not instantiated on its own. Members marked as abstract must be implemented by classes that derive from the abstract class.
   
 ## Example  
  In this example, the class `Square` must provide an implementation of `Area` because it derives from `ShapesClass`:  


### PR DESCRIPTION
1. I think it makes sense to explain what `abstract` classes can't do, because otherwise the sentence could be interpreted as implying that e.g. you can't use abstract classes as variable types.
2. Members included in an `abstract` class that are not marked as `abstract` do not have to be overriden in derived classes.