### PR TITLE
Finish improvements to "String Escape Sequences" section of "Strings (C# Programming Guide)" page

### DIFF
--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -56,10 +56,10 @@ A string is an object of type <xref:System.String> whose value is text. Internal
 |\n|New line|0x000A|  
 |\r|Carriage return|0x000D|  
 |\t|Horizontal tab|0x0009|  
-|\U|Unicode escape sequence (UTF-32)|`\U00nnnnnn` (e.g. `\U0001F47D` = "&#x1F47D;")|  
-|\u|Unicode escape sequence (UTF-16)|`\unnnn` (e.g. `\u0041` = "A")|  
 |\v|Vertical tab|0x000B|  
-|\x|Unicode escape sequence similar to "\u" except with variable length.|`\x0041` or `\x41` = "A"|  
+|\u|Unicode escape sequence (UTF-16)|`\uHHHH` (range: 0000 - FFFF; example: `\u00E7` = "ç")|  
+|\U|Unicode escape sequence (UTF-32)|`\U00HHHHHH` (range: 000000 - 10FFFF; example: `\U0001F47D` = "&#x1F47D;")|  
+|\x|Unicode escape sequence similar to "\u" except with variable length|`\xH[H][H][H]` (range: 0 - FFFF; example: `\x00E7` or `\x0E7` or `\xE7` = "ç")|  
   
 > [!WARNING]
 >  When using the `\x` escape sequence and specifying less than 4 hex digits, if the characters that immediately follow the escape sequence are valid hex digits (i.e. 0-9, A-F, and a-f), they will be interpreted as being part of the escape sequence. For example, `\xA1` produces "&#161;", which is code point U+00A1. However, if the next character is "A" or "a", then the escape sequence will instead be interpreted as being `\xA1A` and produce "&#x0A1A;", which is code point U+0A1A. In such cases, specifying all 4 hex digits (e.g. `\x00A1` ) will prevent any possible misinterpretation.  


### PR DESCRIPTION
Make Unicode escapes more consistent with recent improvements made to https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/strings :

1.  Moved `\v` row up to be just under `\t`. This move provides for a more logical grouping of the escape sequences: simple, static ones first, followed by the dynamic Unicode escape sequences that require a user-supplied value. I think having this grouping will make the list more readable for most readers, which I feel is more important than maintaining strict alphabetical ordering of the list. The `\v` just seemed out of place between `\u` and `\x`, and if someone is looking for a Unicode escape sequence, I believe it helps to have those all together.

2. Switched order of `\u` and `\U` so that `\u` could come first as that, again, seems to flow better / be a more logical progression.

3. Changed character used for hex digit placeholder in escape sequence from `n` to `H`, as again, I feel it is more readable / more intuitive that "H" refers to "Hex" whereas "n" is ambiguous as "number"? And, it has more visual clarity since the lower-case "n" blends in a bit with "u" (at least to me it does).

4. Added range for all user-supplied values (why make readers hunt elsewhere for that info, especially when `\U` is not as obvious as the other two?).

5. Added generic format for `\x`

6. Change example code point / character for `\u` and `\x` to something a little more interesting than "A" :-)

7. Added missing example permutation of `\x`

For more details, please visit: https://bit.ly/UnicodeEscapeSequences
