### PR TITLE
Spark: updated spark-submit class

### DIFF
--- a/docs/spark/tutorials/get-started.md
+++ b/docs/spark/tutorials/get-started.md
@@ -108,7 +108,7 @@ git clone https://github.com/dotnet/spark.git c:\github\dotnet-spark
 
    ```powershell
     spark-submit `
-    --class org.apache.spark.deploy.DotnetRunner `
+    --class org.apache.spark.deploy.dotnet.DotnetRunner `
     --master local `
     microsoft-spark-2.4.x-<version>.jar `
     dotnet HelloSpark.dll


### PR DESCRIPTION
## Summary

Changed --class org.apache.spark.deploy.DotnetRunner 
to --class org.apache.spark.deploy.dotnet.DotnetRunner

Fixes #13681
