### PR TITLE
Fix link to Mongo docker image

### DIFF
--- a/docs/architecture/microservices/microservice-ddd-cqrs-patterns/nosql-database-persistence-infrastructure.md
+++ b/docs/architecture/microservices/microservice-ddd-cqrs-patterns/nosql-database-persistence-infrastructure.md
@@ -327,7 +327,7 @@ services:
   <https://hub.docker.com/r/microsoft/azure-cosmosdb-emulator/>
 
 - **The MongoDB Docker image (Linux and Windows Container)**  \
-  <https://hub.docker.com/\_/mongo/>
+  <https://hub.docker.com/_/mongo/>
 
 - **Use MongoChef (Studio 3T) with an Azure Cosmos DB: API for MongoDB account**  \
   <https://docs.microsoft.com/azure/cosmos-db/mongodb-mongochef>


### PR DESCRIPTION
Hello,

## Summary

There was a typo in the link of the Mongo docker image, there was an extra backslash.
Thanks for considering the merge. 😄 