### PR TITLE
remove extra comment

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1612.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1612.md
@@ -65,7 +65,7 @@ public class MyClass
         // You can use the following lines instead.  
         // MyStruct ms;  
         // ms.Width = 5;  
-        // lvi.Size = ms;  // CS1612  
+        // lvi.Size = ms;
     }  
   
     public static void Main()   


### PR DESCRIPTION
In the Example section, second "// CS1612" should be removed

Fixes #13576
