### PR TITLE
Updated verbiage about derived class constructor

### DIFF
--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -17,7 +17,7 @@ with only a get accessor:
 
 [!code-csharp[ReadOnlyAutoProperty](../../../samples/snippets/csharp/new-in-6/newcode.cs#ReadOnlyAutoProperty)]
 
-The `FirstName` and `LastName` properties  can be set only in the body of the same class:
+The `FirstName` and `LastName` properties can be set only in the body of the constructor of the same class:
 
 [!code-csharp[ReadOnlyAutoPropertyConstructor](../../../samples/snippets/csharp/new-in-6/newcode.cs#ReadOnlyAutoPropertyConstructor)]
 

--- a/docs/csharp/whats-new/csharp-6.md
+++ b/docs/csharp/whats-new/csharp-6.md
@@ -17,7 +17,7 @@ with only a get accessor:
 
 [!code-csharp[ReadOnlyAutoProperty](../../../samples/snippets/csharp/new-in-6/newcode.cs#ReadOnlyAutoProperty)]
 
-The `FirstName` and `LastName` properties can be set only in the body of a constructor:
+The `FirstName` and `LastName` properties  can be set only in the body of the same class:
 
 [!code-csharp[ReadOnlyAutoPropertyConstructor](../../../samples/snippets/csharp/new-in-6/newcode.cs#ReadOnlyAutoPropertyConstructor)]
 


### PR DESCRIPTION
## Summary
 A derived class constructor cannot set these read-only properties.
Suggestion: "... can be set only in the body of the same class"


closes #13725 