### PR TITLE
Generic Methods - Add link to compiler error code

### DIFF
--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -25,7 +25,7 @@ A generic method is a method that is declared with type parameters, as follows:
   
  [!code-csharp[csProgGuideGenerics#25](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#25)]  
   
- If you define a generic method that takes the same type parameters as the containing class, the compiler generates warning CS0693 because within the method scope, the argument supplied for the inner `T` hides the argument supplied for the outer `T`. If you require the flexibility of calling a generic class method with type arguments other than the ones provided when the class was instantiated, consider providing another identifier for the type parameter of the method, as shown in `GenericList2<T>` in the following example.  
+ If you define a generic method that takes the same type parameters as the containing class, the compiler generates warning [CS0693](../docs/csharp/misc/cs0693) because within the method scope, the argument supplied for the inner `T` hides the argument supplied for the outer `T`. If you require the flexibility of calling a generic class method with type arguments other than the ones provided when the class was instantiated, consider providing another identifier for the type parameter of the method, as shown in `GenericList2<T>` in the following example.  
   
  [!code-csharp[csProgGuideGenerics#26](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#26)]  
   

--- a/docs/csharp/programming-guide/generics/generic-methods.md
+++ b/docs/csharp/programming-guide/generics/generic-methods.md
@@ -25,7 +25,7 @@ A generic method is a method that is declared with type parameters, as follows:
   
  [!code-csharp[csProgGuideGenerics#25](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#25)]  
   
- If you define a generic method that takes the same type parameters as the containing class, the compiler generates warning [CS0693](../docs/csharp/misc/cs0693) because within the method scope, the argument supplied for the inner `T` hides the argument supplied for the outer `T`. If you require the flexibility of calling a generic class method with type arguments other than the ones provided when the class was instantiated, consider providing another identifier for the type parameter of the method, as shown in `GenericList2<T>` in the following example.  
+ If you define a generic method that takes the same type parameters as the containing class, the compiler generates warning [CS0693](../../misc/cs0693.md) because within the method scope, the argument supplied for the inner `T` hides the argument supplied for the outer `T`. If you require the flexibility of calling a generic class method with type arguments other than the ones provided when the class was instantiated, consider providing another identifier for the type parameter of the method, as shown in `GenericList2<T>` in the following example.  
   
  [!code-csharp[csProgGuideGenerics#26](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csProgGuideGenerics/CS/Generics.cs#26)]  
   


### PR DESCRIPTION
## Summary

Add link to compiler error CS0693 to https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0693

(No description of error code given in text.)
