### PR TITLE
Corrected length of result string with 'X'

### DIFF
--- a/docs/standard/base-types/enumeration-format-strings.md
+++ b/docs/standard/base-types/enumeration-format-strings.md
@@ -42,7 +42,7 @@ Displays the enumeration entry as an integer value in the shortest representatio
 
 ## X or x
 
-Displays the enumeration entry as a hexadecimal value. The value is represented with leading zeros as necessary, to ensure that the value is a minimum eight digits in length. The following example illustrates the X format specifier.
+Displays the enumeration entry as a hexadecimal value. The value is represented with leading zeros as necessary, to ensure that the result string has two digits for each byte in the enumeration type's [underlying numeric type](xref:System.Enum.GetUnderlyingType%2A). The following example illustrates the X format specifier. In the example, the underlying type of both <xref:System.ConsoleColor> and <xref:System.IO.FileAttributes> is <xref:System.Int32>, or a 32-bit (or 4-byte) integer, which produces an 8-digit result string.
 
 [!code-csharp[Formatting.Enum#4](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.Enum/cs/enum1.cs#4)]      
 [!code-vb[Formatting.Enum#4](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Enum/vb/enum1.vb#4)]

--- a/docs/standard/base-types/enumeration-format-strings.md
+++ b/docs/standard/base-types/enumeration-format-strings.md
@@ -42,7 +42,7 @@ Displays the enumeration entry as an integer value in the shortest representatio
 
 ## X or x
 
-Displays the enumeration entry as a hexadecimal value. The value is represented with leading zeros as necessary, to ensure that the result string has two digits for each byte in the enumeration type's [underlying numeric type](xref:System.Enum.GetUnderlyingType%2A). The following example illustrates the X format specifier. In the example, the underlying type of both <xref:System.ConsoleColor> and <xref:System.IO.FileAttributes> is <xref:System.Int32>, or a 32-bit (or 4-byte) integer, which produces an 8-digit result string.
+Displays the enumeration entry as a hexadecimal value. The value is represented with leading zeros as necessary, to ensure that the result string has two characters for each byte in the enumeration type's [underlying numeric type](xref:System.Enum.GetUnderlyingType%2A). The following example illustrates the X format specifier. In the example, the underlying type of both <xref:System.ConsoleColor> and <xref:System.IO.FileAttributes> is <xref:System.Int32>, or a 32-bit (or 4-byte) integer, which produces an 8-digit result string.
 
 [!code-csharp[Formatting.Enum#4](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.Enum/cs/enum1.cs#4)]      
 [!code-vb[Formatting.Enum#4](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Enum/vb/enum1.vb#4)]

--- a/docs/standard/base-types/enumeration-format-strings.md
+++ b/docs/standard/base-types/enumeration-format-strings.md
@@ -42,7 +42,7 @@ Displays the enumeration entry as an integer value in the shortest representatio
 
 ## X or x
 
-Displays the enumeration entry as a hexadecimal value. The value is represented with leading zeros as necessary, to ensure that the result string has two characters for each byte in the enumeration type's [underlying numeric type](xref:System.Enum.GetUnderlyingType%2A). The following example illustrates the X format specifier. In the example, the underlying type of both <xref:System.ConsoleColor> and <xref:System.IO.FileAttributes> is <xref:System.Int32>, or a 32-bit (or 4-byte) integer, which produces an 8-digit result string.
+Displays the enumeration entry as a hexadecimal value. The value is represented with leading zeros as necessary, to ensure that the result string has two characters for each byte in the enumeration type's [underlying numeric type](xref:System.Enum.GetUnderlyingType%2A). The following example illustrates the X format specifier. In the example, the underlying type of both <xref:System.ConsoleColor> and <xref:System.IO.FileAttributes> is <xref:System.Int32>, or a 32-bit (or 4-byte) integer, which produces an 8-character result string.
 
 [!code-csharp[Formatting.Enum#4](~/samples/snippets/csharp/VS_Snippets_CLR/Formatting.Enum/cs/enum1.cs#4)]      
 [!code-vb[Formatting.Enum#4](~/samples/snippets/visualbasic/VS_Snippets_CLR/Formatting.Enum/vb/enum1.vb#4)]


### PR DESCRIPTION
## Corrected length of result string with 'X'

Fixes #12414 

