### PR TITLE
Fixed incorrect Predict() method reference

### DIFF
--- a/docs/machine-learning/tutorials/sentiment-analysis.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis.md
@@ -271,13 +271,13 @@ Use the following code to display the metrics:
 
     [!code-csharp[CallUseModelWithSingleItem](~/samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#CallUseModelWithSingleItem "Call the UseModelWithSingleItem method")]
 
-3. Add the following code to create as the first line in the `Predict()` Method:
+3. Add the following code to create as the first line in the `UseModelWithSingleItem()` Method:
 
     [!code-csharp[CreatePredictionEngine](~/samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#CreatePredictionEngine1 "Create the PredictionEngine")]
 
     The [PredictionEngine](xref:Microsoft.ML.PredictionEngine%602) is a convenience API, which allows you to pass in and then perform a prediction on a single instance of data.
 
-4. Add a comment to test the trained model's prediction in the `Predict()` method by creating an instance of `SentimentData`:
+4. Add a comment to test the trained model's prediction in the `UseModelWithSingleItem()` method by creating an instance of `SentimentData`:
 
     [!code-csharp[PredictionData](~/samples/machine-learning/tutorials/SentimentAnalysis/Program.cs#CreateTestIssue1 "Create test data for single prediction")]
 


### PR DESCRIPTION
## Summary

The Predict() method does not exist and is meant to be the UseModelWithSingleItem() method.
