### PR TITLE
fix explanation of range start and end

### DIFF
--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -375,7 +375,7 @@ This language support relies on two new types, and two new operators.
 
 Let's start with the rules for indexes. Consider an array `sequence`. The `0` index is the same as `sequence[0]`. The `^0` index is the same as `sequence[sequence.Length]`. Note that `sequence[^0]` does throw an exception, just as `sequence[sequence.Length]` does. For any number `n`, the index `^n` is the same as `sequence.Length - n`.
 
-A range specifies the *start* and *end* of a range. Ranges are exclusive, meaning the *end* is not included in the range. The range `[0..^0]` represents the entire range, just as `[0..sequence.Length]` represents the entire range. 
+A range specifies the *start* and *end* of a range. The start of the range is inclusive, and the end of the range is exclusive, meaning the *start* is included in the range but the *end* is not included in the range. The range `[0..^0]` represents the entire range, just as `[0..sequence.Length]` represents the entire range. 
 
 Let's look at a few examples. Consider the following array, annotated with its index from the start and from the end:
 


### PR DESCRIPTION
## Summary

The current explanation is wrong, since ranges are not exclusive. The range start is _inclusive_.