### PR TITLE
Clarify "abstract"

### DIFF
--- a/docs/csharp/language-reference/keywords/abstract.md
+++ b/docs/csharp/language-reference/keywords/abstract.md
@@ -11,7 +11,7 @@ helpviewer_keywords:
 ms.assetid: b0797770-c1f3-4b4d-9441-b9122602a6bb
 ---
 # abstract (C# Reference)
-The `abstract` modifier indicates that the thing being modified has a missing or incomplete implementation. The abstract modifier can be used with classes, methods, properties, indexers, and events. Use the `abstract` modifier in a class declaration to indicate that a class is intended only to be a base class of other classes, not instantiated on its own. Members marked as abstract must be implemented by classes that derive from the abstract class.
+The `abstract` modifier indicates that the thing being modified has a missing or incomplete implementation. The abstract modifier can be used with classes, methods, properties, indexers, and events. Use the `abstract` modifier in a class declaration to indicate that a class is intended only to be a base class of other classes, not instantiated on its own. Members marked as abstract must be implemented by non-abstract classes that derive from the abstract class.
   
 ## Example  
  In this example, the class `Square` must provide an implementation of `GetArea` because it derives from `Shape`:  


### PR DESCRIPTION
Clarify that only non-abstract classes must implement abstract members.

## Summary

Reduces observed confusion about the meaning of "abstract".

Fixes #11840
