### PR TITLE
Diagnostics landing

### DIFF
--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -7,7 +7,7 @@ ms.date: 08/05/2019
 ms.topic: overview
 #Customer intent: As a .NET Core developer I want to find the best tools to help me diagnose problems so that I can be productive.
 ---
-# What Diagnostic Tools are Available in .NET Core?
+# What diagnostic tools are available in .NET Core?
 
 Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will help you diagnose these issues quickly and effectively.
 

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -1,6 +1,6 @@
 ---
-title: What Diagnostic Tools are Available in .NET Core?
-description: An overview of the tools and APIs available to diagnose .NET Core applications.
+title: Diagnostics tools overview - .NET Core
+description: An overview of the tools and techniques available to diagnose .NET Core applications.
 author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
@@ -13,11 +13,11 @@ Software doesn't always behave as you would expect, but .NET Core has tools and 
 
 This article helps you find the various tools you need.
 
-## [Managed Debuggers](managed-debuggers.md)
+## [Managed debuggers](managed-debuggers.md)
 Managed debuggers allow you to interact with your program. Pausing, incrementally executing, examining,  and resuming gives you insight into the behavior of your code. A debugger is the first choice for diagnosing functional problems that can be easily reproduced.
 
-## [Logging and Tracing](logging-tracing.md)
+## [Logging and tracing](logging-tracing.md)
 Logging and tracing are related techniques. They refer to instrumenting code to create log files. The files record the details of what a program does. These details can be used to diagnose the most complex problems. When combined with time stamps, these techniques are also valuable in performance investigations.
 
-## [Unit Testing](../testing/index.md)
+## [Unit testing](../testing/index.md)
 Unit testing is a key component of continuous integration and deployment of high-quality software. Unit tests are designed to give you an early warning when you break something.

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -1,0 +1,91 @@
+﻿---
+title: Diagnostic tools and APIs in .NET Core 
+description: An overview of the tools and APIs available to diagnose misbehaving .NET Core applications.
+author: noahfalk
+ms.author: noahfalk
+ms.date: 11/13/2018
+ms.topic: article
+ms.prod: .net-core
+---
+# .NET Core Diagnostics
+
+Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will let you diagnose these issues quickly and effectively.
+ This article covers different diagnostic options available and helps select the right one for the problem at hand.
+
+## Debugging ##
+Debuggers allow programs to be paused or executed step-by-step. At each point the current state of process can be viewed so that you understand why
+ executing the code produces the result that it does. Microsoft provides two primary debuggers for managed code:
+
+- **Visual Studio** is an IDE with the most comprehensive debugger available. This is an excellent default choice for developers working on Windows.
+  - [Debugging a .NET Core application on Windows with Visual Studio](https://docs.microsoft.com/en-us/dotnet/core/tutorials/debugging-with-visual-studio)
+  For Linux and MacOS apps Visual Studio supports remote debugging over the network. The debugger UI will remain on the Windows machine and the app
+  being debugged can run on a separate machine running Linux or OSX.
+  - [Debugging a .Net Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
+
+- **VSCode** is a lighter weight fully cross platform code editor. It shares the same high quality debugger implementation as Visual Studio
+  with a streamlined UI.
+    - [Debugging a .Net Core application with VSCode](https://docs.microsoft.com/en-us/dotnet/core/tutorials/with-visual-studio-code)
+
+- **Windbg and LLDB** - These are command-line debuggers that are natively designed for working with C/C++/assembly code, but using the 'SOS' plugin
+ from .NET Core offers a limited amount of functionality for managed code. These tools have a steeper learning curve and are not suggested as a first
+ choice for most typical managed code debugging tasks, but they can be valuable in understanding low-level details of the .NET Core runtime or how
+ .NET Core is interacting with components written in C/C++.
+ [TODO: link to a guide]
+
+## Logging ##
+Logging allows you to record information as a program runs so that you can understand what happened after the fact. It is useful for diagnosing issues
+ that are hard to reproduce on demand or issues that occur in production where it would be unacceptable to pause a running service with a debugger. 
+
+**Trace.WriteLine** logs to an attached debugger, files or any TextWriter with minimal configuration. Pluggable
+ TraceListener implementations can log to custom destinations. Logging levels, TraceSource and TraceSwitch allow the logging output to be
+ filtered on-demand.
+
+**Console.WriteLine** writes text to the application's console. Useful for very quick ad-hoc logging but not very flexible as a longer term solution.
+
+**ILogger** is part of the ASP.Net Core framework, this logging API serves as a DI-friendly wrapper over a variety of providers. In-box options include console,
+ debugger, Trace, Windows event log, and EventSource. Additional NuGet packages support more providers such as Azure and a variety of 3rd party loggers.
+ This is the recommended logging API for anyone writing ASP.Net Core applications.
+
+**3rd party logging frameworks** - [TODO]: Do we need to vet a list of 3rd party options? As the platform I'd think we want to stay neutral as we can
+ but I expect many of our customers want to see that these options are available.
+
+**EventLog** writes messages to the Windows event log. [TODO: Some guidance for when to use this?]
+
+[TODO]: Should we cover Debug.WriteLine? In .Net Core 1.0-2.1 it had different behavior than it does in .NET Framework and logged to the debugger
+output stream only. In 2.2 (or 3.0?) it has been updated to behave as it used to, which means it does the same as Trace.WriteLine but conditionally
+compiled only for debug builds.
+
+
+## Tracing, Metrics and Monitors ##
+
+[TODO]: Should we plug Application Insights here? What about other monitors?
+
+**EventSource** emits to ETW on Windows, to .NET Core's EventPipe on any OS, or to in-process EventListener API. 
+[TODO]: We should probably cover common runtime instrumentation such as RuntimeEventSource or TplEtwProvider
+**DiagnosticsSource** emits .NET objects that may not be serializable to in-process listeners.
+
+[TODO]: Did we have enough work in EventCounter that it is worth talking about?
+
+
+
+
+## Profiling ##
+**Visual Studio**
+**PerfView**
+**3rd party tools**
+
+
+
+## Dump debugging ##
+**CreateDump**
+**ProcDump**
+**Visual Studio**
+**windbg/LLDB + SOS**
+
+
+## APIs for creating custom tools ##
+**ICorDebug**
+**ICorProfiler**
+**CLRMD**
+**Built-in EventSources**
+**Built-in DiagnosticsSources**

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Core Diagnostics
 description: An overview of the tools and APIs available to diagnose .NET Core applications.
-author: stmaclea
+author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ms.topic: overview
@@ -15,7 +15,7 @@ This article helps you find the various tools you need.
 ## [Managed Debuggers](managed-debuggers.md)
 Managed debuggers allow you to interact with your program. Debuggers give you insight into the behavior of your code.
 
-## [Logging and Tracing](logging-and-tracing.md)
+## [Logging and Tracing](logging-tracing.md)
 Logging and tracing are related techniques. They allow instrumenting code to create log files that can be used to diagnose the most complex problems.
 
 ## [Unit Testing](../testing/index.md)

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -1,91 +1,27 @@
-﻿---
-title: Diagnostic tools and APIs in .NET Core 
-description: An overview of the tools and APIs available to diagnose misbehaving .NET Core applications.
-author: noahfalk
-ms.author: noahfalk
-ms.date: 11/13/2018
+---
+title: .NET Core Diagnostics
+description: An overview of the tools and APIs available to diagnose .NET Core applications.
+author: stmaclea
+ms.author: stmaclea
+ms.date: 8/5/2019
 ms.topic: article
 ms.prod: .net-core
 ---
 # .NET Core Diagnostics
 
-Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will let you diagnose these issues quickly and effectively.
- This article covers different diagnostic options available and helps select the right one for the problem at hand.
+You need a wide variety of diagnostic software tools to write high-quality software. This article helps you find the various tools you need.
 
-## Debugging ##
-Debuggers allow programs to be paused or executed step-by-step. At each point the current state of process can be viewed so that you understand why
- executing the code produces the result that it does. Microsoft provides two primary debuggers for managed code:
+Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will help you diagnose these issues quickly and effectively.
 
-- **Visual Studio** is an IDE with the most comprehensive debugger available. This is an excellent default choice for developers working on Windows.
-  - [Debugging a .NET Core application on Windows with Visual Studio](https://docs.microsoft.com/en-us/dotnet/core/tutorials/debugging-with-visual-studio)
-  For Linux and MacOS apps Visual Studio supports remote debugging over the network. The debugger UI will remain on the Windows machine and the app
-  being debugged can run on a separate machine running Linux or OSX.
-  - [Debugging a .Net Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
+## In This Section
 
-- **VSCode** is a lighter weight fully cross platform code editor. It shares the same high quality debugger implementation as Visual Studio
-  with a streamlined UI.
-    - [Debugging a .Net Core application with VSCode](https://docs.microsoft.com/en-us/dotnet/core/tutorials/with-visual-studio-code)
+[Managed Debuggers](managed-debuggers.md)
+Managed debuggers allow you to interact with your program. Debuggers give you insight into the behavior of your code.
 
-- **Windbg and LLDB** - These are command-line debuggers that are natively designed for working with C/C++/assembly code, but using the 'SOS' plugin
- from .NET Core offers a limited amount of functionality for managed code. These tools have a steeper learning curve and are not suggested as a first
- choice for most typical managed code debugging tasks, but they can be valuable in understanding low-level details of the .NET Core runtime or how
- .NET Core is interacting with components written in C/C++.
- [TODO: link to a guide]
+[Logging and Tracing](logging-and-tracing.md)
+Logging and tracing are related techniques. They allow instrumenting code to create log files that can be used to diagnose the most complex problems.
 
-## Logging ##
-Logging allows you to record information as a program runs so that you can understand what happened after the fact. It is useful for diagnosing issues
- that are hard to reproduce on demand or issues that occur in production where it would be unacceptable to pause a running service with a debugger. 
+## Related Sections
 
-**Trace.WriteLine** logs to an attached debugger, files or any TextWriter with minimal configuration. Pluggable
- TraceListener implementations can log to custom destinations. Logging levels, TraceSource and TraceSwitch allow the logging output to be
- filtered on-demand.
-
-**Console.WriteLine** writes text to the application's console. Useful for very quick ad-hoc logging but not very flexible as a longer term solution.
-
-**ILogger** is part of the ASP.Net Core framework, this logging API serves as a DI-friendly wrapper over a variety of providers. In-box options include console,
- debugger, Trace, Windows event log, and EventSource. Additional NuGet packages support more providers such as Azure and a variety of 3rd party loggers.
- This is the recommended logging API for anyone writing ASP.Net Core applications.
-
-**3rd party logging frameworks** - [TODO]: Do we need to vet a list of 3rd party options? As the platform I'd think we want to stay neutral as we can
- but I expect many of our customers want to see that these options are available.
-
-**EventLog** writes messages to the Windows event log. [TODO: Some guidance for when to use this?]
-
-[TODO]: Should we cover Debug.WriteLine? In .Net Core 1.0-2.1 it had different behavior than it does in .NET Framework and logged to the debugger
-output stream only. In 2.2 (or 3.0?) it has been updated to behave as it used to, which means it does the same as Trace.WriteLine but conditionally
-compiled only for debug builds.
-
-
-## Tracing, Metrics and Monitors ##
-
-[TODO]: Should we plug Application Insights here? What about other monitors?
-
-**EventSource** emits to ETW on Windows, to .NET Core's EventPipe on any OS, or to in-process EventListener API. 
-[TODO]: We should probably cover common runtime instrumentation such as RuntimeEventSource or TplEtwProvider
-**DiagnosticsSource** emits .NET objects that may not be serializable to in-process listeners.
-
-[TODO]: Did we have enough work in EventCounter that it is worth talking about?
-
-
-
-
-## Profiling ##
-**Visual Studio**
-**PerfView**
-**3rd party tools**
-
-
-
-## Dump debugging ##
-**CreateDump**
-**ProcDump**
-**Visual Studio**
-**windbg/LLDB + SOS**
-
-
-## APIs for creating custom tools ##
-**ICorDebug**
-**ICorProfiler**
-**CLRMD**
-**Built-in EventSources**
-**Built-in DiagnosticsSources**
+[Unit Testing](../testing/index.md)
+Unit testing is a key component of continuous integration and deployment of high-quality software.

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -3,25 +3,20 @@ title: .NET Core Diagnostics
 description: An overview of the tools and APIs available to diagnose .NET Core applications.
 author: stmaclea
 ms.author: stmaclea
-ms.date: 8/5/2019
-ms.topic: article
-ms.prod: .net-core
+ms.date: 08/05/2019
+ms.topic: overview
 ---
 # .NET Core Diagnostics
 
-You need a wide variety of diagnostic software tools to write high-quality software. This article helps you find the various tools you need.
-
 Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will help you diagnose these issues quickly and effectively.
 
-## In This Section
+This article helps you find the various tools you need.
 
-[Managed Debuggers](managed-debuggers.md)
+## [Managed Debuggers](managed-debuggers.md)
 Managed debuggers allow you to interact with your program. Debuggers give you insight into the behavior of your code.
 
-[Logging and Tracing](logging-and-tracing.md)
+## [Logging and Tracing](logging-and-tracing.md)
 Logging and tracing are related techniques. They allow instrumenting code to create log files that can be used to diagnose the most complex problems.
 
-## Related Sections
-
-[Unit Testing](../testing/index.md)
+## [Unit Testing](../testing/index.md)
 Unit testing is a key component of continuous integration and deployment of high-quality software.

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -1,12 +1,13 @@
 ---
-title: .NET Core Diagnostics
+title: What Diagnostic Tools are Available in .NET Core?
 description: An overview of the tools and APIs available to diagnose .NET Core applications.
 author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ms.topic: overview
+#Customer intent: As a .NET Core developer I want to find the best tools to help me diagnose problems so that I can be productive.
 ---
-# .NET Core Diagnostics
+# What Diagnostic Tools are Available in .NET Core?
 
 Software doesn't always behave as you would expect, but .NET Core has tools and APIs that will help you diagnose these issues quickly and effectively.
 
@@ -16,7 +17,7 @@ This article helps you find the various tools you need.
 Managed debuggers allow you to interact with your program. Pausing, incrementally executing, examining,  and resuming gives you insight into the behavior of your code. A debugger is the first choice for diagnosing functional problems that can be easily reproduced.
 
 ## [Logging and Tracing](logging-tracing.md)
-Logging and tracing are related techniques. They allow instrumenting code to create log files recording what the program does. The log files that can be used to diagnose the most complex problems. When combined with time stamps, these techniques are also valuable in performance investigations.
+Logging and tracing are related techniques. They refer to instrumenting code to create log files. The files record the details of what a program does. These details can be used to diagnose the most complex problems. When combined with time stamps, these techniques are also valuable in performance investigations.
 
 ## [Unit Testing](../testing/index.md)
 Unit testing is a key component of continuous integration and deployment of high-quality software. Unit tests are designed to give you an early warning when you break something.

--- a/docs/core/diagnostics/index.md
+++ b/docs/core/diagnostics/index.md
@@ -13,10 +13,10 @@ Software doesn't always behave as you would expect, but .NET Core has tools and 
 This article helps you find the various tools you need.
 
 ## [Managed Debuggers](managed-debuggers.md)
-Managed debuggers allow you to interact with your program. Debuggers give you insight into the behavior of your code.
+Managed debuggers allow you to interact with your program. Pausing, incrementally executing, examining,  and resuming gives you insight into the behavior of your code. A debugger is the first choice for diagnosing functional problems that can be easily reproduced.
 
 ## [Logging and Tracing](logging-tracing.md)
-Logging and tracing are related techniques. They allow instrumenting code to create log files that can be used to diagnose the most complex problems.
+Logging and tracing are related techniques. They allow instrumenting code to create log files recording what the program does. The log files that can be used to diagnose the most complex problems. When combined with time stamps, these techniques are also valuable in performance investigations.
 
 ## [Unit Testing](../testing/index.md)
-Unit testing is a key component of continuous integration and deployment of high-quality software.
+Unit testing is a key component of continuous integration and deployment of high-quality software. Unit tests are designed to give you an early warning when you break something.

--- a/docs/core/diagnostics/logging-and-tracing.md
+++ b/docs/core/diagnostics/logging-and-tracing.md
@@ -3,15 +3,13 @@ title: .NET Core Logging and Tracing
 description: An introduction to .NET Core Logging and Tracing.
 author: stmaclea
 ms.author: stmaclea
-ms.date: 8/5/2019
-ms.topic: article
-ms.prod: .net-core
+ms.date: 08/05/2019
 ---
 # .NET Core Logging and Tracing
 
 Logging and tracing is a primitive technique used since the early days of computers. It simply involves instrumenting an application to produce output to be consumed later.
 
-Logging and tracing are similar.  As used here we'll distinguish:
+Logging and tracing are similar. As used here we'll distinguish:
 - Logging outputs text as human readable content.
 - Tracing outputs binary content.  It can use tokenizing, and filtering to reduce overhead in the traced application.
 
@@ -32,12 +30,12 @@ The choice of which API to use is up to you. The key differences:
   - Always compiled in and always writes to the console.
   - Useful for information that your customer may need to see in release.
   - Because it's the simplest approach, it's often used for ad-hoc temporary debugging. This debug code is often never checked in to source control.
-- <xref:System.Diagnostics.Trace>
-  - Only included when `TRACE` is defined.
+- <xref:System.Diagnostics.Trace?displayProperty=nameWithType>
+  - Only enabled when `TRACE` is defined.
   - Writes to attached <xref:System.Diagnostics.TraceListener>s. Usually a debugger.
   - It seems best to use this API when creating release-oriented logs.
-- <xref:System.Diagnostics.Debug>
-  - Only included when `DEBUG` is defined.
+- <xref:System.Diagnostics.Debug?displayProperty=nameWithType>
+  - Only enabled when `DEBUG` is defined.
   - Writes to attached <xref:System.Diagnostics.TraceListener>s. Usually a debugger.
   - It seems best to use this API when creating debug-oriented logs.
 
@@ -55,7 +53,7 @@ provides an overview of the logging techniques it supports.
 
 - The <xref:System.Exception.Message?displayProperty=nameWithType> is useful for logging exceptions.
 
-- The <xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType>
+- The <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType>
 can be useful to provide debugger like logging info.
 
 - <xref:System.Diagnostics.TraceListener> provides an overview of existing listeners and creating a custom listener.

--- a/docs/core/diagnostics/logging-and-tracing.md
+++ b/docs/core/diagnostics/logging-and-tracing.md
@@ -1,0 +1,96 @@
+---
+title: .NET Core Logging and Tracing
+description: An introduction to .NET Core Logging and Tracing.
+author: stmaclea
+ms.author: stmaclea
+ms.date: 8/5/2019
+ms.topic: article
+ms.prod: .net-core
+---
+# .NET Core Logging and Tracing
+
+Logging and tracing is a primitive technique used since the early days of computers. It simply involves instrumenting an application to produce output to be consumed later.
+
+Logging and tracing are similar.  As used here we'll distinguish:
+- Logging outputs text as human readable content.
+- Tracing outputs binary content.  It can use tokenizing, and filtering to reduce overhead in the traced application.
+
+## Why Logging and Tracing?
+
+These simple techniques are surprisingly powerful. They can be used in situations where a fancy debugger fails:
+
+- Issues occurring over long periods of time, can be difficult to debug with a traditional debugger.
+- Multi-threaded applications and distributed applications are often difficult to debug.  Attaching a debugger tends to modify behaviors. Detailed logs can be analyzed as needed to understand complex systems.
+- Many services shouldn't be stalled. Attaching a debugger often causes timeout failures.
+
+## Logging APIs
+
+<xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> each provide similar APIs convenient for logging.
+
+The choice of which API to use is up to you. The key differences:
+- <xref:System.Console?displayProperty=nameWithType>
+  - Always compiled in and always writes to the console.
+  - Useful for information that your customer may need to see in release.
+  - Because it's the simplest approach, it's often used for ad-hoc temporary debugging. This debug code is often never checked in to source control.
+- <xref:System.Diagnostics.Trace>
+  - Only included when `TRACE` is defined.
+  - Writes to attached <xref:System.Diagnostics.TraceListener>s. Usually a debugger.
+  - It seems best to use this API when creating release-oriented logs.
+- <xref:System.Diagnostics.Debug>
+  - Only included when `DEBUG` is defined.
+  - Writes to attached <xref:System.Diagnostics.TraceListener>s. Usually a debugger.
+  - It seems best to use this API when creating debug-oriented logs.
+
+### Logging Related References
+
+- [How to: Compile Conditionally with Trace and Debug](../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug)
+
+- [How to: Add Trace Statements to Application Code](../../framework/debug-trace-profile/how-to-add-trace-statements-to-application-code)
+
+- [ASP.NET Logging](/aspnet/core/fundamentals/logging)
+provides an overview of the logging techniques it supports.
+
+- [C# String Interpolation](../../csharp/language-reference/tokens/interpolated)
+ can simplify writing logging code.
+
+- The <xref:System.Exception.Message?displayProperty=nameWithType> is useful for logging exceptions.
+
+- The <xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType>
+can be useful to provide debugger like logging info.
+
+- <xref:System.Diagnostics.TraceListener> provides an overview of existing listeners and creating a custom listener.
+
+## Tracing APIs
+
+- <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>
+  - EventSource is the primary root .NET Core tracing API
+  - Available in all .NET Standard versions
+  - Emits to .NET Core's event pipe on all platforms
+  - Also emits to ETW on Windows.
+  - Only allows tracing serializable objects
+
+- <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType>
+  - Only available in .NET Core
+  - Allows tracing non-serializable objects
+  - Includes a bridge to allow select fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
+
+- <xref:System.Diagnostics.TraceSource?displayProperty=nameWithType>
+  - This API was introduced in .NET Framework 2.0
+  - Supported in .NET Standard 2.0
+  - Prefer <xref:System.Diagnostics.Tracing.EventSource>
+
+- <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
+  - Windows only
+  - Writes messages to Windows event log
+  - System administrators expect fatal application error messages to appear in the Windows event log.
+
+## Performance Considerations
+
+String formatting can take noticeable CPU processing time.
+
+In performance critical applications, it's good to:
+- Avoid lots of logging when no one is listening
+- Only log what is useful
+- Defer fancy formatting to the analysis stage
+
+Usually tracing is better than logging for most performance critical applications.

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -21,6 +21,8 @@ This simple technique is surprisingly powerful. It can be used in situations whe
 
 ## .NET Core APIs
 
+### Print style APIs
+
 The <xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> classes each provide similar print style APIs convenient for logging.
 
 The choice of which print style API to use is up to you. The key differences are:
@@ -37,6 +39,10 @@ The choice of which print style API to use is up to you. The key differences are
   - Writes to an attached debugger.
   - On `*nix` writes to stderr if `COMPlus_DebugWriteToStdErr` is set.
   - Use this API when creating logs that will be enabled only in debug builds.
+
+### Logging events
+
+The following APIs are more event oriented. Rather than logging simple strings they log event objects.
 
 - <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>
   - EventSource is the primary root .NET Core tracing API.

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -1,45 +1,77 @@
 ---
-title: .NET Core Logging and Tracing
-description: An introduction to .NET Core Logging and Tracing.
+title: .NET Core Logging or Tracing
+description: An introduction to .NET Core Logging or Tracing.
 author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ---
 # .NET Core Logging and Tracing
 
-Logging and tracing is a primitive technique used since the early days of computers. It simply involves instrumenting an application to produce output to be consumed later.
-
-Logging and tracing are similar. As used here we'll distinguish:
-- Logging outputs text as human readable content.
-- Tracing outputs binary content.  It can use tokenizing, and filtering to reduce overhead in the traced application.
+Logging and tracing are really two names for the same technique. The simple technique has been used since the early days of computers. It simply involves instrumenting an application to write output to be consumed later.
 
 ## Why Logging and Tracing?
 
-These simple techniques are surprisingly powerful. They can be used in situations where a fancy debugger fails:
+This simple technique is surprisingly powerful. It can be used in situations where a debugger fails:
 
-- Issues occurring over long periods of time, can be difficult to debug with a traditional debugger.
+- Issues occurring over long periods of time, can be difficult to debug with a traditional debugger. Logs allow for detailed post-mortem review spanning long periods of time. In contrast, debuggers are constrained to real-time analysis.
 - Multi-threaded applications and distributed applications are often difficult to debug.  Attaching a debugger tends to modify behaviors. Detailed logs can be analyzed as needed to understand complex systems.
+- Issues in distributed applications may arise from a complex interaction between many components and it may not be reasonable to connect a debugger to every part of the system.
 - Many services shouldn't be stalled. Attaching a debugger often causes timeout failures.
+- Issues aren't always foreseen. Logging and tracing are designed for low overhead so that programs can always be recording in case an issue occurs.
 
-## Logging APIs
+## .NET Core APIs
 
-<xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> each provide similar APIs convenient for logging.
+<xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> each provide similar print style APIs convenient for logging.
 
-The choice of which API to use is up to you. The key differences:
+The choice of which print style API to use is up to you. The key differences:
 - <xref:System.Console?displayProperty=nameWithType>
-  - Always compiled in and always writes to the console.
+  - Always enabled and always writes to the console.
   - Useful for information that your customer may need to see in release.
   - Because it's the simplest approach, it's often used for ad-hoc temporary debugging. This debug code is often never checked in to source control.
 - <xref:System.Diagnostics.Trace?displayProperty=nameWithType>
   - Only enabled when `TRACE` is defined.
-  - Writes to attached <xref:System.Diagnostics.TraceListener>s. Usually a debugger.
-  - It seems best to use this API when creating release-oriented logs.
+  - Writes to attached <xref:System.Diagnostics.Trace.Listeners>, by default the <xref:System.Diagnostics.DefaultTraceListener>.
+  - It seems best to use this API when creating logs that will be enabled in most builds.
 - <xref:System.Diagnostics.Debug?displayProperty=nameWithType>
   - Only enabled when `DEBUG` is defined.
-  - Writes to attached <xref:System.Diagnostics.TraceListener>s. Usually a debugger.
-  - It seems best to use this API when creating debug-oriented logs.
+  - Writes to an attached debugger.
+  - On `*nix` writes to stderr if `COMPlus_DebugWriteToStdErr` is set.
+  - It seems best to use this API when creating logs that will only be useful in a debguenabled in debug builds.
 
-### Logging Related References
+- <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>
+  - EventSource is the primary root .NET Core tracing API
+  - Available in all .NET Standard versions
+  - Only allows tracing serializable objects
+  - Writes to attached <xref:System.Diagnostics.EventListener>s.
+  - .NET Core provides listeners for:
+    - .NET Core's event pipe on all platforms
+    - [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal)
+    - [LTTng tracing framework for Linux](https://lttng.org/)
+
+- <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType>
+  - Included in .NET Core and as a [Nuget package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) for .NET Framework
+  - Allows in process tracing non-serializable objects
+  - Includes a bridge to allow select fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
+
+- <xref:System.Diagnostics.Activity?displayProperty=nameWithType>
+  - Provides a definitive way to identify log messages resulting from a specific activity or transaction. This object can be used to correlate logs across different services.
+
+- <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
+  - Windows only
+  - Writes messages to Windows event log
+  - System administrators expect fatal application error messages to appear in the Windows event log.
+
+## ILogger and Logging Frameworks
+
+The low-level APIs may not be the right choice for your logging needs. You may want to consider a logging framework.
+
+The <xref:Microsoft.Extensions.Logging.ILogger> interface has been used to create a common logging interface where the loggers can be inserted through dependency injection.
+
+For instance, to allow you to make the best choice for your application `ASP.NET` offers support for a selection of built-in and third-party frameworks:
+- [ASP.NET built in logging providers](/aspnet/core/fundamentals/logging/#built-in-logging-providers)
+- [ASP.NET Third-party logging providers](/aspnet/core/fundamentals/logging/#third-party-logging-providers)
+
+## Logging Related References
 
 - [How to: Compile Conditionally with Trace and Debug](../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug)
 
@@ -56,38 +88,12 @@ provides an overview of the logging techniques it supports.
 - The <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType>
 can be useful to provide debugger like logging info.
 
-- <xref:System.Diagnostics.TraceListener> provides an overview of existing listeners and creating a custom listener.
-
-## Tracing APIs
-
-- <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>
-  - EventSource is the primary root .NET Core tracing API
-  - Available in all .NET Standard versions
-  - Emits to .NET Core's event pipe on all platforms
-  - Also emits to ETW on Windows.
-  - Only allows tracing serializable objects
-
-- <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType>
-  - Only available in .NET Core
-  - Allows tracing non-serializable objects
-  - Includes a bridge to allow select fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
-
-- <xref:System.Diagnostics.TraceSource?displayProperty=nameWithType>
-  - This API was introduced in .NET Framework 2.0
-  - Supported in .NET Standard 2.0
-  - Prefer <xref:System.Diagnostics.Tracing.EventSource>
-
-- <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
-  - Windows only
-  - Writes messages to Windows event log
-  - System administrators expect fatal application error messages to appear in the Windows event log.
-
 ## Performance Considerations
 
 String formatting can take noticeable CPU processing time.
 
 In performance critical applications, it's good to:
-- Avoid lots of logging when no one is listening
+- Avoid lots of logging when no one is listening. Avoid constructing costly logging messages by checking if logging is enabled first.
 - Only log what is useful
 - Defer fancy formatting to the analysis stage
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -50,7 +50,7 @@ The following APIs are more event oriented. Rather than logging simple strings t
   - Only allows tracing serializable objects.
   - Writes to attached <xref:System.Diagnostics.Tracing.EventListener>s.
   - .NET Core provides listeners for:
-    - .NET Core's event pipe on all platforms
+    - .NET Core's EventPipe on all platforms
     - [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal)
     - [LTTng tracing framework for Linux](https://lttng.org/)
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -21,9 +21,9 @@ This simple technique is surprisingly powerful. It can be used in situations whe
 
 ## .NET Core APIs
 
-<xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> each provide similar print style APIs convenient for logging.
+The <xref:System.Console?displayProperty=nameWithType>, <xref:System.Diagnostics.Trace?displayProperty=nameWithType>, and <xref:System.Diagnostics.Debug?displayProperty=nameWithType> classes each provide similar print style APIs convenient for logging.
 
-The choice of which print style API to use is up to you. The key differences:
+The choice of which print style API to use is up to you. The key differences are:
 - <xref:System.Console?displayProperty=nameWithType>
   - Always enabled and always writes to the console.
   - Useful for information that your customer may need to see in the release.
@@ -31,18 +31,18 @@ The choice of which print style API to use is up to you. The key differences:
 - <xref:System.Diagnostics.Trace?displayProperty=nameWithType>
   - Only enabled when `TRACE` is defined.
   - Writes to attached <xref:System.Diagnostics.Trace.Listeners>, by default the <xref:System.Diagnostics.DefaultTraceListener>.
-  - It seems best to use this API when creating logs that will be enabled in most builds.
+  - Use this API when creating logs that will be enabled in most builds.
 - <xref:System.Diagnostics.Debug?displayProperty=nameWithType>
   - Only enabled when `DEBUG` is defined.
   - Writes to an attached debugger.
   - On `*nix` writes to stderr if `COMPlus_DebugWriteToStdErr` is set.
-  - It seems best to use this API when creating logs that will only be useful in a debguenabled in debug builds.
+  - Use this API when creating logs that will be enabled only in debug builds.
 
 - <xref:System.Diagnostics.Tracing.EventSource?displayProperty=nameWithType>
-  - EventSource is the primary root .NET Core tracing API
-  - Available in all .NET Standard versions
-  - Only allows tracing serializable objects
-  - Writes to attached <xref:System.Diagnostics.EventListener>s.
+  - EventSource is the primary root .NET Core tracing API.
+  - Available in all .NET Standard versions.
+  - Only allows tracing serializable objects.
+  - Writes to attached <xref:System.Diagnostics.Tracing.EventListener>s.
   - .NET Core provides listeners for:
     - .NET Core's event pipe on all platforms
     - [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal)
@@ -50,15 +50,15 @@ The choice of which print style API to use is up to you. The key differences:
 
 - <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType>
   - Included in .NET Core and as a [Nuget package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) for .NET Framework
-  - Allows in process tracing non-serializable objects
+  - Allows in process tracing non-serializable objects.
   - Includes a bridge to allow select fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
 
 - <xref:System.Diagnostics.Activity?displayProperty=nameWithType>
   - Provides a definitive way to identify log messages resulting from a specific activity or transaction. This object can be used to correlate logs across different services.
 
 - <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
-  - Windows only
-  - Writes messages to Windows event log
+  - Windows only.
+  - Writes messages to Windows event log.
   - System administrators expect fatal application error messages to appear in the Windows event log.
 
 ## ILogger and logging frameworks

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -64,8 +64,8 @@ The following APIs are more event oriented. Rather than logging simple strings t
 
 - <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
   - Windows only.
-  - Writes messages to Windows event log.
-  - System administrators expect fatal application error messages to appear in the Windows event log.
+  - Writes messages to Windows Event Log.
+  - System administrators expect fatal application error messages to appear in the Windows Event Log.
 
 ## ILogger and logging frameworks
 

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -1,6 +1,6 @@
 ---
 title: Logging and tracing - .NET Core
-description: An introduction to .NET Core Logging or Tracing.
+description: An introduction to .NET Core logging and tracing.
 author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
@@ -48,23 +48,23 @@ The following APIs are more event oriented. Rather than logging simple strings t
   - EventSource is the primary root .NET Core tracing API.
   - Available in all .NET Standard versions.
   - Only allows tracing serializable objects.
-  - Writes to attached <xref:System.Diagnostics.Tracing.EventListener>s.
+  - Writes to the attached [event listeners](xref:System.Diagnostics.Tracing.EventListener).
   - .NET Core provides listeners for:
     - .NET Core's EventPipe on all platforms
     - [Event Tracing for Windows (ETW)](/windows/win32/etw/event-tracing-portal)
     - [LTTng tracing framework for Linux](https://lttng.org/)
 
 - <xref:System.Diagnostics.DiagnosticSource?displayProperty=nameWithType>
-  - Included in .NET Core and as a [Nuget package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) for .NET Framework
-  - Allows in process tracing non-serializable objects.
-  - Includes a bridge to allow select fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
+  - Included in .NET Core and as a [NuGet package](https://www.nuget.org/packages/System.Diagnostics.DiagnosticSource) for .NET Framework.
+  - Allows in-process tracing of non-serializable objects.
+  - Includes a bridge to allow selected fields of logged objects to be written to an <xref:System.Diagnostics.Tracing.EventSource>.
 
 - <xref:System.Diagnostics.Activity?displayProperty=nameWithType>
   - Provides a definitive way to identify log messages resulting from a specific activity or transaction. This object can be used to correlate logs across different services.
 
 - <xref:System.Diagnostics.EventLog?displayProperty=nameWithType>
   - Windows only.
-  - Writes messages to Windows Event Log.
+  - Writes messages to the Windows Event Log.
   - System administrators expect fatal application error messages to appear in the Windows Event Log.
 
 ## ILogger and logging frameworks

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -1,15 +1,15 @@
 ---
-title: .NET Core Logging or Tracing
+title: Logging and tracing - .NET Core
 description: An introduction to .NET Core Logging or Tracing.
 author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ---
-# .NET Core Logging and Tracing
+# .NET Core logging and tracing
 
 Logging and tracing are really two names for the same technique. The simple technique has been used since the early days of computers. It simply involves instrumenting an application to write output to be consumed later.
 
-## Why Logging and Tracing?
+## Reasons to use logging and tracing
 
 This simple technique is surprisingly powerful. It can be used in situations where a debugger fails:
 
@@ -26,7 +26,7 @@ This simple technique is surprisingly powerful. It can be used in situations whe
 The choice of which print style API to use is up to you. The key differences:
 - <xref:System.Console?displayProperty=nameWithType>
   - Always enabled and always writes to the console.
-  - Useful for information that your customer may need to see in release.
+  - Useful for information that your customer may need to see in the release.
   - Because it's the simplest approach, it's often used for ad-hoc temporary debugging. This debug code is often never checked in to source control.
 - <xref:System.Diagnostics.Trace?displayProperty=nameWithType>
   - Only enabled when `TRACE` is defined.
@@ -61,7 +61,7 @@ The choice of which print style API to use is up to you. The key differences:
   - Writes messages to Windows event log
   - System administrators expect fatal application error messages to appear in the Windows event log.
 
-## ILogger and Logging Frameworks
+## ILogger and logging frameworks
 
 The low-level APIs may not be the right choice for your logging needs. You may want to consider a logging framework.
 
@@ -71,30 +71,27 @@ For instance, to allow you to make the best choice for your application `ASP.NET
 - [ASP.NET built in logging providers](/aspnet/core/fundamentals/logging/#built-in-logging-providers)
 - [ASP.NET Third-party logging providers](/aspnet/core/fundamentals/logging/#third-party-logging-providers)
 
-## Logging Related References
+## Logging related references
 
-- [How to: Compile Conditionally with Trace and Debug](../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug)
+- [How to: Compile Conditionally with Trace and Debug](../../framework/debug-trace-profile/how-to-compile-conditionally-with-trace-and-debug.md)
 
-- [How to: Add Trace Statements to Application Code](../../framework/debug-trace-profile/how-to-add-trace-statements-to-application-code)
+- [How to: Add Trace Statements to Application Code](../../framework/debug-trace-profile/how-to-add-trace-statements-to-application-code.md)
 
 - [ASP.NET Logging](/aspnet/core/fundamentals/logging)
 provides an overview of the logging techniques it supports.
 
-- [C# String Interpolation](../../csharp/language-reference/tokens/interpolated)
+- [C# String Interpolation](../../csharp/language-reference/tokens/interpolated.md)
  can simplify writing logging code.
 
-- The <xref:System.Exception.Message?displayProperty=nameWithType> is useful for logging exceptions.
+- The <xref:System.Exception.Message?displayProperty=nameWithType> property is useful for logging exceptions.
 
-- The <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType>
-can be useful to provide debugger like logging info.
+- The <xref:System.Diagnostics.StackTrace?displayProperty=nameWithType> class can be useful to provide stack info in your logs.
 
-## Performance Considerations
+## Performance considerations
 
 String formatting can take noticeable CPU processing time.
 
-In performance critical applications, it's good to:
+In performance critical applications, it's recommended that you:
 - Avoid lots of logging when no one is listening. Avoid constructing costly logging messages by checking if logging is enabled first.
-- Only log what is useful
-- Defer fancy formatting to the analysis stage
-
-Usually tracing is better than logging for most performance critical applications.
+- Only log what's useful.
+- Defer fancy formatting to the analysis stage.

--- a/docs/core/diagnostics/logging-tracing.md
+++ b/docs/core/diagnostics/logging-tracing.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Core Logging and Tracing
 description: An introduction to .NET Core Logging and Tracing.
-author: stmaclea
+author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ---

--- a/docs/core/diagnostics/managed-debuggers.md
+++ b/docs/core/diagnostics/managed-debuggers.md
@@ -3,31 +3,28 @@ title: .NET Core Managed Debuggers
 description: An overview of the Visual Studio and VS Code managed debuggers.
 author: stmaclea
 ms.author: stmaclea
-ms.date: 8/5/2019
-ms.topic: article
-ms.prod: .net-core
+ms.date: 08/05/2019
 ---
 # .NET Core Managed Debuggers
 
 Debuggers allow programs to be paused or executed step-by-step. When paused, the current state of the process can be viewed. By stepping through key sections, you gain understanding of your code and why it produces the result that it does.
 
-Microsoft provides debuggers for managed code in the **Visual Studio** and **Visual Studio Code** integrated development environments.
+Microsoft provides debuggers for managed code in the **Visual Studio** and **Visual Studio Code** integrated development environments (IDE).
 
 ## Visual Studio Managed Debugger
 
-**Visual Studio** is an IDE with the most comprehensive debugger available. Visual Studio is an excellent default choice for developers working on Windows.
-  - [Tutorial - Debugging a .NET Core application on Windows with Visual Studio](https://docs.microsoft.com/dotnet/core/tutorials/debugging-with-visual-studio)
+**Visual Studio** is an IDE with the most comprehensive debugger available. Visual Studio is an excellent choice for developers working on Windows.
+- [Tutorial - Debugging a .NET Core application on Windows with Visual Studio](../tutorials/debugging-with-visual-studio)
 
 While Visual Studio is a Windows application, it can still be used to debug Linux and MacOS apps remotely.
-  - [Debugging a .Net Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
+- [Debugging a .Net Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
 
  Debugging ASP.NET Core apps require slightly different instructions.
 
-  - [Debug ASP.NET Core apps in Visual Studio](https://docs.microsoft.com/visualstudio/debugger/how-to-enable-debugging-for-aspnet-applications#debug-aspnet-core-apps)
-
+- [Debug ASP.NET Core apps in Visual Studio](/visualstudio/debugger/how-to-enable-debugging-for-aspnet-applications#debug-aspnet-core-apps)
 
 ## Visual Studio Code Managed Debugger
 
-**Visual Studio Code** is a lightweight fully cross platform code editor. It uses the same .NET Core debugger implementation as Visual Studio with a simplified user interface.
-  - [Tutorial - Debugging a .Net Core application with Visual Studio Code](https://docs.microsoft.com/dotnet/core/tutorials/with-visual-studio-code)
-  - [Visual Studio Code's Debugging Overview](https://code.visualstudio.com/docs/editor/debugging)
+**Visual Studio Code** is a lightweight cross-platform code editor. It uses the same .NET Core debugger implementation as Visual Studio, but with a simplified user interface.
+- [Tutorial - Debugging a .Net Core application with Visual Studio Code](../tutorials/with-visual-studio-code)
+- [Visual Studio Code's Debugging Overview](https://code.visualstudio.com/docs/editor/debugging)

--- a/docs/core/diagnostics/managed-debuggers.md
+++ b/docs/core/diagnostics/managed-debuggers.md
@@ -1,30 +1,31 @@
 ---
-title: .NET Core Managed Debuggers
-description: An overview of the Visual Studio and VS Code managed debuggers.
+title: Managed debuggers - .NET Core
+description: An overview of the Visual Studio and Visual Studio Code managed debuggers.
 author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ---
-# .NET Core Managed Debuggers
+# .NET Core managed debuggers
 
 Debuggers allow programs to be paused or executed step-by-step. When paused, the current state of the process can be viewed. By stepping through key sections, you gain understanding of your code and why it produces the result that it does.
 
-Microsoft provides debuggers for managed code in the **Visual Studio** and **Visual Studio Code** integrated development environments (IDE).
+Microsoft provides debuggers for managed code in **Visual Studio** and **Visual Studio Code**.
 
-## Visual Studio Managed Debugger
+## Visual Studio managed debugger
 
-**Visual Studio** is an IDE with the most comprehensive debugger available. Visual Studio is an excellent choice for developers working on Windows.
-- [Tutorial - Debugging a .NET Core application on Windows with Visual Studio](../tutorials/debugging-with-visual-studio)
+**Visual Studio** is an integrated development environment with the most comprehensive debugger available. Visual Studio is an excellent choice for developers working on Windows.
+- [Tutorial - Debugging a .NET Core application on Windows with Visual Studio](../tutorials/debugging-with-visual-studio.md)
 
-While Visual Studio is a Windows application, it can still be used to debug Linux and MacOS apps remotely.
-- [Debugging a .Net Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
+While Visual Studio is a Windows application, it can still be used to debug Linux and macOS apps remotely.
+- [Debugging a .NET Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
 
  Debugging ASP.NET Core apps require slightly different instructions.
 
 - [Debug ASP.NET Core apps in Visual Studio](/visualstudio/debugger/how-to-enable-debugging-for-aspnet-applications#debug-aspnet-core-apps)
 
-## Visual Studio Code Managed Debugger
+## Visual Studio Code managed debugger
 
 **Visual Studio Code** is a lightweight cross-platform code editor. It uses the same .NET Core debugger implementation as Visual Studio, but with a simplified user interface.
-- [Tutorial - Debugging a .Net Core application with Visual Studio Code](../tutorials/with-visual-studio-code#debug)
-- [Visual Studio Code's Debugging Overview](https://code.visualstudio.com/docs/editor/debugging)
+
+- [Tutorial - Debugging a .NET Core application with Visual Studio Code](../tutorials/with-visual-studio-code.md#debug)
+- [Debugging in Visual Studio Code](https://code.visualstudio.com/docs/editor/debugging)

--- a/docs/core/diagnostics/managed-debuggers.md
+++ b/docs/core/diagnostics/managed-debuggers.md
@@ -1,7 +1,7 @@
 ---
 title: .NET Core Managed Debuggers
 description: An overview of the Visual Studio and VS Code managed debuggers.
-author: stmaclea
+author: sdmaclea
 ms.author: stmaclea
 ms.date: 08/05/2019
 ---

--- a/docs/core/diagnostics/managed-debuggers.md
+++ b/docs/core/diagnostics/managed-debuggers.md
@@ -1,0 +1,33 @@
+---
+title: .NET Core Managed Debuggers
+description: An overview of the Visual Studio and VS Code managed debuggers.
+author: stmaclea
+ms.author: stmaclea
+ms.date: 8/5/2019
+ms.topic: article
+ms.prod: .net-core
+---
+# .NET Core Managed Debuggers
+
+Debuggers allow programs to be paused or executed step-by-step. When paused, the current state of the process can be viewed. By stepping through key sections, you gain understanding of your code and why it produces the result that it does.
+
+Microsoft provides debuggers for managed code in the **Visual Studio** and **Visual Studio Code** integrated development environments.
+
+## Visual Studio Managed Debugger
+
+**Visual Studio** is an IDE with the most comprehensive debugger available. Visual Studio is an excellent default choice for developers working on Windows.
+  - [Tutorial - Debugging a .NET Core application on Windows with Visual Studio](https://docs.microsoft.com/dotnet/core/tutorials/debugging-with-visual-studio)
+
+While Visual Studio is a Windows application, it can still be used to debug Linux and MacOS apps remotely.
+  - [Debugging a .Net Core application on Linux/OSX with Visual Studio](https://github.com/Microsoft/MIEngine/wiki/Offroad-Debugging-of-.NET-Core-on-Linux---OSX-from-Visual-Studio)
+
+ Debugging ASP.NET Core apps require slightly different instructions.
+
+  - [Debug ASP.NET Core apps in Visual Studio](https://docs.microsoft.com/visualstudio/debugger/how-to-enable-debugging-for-aspnet-applications#debug-aspnet-core-apps)
+
+
+## Visual Studio Code Managed Debugger
+
+**Visual Studio Code** is a lightweight fully cross platform code editor. It uses the same .NET Core debugger implementation as Visual Studio with a simplified user interface.
+  - [Tutorial - Debugging a .Net Core application with Visual Studio Code](https://docs.microsoft.com/dotnet/core/tutorials/with-visual-studio-code)
+  - [Visual Studio Code's Debugging Overview](https://code.visualstudio.com/docs/editor/debugging)

--- a/docs/core/diagnostics/managed-debuggers.md
+++ b/docs/core/diagnostics/managed-debuggers.md
@@ -26,5 +26,5 @@ While Visual Studio is a Windows application, it can still be used to debug Linu
 ## Visual Studio Code Managed Debugger
 
 **Visual Studio Code** is a lightweight cross-platform code editor. It uses the same .NET Core debugger implementation as Visual Studio, but with a simplified user interface.
-- [Tutorial - Debugging a .Net Core application with Visual Studio Code](../tutorials/with-visual-studio-code)
+- [Tutorial - Debugging a .Net Core application with Visual Studio Code](../tutorials/with-visual-studio-code#debug)
 - [Visual Studio Code's Debugging Overview](https://code.visualstudio.com/docs/editor/debugging)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -267,9 +267,10 @@
       href: core/docker/build-container.md
     - name: Container Tools in Visual Studio
       href: /visualstudio/containers/overview
-  - name: Diagnostics
-    href: core/diagnostics/index.md
+  - name: Diagnostic Tools
     items:
+    - name: Overview
+      href: core/diagnostics/index.md
     - name: Managed Debuggers
       href: core/diagnostics/managed-debuggers.md
     - name: Logging and Tracing

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -267,13 +267,13 @@
       href: core/docker/build-container.md
     - name: Container Tools in Visual Studio
       href: /visualstudio/containers/overview
-  - name: Diagnostic Tools
+  - name: Diagnostic tools
     items:
     - name: Overview
       href: core/diagnostics/index.md
-    - name: Managed Debuggers
+    - name: Managed debuggers
       href: core/diagnostics/managed-debuggers.md
-    - name: Logging and Tracing
+    - name: Logging and tracing
       href: core/diagnostics/logging-tracing.md
   - name: Unit Testing
     href: core/testing/index.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -267,6 +267,13 @@
       href: core/docker/build-container.md
     - name: Container Tools in Visual Studio
       href: /visualstudio/containers/overview
+  - name: Diagnostics
+    href: core/diagnostics/index.md
+    items:
+    - name: Managed Debuggers
+      href: core/diagnostics/managed-debuggers.md
+    - name: Logging and Tracing
+      href: core/diagnostics/logging-and-tracing.md
   - name: Unit Testing
     href: core/testing/index.md
     items:

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -273,7 +273,7 @@
     - name: Managed Debuggers
       href: core/diagnostics/managed-debuggers.md
     - name: Logging and Tracing
-      href: core/diagnostics/logging-and-tracing.md
+      href: core/diagnostics/logging-tracing.md
   - name: Unit Testing
     href: core/testing/index.md
     items:


### PR DESCRIPTION
## Summary

Add a diagnostic landing page and overview docs for using a debugger, logging and tracing.

Begins to fix #9276
