### PR TITLE
Update global-tools.md

### DIFF
--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -18,7 +18,7 @@ ms.date: 06/15/2019
 `aspnet-codegenerator` is a [global tool](global-tools.md) that must be installed. The following command installs the latest stable version of the `aspnet-codegenerator` tool:
 
 ```console
-dotnet tool install --g dotnet-aspnet-codegenerator
+dotnet tool install -g aspnet-codegenerator
 ```
 
 The following command updates `aspnet-codegenerator` to the latest stable version available from the installed .NET Core SDKs:

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -90,9 +90,16 @@ Specifies the path of the project file to run (folder name or full path). If not
 
 ### controller options
 
-The following table lists the `aspnet-codegenerator controller` options:
+The following table lists options for  `aspnet-codegenerator` `controller` and `razorpage`:
 
-[!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)] | --controllerName or -name | Name of the controller. |
+[!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)]
+
+The following table lists options unique to  `aspnet-codegenerator controller`:
+
+| Option               | Description|
+| ----------------- | ------------ |
+
+| --controllerName or -name | Name of the controller. |
 | --useAsyncActions or -async | Generate async controller actions. |
 | --noViews or -nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |
 | --restWithNoViews or -api  | Generate a Controller with REST style API. `noViews` is assumed and any view related options are ignored. |
@@ -103,3 +110,5 @@ Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 ```console
 dotnet aspnet-codegenerator controller -h
 ```
+
+See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of using `aspnet-codegenerator controller`

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -118,4 +118,51 @@ Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 dotnet aspnet-codegenerator controller -h
 ```
 
-See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of using `aspnet-codegenerator controller`
+See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of using `dotnet aspnet-codegenerator controller`.
+
+### Razorpage options
+
+#### Razorpage generator arguments
+
+Razor Pages can be individually scaffolded by specifying the name of the new page and the template to use. The supported templates are:
+
+* `Empty`
+* `Create`
+* `Edit`
+* `Delete`
+* `Details`
+* `List`
+
+For example, the following command uses the Edit template to generate *MyEdit.cshtml* and *MyEdit.cshtml.cs*:
+
+```console
+dotnet aspnet-codegenerator razorpage MyEdit Edit -m Movie -dc RazorPagesMovieContext -outDir Pages\Movies
+```
+
+Typically, the template and generated file name is not specified, and the following templates are created:
+
+* `Create`
+* `Edit`
+* `Delete`
+* `Details`
+* `List`
+
+The following table lists options for  `aspnet-codegenerator` `razorpage` and `controller`:
+
+[!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)]
+
+The following table lists options unique to  `aspnet-codegenerator razorpage`:
+
+| Option               | Description|
+| ----------------- | ------------ |
+|   --namespaceName or -namespace | The name of the namespace to use for the generated PageModel |
+| --partialView or -partial | Generate a partial view. Layout options -l and -udl are ignored if this is specified. |
+| --noPageModel or -npm | Switch to not generate a PageModel class for Empty template |
+
+Use the `-h` switch for help on the `aspnet-codegenerator razorpage` command:
+
+```console
+dotnet aspnet-codegenerator razorpage -h
+```
+
+See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of using `dotnet aspnet-codegenerator razorpage`.

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -7,11 +7,9 @@ ms.date: 06/15/2019
 ---
 # dotnet aspnet-codegenerator
 
-[!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
-
-## Name
-
 `dotnet aspnet-codegenerator` - Runs the ASP.NET Core scaffolding engine.
+
+[!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
 
 ## Installing aspnet-codegenerator
 

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -7,7 +7,7 @@ ms.date: 06/15/2019
 
 https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model
 
-[!INCLUDE [topic-appliesto-net-core-all](../../../includes/topic-appliesto-net-core-all.md)]
+[!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
 
 ## Name
 
@@ -29,21 +29,10 @@ dotnet tool update -g aspnet-codegenerator
 
 ## Synopsis
 
-# [.NET Core 2.1](#tab/netcore21)
-
 ```
 dotnet aspnet-codegenerator [arguments] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
 dotnet aspnet-codegenerator [-h|--help]
 ```
-
-# [.NET Core 2.2](#tab/netcore22)
-
-```
-dotnet aspnet-codegenerator [arguments] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
-dotnet aspnet-codegenerator [-h|--help]
-```
-
----
 
 ## Description
 
@@ -57,33 +46,48 @@ The code generator to run. The following generators are available:
 
 | Generator | Operation |
 | ----------------- | ------------ | 
-| area      | Generates an MVC Area |
+| area      | Generates an [Area](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/areas?view=aspnetcore-2.2) |
   controller| [Scaffolds a controller](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) |
   identity  | [Scaffolds Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.2&tabs=netcore-cli) |
   razorpage | [Scaffolds Razor Pages](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code) |
-  view      | Generates a view |
-
+  view      | Generates a [view](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/overview?view=aspnetcore-2.2) |
 
 ## Options
 
-# [.NET Core 2.1](#tab/netcore21)
+**`-n|--nuget-package-dir`**
 
-dotnet aspnet-codegenerator [arguments] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
+Specifies the NuGet package directory.
 
-`-h|--help`
+**`-c|--configuration {Debug|Release}`**
+
+  Defines the build configuration. The default value is `Debug`.
+
+**`-tfm|--target-framework`**
+
+Target [Framework](../../standard/frameworks.md) to use. For example, `net46`.
+
+<!-- REVIEW: Is this specified on the command line or in the project file? -->
+
+**`-b|--build-base-path`**
+
+The build base path.
+
+**`-h|--help`**
 
 Prints out a short help for the command.
 
-`--no-build`
+**`--no-build`**
 
 Doesn't build the project before running. It also implicit sets the `--no-restore` flag.
 
-`-p|--project <PATH>`
+**`-p|--project <PATH>`**
 
 Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
 
-# [.NET Core 2.0](#tab/netcore22)
+## Generator options
 
----
+### controller options
 
-## Examples
+The following table lists the `aspnet-codegenerator controller` options:
+
+[!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)]

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -88,7 +88,15 @@ Specifies the path of the project file to run (folder name or full path). If not
 
 ## Generator options
 
-### controller options
+The following sections detail the options available for the supported generators:
+
+* Area
+* Controller
+* Identity  
+* Razorpage
+* View
+
+### Controller options
 
 The following table lists options for  `aspnet-codegenerator` `controller` and `razorpage`:
 
@@ -98,7 +106,6 @@ The following table lists options unique to  `aspnet-codegenerator controller`:
 
 | Option               | Description|
 | ----------------- | ------------ |
-
 | --controllerName or -name | Name of the controller. |
 | --useAsyncActions or -async | Generate async controller actions. |
 | --noViews or -nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -1,0 +1,89 @@
+---
+title: dotnet aspnet-codegenerator command
+description: The dotnet aspnet-codegenerator command scaffolds ASP.NET Core projects
+ms.date: 06/15/2019
+---
+# dotnet aspnet-codegenerator
+
+https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model
+
+[!INCLUDE [topic-appliesto-net-core-all](../../../includes/topic-appliesto-net-core-all.md)]
+
+## Name
+
+`dotnet aspnet-codegenerator` - Runs the ASP.NET Core scaffolding engine.
+
+## Installing aspnet-codegenerator
+
+`aspnet-codegenerator` is a [global tool](global-tools.md) that must be installed. The following command installs the lastest stable version of the `aspnet-codegenerator` tool:
+
+```console
+dotnet tool install --g dotnet-aspnet-codegenerator
+```
+
+The following command updates `aspnet-codegenerator` to the latest stable version available from the installed .NET Core SDKs:
+
+```console
+dotnet tool update -g aspnet-codegenerator
+```
+
+## Synopsis
+
+# [.NET Core 2.1](#tab/netcore21)
+
+```
+dotnet aspnet-codegenerator [arguments] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
+dotnet aspnet-codegenerator [-h|--help]
+```
+
+# [.NET Core 2.2](#tab/netcore22)
+
+```
+dotnet aspnet-codegenerator [arguments] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
+dotnet aspnet-codegenerator [-h|--help]
+```
+
+---
+
+## Description
+
+The `dotnet aspnet-codegenerator ` global command runs the ASP.NET Core code generator and scaffolding engine.
+
+## Arguments
+
+`generator`
+
+The code generator to run. The following generators are available:
+
+| Generator | Operation |
+| ----------------- | ------------ | 
+| area      | Generates an MVC Area |
+  controller| [Scaffolds a controller](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) |
+  identity  | [Scaffolds Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.2&tabs=netcore-cli) |
+  razorpage | [Scaffolds Razor Pages](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code) |
+  view      | Generates a view |
+
+
+## Options
+
+# [.NET Core 2.1](#tab/netcore21)
+
+dotnet aspnet-codegenerator [arguments] [-p|--project] [-n|--nuget-package-dir] [-c|--configuration] [-tfm|--target-framework] [-b|--build-base-path] [--no-build] 
+
+`-h|--help`
+
+Prints out a short help for the command.
+
+`--no-build`
+
+Doesn't build the project before running. It also implicit sets the `--no-restore` flag.
+
+`-p|--project <PATH>`
+
+Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
+
+# [.NET Core 2.0](#tab/netcore22)
+
+---
+
+## Examples

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -44,11 +44,11 @@ The code generator to run. The following generators are available:
 
 | Generator | Operation |
 | ----------------- | ------------ | 
-| area      | Generates an [Area](/aspnet/core/mvc/controllers/areas) |
+| area      | [Scaffolds an Area](/aspnet/core/mvc/controllers/areas) |
   controller| [Scaffolds a controller](/aspnet/core/tutorials/first-mvc-app/adding-model) |
   identity  | [Scaffolds Identity](/aspnet/core/security/authentication/scaffold-identity) |
   razorpage | [Scaffolds Razor Pages](/aspnet/core/tutorials/razor-pages/model) |
-  view      | Generates a [view](/aspnet/core/mvc/views/overview) |
+  view      | [Scaffolds a view](/aspnet/core/mvc/views/overview) |
 
 ## Options
 
@@ -127,7 +127,7 @@ The following table lists options unique to  `aspnet-codegenerator controller`:
 | ----------------- | ------------ |
 | --controllerName or -name | Name of the controller. |
 | --useAsyncActions or -async | Generate async controller actions. |
-| --noViews or -nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |
+| --noViews or -nv | Generate **no** views. |
 | --restWithNoViews or -api  | Generate a Controller with REST style API. `noViews` is assumed and any view related options are ignored. |
 | --readWriteActions or -actions | Generate controller with read/write actions without a model. |
 
@@ -141,11 +141,7 @@ See [Scaffold the movie model](/aspnet/core/tutorials/razor-pages/model) for an 
 
 ### Razorpage
 
-See [Scaffold Identity](/aspnet/core/security/authentication/scaffold-identity)
-
 <a name="rp"></a>
-
-### Razorpage options
 
 Razor Pages can be individually scaffolded by specifying the name of the new page and the template to use. The supported templates are:
 
@@ -189,3 +185,7 @@ dotnet aspnet-codegenerator razorpage -h
 ```
 
 See [Scaffold the movie model](/aspnet/core/tutorials/razor-pages/model) for an example of `dotnet aspnet-codegenerator razorpage`.
+
+### Identity
+
+See [Scaffold Identity](/aspnet/core/security/authentication/scaffold-identity)

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -5,8 +5,6 @@ ms.date: 06/15/2019
 ---
 # dotnet aspnet-codegenerator
 
-/aspnet/core/tutorials/first-mvc-app/adding-model
-
 [!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
 
 ## Name
@@ -62,7 +60,7 @@ Specifies the NuGet package directory.
 
 `-c|--configuration {Debug|Release}`
 
-  Defines the build configuration. The default value is `Debug`.
+Defines the build configuration. The default value is `Debug`.
 
 `-tfm|--target-framework`
 
@@ -131,7 +129,7 @@ The following table lists options unique to  `aspnet-codegenerator controller`:
 | --useAsyncActions or -async | Generate async controller actions. |
 | --noViews or -nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |
 | --restWithNoViews or -api  | Generate a Controller with REST style API. `noViews` is assumed and any view related options are ignored. |
-  | --readWriteActions or -actions | Generate controller with read/write actions without a model. |
+| --readWriteActions or -actions | Generate controller with read/write actions without a model. |
 
 Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -56,33 +56,33 @@ The code generator to run. The following generators are available:
 
 <!-- dotnet build to dotnet help use **bold** on options, most don't -->
 
-**`-n|--nuget-package-dir`**
+`-n|--nuget-package-dir`
 
 Specifies the NuGet package directory.
 
-**`-c|--configuration {Debug|Release}`**
+`-c|--configuration {Debug|Release}`
 
   Defines the build configuration. The default value is `Debug`.
 
-**`-tfm|--target-framework`**
+`-tfm|--target-framework`
 
 Target [Framework](../../standard/frameworks.md) to use. For example, `net46`.
 
 <!-- REVIEW: Is this specified on the command line or in the project file? -->
 
-**`-b|--build-base-path`**
+`-b|--build-base-path`
 
 The build base path.
 
-**`-h|--help`**
+`-h|--help`
 
 Prints out a short help for the command.
 
-**`--no-build`**
+`--no-build`
 
 Doesn't build the project before running. It also implicit sets the `--no-restore` flag.
 
-**`-p|--project <PATH>`**
+`-p|--project <PATH>`
 
 Specifies the path of the project file to run (folder name or full path). If not specified, it defaults to the current directory.
 
@@ -95,6 +95,27 @@ The following sections detail the options available for the supported generators
 * Identity  
 * Razorpage
 * View
+
+<a name="area"></a>
+
+### Area options
+
+<!-- Review: I ran the following command in a Razor Pages project
+I was expecting Areas\AreaNameToGenerate\Pages
+Should I say this is intended for MVC projects and not RP projects
+-->
+Usage: `dotnet aspnet-codegenerator area AreaNameToGenerate`
+
+The preceding command generates the following folders:
+
+* *Areas*
+  * *AreaNameToGenerate*
+    * *Controllers*
+    * *Data*
+    * *Models*
+    * *Views*
+
+<a name="ctl"></a>
 
 ### Controller options
 
@@ -118,11 +139,15 @@ Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 dotnet aspnet-codegenerator controller -h
 ```
 
-See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of using `dotnet aspnet-codegenerator controller`.
+See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of `dotnet aspnet-codegenerator controller`.
+
+### Razorpage
+
+See [Scaffold Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.2&tabs=netcore-cli)
+
+<a name="rp"></a>
 
 ### Razorpage options
-
-#### Razorpage generator arguments
 
 Razor Pages can be individually scaffolded by specifying the name of the new page and the template to use. The supported templates are:
 
@@ -165,4 +190,4 @@ Use the `-h` switch for help on the `aspnet-codegenerator razorpage` command:
 dotnet aspnet-codegenerator razorpage -h
 ```
 
-See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of using `dotnet aspnet-codegenerator razorpage`.
+See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of `dotnet aspnet-codegenerator razorpage`.

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -5,7 +5,7 @@ ms.date: 06/15/2019
 ---
 # dotnet aspnet-codegenerator
 
-https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model
+/aspnet/core/tutorials/first-mvc-app/adding-model
 
 [!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
 
@@ -46,11 +46,11 @@ The code generator to run. The following generators are available:
 
 | Generator | Operation |
 | ----------------- | ------------ | 
-| area      | Generates an [Area](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/areas?view=aspnetcore-2.2) |
-  controller| [Scaffolds a controller](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) |
-  identity  | [Scaffolds Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.2&tabs=netcore-cli) |
-  razorpage | [Scaffolds Razor Pages](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code) |
-  view      | Generates a [view](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/overview?view=aspnetcore-2.2) |
+| area      | Generates an [Area](/aspnet/core/mvc/controllers/areas) |
+  controller| [Scaffolds a controller](/aspnet/core/tutorials/first-mvc-app/adding-model) |
+  identity  | [Scaffolds Identity](/aspnet/core/security/authentication/scaffold-identity) |
+  razorpage | [Scaffolds Razor Pages](/aspnet/core/tutorials/razor-pages/model) |
+  view      | Generates a [view](/aspnet/core/mvc/views/overview) |
 
 ## Options
 
@@ -139,11 +139,11 @@ Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 dotnet aspnet-codegenerator controller -h
 ```
 
-See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of `dotnet aspnet-codegenerator controller`.
+See [Scaffold the movie model](/aspnet/core/tutorials/razor-pages/model) for an example of `dotnet aspnet-codegenerator controller`.
 
 ### Razorpage
 
-See [Scaffold Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.2&tabs=netcore-cli)
+See [Scaffold Identity](/aspnet/core/security/authentication/scaffold-identity)
 
 <a name="rp"></a>
 
@@ -190,4 +190,4 @@ Use the `-h` switch for help on the `aspnet-codegenerator razorpage` command:
 dotnet aspnet-codegenerator razorpage -h
 ```
 
-See [Scaffold the movie model](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-2.2&tabs=visual-studio-code#scaffold-the-movie-model) for an example of `dotnet aspnet-codegenerator razorpage`.
+See [Scaffold the movie model](/aspnet/core/tutorials/razor-pages/model) for an example of `dotnet aspnet-codegenerator razorpage`.

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -1,5 +1,7 @@
 ---
 title: dotnet aspnet-codegenerator command
+author: rick-anderson
+ms.author: riande
 description: The dotnet aspnet-codegenerator command scaffolds ASP.NET Core projects
 ms.date: 06/15/2019
 ---
@@ -13,7 +15,7 @@ ms.date: 06/15/2019
 
 ## Installing aspnet-codegenerator
 
-`aspnet-codegenerator` is a [global tool](global-tools.md) that must be installed. The following command installs the lastest stable version of the `aspnet-codegenerator` tool:
+`aspnet-codegenerator` is a [global tool](global-tools.md) that must be installed. The following command installs the latest stable version of the `aspnet-codegenerator` tool:
 
 ```console
 dotnet tool install --g dotnet-aspnet-codegenerator

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -78,7 +78,7 @@ Prints out a short help for the command.
 
 `--no-build`
 
-Doesn't build the project before running. It also implicit sets the `--no-restore` flag.
+Doesn't build the project before running. It also implicitly sets the `--no-restore` flag.
 
 `-p|--project <PATH>`
 
@@ -98,10 +98,8 @@ The following sections detail the options available for the supported generators
 
 ### Area options
 
-<!-- Review: I ran the following command in a Razor Pages project
-I was expecting Areas\AreaNameToGenerate\Pages
-Should I say this is intended for MVC projects and not RP projects
--->
+This tool is intended for ASP.NET Core web projects with controllers and views. It's not intended for Razor Pages apps.
+
 Usage: `dotnet aspnet-codegenerator area AreaNameToGenerate`
 
 The preceding command generates the following folders:

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -54,6 +54,8 @@ The code generator to run. The following generators are available:
 
 ## Options
 
+<!-- dotnet build to dotnet help use **bold** on options, most don't -->
+
 **`-n|--nuget-package-dir`**
 
 Specifies the NuGet package directory.
@@ -91,3 +93,14 @@ Specifies the path of the project file to run (folder name or full path). If not
 The following table lists the `aspnet-codegenerator controller` options:
 
 [!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)]
+|  --controllerName`|-`name | Name of the controller. |
+| --useAsyncActions`|-`async | Generate async controller actions. |
+| --noViews`|-`nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |
+| --restWithNoViews`|-`api  | Generate a Controller with REST style API. `noViews` is assumed and any view related options are ignored. |
+  | --readWriteActions`|-`actions | Generate controller with read/write actions without a model. |
+
+Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
+
+```console
+dotnet aspnet-codegenerator controller -h
+```

--- a/docs/core/tools/dotnet-aspnet-codegenerator.md
+++ b/docs/core/tools/dotnet-aspnet-codegenerator.md
@@ -92,12 +92,11 @@ Specifies the path of the project file to run (folder name or full path). If not
 
 The following table lists the `aspnet-codegenerator controller` options:
 
-[!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)]
-|  --controllerName`|-`name | Name of the controller. |
-| --useAsyncActions`|-`async | Generate async controller actions. |
-| --noViews`|-`nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |
-| --restWithNoViews`|-`api  | Generate a Controller with REST style API. `noViews` is assumed and any view related options are ignored. |
-  | --readWriteActions`|-`actions | Generate controller with read/write actions without a model. |
+[!INCLUDE [aspnet-codegenerator-args-md.md](../../../includes/aspnet-codegenerator-args-md.md)] | --controllerName or -name | Name of the controller. |
+| --useAsyncActions or -async | Generate async controller actions. |
+| --noViews or -nv | Generate [CRUD](https://wikipedia.org/wiki/Create,_read,_update_and_delete) views. |
+| --restWithNoViews or -api  | Generate a Controller with REST style API. `noViews` is assumed and any view related options are ignored. |
+  | --readWriteActions or -actions | Generate controller with read/write actions without a model. |
 
 Use the `-h` switch for help on the `aspnet-codegenerator controller` command:
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -126,26 +126,38 @@ The .NET Core CLI tries to add the default locations to the PATH environment var
 * On macOS, if you've installed the .NET Core SDK using *.tar.gz* files and not *.pkg*.
 * On Linux, you need to edit the shell environment file to configure the PATH.
 
-## Other CLI commands
+## Global tools available in the .NET Core SDK
 
-The .NET Core SDK contains other commands that support .NET Core Global Tools. Use any of the `dotnet tool` commands with one of the following options:
+The .NET Core SDK contains global tools that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
+
+```console
+dotnet tool install --global dotnet-aspnet-codegenerator
+```
+
+`dotnet tool` commands support the following options:
 
 * `--global` or `-g` specifies that the command is applicable to user-wide Global Tools.
 * `--tool-path` specifies a custom location for Global Tools.
 
-To find out which commands are available for Global Tools:
+The following command shows which commands are available for Global Tools:
 
 ```console
 dotnet tool --help
 ```
 
-Updating a Global Tool involves uninstalling and reinstalling it with the latest stable version. To update a Global Tool, use the [dotnet tool update](dotnet-tool-update.md) command:
+The [dotnet tool update](dotnet-tool-update.md) command updates a global tool tool to the latest stable version available from the installed .NET Core SDKs:
 
 ```console
 dotnet tool update -g <packagename>
 ```
 
-Remove a Global Tool using the [dotnet tool uninstall](dotnet-tool-uninstall.md):
+For example, the following code updates the ASP.NET Core scaffolding tool to the latest stable version:
+
+```console
+dotnet tool install --g dotnet-aspnet-codegenerator
+```
+
+Global Tools are removed with the [dotnet tool uninstall](dotnet-tool-uninstall.md):
 
 ```console
 dotnet tool uninstall -g <packagename>

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -128,7 +128,7 @@ The .NET Core CLI tries to add the default locations to the PATH environment var
 
 ## Global tools available in the .NET Core SDK
 
-The .NET Core SDK contains global tools that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
+The .NET Core SDK contains the `dotnet-aspnet-codegenerator` global tool that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
 
 ```console
 dotnet tool install --global dotnet-aspnet-codegenerator

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -145,6 +145,12 @@ The following command shows which commands are available for Global Tools:
 dotnet tool --help
 ```
 
+To display all of the Global Tools currently installed on the machine, along with their version and commands, use the [dotnet tool list](dotnet-tool-list.md) command:
+
+```console
+dotnet tool list -g
+```
+
 The [dotnet tool update](dotnet-tool-update.md) command updates a global tool tool to the latest stable version available from the installed .NET Core SDKs:
 
 ```console
@@ -163,8 +169,4 @@ Global Tools are removed with the [dotnet tool uninstall](dotnet-tool-uninstall.
 dotnet tool uninstall -g <packagename>
 ```
 
-To display all of the Global Tools currently installed on the machine, along with their version and commands, use the [dotnet tool list](dotnet-tool-list.md) command:
-
-```console
-dotnet tool list -g
-```
+For more information on `aspnet-codegenerator`, see [dotnet aspnet-codegenerator](dotnet aspnet-codegenerator.md)

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -126,7 +126,7 @@ The .NET Core CLI tries to add the default locations to the PATH environment var
 * On macOS, if you've installed the .NET Core SDK using *.tar.gz* files and not *.pkg*.
 * On Linux, you need to edit the shell environment file to configure the PATH.
 
-## Global tools available in the .NET Core SDK
+## Global tools in the .NET Core SDK
 
 The .NET Core SDK contains the `dotnet-aspnet-codegenerator` global tool that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -7,8 +7,6 @@ ms.custom: "seodec18"
 ---
 # .NET Core Global Tools overview
 
-https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed?view=aspnetcore-2.2#distributed-sql-server-cache
-
 [!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
 
 A .NET Core Global Tool is a special NuGet package that contains a console application. A Global Tool can be installed on your machine on a default location that is included in the PATH environment variable or on a custom location.
@@ -137,11 +135,11 @@ Linux is no longer a problem when installed on bash with .deb and .rpm - see htt
 
 The .NET Core SDK contains the following tools:
 
-* [dev-certs](https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-2.2&tabs=visual-studio#trust) : Must be installed.
-* [ef](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet)
-* [sql-cache](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed?view=aspnetcore-2.2#distributed-sql-server-cache)
-* [user-secrets](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-2.2&tabs=windows)
-* [dotnet-watch](https://docs.microsoft.com/en-us/aspnet/core/tutorials/dotnet-watch?view=aspnetcore-2.2)
+* [dev-certs](/aspnet/core/security/enforcing-ssl#trust) : Must be installed.
+* [ef](/ef/core/miscellaneous/cli/dotnet)
+* [sql-cache](/aspnet/core/performance/caching/distributed#distributed-sql-server-cache)
+* [user-secrets](/aspnet/core/security/app-secrets)
+* [dotnet-watch](/aspnet/core/tutorials/dotnet-watch)
 
 [dotnet-aspnet-codegenerator](dotnet-aspnet-codegenerator.md) is global tool that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
 

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -7,6 +7,8 @@ ms.custom: "seodec18"
 ---
 # .NET Core Global Tools overview
 
+https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed?view=aspnetcore-2.2#distributed-sql-server-cache
+
 [!INCLUDE [topic-appliesto-net-core-21plus.md](../../../includes/topic-appliesto-net-core-21plus.md)]
 
 A .NET Core Global Tool is a special NuGet package that contains a console application. A Global Tool can be installed on your machine on a default location that is included in the PATH environment variable or on a custom location.
@@ -120,15 +122,28 @@ dotnet --list-runtimes
 
 Contact the author of the Global Tool and see if they can recompile and republish their tool package to NuGet with an updated version number. Once they have updated the package on NuGet, you can update your copy.
 
-The .NET Core CLI tries to add the default locations to the PATH environment variable on its first usage. However, there are a couple of scenarios where the location might not be added to PATH automatically, such as:
+The .NET Core CLI tries to add the default locations to the `PATH` environment variable on its first usage. `PATH` isn't updated on macOS if you've installed the .NET Core SDK using *.tar.gz* files and not *.pkg*.
 
-* If you've set the `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` environment variable.
+<!-- 
+However, there are a couple of scenarios where the location might not be added to PATH automatically, such as:
+
+* If you've set the `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` environment variable. 
 * On macOS, if you've installed the .NET Core SDK using *.tar.gz* files and not *.pkg*.
 * On Linux, you need to edit the shell environment file to configure the PATH.
+Linux is no longer a problem when installed on bash with .deb and .rpm - see https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current
+-->
 
-## Global tools in the .NET Core SDK
+## Tools in the .NET Core SDK
 
-The .NET Core SDK contains the `dotnet-aspnet-codegenerator` global tool that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
+The .NET Core SDK contains the following tools:
+
+* [dev-certs](https://docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-2.2&tabs=visual-studio#trust) : Must be installed.
+* [ef](https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet)
+* [sql-cache](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed?view=aspnetcore-2.2#distributed-sql-server-cache)
+* [user-secrets](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-2.2&tabs=windows)
+* [dotnet-watch](https://docs.microsoft.com/en-us/aspnet/core/tutorials/dotnet-watch?view=aspnetcore-2.2)
+
+[dotnet-aspnet-codegenerator](dotnet-aspnet-codegenerator.md) is global tool that can be installed. For example, the following command installs the ASP.NET Core scaffolding tool:
 
 ```console
 dotnet tool install --global dotnet-aspnet-codegenerator

--- a/docs/core/tools/global-tools.md
+++ b/docs/core/tools/global-tools.md
@@ -163,10 +163,10 @@ For example, the following code updates the ASP.NET Core scaffolding tool to the
 dotnet tool install --g dotnet-aspnet-codegenerator
 ```
 
-Global Tools are removed with the [dotnet tool uninstall](dotnet-tool-uninstall.md):
+Uninstall Global Tools with [dotnet tool uninstall](dotnet-tool-uninstall.md):
 
 ```console
 dotnet tool uninstall -g <packagename>
 ```
 
-For more information on `aspnet-codegenerator`, see [dotnet aspnet-codegenerator](dotnet aspnet-codegenerator.md)
+For more information on `aspnet-codegenerator`, see [dotnet aspnet-codegenerator](dotnet-aspnet-codegenerator.md)

--- a/docs/core/tools/index.md
+++ b/docs/core/tools/index.md
@@ -91,6 +91,10 @@ The following commands are installed by default:
 
 The CLI adopts an extensibility model that allows you to specify additional tools for your projects. For more information, see the [.NET Core CLI extensibility model](extensibility.md) topic.
 
+## Global commands
+
+For information on global commands such as `aspnet-codegenerator`, see [.NET Core Global Tools overview](global-tools.md).
+
 ## Command structure
 
 CLI command structure consists of [the driver ("dotnet")](#driver), [the command (or "verb")](#command-verb), and possibly command [arguments](#arguments) and [options](#options). You see this pattern in most CLI operations, such as creating a new console app and running it from the command line as the following commands show when executed from a directory named *my_app*:

--- a/includes/aspnet-codegenerator-args-md.md
+++ b/includes/aspnet-codegenerator-args-md.md
@@ -1,10 +1,10 @@
 <!-- Options common to Razor Pages and Controller -->
 | Option               | Description|
 | ----------------- | ------------ |
-| --model`|`-m  | Model class to use. |
-| --dataContext`|-`dc  | The `DbContext` class to use. |
-| --referenceScriptLibraries`|-`scripts : Reference script libraries in the generated views. Adds `_ValidationScriptsPartial` to Edit and Create pages. |
-| --layout`|-`l  Custom Layout page to use. |
-| --useDefaultLayout`|`-udl | Use the default layout for the views. |
-| --force`|-`f | Overwrite existing files. |
-| --relativeFolderPath`|-`outDir | The relative output folder path from project where the file are generated. If not specified, files are generated in the project folder. |
+| --model or -m  | Model class to use. |
+| --dataContext or -dc  | The `DbContext` class to use. |
+| --referenceScriptLibraries or -scripts : Reference script libraries in the generated views. Adds `_ValidationScriptsPartial` to Edit and Create pages. |
+| --layout or -l  Custom Layout page to use. |
+| --useDefaultLayout or -udl | Use the default layout for the views. |
+| --force or -f | Overwrite existing files. |
+| --relativeFolderPath or -outDir | The relative output folder path from project where the file are generated. If not specified, files are generated in the project folder. |

--- a/includes/aspnet-codegenerator-args-md.md
+++ b/includes/aspnet-codegenerator-args-md.md
@@ -1,0 +1,14 @@
+
+| Option               | Description|
+| ----------------- | ------------ |
+| -m  | The name of the model. |
+| -dc  | The `DbContext` class to use. |
+| -udl | Use the default layout. |
+| -outDir | The relative output folder path to create the views. |
+| --referenceScriptLibraries | Adds `_ValidationScriptsPartial` to Edit and Create pages |
+
+Use the `h` switch to get help on the `aspnet-codegenerator razorpage` command:
+
+```console
+dotnet aspnet-codegenerator razorpage -h
+```

--- a/includes/aspnet-codegenerator-args-md.md
+++ b/includes/aspnet-codegenerator-args-md.md
@@ -3,6 +3,7 @@
 | ----------------- | ------------ |
 | --model or -m  | Model class to use. |
 | --dataContext or -dc  | The `DbContext` class to use. |
+| --bootstrapVersion or -b  | Specifies the bootstrap version. Valid values are `3` or `4`. Default is `4`. If needed and not present, a *wwwroot* directory is created that includes the bootstrap files of the specified version. |
 | --referenceScriptLibraries or -scripts |  Reference script libraries in the generated views. Adds `_ValidationScriptsPartial` to Edit and Create pages. |
 | --layout or -l | Custom Layout page to use. |
 | --useDefaultLayout or -udl | Use the default layout for the views. |

--- a/includes/aspnet-codegenerator-args-md.md
+++ b/includes/aspnet-codegenerator-args-md.md
@@ -3,8 +3,8 @@
 | ----------------- | ------------ |
 | --model or -m  | Model class to use. |
 | --dataContext or -dc  | The `DbContext` class to use. |
-| --referenceScriptLibraries or -scripts : Reference script libraries in the generated views. Adds `_ValidationScriptsPartial` to Edit and Create pages. |
-| --layout or -l  Custom Layout page to use. |
+| --referenceScriptLibraries or -scripts |  Reference script libraries in the generated views. Adds `_ValidationScriptsPartial` to Edit and Create pages. |
+| --layout or -l | Custom Layout page to use. |
 | --useDefaultLayout or -udl | Use the default layout for the views. |
 | --force or -f | Overwrite existing files. |
 | --relativeFolderPath or -outDir | The relative output folder path from project where the file are generated. If not specified, files are generated in the project folder. |

--- a/includes/aspnet-codegenerator-args-md.md
+++ b/includes/aspnet-codegenerator-args-md.md
@@ -1,14 +1,10 @@
-
+<!-- Options common to Razor Pages and Controller -->
 | Option               | Description|
 | ----------------- | ------------ |
-| -m  | The name of the model. |
-| -dc  | The `DbContext` class to use. |
-| -udl | Use the default layout. |
-| -outDir | The relative output folder path to create the views. |
-| --referenceScriptLibraries | Adds `_ValidationScriptsPartial` to Edit and Create pages |
-
-Use the `h` switch to get help on the `aspnet-codegenerator razorpage` command:
-
-```console
-dotnet aspnet-codegenerator razorpage -h
-```
+| --model`|`-m  | Model class to use. |
+| --dataContext`|-`dc  | The `DbContext` class to use. |
+| --referenceScriptLibraries`|-`scripts : Reference script libraries in the generated views. Adds `_ValidationScriptsPartial` to Edit and Create pages. |
+| --layout`|-`l  Custom Layout page to use. |
+| --useDefaultLayout`|`-udl | Use the default layout for the views. |
+| --force`|-`f | Overwrite existing files. |
+| --relativeFolderPath`|-`outDir | The relative output folder path from project where the file are generated. If not specified, files are generated in the project folder. |

--- a/includes/topic-appliesto-net-core-21plus.md
+++ b/includes/topic-appliesto-net-core-21plus.md
@@ -1,1 +1,1 @@
-**This article applies to: ✓** .NET Core 2.1 SDK
+**This article applies to: ✓** .NET Core 2.1 SDK and later


### PR DESCRIPTION
Hold off on review.

Fixes #10100

@prafullbhosale  is the following true:

The `dotnet tool update` command updates a global tool tool to the **latest stable version available** from the installed .NET Core SDKs:

[aspnet-codegenerator internal review URL](https://review.docs.microsoft.com/en-us/dotnet/core/tools/dotnet-aspnet-codegenerator?branch=pr-en-us-12566&tabs=netcore21)
[Internal review URL global tools](https://review.docs.microsoft.com/en-us/dotnet/core/tools/global-tools?branch=pr-en-us-12566)