### PR TITLE
Tour of C#: reference numeric types tables

### DIFF
--- a/docs/csharp/tour-of-csharp/types-and-variables.md
+++ b/docs/csharp/tour-of-csharp/types-and-variables.md
@@ -18,8 +18,8 @@ The following provides an overview of C#’s type system.
     * Signed integral: `sbyte`, `short`, `int`, `long`
     * Unsigned integral: `byte`, `ushort`, `uint`, `ulong`
     * Unicode characters: `char`
-    * IEEE floating point: `float`, `double`
-    * High-precision decimal: `decimal`
+    * IEEE binary floating-point: `float`, `double`
+    * High-precision decimal floating-point: `decimal`
     * Boolean: `bool`
   - [Enum types][EnumTypes]
     * User-defined types of the form `enum E {...}`
@@ -50,33 +50,11 @@ The following provides an overview of C#’s type system.
 [DelegateTypes]: ../language-reference/keywords/delegate.md
 [ArrayTypes]: ../programming-guide/arrays/index.md
 
-The eight integral types provide support for 8-bit, 16-bit, 32-bit, and 64-bit values in signed or unsigned form.
-
-The two floating-point types, `float` and `double`, are represented using the 32-bit single-precision and 64-bit double-precision IEC-60559 formats, respectively.
-
-The `decimal` type is a 128-bit data type suitable for financial and monetary calculations.
+For more information about numeric types, see [Integral types table](../language-reference/keywords/integral-types-table.md) and [Floating-point types table](../language-reference/keywords/floating-point-types-table.md).
 
 C#’s `bool` type is used to represent Boolean values—values that are either `true` or `false`.
 
 Character and string processing in C# uses Unicode encoding. The `char` type represents a UTF-16 code unit, and the `string` type represents a sequence of UTF-16 code units.
-
-This summarizes C#’s numeric types.
-
-* Signed Integral
-  - `sbyte`:  8 bits, range from -128 to 127
-  - `short`: 16 bits, range from -32,768 to 32,767
-  - `int`  : 32 bits, range from -2,147,483,648 to 2,147,483,647
-  - `long` : 64 bits, range from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
-* Unsigned integral
-  - `byte`   :  8 bits, range from 0 to 255
-  - `ushort` : 16 bits, range from 0 to 65,535
-  - `uint`   : 32 bits, range from 0 to 4,294,967,295
-  - `ulong`  : 64 bits, range from 0 to 18,446,744,073,709,551,615
-* Floating point
-  - `float`  : 32 bits, range from 1.5 × 10<sup>-45</sup> to 3.4 × 10<sup>38</sup>,    7-digit precision
-  - `double` : 64 bits, range from 5.0 × 10<sup>-324</sup> to 1.7 × 10<sup>308</sup>, 15-digit precision
-* Decimal
-  - `decimal` : 128 bits, range is at least -7.9 × 10<sup>-28</sup> to 7.9 × 10<sup>28</sup>, with at least 28-digit precision
 
 C# programs use *type declarations* to create new types. A type declaration specifies the name and the members of the new type. Five of C#’s categories of types are user-definable: class types, struct types, interface types, enum types, and delegate types.
 


### PR DESCRIPTION
Rather than duplicate, let's use existing reference material.
Fixes #9904

