### PR TITLE
 More String escape sequence improvements (F#)

### DIFF
--- a/docs/fsharp/language-reference/literals.md
+++ b/docs/fsharp/language-reference/literals.md
@@ -63,7 +63,7 @@ let Literal3 = System.IO.FileAccess.Read ||| System.IO.FileAccess.Write
 
 ## Remarks
 
-Unicode strings can contain explicit encodings that you can specify by using `\u` followed by a 16-bit hexadecimal code (0000 - FFFF), or UTF-32 encodings that you can specify by using `\U` followed by a 32-bit hexadecimal code that represents any Unicode code point (00000000 - 00010FFFF).
+Unicode strings can contain explicit encodings that you can specify by using `\u` followed by a 16-bit hexadecimal code (0000 - FFFF), or UTF-32 encodings that you can specify by using `\U` followed by a 32-bit hexadecimal code that represents any Unicode code point (00000000 - 0010FFFF).
 
 The use of other bitwise operators other than `|||` isn't allowed.
 

--- a/docs/fsharp/language-reference/strings.md
+++ b/docs/fsharp/language-reference/strings.md
@@ -1,7 +1,7 @@
 ---
 title: Strings
 description: Learn how the F# 'string' type represents immutable text as a sequence of Unicode characters.
-ms.date: 06/28/2019
+ms.date: 07/05/2019
 ---
 # Strings
 
@@ -16,14 +16,26 @@ String literals are delimited by the quotation mark (") character. The backslash
 
 |Character|Escape sequence|
 |---------|---------------|
+|Alert|`\a`|
 |Backspace|`\b`|
+|Form feed|`\f`|
 |Newline|`\n`|
 |Carriage return|`\r`|
 |Tab|`\t`|
+|Vertical tab|`\v`|
 |Backslash|`\\`|
 |Quotation mark|`\"`|
 |Apostrophe|`\'`|
-|Unicode character|`\uXXXX` (UTF-16) or `\U00XXXXXX` (UTF-32) (where `X` indicates a hexadecimal digit)|
+|Unicode character|`\DDD` (where `D` indicates a decimal digit; range of 000 - 255; e.g. `\231` = "ç")|
+|Unicode character|`\xHH` (where `H` indicates a hexadecimal digit; range of 00 - FF; e.g. `\xE7` = "ç")|
+|Unicode character|`\uHHHH` (UTF-16) (where `H` indicates a hexadecimal digit; range of 0000 - FFFF;  e.g. `\u00E7` = "ç")|
+|Unicode character|`\U00HHHHHH` (UTF-32) (where `H` indicates a hexadecimal digit; range of 000000 - 10FFFF;  e.g. `\U0001F47D` = "👽")|
+
+> [!IMPORTANT]
+> The `\DDD` escape sequence is decimal notation, not octal notation like in most other languages. Therefore, digits `8` and `9` are valid, and a sequence of `\032` represents a space (U+0020), whereas that same code point in octal notation would be `\040`.
+
+> [!NOTE]
+> Being constrained to a range of 0 - 255 (0xFF), the `\DDD` and `\x` escape sequences are effectively the [ISO-8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Code_page_layout) character set, since that matches the first 256 Unicode code points.
 
 If preceded by the @ symbol, the literal is a verbatim string. This means that any escape sequences are ignored, except that two quotation mark characters are interpreted as one quotation mark character.
 


### PR DESCRIPTION
### "Literals" page

In my previous update I seem to have added an extra `0` to the `0010FFFF` at the end of the first paragraph in the **Remarks** section.

### "Strings" page

1.  Added 5 missing sequences: `\a`, `\f`, `v`, `\x`, and `\DDD`. The following example code ran in LINQPad 5 (Language = "F# Program"):

    ```fsharp
    printfn "Decimal (NOT Octal) \\DDD requires 3 digits: TAB\9TAB\09TAB\009TAB";
    printfn "\\DDD notation is ISO-8859-1 (U+0000 - U+00FF): {\128-\129-\144-\152-\160-\161}";
    printfn "CHAR for \\DDD = (DDD %% 256); Max = \\999 (U+00E7): {\365-\621-\6210-\176-\100-\999-\1000}";
    printfn "---------------------";
    printfn "\\x only works with two hex digits: TAB\x9TAB\x090TAB";
    printfn "\\x is ISO-8859-1: 0x80 = \x80, 0x81 = \x81, 0x90 = \x90, 0x9A = \x9A, 0x9F = \x9F";
    printfn "\\x is _not_ creating UTF-8: \xE0\xBC\x82"; // UTF-8 bytes for U+0F02
    printfn "---------------------";printfn "Test \\a: \a";
    printfn "Test \\f: \f";
    printfn "Test \\v: \v";
    ```

    They can also be found in the source code on GitHub:

    * Defined here:
        * https://github.com/dotnet/fsharp/blob/master/src/fsharp/lex.fsl#L209
    * Processed here:
        * https://github.com/dotnet/fsharp/blob/master/src/fsharp/lexhelp.fs#L142
        * https://github.com/dotnet/fsharp/blob/master/src/fsharp/lexhelp.fs#L179

2. Broke `\u` and `\U` sequences into separate entries.

3. Provided range and an example for each Unicode character sequence.

4. Added "Important" note regarding `\DDD` being decimal, not octal, notation.

5. Added note regarding `\DDD` and `\xx` effectively being ISO-8859-1 (which is the first 256 Unicode code points), including a link to the WikiPedia article for ISO-8859-1.

6. **NOTE:** I changed the `X`s into `H`s for the `\u` and `\U` sequences due to adding the `\x` sequence and not wanting to have `\xXX` as I feel that is less readable, and I wanted to be consistent between all of them regarding what represented a hex digit (and "H" meaning hex also helps distinguish it from the `D`s used for the newly added `\DDD` sequence). If anyone feels strongly that it should remain as `X`, then it can be changed back.

Please see [Unicode Escape Sequences Across Various Languages and Platforms (including Supplementary Characters)](https://sqlquantumleap.com/2019/06/26/unicode-escape-sequences-across-various-languages-and-platforms-including-supplementary-characters/#fsharp) for more details.
