### PR TITLE
Add plugin tutorial to toc

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -164,6 +164,8 @@
       href: core/tutorials/with-visual-studio.md
     - name: Build a Visual Basic Hello World app with .NET Core in Visual Studio 2017
       href: core/tutorials/vb-with-visual-studio.md
+    - name: Create a .NET Core application with plugins
+      href: core/tutorials/creating-app-with-plugin-support.md
     - name: Debug your C# or Visual Basic .NET Core Hello World application using Visual Studio 2017
       href: core/tutorials/debugging-with-visual-studio.md
     - name: Publish your Hello World application with Visual Studio 2017


### PR DESCRIPTION
I forgot to add the plugin tutorial to the Table of Contents when I created it.

Contributes to #12184 
