### PR TITLE
Create initial tutorial for Default Interface Members

### DIFF
--- a/docs/csharp/tutorials/default-interface-members-versions.md
+++ b/docs/csharp/tutorials/default-interface-members-versions.md
@@ -21,7 +21,7 @@ You’ll need to set up your machine to run .NET Core, including the C# 8.0 prev
 
 ## Scenario overview
 
-This tutorial starts with version 1 of a customer relationship library. The company that built this library intended customers with existing applications to adopt their library. They provided minimal interface definitions for users of their library to implement. They defined an interface with methods for a customer:
+This tutorial starts with version 1 of a customer relationship library. The company that built this library intended customers with existing applications to adopt their library. They provided minimal interface definitions for users of their library to implement. Here's the interface definition for a customer:
 
 [!code-csharp[InitialCustomerInterface](~/samples/csharp/tutorials/default-interface-members-versions/starter/customer-relationship/ICustomer.cs?name=SnippetICustomerVersion1)]
 
@@ -33,7 +33,7 @@ From those interfaces, the team could build a library for their users to create 
 
 Now, it's time to upgrade the library for the next release. One of the requested features enables a loyalty discount for customers that have lots of orders. This new loyalty discount gets applied whenever a customer makes an order. The specific discount is a property of each individual customer. Each implementation of ICustomer can set different rules for the loyalty discount. 
 
-The most natural way to add this functionality is to enhance the `ICustomer` interface with a method to apply any loyalty discount. This design suggestion caused concern among experienced developers: "Interfaces are immutable once they've been released! This is a breaking change!" C# 8.0 adds *default interface implementations* for scenarios like these. The library authors can add new members to the interface and provide a default implementation for those members.
+The most natural way to add this functionality is to enhance the `ICustomer` interface with a method to apply any loyalty discount. This design suggestion caused concern among experienced developers: "Interfaces are immutable once they've been released! This is a breaking change!" C# 8.0 adds *default interface implementations* for upgrading interfaces. The library authors can add new members to the interface and provide a default implementation for those members.
 
 Default interface implementations enable developers to upgrade an interface while still enabling any implementors to override that implementation. Users of the library can accept the default implementation as a non-breaking change. If their business rules are different, they can override.
 
@@ -51,7 +51,7 @@ The library author wrote a first test to check the implementation:
 
 [!code-csharp[TestDefaultImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetTestDefaultImplementation&highlight=SnippetHighlightCast)]
 
-Notice the highlighted portion of the test. That cast from `SampleCustomer` to `ICustomer` is necessary. The `SampleCustomer` class does not need to provide an implementation for `ComputeLoyaltyDiscount`; that's provided by the `ICustomer` interface. However, the `SampleCustomer` class does not inherit members from its interfaces. That hasn't changed. In order to call any method declared and implemented in the interface, the variable must be the type of the interface, `ICustomer` in this example.
+Notice the highlighted portion of the test. That cast from `SampleCustomer` to `ICustomer` is necessary. The `SampleCustomer` class doesn't need to provide an implementation for `ComputeLoyaltyDiscount`; that's provided by the `ICustomer` interface. However, the `SampleCustomer` class doesn't inherit members from its interfaces. That rule hasn't changed. In order to call any method declared and implemented in the interface, the variable must be the type of the interface, `ICustomer` in this example.
 
 ## Provide parameterization
 
@@ -59,7 +59,7 @@ That's a good start. But, the default implementation is too restrictive. Many co
 
 [!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetLoyaltyDiscountVersionTwo)]
 
-There's a lot of new capabilities shown in that small code fragment. Interfaces can now include static members, including fields and methods. Different access modifiers are also enabled. In the previous example, the additional fields are private, and the new method is public. Any of the modifiers are allowed on interface members.
+There's many new capabilities shown in that small code fragment. Interfaces can now include static members, including fields and methods. Different access modifiers are also enabled. In the previous example, the additional fields are private, and the new method is public. Any of the modifiers are allowed on interface members.
 
 Applications that use the general formula for computing the loyalty discount, but different parameters don't need to provide a custom implementation; they can set the arguments through a static method. For example, the following code sets a "customer appreciation" that rewards any customer with more than one month's membership:
 
@@ -69,7 +69,7 @@ Applications that use the general formula for computing the loyalty discount, bu
 
 The code you've added so far has provided a convenient implementation for those scenarios where users want something like the default implementation, or to provide an unrelated set of rules. For a final feature, let's refactor the code a bit to enable scenarios where users may want to build on the default implementation. 
 
-Consider a startup that wants to attract new customers. They will offer a 50% discount off a new customer's first order. Otherwise, existing customers get the standard discount. A bit of refactoring in the `ICustomer` interface makes this possible:
+Consider a startup that wants to attract new customers. They offer a 50% discount off a new customer's first order. Otherwise, existing customers get the standard discount. A bit of refactoring in the `ICustomer` interface makes this scenerio easy:
 
 [!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetFinalVersion)]
 
@@ -77,4 +77,4 @@ This final version uses a `protected` static method to implement the default alg
 
 [!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/SampleCustomer.cs?name=SnippetOverrideAndExtend)]
 
-These new features mean that interfaces can be updated safely when there is a reasonable default implementation for those new members. You should carefully design interfaces to express single functional ideas that can be implemented by multiple classes. That will make it easier to upgrade those interface definitions when new requirements are discovered for that same functional idea.
+These new features mean that interfaces can be updated safely when there's a reasonable default implementation for those new members. Carefully design interfaces to express single functional ideas that can be implemented by multiple classes. That makes it easier to upgrade those interface definitions when new requirements are discovered for that same functional idea.

--- a/docs/csharp/tutorials/default-interface-members-versions.md
+++ b/docs/csharp/tutorials/default-interface-members-versions.md
@@ -4,7 +4,7 @@ description: This advanced tutorial explores how you can safely add new capabili
 ms.date: 05/06/2019
 ms.custom: mvc
 ---
-# Tutorial: Learn how to use default interface members in C# 8 to safely update interface definitions to add functionality to all implementations
+# Tutorial: Update interfaces with default interface members in C# 8
 
 Beginning in C# 8 on .NET Core 3.0 you can define an implementation when you declare a member of an interface. The most common scenario is to safely add members to an interface already released and used by innumerable clients.
 
@@ -39,7 +39,7 @@ Default interface implementations enable developers to upgrade an interface whil
 
 ## Upgrade with default interface members
 
-The team agreed on the most likely default implementation: a loyalty discount for customers 
+The team agreed on the most likely default implementation: a loyalty discount for customers.
 
 The upgrade should provide the functionality to set two properties: the number of orders needed to be eligible for the discount, and the percentage of the discount. This makes it a perfect scenario for default interface members. You can add a method to the ICustomer interface, and provide the most likely implementation. All existing, and any new implementations can use the default implementation, or provide their own.
 
@@ -61,7 +61,7 @@ That's a good start. But, the default implementation is too restrictive. Many co
 
 There's many new capabilities shown in that small code fragment. Interfaces can now include static members, including fields and methods. Different access modifiers are also enabled. In the previous example, the additional fields are private, and the new method is public. Any of the modifiers are allowed on interface members.
 
-Applications that use the general formula for computing the loyalty discount, but different parameters don't need to provide a custom implementation; they can set the arguments through a static method. For example, the following code sets a "customer appreciation" that rewards any customer with more than one month's membership:
+Applications that use the general formula for computing the loyalty discount, but different parameters, don't need to provide a custom implementation; they can set the arguments through a static method. For example, the following code sets a "customer appreciation" that rewards any customer with more than one month's membership:
 
 [!code-csharp[SetLoyaltyThresholds](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetSetLoyaltyThresholds)]
 

--- a/docs/csharp/tutorials/default-interface-members-versions.md
+++ b/docs/csharp/tutorials/default-interface-members-versions.md
@@ -21,7 +21,7 @@ You’ll need to set up your machine to run .NET Core, including the C# 8.0 prev
 
 ## Scenario overview
 
-This tutorial starts with version 1 of a customer relationship library. The company that built this library intended customers with existing applications to adopt their library. They provided minimal interface definitions for users of their library to implement. Here's the interface definition for a customer:
+This tutorial starts with version 1 of a customer relationship library. You can get the starter application on our [samples repo on GitHub](https://github.com/dotnet/samples/tree/master/csharp/tutorials/default-interface-members-versions/starter/customer-relationship). The company that built this library intended customers with existing applications to adopt their library. They provided minimal interface definitions for users of their library to implement. Here's the interface definition for a customer:
 
 [!code-csharp[InitialCustomerInterface](~/samples/csharp/tutorials/default-interface-members-versions/starter/customer-relationship/ICustomer.cs?name=SnippetICustomerVersion1)]
 
@@ -49,9 +49,13 @@ First, add the new method to the implementation:
 
 The library author wrote a first test to check the implementation:
 
-[!code-csharp[TestDefaultImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetTestDefaultImplementation&highlight=SnippetHighlightCast)]
+[!code-csharp[TestDefaultImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetTestDefaultImplementation)]
 
-Notice the highlighted portion of the test. That cast from `SampleCustomer` to `ICustomer` is necessary. The `SampleCustomer` class doesn't need to provide an implementation for `ComputeLoyaltyDiscount`; that's provided by the `ICustomer` interface. However, the `SampleCustomer` class doesn't inherit members from its interfaces. That rule hasn't changed. In order to call any method declared and implemented in the interface, the variable must be the type of the interface, `ICustomer` in this example.
+Notice the following portion of the test:
+
+[!code-csharp[TestDefaultImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetHighlightCast)]
+
+That cast from `SampleCustomer` to `ICustomer` is necessary. The `SampleCustomer` class doesn't need to provide an implementation for `ComputeLoyaltyDiscount`; that's provided by the `ICustomer` interface. However, the `SampleCustomer` class doesn't inherit members from its interfaces. That rule hasn't changed. In order to call any method declared and implemented in the interface, the variable must be the type of the interface, `ICustomer` in this example.
 
 ## Provide parameterization
 
@@ -59,7 +63,7 @@ That's a good start. But, the default implementation is too restrictive. Many co
 
 [!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetLoyaltyDiscountVersionTwo)]
 
-There's many new capabilities shown in that small code fragment. Interfaces can now include static members, including fields and methods. Different access modifiers are also enabled. In the previous example, the additional fields are private, and the new method is public. Any of the modifiers are allowed on interface members.
+There's many new language capabilities shown in that small code fragment. Interfaces can now include static members, including fields and methods. Different access modifiers are also enabled. The additional fields are private, the new method is public. Any of the modifiers are allowed on interface members.
 
 Applications that use the general formula for computing the loyalty discount, but different parameters, don't need to provide a custom implementation; they can set the arguments through a static method. For example, the following code sets a "customer appreciation" that rewards any customer with more than one month's membership:
 
@@ -69,12 +73,14 @@ Applications that use the general formula for computing the loyalty discount, bu
 
 The code you've added so far has provided a convenient implementation for those scenarios where users want something like the default implementation, or to provide an unrelated set of rules. For a final feature, let's refactor the code a bit to enable scenarios where users may want to build on the default implementation. 
 
-Consider a startup that wants to attract new customers. They offer a 50% discount off a new customer's first order. Otherwise, existing customers get the standard discount. A bit of refactoring in the `ICustomer` interface makes this scenerio easy:
+Consider a startup that wants to attract new customers. They offer a 50% discount off a new customer's first order. Otherwise, existing customers get the standard discount. The library author needs to move the default implementation into a `protected static` method so that any class implementing this interface can reuse the code in their implementation. The default implementation of the interface member calls this shared method as well:
 
 [!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetFinalVersion)]
 
-This final version uses a `protected` static method to implement the default algorithm. The public interface method uses that version.  A derived implementation can now extend that default implementation:
+In an implementation of a class that implements this interface, the override can call the static helper method, and extend that logic to provide the "new customer" discount:
 
 [!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/SampleCustomer.cs?name=SnippetOverrideAndExtend)]
+
+You can see the entire finished code in our [samples repo on GitHub](You can get the starter application on our [samples repo on GitHub](https://github.com/dotnet/samples/tree/master/csharp/tutorials/default-interface-members-versions/finished/customer-relationship).
 
 These new features mean that interfaces can be updated safely when there's a reasonable default implementation for those new members. Carefully design interfaces to express single functional ideas that can be implemented by multiple classes. That makes it easier to upgrade those interface definitions when new requirements are discovered for that same functional idea.

--- a/docs/csharp/tutorials/default-interface-members-versions.md
+++ b/docs/csharp/tutorials/default-interface-members-versions.md
@@ -1,7 +1,7 @@
 ---
 title: Safely update interfaces using default interface members in C#
 description: This advanced tutorial explores how you can safely add new capabilities to existing interface definitions without breaking all classes and structs that implement that interface.
-ms.date: 05/02/2019
+ms.date: 05/06/2019
 ms.custom: mvc
 ---
 # Tutorial: Learn how to use default interface members in C# 8 to safely update interface definitions to add functionality to all implementations
@@ -38,6 +38,9 @@ First, add the new method to the implementation:
 ```csharp
 // code
 ```
+
+. Add that it's an explicit interface implementation.
+.. Reason: avoid collisions with existing code.
 
 That's a good start. But, the default implementation is too restrictive. Many consumers of this system may choose different thresholds for number of purchases, or a different percentage discount. You can provide a better upgrade experience for more customers by providing a way to set those parameters. Let's add a static method that sets those two parameters controlling the default implementation:
 

--- a/docs/csharp/tutorials/default-interface-members-versions.md
+++ b/docs/csharp/tutorials/default-interface-members-versions.md
@@ -1,0 +1,55 @@
+---
+title: Safely update interfaces using default interface members in C#
+description: This advanced tutorial explores how you can safely add new capabilities to existing interface definitions without breaking all classes and structs that implement that interface.
+ms.date: 05/02/2019
+ms.custom: mvc
+---
+# Tutorial: Learn how to use default interface members in C# 8 to safely update interface definitions to add functionality to all implementations
+
+Beginning in C# 8 on .NET Core 3.0 you can define an implementation when you declare a member of an interface. The most common scenario is to safely add members to an interface already released and used by innumerable clients.
+
+In this tutorial, you'll learn how to:
+
+> [!div class="checklist"]
+> * Create a data source that generates a sequence of data elements asynchronously.
+> * Consume that data source asynchronously.
+> * Recognize when the new interface and data source are preferred to earlier synchronous data sequences.
+
+## Prerequisites
+
+You’ll need to set up your machine to run .NET Core, including the C# 8.0 beta compiler. The C# 8 beta compiler is available starting with [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019), or the latest [.NET Core 3.0 preview SDK](https://dotnet.microsoft.com/download/dotnet-core/3.0). Async streams are first available in .NET Core 3.0 preview 3.
+
+The starter application models an eCommerce library that defines interfaces that applications implement in the classes that implement their specific business needs. The unit test library exercises the core functionality with a reference implementation of these classes.
+
+## Scenario overview
+
+Now, it's time to upgrade his product for the next release. One of the features requested is to enable a loyalty discount for customers that have lots of orders. This new loyalty discount gets applied whenever a customer makes an order. The system should retrieve any loyalty discount from the customer as part of processing the order. Each implementation of ICustomer can set different rules for the loyalty discount. 
+
+The most natural way to add this functionality is to enhance the `ICustomer` interface with a method to apply any loyalty discount. The problem with that plan is that it break all the existing customers' code. That's a bad experience for the very customers that would use the loyalty discount feature on its initial rollout. If this new functionality were added in the initial release, you would have added it to the ICustomer interface. Each implementation would set their business rules, expressed through the implementation of ICustomer.
+
+## Upgrade with default interface members
+
+If every implementation of ICustomer would use the same rules, you could create an extension method for this new feature. The requirements include letting each implementation set their own rules for loyalty discounts, so that design won't work. There is one implementation that is more likely: a loyalty discount that has a minimum number of orders to be eligible, and provides a constant 
+
+The upgrade should provide the functionality to set two properties: the number of orders needed to be eligible for the discount, and the percentage of the discount. This makes it a perfect scenario for default interface members. You can add a method to the ICustomer interface, and provide the most likely implementation. All existing, and any new implementations can use the default implementation, or provide their own.
+
+First, add the new method to the implementation:
+
+```csharp
+// code
+```
+
+That's a good start. But, the default implementation is too restrictive. Many consumers of this system may choose different thresholds for number of purchases, or a different percentage discount. You can provide a better upgrade experience for more customers by providing a way to set those parameters. Let's add a static method that sets those two parameters controlling the default implementation:
+
+```csharp
+// more code.
+```
+
+Now any customer whose loyalty program depends on those two constants can use this static method to set the parameters of the loyalty program.  Those customers that use different formulas for a loyalty program can still provide their own implementation. For example, here's a version that provides a loyalty discount for shopping on Monday:
+
+```csharp
+// code
+```
+
+These new features mean that interfaces can be updated safely when there is a reasonable default implementation for those new members. You should carefully design interfaces to express single functional ideas that can be implemented by multiple classes. That will make it easier to upgrade those interface definitions when new requirements are discovered for that same funtional idea.
+

--- a/docs/csharp/tutorials/default-interface-members-versions.md
+++ b/docs/csharp/tutorials/default-interface-members-versions.md
@@ -11,48 +11,70 @@ Beginning in C# 8 on .NET Core 3.0 you can define an implementation when you dec
 In this tutorial, you'll learn how to:
 
 > [!div class="checklist"]
-> * Create a data source that generates a sequence of data elements asynchronously.
-> * Consume that data source asynchronously.
-> * Recognize when the new interface and data source are preferred to earlier synchronous data sequences.
+> * Extend interfaces safely by adding methods with implementations.
+> * Create parameterized implementations to provide greater flexibility.
+> * Enable implementers to provide a more specific implementation in the form of an override.
 
 ## Prerequisites
 
-You’ll need to set up your machine to run .NET Core, including the C# 8.0 beta compiler. The C# 8 beta compiler is available starting with [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019), or the latest [.NET Core 3.0 preview SDK](https://dotnet.microsoft.com/download/dotnet-core/3.0). Async streams are first available in .NET Core 3.0 preview 3.
-
-The starter application models an eCommerce library that defines interfaces that applications implement in the classes that implement their specific business needs. The unit test library exercises the core functionality with a reference implementation of these classes.
+You’ll need to set up your machine to run .NET Core, including the C# 8.0 preview compiler. The C# 8 preview compiler is available starting with [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019), or the latest [.NET Core 3.0 preview SDK](https://dotnet.microsoft.com/download/dotnet-core/3.0). Default interface members are available beginning with .NET Core 3.0 preview 4.
 
 ## Scenario overview
 
-Now, it's time to upgrade his product for the next release. One of the features requested is to enable a loyalty discount for customers that have lots of orders. This new loyalty discount gets applied whenever a customer makes an order. The system should retrieve any loyalty discount from the customer as part of processing the order. Each implementation of ICustomer can set different rules for the loyalty discount. 
+This tutorial starts with version 1 of a customer relationship library. The company that built this library intended customers with existing applications to adopt their library. They provided minimal interface definitions for users of their library to implement. They defined an interface with methods for a customer:
 
-The most natural way to add this functionality is to enhance the `ICustomer` interface with a method to apply any loyalty discount. The problem with that plan is that it break all the existing customers' code. That's a bad experience for the very customers that would use the loyalty discount feature on its initial rollout. If this new functionality were added in the initial release, you would have added it to the ICustomer interface. Each implementation would set their business rules, expressed through the implementation of ICustomer.
+[!code-csharp[InitialCustomerInterface](~/samples/csharp/tutorials/default-interface-members-versions/starter/customer-relationship/ICustomer.cs?name=SnippetICustomerVersion1)]
+
+They defined a second interface that represents an order:
+
+[!code-csharp[InitialOrderInterface](~/samples/csharp/tutorials/default-interface-members-versions/starter/customer-relationship/IOrder.cs?name=SnippetIorderVersion1)]
+
+From those interfaces, the team could build a library for their users to create a better experience for their customers. Their goal was to create a deeper relationship with existing customers and improve their relationships with new customers.
+
+Now, it's time to upgrade the library for the next release. One of the requested features enables a loyalty discount for customers that have lots of orders. This new loyalty discount gets applied whenever a customer makes an order. The specific discount is a property of each individual customer. Each implementation of ICustomer can set different rules for the loyalty discount. 
+
+The most natural way to add this functionality is to enhance the `ICustomer` interface with a method to apply any loyalty discount. This design suggestion caused concern among experienced developers: "Interfaces are immutable once they've been released! This is a breaking change!" C# 8.0 adds *default interface implementations* for scenarios like these. The library authors can add new members to the interface and provide a default implementation for those members.
+
+Default interface implementations enable developers to upgrade an interface while still enabling any implementors to override that implementation. Users of the library can accept the default implementation as a non-breaking change. If their business rules are different, they can override.
 
 ## Upgrade with default interface members
 
-If every implementation of ICustomer would use the same rules, you could create an extension method for this new feature. The requirements include letting each implementation set their own rules for loyalty discounts, so that design won't work. There is one implementation that is more likely: a loyalty discount that has a minimum number of orders to be eligible, and provides a constant 
+The team agreed on the most likely default implementation: a loyalty discount for customers 
 
 The upgrade should provide the functionality to set two properties: the number of orders needed to be eligible for the discount, and the percentage of the discount. This makes it a perfect scenario for default interface members. You can add a method to the ICustomer interface, and provide the most likely implementation. All existing, and any new implementations can use the default implementation, or provide their own.
 
 First, add the new method to the implementation:
 
-```csharp
-// code
-```
+[!code-csharp[InitialOrderInterface](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetLoyaltyDiscountVersionOne)]
 
-. Add that it's an explicit interface implementation.
-.. Reason: avoid collisions with existing code.
+The library author wrote a first test to check the implementation:
 
-That's a good start. But, the default implementation is too restrictive. Many consumers of this system may choose different thresholds for number of purchases, or a different percentage discount. You can provide a better upgrade experience for more customers by providing a way to set those parameters. Let's add a static method that sets those two parameters controlling the default implementation:
+[!code-csharp[TestDefaultImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetTestDefaultImplementation&highlight=SnippetHighlightCast)]
 
-```csharp
-// more code.
-```
+Notice the highlighted portion of the test. That cast from `SampleCustomer` to `ICustomer` is necessary. The `SampleCustomer` class does not need to provide an implementation for `ComputeLoyaltyDiscount`; that's provided by the `ICustomer` interface. However, the `SampleCustomer` class does not inherit members from its interfaces. That hasn't changed. In order to call any method declared and implemented in the interface, the variable must be the type of the interface, `ICustomer` in this example.
 
-Now any customer whose loyalty program depends on those two constants can use this static method to set the parameters of the loyalty program.  Those customers that use different formulas for a loyalty program can still provide their own implementation. For example, here's a version that provides a loyalty discount for shopping on Monday:
+## Provide parameterization
 
-```csharp
-// code
-```
+That's a good start. But, the default implementation is too restrictive. Many consumers of this system may choose different thresholds for number of purchases, a different length of membership, or a different percentage discount. You can provide a better upgrade experience for more customers by providing a way to set those parameters. Let's add a static method that sets those three parameters controlling the default implementation:
 
-These new features mean that interfaces can be updated safely when there is a reasonable default implementation for those new members. You should carefully design interfaces to express single functional ideas that can be implemented by multiple classes. That will make it easier to upgrade those interface definitions when new requirements are discovered for that same funtional idea.
+[!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetLoyaltyDiscountVersionTwo)]
 
+There's a lot of new capabilities shown in that small code fragment. Interfaces can now include static members, including fields and methods. Different access modifiers are also enabled. In the previous example, the additional fields are private, and the new method is public. Any of the modifiers are allowed on interface members.
+
+Applications that use the general formula for computing the loyalty discount, but different parameters don't need to provide a custom implementation; they can set the arguments through a static method. For example, the following code sets a "customer appreciation" that rewards any customer with more than one month's membership:
+
+[!code-csharp[SetLoyaltyThresholds](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/Program.cs?name=SnippetSetLoyaltyThresholds)]
+
+## Extend the default implementation
+
+The code you've added so far has provided a convenient implementation for those scenarios where users want something like the default implementation, or to provide an unrelated set of rules. For a final feature, let's refactor the code a bit to enable scenarios where users may want to build on the default implementation. 
+
+Consider a startup that wants to attract new customers. They will offer a 50% discount off a new customer's first order. Otherwise, existing customers get the standard discount. A bit of refactoring in the `ICustomer` interface makes this possible:
+
+[!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/ICustomer.cs?name=SnippetFinalVersion)]
+
+This final version uses a `protected` static method to implement the default algorithm. The public interface method uses that version.  A derived implementation can now extend that default implementation:
+
+[!code-csharp[VersionTwoImplementation](~/samples/csharp/tutorials/default-interface-members-versions/finished/customer-relationship/SampleCustomer.cs?name=SnippetOverrideAndExtend)]
+
+These new features mean that interfaces can be updated safely when there is a reasonable default implementation for those new members. You should carefully design interfaces to express single functional ideas that can be implemented by multiple classes. That will make it easier to upgrade those interface definitions when new requirements are discovered for that same functional idea.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -533,6 +533,8 @@
       href: csharp/tutorials/exploration/interpolated-strings-local.md
     - name: Advanced scenarios for string Interpolation
       href: csharp/tutorials/string-interpolation.md
+    - name: Safely update interfaces with default interface members
+      href: csharp/tutorials/default-interface-members-versions.md
     - name: Explore indexes and ranges
       href: csharp/tutorials/ranges-indexes.md
     - name: Work with nullable reference types


### PR DESCRIPTION
Fixes #11604 

This relies on the samples in dotnet/samples#888

According to one of our site engineers, highlighting code using named snippets is currently supported. I'm testing that in this PR.

[internal review link](https://review.docs.microsoft.com/en-us/dotnet/csharp/tutorials/default-interface-members-versions?branch=pr-en-us-12241)

