### PR TITLE
 The term  'default ' should be used with or instead of 'null'

### DIFF
--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -49,7 +49,7 @@ A class can provide methods or properties that enable you to avoid making a call
 [!code-csharp[Conceptual.Exception.Handling#5](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.exception.handling/cs/source.cs#5)]
 [!code-vb[Conceptual.Exception.Handling#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.exception.handling/vb/source.vb#5)]
 
-Another way to avoid exceptions is to return `null` for extremely common error cases instead of throwing an exception. An extremely common error case can be considered normal flow of control. By returning `null` in these cases, you minimize the performance impact to an app.
+Another way to avoid exceptions is to return `null` or `default` for extremely common error cases instead of throwing an exception. An extremely common error case can be considered normal flow of control. By returning `null` or `default` in these cases, you minimize the performance impact to an app.
 
 ## Throw exceptions instead of returning an error code
 

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -49,7 +49,9 @@ A class can provide methods or properties that enable you to avoid making a call
 [!code-csharp[Conceptual.Exception.Handling#5](../../../samples/snippets/csharp/VS_Snippets_CLR/conceptual.exception.handling/cs/source.cs#5)]
 [!code-vb[Conceptual.Exception.Handling#5](../../../samples/snippets/visualbasic/VS_Snippets_CLR/conceptual.exception.handling/vb/source.vb#5)]
 
-Another way to avoid exceptions is to return `null` or `default` for extremely common error cases instead of throwing an exception. An extremely common error case can be considered normal flow of control. By returning `null` or `default` in these cases, you minimize the performance impact to an app.
+Another way to avoid exceptions is to return null (or default) for extremely common error cases instead of throwing an exception. An extremely common error case can be considered normal flow of control. By returning null (or default) in these cases, you minimize the performance impact to an app.
+
+For value types, whether to use Nullable<T> or default as your error indicator is something to consider for your particular app. By using `Nullable<Guid>`, `default` becomes `null` instead of `Guid.Empty`. Some times, adding `Nullable<T>` can make it clearer when a value is present or absent. Other times, adding `Nullable<T>` can create extra cases to check that aren't necessary, and only serve to create potential sources of errors. 
 
 ## Throw exceptions instead of returning an error code
 


### PR DESCRIPTION
A developer I was talking with felt this article was pushing for the use of only types that are nullable. In order to clarify 'default' should also be included so no one sees this as a reason to forbid structs, primitive types, ect...

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
