### PR TITLE
Minor improvements to serializing XAML topic

### DIFF
--- a/docs/framework/windows-workflow-foundation/serializing-workflows-and-activities-to-and-from-xaml.md
+++ b/docs/framework/windows-workflow-foundation/serializing-workflows-and-activities-to-and-from-xaml.md
@@ -3,85 +3,88 @@ title: "Serializing Workflows and Activities to and from XAML"
 ms.date: "03/30/2017"
 ms.assetid: 37685b32-24e3-4d72-88d8-45d5fcc49ec2
 ---
-# Serializing Workflows and Activities to and from XAML
-In addition to being compiled into types that are contained in assemblies, workflow definitions can also be serialized to XAML. These serialized definitions can be reloaded for editing or inspection, passed to a build system for compilation, or loaded and invoked. This topic provides an overview of serializing workflow definitions and working with XAML workflow definitions.  
-  
-## Working with XAML Workflow Definitions  
- To create a workflow definition for serialization, the <xref:System.Activities.ActivityBuilder> class is used. Creating an <xref:System.Activities.ActivityBuilder> is very similar to creating a <xref:System.Activities.DynamicActivity>. Any desired arguments are specified, and the activities that constitute the behavior are configured. In the following example, an `Add` activity is created that takes two input arguments, adds them together, and returns the result. Because this activity returns a result, the generic <xref:System.Activities.ActivityBuilder%601> class is used.  
-  
- [!code-csharp[CFX_WorkflowApplicationExample#41](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#41)]  
-  
- Each of the <xref:System.Activities.DynamicActivityProperty> instances represents one of the input arguments to the workflow, and the <xref:System.Activities.ActivityBuilder.Implementation%2A> contains the activities that make up the logic of the workflow. Note that the r-value expressions in this example are Visual Basic expressions. Lambda expressions are not serializable to XAML unless <xref:System.Activities.Expressions.ExpressionServices.Convert%2A> is used. If the serialized workflows are intended to be opened or edited in the workflow designer then Visual Basic expressions should be used. For more information, see [Authoring Workflows, Activities, and Expressions Using Imperative Code](authoring-workflows-activities-and-expressions-using-imperative-code.md).  
-  
- To serialize the workflow definition represented by the <xref:System.Activities.ActivityBuilder> instance to XAML, use <xref:System.Activities.XamlIntegration.ActivityXamlServices> to create a <xref:System.Xaml.XamlWriter>, and then use <xref:System.Xaml.XamlServices> to serialize the workflow definition by using the <xref:System.Xaml.XamlWriter>. <xref:System.Activities.XamlIntegration.ActivityXamlServices> has methods to map <xref:System.Activities.ActivityBuilder> instances to and from XAML, and to load XAML workflows and return a <xref:System.Activities.DynamicActivity> that can be invoked. In the following example, the <xref:System.Activities.ActivityBuilder> instance from the previous example is serialized to a string, and also saved to a file.  
-  
-```csharp  
-// Serialize the workflow to XAML and store it in a string.  
-StringBuilder sb = new StringBuilder();  
-StringWriter tw = new StringWriter(sb);  
-XamlWriter xw = ActivityXamlServices.CreateBuilderWriter(new XamlXmlWriter(tw, new XamlSchemaContext()));  
-XamlServices.Save(xw , ab);  
-string serializedAB = sb.ToString();  
-  
-// Display the XAML to the console.  
-Console.WriteLine(serializedAB);  
-  
-// Serialize the workflow to XAML and save it to a file.  
-StreamWriter sw = File.CreateText(@"C:\Workflows\add.xaml");  
-XamlWriter xw2 = ActivityXamlServices.CreateBuilderWriter(new XamlXmlWriter(sw, new XamlSchemaContext()));  
-XamlServices.Save(xw2, ab);  
-sw.Close();  
-```  
-  
- The following example represents the serialized workflow.  
-  
-```xaml  
-<Activity   
-  x:TypeArguments="x:Int32"   
-  x:Class="Add"   
-  xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities"   
-  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">  
-  <x:Members>  
-    <x:Property Name="Operand1" Type="InArgument(x:Int32)" />  
-    <x:Property Name="Operand2" Type="InArgument(x:Int32)" />  
-  </x:Members>  
-  <Sequence>  
-    <WriteLine Text="[Operand1.ToString() + " + " + Operand2.ToString()]" />  
-    <Assign x:TypeArguments="x:Int32" Value="[Operand1 + Operand2]">  
-      <Assign.To>  
-        <OutArgument x:TypeArguments="x:Int32">  
-          <ArgumentReference x:TypeArguments="x:Int32" ArgumentName="Result" />  
-          </OutArgument>  
-      </Assign.To>  
-    </Assign>  
-  </Sequence>  
-</Activity>  
-```  
-  
- To load a serialized workflow, the <xref:System.Activities.XamlIntegration.ActivityXamlServices> <xref:System.Activities.XamlIntegration.ActivityXamlServices.Load%2A> method is used. This takes the serialized workflow definition and returns a <xref:System.Activities.DynamicActivity> that represents the workflow definition. Note that the XAML is not deserialized until <xref:System.Activities.Activity.CacheMetadata%2A> is called on the body of the <xref:System.Activities.DynamicActivity> during the validation process. If validation is not explicitly called then it is performed when the workflow is invoked. If the XAML workflow definition is invalid, then an <xref:System.ArgumentException> exception is thrown. Any exceptions thrown from <xref:System.Activities.Activity.CacheMetadata%2A> escape from the call to <xref:System.Activities.Validation.ActivityValidationServices.Validate%2A> and must be handled by the caller. In the following example, the serialized workflow from the previous example is loaded and invoked by using <xref:System.Activities.WorkflowInvoker>.  
-  
- [!code-csharp[CFX_WorkflowApplicationExample#43](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#43)]  
-  
- When this workflow is invoked, the following output is displayed to the console.  
-  
- **25 + 15**  
-**40**    
+# Serialize Workflows and Activities to and from XAML
+
+In addition to being compiled into types that are contained in assemblies, workflow definitions can also be serialized to XAML. These serialized definitions can be reloaded for editing or inspection, passed to a build system for compilation, or loaded and invoked. This topic provides an overview of serializing workflow definitions and working with XAML workflow definitions.
+
+## Work with XAML Workflow definitions
+
+To create a workflow definition for serialization, the <xref:System.Activities.ActivityBuilder> class is used. Creating an <xref:System.Activities.ActivityBuilder> is very similar to creating a <xref:System.Activities.DynamicActivity>. Any desired arguments are specified, and the activities that constitute the behavior are configured. In the following example, an `Add` activity is created that takes two input arguments, adds them together, and returns the result. Because this activity returns a result, the generic <xref:System.Activities.ActivityBuilder%601> class is used.
+
+[!code-csharp[CFX_WorkflowApplicationExample#41](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#41)]
+
+Each of the <xref:System.Activities.DynamicActivityProperty> instances represents one of the input arguments to the workflow, and the <xref:System.Activities.ActivityBuilder.Implementation%2A> contains the activities that make up the logic of the workflow. Note that the r-value expressions in this example are Visual Basic expressions. Lambda expressions are not serializable to XAML unless <xref:System.Activities.Expressions.ExpressionServices.Convert%2A> is used. If the serialized workflows are intended to be opened or edited in the workflow designer, then Visual Basic expressions should be used. For more information, see [Authoring Workflows, Activities, and Expressions Using Imperative Code](authoring-workflows-activities-and-expressions-using-imperative-code.md).
+
+To serialize the workflow definition represented by the <xref:System.Activities.ActivityBuilder> instance to XAML, use <xref:System.Activities.XamlIntegration.ActivityXamlServices> to create a <xref:System.Xaml.XamlWriter>, and then use <xref:System.Xaml.XamlServices> to serialize the workflow definition by using the <xref:System.Xaml.XamlWriter>. <xref:System.Activities.XamlIntegration.ActivityXamlServices> has methods to map <xref:System.Activities.ActivityBuilder> instances to and from XAML and to load XAML workflows and return a <xref:System.Activities.DynamicActivity> that can be invoked. In the following example, the <xref:System.Activities.ActivityBuilder> instance from the previous example is serialized to a string and saved to a file.
+
+```csharp
+// Serialize the workflow to XAML and store it in a string.
+StringBuilder sb = new StringBuilder();
+StringWriter tw = new StringWriter(sb);
+XamlWriter xw = ActivityXamlServices.CreateBuilderWriter(new XamlXmlWriter(tw, new XamlSchemaContext()));
+XamlServices.Save(xw, ab);
+string serializedAB = sb.ToString();
+
+// Display the XAML to the console.
+Console.WriteLine(serializedAB);
+
+// Serialize the workflow to XAML and save it to a file.
+StreamWriter sw = File.CreateText(@"C:\Workflows\add.xaml");
+XamlWriter xw2 = ActivityXamlServices.CreateBuilderWriter(new XamlXmlWriter(sw, new XamlSchemaContext()));
+XamlServices.Save(xw2, ab);
+sw.Close();
+```
+
+The following example represents the serialized workflow.
+
+```xaml
+<Activity
+  x:TypeArguments="x:Int32"
+  x:Class="Add"
+  xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <x:Members>
+    <x:Property Name="Operand1" Type="InArgument(x:Int32)" />
+    <x:Property Name="Operand2" Type="InArgument(x:Int32)" />
+  </x:Members>
+  <Sequence>
+    <WriteLine Text="[Operand1.ToString() + " + " + Operand2.ToString()]" />
+    <Assign x:TypeArguments="x:Int32" Value="[Operand1 + Operand2]">
+      <Assign.To>
+        <OutArgument x:TypeArguments="x:Int32">
+          <ArgumentReference x:TypeArguments="x:Int32" ArgumentName="Result" />
+          </OutArgument>
+      </Assign.To>
+    </Assign>
+  </Sequence>
+</Activity>
+```
+
+To load a serialized workflow, use the <xref:System.Activities.XamlIntegration.ActivityXamlServices> <xref:System.Activities.XamlIntegration.ActivityXamlServices.Load%2A> method. This takes the serialized workflow definition and returns a <xref:System.Activities.DynamicActivity> that represents the workflow definition. Note that the XAML is not deserialized until <xref:System.Activities.Activity.CacheMetadata%2A> is called on the body of the <xref:System.Activities.DynamicActivity> during the validation process. If validation is not explicitly called, then it is performed when the workflow is invoked. If the XAML workflow definition is invalid, then an <xref:System.ArgumentException> exception is thrown. Any exceptions thrown from <xref:System.Activities.Activity.CacheMetadata%2A> escape from the call to <xref:System.Activities.Validation.ActivityValidationServices.Validate%2A> and must be handled by the caller. In the following example, the serialized workflow from the previous example is loaded and invoked by using <xref:System.Activities.WorkflowInvoker>.
+
+[!code-csharp[CFX_WorkflowApplicationExample#43](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#43)]
+
+When this workflow is invoked, the following output is displayed to the console.
+
+**25 + 15**
+**40**
+
 > [!NOTE]
->  For more information about invoking workflows with input and output arguments, see [Using WorkflowInvoker and WorkflowApplication](using-workflowinvoker-and-workflowapplication.md) and <xref:System.Activities.WorkflowInvoker.Invoke%2A>.  
-  
- If the serialized workflow contains C# expressions, then an <xref:System.Activities.XamlIntegration.ActivityXamlServicesSettings> instance with its <xref:System.Activities.XamlIntegration.ActivityXamlServicesSettings.CompileExpressions%2A> property set to `true` must be passed as a parameter to <xref:System.Activities.XamlIntegration.ActivityXamlServices.Load%2A?displayProperty=nameWithType>, otherwise a <xref:System.NotSupportedException> will be thrown with a message similar to the following: `Expression Activity type 'CSharpValue`1' requires compilation in order to run.  Please ensure that the workflow has been compiled.`  
-  
-```csharp  
-ActivityXamlServicesSettings settings = new ActivityXamlServicesSettings  
-{  
-    CompileExpressions = true  
-};  
-  
-DynamicActivity<int> wf = ActivityXamlServices.Load(new StringReader(serializedAB), settings) as DynamicActivity<int>;  
-```  
-  
- For more information, see [C# Expressions](csharp-expressions.md).  
-  
- A serialized workflow definition can also be loaded into an <xref:System.Activities.ActivityBuilder> instance by using the <xref:System.Activities.XamlIntegration.ActivityXamlServices> <xref:System.Activities.XamlIntegration.ActivityXamlServices.CreateBuilderReader%2A> method. After a serialized workflow is loaded into an <xref:System.Activities.ActivityBuilder> instance it can be inspected and modified. This is useful for custom workflow designer authors and provides a mechanism for saving and reloading workflow definitions during the design process. In the following example, the serialized workflow definition from the previous example is loaded and its properties are inspected.  
-  
- [!code-csharp[CFX_WorkflowApplicationExample#44](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#44)]
+> For more information about invoking workflows with input and output arguments, see [Using WorkflowInvoker and WorkflowApplication](using-workflowinvoker-and-workflowapplication.md) and <xref:System.Activities.WorkflowInvoker.Invoke%2A>.
+
+If the serialized workflow contains C# expressions, then an <xref:System.Activities.XamlIntegration.ActivityXamlServicesSettings> instance with its <xref:System.Activities.XamlIntegration.ActivityXamlServicesSettings.CompileExpressions%2A> property set to `true` must be passed as a parameter to <xref:System.Activities.XamlIntegration.ActivityXamlServices.Load%2A?displayProperty=nameWithType>, otherwise a <xref:System.NotSupportedException> will be thrown with a message similar to the following: **Expression Activity type 'CSharpValue`1' requires compilation in order to run.  Please ensure that the workflow has been compiled.**
+
+```csharp
+ActivityXamlServicesSettings settings = new ActivityXamlServicesSettings
+{
+    CompileExpressions = true
+};
+
+DynamicActivity<int> wf = ActivityXamlServices.Load(new StringReader(serializedAB), settings) as DynamicActivity<int>;
+```
+
+For more information, see [C# Expressions](csharp-expressions.md).
+
+A serialized workflow definition can also be loaded into an <xref:System.Activities.ActivityBuilder> instance by using the <xref:System.Activities.XamlIntegration.ActivityXamlServices> <xref:System.Activities.XamlIntegration.ActivityXamlServices.CreateBuilderReader%2A> method. After a serialized workflow is loaded into an <xref:System.Activities.ActivityBuilder> instance, it can be inspected and modified. This is useful for custom workflow designer authors and provides a mechanism for saving and reloading workflow definitions during the design process. In the following example, the serialized workflow definition from the previous example is loaded and its properties are inspected.
+
+[!code-csharp[CFX_WorkflowApplicationExample#44](~/samples/snippets/csharp/VS_Snippets_CFX/cfx_workflowapplicationexample/cs/program.cs#44)]

--- a/docs/framework/windows-workflow-foundation/serializing-workflows-and-activities-to-and-from-xaml.md
+++ b/docs/framework/windows-workflow-foundation/serializing-workflows-and-activities-to-and-from-xaml.md
@@ -66,7 +66,7 @@ To load a serialized workflow, use the <xref:System.Activities.XamlIntegration.A
 
 When this workflow is invoked, the following output is displayed to the console.
 
-**25 + 15**
+**25 + 15**\
 **40**
 
 > [!NOTE]


### PR DESCRIPTION
- Fix message rendering
- Use of commas, whitespace, and -ing works in headings.