### PR TITLE
Fix contravariant/covariant markings for IReadOnlyList and IReadOnlyCollection

### DIFF
--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-generic-interfaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Variance in Generic Interfaces (C#)"
-ms.date: 04/10/2019
+ms.date: 06/06/2019
 ms.assetid: 4828a8f9-48c0-4128-9749-7fcd6bf19a06
 ---
 
@@ -26,9 +26,9 @@ Staring with .NET Framework 4, the following interfaces are variant:
 
 Starting with .NET Framework 4.5, the following interfaces are variant:
 
-- <xref:System.Collections.Generic.IReadOnlyList%601> (T is contravariant)
+- <xref:System.Collections.Generic.IReadOnlyList%601> (T is covariant)
 
-- <xref:System.Collections.Generic.IReadOnlyCollection%601> (T is contravariant)
+- <xref:System.Collections.Generic.IReadOnlyCollection%601> (T is covariant)
 
 Covariance permits a method to have a more derived return type than that defined by the generic type parameter of the interface. To illustrate the covariance feature, consider these generic interfaces: `IEnumerable<Object>` and `IEnumerable<String>`. The `IEnumerable<String>` interface does not inherit the `IEnumerable<Object>` interface. However, the `String` type does inherit the `Object` type, and in some cases you may want to assign objects of these interfaces to each other. This is shown in the following code example.
 


### PR DESCRIPTION
## Summary

`IReadOnlyList<T>` and `IReadOnlyCollection<T>` are actually covariant in `T`, not contravariant (as evident by the fact they both declare `<out T>` and inherit from the covariant `IEnumerable<T>`).