### PR TITLE
C103797: Adding break-line before Snippet

### DIFF
--- a/docs/machine-learning/tutorials/movie-recommendation.md
+++ b/docs/machine-learning/tutorials/movie-recommendation.md
@@ -242,6 +242,7 @@ public static void EvaluateModel(MLContext mlContext, IDataView testDataView, IT
 ```
 
 Transform the `Test` data by adding the following code to `EvaluateModel()`:
+
 [!code-csharp[Transform](~/samples/machine-learning/tutorials/MovieRecommendation/Program.cs#Transform "Transform the test data")]
 
 The [Transform()](xref:Microsoft.ML.ITransformer.Transform%2A) method makes predictions for multiple provided input rows of a test dataset.


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: Missing hard break-line before snippet is preventing content to show properly.

Fixes #13486