### PR TITLE
Reusing the StringBuilder sample for the 'var' sample

### DIFF
--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -93,7 +93,7 @@ ms.assetid: f4f60de9-d49b-4fb6-bab1-20e19ea24710
   
      The following example uses implicit typing in a `for` statement.  
   
-     [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#11)]  
+     [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#7)]  
   
      The following example uses implicit typing in a `foreach` statement.  
   

--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -93,7 +93,7 @@ ms.assetid: f4f60de9-d49b-4fb6-bab1-20e19ea24710
   
      The following example uses implicit typing in a `for` statement.  
   
-     [!code-csharp[csProgGuideCodingConventions#11](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#11)]  
+     [!code-csharp[csProgGuideCodingConventions#7](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#11)]  
   
      The following example uses implicit typing in a `foreach` statement.  
   


### PR DESCRIPTION
As suggested in #12591 , the sample for 'var' doesn't reflect the guidance provided earlier about using StringBuilder. As suggested, this change reuses the sample in StringBuilder for the 'var' section

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
