### PR TITLE
fixed keyword: minor edits

### DIFF
--- a/docs/csharp/language-reference/keywords/fixed-statement.md
+++ b/docs/csharp/language-reference/keywords/fixed-statement.md
@@ -11,13 +11,13 @@ helpviewer_keywords:
 ---
 # fixed Statement (C# Reference)
 
-The `fixed` statement prevents the garbage collector from relocating a movable variable. The `fixed` statement is only permitted in an [unsafe](unsafe.md) context. `fixed` can also be used to create [fixed size buffers](../../programming-guide/unsafe-code-pointers/fixed-size-buffers.md).
+The `fixed` statement prevents the garbage collector from relocating a movable variable. The `fixed` statement is only permitted in an [unsafe](unsafe.md) context. You can also use the `fixed` keyword to create [fixed size buffers](../../programming-guide/unsafe-code-pointers/fixed-size-buffers.md).
 
 The `fixed` statement sets a pointer to a managed variable and "pins" that variable during the execution of the statement. Pointers to movable managed variables are useful only in a `fixed` context. Without a `fixed` context, garbage collection could relocate the variables unpredictably. The C# compiler only lets you assign a pointer to a managed variable in a `fixed` statement.
 
 [!code-csharp[Accessing fixed memory](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#1)]
 
-You can initialize a pointer by using an array, a string, a fixed-size buffer, or the address of a variable. The following example illustrates the use of variable addresses, arrays, and strings. For more information about fixed-size buffers, see [Fixed Size Buffers](../../programming-guide/unsafe-code-pointers/fixed-size-buffers.md).
+You can initialize a pointer by using an array, a string, a fixed-size buffer, or the address of a variable. The following example illustrates the use of variable addresses, arrays, and strings:
 
 [!code-csharp[Initializing fixed size buffers](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#2)]
 
@@ -58,7 +58,7 @@ fixed (byte* ps = srcarray, pd = dstarray)
 }
 ```
 
-In unsafe mode, you can allocate memory on the stack, where it is not subject to garbage collection and therefore does not need to be pinned. For more information, see [stackalloc](stackalloc.md).
+You can allocate memory on the stack, where it is not subject to garbage collection and therefore does not need to be pinned. For more information, see [stackalloc](stackalloc.md).
 
 [!code-csharp[Initializing multiple pointers](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#4)]
 


### PR DESCRIPTION
Two changes:
- Remove the duplicate link to the fixed size buffers article from the middle of the article. First, it's mentioned in the first paragraph. Second, in the middle, it was just in-between the example intro and the example itself.
- Remove details about `stackalloc`. Now, with `Span<T>`, `stackalloc` can be used in safe blocks, `unsafe` not always required. The `stackalloc` article describes that, so I've just removed not precise info, rather that describe a new behavior.
