### PR TITLE
vs2019 compiler platform sdk clarifications

### DIFF
--- a/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
+++ b/docs/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix.md
@@ -13,9 +13,10 @@ In this tutorial, you'll explore the creation of an **analyzer** and an accompan
 
 ## Prerequisites
 
-* [Visual Studio 2017](https://www.visualstudio.com/downloads)
+* [Visual Studio 2017](https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2017-and-other-products)
+* [Visual Studio 2019](https://www.visualstudio.com/downloads)
 
-You'll need to install the **.NET Compiler Platform SDK**:
+You'll need to install the **.NET Compiler Platform SDK** via the Visual Studio Intaller:
 
 [!INCLUDE[interactive-note](~/includes/roslyn-installation.md)]
 

--- a/includes/roslyn-installation.md
+++ b/includes/roslyn-installation.md
@@ -1,8 +1,8 @@
-## Installation instructions 
+## Installation instructions - Visual Studio Installer
 
 There are two different ways to find the **.NET Compiler Platform SDK** in the **Visual Studio Installer**:
 
-### Install using the Workloads view
+### Install using the Visual Studio Installer - Workloads view
 
 The .NET Compiler Platform SDK is not automatically selected as part of the Visual Studio extension development workload. You must select it as an optional component.
 
@@ -17,7 +17,7 @@ Optionally, you'll also want the **DGML editor** to display graphs in the visual
 1. Open the **Individual components** node in the summary tree.
 1. Check the box for **DGML editor**
 
-### Install using the Individual components tab
+### Install using the Visual Studio Installer - Individual components tab
 
 1. Run **Visual Studio Installer** 
 1. Select **Modify** 


### PR DESCRIPTION
## Summary

Added some clarity around compiler platform and 2019 in relation to 2017

see https://github.com/dotnet/roslyn/issues/34767 
