### PR TITLE
Equality operators: reordered sections about reference type equality

### DIFF
--- a/docs/csharp/language-reference/operators/equality-operators.md
+++ b/docs/csharp/language-reference/operators/equality-operators.md
@@ -39,6 +39,14 @@ User-defined [struct](../keywords/struct.md) types don't support the `==` operat
 
 Beginning with C# 7.3, the `==` and `!=` operators are supported by C# [tuples](../../tuples.md). For more information, see the [Equality and tuples](../../tuples.md#equality-and-tuples) section of the [C# tuple types](../../tuples.md) article.
 
+### Reference types equality
+
+By default, two reference-type operands are equal if they refer to the same object:
+
+[!code-csharp[reference type equality](~/samples/csharp/language-reference/operators/EqualityOperators.cs#ReferenceTypesEquality)]
+
+As the example shows, user-defined reference types support the `==` operator by default. However, a reference type can overload the `==` operator. If a reference type overloads the `==` operator, use the <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> method to check if two references of that type refer to the same object.
+
 ### String equality
 
 Two [string](../keywords/string.md) operands are equal when both of them are `null` or both string instances are of the same length and have identical characters in each character position:
@@ -47,15 +55,7 @@ Two [string](../keywords/string.md) operands are equal when both of them are `nu
 
 That is case-sensitive ordinal comparison. For more information about string comparison, see [How to compare strings in C#](../../how-to/compare-strings.md).
 
-### Reference types equality
-
-Two other than `string` reference type operands are equal when they refer to the same object:
-
-[!code-csharp[reference type equality](~/samples/csharp/language-reference/operators/EqualityOperators.cs#ReferenceTypesEquality)]
-
-As the example shows, user-defined reference types support the `==` operator by default. However, a user-defined reference type can overload the `==` operator. If a reference type overloads the `==` operator, use the <xref:System.Object.ReferenceEquals%2A?displayProperty=nameWithType> method to check if two references of that type refer to the same object.
-
-## Delegate equality
+### Delegate equality
 
 Two [delegate](../../programming-guide/delegates/index.md) operands of the same runtime type are equal when both of them are `null` or their invocation lists are of the same length and have equal entries in each position:
 


### PR DESCRIPTION
Moved the "Reference types equality" section before the "String equality" section. Also, reworded the "Reference types equality" section in order not to give impression that only strings are compared differently.