### PR TITLE
C98833: Fixing bookmark to avoid issues on localized pages

### DIFF
--- a/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
+++ b/docs/csharp/language-reference/operators/bitwise-and-shift-operators.md
@@ -86,7 +86,7 @@ The high-order empty bit positions are set based on the type of the left-hand op
 
 For information about how the right-hand operand of the `>>` operator defines the shift count, see the [Shift count of the shift operators](#shift-count-of-the-shift-operators) section.
 
-## Logical AND operator &amp;
+## <a name="logical-and-operator-"></a> Logical AND operator &amp;
 
 The `&` operator computes the bitwise logical AND of its operands:
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: The lack of tags reference at the beginning of the line prevents bookmarks correct functionality. Kindly consider adding the proposed fixes in order to match bookmarks that are working.
@pkulikov