### PR TITLE
Added the article about unmanaged types

### DIFF
--- a/docs/csharp/language-reference/builtin-types/unmanaged-types.md
+++ b/docs/csharp/language-reference/builtin-types/unmanaged-types.md
@@ -13,7 +13,7 @@ An **unmanaged type** is any type that isn't a reference type or constructed typ
 - Any [pointer](../../programming-guide/unsafe-code-pointers/pointer-types.md) type
 - Any user-defined [struct](../keywords/struct.md) type that is not a constructed type and contains fields of unmanaged types only.
 
-Beginning with C# 7.3, you can use the [`unmanaged` constraint](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to specify that a type parameter must be a non-pointer unmanaged type.
+Beginning with C# 7.3, you can use the [`unmanaged` constraint](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to specify that a type parameter is a non-pointer unmanaged type.
 
 ## C# language specification
 

--- a/docs/csharp/language-reference/builtin-types/unmanaged-types.md
+++ b/docs/csharp/language-reference/builtin-types/unmanaged-types.md
@@ -1,0 +1,27 @@
+---
+title: "Unmanaged types - C# reference"
+ms.date: 07/23/2019
+helpviewer_keywords: 
+  - "unmanaged type [C#]"
+---
+# Unmanaged types (C# reference)
+
+An **unmanaged type** is any type that isn't a reference type or constructed type (a type that includes at least one type argument), and doesn't contain reference type or constructed type fields at any level of nesting. In other words, an unmanaged type is one of the following:
+
+- `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, or `bool`
+- Any [enum](../keywords/enum.md) type
+- Any [pointer](../../programming-guide/unsafe-code-pointers/pointer-types.md) type
+- Any user-defined [struct](../keywords/struct.md) type that is not a constructed type and contains fields of unmanaged types only.
+
+Beginning with C# 7.3, you can use the [`unmanaged` constraint](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to specify that a type parameter must be a non-pointer unmanaged type.
+
+## C# language specification
+
+For more information, see the [Pointer types](~/_csharplang/spec/unsafe-code.md#pointer-types) section of the [C# language specification](~/_csharplang/spec/introduction.md).
+
+## See also
+
+- [C# reference](../index.md)
+- [Pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md)
+- [sizeof operator](../keywords/sizeof.md)
+- [stackalloc operator](../operators/stackalloc.md)

--- a/docs/csharp/language-reference/builtin-types/unmanaged-types.md
+++ b/docs/csharp/language-reference/builtin-types/unmanaged-types.md
@@ -11,7 +11,7 @@ An **unmanaged type** is any type that isn't a reference type or constructed typ
 - `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `char`, `float`, `double`, `decimal`, or `bool`
 - Any [enum](../keywords/enum.md) type
 - Any [pointer](../../programming-guide/unsafe-code-pointers/pointer-types.md) type
-- Any user-defined [struct](../keywords/struct.md) type that is not a constructed type and contains fields of unmanaged types only.
+- Any user-defined [struct](../keywords/struct.md) type that is not a constructed type and contains fields of unmanaged types only
 
 Beginning with C# 7.3, you can use the [`unmanaged` constraint](../../programming-guide/generics/constraints-on-type-parameters.md#unmanaged-constraint) to specify that a type parameter is a non-pointer unmanaged type.
 

--- a/docs/csharp/language-reference/keywords/enum.md
+++ b/docs/csharp/language-reference/keywords/enum.md
@@ -1,7 +1,6 @@
 ---
 title: "enum keyword - C# Reference"
 ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords:
   - "enum"

--- a/docs/csharp/language-reference/keywords/fixed-statement.md
+++ b/docs/csharp/language-reference/keywords/fixed-statement.md
@@ -20,7 +20,7 @@ You can initialize a pointer by using an array, a string, a fixed-size buffer, o
 
 [!code-csharp[Initializing fixed size buffers](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#2)]
 
-Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed-size buffers, or unmanaged variables. Any type that implements a method named `GetPinnableReference` can be pinned. The `GetPinnableReference` must return a `ref` variable to an unmanaged type. See the topic on [pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md) for more information. The .NET types <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> introduced in .NET Core 2.0 make use of this pattern and can be pinned. This is shown in the following example:
+Starting with C# 7.3, the `fixed` statement operates on additional types beyond arrays, strings, fixed size buffers, or unmanaged variables. Any type that implements a method named `GetPinnableReference` can be pinned. The `GetPinnableReference` must return a `ref` variable of an [unmanaged type](../builtin-types/unmanaged-types.md). The .NET types <xref:System.Span%601?displayProperty=nameWithType> and <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> introduced in .NET Core 2.0 make use of this pattern and can be pinned. This is shown in the following example:
 
 [!code-csharp[Accessing fixed memory](../../../../samples/snippets/csharp/keywords/FixedKeywordExamples.cs#FixedSpan)]
 
@@ -69,4 +69,5 @@ For more information, see [The fixed statement](~/_csharplang/spec/unsafe-code.m
 - [C# Programming Guide](../../programming-guide/index.md)
 - [C# Keywords](index.md)
 - [unsafe](unsafe.md)
+- [Pointer types](../../programming-guide/unsafe-code-pointers/pointer-types.md)
 - [Fixed Size Buffers](../../programming-guide/unsafe-code-pointers/fixed-size-buffers.md)

--- a/docs/csharp/language-reference/keywords/sizeof.md
+++ b/docs/csharp/language-reference/keywords/sizeof.md
@@ -12,7 +12,7 @@ ms.assetid: c548592c-677c-4f40-a4ce-e613f7529141
 ---
 # sizeof (C# Reference)
 
-Used to obtain the size in bytes for an unmanaged type.
+Used to obtain the size in bytes for an [unmanaged type](../builtin-types/unmanaged-types.md).
 
 Unmanaged types include:
 

--- a/docs/csharp/language-reference/keywords/struct.md
+++ b/docs/csharp/language-reference/keywords/struct.md
@@ -1,7 +1,6 @@
 ---
 title: "struct - C# Reference"
 ms.custom: seodec18
-
 ms.date: 07/20/2015
 f1_keywords: 
   - "struct_CSharpKeyword"

--- a/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
+++ b/docs/csharp/language-reference/keywords/where-generic-type-constraint.md
@@ -28,7 +28,7 @@ The `where` clause can specify that the type is a `class` or a `struct`. The `st
 
 [!code-csharp[using the class and struct constraints](../../../../samples/snippets/csharp/keywords/GenericWhereConstraints.cs#3)]
 
-The `where` clause may also include an `unmanaged` constraint. The `unmanaged` constraint limits the type parameter to types known as **unmanaged types**. An **unmanaged type** is a type that isn't a reference type and doesn't contain reference type fields at any level of nesting. The `unmanaged` constraint makes it easier to write low-level interop code in C#. This constraint enables reusable routines across all unmanaged types. The `unmanaged` constraint can't be combined with the `class` or `struct` constraint. The `unmanaged` constraint enforces that the type must be a `struct`:
+The `where` clause may also include an `unmanaged` constraint. The `unmanaged` constraint limits the type parameter to types known as [unmanaged types](../builtin-types/unmanaged-types.md). The `unmanaged` constraint makes it easier to write low-level interop code in C#. This constraint enables reusable routines across all unmanaged types. The `unmanaged` constraint can't be combined with the `class` or `struct` constraint. The `unmanaged` constraint enforces that the type must be a `struct`:
 
 [!code-csharp[using the unmanaged constraint](../../../../samples/snippets/csharp/keywords/GenericWhereConstraints.cs#4)]
 

--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -11,6 +11,8 @@ helpviewer_keywords:
 
 The `stackalloc` operator allocates a block of memory on the stack. A stack allocated memory block created during the method execution is automatically discarded when that method returns. You cannot explicitly free memory allocated with the `stackalloc` operator. A stack allocated memory block is not subject to [garbage collection](../../../standard/garbage-collection/index.md) and doesn't have to be pinned with the [`fixed` statement](../keywords/fixed-statement.md).
 
+In expression `stackalloc T[E]`, `T` must be an [unmanaged type](../builtin-types/unmanaged-types.md) and `E` must be an expression of type `int`.
+
 You can assign the result of the `stackalloc` operator to a variable of one of the following types:
 
 - Starting with C# 7.2, <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType>, as the following example shows:

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -43,6 +43,8 @@
         href: keywords/void.md
       - name: var
         href: keywords/var.md
+      - name: Unmanaged types
+        href: builtin-types/unmanaged-types.md
       - name: Reference tables for types
         items:
         - name: Built-in types table

--- a/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
+++ b/docs/csharp/programming-guide/generics/constraints-on-type-parameters.md
@@ -1,5 +1,5 @@
 ---
-title: "Constraints on Type Parameters - C# Programming Guide"
+title: "Constraints on type parameters - C# Programming Guide"
 ms.custom: seodec18
 ms.date: 04/12/2018
 helpviewer_keywords: 
@@ -16,7 +16,7 @@ Constraints inform the compiler about the capabilities a type argument must have
 |----------------|-----------------|
 |`where T : struct`|The type argument must be a value type. Any value type except <xref:System.Nullable%601> can be specified. For more information about nullable types, see [Nullable types](../nullable-types/index.md).|
 |`where T : class`|The type argument must be a reference type. This constraint applies also to any class, interface, delegate, or array type.|
-|`where T : unmanaged`|The type argument must not be a reference type and must not contain any reference type members at any level of nesting.|
+|`where T : unmanaged`|The type argument must be an [unmanaged type](../../language-reference/builtin-types/unmanaged-types.md).|
 |`where T : new()`|The type argument must have a public parameterless constructor. When used together with other constraints, the `new()` constraint must be specified last.|
 |`where T :` *\<base class name>*|The type argument must be or derive from the specified base class.|
 |`where T :` *\<interface name>*|The type argument must be or implement the specified interface. Multiple interface constraints can be specified. The constraining interface can also be generic.|
@@ -72,7 +72,7 @@ The usefulness of type parameters as constraints with generic classes is limited
 
 ## Unmanaged constraint
 
-Beginning with C# 7.3, you can use the `unmanaged` constraint to specify that the type parameter must be an **unmanaged type**. An **unmanaged type** is a type that is not a reference type and doesn't contain reference type fields at any level of nesting. The `unmanaged` constraint enables you to write reusable routines to work with types that can be manipulated as blocks of memory, as shown in the following example:
+Beginning with C# 7.3, you can use the `unmanaged` constraint to specify that the type parameter must be an [unmanaged type](../../language-reference/builtin-types/unmanaged-types.md). The `unmanaged` constraint enables you to write reusable routines to work with types that can be manipulated as blocks of memory, as shown in the following example:
 
 [!code-csharp[using the unmanaged constraint](../../../../samples/snippets/csharp/keywords/GenericWhereConstraints.cs#15)]
 

--- a/docs/csharp/programming-guide/unsafe-code-pointers/pointer-types.md
+++ b/docs/csharp/programming-guide/unsafe-code-pointers/pointer-types.md
@@ -15,16 +15,7 @@ type* identifier;
 void* identifier; //allowed but not recommended
 ```
 
-The type specified before the `*` in a pointer type is called the **referent type**. Any of the following types may be a referent type:
-
-- Any integral type: [sbyte](../../language-reference/builtin-types/integral-numeric-types.md), [byte](../../language-reference/builtin-types/integral-numeric-types.md), [short](../../language-reference/builtin-types/integral-numeric-types.md), [ushort](../../language-reference/builtin-types/integral-numeric-types.md), [int](../../language-reference/builtin-types/integral-numeric-types.md), [uint](../../language-reference/builtin-types/integral-numeric-types.md), [long](../../language-reference/builtin-types/integral-numeric-types.md), [ulong](../../language-reference/builtin-types/integral-numeric-types.md).
-- Any floating-point type: [float](../../language-reference/builtin-types/floating-point-numeric-types.md), [double](../../language-reference/builtin-types/floating-point-numeric-types.md).
-- [char](../../language-reference/keywords/char.md).
-- [bool](../../language-reference/keywords/bool.md).
-- [decimal](../../language-reference/builtin-types/floating-point-numeric-types.md).
-- Any [enum](../../language-reference/keywords/enum.md) type.
-- Any pointer type. This allows expressions such as `void**`.
-- Any user-defined struct type that contains fields of unmanaged types only.
+The type specified before the `*` in a pointer type is called the **referent type**. Only an [unmanaged type](../../language-reference/builtin-types/unmanaged-types.md) can be a referent type.
 
 Pointer types do not inherit from [object](../../language-reference/keywords/object.md) and no conversions exist between pointer types and `object`. Also, boxing and unboxing do not support pointers. However, you can convert between different pointer types and between pointer types and integral types.
 

--- a/docs/csharp/whats-new/csharp-7-3.md
+++ b/docs/csharp/whats-new/csharp-7-3.md
@@ -123,7 +123,7 @@ For more information, see the [`fixed` statement](../language-reference/keywords
 
 You can now specify the type <xref:System.Enum?displayProperty=nameWithType> or <xref:System.Delegate?displayProperty=nameWithType> as base class constraints for a type parameter.
 
-You can also use the new `unmanaged` constraint, to specify that a type parameter must be an **unmanaged type**. An **unmanaged type** is a type that isn't a reference type and doesn't contain any reference type at any level of nesting.
+You can also use the new `unmanaged` constraint, to specify that a type parameter must be an [unmanaged type](../language-reference/builtin-types/unmanaged-types.md).
 
 For more information, see the articles on [`where` generic constraints](../language-reference/keywords/where-generic-type-constraint.md) and [constraints on type parameters](../programming-guide/generics/constraints-on-type-parameters.md).
 


### PR DESCRIPTION
Fixes #10583

@BillWagner please advise on the proper location of the article within the C# reference. As soon as the location is settled, I'll add the links to this article from where it's necessary (pointer types, `sizeof` and `stackalloc` operators, `unmanaged` constraint).
