### PR TITLE
Make is and as more discoverable in TOC

### DIFF
--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -342,7 +342,7 @@
       displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation"
     - name: Type-testing and conversion operators
       href: operators/type-testing-and-conversion-operators.md
-      displayName: "is, as, typeof, (), cast"
+      displayName: "is operator, is keyword, as operator, as keyword, typeof, (), cast"
     - name: Pointer related operators
       href: operators/pointer-related-operators.md
       displayName: "&, *, ->, [], +, -, ++, --, ==, !=, <, >, <=, >=, dereference, address-of, indirection"


### PR DESCRIPTION
I've tried to filter TOC by "is" and "as": not the best experience with too many not relevant results. Thus, this update.