### PR TITLE
fix: primary NuGet package cache path for Windows

### DIFF
--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -298,7 +298,7 @@ Run an application DLL, such as `myapp.dll`:
 
 `DOTNET_PACKAGES`
 
-The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%HOME%\NuGet\Packages` on Windows.
+The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%userprofile%\.nuget\packages` on Windows.
 
 `DOTNET_SERVICING`
 
@@ -320,7 +320,7 @@ Disables minor version roll forward, if set to `0`. For more information, see [R
 
 `DOTNET_PACKAGES`
 
-The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%HOME%\NuGet\Packages` on Windows.
+The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%userprofile%\.nuget\packages` on Windows.
 
 `DOTNET_SERVICING`
 
@@ -338,7 +338,7 @@ Specifies whether .NET Core runtime, shared framework, or SDK are resolved from 
 
 `DOTNET_PACKAGES`
 
-The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%HOME%\NuGet\Packages` on Windows.
+The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%userprofile%\.nuget\packages` on Windows.
 
 `DOTNET_SERVICING`
 

--- a/docs/core/tools/dotnet.md
+++ b/docs/core/tools/dotnet.md
@@ -298,7 +298,7 @@ Run an application DLL, such as `myapp.dll`:
 
 `DOTNET_PACKAGES`
 
-The primary package cache. If not set, it defaults to `$HOME/.nuget/packages` on Unix or `%userprofile%\.nuget\packages` on Windows.
+The global packages folder. If not set, it defaults to `~/.nuget/packages` on Unix or `%userprofile%\.nuget\packages` on Windows.
 
 `DOTNET_SERVICING`
 


### PR DESCRIPTION
## Summary

This PR fixes the documentation of the primary NuGet package cache path for Windows in `docs/core/tools/dotnet.md`.

Fixes #9979 
