### PR TITLE
Remove references to ".NET Framework on Docker Guide"

### DIFF
--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -23,7 +23,7 @@ The .NET Framework provides many services, including memory management, type and
 
 For a general introduction to the .NET Framework for both users and developers, see [Getting Started](./get-started/index.md). For an introduction to the architecture and key features of the .NET Framework, see the [overview](./get-started/overview.md).
 
-The .NET Framework can be used with Docker and with [Windows Containers](/virtualization/windowscontainers/about/). See [Deploying .NET Framework applications with Docker](./docker/index.md) to learn how to run your applications in Docker containers.
+The .NET Framework can be used with Docker and with [Windows Containers](/virtualization/windowscontainers/about/).
 
 ## Installation
 
@@ -46,9 +46,6 @@ Provides resources and guidance about .NET Framework installation and troublesho
 
 * [Migration Guide](./migration-guide/index.md)  
 Provides resources and a list of changes you need to consider if you're migrating your application to a new version of the .NET Framework.
-
-* [.NET Framework on Docker Guide](./docker/index.md)  
-Provides resources to run .NET Framework applications with Docker, using Windows Containers.
 
 * [Development Guide](./development-guide.md)  
 Provides a guide to all key technology areas and tasks for application development, including creating, configuring, debugging, securing, and deploying your application, and information about dynamic programming, interoperability, extensibility, memory management, and threading.

--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -102,6 +102,6 @@ Some Microsoft or third-party platforms don’t support .NET Core. Some Azure se
 - [Target frameworks](frameworks.md)
 - [.NET Core Guide](../core/index.md)
 - [Porting from .NET Framework to .NET Core](../core/porting/index.md)
-- [.NET Framework on Docker Guide](../framework/docker/index.md)
+- [Introduction to .NET and Docker](../core/docker/index.md)
 - [.NET Components Overview](components.md)
 - [.NET Microservices. Architecture for Containerized .NET Applications](microservices-architecture/index.md)

--- a/docs/standard/choosing-core-framework-server.md
+++ b/docs/standard/choosing-core-framework-server.md
@@ -102,6 +102,6 @@ Some Microsoft or third-party platforms don’t support .NET Core. Some Azure se
 - [Target frameworks](frameworks.md)
 - [.NET Core Guide](../core/index.md)
 - [Porting from .NET Framework to .NET Core](../core/porting/index.md)
-- [Introduction to .NET and Docker](../core/docker/index.md)
+- [Introduction to .NET and Docker](../core/docker/intro-net-docker.md)
 - [.NET Components Overview](components.md)
 - [.NET Microservices. Architecture for Containerized .NET Applications](microservices-architecture/index.md)

--- a/docs/standard/get-started.md
+++ b/docs/standard/get-started.md
@@ -27,4 +27,4 @@ There are a number of ways to get started with .NET. Because .NET is a massive p
 
 ## Get started using Docker on .NET Core
 
-[Introduction to .NET and Docker](../core/docker/index.md) shows how you can use .NET Core on Windows Docker containers.
+[Introduction to .NET and Docker](../core/docker/intro-net-docker.md) shows how you can use .NET Core on Windows Docker containers.

--- a/docs/standard/get-started.md
+++ b/docs/standard/get-started.md
@@ -25,6 +25,6 @@ There are a number of ways to get started with .NET. Because .NET is a massive p
 
 * The [.NET Core Tutorials](../core/tutorials/index.md) detail a number of ways you can get started with .NET Core using your operating system and tooling of choice.
 
-## Get started using Docker on .NET Framework
+## Get started using Docker on .NET Core
 
-[Docker on .NET Framework](../framework/docker/index.md) shows how you can use .NET Framework on Windows Docker containers.
+[Introduction to .NET and Docker](../core/docker/index.md) shows how you can use .NET Core on Windows Docker containers.

--- a/docs/standard/get-started.md
+++ b/docs/standard/get-started.md
@@ -25,6 +25,6 @@ There are a number of ways to get started with .NET. Because .NET is a massive p
 
 * The [.NET Core Tutorials](../core/tutorials/index.md) detail a number of ways you can get started with .NET Core using your operating system and tooling of choice.
 
-## Get started using Docker on .NET Core
+## Get started using .NET Core on Docker
 
 [Introduction to .NET and Docker](../core/docker/intro-net-docker.md) shows how you can use .NET Core on Windows Docker containers.

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/net-framework-container-scenarios.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/net-framework-container-scenarios.md
@@ -54,7 +54,7 @@ In the meantime, if any platform or service in Azure still doesn't support .NET 
     [https://docs.microsoft.com/dotnet/core/porting/index](../../../core/porting/index.md)
 
 - **.NET Core on Docker Guide**
-    [https://docs.microsoft.com/dotnet/framework/docker/](../../../core/docker/index.md)
+    [https://docs.microsoft.com/dotnet/core/docker/intro-net-docker](../../../core/docker/intro-net-docker.md)
 
 - **.NET Components Overview**  
     [https://docs.microsoft.com/dotnet/standard/components](../../components.md)

--- a/docs/standard/microservices-architecture/net-core-net-framework-containers/net-framework-container-scenarios.md
+++ b/docs/standard/microservices-architecture/net-core-net-framework-containers/net-framework-container-scenarios.md
@@ -53,8 +53,8 @@ In the meantime, if any platform or service in Azure still doesn't support .NET 
 - **Porting from .NET Framework to .NET Core**  
     [https://docs.microsoft.com/dotnet/core/porting/index](../../../core/porting/index.md)
 
-- **.NET Framework on Docker Guide**  
-    [https://docs.microsoft.com/dotnet/framework/docker/](../../../framework/docker/index.md)
+- **.NET Core on Docker Guide**
+    [https://docs.microsoft.com/dotnet/framework/docker/](../../../core/docker/index.md)
 
 - **.NET Components Overview**  
     [https://docs.microsoft.com/dotnet/standard/components](../../components.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -434,11 +434,6 @@
     href: framework/install/
   - name: Migration Guide
     href: framework/migration-guide/
-  - name: .NET Framework on Docker Guide
-    href: framework/docker/index.md
-    items:
-    - name: Running Console Apps in Containers
-      href: framework//docker/console.md
   - name: Development Guide
     href: framework/development-guide.md
     items:


### PR DESCRIPTION
The "NET Framework docker content" was removed in #12032. This PR removes references to this content.

Fixes #12286