### PR TITLE
Remove empty top-level node and shift indentation

### DIFF
--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -1,632 +1,630 @@
-- name: Language reference
+- name: C# language reference
+  href: index.md
+- name: Configure language version
+  href: configure-language-version.md
+- name: C# keywords
   items:
-  - name: C# language reference
-    href: index.md
-  - name: Configure language version
-    href: configure-language-version.md
-  - name: C# keywords
+  - name: Overview
+    href: keywords/index.md
+  - name: Built-in types
     items:
-    - name: Overview
-      href: keywords/index.md
-    - name: Built-in types
+    - name: Value Types
       items:
-      - name: Value Types
-        items:
-        - name: Features of value types
-          href: keywords/value-types.md
-        - name: bool
-          href: keywords/bool.md
-        - name: Integral numeric types
-          displayName: sbyte, byte, short, ushort, int, uint, long, ulong, integer
-          href: builtin-types/integral-numeric-types.md
-        - name: Floating-point numeric types
-          displayName: float, decimal, double, rational, real
-          href: builtin-types/floating-point-numeric-types.md
-        - name: char
-          href: keywords/char.md
-        - name: enum
-          href: keywords/enum.md
-        - name: struct
-          href: keywords/struct.md
-      - name: Reference Types
-        items:
-        - name: Features of reference types
-          href: keywords/reference-types.md
-        - name: class
-          href: keywords/class.md
-        - name: Built-in reference types
-          displayName: object, delegate, dynamic, string
-          href: builtin-types/reference-types.md
-        - name: interface
-          href: keywords/interface.md
-      - name: void
-        href: keywords/void.md
-      - name: var
-        href: keywords/var.md
-      - name: Unmanaged types
-        href: builtin-types/unmanaged-types.md
-      - name: Reference tables for types
-        items:
-        - name: Built-in types table
-          href: keywords/built-in-types-table.md
-        - name: Value types table
-          href: keywords/value-types-table.md
-        - name: Default values table
-          href: keywords/default-values-table.md
-        - name: Implicit numeric conversions table
-          href: keywords/implicit-numeric-conversions-table.md
-        - name: Explicit numeric conversions table
-          href: keywords/explicit-numeric-conversions-table.md
-        - name: Formatting numeric results table
-          href: keywords/formatting-numeric-results-table.md
-    - name: Modifiers
+      - name: Features of value types
+        href: keywords/value-types.md
+      - name: bool
+        href: keywords/bool.md
+      - name: Integral numeric types
+        displayName: sbyte, byte, short, ushort, int, uint, long, ulong, integer
+        href: builtin-types/integral-numeric-types.md
+      - name: Floating-point numeric types
+        displayName: float, decimal, double, rational, real
+        href: builtin-types/floating-point-numeric-types.md
+      - name: char
+        href: keywords/char.md
+      - name: enum
+        href: keywords/enum.md
+      - name: struct
+        href: keywords/struct.md
+    - name: Reference Types
       items:
-      - name: Access Modifiers
-        items:
-        - name: Quick reference
-          href: keywords/access-modifiers.md
-        - name: Accessibility Levels
-          href: keywords/accessibility-levels.md
-        - name: Accessibility Domain
-          href: keywords/accessibility-domain.md
-        - name: Restrictions on Using Accessibility Levels
-          href: keywords/restrictions-on-using-accessibility-levels.md
-        - name: internal
-          href: keywords/internal.md
-        - name: private
-          href: keywords/private.md
-        - name: protected
-          href: keywords/protected.md
-        - name: public
-          href: keywords/public.md
-        - name: protected internal
-          href: keywords/protected-internal.md
-        - name: private protected
-          href: keywords/private-protected.md
-      - name: abstract
-        href: keywords/abstract.md
-      - name: async
-        href: keywords/async.md
-      - name: const
-        href: keywords/const.md
-      - name: event
-        href: keywords/event.md
-      - name: extern
-        href: keywords/extern.md
-      - name: in (generic modifier)
-        href: keywords/in-generic-modifier.md
-      - name: new (member modifier)
-        href: keywords/new-modifier.md
-      - name: out (generic modifier)
-        href: keywords/out-generic-modifier.md
-      - name: override
-        href: keywords/override.md
-      - name: readonly
-        href: keywords/readonly.md
-      - name: sealed
-        href: keywords/sealed.md
-      - name: static
-        href: keywords/static.md
-      - name: unsafe
-        href: keywords/unsafe.md
-      - name: virtual
-        href: keywords/virtual.md
-      - name: volatile
-        href: keywords/volatile.md
-    - name: Statement Keywords
+      - name: Features of reference types
+        href: keywords/reference-types.md
+      - name: class
+        href: keywords/class.md
+      - name: Built-in reference types
+        displayName: object, delegate, dynamic, string
+        href: builtin-types/reference-types.md
+      - name: interface
+        href: keywords/interface.md
+    - name: void
+      href: keywords/void.md
+    - name: var
+      href: keywords/var.md
+    - name: Unmanaged types
+      href: builtin-types/unmanaged-types.md
+    - name: Reference tables for types
       items:
-      - name: Statement categories
-        href: keywords/statement-keywords.md
-      - name: Selection Statements
-        items:
-        - name: if-else
-          href: keywords/if-else.md
-        - name: switch
-          href: keywords/switch.md
-      - name: Iteration Statements
-        items:
-        - name: do
-          href: keywords/do.md
-        - name: for
-          href: keywords/for.md
-        - name: foreach, in
-          href: keywords/foreach-in.md
-        - name: while
-          href: keywords/while.md
-      - name: Jump Statements
-        items:
-        - name: break
-          href: keywords/break.md
-        - name: continue
-          href: keywords/continue.md
-        - name: goto
-          href: keywords/goto.md
-        - name: return
-          href: keywords/return.md
-      - name: Exception Handling Statements
-        items:
-        - name: throw
-          href: keywords/throw.md
-        - name: try-catch
-          href: keywords/try-catch.md
-        - name: try-finally
-          href: keywords/try-finally.md
-        - name: try-catch-finally
-          href: keywords/try-catch-finally.md
-      - name: Checked and Unchecked
-        items:
-        - name: Overview
-          href: keywords/checked-and-unchecked.md
-        - name: checked
-          href: keywords/checked.md
-        - name: unchecked
-          href: keywords/unchecked.md
-      - name: fixed Statement
-        href: keywords/fixed-statement.md
-      - name: lock Statement
-        href: keywords/lock-statement.md
-    - name: Method Parameters
-      items:
-      - name: Passing parameters
-        href: keywords/method-parameters.md
-      - name: params
-        href: keywords/params.md
-      - name: in (Parameter Modifier)
-        href: keywords/in-parameter-modifier.md
-      - name: ref
-        href: keywords/ref.md
-      - name: out (Parameter Modifier)
-        href: keywords/out-parameter-modifier.md
-    - name: Namespace Keywords
-      items:
-      - name: namespace
-        href: keywords/namespace.md
-      - name: using
-        items:
-        - name: Contexts for using
-          href: keywords/using.md
-        - name: using Directive
-          href: keywords/using-directive.md
-        - name: using static Directive
-          href: keywords/using-static.md
-        - name: using Statement
-          href: keywords/using-statement.md
-      - name: extern alias
-        href: keywords/extern-alias.md
-    - name: Type-testing Keywords
-      items:
-        - name: is
-          href: keywords/is.md
-    - name: Generic Type Constraint Keywords
-      items:
-        - name: new constraint
-          href: keywords/new-constraint.md
-        - name: where
-          href: keywords/where-generic-type-constraint.md
-    - name: Operator Keywords
-      items:
-      - name: await
-        href: keywords/await.md
-    - name: Access Keywords
-      items:
-      - name: base
-        href: keywords/base.md
-      - name: this
-        href: keywords/this.md
-    - name: Literal Keywords
-      items:
-      - name: "null"
-        href: keywords/null.md
-      - name: "true"
-        href: keywords/true-literal.md
-      - name: "false"
-        href: keywords/false-literal.md
-      - name: default
-        href: keywords/default.md
-    - name: Contextual Keywords
+      - name: Built-in types table
+        href: keywords/built-in-types-table.md
+      - name: Value types table
+        href: keywords/value-types-table.md
+      - name: Default values table
+        href: keywords/default-values-table.md
+      - name: Implicit numeric conversions table
+        href: keywords/implicit-numeric-conversions-table.md
+      - name: Explicit numeric conversions table
+        href: keywords/explicit-numeric-conversions-table.md
+      - name: Formatting numeric results table
+        href: keywords/formatting-numeric-results-table.md
+  - name: Modifiers
+    items:
+    - name: Access Modifiers
       items:
       - name: Quick reference
-        href: keywords/contextual-keywords.md
-      - name: add
-        href: keywords/add.md
-      - name: get
-        href: keywords/get.md
-      - name: global
-        href: keywords/global.md
-      - name: partial (Type)
-        href: keywords/partial-type.md
-      - name: partial (Method)
-        href: keywords/partial-method.md
-      - name: remove
-        href: keywords/remove.md
-      - name: set
-        href: keywords/set.md
-      - name: when (filter condition)
-        href: keywords/when.md
-      - name: value
-        href: keywords/value.md
-      - name: yield
-        href: keywords/yield.md
-    - name: Query Keywords
+        href: keywords/access-modifiers.md
+      - name: Accessibility Levels
+        href: keywords/accessibility-levels.md
+      - name: Accessibility Domain
+        href: keywords/accessibility-domain.md
+      - name: Restrictions on Using Accessibility Levels
+        href: keywords/restrictions-on-using-accessibility-levels.md
+      - name: internal
+        href: keywords/internal.md
+      - name: private
+        href: keywords/private.md
+      - name: protected
+        href: keywords/protected.md
+      - name: public
+        href: keywords/public.md
+      - name: protected internal
+        href: keywords/protected-internal.md
+      - name: private protected
+        href: keywords/private-protected.md
+    - name: abstract
+      href: keywords/abstract.md
+    - name: async
+      href: keywords/async.md
+    - name: const
+      href: keywords/const.md
+    - name: event
+      href: keywords/event.md
+    - name: extern
+      href: keywords/extern.md
+    - name: in (generic modifier)
+      href: keywords/in-generic-modifier.md
+    - name: new (member modifier)
+      href: keywords/new-modifier.md
+    - name: out (generic modifier)
+      href: keywords/out-generic-modifier.md
+    - name: override
+      href: keywords/override.md
+    - name: readonly
+      href: keywords/readonly.md
+    - name: sealed
+      href: keywords/sealed.md
+    - name: static
+      href: keywords/static.md
+    - name: unsafe
+      href: keywords/unsafe.md
+    - name: virtual
+      href: keywords/virtual.md
+    - name: volatile
+      href: keywords/volatile.md
+  - name: Statement Keywords
+    items:
+    - name: Statement categories
+      href: keywords/statement-keywords.md
+    - name: Selection Statements
       items:
-      - name: Quick reference
-        href: keywords/query-keywords.md
-      - name: from clause
-        href: keywords/from-clause.md
-      - name: where clause
-        href: keywords/where-clause.md
-      - name: select clause
-        href: keywords/select-clause.md
-      - name: group clause
-        href: keywords/group-clause.md
-      - name: into
-        href: keywords/into.md
-      - name: orderby clause
-        href: keywords/orderby-clause.md
-      - name: join clause
-        href: keywords/join-clause.md
-      - name: let clause
-        href: keywords/let-clause.md
-      - name: ascending
-        href: keywords/ascending.md
-      - name: descending
-        href: keywords/descending.md
-      - name: "on"
-        href: keywords/on.md
-      - name: equals
-        href: keywords/equals.md
-      - name: by
-        href: keywords/by.md
-      - name: in
-        href: keywords/in.md
-  - name: C# operators
-    items:
-    - name: Overview
-      href: operators/index.md
-    - name: Arithmetic operators
-      href: operators/arithmetic-operators.md
-      displayName: ++, --, +, -, *, /, %, +=, -=, *=, /=, %=, checked, unchecked
-    - name: Boolean logical operators
-      href: operators/boolean-logical-operators.md
-      displayName: "!, &&, ||, &, |, ^, &=, |=, ^="
-    - name: Bitwise and shift operators
-      href: operators/bitwise-and-shift-operators.md
-      displayName: "~, &, |, ^, <<, >>, &=, |=, ^=, <<=, >>="
-    - name: Equality operators
-      href: operators/equality-operators.md
-      displayName: ==, !=
-    - name: Comparison operators
-      href: operators/comparison-operators.md
-      displayName: ">, <, >=, <=, greater, less"
-    - name: Member access operators
-      href: operators/member-access-operators.md
-      displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation"
-    - name: Type-testing and conversion operators
-      href: operators/type-testing-and-conversion-operators.md
-      displayName: "is operator, is keyword, as operator, as keyword, typeof, (), cast"
-    - name: User-defined conversion operators
-      href: operators/user-defined-conversion-operators.md
-      displayName: implicit, explicit
-    - name: Pointer related operators
-      href: operators/pointer-related-operators.md
-      displayName: "&, *, ->, [], +, -, ++, --, ==, !=, <, >, <=, >=, dereference, address-of, indirection"
-    - name: "= operator"
-      href: operators/assignment-operator.md
-      displayName: "assignment, ref"
-    - name: + and += operators
-      href: operators/addition-operator.md
-      displayName: string concatenation, delegate combination, event subscription
-    - name: "- and -= operators"
-      href: operators/subtraction-operator.md
-      displayName: delegate removal, event unsubscription
-    - name: "?: operator"
-      href: operators/conditional-operator.md
-      displayName: conditional, ternary, ref
-    - name: "?? operator"
-      href: operators/null-coalescing-operator.md
-      displayName: null-coalescing
-    - name: => operator
-      href: operators/lambda-operator.md
-      displayName: lambda
-    - name: ":: operator"
-      href: operators/namespace-alias-qualifier.md
-      displayName: "namespace alias qualifier"
-    - name: delegate operator
-      href: operators/delegate-operator.md
-      displayName: anonymous
-    - name: nameof operator
-      href: operators/nameof.md
-    - name: new operator
-      href: operators/new-operator.md
-    - name: sizeof operator
-      href: operators/sizeof.md
-    - name: stackalloc operator
-      href: operators/stackalloc.md
-    - name: true and false operators
-      href: operators/true-false-operators.md
-    - name: Operator overloading
-      href: operators/operator-overloading.md
-  - name: C# special characters
-    items:
-    - name: Overview
-      href: tokens/index.md
-    - name: $ -- string interpolation
-      href: tokens/interpolated.md
-    - name: "@ -- verbatim identifier"
-      href: tokens/verbatim.md
-  - name: C# preprocessor directives
-    items:
-    - name: Overview
-      href: preprocessor-directives/index.md
-    - name: "#if"
-      href: preprocessor-directives/preprocessor-if.md
-    - name: "#else"
-      href: preprocessor-directives/preprocessor-else.md
-    - name: "#elif"
-      href: preprocessor-directives/preprocessor-elif.md
-    - name: "#endif"
-      href: preprocessor-directives/preprocessor-endif.md
-    - name: "#define"
-      href: preprocessor-directives/preprocessor-define.md
-    - name: "#undef"
-      href: preprocessor-directives/preprocessor-undef.md
-    - name: "#warning"
-      href: preprocessor-directives/preprocessor-warning.md
-    - name: "#error"
-      href: preprocessor-directives/preprocessor-error.md
-    - name: "#line"
-      href: preprocessor-directives/preprocessor-line.md
-    - name: "#region"
-      href: preprocessor-directives/preprocessor-region.md
-    - name: "#endregion"
-      href: preprocessor-directives/preprocessor-endregion.md
-    - name: "#pragma"
-      href: preprocessor-directives/preprocessor-pragma.md
-    - name: "#pragma warning"
-      href: preprocessor-directives/preprocessor-pragma-warning.md
-    - name: "#pragma checksum"
-      href: preprocessor-directives/preprocessor-pragma-checksum.md
-  - name: C# compiler options
-    items:
-    - name: Overview
-      href: compiler-options/index.md
-    - name: Command-line Building With csc.exe
-      href: compiler-options/command-line-building-with-csc-exe.md
-    - name: "How to: Set Environment Variables for the Visual Studio Command Line"
-      href: compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
-    - name: C# Compiler Options Listed by Category
-      href: compiler-options/listed-by-category.md
-    - name: C# Compiler Options Listed Alphabetically
-      href: compiler-options/listed-alphabetically.md
+      - name: if-else
+        href: keywords/if-else.md
+      - name: switch
+        href: keywords/switch.md
+    - name: Iteration Statements
       items:
-      - name: "@"
-        href: compiler-options/response-file-compiler-option.md
-      - name: -addmodule
-        href: compiler-options/addmodule-compiler-option.md
-      - name: -appconfig
-        href: compiler-options/appconfig-compiler-option.md
-      - name: -baseaddress
-        href: compiler-options/baseaddress-compiler-option.md
-      - name: -bugreport
-        href: compiler-options/bugreport-compiler-option.md
-      - name: -checked
-        href: compiler-options/checked-compiler-option.md
-      - name: -codepage
-        href: compiler-options/codepage-compiler-option.md
-      - name: -debug
-        href: compiler-options/debug-compiler-option.md
-      - name: -define
-        href: compiler-options/define-compiler-option.md
-      - name: -delaysign
-        href: compiler-options/delaysign-compiler-option.md
-      - name: -deterministic
-        href: compiler-options/deterministic-compiler-option.md
-      - name: -doc
-        href: compiler-options/doc-compiler-option.md
-      - name: -errorreport
-        href: compiler-options/errorreport-compiler-option.md
-      - name: -filealign
-        href: compiler-options/filealign-compiler-option.md
-      - name: -fullpaths
-        href: compiler-options/fullpaths-compiler-option.md
-      - name: -help, -?
-        href: compiler-options/help-compiler-option.md
-      - name: -highentropyva
-        href: compiler-options/highentropyva-compiler-option.md
-      - name: -keycontainer
-        href: compiler-options/keycontainer-compiler-option.md
-      - name: -keyfile
-        href: compiler-options/keyfile-compiler-option.md
-      - name: -langversion
-        href: compiler-options/langversion-compiler-option.md
-      - name: -lib
-        href: compiler-options/lib-compiler-option.md
-      - name: -link
-        href: compiler-options/link-compiler-option.md
-      - name: -linkresource
-        href: compiler-options/linkresource-compiler-option.md
-      - name: -main
-        href: compiler-options/main-compiler-option.md
-      - name: -moduleassemblyname
-        href: compiler-options/moduleassemblyname-compiler-option.md
-      - name: -noconfig
-        href: compiler-options/noconfig-compiler-option.md
-      - name: -nologo
-        href: compiler-options/nologo-compiler-option.md
-      - name: -nostdlib
-        href: compiler-options/nostdlib-compiler-option.md
-      - name: -nowarn
-        href: compiler-options/nowarn-compiler-option.md
-      - name: -nowin32manifest
-        href: compiler-options/nowin32manifest-compiler-option.md
-      - name: -optimize
-        href: compiler-options/optimize-compiler-option.md
-      - name: -out
-        href: compiler-options/out-compiler-option.md
-      - name: -pathmap
-        href: compiler-options/pathmap-compiler-option.md
-      - name: -pdb
-        href: compiler-options/pdb-compiler-option.md
-      - name: -platform
-        href: compiler-options/platform-compiler-option.md
-      - name: -preferreduilang
-        href: compiler-options/preferreduilang-compiler-option.md
-      - name: -publicsign
-        href: compiler-options/publicsign-compiler-option.md
-      - name: -recurse
-        href: compiler-options/recurse-compiler-option.md
-      - name: -reference
-        href: compiler-options/reference-compiler-option.md
-      - name: -refout
-        href: compiler-options/refout-compiler-option.md
-      - name: -refonly
-        href: compiler-options/refonly-compiler-option.md
-      - name: -resource
-        href: compiler-options/resource-compiler-option.md
-      - name: -subsystemversion
-        href: compiler-options/subsystemversion-compiler-option.md
-      - name: -target
-        href: compiler-options/target-compiler-option.md
-        items:
-        - name: "-target:appcontainerexe"
-          href: compiler-options/target-appcontainerexe-compiler-option.md
-        - name: "-target:exe"
-          href: compiler-options/target-exe-compiler-option.md
-        - name: "-target:library"
-          href: compiler-options/target-library-compiler-option.md
-        - name: "-target:module"
-          href: compiler-options/target-module-compiler-option.md
-        - name: "-target:winexe"
-          href: compiler-options/target-winexe-compiler-option.md
-        - name: "-target:winmdobj"
-          href: compiler-options/target-winmdobj-compiler-option.md
-      - name: -unsafe
-        href: compiler-options/unsafe-compiler-option.md
-      - name: -utf8output
-        href: compiler-options/utf8output-compiler-option.md
-      - name: -warn
-        href: compiler-options/warn-compiler-option.md
-      - name: -warnaserror
-        href: compiler-options/warnaserror-compiler-option.md
-      - name: -win32icon
-        href: compiler-options/win32icon-compiler-option.md
-      - name: -win32manifest
-        href: compiler-options/win32manifest-compiler-option.md
-      - name: -win32res
-        href: compiler-options/win32res-compiler-option.md
-  - name: C# compiler errors
-    href: compiler-messages/index.md
-  - name: C# 6.0 draft specification
+      - name: do
+        href: keywords/do.md
+      - name: for
+        href: keywords/for.md
+      - name: foreach, in
+        href: keywords/foreach-in.md
+      - name: while
+        href: keywords/while.md
+    - name: Jump Statements
+      items:
+      - name: break
+        href: keywords/break.md
+      - name: continue
+        href: keywords/continue.md
+      - name: goto
+        href: keywords/goto.md
+      - name: return
+        href: keywords/return.md
+    - name: Exception Handling Statements
+      items:
+      - name: throw
+        href: keywords/throw.md
+      - name: try-catch
+        href: keywords/try-catch.md
+      - name: try-finally
+        href: keywords/try-finally.md
+      - name: try-catch-finally
+        href: keywords/try-catch-finally.md
+    - name: Checked and Unchecked
+      items:
+      - name: Overview
+        href: keywords/checked-and-unchecked.md
+      - name: checked
+        href: keywords/checked.md
+      - name: unchecked
+        href: keywords/unchecked.md
+    - name: fixed Statement
+      href: keywords/fixed-statement.md
+    - name: lock Statement
+      href: keywords/lock-statement.md
+  - name: Method Parameters
     items:
-    - name: Introduction
-      href: ../../../_csharplang/spec/introduction.md
-    - name: Lexical structure
-      href: ../../../_csharplang/spec/lexical-structure.md
-    - name: Basic concepts
-      href: ../../../_csharplang/spec/basic-concepts.md
-    - name: Types
-      href: ../../../_csharplang/spec/types.md
-    - name: Variables
-      href: ../../../_csharplang/spec/variables.md
-    - name: Conversions
-      href: ../../../_csharplang/spec/conversions.md
-    - name: Expressions
-      href: ../../../_csharplang/spec/expressions.md
-    - name: Statements
-      href: ../../../_csharplang/spec/statements.md
-    - name: Namespaces
-      href: ../../../_csharplang/spec/namespaces.md
-    - name: Classes
-      href: ../../../_csharplang/spec/classes.md
-    - name: Structs
-      href: ../../../_csharplang/spec/structs.md
-    - name: Arrays
-      href: ../../../_csharplang/spec/arrays.md
-    - name: Interfaces
-      href: ../../../_csharplang/spec/interfaces.md
-    - name: Enums
-      href: ../../../_csharplang/spec/enums.md
-    - name: Delegates
-      href: ../../../_csharplang/spec/delegates.md
-    - name: Exceptions
-      href: ../../../_csharplang/spec/exceptions.md
-    - name: Attributes
-      href: ../../../_csharplang/spec/attributes.md
-    - name: Unsafe code
-      href: ../../../_csharplang/spec/unsafe-code.md
-    - name: Documentation comments
-      href: ../../../_csharplang/spec/documentation-comments.md
-  - name: C# 7.0 language proposals
+    - name: Passing parameters
+      href: keywords/method-parameters.md
+    - name: params
+      href: keywords/params.md
+    - name: in (Parameter Modifier)
+      href: keywords/in-parameter-modifier.md
+    - name: ref
+      href: keywords/ref.md
+    - name: out (Parameter Modifier)
+      href: keywords/out-parameter-modifier.md
+  - name: Namespace Keywords
     items:
-    - name: Pattern matching
-      href: ../../../_csharplang/proposals/csharp-7.0/pattern-matching.md
-    - name: Local functions
-      href: ../../../_csharplang/proposals/csharp-7.0/local-functions.md
-    - name: Out variable declarations
-      href: ../../../_csharplang/proposals/csharp-7.0/out-var.md
-    - name: Throw expressions
-      href: ../../../_csharplang/proposals/csharp-7.0/throw-expression.md
-    - name: Binary literals
-      href: ../../../_csharplang/proposals/csharp-7.0/binary-literals.md
-    - name: Digit separators
-      href: ../../../_csharplang/proposals/csharp-7.0/digit-separators.md
-  - name: C# 7.1 language proposals
+    - name: namespace
+      href: keywords/namespace.md
+    - name: using
+      items:
+      - name: Contexts for using
+        href: keywords/using.md
+      - name: using Directive
+        href: keywords/using-directive.md
+      - name: using static Directive
+        href: keywords/using-static.md
+      - name: using Statement
+        href: keywords/using-statement.md
+    - name: extern alias
+      href: keywords/extern-alias.md
+  - name: Type-testing Keywords
     items:
-    - name: Async main method
-      href: ../../../_csharplang/proposals/csharp-7.1/async-main.md
-    - name: Default expressions
-      href: ../../../_csharplang/proposals/csharp-7.1/target-typed-default.md
-    - name: Infer tuple names
-      href: ../../../_csharplang/proposals/csharp-7.1/infer-tuple-names.md
-    - name: Pattern matching with generics
-      href: ../../../_csharplang/proposals/csharp-7.1/generics-pattern-match.md
-  - name: C# 7.2 language proposals
+      - name: is
+        href: keywords/is.md
+  - name: Generic Type Constraint Keywords
     items:
-    - name: Readonly references
-      href: ../../../_csharplang/proposals/csharp-7.2/readonly-ref.md
-    - name: Compile time safety for ref-like types
-      href: ../../../_csharplang/proposals/csharp-7.2/span-safety.md
-    - name: Non-trailing named arguments
-      href: ../../../_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md
-    - name: Private protected
-      href: ../../../_csharplang/proposals/csharp-7.2/private-protected.md
-    - name: Conditional ref
-      href: ../../../_csharplang/proposals/csharp-7.2/conditional-ref.md
-    - name: Leading digit separator
-      href: ../../../_csharplang/proposals/csharp-7.2/leading-separator.md
-  - name: C# 7.3 language proposals
+      - name: new constraint
+        href: keywords/new-constraint.md
+      - name: where
+        href: keywords/where-generic-type-constraint.md
+  - name: Operator Keywords
     items:
-    - name: Unmanaged generic type constraints
-      href: ../../../_csharplang/proposals/csharp-7.3/blittable.md
-    - name: Indexing `fixed` fields should not require pinning regardless of the movable/unmovable context
-      href: ../../../_csharplang/proposals/csharp-7.3/indexing-movable-fixed-fields.md
-    - name: Pattern-based `fixed` statement
-      href: ../../../_csharplang/proposals/csharp-7.3/pattern-based-fixed.md
-    - name: Ref local reassignment
-      href: ../../../_csharplang/proposals/csharp-7.3/ref-local-reassignment.md
-    - name: Stackalloc array initializers
-      href: ../../../_csharplang/proposals/csharp-7.3/stackalloc-array-initializers.md
-    - name: Auto-implemented property field-targeted attributes
-      href: ../../../_csharplang/proposals/csharp-7.3/auto-prop-field-attrs.md
-    - name: expression variables in initializers
-      href: ../../../_csharplang/proposals/csharp-7.3/expression-variables-in-initializers.md
-    - name: Tuple equality (==) and inequality (!=)
-      href: ../../../_csharplang/proposals/csharp-7.3/tuple-equality.md
-    - name: Improved overload candidates
-      href: ../../../_csharplang/proposals/csharp-7.3/improved-overload-candidates.md
-  - name: C# 8.0 language proposals
+    - name: await
+      href: keywords/await.md
+  - name: Access Keywords
     items:
-    - name: Null reference types - proposal
-      href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
-    - name: nullable reference types - specification
-      href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md
-    - name: Recursive pattern matching
-      href: ../../../_csharplang/proposals/csharp-8.0/patterns.md
-    - name: async streams
-      href: ../../../_csharplang/proposals/csharp-8.0/async-streams.md
-    - name: Ranges
-      href: ../../../_csharplang/proposals/csharp-8.0/ranges.md
-    - name: Pattern based using and using declarations
-      href: ../../../_csharplang/proposals/csharp-8.0/using.md
-    - name: null coalescing assignment
-      href: ../../../_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md
+    - name: base
+      href: keywords/base.md
+    - name: this
+      href: keywords/this.md
+  - name: Literal Keywords
+    items:
+    - name: "null"
+      href: keywords/null.md
+    - name: "true"
+      href: keywords/true-literal.md
+    - name: "false"
+      href: keywords/false-literal.md
+    - name: default
+      href: keywords/default.md
+  - name: Contextual Keywords
+    items:
+    - name: Quick reference
+      href: keywords/contextual-keywords.md
+    - name: add
+      href: keywords/add.md
+    - name: get
+      href: keywords/get.md
+    - name: global
+      href: keywords/global.md
+    - name: partial (Type)
+      href: keywords/partial-type.md
+    - name: partial (Method)
+      href: keywords/partial-method.md
+    - name: remove
+      href: keywords/remove.md
+    - name: set
+      href: keywords/set.md
+    - name: when (filter condition)
+      href: keywords/when.md
+    - name: value
+      href: keywords/value.md
+    - name: yield
+      href: keywords/yield.md
+  - name: Query Keywords
+    items:
+    - name: Quick reference
+      href: keywords/query-keywords.md
+    - name: from clause
+      href: keywords/from-clause.md
+    - name: where clause
+      href: keywords/where-clause.md
+    - name: select clause
+      href: keywords/select-clause.md
+    - name: group clause
+      href: keywords/group-clause.md
+    - name: into
+      href: keywords/into.md
+    - name: orderby clause
+      href: keywords/orderby-clause.md
+    - name: join clause
+      href: keywords/join-clause.md
+    - name: let clause
+      href: keywords/let-clause.md
+    - name: ascending
+      href: keywords/ascending.md
+    - name: descending
+      href: keywords/descending.md
+    - name: "on"
+      href: keywords/on.md
+    - name: equals
+      href: keywords/equals.md
+    - name: by
+      href: keywords/by.md
+    - name: in
+      href: keywords/in.md
+- name: C# operators
+  items:
+  - name: Overview
+    href: operators/index.md
+  - name: Arithmetic operators
+    href: operators/arithmetic-operators.md
+    displayName: ++, --, +, -, *, /, %, +=, -=, *=, /=, %=, checked, unchecked
+  - name: Boolean logical operators
+    href: operators/boolean-logical-operators.md
+    displayName: "!, &&, ||, &, |, ^, &=, |=, ^="
+  - name: Bitwise and shift operators
+    href: operators/bitwise-and-shift-operators.md
+    displayName: "~, &, |, ^, <<, >>, &=, |=, ^=, <<=, >>="
+  - name: Equality operators
+    href: operators/equality-operators.md
+    displayName: ==, !=
+  - name: Comparison operators
+    href: operators/comparison-operators.md
+    displayName: ">, <, >=, <=, greater, less"
+  - name: Member access operators
+    href: operators/member-access-operators.md
+    displayName: "., [], ?., ?[], (), indexer, null-conditional, Elvis, invocation"
+  - name: Type-testing and conversion operators
+    href: operators/type-testing-and-conversion-operators.md
+    displayName: "is operator, is keyword, as operator, as keyword, typeof, (), cast"
+  - name: User-defined conversion operators
+    href: operators/user-defined-conversion-operators.md
+    displayName: implicit, explicit
+  - name: Pointer related operators
+    href: operators/pointer-related-operators.md
+    displayName: "&, *, ->, [], +, -, ++, --, ==, !=, <, >, <=, >=, dereference, address-of, indirection"
+  - name: "= operator"
+    href: operators/assignment-operator.md
+    displayName: "assignment, ref"
+  - name: + and += operators
+    href: operators/addition-operator.md
+    displayName: string concatenation, delegate combination, event subscription
+  - name: "- and -= operators"
+    href: operators/subtraction-operator.md
+    displayName: delegate removal, event unsubscription
+  - name: "?: operator"
+    href: operators/conditional-operator.md
+    displayName: conditional, ternary, ref
+  - name: "?? operator"
+    href: operators/null-coalescing-operator.md
+    displayName: null-coalescing
+  - name: => operator
+    href: operators/lambda-operator.md
+    displayName: lambda
+  - name: ":: operator"
+    href: operators/namespace-alias-qualifier.md
+    displayName: "namespace alias qualifier"
+  - name: delegate operator
+    href: operators/delegate-operator.md
+    displayName: anonymous
+  - name: nameof operator
+    href: operators/nameof.md
+  - name: new operator
+    href: operators/new-operator.md
+  - name: sizeof operator
+    href: operators/sizeof.md
+  - name: stackalloc operator
+    href: operators/stackalloc.md
+  - name: true and false operators
+    href: operators/true-false-operators.md
+  - name: Operator overloading
+    href: operators/operator-overloading.md
+- name: C# special characters
+  items:
+  - name: Overview
+    href: tokens/index.md
+  - name: $ -- string interpolation
+    href: tokens/interpolated.md
+  - name: "@ -- verbatim identifier"
+    href: tokens/verbatim.md
+- name: C# preprocessor directives
+  items:
+  - name: Overview
+    href: preprocessor-directives/index.md
+  - name: "#if"
+    href: preprocessor-directives/preprocessor-if.md
+  - name: "#else"
+    href: preprocessor-directives/preprocessor-else.md
+  - name: "#elif"
+    href: preprocessor-directives/preprocessor-elif.md
+  - name: "#endif"
+    href: preprocessor-directives/preprocessor-endif.md
+  - name: "#define"
+    href: preprocessor-directives/preprocessor-define.md
+  - name: "#undef"
+    href: preprocessor-directives/preprocessor-undef.md
+  - name: "#warning"
+    href: preprocessor-directives/preprocessor-warning.md
+  - name: "#error"
+    href: preprocessor-directives/preprocessor-error.md
+  - name: "#line"
+    href: preprocessor-directives/preprocessor-line.md
+  - name: "#region"
+    href: preprocessor-directives/preprocessor-region.md
+  - name: "#endregion"
+    href: preprocessor-directives/preprocessor-endregion.md
+  - name: "#pragma"
+    href: preprocessor-directives/preprocessor-pragma.md
+  - name: "#pragma warning"
+    href: preprocessor-directives/preprocessor-pragma-warning.md
+  - name: "#pragma checksum"
+    href: preprocessor-directives/preprocessor-pragma-checksum.md
+- name: C# compiler options
+  items:
+  - name: Overview
+    href: compiler-options/index.md
+  - name: Command-line Building With csc.exe
+    href: compiler-options/command-line-building-with-csc-exe.md
+  - name: "How to: Set Environment Variables for the Visual Studio Command Line"
+    href: compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line.md
+  - name: C# Compiler Options Listed by Category
+    href: compiler-options/listed-by-category.md
+  - name: C# Compiler Options Listed Alphabetically
+    href: compiler-options/listed-alphabetically.md
+    items:
+    - name: "@"
+      href: compiler-options/response-file-compiler-option.md
+    - name: -addmodule
+      href: compiler-options/addmodule-compiler-option.md
+    - name: -appconfig
+      href: compiler-options/appconfig-compiler-option.md
+    - name: -baseaddress
+      href: compiler-options/baseaddress-compiler-option.md
+    - name: -bugreport
+      href: compiler-options/bugreport-compiler-option.md
+    - name: -checked
+      href: compiler-options/checked-compiler-option.md
+    - name: -codepage
+      href: compiler-options/codepage-compiler-option.md
+    - name: -debug
+      href: compiler-options/debug-compiler-option.md
+    - name: -define
+      href: compiler-options/define-compiler-option.md
+    - name: -delaysign
+      href: compiler-options/delaysign-compiler-option.md
+    - name: -deterministic
+      href: compiler-options/deterministic-compiler-option.md
+    - name: -doc
+      href: compiler-options/doc-compiler-option.md
+    - name: -errorreport
+      href: compiler-options/errorreport-compiler-option.md
+    - name: -filealign
+      href: compiler-options/filealign-compiler-option.md
+    - name: -fullpaths
+      href: compiler-options/fullpaths-compiler-option.md
+    - name: -help, -?
+      href: compiler-options/help-compiler-option.md
+    - name: -highentropyva
+      href: compiler-options/highentropyva-compiler-option.md
+    - name: -keycontainer
+      href: compiler-options/keycontainer-compiler-option.md
+    - name: -keyfile
+      href: compiler-options/keyfile-compiler-option.md
+    - name: -langversion
+      href: compiler-options/langversion-compiler-option.md
+    - name: -lib
+      href: compiler-options/lib-compiler-option.md
+    - name: -link
+      href: compiler-options/link-compiler-option.md
+    - name: -linkresource
+      href: compiler-options/linkresource-compiler-option.md
+    - name: -main
+      href: compiler-options/main-compiler-option.md
+    - name: -moduleassemblyname
+      href: compiler-options/moduleassemblyname-compiler-option.md
+    - name: -noconfig
+      href: compiler-options/noconfig-compiler-option.md
+    - name: -nologo
+      href: compiler-options/nologo-compiler-option.md
+    - name: -nostdlib
+      href: compiler-options/nostdlib-compiler-option.md
+    - name: -nowarn
+      href: compiler-options/nowarn-compiler-option.md
+    - name: -nowin32manifest
+      href: compiler-options/nowin32manifest-compiler-option.md
+    - name: -optimize
+      href: compiler-options/optimize-compiler-option.md
+    - name: -out
+      href: compiler-options/out-compiler-option.md
+    - name: -pathmap
+      href: compiler-options/pathmap-compiler-option.md
+    - name: -pdb
+      href: compiler-options/pdb-compiler-option.md
+    - name: -platform
+      href: compiler-options/platform-compiler-option.md
+    - name: -preferreduilang
+      href: compiler-options/preferreduilang-compiler-option.md
+    - name: -publicsign
+      href: compiler-options/publicsign-compiler-option.md
+    - name: -recurse
+      href: compiler-options/recurse-compiler-option.md
+    - name: -reference
+      href: compiler-options/reference-compiler-option.md
+    - name: -refout
+      href: compiler-options/refout-compiler-option.md
+    - name: -refonly
+      href: compiler-options/refonly-compiler-option.md
+    - name: -resource
+      href: compiler-options/resource-compiler-option.md
+    - name: -subsystemversion
+      href: compiler-options/subsystemversion-compiler-option.md
+    - name: -target
+      href: compiler-options/target-compiler-option.md
+      items:
+      - name: "-target:appcontainerexe"
+        href: compiler-options/target-appcontainerexe-compiler-option.md
+      - name: "-target:exe"
+        href: compiler-options/target-exe-compiler-option.md
+      - name: "-target:library"
+        href: compiler-options/target-library-compiler-option.md
+      - name: "-target:module"
+        href: compiler-options/target-module-compiler-option.md
+      - name: "-target:winexe"
+        href: compiler-options/target-winexe-compiler-option.md
+      - name: "-target:winmdobj"
+        href: compiler-options/target-winmdobj-compiler-option.md
+    - name: -unsafe
+      href: compiler-options/unsafe-compiler-option.md
+    - name: -utf8output
+      href: compiler-options/utf8output-compiler-option.md
+    - name: -warn
+      href: compiler-options/warn-compiler-option.md
+    - name: -warnaserror
+      href: compiler-options/warnaserror-compiler-option.md
+    - name: -win32icon
+      href: compiler-options/win32icon-compiler-option.md
+    - name: -win32manifest
+      href: compiler-options/win32manifest-compiler-option.md
+    - name: -win32res
+      href: compiler-options/win32res-compiler-option.md
+- name: C# compiler errors
+  href: compiler-messages/index.md
+- name: C# 6.0 draft specification
+  items:
+  - name: Introduction
+    href: ../../../_csharplang/spec/introduction.md
+  - name: Lexical structure
+    href: ../../../_csharplang/spec/lexical-structure.md
+  - name: Basic concepts
+    href: ../../../_csharplang/spec/basic-concepts.md
+  - name: Types
+    href: ../../../_csharplang/spec/types.md
+  - name: Variables
+    href: ../../../_csharplang/spec/variables.md
+  - name: Conversions
+    href: ../../../_csharplang/spec/conversions.md
+  - name: Expressions
+    href: ../../../_csharplang/spec/expressions.md
+  - name: Statements
+    href: ../../../_csharplang/spec/statements.md
+  - name: Namespaces
+    href: ../../../_csharplang/spec/namespaces.md
+  - name: Classes
+    href: ../../../_csharplang/spec/classes.md
+  - name: Structs
+    href: ../../../_csharplang/spec/structs.md
+  - name: Arrays
+    href: ../../../_csharplang/spec/arrays.md
+  - name: Interfaces
+    href: ../../../_csharplang/spec/interfaces.md
+  - name: Enums
+    href: ../../../_csharplang/spec/enums.md
+  - name: Delegates
+    href: ../../../_csharplang/spec/delegates.md
+  - name: Exceptions
+    href: ../../../_csharplang/spec/exceptions.md
+  - name: Attributes
+    href: ../../../_csharplang/spec/attributes.md
+  - name: Unsafe code
+    href: ../../../_csharplang/spec/unsafe-code.md
+  - name: Documentation comments
+    href: ../../../_csharplang/spec/documentation-comments.md
+- name: C# 7.0 language proposals
+  items:
+  - name: Pattern matching
+    href: ../../../_csharplang/proposals/csharp-7.0/pattern-matching.md
+  - name: Local functions
+    href: ../../../_csharplang/proposals/csharp-7.0/local-functions.md
+  - name: Out variable declarations
+    href: ../../../_csharplang/proposals/csharp-7.0/out-var.md
+  - name: Throw expressions
+    href: ../../../_csharplang/proposals/csharp-7.0/throw-expression.md
+  - name: Binary literals
+    href: ../../../_csharplang/proposals/csharp-7.0/binary-literals.md
+  - name: Digit separators
+    href: ../../../_csharplang/proposals/csharp-7.0/digit-separators.md
+- name: C# 7.1 language proposals
+  items:
+  - name: Async main method
+    href: ../../../_csharplang/proposals/csharp-7.1/async-main.md
+  - name: Default expressions
+    href: ../../../_csharplang/proposals/csharp-7.1/target-typed-default.md
+  - name: Infer tuple names
+    href: ../../../_csharplang/proposals/csharp-7.1/infer-tuple-names.md
+  - name: Pattern matching with generics
+    href: ../../../_csharplang/proposals/csharp-7.1/generics-pattern-match.md
+- name: C# 7.2 language proposals
+  items:
+  - name: Readonly references
+    href: ../../../_csharplang/proposals/csharp-7.2/readonly-ref.md
+  - name: Compile time safety for ref-like types
+    href: ../../../_csharplang/proposals/csharp-7.2/span-safety.md
+  - name: Non-trailing named arguments
+    href: ../../../_csharplang/proposals/csharp-7.2/non-trailing-named-arguments.md
+  - name: Private protected
+    href: ../../../_csharplang/proposals/csharp-7.2/private-protected.md
+  - name: Conditional ref
+    href: ../../../_csharplang/proposals/csharp-7.2/conditional-ref.md
+  - name: Leading digit separator
+    href: ../../../_csharplang/proposals/csharp-7.2/leading-separator.md
+- name: C# 7.3 language proposals
+  items:
+  - name: Unmanaged generic type constraints
+    href: ../../../_csharplang/proposals/csharp-7.3/blittable.md
+  - name: Indexing `fixed` fields should not require pinning regardless of the movable/unmovable context
+    href: ../../../_csharplang/proposals/csharp-7.3/indexing-movable-fixed-fields.md
+  - name: Pattern-based `fixed` statement
+    href: ../../../_csharplang/proposals/csharp-7.3/pattern-based-fixed.md
+  - name: Ref local reassignment
+    href: ../../../_csharplang/proposals/csharp-7.3/ref-local-reassignment.md
+  - name: Stackalloc array initializers
+    href: ../../../_csharplang/proposals/csharp-7.3/stackalloc-array-initializers.md
+  - name: Auto-implemented property field-targeted attributes
+    href: ../../../_csharplang/proposals/csharp-7.3/auto-prop-field-attrs.md
+  - name: expression variables in initializers
+    href: ../../../_csharplang/proposals/csharp-7.3/expression-variables-in-initializers.md
+  - name: Tuple equality (==) and inequality (!=)
+    href: ../../../_csharplang/proposals/csharp-7.3/tuple-equality.md
+  - name: Improved overload candidates
+    href: ../../../_csharplang/proposals/csharp-7.3/improved-overload-candidates.md
+- name: C# 8.0 language proposals
+  items:
+  - name: Null reference types - proposal
+    href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
+  - name: nullable reference types - specification
+    href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md
+  - name: Recursive pattern matching
+    href: ../../../_csharplang/proposals/csharp-8.0/patterns.md
+  - name: async streams
+    href: ../../../_csharplang/proposals/csharp-8.0/async-streams.md
+  - name: Ranges
+    href: ../../../_csharplang/proposals/csharp-8.0/ranges.md
+  - name: Pattern based using and using declarations
+    href: ../../../_csharplang/proposals/csharp-8.0/using.md
+  - name: null coalescing assignment
+    href: ../../../_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md


### PR DESCRIPTION
This fix would "fix" the offline book issue - this TOC is not read in by the current version of the offline book tool, resulting in missing content.

## Summary

Remove the top line of the TOC and indent everything else.

