### PR TITLE
Remove reference to F# 4.1 in records doc

### DIFF
--- a/docs/fsharp/language-reference/records.md
+++ b/docs/fsharp/language-reference/records.md
@@ -1,11 +1,11 @@
 ---
 title: Records
 description: Learn how F# records represent simple aggregates of named values, optionally with members.
-ms.date: 05/16/2016
+ms.date: 06/09/2019
 ---
 # Records
 
-Records represent simple aggregates of named values, optionally with members.  Starting with F# 4.1, they can either be structs or reference types.  They are reference types by default.
+Records represent simple aggregates of named values, optionally with members. They can either be structs or reference types.  They are reference types by default.
 
 ## Syntax
 


### PR DESCRIPTION
F# 4.6 is now out, so there's been more than enough time to have the structness spread such that it's a new normal