### PR TITLE
Corrected info about < > symbols

### DIFF
--- a/docs/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
+++ b/docs/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments.md
@@ -30,12 +30,13 @@ The C# compiler processes documentation comments in your code and formats them a
   
  (* denotes that the compiler verifies syntax.)  
   
- If you want angle brackets to appear in the text of a documentation comment, use `<` and `>`, as shown in the following example.  
+ If you want angle brackets to appear in the text of a documentation comment, use the HTML encoding of `<` and `>` which is `&lt;` and `&gt;` respectively. This encoding is shown in the following example:
   
 ```csharp  
-/// <summary cref="C < T >">  
-/// </summary>  
-```  
+/// <summary>
+/// This property always returns a value &lt; 1.
+/// </summary>
+```
   
 ## See also
 


### PR DESCRIPTION
## Summary

Changed the < > to `&lt;` and `&gt;`.

Fixes #8846 
