### PR TITLE
Add a note about the point-in-time concern with VS and the CLI

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -65,7 +65,7 @@ The nullable annotation context and nullable warning context can be set for a pr
 - `safeonlywarnings`: The nullable annotation context is **disabled**. The nullable warning context is **safeonly**.
   - Variables of a reference type are oblivious. All safety nullability warnings are enabled.
 
-> [!NOTE]
+> [!IMPORTANT]
 > The `Nullable` element was previously named `NullableContextOptions`. The rename ships with Visual Studio 2019, 16.2-p1. The .NET Core SDK 3.0.100-preview5-011568 does not have this change. If you are using the .NET Core CLI, you'll need to use `NullableContextOptions` until the next preview is available.
 
 You can also use directives to set these same contexts anywhere in your project:

--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -65,6 +65,9 @@ The nullable annotation context and nullable warning context can be set for a pr
 - `safeonlywarnings`: The nullable annotation context is **disabled**. The nullable warning context is **safeonly**.
   - Variables of a reference type are oblivious. All safety nullability warnings are enabled.
 
+> [!NOTE]
+> The `Nullable` element was previously named `NullableContextOptions`. The rename ships with Visual Studio 2019, 16.2-p1. The .NET Core SDK 3.0.100-preview5-011568 does not have this change. If you are using the .NET Core CLI, you'll need to use `NullableContextOptions` until the next preview is available.
+
 You can also use directives to set these same contexts anywhere in your project:
 
 - `#nullable enable`: Sets the nullable annotation context and nullable warning context to **enabled**.

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -38,6 +38,9 @@ Create a new console application either in Visual Studio or from the command lin
 ```
 
 > [!NOTE]
+> The `Nullable` element was previously named `NullableContextOptions`. The rename ships with Visual Studio 2019, 16.2-p1. The .NET Core SDK 3.0.100-preview5-011568 does not have this change. If you are using the .NET Core CLI, you'll need to use `NullableContextOptions` until the next preview is available.
+
+> [!NOTE]
 > When C# 8 is released (not in preview mode), the `Nullable` element will be added by new project templates. Until then, you'll need to add it manually.
 
 ### Design the types for the application

--- a/docs/csharp/tutorials/nullable-reference-types.md
+++ b/docs/csharp/tutorials/nullable-reference-types.md
@@ -37,7 +37,7 @@ Create a new console application either in Visual Studio or from the command lin
 <Nullable>enable</Nullable>
 ```
 
-> [!NOTE]
+> [!IMPORTANT]
 > The `Nullable` element was previously named `NullableContextOptions`. The rename ships with Visual Studio 2019, 16.2-p1. The .NET Core SDK 3.0.100-preview5-011568 does not have this change. If you are using the .NET Core CLI, you'll need to use `NullableContextOptions` until the next preview is available.
 
 > [!NOTE]

--- a/docs/csharp/tutorials/upgrade-to-nullable-references.md
+++ b/docs/csharp/tutorials/upgrade-to-nullable-references.md
@@ -45,6 +45,8 @@ A good next step is to turn on the nullable annotation context and see how many 
 ```xml
 <Nullable>enable</Nullable>
 ```
+> [!NOTE]
+> The `Nullable` element was previously named `NullableContextOptions`. The rename ships with Visual Studio 2019, 16.2-p1. The .NET Core SDK 3.0.100-preview5-011568 does not have this change. If you are using the .NET Core CLI, you'll need to use `NullableContextOptions` until the next preview is available.
 
 Do a test build, and notice the warning list. In this small application, the compiler generates five warnings, so it's likely you'd leave the nullable annotation context enabled and start fixing warnings for the entire project.
 

--- a/docs/csharp/tutorials/upgrade-to-nullable-references.md
+++ b/docs/csharp/tutorials/upgrade-to-nullable-references.md
@@ -45,7 +45,8 @@ A good next step is to turn on the nullable annotation context and see how many 
 ```xml
 <Nullable>enable</Nullable>
 ```
-> [!NOTE]
+
+> [!IMPORTANT]
 > The `Nullable` element was previously named `NullableContextOptions`. The rename ships with Visual Studio 2019, 16.2-p1. The .NET Core SDK 3.0.100-preview5-011568 does not have this change. If you are using the .NET Core CLI, you'll need to use `NullableContextOptions` until the next preview is available.
 
 Do a test build, and notice the warning list. In this small application, the compiler generates five warnings, so it's likely you'd leave the nullable annotation context enabled and start fixing warnings for the entire project.


### PR DESCRIPTION
The .NET SDK CLI does not yet include the rename from NullableContextOptions to Nullable.

See https://github.com/dotnet/docs/pull/12497#issuecomment-495242895

/cc @rainersigwald 