### PR TITLE
Removed extra spaces and requirements section

### DIFF
--- a/docs/visual-basic/language-reference/statements/throw-statement.md
+++ b/docs/visual-basic/language-reference/statements/throw-statement.md
@@ -16,36 +16,30 @@ helpviewer_keywords:
 ms.assetid: a6e07406-5c8a-4498-87a2-8339f3651d62
 ---
 # Throw Statement (Visual Basic)
-Throws an exception within a procedure.  
+Throws an exception within a procedure.
+
+## Syntax
+
+```vb
+Throw [ expression ]
+```
+
+## Part
+ `expression`
+ Provides information about the exception to be thrown. Optional when residing in a `Catch` statement, otherwise required.
   
-## Syntax  
-  
-```  
-Throw [ expression ]  
-```  
-  
-## Part  
- `expression`  
- Provides information about the exception to be thrown. Optional when residing in a `Catch` statement, otherwise required.  
-  
-## Remarks  
- The `Throw` statement throws an exception that you can handle with structured exception-handling code (`Try`...`Catch`...`Finally`) or unstructured exception-handling code (`On Error GoTo`). You can use the `Throw` statement to trap errors within your code because Visual Basic moves up the call stack until it finds the appropriate exception-handling code.  
-  
- A `Throw` statement with no expression can only be used in a `Catch` statement, in which case the statement rethrows the exception currently being handled by the `Catch` statement.  
-  
- The `Throw` statement resets the call stack for the `expression` exception. If `expression` is not provided, the call stack is left unchanged. You can access the call stack for the exception through the <xref:System.Exception.StackTrace%2A> property.  
-  
-## Example  
- The following code uses the `Throw` statement to throw an exception:  
-  
- [!code-vb[VbVbalrStatements#84](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrStatements/VB/Class1.vb#84)]  
-  
-## Requirements  
- **Namespace:** [Microsoft.VisualBasic](../../../visual-basic/language-reference/runtime-library-members.md)  
-  
- **Module:** `Interaction`  
-  
- **Assembly:** Visual Basic Runtime Library (in Microsoft.VisualBasic.dll)  
+## Remarks
+ The `Throw` statement throws an exception that you can handle with structured exception-handling code (`Try`...`Catch`...`Finally`) or unstructured exception-handling code (`On Error GoTo`). You can use the `Throw` statement to trap errors within your code because Visual Basic moves up the call stack until it finds the appropriate exception-handling code.
+ 
+ A `Throw` statement with no expression can only be used in a `Catch` statement, in which case the statement rethrows the exception currently being handled by the `Catch` statement.
+
+ The `Throw` statement resets the call stack for the `expression` exception. If `expression` is not provided, the call stack is left unchanged. You can access the call stack for the exception through the <xref:System.Exception.StackTrace%2A> property.
+
+## Example
+ The following code uses the `Throw` statement to throw an exception:
+ 
+ [!code-vb[VbVbalrStatements#84](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrStatements/VB/Class1.vb#84)]
+
   
 ## See also
 


### PR DESCRIPTION
I think that requirements section contain wrong information. Why I would need `Microsoft.VisualBasic.dll` to use the `Throw` keyword ?
