### PR TITLE
Revert "Incorrect image referenced in Dockerfile"

### DIFF
--- a/docs/core/docker/build-container.md
+++ b/docs/core/docker/build-container.md
@@ -173,7 +173,7 @@ The *Dockerfile* file is used by the `docker build` command to create a containe
 In your terminal, navigate to up a directory to the working folder you created at the start. Create a file named *Dockerfile* in your working folder and open it in a text editor. Add the following command as the first line of the file:
 
 ```dockerfile
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2
 ```
 
 The `FROM` command tells Docker to pull down the image tagged **2.2** from the **mcr.microsoft.com/dotnet/core/runtime** repository. Make sure that you pull the .NET Core runtime that matches the runtime targeted by your SDK. For example, the app created in the previous section used the .NET Core 2.2 SDK and created an app that targeted .NET Core 2.2. So the base image referred to in the *Dockerfile* is tagged with **2.2**.


### PR DESCRIPTION
Reverts dotnet/docs#13231

@TracyGH Can you clarify why you got the error in the original issue? This tutorial doesn't use ASP.NET at all and the original command works as intended if you're following the tutorial.