### PR TITLE
Expression-bodied members: clarified logic

### DIFF
--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -39,7 +39,7 @@ An expression body definition has the following general syntax:
 member => expression;
 ```
 
-where *expression* is a valid expression. Note that *expression* can be a *statement expression* only if the member's return type is `void`, or if the member is a constructor, a finalizer, or a property `set` accessor.
+where *expression* is a valid expression. If the member's return type is `void` or if the member is a constructor, a finalizer, or a property `set` accessor, the *expression* must be a [*statement expression*](~/_csharplang/spec/statements.md#expression-statements).
 
 The following example shows an expression body definition for a `Person.ToString` method:
 

--- a/docs/csharp/language-reference/operators/lambda-operator.md
+++ b/docs/csharp/language-reference/operators/lambda-operator.md
@@ -39,7 +39,7 @@ An expression body definition has the following general syntax:
 member => expression;
 ```
 
-where *expression* is a valid expression. If the member's return type is `void` or if the member is a constructor, a finalizer, or a property `set` accessor, the *expression* must be a [*statement expression*](~/_csharplang/spec/statements.md#expression-statements).
+where `expression` is a valid expression. The return type of `expression` must be implicitly convertible to the member's return type. If the member's return type is `void` or if the member is a constructor, a finalizer, or a property `set` accessor, `expression` must be a [*statement expression*](~/_csharplang/spec/statements.md#expression-statements); it can be of any type then.
 
 The following example shows an expression body definition for a `Person.ToString` method:
 


### PR DESCRIPTION
Fixes #13764

The text can be made clearer. Now, it might be read (if one puts comma before "only") as if statement expressions can be used only with some kinds of members, with which other expressions also can be used. However, it's about members, not expressions. Some kinds of members allow *only* statement expressions; that said, statement expressions (any method call or `await` expression) still can be used with other kinds of members.

For example, from [the spec](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/classes#method-body):
>When a method has a void result and an expression body, the expression E must be a statement_expression
