### PR TITLE
Note that these features aren't installed by default.

### DIFF
--- a/docs/framework/wcf/using-the-wcf-development-tools.md
+++ b/docs/framework/wcf/using-the-wcf-development-tools.md
@@ -9,7 +9,7 @@ This section describes the Visual Studio development tools that can assist you i
  You can use the Visual Studio templates as a foundation to quickly build your own service, then use WCF Service Auto Host and WCF Test Client to debug and test your service. These tools together provide a fast and seamless debug and testing cycle, and preclude the need to commit to a hosting model at an early stage.  
  
  > [!NOTE]
- > Starting with Visual Studio 2017 the WCF Development Tools are not installed by default. In order to use these features you must ensure the Windows Communication Foundation individual component is selected in the Visual Studio installer.
+ > Starting with Visual Studio 2017, the WCF development tools are not installed by default. In order to use these features, you must ensure the Windows Communication Foundation component is selected in the Visual Studio installer.
   
 ## The WCF Developer Tools  
  [WCF Visual Studio Templates](../../../docs/framework/wcf/wcf-vs-templates.md)  

--- a/docs/framework/wcf/using-the-wcf-development-tools.md
+++ b/docs/framework/wcf/using-the-wcf-development-tools.md
@@ -7,6 +7,9 @@ ms.assetid: 054adb87-c244-4d5a-83d1-0b2b44bd454b
 This section describes the Visual Studio development tools that can assist you in developing your WCFservice.  
   
  You can use the Visual Studio templates as a foundation to quickly build your own service, then use WCF Service Auto Host and WCF Test Client to debug and test your service. These tools together provide a fast and seamless debug and testing cycle, and preclude the need to commit to a hosting model at an early stage.  
+ 
+ > [!NOTE]
+ > Starting with Visual Studio 2017 the WCF Development Tools are not installed by default. In order to use these features you must ensure the Windows Communication Foundation individual component is selected in the Visual Studio installer.
   
 ## The WCF Developer Tools  
  [WCF Visual Studio Templates](../../../docs/framework/wcf/wcf-vs-templates.md)  


### PR DESCRIPTION
Customers have reported confusion when they're unable to create new WCF files by default in recent version of Visual Studio. This not should give them a hint if they look for documentation as to why these are missing.