### PR TITLE
Update max exploration time default

### DIFF
--- a/docs/machine-learning/reference/ml-net-cli-reference.md
+++ b/docs/machine-learning/reference/ml-net-cli-reference.md
@@ -223,7 +223,7 @@ In order to use the `--label-column-name` argument, you need to have a header in
 
 `--max-exploration-time | -x` (string)
 
-By default, the maximum exploration time is 10 seconds.
+By default, the maximum exploration time is 30 minutes.
 
 This argument sets the maximum time (in seconds) for the process to explore multiple trainers and configurations. The configured time may be exceeded if the provided time is too short (say 2 seconds) for a single iteration. In this case, the actual time is the required time to produce one model configuration in a single iteration.
 


### PR DESCRIPTION
The doc mentions that the default maximum exploration time is 10 seconds, however [the code for this option](https://github.com/dotnet/machinelearning/blob/fac974daaec029b732802c1d0802818a27ab37be/src/mlnet/Commands/CommandDefinitions.cs#L88-L90) has it as 30 minutes.

```csharp
Option MaxExplorationTime() =>
  Option(new List<string>() { "--max-exploration-time", "-x" }, "Maximum time in seconds for 
  exploring models with best configuration.",Argument<uint>(defaultValue: 60*30));
```

Updating the doc to reflect the default value that's in the code.

[AB#1536261](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1536261)
