### PR TITLE
CC140377: Correcting comment syntax inside code-block

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md
+++ b/docs/csharp/programming-guide/concepts/async/cancel-remaining-async-tasks-after-one-is-complete.md
@@ -38,7 +38,7 @@ By using the <xref:System.Threading.Tasks.Task.WhenAny%2A?displayProperty=nameWi
  In the MainWindow.xaml.cs file of the **CancelAListOfTasks** project, start the transition by moving the processing steps for each website from the loop in `AccessTheWebAsync` to the following async method.  
   
 ```csharp  
-/ ***Bundle the processing steps for a website into one async method.  
+// ***Bundle the processing steps for a website into one async method.  
 async Task<int> ProcessURLAsync(string url, HttpClient client, CancellationToken ct)  
 {  
     // GetAsync returns a Task<HttpResponseMessage>.   


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: comment syntax inside code-block doesn't work when the example is used.