### PR TITLE
Added the word "such"

### DIFF
--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -21,7 +21,7 @@ The name of the struct must be a valid C# [identifier name](../inside-a-program/
 
 Any class or struct that implements the <xref:System.IEquatable%601> interface must contain a definition for an <xref:System.IEquatable%601.Equals%2A> method that matches the signature that the interface specifies. As a result, you can count on a class that implements `IEquatable<T>` to contain an `Equals` method with which an instance of the class can determine whether it's equal to another instance of the same class.  
   
-The definition of `IEquatable<T>` doesn’t provide an implementation for `Equals`. The interface defines only the signature. In that way, an interface in C# is similar to such an abstract class in which all the methods are abstract. However, a class or struct can implement multiple interfaces, but a class can inherit only a single class, abstract or not.
+The definition of `IEquatable<T>` doesn’t provide an implementation for `Equals`. A class or struct can implement multiple interfaces, but a class can only inherit from a single class.
   
 For more information about abstract classes, see [Abstract and Sealed Classes and Class Members](../classes-and-structs/abstract-and-sealed-classes-and-class-members.md).  
   

--- a/docs/csharp/programming-guide/interfaces/index.md
+++ b/docs/csharp/programming-guide/interfaces/index.md
@@ -21,7 +21,7 @@ The name of the struct must be a valid C# [identifier name](../inside-a-program/
 
 Any class or struct that implements the <xref:System.IEquatable%601> interface must contain a definition for an <xref:System.IEquatable%601.Equals%2A> method that matches the signature that the interface specifies. As a result, you can count on a class that implements `IEquatable<T>` to contain an `Equals` method with which an instance of the class can determine whether it's equal to another instance of the same class.  
   
-The definition of `IEquatable<T>` doesn’t provide an implementation for `Equals`. The interface defines only the signature. In that way, an interface in C# is similar to an abstract class in which all the methods are abstract. However, a class or struct can implement multiple interfaces, but a class can inherit only a single class, abstract or not.
+The definition of `IEquatable<T>` doesn’t provide an implementation for `Equals`. The interface defines only the signature. In that way, an interface in C# is similar to such an abstract class in which all the methods are abstract. However, a class or struct can implement multiple interfaces, but a class can inherit only a single class, abstract or not.
   
 For more information about abstract classes, see [Abstract and Sealed Classes and Class Members](../classes-and-structs/abstract-and-sealed-classes-and-class-members.md).  
   


### PR DESCRIPTION
I explicitly added the word "such" because I thought the sentence "an abstract class in which all the methods are abstract" seemed ambiguous to me. It seems like it is conveying two meanings.  One interpretation seems like it is saying "All the methods in an abstract class are abstract" which is completely wrong.  To make the second interpretation more likely to be assumed which says "such an abstract class in which all the methods are abstract", I thought this word or any word that emphasizes this second interpretation should be used. Looking forward to what the community thinks about this change.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
