### PR TITLE
Extend tutorial to include publishing

### DIFF
--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -2,6 +2,7 @@
 title: Get started with .NET Core using the CLI
 description: A step-by-step tutorial showing how to get started with .NET Core on Windows, Linux, or macOS using the .NET Core command-line interface (CLI).
 author: thraka
+ms.author: adegeo
 ms.date: 09/10/2018
 ms.technology: dotnet-cli
 ms.custom: "seodec18"
@@ -149,7 +150,7 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 ## Publish your app
 
-Once you're ready to distribute your app, you can publish it with the command [`dotnet publish`](../tools/dotnet-publish.md). Depending on the current .NET Core SDK you're using, the default [`dotnet publish`](../tools/dotnet-publish.md) command will choose a specific publishing method by default. For more information on what the default publishing method is for your SDK version, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli,md) .
+Once you're ready to distribute your app, you can publish it with the command [`dotnet publish`](../tools/dotnet-publish.md). Depending on the current .NET Core SDK you're using, the default [`dotnet publish`](../tools/dotnet-publish.md) command will choose a specific publishing method by default. For more information on what the default publishing method is for your SDK version, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md) .
 
 There are two publishing methods:
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -1,7 +1,7 @@
 ---
 title: Get started with .NET Core using the CLI
 description: A step-by-step tutorial showing how to get started with .NET Core on Windows, Linux, or macOS using the .NET Core command-line interface (CLI).
-author: cartermp
+author: thraka
 ms.date: 09/10/2018
 ms.technology: dotnet-cli
 ms.custom: "seodec18"
@@ -146,6 +146,39 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
    233
    377
    ```
+
+## Publish your app
+
+Once you're ready to distribute your app, you can publish it with the command [`dotnet publish`](../tools/dotnet-publish.md). Depending on the current .NET Core SDK you're using, the default [`dotnet publish`](../tools/dotnet-publish.md) command will choose a specific publishing method by default. For more information on what the default publishing method is for your SDK version, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli,md) .
+
+There are two publishing methods:
+
+01. **Framework-dependent deployments** (FDD)\
+Framework-dependent deployment (FDD) relies on the presence of a shared system-wide version of .NET Core. Because .NET Core is already present, your app is portable between installations of .NET Core. Your app deployment contains your app along with any third-party dependencies that are outside of the .NET Core libraries. FDDs produce a *.dll* file that can be launched by using the `dotnet` utility from the command line. For example, `dotnet app.dll` runs an application named app.
+
+    ```console
+    dotnet publish
+    ```
+
+01. **Self-contained deployments** (SCD)\
+Unlike FDD, a self-contained deployment (SCD) doesn't rely on the presence of shared components on the target system. All components, including both the .NET Core libraries and the .NET Core runtime, are included with the application and are isolated from other .NET Core applications. SCDs include an executable named similar to your app which is a of the platform-specific .NET Core host, and your app *.dll* file, which is the actual application. SCD produces platform-specific binaries.
+
+    ```console
+    dotnet publish -c Release -r <RID> --self-contained true
+    ```
+
+    For more information about runtime identifiers (RID), see the [.NET Core RID Catalog](../rid-catalog.md).
+
+<!-- Does not exist in 2.1 which this tutorial was written for --- Update this article for 3.0
+
+01. **Framework-dependent executables** (FDE)\
+Produces an executable that runs on a target platform. Similar to FDDs, framework-dependent executables (FDE) are platform-specific and aren't self-contained. These deployments still rely on the presence of a shared system-wide version of .NET Core to run.
+
+-->
+
+For more information on the three publishing methods, see [Application Deployment](../deploying/index.md)
+
+## Conclusion
 
 And that's it! Now, you can start using the basic concepts learned here to create your own programs.
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -150,7 +150,12 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 ## Publish your app
 
-Once you're ready to distribute your app, you can publish it with the command [`dotnet publish`](../tools/dotnet-publish.md). Depending on the current .NET Core SDK you're using, the default [`dotnet publish`](../tools/dotnet-publish.md) command will choose a specific publishing method by default. For more information on what the default publishing method is for your SDK version, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md) .
+Once you're ready to distribute your app, you can publish it with the command [`dotnet publish`](../tools/dotnet-publish.md). Depending on the current .NET Core SDK you're using, the default [`dotnet publish`](../tools/dotnet-publish.md) command will choose a specific publishing method. For more information on what the default publishing method is for your SDK version, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md). For more information on the different publishing modes, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md)
+
+Run the `dotnet publish` command to publish your app. The output is placed in the _bin\\debug\\netcoreapp3.0\\publish\\_ folder_
+
+
+
 
 There are two publishing methods:
 
@@ -169,13 +174,6 @@ Unlike FDD, a self-contained deployment doesn't rely on the presence of shared c
     ```
 
     For more information about runtime identifiers (RID), see the [.NET Core RID Catalog](../rid-catalog.md).
-
-<!-- Does not exist in 2.1 which this tutorial was written for --- Update this article for 3.0
-
-01. **Framework-dependent executables** (FDE)\
-Produces an executable that runs on a target platform. Similar to FDDs, framework-dependent executables (FDE) are platform-specific and aren't self-contained. These deployments still rely on the presence of a shared system-wide version of .NET Core to run.
-
--->
 
 For more information on the three publishing methods, see [Application Deployment](../deploying/index.md)
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -3,7 +3,7 @@ title: Get started with .NET Core using the CLI
 description: A step-by-step tutorial showing how to get started with .NET Core on Windows, Linux, or macOS using the .NET Core command-line interface (CLI).
 author: thraka
 ms.author: adegeo
-ms.date: 09/10/2018
+ms.date: 08/07/2019
 ms.technology: dotnet-cli
 ms.custom: "seodec18"
 ---
@@ -163,10 +163,8 @@ Hello World!
 
 And that's it! Now, you can start using the basic concepts learned here to create your own programs.
 
-Note that the commands and steps shown in this tutorial to run your application are used during development time only. Once you're ready to deploy your app, you'll want to take a look at the different [deployment strategies](../deploying/index.md) for .NET Core apps and the [`dotnet publish`](../tools/dotnet-publish.md) command.
-
 ## See also
 
 - [Organizing and testing projects with the .NET Core CLI tools](testing-with-cli.md)
 - [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md)
-- [Application Deployment](../deploying/index.md)
+- [Learn more about app deployment](../deploying/index.md)

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -152,7 +152,7 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to generate the _publish_ folder at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems). You can distribute the contents of the _publish_ folder to other platforms as long as they've already installed the dotnet runtime.
 
-You can run your published app with the `dotnet` command:
+You can run your published app with the [dotnet](../tools/dotnet.md) command:
 
 ```console
 $ dotnet bin\Debug\netcoreapp2.1\publish\Hello.dll

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -150,7 +150,7 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 ## Publish your app
 
-Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to generate the _publish_ folder. This command produces a _publish_ folder at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems) which you can use to distribute your app. You can distribute the contents of the _publish_ folder to other platforms as long as they've already installed the dotnet runtime.
+Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to generate the _publish_ at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems). You can distribute the contents of the _publish_ folder to other platforms as long as they've already installed the dotnet runtime.
 
 You can run your published app with the `dotnet` command:
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -150,32 +150,14 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 ## Publish your app
 
-Once you're ready to distribute your app, you can publish it with the command [`dotnet publish`](../tools/dotnet-publish.md). Depending on the current .NET Core SDK you're using, the default [`dotnet publish`](../tools/dotnet-publish.md) command will choose a specific publishing method. For more information on what the default publishing method is for your SDK version, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md). For more information on the different publishing modes, see [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md)
+Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to publish your app. This command produces a _publish_ folder at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems). You can distribute this app to other platforms as long as long as they have installed the dotnet runtime.
 
-Run the `dotnet publish` command to publish your app. The output is placed in the _bin\\debug\\netcoreapp3.0\\publish\\_ folder_
+You can run your published app with the `dotnet` command:
 
-
-
-
-There are two publishing methods:
-
-01. **Framework-dependent deployments** (FDD)\
-Framework-dependent deployment relies on the presence of a shared system-wide version of .NET Core. Because .NET Core is already present, your app is portable between installations of .NET Core. Your app deployment contains your app along with any third-party dependencies that are outside of the .NET Core libraries. Framework-dependent deployments produce a *.dll* file that can be run by using the `dotnet` utility from the command line. For example, `dotnet app.dll` runs an application named app.
-
-    ```console
-    dotnet publish
-    ```
-
-01. **Self-contained deployments** (SCD)\
-Unlike FDD, a self-contained deployment doesn't rely on the presence of shared components on the system. All components, both the .NET Core libraries and the .NET Core runtime, are included with the application and are isolated from other .NET Core runtimes and applications. self-contained deployments include an executable named for your app, which is a copy of the platform-specific .NET Core host, and your app *.dll* file, which is the actual application. SCD produces platform-specific binaries.
-
-    ```console
-    dotnet publish -c Release -r <RID> --self-contained true
-    ```
-
-    For more information about runtime identifiers (RID), see the [.NET Core RID Catalog](../rid-catalog.md).
-
-For more information on the three publishing methods, see [Application Deployment](../deploying/index.md)
+```console
+$ dotnet bin\Debug\netcoreapp2.1\publish\Hello.dll
+Hello World!
+```
 
 ## Conclusion
 
@@ -186,3 +168,5 @@ Note that the commands and steps shown in this tutorial to run your application 
 ## See also
 
 - [Organizing and testing projects with the .NET Core CLI tools](testing-with-cli.md)
+- [Publish .NET Core apps with the CLI](../deploying/deploy-with-cli.md)
+- [Application Deployment](../deploying/index.md)

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -150,7 +150,7 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 ## Publish your app
 
-Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to publish your app. This command produces a _publish_ folder at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems). You can distribute this app to other platforms as long as long as they have installed the dotnet runtime.
+Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to generate the _publish_ folder. This command produces a _publish_ folder at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems) which you can use to distribute your app. You can distribute the contents of the _publish_ folder to other platforms as long as they've already installed the dotnet runtime.
 
 You can run your published app with the `dotnet` command:
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -150,7 +150,7 @@ Let's build off of the previous Fibonacci example by caching some Fibonacci valu
 
 ## Publish your app
 
-Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to generate the _publish_ at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems). You can distribute the contents of the _publish_ folder to other platforms as long as they've already installed the dotnet runtime.
+Once you're ready to distribute your app, use the [`dotnet publish`](../tools/dotnet-publish.md) command to generate the _publish_ folder at _bin\\debug\\netcoreapp2.1\\publish\\_ (use `/` for non-Windows systems). You can distribute the contents of the _publish_ folder to other platforms as long as they've already installed the dotnet runtime.
 
 You can run your published app with the `dotnet` command:
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -155,14 +155,14 @@ Once you're ready to distribute your app, you can publish it with the command [`
 There are two publishing methods:
 
 01. **Framework-dependent deployments** (FDD)\
-Framework-dependent deployment (FDD) relies on the presence of a shared system-wide version of .NET Core. Because .NET Core is already present, your app is portable between installations of .NET Core. Your app deployment contains your app along with any third-party dependencies that are outside of the .NET Core libraries. FDDs produce a *.dll* file that can be launched by using the `dotnet` utility from the command line. For example, `dotnet app.dll` runs an application named app.
+Framework-dependent deployment relies on the presence of a shared system-wide version of .NET Core. Because .NET Core is already present, your app is portable between installations of .NET Core. Your app deployment contains your app along with any third-party dependencies that are outside of the .NET Core libraries. Framework-dependent deployments produce a *.dll* file that can be run by using the `dotnet` utility from the command line. For example, `dotnet app.dll` runs an application named app.
 
     ```console
     dotnet publish
     ```
 
 01. **Self-contained deployments** (SCD)\
-Unlike FDD, a self-contained deployment (SCD) doesn't rely on the presence of shared components on the target system. All components, including both the .NET Core libraries and the .NET Core runtime, are included with the application and are isolated from other .NET Core applications. SCDs include an executable named similar to your app which is a of the platform-specific .NET Core host, and your app *.dll* file, which is the actual application. SCD produces platform-specific binaries.
+Unlike FDD, a self-contained deployment doesn't rely on the presence of shared components on the system. All components, both the .NET Core libraries and the .NET Core runtime, are included with the application and are isolated from other .NET Core runtimes and applications. self-contained deployments include an executable named for your app, which is a copy of the platform-specific .NET Core host, and your app *.dll* file, which is the actual application. SCD produces platform-specific binaries.
 
     ```console
     dotnet publish -c Release -r <RID> --self-contained true


### PR DESCRIPTION
## Summary

This extends the .NET Core CLI 2.1 tutorial to include a publishing section at the end. I'll file a new issue to track updating this to 3.0 which includes an additional publishing method.

Fixes #12735
