### PR TITLE
Add ignore for samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ docs/_build/
 .idea/
 *.swp
 rebuild.cmd
+samples/
 
 # Business Intelligence projects
 *.rdl.data


### PR DESCRIPTION
This adds an ignore for the `samples` folder in this repo. This will let you clone the code samples repo into the root of this repo. If you do clone the samples repo locally into this ignored folder, you can click on any relative code sample reference in the documentation which will open the file in your editor.