### PR TITLE
WIP Documentation for .NET Core Uninstall Tool

### DIFF
--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -10,7 +10,7 @@ The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsof
 
 The tool supports Windows and macOS. Linux is currently not supported.
 
-Note that the Windows version of this tool can only uninstall .NET Core SDKs and Runtimes that were installed using .NET Core SDK or Runtime installers.
+Note that the Windows version of this tool can only uninstall .NET Core SDKs and Runtimes that were installed using .NET Core SDK or Runtime installers. Prior to Visual Studio 2019 Update 16.3, the Visual Studio installer called the .NET Core SDK installer and these can be uninstalled with the tool. The `dotnet-core-uninstall list` command displays which SDKs can be uninstalled with the tool.  
 
 ## How to use the tool
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -6,7 +6,7 @@ ms.date: 08/06/2019
 ---
 # .NET Core Uninstall Tool
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) let's you clean-up of .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall. 
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) lets you clean-up .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall.
 
 The tool supports Windows and macOS. Linux is currently not supported.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -288,31 +288,31 @@ Note:
 
 #### Examples
 
-* Dry run of uninstalling all .NET Core Runtimes that have been superceded by higher patches.
+* Dry run of removing all .NET Core Runtimes that have been superceded by higher patches.
 
   ```
   dotnet-core-uninstall --all-lower-patches --runtime --dry-run
   ```
 
-* Dry run of uninstalling all .NET Core SDKs below the version `2.2.301`:
+* Dry run of removing all .NET Core SDKs below the version `2.2.301`:
 
   ```
   dotnet-core-uninstall --all-below 2.2.301 --sdk --dry-run
   ```
 
-* Uninstall all x86 .NET Core Runtimes except the version `3.0.0-preview6-27804-01` without requiring Y/n confirmation:
+* Remove all x86 .NET Core Runtimes except the version `3.0.0-preview6-27804-01` without requiring Y/n confirmation:
 
   ```
   dotnet-core-uninstall --all-but 3.0.0-preview6-27804-01 --runtime --yes
   ```
 
-* Uninstall all .NET Core 1.1 SDKs without requiring Y/n confirmation:
+* Remove all .NET Core 1.1 SDKs without requiring Y/n confirmation:
 
   ```
   dotnet-core-uninstall --major-minor 1.1 -y
   ```
 
-* Uninstall all .NET Core SDKs that can be removed by this tool:
+* Remove all .NET Core SDKs that can be removed by this tool:
 
   ```
   dotnet-core-uninstall --all --sdk

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -18,7 +18,7 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
 3. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes.
 4. Optional: delete the `NuGetFallbackFolder` folder if you no longer need it.
-5. Uninstall the tool.
+5. Remove the `dotnet-core-unintall`  tool.
 
 Read the following sections for details.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -172,7 +172,7 @@ The specified version to uninstall. You may list several versions, and response 
 
 * **`--all-previews-but-latest`**
 
-  Remove .NET Core SDKs or Runtimes that are marked as previews except the one with the highest version number.
+  Remove .NET Core SDKs or Runtimes that are marked as previews except the one highest preview.
 
 * **`--aspnet-runtime`**
 
@@ -214,7 +214,7 @@ The specified version to uninstall. You may list several versions, and response 
   Execute the command without requiring Y/n confirmation.
 
 Note:
-1. Exactly one of `--sdk` and `--runtime` is required.
+1. Exactly one of `--sdk`, `--runtime`, `--aspnet-runtime` and `--hosting-bundle` is required.
 2. `--all`, `--all-below`, `--all-but`, `--all-but-latest`, `--all-lower-patches`, `--all-previews`, `--all-previews-but-latest`, `--major-minor` and `[<VERSION>...]` are exclusive.
 3. If neither of `--x64` or `--x86` is specified, then both x64 and x86 will be removed.
 
@@ -248,17 +248,9 @@ Note:
 
   Remove .NET Core SDKs or Runtimes that are marked as previews except the one highest preview.
 
-* **`--aspnet-runtime`**
-
-  Remove ASP.NET Core Runtimes only.
-
 * **`--dry-run`**
 
   Display .NET Core SDKs and Runtimes that will be removed.
-
-* **`--hosting-bundle`**
-
-  Remove .NET Core Runtime & Hosting Bundles only.
 
 * **`--major-minor <MAJOR_MINOR>`**
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -140,7 +140,7 @@ dotnet-core-uninstall [options] [<VERSION>...]
 
 `VERSION`
 
-The specified version to uninstall. You may list several versions, and response files are supported [[get syntax from Jon]].
+The specified version to uninstall. You may list several versions, and response files are supported.
 
 #### Options
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -330,6 +330,6 @@ Note:
 
 The `NuGetFallbackFolder` folder contains a cache of NuGet packages used by a .NET Core SDK during the restore operation, such as running `dotnet restore` or `dotnet build /t:Restore`. It is located at `C:\Program Files\dotnet\sdk` on Windows and at `/usr/local/share/dotnet/sdk` on macOS. Delete this folder from your machine if you no longer need it after uninstalling .NET Core SDKs.
 
-### Uninstalling the tool
+### Remove the `dotnet-core-uninstall` tool
 
 Remove the downloaded single executable `dotnet-core-uninstall.exe` from the directory where it was installed.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -32,7 +32,7 @@ __Note__: The tool requires elevation to uninstall .NET Core SDKs and Runtimes. 
 
 `dotnet-core-uninstall list` lists installed .NET Core SDKs and Runtimes that can be removed with this tool.
 
-On Windows, the .NET Core Uninstall Tool can only uninstall things that have been installed via the .NET Core SDK or Runtime installer, or the Visual Studio installer prior to Visual Studio 2019 16.3. On macOS, the tool can only uninstall things in the `/usr/local/share/dotnet` folder. This tool does not work on Linux. Because of these limitations, the tool may not be able to uninstall all of the .NET Core SDKs and Runtimes on your machine. You can use `dotnet --info` to find all of the .NET Core SDK's and Runtimes available.
+On Windows, the .NET Core Uninstall Tool can only uninstall things that have been installed via the .NET Core SDK or Runtime installer, or the Visual Studio installer prior to Visual Studio 2019 16.3. On macOS, the tool can only uninstall things in the `/usr/local/share/dotnet` folder. This tool does not work on Linux. Because of these limitations, the tool may not be able to uninstall all of the .NET Core SDKs and Runtimes on your machine. You can use `dotnet --info` to find all of the .NET Core SDK's and Runtimes available, including those this tool cannot remove.
 
 #### Synopsis
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -172,7 +172,7 @@ The specified version to uninstall.
 
 * **`--all-previews-but-latest`**
 
-  Remove .NET Core SDKs or Runtimes that are marked as previews except the one highest preview.
+  Remove .NET Core SDKs or Runtimes that are marked as previews except the one with the highest version number.
 
 * **`--aspnet-runtime`**
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -324,4 +324,4 @@ In some cases, you no longer need the `NuGetFallbackFolder` and may wish to dele
 
 ### Remove the `dotnet-core-uninstall` tool
 
-Remove the downloaded single executable `dotnet-core-uninstall.exe` from the directory where it was installed.
+Delete the downloaded single executable `dotnet-core-uninstall.exe` from the directory where it was installed.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -16,7 +16,7 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 
 1. Download and install the tool.
 2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
-3. Do a dry run to ensure the right things will be uninstalled, uninstall .NET Core SDKs and Runtimes bu running the tool with Admin privileges.
+3. Do a dry run to ensure the right things will be uninstalled, and uninstall .NET Core SDKs and Runtimes by running the tool with Admin privileges.
 4. Optional: delete the `NuGetFallbackFolder` folder if you no longer need it.
 5. Remove the `dotnet-core-unintall`  tool.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -17,7 +17,7 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 1. Download and install the tool.
 2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
 3. Do a dry run to ensure the right things will be uninstalled, and uninstall .NET Core SDKs and Runtimes by running the tool with Admin privileges.
-4. Optional: delete the `NuGetFallbackFolder` folder if you no longer need it.
+4. Optional: delete the `NuGetFallbackFolder` if you no longer need it.
 5. Remove the `dotnet-core-unintall`  tool.
 
 Read the following sections for details.
@@ -326,9 +326,9 @@ Note:
   dotnet-core-uninstall --all --sdk
   ```
 
-### Optional: deleting the `NuGetFallbackFolder` folder
+### Optional: deleting `NuGetFallbackFolder`
 
-In some cases, you no longer need the NuGetFallbackFolder and may wish to delete it. See [[ section reference to docs/core/versions/remove-runtime-sdk-versions.md ]]
+In some cases, you no longer need the `NuGetFallbackFolder` and may wish to delete it. See this article on [Removing the NuGet Fallback Folder](../versions/remove-runtime-sdk-versions.md#removing-the-nuget-fallback-folder).
 
 ### Remove the `dotnet-core-uninstall` tool
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -6,7 +6,7 @@ ms.date: 08/06/2019
 ---
 # .NET Core Uninstall Tool
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a too that provides controlled clean-up of .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall. 
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) let's you clean-up of .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall. 
 
 The tool supports Windows and macOS. Linux is currently not supported.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -140,7 +140,7 @@ dotnet-core-uninstall [options] [<VERSION>...]
 
 `VERSION`
 
-The specified version to uninstall.
+The specified version to uninstall. You may list several versions, and response files are supported [[get syntax from Jon]].
 
 #### Options
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -16,7 +16,7 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 
 1. Download and install the tool.
 2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
-3. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes.
+3. Do a dry run to ensure the right things will be uninstalled, uninstall .NET Core SDKs and Runtimes bu running the tool with Admin privileges.
 4. Optional: delete the `NuGetFallbackFolder` folder if you no longer need it.
 5. Remove the `dotnet-core-unintall`  tool.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -328,7 +328,7 @@ Note:
 
 ### Optional: deleting the `NuGetFallbackFolder` folder
 
-The `NuGetFallbackFolder` folder contains a cache of NuGet packages used by a .NET Core SDK during the restore operation, such as running `dotnet restore` or `dotnet build /t:Restore`. It is located at `C:\Program Files\dotnet\sdk` on Windows and at `/usr/local/share/dotnet/sdk` on macOS. Delete this folder from your machine if you no longer need it after uninstalling .NET Core SDKs.
+In some cases, you no longer need the NuGetFallbackFolder and may wish to delete it. See [[ section reference to docs/core/versions/remove-runtime-sdk-versions.md ]]
 
 ### Remove the `dotnet-core-uninstall` tool
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -322,6 +322,6 @@ Note:
 
 In some cases, you no longer need the `NuGetFallbackFolder` and may wish to delete it. See this article on [Removing the NuGet Fallback Folder](../versions/remove-runtime-sdk-versions.md#removing-the-nuget-fallback-folder).
 
-### Remove the `dotnet-core-uninstall` tool
+### Deleting the `dotnet-core-uninstall` tool
 
 Delete the downloaded single executable `dotnet-core-uninstall.exe` from the directory where it was installed.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -318,6 +318,18 @@ Note:
   dotnet-core-uninstall --all --sdk
   ```
 
+* Remove all .NET Core SDKs specified in the response file `versions.rsp`
+
+  ```
+  dotnet-core-uninstall --sdk @versions.rsp
+  ```
+
+  The content of `versions.rsp` is as follows:
+  ```
+  2.2.300
+  2.1.700
+  ```
+
 ### Optional: deleting `NuGetFallbackFolder`
 
 In some cases, you no longer need the `NuGetFallbackFolder` and may wish to delete it. See this article on [Removing the NuGet Fallback Folder](../versions/remove-runtime-sdk-versions.md#removing-the-nuget-fallback-folder).

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -290,28 +290,34 @@ Note:
 
 #### Examples
 
-* Dry run of uninstalling all .NET Core SDKs that can be removed by this tool:
+* Dry run of uninstalling all .NET Core Runtimes that have been superceded by higher patches.
+
+  ```
+  dotnet-core-uninstall --all-lower-patches --runtime --dry-run
+  ```
+
+* Dry run of uninstalling all .NET Core SDKs below the version `2.2.301`:
+
+  ```
+  dotnet-core-uninstall --all-below 2.2.301 --sdk --dry-run
+  ```
+
+* Uninstall all x86 .NET Core Runtimes except the version `3.0.0-preview6-27804-01` without requiring Y/n confirmation:
+
+  ```
+  dotnet-core-uninstall --all-but 3.0.0-preview6-27804-01 --runtime --yes
+  ```
+
+* Uninstall all .NET Core 1.1 SDKs without requiring Y/n confirmation:
+
+  ```
+  dotnet-core-uninstall --major-minor 1.1 -y
+  ```
+
+* Uninstall all .NET Core SDKs that can be removed by this tool:
 
   ```
   dotnet-core-uninstall --all --sdk
-  ```
-
-* Uninstall all .NET Core SDKs below the version `2.2.301`:
-
-  ```
-  dotnet-core-uninstall --all-below 2.2.301 --sdk --do-it
-  ```
-
-* Uninstall all x86 .NET Core Runtimes except the version `3.0.0-preview6-27804-01`:
-
-  ```
-  dotnet-core-uninstall --all-but 3.0.0-preview6-27804-01 --runtime --do-it
-  ```
-
-* Uninstall all .NET Core 1.1 SDKs:
-
-  ```
-  dotnet-core-uninstall --major-minor 1.1 --do-it
   ```
 
 ### Uninstalling the tool

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -122,7 +122,7 @@ dotnet-core-uninstall list [options]
 
 Since this is a destructive tool, the default behavior of a command execution is a dry run; the tool displays the .NET Core SDKs and Runtimes to be uninstalled. To actually uninstall the items, re-run the command with the `--do-it` option.
 
-The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Run the tool in an Administrator command prompt on Windows and with `sudo` on macOS.
+The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Run the tool in an Administrator command prompt on Windows and with `sudo` on macOS. Elevation is not required when the `--dry-run` switch is used.
 
 #### Synopsis
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -131,7 +131,7 @@ dotnet-core-uninstall [options] [<VERSION>...]
 
 `VERSION`
 
-A specified version to uninstall.
+The specified version to uninstall.
 
 #### Options
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -122,7 +122,13 @@ dotnet-core-uninstall list [options]
 
 
 
-Since this is a destructive tool, the default behavior of a command execution is a dry run; the tool displays the .NET Core SDKs and Runtimes to be uninstalled. To actually uninstall the items, re-run the command with the `--do-it` option.
+Since this is a destructive tool, it is **highly** recommended that you run with the `--dry-run` option first to determine the .NET Core SDKs and Runtimes that will be remove. [This article explains which SDKs and Runtimes are safe to remove.](https://docs.microsoft.com/en-us/dotnet/core/versions/remove-runtime-sdk-versions?tabs=macos#should-i-remove-a-version)
+
+***Warning*** This tool can uninstall versions of the .NET Core SDK that are required by `global.json` files on your machine. You can reinstall .NET Core SDKs from https://dotnet.microsoft.com/download.
+
+***Warning*** This tool can uninstall versions of the .NET Core Runtime that are required by framework dependent applications on your machine. You can reinstall .NET Core Runtimes from https://dotnet.microsoft.com/download.
+
+***Warning*** This tool can uninstall versions of the .NET Core SDK and Runtime that Visual Studio relies on. If you break your Visual Studio installation , run "Repair" in the Visual Studio installer to get back to a working state. 
 
 The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Run the tool in an Administrator command prompt on Windows and with `sudo` on macOS. Elevation is not required when the `--dry-run` switch is used.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -116,7 +116,9 @@ dotnet-core-uninstall list [options]
 
 ### Uninstalling .NET Core SDKs and Runtimes
 
-`dotnet-core-uninstall` uses a collection of options to aggregate uninstallations, as shown below.
+`dotnet-core-uninstall` uses a collection of options to specify what will be uninstalled.
+
+
 
 Since this is a destructive tool, the default behavior of a command execution is a dry run; the tool displays the .NET Core SDKs and Runtimes to be uninstalled. To actually uninstall the items, re-run the command with the `--do-it` option.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -32,7 +32,7 @@ __Note__: The tool requires elevation to uninstall .NET Core SDKs and Runtimes. 
 
 `dotnet-core-uninstall list` lists installed .NET Core SDKs and Runtimes that can be removed with this tool.
 
-On Windows, the .NET Core Uninstall Tool can only uninstall things that have been installed via the .NET Core SDK or Runtime installer, or the Visual Studio installer prior to Visual Studio 2019 16.3. On MacOS, the tool can only uninstall things in the Applications folder. This tool does not work on Linux. Because of these limitations, the tool may not be able to uninstall all of the .NET Core SDKs and Runtimes on your machine. You can use `dotnet --info` to find all of the .NET Core SDK's and Runtimes available. 
+On Windows, the .NET Core Uninstall Tool can only uninstall things that have been installed via the .NET Core SDK or Runtime installer, or the Visual Studio installer prior to Visual Studio 2019 16.3. On macOS, the tool can only uninstall things in the `/usr/local/share/dotnet` folder. This tool does not work on Linux. Because of these limitations, the tool may not be able to uninstall all of the .NET Core SDKs and Runtimes on your machine. You can use `dotnet --info` to find all of the .NET Core SDK's and Runtimes available.
 
 #### Synopsis
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -8,27 +8,36 @@ ms.date: 07/25/2019
 
 The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
 
-The tool currently supports Windows and macOS. The Linux operating systems are not supported because .NET Core installations and clean-up are well managed by package managers.
+The tool supports Windows and macOS. Linux is currently not supported.
 
 Note that the Windows version of this tool can only uninstall .NET Core SDKs and Runtimes that were installed using .NET Core SDK or Runtime installers.
 
-## Installing
+## How to use the tool
+
+1. Download and install the tool.
+2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
+3. Make sure that the tool gets elevated and uninstall .NET Core SDKs and Runtimes.
+4. Uninstall the tool.
+
+Read the following sections for details.
+
+### Installing
 
 You can download the .NET Core Uninstall Tool from [https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) and put the single executable (`dotnet-core-uninstall.exe`) in a directory.
 
-__Note__: Be aware that, since the tool requires elevation, it should be installed in a write-protected directory (e.g., `C:\Program Files` on Windows and `/usr/local/bin` on macOS).
+__Note__: The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Therefore, it should be installed in a write-protected directory such as `C:\Program Files` on Windows and `/usr/local/bin` on macOS. See also [Elevated access for dotnet commands](https://docs.microsoft.com/en-us/dotnet/core/tools/elevated-access).
 
-## Display installed .NET Core SDKs and Runtimes
+### Displaying installed .NET Core SDKs and Runtimes
 
 `dotnet-core-uninstall list` lists installed .NET Core SDKs and Runtimes that can be removed with this tool.
 
-### Synopsis
+#### Synopsis
 
 ```
 dotnet-core-uninstall list [options]
 ```
 
-### Options
+#### Options
 
 # [Windows](#tab/windows)
 
@@ -84,7 +93,7 @@ dotnet-core-uninstall list [options]
   
 ---
 
-### Examples
+#### Examples
 
 * List all .NET Core SDKs and Runtimes that can be removed with this tool:
 
@@ -104,27 +113,27 @@ dotnet-core-uninstall list [options]
   dotnet-core-uninstall list --sdk --x86
   ```
 
-## Uninstalling .NET Core SDKs and Runtimes
+### Uninstalling .NET Core SDKs and Runtimes
 
 `dotnet-core-uninstall` uses a collection of options to aggregate uninstallations, as shown below.
 
 Since this is a destructive tool, the default behavior of a command execution is a dry run; the tool displays the .NET Core SDKs and Runtimes to be uninstalled. To actually uninstall the items, re-run the command with the `--do-it` option.
 
-Since the tool requires elevation to uninstall .NET Core SDKs and Runtimes, it should be run with elevated access. On Windows, run the tool in a command prompt with administrator privileges. On macOS, add `sudo` before the command.
+The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Run the tool in an Administrator command prompt on Windows and with `sudo` on macOS.
 
-### Synopsis
+#### Synopsis
 
 ```
 dotnet-core-uninstall [options] [<VERSION>...]
 ```
 
-### Arguments
+#### Arguments
 
 `VERSION`
 
-The specified version to uninstall.
+A specified version to uninstall.
 
-### Options
+#### Options
 
 # [Windows](#tab/windows)
 
@@ -270,7 +279,7 @@ Note:
 
 ---
 
-### Examples
+#### Examples
 
 * Dry run of uninstalling all .NET Core SDKs that can be removed by this tool:
 
@@ -295,3 +304,7 @@ Note:
   ```
   dotnet-core-uninstall --major-minor 1.1 --do-it
   ```
+
+### Uninstalling the tool
+
+Remove the downloaded single executable `dotnet-core-uninstall.exe` from the directory where it was installed.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -16,7 +16,8 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 
 1. Download and install the tool.
 2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
-3. Make sure that the tool gets elevated and uninstall .NET Core SDKs and Runtimes.
+1. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes. 
+1. Optional: delete the NuGetFallback folder if you no longer need it.
 4. Uninstall the tool.
 
 Read the following sections for details.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -1,0 +1,297 @@
+---
+title: .NET Core Uninstall Tool
+description: An overview of the .NET Core Uninstall Tool, a guided tool that enables the controlled clean-up of .NET Core SDKs and Runtimes.
+author: yuchong-pan
+ms.date: 07/25/2019
+---
+# .NET Core Uninstall Tool
+
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
+
+The tool currently supports Windows and macOS. The Linux operating systems are not supported because .NET Core installations and clean-up are well managed by package managers.
+
+Note that the Windows version of this tool can only uninstall .NET Core SDKs and Runtimes that were installed using .NET Core SDK or Runtime installers.
+
+## Installing
+
+You can download the .NET Core Uninstall Tool from [https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) and put the single executable (`dotnet-core-uninstall.exe`) in a directory.
+
+__Note__: Be aware that, since the tool requires elevation, it should be installed in a write-protected directory (e.g., `C:\Program Files` on Windows and `/usr/local/bin` on macOS).
+
+## Display installed .NET Core SDKs and Runtimes
+
+`dotnet-core-uninstall list` lists installed .NET Core SDKs and Runtimes that can be removed with this tool.
+
+### Synopsis
+
+```
+dotnet-core-uninstall list [options]
+```
+
+### Options
+
+# [Windows](#tab/windows)
+
+* **`--aspnet-runtime`**
+
+  List ASP.NET Core Runtimes.
+
+* **`--hosting-bundle`**
+
+  List .NET Core Runtime & Hosting Bundles.
+
+* **`--runtime`**
+
+  List .NET Core Runtimes.
+
+* **`--sdk`**
+
+  List .NET Core SDKs.
+
+* **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+* **`--x64`**
+
+  List x64 .NET Core SDKs or Runtimes.
+
+* **`--x86`**
+
+  List x86 .NET Core SDKs or Runtimes.
+
+# [macOS](#tab/macos)
+
+* **`--runtime`**
+
+  List .NET Core Runtimes.
+
+* **`--sdk`**
+
+  List .NET Core SDKs.
+
+* **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+* **`--x64`**
+
+  List x64 .NET Core SDKs or Runtimes.
+
+* **`--x86`**
+
+  List x86 .NET Core SDKs or Runtimes.
+  
+---
+
+### Examples
+
+* List all .NET Core SDKs and Runtimes that can be removed with this tool:
+
+  ```
+  dotnet-core-uninstall list
+  ```
+
+* List all x64 .NET Core SDKs and Runtimes:
+
+  ```
+  dotnet-core-uninstall list --x64
+  ```
+
+* List all x86 .NET Core SDKs:
+
+  ```
+  dotnet-core-uninstall list --sdk --x86
+  ```
+
+## Uninstalling .NET Core SDKs and Runtimes
+
+`dotnet-core-uninstall` uses a collection of options to aggregate uninstallations, as shown below.
+
+Since this is a destructive tool, the default behavior of a command execution is a dry run; the tool displays the .NET Core SDKs and Runtimes to be uninstalled. To actually uninstall the items, re-run the command with the `--do-it` option.
+
+Since the tool requires elevation to uninstall .NET Core SDKs and Runtimes, it should be run with elevated access. On Windows, run the tool in a command prompt with administrator privileges. On macOS, add `sudo` before the command.
+
+### Synopsis
+
+```
+dotnet-core-uninstall [options] [<VERSION>...]
+```
+
+### Arguments
+
+`VERSION`
+
+The specified version to uninstall.
+
+### Options
+
+# [Windows](#tab/windows)
+
+* **`--all`**
+
+  Remove all .NET Core SDKs or Runtimes.
+
+* **`--all-below <VERSION>`**
+
+  Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.
+
+* **`--all-but <VERSIONS>`**
+
+  Remove .NET Core SDKs or Runtimes, except those specified.
+
+* **`--all-but-latest`**
+
+  Remove .NET Core SDKs or Runtimes, except the one highest version.
+
+* **`--all-lower-patches`**
+
+  Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.
+
+* **`--all-previews`**
+
+  Remove .NET Core SDKs or Runtimes that are marked as previews.
+
+* **`--all-previews-but-latest`**
+
+  Remove .NET Core SDKs or Runtimes that are marked as previews except the one highest preview.
+
+* **`--aspnet-runtime`**
+
+  Remove ASP.NET Core Runtimes only.
+
+* **`--do-it`**
+
+  Actually uninstall specified .NET Core SDKs or Runtimes.
+
+* **`--hosting-bundle`**
+
+  Remove .NET Core Runtime & Hosting Bundles only.
+
+* **`--major-minor <MAJOR_MINOR>`**
+
+  Remove .NET Core SDKs or Runtimes that match the specified `major.minor` version.
+
+* **`--runtime`**
+
+  Remove .NET Core Runtimes only.
+
+* **`--sdk`**
+
+  Remove .NET Core SDKs only.
+
+* **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+* **`--x64`**
+
+  Can be used with `--sdk`, `--runtime` and `--aspnet-runtime` to remove x64.
+
+* **`--x86`**
+
+  Can be used with `--sdk`, `--runtime` and `--aspnet-runtime` to remove x86.
+
+Note:
+1. Exactly one of `--sdk` and `--runtime` is required.
+2. `--all`, `--all-below`, `--all-but`, `--all-but-latest`, `--all-lower-patches`, `--all-previews`, `--all-previews-but-latest`, `--major-minor` and `[<VERSION>...]` are exclusive.
+3. If neither of `--x64` or `--x86` is specified, then both x64 and x86 will be removed.
+
+# [macOS](#tab/macos)
+
+* **`--all`**
+
+  Remove all .NET Core SDKs or Runtimes.
+
+* **`--all-below <VERSION>`**
+
+  Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.
+
+* **`--all-but <VERSIONS>`**
+
+  Remove .NET Core SDKs or Runtimes, except those specified.
+
+* **`--all-but-latest`**
+
+  Remove .NET Core SDKs or Runtimes, except the one highest version.
+
+* **`--all-lower-patches`**
+
+  Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.
+
+* **`--all-previews`**
+
+  Remove .NET Core SDKs or Runtimes that are marked as previews.
+
+* **`--all-previews-but-latest`**
+
+  Remove .NET Core SDKs or Runtimes that are marked as previews except the one highest preview.
+
+* **`--aspnet-runtime`**
+
+  Remove ASP.NET Core Runtimes only.
+
+* **`--do-it`**
+
+  Actually uninstall specified .NET Core SDKs or Runtimes.
+
+* **`--hosting-bundle`**
+
+  Remove .NET Core Runtime & Hosting Bundles only.
+
+* **`--major-minor <MAJOR_MINOR>`**
+
+  Remove .NET Core SDKs or Runtimes that match the specified `major.minor` version.
+
+* **`--runtime`**
+
+  Remove .NET Core Runtimes only.
+
+* **`--sdk`**
+
+  Remove .NET Core SDKs only.
+
+* **`-v, --verbosity <LEVEL>`**
+
+  Set the verbosity level. Allowed values are `q[uiet]`, `m[inimal]`, `n[ormal]`, `d[etailed]`, and `diag[nostic]`.
+
+* **`--x64`**
+
+  Can be used with `--sdk`, `--runtime` and `--aspnet-runtime` to remove x64.
+
+* **`--x86`**
+
+  Can be used with `--sdk`, `--runtime` and `--aspnet-runtime` to remove x86.
+
+Note:
+1. Exactly one of `--sdk` and `--runtime` is required.
+2. `--all`, `--all-below`, `--all-but`, `--all-but-latest`, `--all-lower-patches`, `--all-previews`, `--all-previews-but-latest`, `--major-minor` and `[<VERSION>...]` are exclusive.
+3. If neither of `--x64` or `--x86` is specified, then both x64 and x86 will be removed.
+
+---
+
+### Examples
+
+* Dry run of uninstalling all .NET Core SDKs that can be removed by this tool:
+
+  ```
+  dotnet-core-uninstall --all --sdk
+  ```
+
+* Uninstall all .NET Core SDKs below the version `2.2.301`:
+
+  ```
+  dotnet-core-uninstall --all-below 2.2.301 --sdk --do-it
+  ```
+
+* Uninstall all x86 .NET Core Runtimes except the version `3.0.0-preview6-27804-01`:
+
+  ```
+  dotnet-core-uninstall --all-but 3.0.0-preview6-27804-01 --runtime --do-it
+  ```
+
+* Uninstall all .NET Core 1.1 SDKs:
+
+  ```
+  dotnet-core-uninstall --major-minor 1.1 --do-it
+  ```

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -122,7 +122,7 @@ dotnet-core-uninstall list [options]
 
 
 
-Since this is a destructive tool, it is **highly** recommended that you run with the `--dry-run` option first to determine the .NET Core SDKs and Runtimes that will be removed. [This article explains which SDKs and Runtimes are safe to remove.](https://docs.microsoft.com/en-us/dotnet/core/versions/remove-runtime-sdk-versions?tabs=macos#should-i-remove-a-version)
+Since this is a destructive tool, it is **highly** recommended that you run with the `--dry-run` option first to determine the .NET Core SDKs and Runtimes that will be removed. [This article explains which SDKs and Runtimes are safe to remove.](https://docs.microsoft.com/dotnet/core/versions/remove-runtime-sdk-versions#should-i-remove-a-version)
 
 ***Warning:*** This tool can uninstall versions of the .NET Core SDK that are required by `global.json` files on your machine. You can reinstall .NET Core SDKs from https://dotnet.microsoft.com/download.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -122,13 +122,13 @@ dotnet-core-uninstall list [options]
 
 
 
-Since this is a destructive tool, it is **highly** recommended that you run with the `--dry-run` option first to determine the .NET Core SDKs and Runtimes that will be remove. [This article explains which SDKs and Runtimes are safe to remove.](https://docs.microsoft.com/en-us/dotnet/core/versions/remove-runtime-sdk-versions?tabs=macos#should-i-remove-a-version)
+Since this is a destructive tool, it is **highly** recommended that you run with the `--dry-run` option first to determine the .NET Core SDKs and Runtimes that will be removed. [This article explains which SDKs and Runtimes are safe to remove.](https://docs.microsoft.com/en-us/dotnet/core/versions/remove-runtime-sdk-versions?tabs=macos#should-i-remove-a-version)
 
-***Warning*** This tool can uninstall versions of the .NET Core SDK that are required by `global.json` files on your machine. You can reinstall .NET Core SDKs from https://dotnet.microsoft.com/download.
+***Warning:*** This tool can uninstall versions of the .NET Core SDK that are required by `global.json` files on your machine. You can reinstall .NET Core SDKs from https://dotnet.microsoft.com/download.
 
-***Warning*** This tool can uninstall versions of the .NET Core Runtime that are required by framework dependent applications on your machine. You can reinstall .NET Core Runtimes from https://dotnet.microsoft.com/download.
+***Warning:*** This tool can uninstall versions of the .NET Core Runtime that are required by framework dependent applications on your machine. You can reinstall .NET Core Runtimes from https://dotnet.microsoft.com/download.
 
-***Warning*** This tool can uninstall versions of the .NET Core SDK and Runtime that Visual Studio relies on. If you break your Visual Studio installation , run "Repair" in the Visual Studio installer to get back to a working state. 
+***Warning:*** This tool can uninstall versions of the .NET Core SDK and Runtime that Visual Studio relies on. If you break your Visual Studio installation , run "Repair" in the Visual Studio installer to get back to a working state. 
 
 The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Run the tool in an Administrator command prompt on Windows and with `sudo` on macOS. Elevation is not required when the `--dry-run` switch is used.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -2,7 +2,7 @@
 title: .NET Core Uninstall Tool
 description: An overview of the .NET Core Uninstall Tool, a guided tool that enables the controlled clean-up of .NET Core SDKs and Runtimes.
 author: yuchong-pan
-ms.date: 07/25/2019
+ms.date: 08/06/2019
 ---
 # .NET Core Uninstall Tool
 
@@ -15,10 +15,10 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 ## How to use the tool
 
 1. Download and install the tool.
-1. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
-1. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes. 
-1. Optional: delete the NuGetFallback folder if you no longer need it.
-4. Uninstall the tool.
+2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
+3. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes.
+4. Optional: delete the NuGetFallback folder if you no longer need it.
+5. Uninstall the tool.
 
 Read the following sections for details.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -15,7 +15,7 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 ## How to use the tool
 
 1. Download and install the tool.
-2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
+1. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
 1. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes. 
 1. Optional: delete the NuGetFallback folder if you no longer need it.
 4. Uninstall the tool.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -17,7 +17,7 @@ Note that the Windows version of this tool can only uninstall .NET Core SDKs and
 1. Download and install the tool.
 2. Display installed .NET Core SDKs and Runtimes that can be removed by this tool.
 3. Do a dry run to ensure the right things will be installed, then run the tool with Admin privileges to uninstall .NET Core SDKs and Runtimes.
-4. Optional: delete the NuGetFallback folder if you no longer need it.
+4. Optional: delete the `NuGetFallbackFolder` folder if you no longer need it.
 5. Uninstall the tool.
 
 Read the following sections for details.
@@ -119,8 +119,6 @@ dotnet-core-uninstall list [options]
 ### Uninstalling .NET Core SDKs and Runtimes
 
 `dotnet-core-uninstall` uses a collection of options to specify what will be uninstalled.
-
-
 
 Since this is a destructive tool, it is **highly** recommended that you run with the `--dry-run` option first to determine the .NET Core SDKs and Runtimes that will be removed. [This article explains which SDKs and Runtimes are safe to remove.](https://docs.microsoft.com/dotnet/core/versions/remove-runtime-sdk-versions#should-i-remove-a-version)
 
@@ -327,6 +325,10 @@ Note:
   ```
   dotnet-core-uninstall --all --sdk
   ```
+
+### Optional: deleting the `NuGetFallbackFolder` folder
+
+The `NuGetFallbackFolder` folder contains a cache of NuGet packages used by a .NET Core SDK during the restore operation, such as running `dotnet restore` or `dotnet build /t:Restore`. It is located at `C:\Program Files\dotnet\sdk` on Windows and at `/usr/local/share/dotnet/sdk` on macOS. Delete this folder from your machine if you no longer need it after uninstalling .NET Core SDKs.
 
 ### Uninstalling the tool
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -6,7 +6,7 @@ ms.date: 07/25/2019
 ---
 # .NET Core Uninstall Tool
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a too that provides controlled clean-up of .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall. 
 
 The tool supports Windows and macOS. Linux is currently not supported.
 

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -172,9 +172,9 @@ The specified version to uninstall.
 
   Remove ASP.NET Core Runtimes only.
 
-* **`--do-it`**
+* **`--dry-run`**
 
-  Actually uninstall specified .NET Core SDKs or Runtimes.
+  Display .NET Core SDKs and Runtimes that will be removed.
 
 * **`--hosting-bundle`**
 
@@ -203,6 +203,9 @@ The specified version to uninstall.
 * **`--x86`**
 
   Can be used with `--sdk`, `--runtime` and `--aspnet-runtime` to remove x86.
+
+* **`-y, --yes`**
+  Execute the command without requiring Y/n confirmation.
 
 Note:
 1. Exactly one of `--sdk` and `--runtime` is required.
@@ -243,9 +246,9 @@ Note:
 
   Remove ASP.NET Core Runtimes only.
 
-* **`--do-it`**
+* **`--dry-run`**
 
-  Actually uninstall specified .NET Core SDKs or Runtimes.
+  Display .NET Core SDKs and Runtimes that will be removed.
 
 * **`--hosting-bundle`**
 
@@ -274,6 +277,9 @@ Note:
 * **`--x86`**
 
   Can be used with `--sdk`, `--runtime` and `--aspnet-runtime` to remove x86.
+
+* **`-y, --yes`**
+  Execute the command without requiring Y/n confirmation.
 
 Note:
 1. Exactly one of `--sdk` and `--runtime` is required.

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -32,6 +32,8 @@ __Note__: The tool requires elevation to uninstall .NET Core SDKs and Runtimes. 
 
 `dotnet-core-uninstall list` lists installed .NET Core SDKs and Runtimes that can be removed with this tool.
 
+On Windows, the .NET Core Uninstall Tool can only uninstall things that have been installed via the .NET Core SDK or Runtime installer, or the Visual Studio installer prior to Visual Studio 2019 16.3. On MacOS, the tool can only uninstall things in the Applications folder. This tool does not work on Linux. Because of these limitations, the tool may not be able to uninstall all of the .NET Core SDKs and Runtimes on your machine. You can use `dotnet --info` to find all of the .NET Core SDK's and Runtimes available. 
+
 #### Synopsis
 
 ```

--- a/docs/core/additional-tools/dotnet-core-uninstall.md
+++ b/docs/core/additional-tools/dotnet-core-uninstall.md
@@ -25,7 +25,7 @@ Read the following sections for details.
 
 You can download the .NET Core Uninstall Tool from [https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) and put the single executable (`dotnet-core-uninstall.exe`) in a directory.
 
-__Note__: The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Therefore, it should be installed in a write-protected directory such as `C:\Program Files` on Windows and `/usr/local/bin` on macOS. See also [Elevated access for dotnet commands](https://docs.microsoft.com/en-us/dotnet/core/tools/elevated-access).
+__Note__: The tool requires elevation to uninstall .NET Core SDKs and Runtimes. Therefore, it should be installed in a write-protected directory such as `C:\Program Files` on Windows and `/usr/local/bin` on macOS. See also [Elevated access for dotnet commands](https://docs.microsoft.com/dotnet/core/tools/elevated-access).
 
 ### Displaying installed .NET Core SDKs and Runtimes
 

--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -28,4 +28,4 @@ Like the [Xml Serializer Generator (sgen.exe)](../../standard/serialization/xml-
 
 ## [.NET Core Uninstall Tool](dotnet-core-uninstall.md)
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a tool that provides controlled clean-up of .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall. 
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) lets you clean-up of .NET Core SDKs and Runtimes on a system such that only the specified versions remain. A collection of options is available to specify which versions are uninstalled. 

--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -28,4 +28,4 @@ Like the [Xml Serializer Generator (sgen.exe)](../../standard/serialization/xml-
 
 ## [.NET Core Uninstall Tool](dotnet-core-uninstall.md)
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a tool that provides controlled clean-up of .NET Core SDKs and Runtimes on a system such that only the desired versions remain. A collection of options is available to specify which versions you want to uninstall. 

--- a/docs/core/additional-tools/index.md
+++ b/docs/core/additional-tools/index.md
@@ -25,3 +25,7 @@ On the .NET Framework, you can pre-generate a serialization assembly using the s
 ## [XML Serializer Generator](xml-serializer-generator.md)
 
 Like the [Xml Serializer Generator (sgen.exe)](../../standard/serialization/xml-serializer-generator-tool-sgen-exe.md) for the .NET Framework, the [Microsoft.XmlSerializer.Generator NuGet package](https://www.nuget.org/packages/Microsoft.XmlSerializer.Generator) is the solution for .NET Core and .NET Standard libraries. It creates an XML serialization assembly for types contained in an assembly to improve the startup performance of XML serialization when serializing or de-serializing objects of those types using <xref:System.Xml.Serialization.XmlSerializer>.
+
+## [.NET Core Uninstall Tool](dotnet-core-uninstall.md)
+
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -199,7 +199,7 @@ The parent directories for the SDK and runtime are listed in the output from the
 
 ## .NET Core Uninstall Tool
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) lets you clean-up of .NET Core SDKs and Runtimes on a system such that only the specified versions remain. A collection of options is available to specify which versions are uninstalled. 
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) lets you clean-up .NET Core SDKs and Runtimes on a system such that only the specified versions remain. A collection of options is available to specify which versions are uninstalled. 
 
 The documentation of the tool is available [here](../additional-tools/dotnet-core-uninstall.md).
 

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -205,7 +205,7 @@ The documentation of the tool is available [here](../additional-tools/dotnet-cor
 
 ## Visual Studio dependencies on .NET Core SDK versions
 
-Visual Studio installers prior to Visual Studio 2019 16.3 install a standalone .NET Core SDK, which is listed in the Windows **Add/Remove Programs** dialog. Hence, be aware that removing .NET Core SDKs installed via the Visual Studio installer prior to Visual Studio 2019 16.3 may break the Visual Studio. The following table shows some of the Visual Studio dependencies on .NET Core SDK versions.
+Visual Studio installers prior to Visual Studio 2019 16.3 called the standalone .NET Core SDK installer. As a result, these versions of the SDK appear in the Windows **Add/Remove Programs** dialog. Hence, be aware that removing .NET Core SDKs installed prior to Visual Studio 2019 16.3 may break Visual Studio. If Visual Studio has problems after you uninstall SDKs, run Repair on that version of Visual Studio. The following table shows some of the Visual Studio dependencies on .NET Core SDK versions:
 
 | Visual Studio version | .NET Core SDK version |
 | -- | -- |

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -205,7 +205,7 @@ The documentation of the tool is available [here](../additional-tools/dotnet-cor
 
 ## Visual Studio dependencies on .NET Core SDK versions
 
-Visual Studio installers prior to Visual Studio 2019 16.3 called the standalone .NET Core SDK installer. As a result, these versions of the SDK appear in the Windows **Add/Remove Programs** dialog. Hence, be aware that removing .NET Core SDKs installed prior to Visual Studio 2019 16.3 may break Visual Studio. If Visual Studio has problems after you uninstall SDKs, run Repair on that version of Visual Studio. The following table shows some of the Visual Studio dependencies on .NET Core SDK versions:
+Visual Studio installers prior to Visual Studio 2019 Update 16.3 call the standalone .NET Core SDK installer. As a result, these versions of the SDK appear in the Windows **Add/Remove Programs** dialog. Hence, be aware that removing .NET Core SDKs installed prior to Visual Studio 2019 Update 16.3 may break Visual Studio. If Visual Studio has problems after you uninstall SDKs, run Repair on that version of Visual Studio. The following table shows some of the Visual Studio dependencies on .NET Core SDK versions:
 
 | Visual Studio version | .NET Core SDK version |
 | -- | -- |

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -199,7 +199,7 @@ The parent directories for the SDK and runtime are listed in the output from the
 
 ## .NET Core Uninstall Tool
 
-The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) lets you clean-up of .NET Core SDKs and Runtimes on a system such that only the specified versions remain. A collection of options is available to specify which versions are uninstalled. 
 
 The documentation of the tool is available [here](../additional-tools/dotnet-core-uninstall.md).
 

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -214,3 +214,16 @@ Visual Studio installers prior to Visual Studio 2019 16.3 called the standalone 
 | Visual Studio 2019 16.0 | .NET Core SDK 2.2.2xx, 2.1.6xx |
 | Visual Studio 2017 15.9 (Update 9) | .NET Core SDK 2.2.1xx, 2.1.5xx |
 | Visual Studio 2017 15.8 (Update 8) | .NET Core SDK 2.1.4xx |
+
+## Removing the NuGet Fallback Folder
+
+Prior to .NET Core SDK 3.0, the .NET Core SDK installers used the `NuGetFallbackFolder` to store a cache of NuGet packages. This cache was used during operations such as `dotnet restore` or `dotnet build /t:Restore`. The `NuGetFallbackFolder` is located at `C:\Program Files\dotnet\sdk` on Windows and at `/usr/local/share/dotnet/sdk` on macOS.
+
+In some cases you may want to remove this folder:
+
+* You are no longer doing .NET development with SDKs below .NET Core SDK 3.0.
+* You are doing development on lower SDKs, but you don't mind being on line and things being slower once.
+
+If you want to remove the NuGet Fallback folder, you can delete it, although you will need Admin privileges.
+
+It is generally undesirable to delete the `dotnet` folder. Doing so would remove any global tools you have installed. Also, on Windows, you will break Visual Studio 2019 Update 16.3 (run **Repair** to recover) and if there are SDK entries in the **Add/Remove Programs** dialog they will be orphaned.

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -202,3 +202,15 @@ The parent directories for the SDK and runtime are listed in the output from the
 The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
 
 The documentation of the tool is available [here](../additional-tools/dotnet-core-uninstall.md).
+
+## Visual Studio dependencies on .NET Core SDK versions
+
+Visual Studio installers prior to Visual Studio 2019 16.3 install a standalone .NET Core SDK, which is listed in the Windows **Add/Remove Programs** dialog. Hence, be aware that removing .NET Core SDKs installed via the Visual Studio installer prior to Visual Studio 2019 16.3 may break the Visual Studio. The following table shows some of the Visual Studio dependencies on .NET Core SDK versions.
+
+| Visual Studio version | .NET Core SDK version |
+| -- | -- |
+| Visual Studio 2019 16.2 (Update 2) | .NET Core SDK 2.2.4xx, 2.1.8xx |
+| Visual Studio 2019 16.1 (Update 1) | .NET Core SDK 2.2.3xx, 2.1.7xx |
+| Visual Studio 2019 16.0 | .NET Core SDK 2.2.2xx, 2.1.6xx |
+| Visual Studio 2017 15.9 (Update 9) | .NET Core SDK 2.2.1xx, 2.1.5xx |
+| Visual Studio 2017 15.8 (Update 8) | .NET Core SDK 2.1.4xx |

--- a/docs/core/versions/remove-runtime-sdk-versions.md
+++ b/docs/core/versions/remove-runtime-sdk-versions.md
@@ -196,3 +196,9 @@ sudo rm -rf /usr/local/share/dotnet/host/fxr/1.0.1
 The parent directories for the SDK and runtime are listed in the output from the `dotnet --list-sdks` and `dotnet --list-runtimes` command, as shown in the earlier table.
 
 ---
+
+## .NET Core Uninstall Tool
+
+The [.NET Core Uninstall Tool (`dotnet-core-uninstall`)](https://dotnet.microsoft.com/download/dotnet-core/uninstall-tool) is a guided tool provided to enable the controlled clean-up of a system such that only the desired versions of .NET Core SDKs and Runtimes remain. A collection of options is available to facilitate the aggregation of uninstallations.
+
+The documentation of the tool is available [here](../additional-tools/dotnet-core-uninstall.md).


### PR DESCRIPTION
## Summary

Added documentation for .NET Core Uninstall Tool (`dotnet-core-uninstall`). Following the suggestions in #13529, the documentation is now standalone with a link from [How to remove the .NET Core Runtime and SDK](https://docs.microsoft.com/en-us/dotnet/core/versions/remove-runtime-sdk-versions).

Discussed with @KathleenDollard, @rowanmiller and @leecow.