### PR TITLE
C# Readonly - Add mutability difference for value/reference types

### DIFF
--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -17,7 +17,10 @@ The `readonly` keyword is a modifier that can be used in three contexts:
 - In a [field declaration](#readonly-field-example), `readonly` indicates that assignment to the field can only occur as part of the declaration or in a constructor in the same class. A readonly field can be assigned and reassigned multiple times within the field declaration and constructor. 
 A `readonly` field cannot be assigned after the constructor exits. That has different implications for value types and reference types:
 - Because value types directly contain their data, a field that is a  `readonly` value type is immutable. 
-  - If the `readonly` field is a reference type, the field is not made immutable. The `readonly` prevents the field from being replaced by a different instance of the reference type. However, the modifier does not prevent the instance data of the field from being modified through the reference type. An externally visible type that contains an externally visible read-only field that is a mutable reference type may be a security vulnerability and may trigger warning [CA2104](../code-quality/ca2104-do-not-declare-read-only-mutable-reference-types.md) : "Do not declare read only mutable reference types."
+- Because reference types contain a reference to their data, a field that is a `readonly` reference type must always refer to the same object. That object is not immutable. The `readonly` modifier prevents the field from being replaced by a different instance of the reference type. However, the modifier does not prevent the instance data of the field from being modified through the read-only field.
+
+> [!WARNING]
+> An externally visible type that contains an externally visible read-only field that is a mutable reference type may be a security vulnerability and may trigger warning [CA2104](../code-quality/ca2104-do-not-declare-read-only-mutable-reference-types.md) : "Do not declare read only mutable reference types."
 
 - In a [`readonly struct` definition](#readonly-struct-example), `readonly` indicates that the `struct` is immutable.
 - In a [`ref readonly` method return](#ref-readonly-return-example), the `readonly` modifier indicates that method returns a reference and writes are not allowed to that reference.

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -15,7 +15,8 @@ ms.assetid: 2f8081f6-0de2-4903-898d-99696c48d2f4
 The `readonly` keyword is a modifier that can be used in three contexts:
 
 - In a [field declaration](#readonly-field-example), `readonly` indicates that assignment to the field can only occur as part of the declaration or in a constructor in the same class. A readonly field can be assigned and reassigned multiple times within the field declaration and constructor. 
-  - If the `readonly` field is a value type, it is made immutable. 
+A `readonly` field cannot be assigned after the constructor exits. That has different implications for value types and reference types:
+- Because value types directly contain their data, a field that is a  `readonly` value type is immutable. 
   - If the `readonly` field is a reference type, the field is not made immutable. The `readonly` prevents the field from being replaced by a different instance of the reference type. However, the modifier does not prevent the instance data of the field from being modified through the reference type. An externally visible type that contains an externally visible read-only field that is a mutable reference type may be a security vulnerability and may trigger warning [CA2104](../code-quality/ca2104-do-not-declare-read-only-mutable-reference-types.md) : "Do not declare read only mutable reference types."
 
 - In a [`readonly struct` definition](#readonly-struct-example), `readonly` indicates that the `struct` is immutable.

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -14,7 +14,9 @@ ms.assetid: 2f8081f6-0de2-4903-898d-99696c48d2f4
 
 The `readonly` keyword is a modifier that can be used in three contexts:
 
-- In a [field declaration](#readonly-field-example), `readonly` indicates that assignment to the field can only occur as part of the declaration or in a constructor in the same class.
+- In a [field declaration](#readonly-field-example), `readonly` indicates that assignment to the field can only occur as part of the declaration or in a constructor in the same class. A readonly field can be assigned and reassigned multiple times within the field declaration and constructor. 
+  - If the field is a value type, it is made immutable. 
+  - If the field is a reference type, the field is not made immutable. Though the reference cannot be reassigned, the object identified by the reference is mutable.
 - In a [`readonly struct` definition](#readonly-struct-example), `readonly` indicates that the `struct` is immutable.
 - In a [`ref readonly` method return](#ref-readonly-return-example), the `readonly` modifier indicates that method returns a reference and writes are not allowed to that reference.
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -15,8 +15,9 @@ ms.assetid: 2f8081f6-0de2-4903-898d-99696c48d2f4
 The `readonly` keyword is a modifier that can be used in three contexts:
 
 - In a [field declaration](#readonly-field-example), `readonly` indicates that assignment to the field can only occur as part of the declaration or in a constructor in the same class. A readonly field can be assigned and reassigned multiple times within the field declaration and constructor. 
-  - If the field is a value type, it is made immutable. 
-  - If the field is a reference type, the field is not made immutable. Though the reference cannot be reassigned, the object identified by the reference is mutable.
+  - If the `readonly` field is a value type, it is made immutable. 
+  - If the `readonly` field is a reference type, the field is not made immutable. The `readonly` prevents the field from being replaced by a different instance of the reference type. However, the modifier does not prevent the instance data of the field from being modified through the reference type. An externally visible type that contains an externally visible read-only field that is a mutable reference type may be a security vulnerability and may trigger warning [CA2104](../code-quality/ca2104-do-not-declare-read-only-mutable-reference-types.md) : "Do not declare read only mutable reference types."
+
 - In a [`readonly struct` definition](#readonly-struct-example), `readonly` indicates that the `struct` is immutable.
 - In a [`ref readonly` method return](#ref-readonly-return-example), the `readonly` modifier indicates that method returns a reference and writes are not allowed to that reference.
 

--- a/docs/csharp/language-reference/keywords/readonly.md
+++ b/docs/csharp/language-reference/keywords/readonly.md
@@ -53,7 +53,9 @@ These constructor contexts are also the only contexts in which it is valid to pa
 
 In the preceding example, if you use a statement like the following example:
 
-`p2.y = 66;        // Error`
+```csharp
+p2.y = 66;        // Error
+```
 
 you will get the compiler error message:
 
@@ -86,7 +88,7 @@ Adding a field not marked `readonly` generates compiler error `CS8340`: "Instanc
 The `readonly` modifier on a `ref return` indicates that the returned reference cannot be modified. The following example returns a reference to the origin. It uses the `readonly` modifier to indicate that callers cannot modify the origin:
 
 [!code-csharp[readonly struct example](~/samples/snippets/csharp/keywords/ReadonlyKeywordExamples.cs#ReadonlyReturn)]
-The type returned doesn't need to be a `readonly struct`. Any type that can be returned by `ref` can be returned by `ref readonly`
+The type returned doesn't need to be a `readonly struct`. Any type that can be returned by `ref` can be returned by `ref readonly`.
 
 ## C# language specification
 


### PR DESCRIPTION
## Summary

Add info on mutability:
  - If the field is a value type, it is made immutable. 
  - If the field is a reference type, the field is not made immutable. Though the reference cannot be reassigned, the object identified by the reference may be mutable.
 - CA2104: Do not declare read only mutable reference types

Add that `readonly` can be reassigned while in constructor or declaration.

Fixes https://github.com/dotnet/docs/issues/12638
