### PR TITLE
Removed link to code gallery, changed header titles

### DIFF
--- a/docs/visual-basic/getting-started/additional-resources.md
+++ b/docs/visual-basic/getting-started/additional-resources.md
@@ -17,40 +17,39 @@ The following web sites provide guidance and can help you find answers to common
 
 ### On the web
 
-|Term|Definition|
+|URL|Description|
 |----------|----------------|
 |[Visual Basic .NET Language Design](https://github.com/dotnet/vblang)|Official repository on GitHub for Visual Basic .NET language design.|
 |[Microsoft Visual Basic Team Blog](https://devblogs.microsoft.com/vbteam/)|Provides access to the Visual Basic team blog.|
 
 ### Code samples
 
-|Term|Definition|
+|URL|Description|
 |----------|----------------|
-|[Code Gallery](https://code.msdn.microsoft.com/site/search?f%5B0%5D.Type=ProgrammingLanguage&f%5B0%5D.Value=VB&f%5B0%5D.Text=VB.NET)|Download and share sample applications and other resources with the developer community.|
 |[Visual Basic documentation samples](https://github.com/dotnet/samples/tree/master/snippets/visualbasic)|Contains the samples used throughout the Visual Basic and .NET documentation.|
 
 ### Forums
 
-|Term|Definition|
+|URL|Description|
 |----------|----------------|
 |[Visual Basic Forums](https://social.msdn.microsoft.com/Forums/vstudio/home?forum=vbgeneral)|Discusses general Visual Basic issues.|
 
 ### Videos and webcasts
 
-|Term|Definition|
+|URL|Description|
 |----------|----------------|
 |[Channel9](https://channel9.msdn.com/)|Provides continuous community through videos, Wikis, and forums.|
 
 ### Support
 
-|Term|Definition|
+|URL|Description|
 |----------|----------------|
 |[Microsoft Support](https://support.microsoft.com)|Provides access to Knowledge Base (KB) articles, downloads and updates, support webcasts, and other services.|
 |[Visual Studio Questions](https://developercommunity.visualstudio.com)|Enables you to file bugs or provide suggestions to Microsoft about .NET and Visual Studio. You can also report a bug by selecting **Help** > **Send Feedback** > **Report a Problem** in Visual Studio.|
 
 ## Third-party resources
 
-|Term|Definition|
+|URL|Description|
 |----------|----------------|
 |[VBForums](http://www.vbforums.com/)|Provides a forum to discuss Visual Basic, .NET, and more.|
 |[vbCity](http://vbcity.com/)|A community site for people to learn and ask questions about Visual Basic and .NET.|


### PR DESCRIPTION
## Removed link to code gallery, changed header titles

This PR:

- Removes a general link to VB samples on Code Gallery.
- Changes the header cell titles from "Term" to "URL" and "Definition" to "Description".

