### PR TITLE
Fixed possible typo

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/task-asynchronous-programming-model.md
+++ b/docs/csharp/programming-guide/concepts/async/task-asynchronous-programming-model.md
@@ -121,7 +121,7 @@ The numbers in the diagram correspond to the following steps, initiated when the
      Therefore, `AccessTheWebAsync` uses an await operator to suspend its progress and to yield control to the method that called `AccessTheWebAsync`. `AccessTheWebAsync` returns a `Task<int>` to the caller. The task represents a promise to produce an integer result that's the length of the downloaded string.
 
     > [!NOTE]
-    > If `GetStringAsync` (and therefore `getStringTask`) completes before `AccessTheWebAsync` awaits it, control remains in `AccessTheWebAsync`. The expense of suspending and then returning to `AccessTheWebAsync` would be wasted if the called asynchronous process (`getStringTask`) has already completed and `AccessTheWebSync` doesn't have to wait for the final result.
+    > If `GetStringAsync` (and therefore `getStringTask`) completes before `AccessTheWebAsync` awaits it, control remains in `AccessTheWebAsync`. The expense of suspending and then returning to `AccessTheWebAsync` would be wasted if the called asynchronous process (`getStringTask`) has already completed and `AccessTheWebAsync` doesn't have to wait for the final result.
 
      Inside the caller (the event handler in this example), the processing pattern continues. The caller might do other work that doesn't depend on the result from `AccessTheWebAsync` before awaiting that result, or the caller might await immediately.   The event handler is waiting for `AccessTheWebAsync`, and `AccessTheWebAsync` is waiting for `GetStringAsync`.
 


### PR DESCRIPTION
Fixed (clever) typo in the [!NOTE] section from AccessTheWebSync to AccessTheWebAsync

## Summary

A possible typo was found in the [!NOTE] section:
![image](https://user-images.githubusercontent.com/25067885/59554618-9cae2d80-8f5a-11e9-9c92-b03f16f7e3c2.png)
