### PR TITLE
Corrected that datatype is optional in for each

### DIFF
--- a/docs/visual-basic/language-reference/statements/for-each-next-statement.md
+++ b/docs/visual-basic/language-reference/statements/for-each-next-statement.md
@@ -107,8 +107,8 @@ Next [ element ]
  When a `For Each`…`Next` statement runs, Visual Basic evaluates the collection only one time, before the loop starts. If your statement block changes `element` or `group`, these changes don't affect the iteration of the loop.  
   
  When all the elements in the collection have been successively assigned to `element`, the `For Each` loop stops and control passes to the statement following the `Next` statement.  
-  
- If `element` hasn't been declared outside this loop, you must declare it in the `For Each` statement. You can declare the type of `element` explicitly by using an `As` statement, or you can rely on type inference to assign the type. In either case, the scope of `element` is the body of the loop. However, you cannot declare `element` both outside and inside the loop.  
+ 
+If [Option Infer](option-infer-statement.md) is on (its default setting), the Visual Basic compiler can infer the data type of `element`. If it is off and `element` hasn't been declared outside the loop, you must declare it in the `For Each` statement. To declare the data type of `element` explicitly, use an `As` clause. Unless the data type of element is defined outside the `For Each`...`Next` construct, its scope is the body of the loop. Note that you cannot declare `element` both outside and inside the loop.
   
  You can optionally specify `element` in the `Next` statement. This improves the readability of your program, especially if you have nested `For Each` loops. You must specify the same variable as the one that appears in the corresponding `For Each` statement.  
   
@@ -118,7 +118,7 @@ Next [ element ]
   
  If your code depends on traversing a collection in a particular order, a `For Each`...`Next` loop isn't the best choice, unless you know the characteristics of the enumerator object the collection exposes. The order of traversal isn't determined by Visual Basic, but by the <xref:System.Collections.IEnumerator.MoveNext%2A> method of the enumerator object. Therefore, you might not be able to predict which element of the collection is the first to be returned in `element`, or which is the next to be returned after a given element. You might achieve more reliable results using a different loop structure, such as `For`...`Next` or `Do`...`Loop`.  
   
- The data type of `element` must be such that the data type of the elements of `group` can be converted to it.  
+The runtime must be able to convert the elements in `group` to `element`. The [`Option Strict`] statement controls whether both widening and narrowing conversions are allowed (`Option Strict` is off, its default value), or whether only widening conversions are allowed (`Option Strict` is on). For more information, see [Narrowing conversions](#narrowing-conversions).
   
  The data type of `group` must be a reference type that refers to a collection or an array that's enumerable. Most commonly this means that `group` refers to an object that implements the <xref:System.Collections.IEnumerable> interface of the `System.Collections` namespace or the <xref:System.Collections.Generic.IEnumerable%601> interface of the `System.Collections.Generic` namespace. `System.Collections.IEnumerable` defines the <xref:System.Collections.IEnumerable.GetEnumerator%2A> method, which returns an enumerator object for the collection. The enumerator object implements the `System.Collections.IEnumerator` interface of the `System.Collections` namespace and exposes the <xref:System.Collections.IEnumerator.Current%2A> property and the <xref:System.Collections.IEnumerator.Reset%2A> and <xref:System.Collections.IEnumerator.MoveNext%2A> methods. Visual Basic uses these to traverse the collection.  
   

--- a/docs/visual-basic/language-reference/statements/for-each-next-statement.md
+++ b/docs/visual-basic/language-reference/statements/for-each-next-statement.md
@@ -43,7 +43,7 @@ Next [ element ]
 |Term|Definition|  
 |---|---|  
 |`element`|Required in the `For Each` statement. Optional in the `Next` statement. Variable. Used to iterate through the elements of the collection.|  
-|`datatype`|Optional. Data type of `element`.|  
+|`datatype`|Optional if [`Option Infer`](option-infer-statement.md) is on (the default) or `element` is already declared; required if `Option Infer` is off and `element` isn't already declared. The data type of `element`.|  
 |`group`|Required. A variable with a type that's a collection type or Object. Refers to the collection over which the `statements` are to be repeated.|  
 |`statements`|Optional. One or more statements between `For Each` and `Next` that run on each item in `group`.|  
 |`Continue For`|Optional. Transfers control to the start of the `For Each` loop.|  

--- a/docs/visual-basic/language-reference/statements/for-each-next-statement.md
+++ b/docs/visual-basic/language-reference/statements/for-each-next-statement.md
@@ -43,7 +43,7 @@ Next [ element ]
 |Term|Definition|  
 |---|---|  
 |`element`|Required in the `For Each` statement. Optional in the `Next` statement. Variable. Used to iterate through the elements of the collection.|  
-|`datatype`|Required if `element` isn't already declared. Data type of `element`.|  
+|`datatype`|Optional. Data type of `element`.|  
 |`group`|Required. A variable with a type that's a collection type or Object. Refers to the collection over which the `statements` are to be repeated.|  
 |`statements`|Optional. One or more statements between `For Each` and `Next` that run on each item in `group`.|  
 |`Continue For`|Optional. Transfers control to the start of the `For Each` loop.|  


### PR DESCRIPTION
The docs said the the as datatype part in for each loop is required if element isn't already declared.
I've tested for each loop without the datatype part and it works for me

[testing witout datatype part]
![image](https://user-images.githubusercontent.com/31348972/59261478-d3740300-8c3d-11e9-85e6-4513bc31ab95.png)

[testing with datatype part]
![image](https://user-images.githubusercontent.com/31348972/59261622-1df57f80-8c3e-11e9-8099-7f434a266e98.png)
