### PR TITLE
Replace AddSingleton with AddHostedService

### DIFF
--- a/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
+++ b/docs/standard/microservices-architecture/multi-container-microservice-net-applications/background-tasks-with-ihostedservice.md
@@ -39,7 +39,7 @@ SignalR is one example of an artifact using hosted services, but you can also us
 
 You can basically offload any of those actions to a background task based on IHostedService.
 
-The way you add one or multiple `IHostedServices` into your `WebHost` or `Host` is by registering them up through the standard DI (dependency injection) in an ASP.NET Core `WebHost` (or in a `Host` in .NET Core 2.1 and above). Basically, you have to register the hosted services within the familiar `ConfigureServices()` method of the `Startup` class, as in the following code from a typical ASP.NET WebHost.
+The way you add one or multiple `IHostedServices` into your `WebHost` or `Host` is by registering them up through the `AddHostedService` extension method in an ASP.NET Core `WebHost` (or in a `Host` in .NET Core 2.1 and above). Basically, you have to register the hosted services within the familiar `ConfigureServices()` method of the `Startup` class, as in the following code from a typical ASP.NET WebHost.
 
 ```csharp
 public IServiceProvider ConfigureServices(IServiceCollection services)
@@ -47,9 +47,9 @@ public IServiceProvider ConfigureServices(IServiceCollection services)
     //Other DI registrations;
 
     // Register Hosted Services
-    services.AddSingleton<IHostedService, GracePeriodManagerService>();
-    services.AddSingleton<IHostedService, MyHostedServiceB>();
-    services.AddSingleton<IHostedService, MyHostedServiceC>();
+    services.AddHostedService<GracePeriodManagerService>();
+    services.AddHostedService<MyHostedServiceB>();
+    services.AddHostedService<MyHostedServiceC>();
     //...
 }
 ```


### PR DESCRIPTION
As recommended by the [Microsoft Doc on running background tasks with IHostedService](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.1&tabs=visual-studio#consuming-a-scoped-service-in-a-background-task) and also based on this [Stack Overflow answer](https://stackoverflow.com/questions/51480324/proper-way-to-register-hostedservice-in-asp-net-core-addhostedservice-vs-addsin) , an `IHostedService` should be configured with `AddHostedService` as opposed to using `AddSingleton`