### PR TITLE
Add MetadataLoadContext references

### DIFF
--- a/docs/standard/assembly/file-format.md
+++ b/docs/standard/assembly/file-format.md
@@ -30,4 +30,4 @@ Assembly Headers from ECMA 335 II.25.1, Structure of the runtime file format.
 
 ## Processing the Assemblies
 
-It is possible to write tools or APIs to process assemblies. Assembly information enables making programmatic decisions at runtime, re-writing assemblies, providing API IntelliSense in an editor and generating documentation. <xref:System.Reflection?displayProperty=nameWithType> and [Mono.Cecil](https://www.mono-project.com/docs/tools+libraries/libraries/Mono.Cecil/) are good examples of tools that are frequently used for this purpose.
+It is possible to write tools or APIs to process assemblies. Assembly information enables making programmatic decisions at runtime, re-writing assemblies, providing API IntelliSense in an editor and generating documentation. <xref:System.Reflection?displayProperty=nameWithType>, <xref:System.Reflection.MetadataLoadContext?displayProperty=nameWithType>, and [Mono.Cecil](https://www.mono-project.com/docs/tools+libraries/libraries/Mono.Cecil/) are good examples of tools that are frequently used for this purpose.

--- a/docs/standard/assembly/index.md
+++ b/docs/standard/assembly/index.md
@@ -19,7 +19,7 @@ Assemblies have the following properties:
 
 - You can programmatically obtain information about an assembly by using reflection. For more information, see [Reflection (C#)](../../csharp/programming-guide/concepts/reflection.md) or [Reflection (Visual Basic)](../../visual-basic/programming-guide/concepts/reflection.md).
 
-- You can load an assembly only to inspect it by calling a method <xref:System.Reflection.Assembly.ReflectionOnlyLoadFrom%2A?displayProperty=nameWithType>.
+- You can load an assembly only to inspect by using the <xref:System.Reflection.MetadataLoadContext> class.
 
 ## Assembly manifest
 


### PR DESCRIPTION
## Summary

Update .NET Standard to refer to `MetadataLoadContext` rather than `ReflectionOnlyLoad*`.

`MetadataLoadContext` is supported on .NET Standard platforms.

`ReflectionOnlyLoad*` is not supported on .NET Core.  

Fixes #13267 
Fixes #13268 