### PR TITLE
Fix link to interactive version table

### DIFF
--- a/includes/net-standard-table.md
+++ b/includes/net-standard-table.md
@@ -16,7 +16,7 @@
 - The columns represent .NET Standard versions. Each header cell is a link to a document that shows which APIs got added in that version of .NET Standard.
 - The rows represent the different .NET implementations.
 - The version number in each cell indicates the *minimum* version of the implementation you'll need in order to target that .NET Standard version.
-- For an interactive table, see [.NET Standard versions](https://immo.landwerth.net/netstandard-versions/#).
+- For an interactive table, see [.NET Standard versions](https://dotnet.microsoft.com/platform/dotnet-standard#versions).
 
 [1.0]: https://github.com/dotnet/standard/blob/master/docs/versions/netstandard1.0.md
 [1.1]: https://github.com/dotnet/standard/blob/master/docs/versions/netstandard1.1.md


### PR DESCRIPTION
This updates the link to point to the official version created by @rowanmiller.

Fixes #7784 