### PR TITLE
Fixed a typo in the description of the example.

### DIFF
--- a/docs/csharp/language-reference/keywords/abstract.md
+++ b/docs/csharp/language-reference/keywords/abstract.md
@@ -14,7 +14,7 @@ ms.assetid: b0797770-c1f3-4b4d-9441-b9122602a6bb
 The `abstract` modifier indicates that the thing being modified has a missing or incomplete implementation. The abstract modifier can be used with classes, methods, properties, indexers, and events. Use the `abstract` modifier in a class declaration to indicate that a class is intended only to be a base class of other classes, not instantiated on its own. Members marked as abstract must be implemented by classes that derive from the abstract class.
   
 ## Example  
- In this example, the class `Square` must provide an implementation of `Area` because it derives from `ShapesClass`:  
+ In this example, the class `Square` must provide an implementation of `GetArea` because it derives from `Shape`:  
   
  [!code-csharp[csrefKeywordsModifiers#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#1)]
   


### PR DESCRIPTION
## Summary

Fixed a minor typo in the description of the first code sample : Changed `Area` to `GetArea`, and `ShapesClass` to `Shape`, since those are the names used in the example.