### PR TITLE
Updated Code Gallery links for Networking, XAML

### DIFF
--- a/docs/framework/network-programming/index.md
+++ b/docs/framework/network-programming/index.md
@@ -133,5 +133,4 @@ The Microsoft .NET Framework provides a layered, extensible, and managed impleme
 - [Transport Layer Security (TLS) best practices with .NET Framework](../../../docs/framework/network-programming/tls.md)
 - [Network Programming How-to Topics](../../../docs/framework/network-programming/network-programming-how-to-topics.md)
 - [Network Programming Samples](../../../docs/framework/network-programming/network-programming-samples.md)
-- [Networking Samples for .NET on MSDN Code Gallery](https://code.msdn.microsoft.com/Wiki/View.aspx?ProjectName=nclsamples)
-- [HttpClient Sample](https://go.microsoft.com/fwlink/?LinkId=242550)
+- [HttpClient Sample](https://code.msdn.microsoft.com/windowsapps/HttpClient-sample-55700664)

--- a/docs/framework/network-programming/introducing-pluggable-protocols.md
+++ b/docs/framework/network-programming/introducing-pluggable-protocols.md
@@ -65,4 +65,3 @@ The Microsoft .NET Framework provides a layered, extensible, and managed impleme
 - [Programming Pluggable Protocols](../../../docs/framework/network-programming/programming-pluggable-protocols.md)
 - [Network Programming in the .NET Framework](../../../docs/framework/network-programming/index.md)
 - [Network Programming Samples](../../../docs/framework/network-programming/network-programming-samples.md)
-- [Networking Samples for .NET on MSDN Code Gallery](https://code.msdn.microsoft.com/Wiki/View.aspx?ProjectName=nclsamples)

--- a/docs/framework/network-programming/using-application-protocols.md
+++ b/docs/framework/network-programming/using-application-protocols.md
@@ -21,4 +21,3 @@ The .NET Framework supports commonly used Internet application protocols. This s
 
 - [Network Programming in the .NET Framework](../../../docs/framework/network-programming/index.md)
 - [Network Programming Samples](../../../docs/framework/network-programming/network-programming-samples.md)
-- [Networking Samples for .NET on MSDN Code Gallery](https://code.msdn.microsoft.com/Wiki/View.aspx?ProjectName=nclsamples)

--- a/docs/framework/xaml-services/understanding-xaml-node-stream-structures-and-concepts.md
+++ b/docs/framework/xaml-services/understanding-xaml-node-stream-structures-and-concepts.md
@@ -81,9 +81,6 @@ This basic example of a load path XAML node loop transparently connects the XAML
 
 There are potentially other ways to work with a XAML representation other than as a XAML node loop. For example, there could exist a XAML reader that can read an indexed node, or in particular accesses nodes directly by `x:Name`, by `x:Uid`, or through other identifiers. .NET Framework XAML Services does not provide a full implementation, but provides a suggested pattern through services and support types. For more information, see <xref:System.Xaml.IXamlIndexingReader> and <xref:System.Xaml.XamlNodeList>.
 
-> [!TIP]
-> Microsoft also produces an out-of-band release known as the Microsoft XAML Toolkit. This out-of-band release is still in its pre-release stages. However, if you are willing to work with pre-release components, the Microsoft XAML Toolkit provides some interesting resources for XAML tooling and static analysis of XAML. The Microsoft XAML Toolkit includes a XAML DOM API, support for FxCop analysis, and a XAML schema context for Silverlight. For more information, see [Microsoft XAML Toolkit](https://code.msdn.microsoft.com/XAML).
-
 <a name="working_with_the_current_node"></a>
 
 ## Working with the Current Node


### PR DESCRIPTION
## Updated Code Gallery links for Networking 

This PR:

- Removes the general link to nclsamples, which 404s.
- Adds a link to the HTTPClient sample on Code Gallery.
- Changes a FWLink to the actual link to the HTTPClient sample on Code Gallery.
- Removes the link to Microsoft XAML Toolkit.

 Fixes #14065