### PR TITLE
Add vb sample

### DIFF
--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -199,7 +199,7 @@ Catch ex As Exception
     Throw New TransferFundsException("Withdrawal failed.", innerException:=ex) With
     {
         .From = from,
-        .To = to,
+        .[To] = [to],
         .Amount = amount
     }
 End Try

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -167,7 +167,7 @@ private static void TransferFunds(Account from, Account to, decimal amount)
 ```
 
 ```vb
-Private Shared Sub TransferFunds(from As Account, to As Account, amount As Decimal)
+Private Shared Sub TransferFunds(from As Account, [to] As Account, amount As Decimal)
     Dim withdrawalTrxID As String = from.Withdrawal(amount)
     Try
         [to].Deposit(amount)

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -138,6 +138,14 @@ public void TransferFunds(Account from, Account to, decimal amount)
 }
 ```
 
+```vb
+Public Sub TransferFunds(from As Account, to As Account, amount As Decimal)
+    from.Withdrawal(amount)
+    ' If the deposit fails, the withdrawal shouldn't remain in effect.
+    to.Deposit(amount)
+End Sub
+```
+
 The method above does not directly throw any exceptions, but must be written defensively so that if the deposit operation fails, the withdrawal is reversed.
 
 One way to handle this situation is to catch any exceptions thrown by the deposit transaction and roll back the withdrawal.
@@ -158,19 +166,43 @@ private static void TransferFunds(Account from, Account to, decimal amount)
 }
 ```
 
+```vb
+Private Shared Sub TransferFunds(from As Account, to As Account, amount As Decimal)
+    Dim withdrawalTrxID As String = from.Withdrawal(amount)
+    Try
+        to.Deposit(amount)
+    Catch
+        from.RollbackTransaction(withdrawalTrxID)
+        Throw
+    End Try
+End Sub
+```
+
 This example illustrates the use of `throw` to re-throw the original exception, which can make it easier for callers to see the real cause of the problem without having to examine the <xref:System.Exception.InnerException> property. An alternative is to throw a new exception and include the original exception as the inner exception:
 
 ```csharp
 catch (Exception ex)
 {
     from.RollbackTransaction(withdrawalTrxID);
-    throw new TransferFundsException("Withdrawal failed", innerException: ex)
+    throw new TransferFundsException("Withdrawal failed.", innerException: ex)
     {
         From = from,
         To = to,
         Amount = amount
     };
 }
+```
+
+```vb
+Catch ex As Exception ex
+    from.RollbackTransaction(withdrawalTrxID)
+    Throw New TransferFundsException("Withdrawal failed.", innerException:=ex) With
+    {
+        .From = from,
+        .To = to,
+        .Amount = amount
+    }
+End Try
 ```
 
 ## See also

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -170,7 +170,7 @@ private static void TransferFunds(Account from, Account to, decimal amount)
 Private Shared Sub TransferFunds(from As Account, to As Account, amount As Decimal)
     Dim withdrawalTrxID As String = from.Withdrawal(amount)
     Try
-        to.Deposit(amount)
+        [to].Deposit(amount)
     Catch
         from.RollbackTransaction(withdrawalTrxID)
         Throw

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -194,7 +194,7 @@ catch (Exception ex)
 ```
 
 ```vb
-Catch ex As Exception ex
+Catch ex As Exception
     from.RollbackTransaction(withdrawalTrxID)
     Throw New TransferFundsException("Withdrawal failed.", innerException:=ex) With
     {

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -139,7 +139,7 @@ public void TransferFunds(Account from, Account to, decimal amount)
 ```
 
 ```vb
-Public Sub TransferFunds(from As Account, to As Account, amount As Decimal)
+Public Sub TransferFunds(from As Account, [to] As Account, amount As Decimal)
     from.Withdrawal(amount)
     ' If the deposit fails, the withdrawal shouldn't remain in effect.
     [to].Deposit(amount)

--- a/docs/standard/exceptions/best-practices-for-exceptions.md
+++ b/docs/standard/exceptions/best-practices-for-exceptions.md
@@ -142,7 +142,7 @@ public void TransferFunds(Account from, Account to, decimal amount)
 Public Sub TransferFunds(from As Account, to As Account, amount As Decimal)
     from.Withdrawal(amount)
     ' If the deposit fails, the withdrawal shouldn't remain in effect.
-    to.Deposit(amount)
+    [to].Deposit(amount)
 End Sub
 ```
 


### PR DESCRIPTION
Added vb samples and fixed code that was contradicting

> Each sentence in the string assigned to the Exception.Message property should end in a period.