### PR TITLE
C# XML serialization example- text clarification

### DIFF
--- a/docs/csharp/programming-guide/concepts/serialization/how-to-write-object-data-to-an-xml-file.md
+++ b/docs/csharp/programming-guide/concepts/serialization/how-to-write-object-data-to-an-xml-file.md
@@ -39,7 +39,7 @@ public class XMLWrite
 ```  
   
 ## Compiling the Code  
- The class must have a public constructor without parameters.  
+ The class being serialized must have a public constructor without parameters.  
   
 ## Robust Programming  
  The following conditions may cause an exception:  


### PR DESCRIPTION
## Summary

Add in which class requires a a public, parameterless constructor:
The class **_being serialized_** must have a public constructor without parameters.

