### PR TITLE
Fix and improve Unicode escape sequence info (C#)

### DIFF
--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Strings - C# Programming Guide"
 ms.custom: seodec18
-ms.date: 07/20/2015
+ms.date: 06/27/2019
 helpviewer_keywords: 
   - "C# language, strings"
   - "strings [C#]"
@@ -56,13 +56,16 @@ A string is an object of type <xref:System.String> whose value is text. Internal
 |\n|New line|0x000A|  
 |\r|Carriage return|0x000D|  
 |\t|Horizontal tab|0x0009|  
-|\U|Unicode escape sequence for surrogate pairs.|\Unnnnnnnn|  
-|\u|Unicode escape sequence|\u0041 = "A"|  
+|\U|Unicode escape sequence (UTF-32)|`\U00nnnnnn` (e.g. `\U0001F47D` = "&#x1F47D;")|  
+|\u|Unicode escape sequence (UTF-16)|`\unnnn` (e.g. `\u0041` = "A")|  
 |\v|Vertical tab|0x000B|  
-|\x|Unicode escape sequence similar to "\u" except with variable length.|\x0041 or \x41 = "A"|  
+|\x|Unicode escape sequence similar to "\u" except with variable length.|`\x0041` or `\x41` = "A"|  
+  
+> [!WARNING]
+>  When using the `\x` escape sequence and specifying less than 4 hex digits, if the characters that immediately follow the escape sequence are valid hex digits (i.e. 0-9, A-F, and a-f), they will be interpreted as being part of the escape sequence. For example, `\xA1` produces "&#161;", which is code point U+00A1. However, if the next character is "A" or "a", then the escape sequence will instead be interpreted as being `\xA1A` and produce "&#x0A1A;", which is code point U+0A1A. In such cases, specifying all 4 hex digits (e.g. `\x00A1` ) will prevent any possible misinterpretation.  
   
 > [!NOTE]
->  At compile time, verbatim strings are converted to ordinary strings with all the same escape sequences. Therefore, if you view a verbatim string in the debugger watch window, you will see the escape characters that were added by the compiler, not the verbatim version from your source code. For example, the verbatim string @"C:\files.txt" will appear in the watch window as "C:\\\files.txt".  
+>  At compile time, verbatim strings are converted to ordinary strings with all the same escape sequences. Therefore, if you view a verbatim string in the debugger watch window, you will see the escape characters that were added by the compiler, not the verbatim version from your source code. For example, the verbatim string `@"C:\files.txt"` will appear in the watch window as "C:\\\files.txt".  
   
 ## Format Strings  
  A format string is a string whose contents are determined dynamically at runtime. Format strings are created by embedding *interpolated expressions* or placeholders inside of braces within a string. Everything inside the braces (`{...}`) will be resolved to a value and output as a formatted string at runtime. There are two methods to create format strings: string interpolation and composite formatting.


### PR DESCRIPTION
1. Remove erroneous note regarding `\U` being used for specifying surrogate pairs. That note was patently false given that a) specifying a surrogate pair results in a compiler error, and b) specifying any valid code point / UTF-32 code unit returns the correct Unicode character for that code point.
    * Even if the original author meant "supplementary characters" instead of "surrogate pairs", that would still be incorrect as the `\U` escape can also be used for BMP characters.
    * Runnable example code showing that a valid code point (U+1F47E) works via `\U0001F47E`, and its surrogate pair via `\UD83DDC7E` does not, on [IDE One](https://ideone.com/deoylQ)
   * In creating the test noted above, I found a bug in the Mono C\# compiler, so I submitted that here:  
       ["\U" Unicode escape sequence for strings accepts invalid value instead of raising error #15456](https://github.com/mono/mono/issues/15456)
   * Runnable example code showing that invalid code point (U+110000) raises an exception, on [IDE One](https://ideone.com/jpVxL4)

2. Correctly indicated that `\U` is for a 4-byte UTF-32 value, and `\u` is for a 2-byte UTF-16 value.

3. Show the pattern _and_ an example to be more readable / helpful. Please note that `\U00nnnnnn` has two permanent zeros and only 6 user-supplied hex digits. This is not only being completely honest (since those first two zeros can only ever be zeros), it removes any possibility of interpreting the 8 hex digits as being for a surrogate pair (which can never start with two zeros), hence reducing confusion.

4. Properly formatted escape sequences as being inline-code

5. Added warning about using `\x` escape with less than 4 hex digits. For more info on this, please see:
     [Unicode Escape Sequences Across Various Languages and Platforms (including Supplementary Characters)](https://sqlquantumleap.com/2019/06/26/unicode-escape-sequences-across-various-languages-and-platforms-including-supplementary-characters/#csharp)
