### PR TITLE
Replace `ref readonly` with `readonly ref`

### DIFF
--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -85,7 +85,7 @@ return ref DecimalArray[0];
 
 In order for the caller to modify the object's state, the reference return value must be stored to a variable that is explicitly defined as a [ref local](#ref-locals).
 
-The called method may also declare the return value as `readonly ref` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [readonly ref](#readonly-ref-locals) variable.
+The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [ref readonly](#ref-readonly-locals) variable.
 
 For an example, see [A ref returns and ref locals example](#a-ref-returns-and-ref-locals-example).
 
@@ -109,11 +109,11 @@ ref VeryLargeStruct reflocal = ref veryLargeStruct;
 
 Note that in both examples the `ref` keyword must be used in both places, or the compiler generates error CS8172, "Cannot initialize a by-reference variable with a value."
 
-Beginning with C# 7.3, the iteration variable of the `foreach` statement can be ref local or readonly ref local variable. For more information, see the [foreach statement](foreach-in.md) article.
+Beginning with C# 7.3, the iteration variable of the `foreach` statement can be ref local or ref readonly local variable. For more information, see the [foreach statement](foreach-in.md) article.
 
-## Readonly ref locals
+## Ref readonly locals
 
-A readonly ref local is used to refer to values returned by the method or property that has `readonly ref` in its signature and uses `return ref`. A `readonly ref` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
+A ref readonly local is used to refer to values returned by the method or property that has `ref readonly` in its signature and uses `return ref`. A `ref readonly` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
 
 ## A ref returns and ref locals example
 

--- a/docs/csharp/language-reference/keywords/ref.md
+++ b/docs/csharp/language-reference/keywords/ref.md
@@ -17,7 +17,7 @@ The `ref` keyword indicates a value that is passed by reference. It is used in f
 - In a method signature and in a method call, to pass an argument to a method by reference. For more information, see [Passing an argument by reference](#passing-an-argument-by-reference).
 - In a method signature, to return a value to the caller by reference. For more information, see [Reference return values](#reference-return-values).
 - In a member body, to indicate that a reference return value is stored locally as a reference that the caller intends to modify or, in general, a local variable accesses another value by reference. For more information, see [Ref locals](#ref-locals).
-- In a `struct` declaration to declare a `ref struct` or a `ref readonly struct`. For more information, see [ref struct types](#ref-struct-types).
+- In a `struct` declaration to declare a `ref struct` or a `readonly ref struct`. For more information, see [ref struct types](#ref-struct-types).
 
 ## Passing an argument by reference
 
@@ -85,7 +85,7 @@ return ref DecimalArray[0];
 
 In order for the caller to modify the object's state, the reference return value must be stored to a variable that is explicitly defined as a [ref local](#ref-locals).
 
-The called method may also declare the return value as `ref readonly` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [ref readonly](#ref-readonly-locals) variable.
+The called method may also declare the return value as `readonly ref` to return the value by reference, and enforce that the calling code cannot modify the returned value. The calling method can avoid copying the returned valued by storing the value in a local [readonly ref](#readonly-ref-locals) variable.
 
 For an example, see [A ref returns and ref locals example](#a-ref-returns-and-ref-locals-example).
 
@@ -109,11 +109,11 @@ ref VeryLargeStruct reflocal = ref veryLargeStruct;
 
 Note that in both examples the `ref` keyword must be used in both places, or the compiler generates error CS8172, "Cannot initialize a by-reference variable with a value."
 
-Beginning with C# 7.3, the iteration variable of the `foreach` statement can be ref local or ref readonly local variable. For more information, see the [foreach statement](foreach-in.md) article.
+Beginning with C# 7.3, the iteration variable of the `foreach` statement can be ref local or readonly ref local variable. For more information, see the [foreach statement](foreach-in.md) article.
 
-## Ref readonly locals
+## Readonly ref locals
 
-A ref readonly local is used to refer to values returned by the method or property that has `ref readonly` in its signature and uses `return ref`. A `ref readonly` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
+A readonly ref local is used to refer to values returned by the method or property that has `readonly ref` in its signature and uses `return ref`. A `readonly ref` variable combines the properties of a `ref` local variable with a `readonly` variable: it is an alias to the storage it's assigned to, and it cannot be modified. 
 
 ## A ref returns and ref locals example
 


### PR DESCRIPTION
## Summary

Replace `ref readonly` with `readonly ref

Fixes #13868
