### PR TITLE
Clarify that memory doesn't have to be freed MANUALLY.

### DIFF
--- a/docs/standard/garbage-collection/fundamentals.md
+++ b/docs/standard/garbage-collection/fundamentals.md
@@ -18,7 +18,7 @@ ms.author: "ronpet"
 
 <a name="top"></a> In the common language runtime (CLR), the garbage collector serves as an automatic memory manager. It provides the following benefits:
 
-- Enables you to develop your application without having to free memory.
+- Enables you to develop your application without having to manually free memory for objects you create.
 
 - Allocates objects on the managed heap efficiently.
 


### PR DESCRIPTION
Saying that the garbage collector...

> Enables you to develop your application without having to free memory.

...may give the wrong impression that applications can allocate memory indefinitely and keep working even if they never free it...which is obviously not possible. I think the intention here was to say that objects will be freed automatically by the garbage collector, so you don't have to worry about it. I have edited the line to that effect.