### PR TITLE
Fix definition of false operator

### DIFF
--- a/docs/csharp/language-reference/operators/index.md
+++ b/docs/csharp/language-reference/operators/index.md
@@ -91,7 +91,7 @@ These operators have higher precedence than the next section and lower precedenc
 
 [true operator](true-false-operators.md) - returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely true.
 
-[false operator](true-false-operators.md) - returns the [bool](../keywords/bool.md) value `true` to indicate that an operand is definitely false.
+[false operator](true-false-operators.md) - returns the [bool](../keywords/bool.md) value `false` to indicate that an operand is definitely false.
 
 ## Multiplicative operators
 


### PR DESCRIPTION
False operator stated to return the `true` value.