### PR TITLE
[csharp] Replace ~/ links with ../ relatives

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/seedwork-domain-model-base-classes-interfaces.md
@@ -17,7 +17,7 @@ This is the type of copy and paste reuse that many developers share between proj
 
 ## The custom Entity base class
 
-The following code is an example of an Entity base class where you can place code that can be used the same way by any domain entity, such as the entity ID, [equality operators](~/docs/csharp/language-reference/operators/equality-operators.md), a domain event list per entity, etc.
+The following code is an example of an Entity base class where you can place code that can be used the same way by any domain entity, such as the entity ID, [equality operators](../../../csharp/language-reference/operators/equality-operators.md), a domain event list per entity, etc.
 
 ```csharp
 // COMPATIBLE WITH ENTITY FRAMEWORK CORE (1.1 and later)

--- a/docs/csharp/misc/cs1010.md
+++ b/docs/csharp/misc/cs1010.md
@@ -29,4 +29,4 @@ class Sample
   
 ## See also
 
-- [Strings (C# Programming Guide)](~/docs/csharp/programming-guide/strings/index.md)
+- [Strings (C# Programming Guide)](../programming-guide/strings/index.md)

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/using-variance-for-func-and-action-generic-delegates.md
@@ -78,4 +78,4 @@ class Program
 ## See also
 
 - [Covariance and Contravariance (C#)](./index.md)
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../../standard/generics/index.md)

--- a/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md
+++ b/docs/csharp/programming-guide/concepts/covariance-contravariance/variance-in-delegates.md
@@ -192,6 +192,6 @@ public static void Test()
   
 ## See also
 
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../../standard/generics/index.md)
 - [Using Variance for Func and Action Generic Delegates (C#)](./using-variance-for-func-and-action-generic-delegates.md)
 - [How to: Combine Delegates (Multicast Delegates)](../../delegates/how-to-combine-delegates-multicast-delegates.md)

--- a/docs/csharp/programming-guide/concepts/object-oriented-programming.md
+++ b/docs/csharp/programming-guide/concepts/object-oriented-programming.md
@@ -404,7 +404,7 @@ sampleObject.Field = "Sample string";
 
 For more information, see:
 
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)
 
 - [Generics](../generics/index.md)
 

--- a/docs/csharp/programming-guide/generics/generic-delegates.md
+++ b/docs/csharp/programming-guide/generics/generic-delegates.md
@@ -37,4 +37,4 @@ A [delegate](../../language-reference/keywords/delegate.md) can define its own t
 - [Generic Classes](./generic-classes.md)
 - [Generic Interfaces](./generic-interfaces.md)
 - [Delegates](../delegates/index.md)
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)

--- a/docs/csharp/programming-guide/generics/generic-interfaces.md
+++ b/docs/csharp/programming-guide/generics/generic-interfaces.md
@@ -43,4 +43,4 @@ It is often useful to define interfaces either for generic collection classes, o
 - [C# Programming Guide](../index.md)
 - [Introduction to Generics](./index.md)
 - [interface](../../language-reference/keywords/interface.md)
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)

--- a/docs/csharp/programming-guide/generics/generics-and-arrays.md
+++ b/docs/csharp/programming-guide/generics/generics-and-arrays.md
@@ -20,4 +20,4 @@ In C# 2.0 and later, single-dimensional arrays that have a lower bound of zero a
 - [C# Programming Guide](../index.md)
 - [Generics](./index.md)
 - [Arrays](../arrays/index.md)
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)

--- a/docs/csharp/programming-guide/generics/generics-and-reflection.md
+++ b/docs/csharp/programming-guide/generics/generics-and-reflection.md
@@ -44,4 +44,4 @@ Because the Common Language Runtime (CLR) has access to generic type information
 - [C# Programming Guide](../index.md)
 - [Generics](./index.md)
 - [Reflection and Generic Types](../../../framework/reflection-and-codedom/reflection-and-generic-types.md)
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)

--- a/docs/csharp/programming-guide/generics/generics-in-the-run-time.md
+++ b/docs/csharp/programming-guide/generics/generics-in-the-run-time.md
@@ -46,4 +46,4 @@ When a generic type or method is compiled into Microsoft intermediate language (
 - <xref:System.Collections.Generic>
 - [C# Programming Guide](../index.md)
 - [Introduction to Generics](./index.md)
-- [Generics](~/docs/standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)

--- a/docs/fsharp/language-reference/generics/index.md
+++ b/docs/fsharp/language-reference/generics/index.md
@@ -91,6 +91,6 @@ There are two kinds of type parameters that can be used in F# programs. The firs
 - [Language Reference](../index.md)
 - [Types](../fsharp-types.md)
 - [Statically Resolved Type Parameters](statically-resolved-type-parameters.md)
-- [Generics in the .NET Framework](../../../standard/generics/index.md)
+- [Generics](../../../standard/generics/index.md)
 - [Automatic Generalization](automatic-generalization.md)
 - [Constraints](constraints.md)

--- a/docs/fsharp/language-reference/generics/index.md
+++ b/docs/fsharp/language-reference/generics/index.md
@@ -91,6 +91,6 @@ There are two kinds of type parameters that can be used in F# programs. The firs
 - [Language Reference](../index.md)
 - [Types](../fsharp-types.md)
 - [Statically Resolved Type Parameters](statically-resolved-type-parameters.md)
-- [Generics in the .NET Framework](~/docs/standard/generics/index.md)
+- [Generics in the .NET Framework](../../../standard/generics/index.md)
 - [Automatic Generalization](automatic-generalization.md)
 - [Constraints](constraints.md)


### PR DESCRIPTION
## Summary

Replace `~/` links with `../` relative links in /csharp/** files

Contributes to #9968