### PR TITLE
Switch on C#/VB language selection

### DIFF
--- a/docs/standard/using-linq.md
+++ b/docs/standard/using-linq.md
@@ -4,6 +4,9 @@ description: Learn how LINQ provides language-level querying capabilities and an
 author: cartermp
 ms.author: wiwagn
 ms.date: 06/20/2016
+dev_langs: 
+  - "csharp"
+  - "vb"
 ms.technology: dotnet-standard
 ms.assetid: c00939e1-59e3-4e61-8fe9-08ad6b3f1295
 ---


### PR DESCRIPTION
Continuation nits of #13263 

I guess the following current display of the [page](https://docs.microsoft.com/en-us/dotnet/standard/using-linq) is not intentional:
![image](https://user-images.githubusercontent.com/15279990/60861397-a1dd6000-a21a-11e9-80bb-fa0934bf0a4d.png)

