### PR TITLE
C# numeric types: explicitly mention corresponding .NET types

### DIFF
--- a/docs/csharp/language-reference/builtin-types/floating-point-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/floating-point-numeric-types.md
@@ -20,21 +20,30 @@ helpviewer_keywords:
 ---
 # Floating-point numeric types (C# reference)
 
-The **floating-point types** are a subset of the **simple types** and can be initialized with [*literals*](#floating-point-literals). All floating-point types are also value types. All floating-point numeric types support [arithmetic](../operators/arithmetic-operators.md) [comparison, and equality](../operators/equality-operators.md) operators.
+The **floating-point types** are a subset of the **simple types** and can be initialized with [*literals*](#floating-point-literals). All floating-point types are also value types. All floating-point numeric types support [arithmetic](../operators/arithmetic-operators.md), [comparison, and equality](../operators/equality-operators.md) operators.
 
-The following table shows the precision and approximate ranges for the floating-point types:
+## Characteristics of the floating-point types
+
+C# supports the following predefined floating-point types:
   
-|Type|Approximate range|Precision|  
-|----------|-----------------------|---------------|  
-|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|~6-9 digits|  
-|`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|~15-17 digits|  
-|`decimal`|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|  
+|C# type/keyword|Approximate range|Precision|.NET type|
+|----------|-----------------------|---------------|--------------|
+|`float`|±1.5 x 10<sup>−45</sup> to ±3.4 x 10<sup>38</sup>|~6-9 digits|<xref:System.Single?displayProperty=nameWithType>|
+|`double`|±5.0 × 10<sup>−324</sup> to ±1.7 × 10<sup>308</sup>|~15-17 digits|<xref:System.Double?displayProperty=nameWithType>|
+|`decimal`|±1.0 x 10<sup>-28</sup> to ±7.9228 x 10<sup>28</sup>|28-29 digits|<xref:System.Decimal?displayProperty=nameWithType>|
 
-The default value for all floating-point types is `0`. Each of the floating-point types has constants named `MinValue` and `MaxValue` for the minimum and maximum value for that type. The `float` and `double` types have additional constants for `PositiveInfinity`, `NegativeInfinity`, and `NaN` (for "Not a Number"). The `decimal` type includes constants for `Zero`, `One`, and `MinusOne`.
+In the preceding table, each C# type keyword from the leftmost column is an alias for the corresponding .NET type. They are interchangeable. For example, the following declarations declare variables of the same type:
 
-The `decimal` type has more precision and a smaller range than both `float` and `double`, which makes it appropriate for financial and monetary calculations.
+```csharp
+double a = 12.3;
+System.Double b = 12.3;
+```
 
-You can mix integral types and floating-point types in an expression. In this case, the integral types are converted to floating-point types. The evaluation of the expression is performed according to the following rules:
+The default value of each floating-point type is zero, `0`. Each of the floating-point types has the `MinValue` and `MaxValue` constants that provide the minimum and maximum finite value of that type. The `float` and `double` types also provide constants that represent not-a-number and infinity values. For example, the `double` type provides the following constants: <xref:System.Double.NaN?displayProperty=nameWithType>, <xref:System.Double.NegativeInfinity?displayProperty=nameWithType>, and <xref:System.Double.PositiveInfinity?displayProperty=nameWithType>.
+
+Because the `decimal` type has more precision and a smaller range than both `float` and `double`, it's appropriate for financial and monetary calculations.
+
+You can mix [integral](integral-numeric-types.md) types and floating-point types in an expression. In this case, the integral types are converted to floating-point types. The evaluation of the expression is performed according to the following rules:
 
 - If one of the floating-point types is `double`, the expression evaluates to `double`, or to [bool](../keywords/bool.md) in relational comparisons or comparisons for equality.
 - If there is no `double` type in the expression, the expression evaluates to `float`, or to [bool](../keywords/bool.md) in relational comparisons or comparisons for equality.
@@ -71,7 +80,7 @@ myMoney = 400.75M;
 
 ## Conversions
 
-There's an implicit conversion (called a *widening conversion*) from `float` to `double` because the range of `float` values is a proper subset of `double` and there is no loss of precision from `float` to `double`. 
+There's an implicit conversion (called a *widening conversion*) from `float` to `double` because the range of `float` values is a proper subset of `double` and there is no loss of precision from `float` to `double`.
 
 You must use an explicit cast to convert one floating-point type to another floating-point type when an implicit conversion isn't defined from the source type to the destination type. This is called a *narrowing conversion*. The explicit case is required because the conversion can result in data loss. There's no implicit conversion between other floating-point types and the `decimal` type because the `decimal` type has greater precision than either `float` or `double`.
 
@@ -83,15 +92,11 @@ For more information about explicit numeric conversions, see [Explicit Numeric C
 
 - [C# Reference](../index.md)
 - [Integral types](integral-numeric-types.md)
-- [Default values table](../keywords/default-values-table.md)
-- [Formatting numeric results table](../keywords/formatting-numeric-results-table.md)
 - [Built-in types table](../keywords/built-in-types-table.md)
 - [Numerics in .NET](../../../standard/numerics.md)
 - [Casting and Type Conversions](../../programming-guide/types/casting-and-type-conversions.md)
 - [Implicit Numeric Conversions Table](../keywords/implicit-numeric-conversions-table.md)
 - [Explicit Numeric Conversions Table](../keywords/explicit-numeric-conversions-table.md)
-- <xref:System.Single?displayProperty=nameWithType>
-- <xref:System.Double?displayProperty=nameWithType>
-- <xref:System.Decimal?displayProperty=nameWithType>
 - <xref:System.Numerics.Complex?displayProperty=nameWithType>
+- [Formatting numeric results table](../keywords/formatting-numeric-results-table.md)
 - [Standard Numeric Format Strings](../../../standard/base-types/standard-numeric-format-strings.md)

--- a/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
+++ b/docs/csharp/language-reference/builtin-types/integral-numeric-types.md
@@ -35,26 +35,31 @@ helpviewer_keywords:
 ---
 # Integral numeric types  (C# reference)
 
-The **integral numeric types** are a subset of the **simple types** and can be initialized with [*literals*](#integral-literals). All integral types are also value types.
+The **integral numeric types** are a subset of the **simple types** and can be initialized with [*literals*](#integral-literals). All integral types are also value types. All integral numeric types support [arithmetic](../operators/arithmetic-operators.md), [bitwise logical](../operators/bitwise-and-shift-operators.md), [comparison, and equality](../operators/equality-operators.md) operators.
 
-All integral numeric types support [arithmetic](../operators/arithmetic-operators.md), [bitwise logical](../operators/bitwise-and-shift-operators.md), [comparison, and equality](../operators/equality-operators.md) operators.
+## Characteristics of the integral types
 
-## Sizes and ranges
+C# supports the following predefined integral types:
 
-The following table shows the sizes and ranges of the integral types:
+|C# type/keyword|Range|Size|.NET type|
+|----------|-----------|----------|-------------|
+|`sbyte`|-128 to 127|Signed 8-bit integer|<xref:System.SByte?displayProperty=nameWithType>|
+|`byte`|0 to 255|Unsigned 8-bit integer|<xref:System.Byte?displayProperty=nameWithType>|
+|`short`|-32,768 to 32,767|Signed 16-bit integer|<xref:System.Int16?displayProperty=nameWithType>|
+|`ushort`|0 to 65,535|Unsigned 16-bit integer|<xref:System.UInt16?displayProperty=nameWithType>|
+|`int`|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|<xref:System.Int32?displayProperty=nameWithType>|
+|`uint`|0 to 4,294,967,295|Unsigned 32-bit integer|<xref:System.UInt32?displayProperty=nameWithType>|
+|`long`|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|<xref:System.Int64?displayProperty=nameWithType>|
+|`ulong`|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|<xref:System.UInt64?displayProperty=nameWithType>|
 
-|Type|Range|Size|  
-|----------|-----------|----------|  
-|`sbyte`|-128 to 127|Signed 8-bit integer|  
-|`byte`|0 to 255|Unsigned 8-bit integer|  
-|`short`|-32,768 to 32,767|Signed 16-bit integer|  
-|`ushort`|0 to 65,535|Unsigned 16-bit integer|  
-|`int`|-2,147,483,648 to 2,147,483,647|Signed 32-bit integer|  
-|`uint`|0 to 4,294,967,295|Unsigned 32-bit integer|  
-|`long`|-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807|Signed 64-bit integer|  
-|`ulong`|0 to 18,446,744,073,709,551,615|Unsigned 64-bit integer|  
+In the preceding table, each C# type keyword from the leftmost column is an alias for the corresponding .NET type. They are interchangeable. For example, the following declarations declare variables of the same type:
 
-The default value for all integral types is `0`. Each of the integral types has constants named `MinValue` and `MaxValue` for the minimum and maximum value for that type.
+```csharp
+int a = 123;
+System.Int32 b = 123;
+```
+
+The default value of each integral type is zero, `0`. Each of the integral types has the `MinValue` and `MaxValue` constants that provide the minimum and maximum value of that type.
 
 Use the <xref:System.Numerics.BigInteger?displayProperty=nameWithType> structure to represent a signed integer with no upper or lower bounds.
 
@@ -70,7 +75,7 @@ var binaryLiteral = 0b_0010_1010;
 
 Decimal literals don't require any prefix. The `x` or `X` prefix signifies a *hexadecimal literal*. The `b` or `B` prefix signifies a *binary literal*. The declaration of `binaryLiteral` demonstrates the use of `_` as a *digit separator*. The digit separator can be used with all numeric literals. Binary literals and the digit separator `_` are supported starting with C# 7.0.
 
-### Literal suffixes 
+### Literal suffixes
 
 The `l` or `L` suffix specifies that the integral literal should be of the `long` type. The `ul` or `UL` suffix specifies the `ulong` type. If the `L` suffix is used on a literal that is greater than 9,223,372,036,854,775,807 (the maximum value of `long`), the value is converted to the `ulong` type. If the value represented by an integral literal exceeds <xref:System.UInt64.MaxValue?displayProperty=nameWithType>, a compiler error [CS1021](../../misc/cs1021.md) occurs. 
 
@@ -117,11 +122,3 @@ You must use an explicit cast to convert one integral type to another integral t
 - [Formatting numeric results table](../keywords/formatting-numeric-results-table.md)
 - [Built-in types table](../keywords/built-in-types-table.md)
 - [Numerics in .NET](../../../standard/numerics.md)
-- <xref:System.Byte?displayProperty=nameWithType>
-- <xref:System.SByte?displayProperty=nameWithType>
-- <xref:System.Int16?displayProperty=nameWithType>
-- <xref:System.UInt16?displayProperty=nameWithType>
-- <xref:System.Int32?displayProperty=nameWithType>
-- <xref:System.UInt32?displayProperty=nameWithType>
-- <xref:System.Int64?displayProperty=nameWithType>
-- <xref:System.UInt64?displayProperty=nameWithType>


### PR DESCRIPTION
Integrated .NET types into the overview tables of the numeric types. That allows: (1) unload the **See also** sections, (2) mention alias/.NET type relation, which might be useful to the newcomers to C#.

Also, removed the sentence about `decimal` constants, as, based on this [Stack Overflow answer](https://stackoverflow.com/a/745638), it doesn't seem to be worth mentioning.
