### PR TITLE
Delete local tokens TOC

### DIFF
--- a/docs/csharp/language-reference/tokens/toc.yml
+++ b/docs/csharp/language-reference/tokens/toc.yml
@@ -1,7 +1,0 @@
-- name: C# Special Characters
-  href: index.md
-  items:
-  - name: $ -- string interpolation
-    href: interpolated.md
-  - name: "@ -- verbatim identifier"
-    href: verbatim.md


### PR DESCRIPTION
Looks like this TOC was forgotten to be removed. The *keywords* and *operators* folders don't contain local TOC files.
