### PR TITLE
Replace (nonexistent) mdMethodRef with mdMemberRef

### DIFF
--- a/docs/framework/unmanaged-api/metadata/imetadataemit-definemethodimpl-method.md
+++ b/docs/framework/unmanaged-api/metadata/imetadataemit-definemethodimpl-method.md
@@ -36,10 +36,10 @@ HRESULT DefineMethodImpl (
  [in] The `mdTypedef` token of the implementing class.  
   
  `tkBody`  
- [in] The `mdMethodDef` or `mdMethodRef` token of the code body.  
+ [in] The `mdMethodDef` or `mdMemberRef` token of the code body.  
   
  `tkDecl`  
- [in] The `mdMethodDef` or `mdMethodRef` token of the interface method being implemented.  
+ [in] The `mdMethodDef` or `mdMemberRef` token of the interface method being implemented.  
   
 ## Requirements  
  **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  


### PR DESCRIPTION
There's no such thing as mdMethodRef. The original author must have meant mdMemberRef. This also matches what is in the ECMA-335 standard for metadata.

From II.22.27 MethodImpl

> - MethodBody (an index into the MethodDef or MemberRef table; more precisely, a MethodDefOrRef  (§II.24.2.6) coded index)
> - MethodDeclaration (an index into the MethodDef or MemberRef table; more precisely, a MethodDefOrRef  (§II.24.2.6) coded index)"

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
