### PR TITLE
Fix xref links

### DIFF
--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -13,11 +13,11 @@ The `stackalloc` operator allocates a block of memory on the stack. A stack allo
 
 You can assign the result of the `stackalloc` operator to a variable of one of the following types:
 
-- Starting with C# 7.2, <xref:System.Span%601?displayName=nameWithType> or <xref:System.ReadOnlySpan%601?displayName=nameWithType>, as the following example shows:
+- Starting with C# 7.2, <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as the following example shows:
 
   [!code-csharp[stackalloc span](~/samples/csharp/language-reference/operators/StackallocOperator.cs#AssignToSpan)]
 
-  You don't have to use an `unsafe` context when you assign a stack allocated memory block to a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable.
+  You don't have to use an [unsafe](../keywords/unsafe.md) context when you assign a stack allocated memory block to a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable.
 
   When you work with those types, you can use a `stackalloc` expression in [conditional](conditional-operator.md) or assignment expressions, as the following example shows:
 
@@ -30,7 +30,7 @@ You can assign the result of the `stackalloc` operator to a variable of one of t
 
   [!code-csharp[stackalloc pointer](~/samples/csharp/language-reference/operators/StackallocOperator.cs#AssignToPointer)]
 
-  As the preceding example shows, you must use an [unsafe](../keywords/unsafe.md) context when you work with pointer types.
+  As the preceding example shows, you must use an `unsafe` context when you work with pointer types.
 
 The content of the newly allocated memory is undefined. Starting with C# 7.3, you can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 


### PR DESCRIPTION
I've mixed `displayProperty` with `displayName` in TOC
Also added the link to `unsafe` on its first occurrence (missed that when swapped two list items during review)