### PR TITLE
Update package guidelines for .NET Core 3.0

### DIFF
--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -95,11 +95,6 @@ The rest of the version isn't included in the version name. This allows the OS p
 
 The following lists the recommended packages:
 
-* `dotnet-sdk-[major]` - Installs the latest sdk for runtime major
-  * **Version:** \<sdk version>
-  * **Example:** dotnet-sdk-2
-  * **Dependencies:** `dotnet-sdk-[major].[latestminor]`
-
 * `dotnet-sdk-[major].[minor]` - Installs the latest sdk for specific runtime
   * **Version:** \<runtime version>
   * **Example:** dotnet-sdk-2.1

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -78,15 +78,15 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 
 - (11,12) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of an `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
 
-- (13) **Microsoft.NETCore.App.Host.\<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
+- (13) **Microsoft.NETCore.App.Host.\<rid>** contains a native binary for platform `rid`. This binary is a template when compiling a .NET Core application into a native binary for that platform.
 
 - (14) **Microsoft.WindowsDesktop.App.Ref** describes the API of `x.y` version of Windows Desktop applications. These files are used when compiling for that target. This isn't provided on non-Windows platforms.
 
 - (15) **NETStandard.Library.Ref** describes the netstandard `x.y` API. These files are used when compiling for that target.
 
-- (16) **/etc/dotnet/install_location** file that contains the full path to the folder that contains the `dotnet` host binary. The path may be terminated with a newline. It's not necessary to add this file when the root is `/usr/share/dotnet`.
+- (16) **/etc/dotnet/install_location** is a file that contains the full path to the folder that contains the `dotnet` host binary. The path may be terminated with a newline. It's not necessary to add this file when the root is `/usr/share/dotnet`.
 
-- (17) **templates** templates used by the sdk.
+- (17) **templates** contains the templates used by the SDK. For example, `dotnet new` finds project templates here.
 
 ## Recommended packages
 
@@ -103,9 +103,9 @@ The following lists the recommended packages:
   * **Version:** \<runtime version>
   * **Example:** dotnet-sdk-2.1
   * **Contains:** (3),(4)
-  * **Dependencies:** `aspnetcore-runtime-[major].[minor]`, `dotnet-netcoreapp-targeting-pack-[major].[minor]`, `aspnetcore-targeting-pack-[major].[minor]`, `netstandard-targeting-pack-[netstandard_major].[netstandard_minor]`, `dotnet-apphost-pack-[major].[minor]`
+  * **Dependencies:** `aspnetcore-runtime-[major].[minor]`, `dotnet-targeting-pack-[major].[minor]`, `aspnetcore-targeting-pack-[major].[minor]`, `netstandard-targeting-pack-[netstandard_major].[netstandard_minor]`, `dotnet-apphost-pack-[major].[minor]`, `dotnet-templates-[major].[minor]`
 
-* `aspnetcore-runtime-[major].[minor]` - Installs specific ASP.NET Core runtime
+* `aspnetcore-runtime-[major].[minor]` - Installs a specific ASP.NET Core runtime
   * **Version:** \<aspnetcore runtime version>
   * **Example:** aspnetcore-runtime-2.1
   * **Contains:** (6),(7)

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -157,7 +157,7 @@ The `dotnet-runtime-deps-[major].[minor]` requires understanding the _distro spe
 
 When package content is under a versioned folder, the package name `[major].[minor]` match the versioned folder name. For all packages, except the `netstandard-targeting-pack-[major].[minor]`, this also matches with the .NET Core version.
 
-Dependencies between packages should use a _equal or greater than_ version requirement. For example, `dotnet-sdk-2.2:2.2.6` requires `aspnetcore-runtime-2.2 >= 2.2.6`. This makes it possible for the user to upgrade their installation via a root package (e.g. `dnf update dotnet-sdk-2.2`).
+Dependencies between packages should use a _equal or greater than_ version requirement. For example, `dotnet-sdk-2.2:2.2.401` requires `aspnetcore-runtime-2.2 >= 2.2.6`. This makes it possible for the user to upgrade their installation via a root package (e.g. `dnf update dotnet-sdk-2.2`).
 
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -134,15 +134,15 @@ The following lists the recommended packages:
   * **Contains:** (1),(8),(9),(10),(16)
 
 * `dotnet-apphost-pack-[major].[minor]` - dependency
-  * **Version:** \<sdk version>
+  * **Version:** \<runtime version>
   * **Contains:** (13)
 
 * `dotnet-targeting-pack-[major].[minor]` - Allows targeting a non-latest runtime
-  * **Version:** \<sdk version>
+  * **Version:** \<runtime version>
   * **Contains:** (12)
 
 * `aspnetcore-targeting-pack-[major].[minor]` - Allows targeting a non-latest runtime
-  * **Version:** \<sdk version>
+  * **Version:** \<aspnetcore runtime version>
   * **Contains:** (11)
 
 * `netstandard-targeting-pack-[major].[minor]` - Allows targeting a netstandard version

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -155,6 +155,8 @@ The following lists the recommended packages:
 
 The `dotnet-runtime-deps-[major].[minor]` requires understanding the _distro specific dependencies_. Because the distro build system may be able to derive this automatically, the package is optional, in which case these dependencies are added directly to the `dotnet-runtime-[major].[minor]` package.
 
+When package content is under a versioned folder, the package name `[major].[minor]` match the versioned folder name. For all packages, except the `netstandard-targeting-pack-[major].[minor]`, this also matches with the .NET Core version.
+
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 
 - The third-party libraries under `shared/Microsoft.AspNetCore.All` can't be easily built from source. So that folder is omitted from the `aspnetcore-runtime` package.

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -134,23 +134,23 @@ The following lists the recommended packages:
   * **Contains:** (1),(8),(9),(10),(16)
 
 * `dotnet-apphost-pack-[major].[minor]` - dependency
-  * **Version:** \<runtime version>
+  * **Version:** \<sdk version>
   * **Contains:** (13)
 
 * `dotnet-targeting-pack-[major].[minor]` - Allows targeting a non-latest runtime
-  * **Version:** \<runtime version>
+  * **Version:** \<sdk version>
   * **Contains:** (12)
 
 * `aspnetcore-targeting-pack-[major].[minor]` - Allows targeting a non-latest runtime
-  * **Version:** \<aspnetcore runtime version>
+  * **Version:** \<sdk version>
   * **Contains:** (11)
 
 * `netstandard-targeting-pack-[major].[minor]` - Allows targeting a netstandard version
-  * **Version:** \<netstandard version>
+  * **Version:** \<sdk version>
   * **Contains:** (15)
 
 * `dotnet-templates-[major].[minor]`
-  * **Version:** \<templates version>
+  * **Version:** \<sdk version>
   * **Contains:** (15)
 
 The `dotnet-runtime-deps-[major].[minor]` requires understanding the _distro specific dependencies_. Because the distro build system may be able to derive this automatically, the package is optional, in which case these dependencies are added directly to the `dotnet-runtime-[major].[minor]` package.

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -62,7 +62,7 @@ While there's a single host, most of the other components are in versioned direc
 
 - (3) **sdk/\<sdk version>** The SDK (also known as "the tooling") is a set of managed tools that are used to write and build .NET Core libraries and applications. The SDK includes the .NET Core Command-line interface (CLI), the managed languages compilers, MSBuild, and associated build tasks and targets, NuGet, new project templates, and so on.
 
-- (4) **sdk/NuGetFallbackFolder** contains a cache of NuGet packages used by an SDK during the restore operation, such as when running `dotnet restore` or `dotnet build /t:Restore`. This folder is no longer used with .NET Core 3.0+. For earlier versions, it could not be built from source.
+- (4) **sdk/NuGetFallbackFolder** contains a cache of NuGet packages used by an SDK during the restore operation, such as when running `dotnet restore` or `dotnet build /t:Restore`. This folder is only used prior to .NET Core 3.0. It can't be built from source, because it contains prebuilt binary assets from `nuget.org`.
 
 The **shared** folder contains frameworks. A shared framework provides a set of libraries at a central location so they can be used by different applications.
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -112,7 +112,7 @@ The following lists the recommended packages:
   * **Contains:** (6),(7)
   * **Dependencies:** `dotnet-runtime-[major].[minor]`
 
-* `dotnet-runtime-deps-[major].[minor]` - Installs the dependencies for running self-contained applications
+* `dotnet-runtime-deps-[major].[minor]` _(Optional)_ - Installs the dependencies for running self-contained applications
   * **Version:** \<runtime version>
   * **Example:** dotnet-runtime-deps-2.1
   * **Dependencies:** _distro specific dependencies_
@@ -149,6 +149,8 @@ The following lists the recommended packages:
 * `netstandard-targeting-pack-[major].[minor]` - Allows targeting a netstandard version
   * **Version:** \<netstandard version>
   * **Contains:** (15)
+
+The `dotnet-runtime-deps-[major].[minor]` requires understanding the _distro specific dependencies_. Because the distro build system may be able to derive this automatically, the package is optional, in which case these dependencies are added directly to the `dotnet-runtime-[major].[minor]` package.
 
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -104,7 +104,7 @@ The following lists the recommended packages:
   * **Version:** \<runtime version>
   * **Example:** dotnet-sdk-2.1
   * **Contains:** (3),(4)
-  * **Dependencies:** `aspnetcore-runtime-[major].[minor]`, `dotnet-netcoreapp-targeting-pack[major].[minor]`, `dotnet-aspnetcore-targeting-pack[major].[minor]`, `dotnet-netstandard-targeting-pack-[netstandard_major].[netstandard_minor]`, `dotnet-apphost-pack-[major].[minor]`
+  * **Dependencies:** `aspnetcore-runtime-[major].[minor]`, `dotnet-netcoreapp-targeting-pack-[major].[minor]`, `aspnetcore-targeting-pack-[major].[minor]`, `netstandard-targeting-pack-[netstandard_major].[netstandard_minor]`, `dotnet-apphost-pack-[major].[minor]`
 
 * `aspnetcore-runtime-[major].[minor]` - Installs specific ASP.NET Core runtime
   * **Version:** \<aspnetcore runtime version>

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -157,6 +157,8 @@ The `dotnet-runtime-deps-[major].[minor]` requires understanding the _distro spe
 
 When package content is under a versioned folder, the package name `[major].[minor]` match the versioned folder name. For all packages, except the `netstandard-targeting-pack-[major].[minor]`, this also matches with the .NET Core version.
 
+Dependencies between packages should use a _equal or greater than_ version requirement. For example, `dotnet-sdk-2.2:2.2.6` requires `aspnetcore-runtime-2.2 >= 2.2.6`. This makes it possible for the user to upgrade their installation via a root package (e.g. `dnf update dotnet-sdk-2.2`).
+
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 
 - The third-party libraries under `shared/Microsoft.AspNetCore.All` can't be easily built from source. So that folder is omitted from the `aspnetcore-runtime` package.

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -40,11 +40,13 @@ When installed, .NET Core consists of several components that are laid out as fo
 │       └── <netstandard version>        (15)
 ├── shared
 │   ├── Microsoft.NETCore.App
-│   │   └── <runtime version>    (5)
+│   │   └── <runtime version>     (5)
 │   ├── Microsoft.AspNetCore.App
-│   │   └── <aspnetcore version> (6)
-│   └── Microsoft.AspNetCore.All
-│       └── <aspnetcore version> (7)
+│   │   └── <aspnetcore version>  (6)
+│   ├── Microsoft.AspNetCore.All
+│   │   └── <aspnetcore version>  (6)
+│   └── Microsoft.WindowsDesktop.App
+│       └── <desktop app version> (7)
 └── templates
 │   └── <templates version>      (17)
 /
@@ -70,7 +72,9 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 
 - (5) **shared/Microsoft.NETCore.App/\<runtime version>** This framework contains the .NET Core runtime and supporting managed libraries.
 
-- (6,7) **shared/Microsoft.AspNetCore.{App,All}/\<aspnetcore version>** contains the ASP.NET Core libraries. The libraries under `Microsoft.AspNetCore.App` are developed and supported as part of the .NET Core project. The libraries under `Microsoft.AspNetCore.All` are a superset that also contains third-party libraries.
+- (6) **shared/Microsoft.AspNetCore.{App,All}/\<aspnetcore version>** contains the ASP.NET Core libraries. The libraries under `Microsoft.AspNetCore.App` are developed and supported as part of the .NET Core project. The libraries under `Microsoft.AspNetCore.All` are a superset that also contains third-party libraries.
+
+- (7) **shared/Microsoft.Desktop.App/\<desktop app version>** contains the Windows desktop libraries. This isn't included on non-Windows platforms.
 
 - (8) **LICENSE.txt,ThirdPartyNotices.txt** are the .NET Core license and licenses of third-party libraries used in .NET Core, respectively.
 
@@ -108,7 +112,7 @@ The following lists the recommended packages:
 * `aspnetcore-runtime-[major].[minor]` - Installs a specific ASP.NET Core runtime
   * **Version:** \<aspnetcore runtime version>
   * **Example:** aspnetcore-runtime-2.1
-  * **Contains:** (6),(7)
+  * **Contains:** (6)
   * **Dependencies:** `dotnet-runtime-[major].[minor]`
 
 * `dotnet-runtime-deps-[major].[minor]` _(Optional)_ - Installs the dependencies for running self-contained applications

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -38,13 +38,15 @@ When installed, .NET Core consists of several components that are laid out as fo
 │   │   └── <desktop ref version>        (14)
 │   └── NETStandard.Library.Ref
 │       └── <netstandard version>        (15)
-└── shared
-    ├── Microsoft.NETCore.App
-    │   └── <runtime version>    (5)
-    ├── Microsoft.AspNetCore.App
-    │   └── <aspnetcore version> (6)
-    └── Microsoft.AspNetCore.All
-        └── <aspnetcore version> (7)
+├── shared
+│   ├── Microsoft.NETCore.App
+│   │   └── <runtime version>    (5)
+│   ├── Microsoft.AspNetCore.App
+│   │   └── <aspnetcore version> (6)
+│   └── Microsoft.AspNetCore.All
+│       └── <aspnetcore version> (7)
+└── templates
+│   └── <templates version>      (17)
 /
 ├── etc/dotnet
 │       └── install_location     (16)
@@ -83,6 +85,8 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 - (15) **NETStandard.Library.Ref** describes the netstandard `x.y` API. These files are used when compiling for that target.
 
 - (16) **/etc/dotnet/install_location** file that contains the full path to the folder that contains the `dotnet` host binary. The path may be terminated with a newline. It's not necessary to add this file when the root is `/usr/share/dotnet`.
+
+- (17) **templates** templates used by the sdk.
 
 ## Recommended packages
 
@@ -143,6 +147,10 @@ The following lists the recommended packages:
 
 * `netstandard-targeting-pack-[major].[minor]` - Allows targeting a netstandard version
   * **Version:** \<netstandard version>
+  * **Contains:** (15)
+
+* `dotnet-templates-[major].[minor]`
+  * **Version:** \<templates version>
   * **Contains:** (15)
 
 The `dotnet-runtime-deps-[major].[minor]` requires understanding the _distro specific dependencies_. Because the distro build system may be able to derive this automatically, the package is optional, in which case these dependencies are added directly to the `dotnet-runtime-[major].[minor]` package.

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -117,7 +117,7 @@ The following lists the recommended packages:
   * **Example:** dotnet-runtime-deps-2.1
   * **Dependencies:** _distro specific dependencies_
 
-* `dotnet-runtime-[major].[minor]` - Installs specific runtime
+* `dotnet-runtime-[major].[minor]` - Installs a specific runtime
   * **Version:** \<runtime version>
   * **Example:** dotnet-runtime-2.1
   * **Contains:** (5)

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -112,7 +112,7 @@ The following lists the recommended packages:
   * **Contains:** (6),(7)
   * **Dependencies:** `dotnet-runtime-[major].[minor]`
 
-* `dotnet-runtime-deps-[major].[minor]` - Installs dependencies for running self-contained applications
+* `dotnet-runtime-deps-[major].[minor]` - Installs the dependencies for running self-contained applications
   * **Version:** \<runtime version>
   * **Example:** dotnet-runtime-deps-2.1
   * **Dependencies:** _distro specific dependencies_

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -112,11 +112,16 @@ The following lists the recommended packages:
   * **Contains:** (6),(7)
   * **Dependencies:** `dotnet-runtime-[major].[minor]`
 
+* `dotnet-runtime-deps-[major].[minor]` - Installs dependencies for running self-contained applications
+  * **Version:** \<runtime version>
+  * **Example:** dotnet-runtime-deps-2.1
+  * **Dependencies:** _distro specific dependencies_
+
 * `dotnet-runtime-[major].[minor]` - Installs specific runtime
   * **Version:** \<runtime version>
   * **Example:** dotnet-runtime-2.1
   * **Contains:** (5)
-  * **Dependencies:** `dotnet-hostfxr:<runtime version>+`
+  * **Dependencies:** `dotnet-hostfxr:<runtime version>+`, `dotnet-runtime-deps-[major].[minor]`
 
 * `dotnet-hostfxr` - dependency
   * **Version:** \<runtime version>

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -46,9 +46,11 @@ When installed, .NET Core consists of several components that are laid out as fo
     └── Microsoft.AspNetCore.All
         └── <aspnetcore version> (7)
 /
-├─usr/share/man/man1
+├── etc/dotnet
+│       └── install_location     (16)
+├── usr/share/man/man1
 │       └── dotnet.1.gz          (9)
-└─usr/bin
+└── usr/bin
         └── dotnet               (10)
 ```
 
@@ -79,6 +81,8 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 - (14) **Microsoft.WindowsDesktop.App.Ref** describes the API of `x.y` version of Windows Desktop applications. These files are used when compiling for that target. This isn't provided on non-Windows platforms.
 
 - (15) **NETStandard.Library.Ref** describes the netstandard `x.y` API. These files are used when compiling for that target.
+
+- (16) **/etc/dotnet/install_location** file that contains the full path to the folder that contains the `dotnet` host binary. The path may be terminated with a newline. It's not necessary to add this file when the root is `/usr/share/dotnet`.
 
 ## Recommended packages
 
@@ -123,7 +127,7 @@ The following lists the recommended packages:
 * `dotnet-host` - dependency
   * **Version:** \<runtime version>
   * **Example:** dotnet-host
-  * **Contains:** (1),(8),(9),(10)
+  * **Contains:** (1),(8),(9),(10),(16)
 
 * `dotnet-apphost-pack-[major].[minor]` - dependency
   * **Version:** \<runtime version>

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -27,11 +27,22 @@ When installed, .NET Core consists of several components that are laid out as fo
 ├── sdk
 │   ├── <sdk version>            (3)
 │   └── NuGetFallbackFolder      (4)
+├── packs
+│   ├── Microsoft.AspNetCore.App.Ref
+│   │   └── <aspnetcore ref version>     (11)
+│   ├── Microsoft.NETCore.App.Ref
+│   │   └── <netcore ref version>        (11)
+│   ├── Microsoft.NETCore.App.Host.<rid>
+│   │   └── <apphost version>            (12)
+│   ├── Microsoft.WindowsDesktop.App.Ref
+│   │   └── <desktop ref version>        (13)
+│   └── NETStandard.Library.Ref
+│       └── <netstandard version>        (14)
 └── shared
     ├── Microsoft.NETCore.App
     │   └── <runtime version>    (5)
-    └── Microsoft.AspNetCore.App
-        └── <aspnetcore version> (6)
+    ├── Microsoft.AspNetCore.App
+    │   └── <aspnetcore version> (6)
     └── Microsoft.AspNetCore.All
         └── <aspnetcore version> (7)
 /
@@ -61,6 +72,14 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 
 - (9,10) **dotnet.1.gz, dotnet** `dotnet.1.gz` is the dotnet manual page. `dotnet` is a symlink to the dotnet host(1). These files are installed at well known locations for system integration.
 
+- (11) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of a `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
+
+- (12) **Microsoft.NETCore.App.Host.<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
+
+- (13) **Microsoft.WindowsDesktop.App.Ref** describes the API of `x.y` version of Windows Desktop applications. These files are used when compiling for that target.
+
+- (14) **NETStandard.Library.Ref** describes the netstandard `x.y` API. These files are used when compiling for that target.
+
 ## Recommended packages
 
 .NET Core versioning is based on the runtime component `[major].[minor]` version numbers.
@@ -72,19 +91,20 @@ The rest of the version isn't included in the version name. This allows the OS p
 
 The following table shows the recommended packages:
 
-| Name                                    | Example                | Use case: Install ...           | Contains           | Dependencies                                   | Version            |
-|-----------------------------------------|------------------------|---------------------------------|--------------------|------------------------------------------------|--------------------|
-| dotnet-sdk-[major]                      | dotnet-sdk-2           | Latest sdk for runtime major    |                    | dotnet-sdk-[major].[latestminor]               | \<sdk version>     |
-| dotnet-sdk-[major].[minor]              | dotnet-sdk-2.1         | Latest sdk for specific runtime |                    | dotnet-sdk-[major].[minor].[latest sdk feat]xx | \<sdk version>     |
-| dotnet-sdk-[major].[minor].[sdk feat]xx | dotnet-sdk-2.1.3xx     | Specific sdk feature release    | (3),(4)            | aspnetcore-runtime-[major].[minor]             | \<sdk version>     |
-| aspnetcore-runtime-[major].[minor]      | aspnetcore-runtime-2.1 | Specific ASP.NET Core runtime   | (6),[(7)]          | dotnet-runtime-[major].[minor]                 | \<runtime version> |
-| dotnet-runtime-[major].[minor]          | dotnet-runtime-2.1     | Specific runtime                | (5)                | host-fxr:\<runtime version>+                   | \<runtime version> |
-| dotnet-host-fxr                         | dotnet-host-fxr        | _dependency_                    | (2)                | host:\<runtime version>+                       | \<runtime version> |
-| dotnet-host                             | dotnet-host            | _dependency_                    | (1),(8),(9),(10)   |                                                | \<runtime version> |
+| Name                              | Example            | Use case: Install ...           | Contains           | Dependencies                                   | Version            |
+|-----------------------------------|--------------------|---------------------------------|--------------------|------------------------------------------------|--------------------|
+| dotnet-sdk-[major]                | dotnet-sdk-2       | Latest sdk for runtime major    |                    | dotnet-sdk-[major].[latestminor]               | \<sdk version>     |
+| dotnet-sdk-[major].[minor]        | dotnet-sdk-2.1     | Latest sdk for specific runtime | (3),(4),(11),(12)  | aspnet-runtime-[major].[minor], dotnet-netstd-pack-[netstd_major].[netstd_minor] | \<sdk version>     |
+| aspnet-runtime-[major].[minor]    | aspnet-runtime-2.1 | Specific ASP.NET Core runtime   | (6),[(7)]          | dotnet-runtime-[major].[minor]                 | \<runtime version> |
+| dotnet-runtime-[major].[minor]    | dotnet-runtime-2.1 | Specific runtime                | (5)                | host-fxr:\<runtime version>+                   | \<runtime version> |
+| dotnet-host-fxr                   | dotnet-host-fxr    | _dependency_                    | (2)                | host:\<runtime version>+                       | \<runtime version> |
+| dotnet-host                       | dotnet-host        | _dependency_                    | (1),(8),(9),(10)   |                                                | \<runtime version> |
+| dotnet-desktop-pack-[major.minor] |                    | _dependency_                    | (12)               |                                                | \<desktop version>  |
+| dotnet-netstd-pack-[major.minor]  |                    | _dependency_                    | (13)               |                                                | \<netstd version>  |
 
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 
-- The third-party libraries under `shared/Microsoft.AspNetCore.All` can't be easily built from source. So that folder is omitted from the `aspnetcore-runtime` package.
+- The third-party libraries under `shared/Microsoft.AspNetCore.All` can't be easily built from source. So that folder is omitted from the `aspnet-runtime` package.
 
 - The `NuGetFallbackFolder` is populated using binary artifacts from `nuget.org`. It should remain empty.
 
@@ -92,28 +112,7 @@ Multiple `dotnet-sdk` packages may provide the same files for the `NuGetFallback
 
 ### Preview versions
 
-Package maintainers may decide to provide preview versions of the shared framework and SDK. Preview releases may be provided using the `dotnet-sdk-[major].[minor].[sdk feat]xx`, `aspnetcore-runtime-[major].[minor]`, or `dotnet-runtime-[major].[minor]` packages. For preview releases, the package version major must be set to zero. This way, the final release is installed as an upgrade of the package.
-
-### Patch packages
-
-Since a patch version of a package may cause a breaking change, a package maintainer may want to provide _patch packages_. These packages allow you to install a specific patch version that isn't automatically upgraded. Only use patch packages in rare circumstances as they aren't upgraded with (security) fixes.
-
-The following table shows the recommended packages and **patch packages**:
-
-| Name                                           | Example                  | Contains         | Dependencies                                              |
-|------------------------------------------------|--------------------------|------------------|-----------------------------------------------------------|
-| dotnet-sdk-[major]                             | dotnet-sdk-2             |                  | dotnet-sdk-[major].[latest sdk minor]                     |
-| dotnet-sdk-[major].[minor]                     | dotnet-sdk-2.1           |                  | dotnet-sdk-[major].[minor].[latest sdk feat]xx            |
-| dotnet-sdk-[major].[minor].[sdk feat]xx        | dotnet-sdk-2.1.3xx       |                  | dotnet-sdk-[major].[minor].[latest sdk patch]             |
-| **dotnet-sdk-[major].[minor].[patch]**         | dotnet-sdk-2.1.300       | (3),(4)          | aspnetcore-runtime-[major].[minor].[sdk runtime patch]    |
-| aspnetcore-runtime-[major].[minor]             | aspnetcore-runtime-2.1   |                  | aspnetcore-runtime-[major].[minor].[latest runtime patch] |
-| **aspnetcore-runtime-[major].[minor].[patch]** | aspnetcore-runtime-2.1.0 | (6),[(7)]        | dotnet-runtime-[major].[minor].[patch]                    |
-| dotnet-runtime-[major].[minor]                 | dotnet-runtime-2.1       |                  | dotnet-runtime-[major].[minor].[latest runtime patch]     |
-| **dotnet-runtime-[major].[minor].[patch]**     | dotnet-runtime-2.1.0     | (5)              | host-fxr:\<runtime version>+                              |
-| dotnet-host-fxr                                | dotnet-host-fxr          | (2)              | host:\<runtime version>+                                  |
-| dotnet-host                                    | dotnet-host              | (1),(8),(9),(10) |                                                           |
-
-An alternative to using patch packages is _pinning_ the packages to a specific version using the package manager. To avoid affecting other applications/users, such applications can be built and deployed in a container.
+Package maintainers may decide to provide preview versions of the shared framework and SDK. Preview releases may be provided using the `dotnet-sdk-[major].[minor]`, `aspnet-runtime-[major].[minor]`, or `dotnet-runtime-[major].[minor]` packages. For preview releases, the package version major must be set to zero. This way, the final release is installed as an upgrade of the package.
 
 ## Building packages
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -76,7 +76,7 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 
 - (11,12) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of an `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
 
-- (13) **Microsoft.NETCore.App.Host.<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
+- (13) **Microsoft.NETCore.App.Host.\<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
 
 - (14) **Microsoft.WindowsDesktop.App.Ref** describes the API of `x.y` version of Windows Desktop applications. These files are used when compiling for that target. This isn't provided on non-Windows platforms.
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -142,7 +142,7 @@ The following lists the recommended packages:
   * **Version:** \<runtime version>
   * **Contains:** (12)
 
-* `aspnetcore-targeting-pack-[major].[minor]` - allows targeting a non-latest runtime
+* `aspnetcore-targeting-pack-[major].[minor]` - Allows targeting a non-latest runtime
   * **Version:** \<aspnetcore runtime version>
   * **Contains:** (11)
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -31,13 +31,13 @@ When installed, .NET Core consists of several components that are laid out as fo
 │   ├── Microsoft.AspNetCore.App.Ref
 │   │   └── <aspnetcore ref version>     (11)
 │   ├── Microsoft.NETCore.App.Ref
-│   │   └── <netcore ref version>        (11)
+│   │   └── <netcore ref version>        (12)
 │   ├── Microsoft.NETCore.App.Host.<rid>
-│   │   └── <apphost version>            (12)
+│   │   └── <apphost version>            (13)
 │   ├── Microsoft.WindowsDesktop.App.Ref
-│   │   └── <desktop ref version>        (13)
+│   │   └── <desktop ref version>        (14)
 │   └── NETStandard.Library.Ref
-│       └── <netstandard version>        (14)
+│       └── <netstandard version>        (15)
 └── shared
     ├── Microsoft.NETCore.App
     │   └── <runtime version>    (5)
@@ -60,7 +60,7 @@ While there's a single host, most of the other components are in versioned direc
 
 - (3) **sdk/\<sdk version>** The SDK (also known as "the tooling") is a set of managed tools that are used to write and build .NET Core libraries and applications. The SDK includes the .NET Core Command-line interface (CLI), the managed languages compilers, MSBuild, and associated build tasks and targets, NuGet, new project templates, and so on.
 
-- (4) **sdk/NuGetFallbackFolder** contains a cache of NuGet packages used by an SDK during the restore operation, such as when running `dotnet restore` or `dotnet build /t:Restore`.
+- (4) **sdk/NuGetFallbackFolder** contains a cache of NuGet packages used by an SDK during the restore operation, such as when running `dotnet restore` or `dotnet build /t:Restore`. This folder is no longer used with .NET Core 3.0+. For earlier versions, it could not be built from source.
 
 The **shared** folder contains frameworks. A shared framework provides a set of libraries at a central location so they can be used by different applications.
 
@@ -72,13 +72,13 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 
 - (9,10) **dotnet.1.gz, dotnet** `dotnet.1.gz` is the dotnet manual page. `dotnet` is a symlink to the dotnet host(1). These files are installed at well known locations for system integration.
 
-- (11) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of a `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
+- (11,12) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of a `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
 
-- (12) **Microsoft.NETCore.App.Host.<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
+- (13) **Microsoft.NETCore.App.Host.<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
 
-- (13) **Microsoft.WindowsDesktop.App.Ref** describes the API of `x.y` version of Windows Desktop applications. These files are used when compiling for that target.
+- (14) **Microsoft.WindowsDesktop.App.Ref** describes the API of `x.y` version of Windows Desktop applications. These files are used when compiling for that target. This isn't provided on non-Windows platforms.
 
-- (14) **NETStandard.Library.Ref** describes the netstandard `x.y` API. These files are used when compiling for that target.
+- (15) **NETStandard.Library.Ref** describes the netstandard `x.y` API. These files are used when compiling for that target.
 
 ## Recommended packages
 
@@ -91,16 +91,17 @@ The rest of the version isn't included in the version name. This allows the OS p
 
 The following table shows the recommended packages:
 
-| Name                              | Example            | Use case: Install ...           | Contains           | Dependencies                                   | Version            |
-|-----------------------------------|--------------------|---------------------------------|--------------------|------------------------------------------------|--------------------|
-| dotnet-sdk-[major]                | dotnet-sdk-2       | Latest sdk for runtime major    |                    | dotnet-sdk-[major].[latestminor]               | \<sdk version>     |
-| dotnet-sdk-[major].[minor]        | dotnet-sdk-2.1     | Latest sdk for specific runtime | (3),(4),(11),(12)  | aspnet-runtime-[major].[minor], dotnet-netstd-pack-[netstd_major].[netstd_minor] | \<sdk version>     |
-| aspnet-runtime-[major].[minor]    | aspnet-runtime-2.1 | Specific ASP.NET Core runtime   | (6),[(7)]          | dotnet-runtime-[major].[minor]                 | \<runtime version> |
-| dotnet-runtime-[major].[minor]    | dotnet-runtime-2.1 | Specific runtime                | (5)                | host-fxr:\<runtime version>+                   | \<runtime version> |
-| dotnet-host-fxr                   | dotnet-host-fxr    | _dependency_                    | (2)                | host:\<runtime version>+                       | \<runtime version> |
-| dotnet-host                       | dotnet-host        | _dependency_                    | (1),(8),(9),(10)   |                                                | \<runtime version> |
-| dotnet-desktop-pack-[major.minor] |                    | _dependency_                    | (12)               |                                                | \<desktop version>  |
-| dotnet-netstd-pack-[major.minor]  |                    | _dependency_                    | (13)               |                                                | \<netstd version>  |
+| Name                              | Example            | Use case: Install ...           | Contains         | Dependencies                      | Version            |
+|-----------------------------------|--------------------|---------------------------------|------------------|-----------------------------------|--------------------|
+| dotnet-sdk-[major]                | dotnet-sdk-2       | Latest sdk for runtime major    |                  | dotnet-sdk-[major].[latestminor]  | \<sdk version>     |
+| dotnet-sdk-[major].[minor]        | dotnet-sdk-2.1     | Latest sdk for specific runtime | (3),(4),(13)     | aspnet-runtime-[major].[minor], dotnet-netcoreapp-targeting-pack[major].[minor], dotnet-aspnet-targeting-pack[major].[minor], dotnet-netstandard-targeting-pack-[netst_major].[netstd_minor] | \<sdk version>     |
+| aspnet-runtime-[major].[minor]    | aspnet-runtime-2.1 | Specific ASP.NET Core runtime   | (6),[(7)]        | dotnet-runtime-[major].[minor]    | \<runtime version> |
+| dotnet-runtime-[major].[minor]    | dotnet-runtime-2.1 | Specific runtime                | (5)              | host-fxr:\<runtime version>+      | \<runtime version> |
+| dotnet-host-fxr                   | dotnet-host-fxr    | _dependency_                    | (2)              | host:\<runtime version>+          | \<runtime version> |
+| dotnet-host                       | dotnet-host        | _dependency_                    | (1),(8),(9),(10) |                                   | \<runtime version> |
+| dotnet-netcoreapp-targeting-pack-[major].[minor]    |  | _dependency_                    | (12)             |                                   | \<pack version>    |
+| dotnet-aspnet-targeting-pack-[major].[minor]        |  | _dependency_                    | (11)             |                                   | \<pack version>    |
+| dotnet-netstandard-targeting-pack-[netst_major].[netst_minor] || _dependency_            | (15)             |                                   | \<pack version>    |
 
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -99,7 +99,7 @@ The following table shows the recommended packages:
 | dotnet-runtime-[major].[minor]    | dotnet-runtime-2.1 | Specific runtime                | (5)              | host-fxr:\<runtime version>+      | \<runtime version> |
 | dotnet-host-fxr                   | dotnet-host-fxr    | _dependency_                    | (2)              | host:\<runtime version>+          | \<runtime version> |
 | dotnet-host                       | dotnet-host        | _dependency_                    | (1),(8),(9),(10) |                                   | \<runtime version> |
-| dotnet-netcoreapp-targeting-pack-[major].[minor]    |  | _dependency_                    | (12)             |                                   | \<pack version>    |
+| dotnet-targeting-pack-[major].[minor]    |  | _dependency_                    | (12)             |                                   | \<pack version>    |
 | dotnet-aspnet-targeting-pack-[major].[minor]        |  | _dependency_                    | (11)             |                                   | \<pack version>    |
 | dotnet-netstandard-targeting-pack-[netst_major].[netst_minor] || _dependency_            | (15)             |                                   | \<pack version>    |
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -89,20 +89,57 @@ For example: SDK version 2.2.302 is the second patch release of the third featur
 Some of the packages include part of the version number in their name. This allows you to install a specific version.
 The rest of the version isn't included in the version name. This allows the OS package manager to update the packages (for example, automatically installing security fixes). Supported package managers are Linux specific.
 
-The following table shows the recommended packages:
+The following lists the recommended packages:
 
-| Name                               | Example            | Use case: Install ...           | Contains         | Dependencies                       | Version            |
-|------------------------------------|--------------------|---------------------------------|------------------|------------------------------------|--------------------|
-| dotnet-sdk-[major]                 | dotnet-sdk-2       | Latest sdk for runtime major    |                  | dotnet-sdk-[major].[latestminor]   | \<sdk version>     |
-| dotnet-sdk-[major].[minor]         | dotnet-sdk-2.1     | Latest sdk for specific runtime | (3),(4)          | aspnetcore-runtime-[major].[minor], dotnet-netcoreapp-targeting-pack[major].[minor], dotnet-aspnetcore-targeting-pack[major].[minor], dotnet-netstandard-targeting-pack-[netst_major].[netstd_minor], dotnet-apphost-pack-[major].[minor] | \<sdk version>     |
-| aspnetcore-runtime-[major].[minor] | aspnetcore-runtime-2.1 | Specific ASP.NET Core runtime | (6),[(7)]      | dotnet-runtime-[major].[minor]     | \<runtime version> |
-| dotnet-runtime-[major].[minor]     | dotnet-runtime-2.1 | Specific runtime                | (5)              | dotnet-hostfxr:\<runtime version>+ | \<runtime version> |
-| dotnet-hostfxr                     | dotnet-hostfxr     | _dependency_                    | (2)              | host:\<runtime version>+           | \<runtime version> |
-| dotnet-host                        | dotnet-host        | _dependency_                    | (1),(8),(9),(10) |                                    | \<runtime version> |
-| dotnet-apphost-pack-[major].[minor]|                    | _dependency_                    | (13)             |                                    | \<pack version>    |
-| dotnet-targeting-pack-[major].[minor]     |             | _dependency_                    | (12)             |                                    | \<pack version>    |
-| aspnetcore-targeting-pack-[major].[minor] |             | _dependency_                    | (11)             |                                    | \<pack version>    |
-| netstandard-targeting-pack-[netst_major].[netst_minor] || _dependency_                    | (15)             |                                    | \<pack version>    |
+* `dotnet-sdk-[major]` - Installs latest sdk for runtime major
+  * **Version:** \<sdk version>
+  * **Example:** dotnet-sdk-2
+  * **Dependencies:** `dotnet-sdk-[major].[latestminor]`
+
+* `dotnet-sdk-[major].[minor]` - Installs latest sdk for specific runtime
+  * **Version:** \<runtime version>
+  * **Example:** dotnet-sdk-2.1
+  * **Contains:** (3),(4)
+  * **Dependencies:** `aspnetcore-runtime-[major].[minor]`, `dotnet-netcoreapp-targeting-pack[major].[minor]`, `dotnet-aspnetcore-targeting-pack[major].[minor]`, `dotnet-netstandard-targeting-pack-[netstandard_major].[netstandard_minor]`, `dotnet-apphost-pack-[major].[minor]`
+
+* `aspnetcore-runtime-[major].[minor]` - Installs specific ASP.NET Core runtime
+  * **Version:** \<aspnetcore runtime version>
+  * **Example:** aspnetcore-runtime-2.1
+  * **Contains:** (6),(7)
+  * **Dependencies:** `dotnet-runtime-[major].[minor]`
+
+* `dotnet-runtime-[major].[minor]` - Installs specific runtime
+  * **Version:** \<runtime version>
+  * **Example:** dotnet-runtime-2.1
+  * **Contains:** (5)
+  * **Dependencies:** `dotnet-hostfxr:<runtime version>+`
+
+* `dotnet-hostfxr` - dependency
+  * **Version:** \<runtime version>
+  * **Example:** dotnet-hostfxr
+  * **Contains:** (2)
+  * **Dependencies:** `host:<runtime version>+`
+
+* `dotnet-host` - dependency
+  * **Version:** \<runtime version>
+  * **Example:** dotnet-host
+  * **Contains:** (1),(8),(9),(10)
+
+* `dotnet-apphost-pack-[major].[minor]` - dependency
+  * **Version:** \<runtime version>
+  * **Contains:** (13)
+
+* `dotnet-targeting-pack-[major].[minor]` - allows targeting a non-latest runtime
+  * **Version:** \<runtime version>
+  * **Contains:** (12)
+
+* `aspnetcore-targeting-pack-[major].[minor]` - allows targeting a non-latest runtime
+  * **Version:** \<aspnetcore runtime version>
+  * **Contains:** (11)
+
+* `netstandard-targeting-pack-[major].[minor]` - allows targeting a netstandard version
+  * **Version:** \<netstandard version>
+  * **Contains:** (15)
 
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -112,10 +112,6 @@ Most distributions require all artifacts to be built from source. This has some 
 
 Multiple `dotnet-sdk` packages may provide the same files for the `NuGetFallbackFolder`. To avoid issues with the package manager, these files should be identical (checksum, modification date, and so on).
 
-### Preview versions
-
-Package maintainers may decide to provide preview versions of the shared framework and SDK. Preview releases may be provided using the `dotnet-sdk-[major].[minor]`, `aspnetcore-runtime-[major].[minor]`, or `dotnet-runtime-[major].[minor]` packages. For preview releases, the package version major must be set to zero. This way, the final release is installed as an upgrade of the package.
-
 ## Building packages
 
 The [dotnet/source-build](https://github.com/dotnet/source-build) repository provides instructions on how to build a source tarball of the .NET Core SDK and all its components. The output of the source-build repository matches the layout described in the first section of this article.

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -146,7 +146,7 @@ The following lists the recommended packages:
   * **Version:** \<aspnetcore runtime version>
   * **Contains:** (11)
 
-* `netstandard-targeting-pack-[major].[minor]` - allows targeting a netstandard version
+* `netstandard-targeting-pack-[major].[minor]` - Allows targeting a netstandard version
   * **Version:** \<netstandard version>
   * **Contains:** (15)
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -91,21 +91,22 @@ The rest of the version isn't included in the version name. This allows the OS p
 
 The following table shows the recommended packages:
 
-| Name                              | Example            | Use case: Install ...           | Contains         | Dependencies                      | Version            |
-|-----------------------------------|--------------------|---------------------------------|------------------|-----------------------------------|--------------------|
-| dotnet-sdk-[major]                | dotnet-sdk-2       | Latest sdk for runtime major    |                  | dotnet-sdk-[major].[latestminor]  | \<sdk version>     |
-| dotnet-sdk-[major].[minor]        | dotnet-sdk-2.1     | Latest sdk for specific runtime | (3),(4),(13)     | aspnet-runtime-[major].[minor], dotnet-netcoreapp-targeting-pack[major].[minor], dotnet-aspnet-targeting-pack[major].[minor], dotnet-netstandard-targeting-pack-[netst_major].[netstd_minor] | \<sdk version>     |
-| aspnet-runtime-[major].[minor]    | aspnet-runtime-2.1 | Specific ASP.NET Core runtime   | (6),[(7)]        | dotnet-runtime-[major].[minor]    | \<runtime version> |
-| dotnet-runtime-[major].[minor]    | dotnet-runtime-2.1 | Specific runtime                | (5)              | host-fxr:\<runtime version>+      | \<runtime version> |
-| dotnet-host-fxr                   | dotnet-host-fxr    | _dependency_                    | (2)              | host:\<runtime version>+          | \<runtime version> |
-| dotnet-host                       | dotnet-host        | _dependency_                    | (1),(8),(9),(10) |                                   | \<runtime version> |
-| dotnet-targeting-pack-[major].[minor]    |  | _dependency_                    | (12)             |                                   | \<pack version>    |
-| dotnet-aspnet-targeting-pack-[major].[minor]        |  | _dependency_                    | (11)             |                                   | \<pack version>    |
-| dotnet-netstandard-targeting-pack-[netst_major].[netst_minor] || _dependency_            | (15)             |                                   | \<pack version>    |
+| Name                               | Example            | Use case: Install ...           | Contains         | Dependencies                       | Version            |
+|------------------------------------|--------------------|---------------------------------|------------------|------------------------------------|--------------------|
+| dotnet-sdk-[major]                 | dotnet-sdk-2       | Latest sdk for runtime major    |                  | dotnet-sdk-[major].[latestminor]   | \<sdk version>     |
+| dotnet-sdk-[major].[minor]         | dotnet-sdk-2.1     | Latest sdk for specific runtime | (3),(4)          | aspnetcore-runtime-[major].[minor], dotnet-netcoreapp-targeting-pack[major].[minor], dotnet-aspnetcore-targeting-pack[major].[minor], dotnet-netstandard-targeting-pack-[netst_major].[netstd_minor], dotnet-apphost-pack-[major].[minor] | \<sdk version>     |
+| aspnetcore-runtime-[major].[minor] | aspnetcore-runtime-2.1 | Specific ASP.NET Core runtime | (6),[(7)]      | dotnet-runtime-[major].[minor]     | \<runtime version> |
+| dotnet-runtime-[major].[minor]     | dotnet-runtime-2.1 | Specific runtime                | (5)              | dotnet-hostfxr:\<runtime version>+ | \<runtime version> |
+| dotnet-hostfxr                     | dotnet-hostfxr     | _dependency_                    | (2)              | host:\<runtime version>+           | \<runtime version> |
+| dotnet-host                        | dotnet-host        | _dependency_                    | (1),(8),(9),(10) |                                    | \<runtime version> |
+| dotnet-apphost-pack-[major].[minor]|                    | _dependency_                    | (13)             |                                    | \<pack version>    |
+| dotnet-targeting-pack-[major].[minor]     |             | _dependency_                    | (12)             |                                    | \<pack version>    |
+| aspnetcore-targeting-pack-[major].[minor] |             | _dependency_                    | (11)             |                                    | \<pack version>    |
+| netstandard-targeting-pack-[netst_major].[netst_minor] || _dependency_                    | (15)             |                                    | \<pack version>    |
 
 Most distributions require all artifacts to be built from source. This has some impact on the packages:
 
-- The third-party libraries under `shared/Microsoft.AspNetCore.All` can't be easily built from source. So that folder is omitted from the `aspnet-runtime` package.
+- The third-party libraries under `shared/Microsoft.AspNetCore.All` can't be easily built from source. So that folder is omitted from the `aspnetcore-runtime` package.
 
 - The `NuGetFallbackFolder` is populated using binary artifacts from `nuget.org`. It should remain empty.
 
@@ -113,7 +114,7 @@ Multiple `dotnet-sdk` packages may provide the same files for the `NuGetFallback
 
 ### Preview versions
 
-Package maintainers may decide to provide preview versions of the shared framework and SDK. Preview releases may be provided using the `dotnet-sdk-[major].[minor]`, `aspnet-runtime-[major].[minor]`, or `dotnet-runtime-[major].[minor]` packages. For preview releases, the package version major must be set to zero. This way, the final release is installed as an upgrade of the package.
+Package maintainers may decide to provide preview versions of the shared framework and SDK. Preview releases may be provided using the `dotnet-sdk-[major].[minor]`, `aspnetcore-runtime-[major].[minor]`, or `dotnet-runtime-[major].[minor]` packages. For preview releases, the package version major must be set to zero. This way, the final release is installed as an upgrade of the package.
 
 ## Building packages
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -100,7 +100,7 @@ The following lists the recommended packages:
   * **Example:** dotnet-sdk-2
   * **Dependencies:** `dotnet-sdk-[major].[latestminor]`
 
-* `dotnet-sdk-[major].[minor]` - Installs latest sdk for specific runtime
+* `dotnet-sdk-[major].[minor]` - Installs the latest sdk for specific runtime
   * **Version:** \<runtime version>
   * **Example:** dotnet-sdk-2.1
   * **Contains:** (3),(4)

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -74,7 +74,7 @@ The **shared** folder contains frameworks. A shared framework provides a set of 
 
 - (9,10) **dotnet.1.gz, dotnet** `dotnet.1.gz` is the dotnet manual page. `dotnet` is a symlink to the dotnet host(1). These files are installed at well known locations for system integration.
 
-- (11,12) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of a `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
+- (11,12) **Microsoft.NETCore.App.Ref,Microsoft.AspNetCore.App.Ref** describe the API of an `x.y` version of .NET Core and ASP.NET Core respectively. These packs are used when compiling for those target versions.
 
 - (13) **Microsoft.NETCore.App.Host.<rid>** contains a native binary for platform `rid`. This binary as a template when compiling a .NET Core application into a native binary for that platform.
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -138,7 +138,7 @@ The following lists the recommended packages:
   * **Version:** \<runtime version>
   * **Contains:** (13)
 
-* `dotnet-targeting-pack-[major].[minor]` - allows targeting a non-latest runtime
+* `dotnet-targeting-pack-[major].[minor]` - Allows targeting a non-latest runtime
   * **Version:** \<runtime version>
   * **Contains:** (12)
 

--- a/docs/core/build/distribution-packaging.md
+++ b/docs/core/build/distribution-packaging.md
@@ -95,7 +95,7 @@ The rest of the version isn't included in the version name. This allows the OS p
 
 The following lists the recommended packages:
 
-* `dotnet-sdk-[major]` - Installs latest sdk for runtime major
+* `dotnet-sdk-[major]` - Installs the latest sdk for runtime major
   * **Version:** \<sdk version>
   * **Example:** dotnet-sdk-2
   * **Dependencies:** `dotnet-sdk-[major].[latestminor]`


### PR DESCRIPTION
- Remove section on patch packages, sdk feature packages. I believe Microsoft, nor
Red Hat are providing such packages for .NET Core 2.2 for non-Windows platforms.

- Rename aspnetcore-runtime package to aspnet-runtime. No one has provided such
a package. Suggesting a shorter name.

- Add packs. Initial split:
* To reduce the number of packages, I've added Microsoft.AspNetCore.App.Ref,
Microsoft.NETCore.App.Ref and Microsoft.NETCore.App.Host.<rid> to the sdk package.
* NETStandard.Library.Ref is a separate package because multiple .NET Core versions
may be installed side-by-side and provide the same files.
* Microsoft.WindowsDesktop.App.Ref is currently in its own package, I'm not
sure how it versions with the rest.