### PR TITLE
Add reference to IDataView Type System post

### DIFF
--- a/docs/machine-learning/how-does-mldotnet-work.md
+++ b/docs/machine-learning/how-does-mldotnet-work.md
@@ -1,7 +1,7 @@
 ---
 title: What is ML.NET and how does it work?
 description: ML.NET gives you the ability to add machine learning to .NET applications, in either online or offline scenarios. With this capability, you can make automatic predictions using the data available to your application without having to be connected to a network to use ML.NET. This article explains the basics of machine learning in ML.NET. 
-ms.date: 07/17/2019
+ms.date: 08/26/2019
 ms.topic: overview
 ms.custom: mvc
 ms.author: nakersha
@@ -225,7 +225,7 @@ The `CreatePredictionEngine()` method takes an input class and an output class. 
 
 At the core of an ML.NET machine learning pipeline are [DataView](xref:Microsoft.ML.IDataView) objects.
 
-Each transformation in the pipeline has an input schema (data names, types, and sizes that the transform expects to see on its input); and an output schema (data names, types, and sizes that the transform produces after the transformation). 
+Each transformation in the pipeline has an input schema (data names, types, and sizes that the transform expects to see on its input); and an output schema (data names, types, and sizes that the transform produces after the transformation). The following document provides an in-depth explanation of the [IDataView interface and its type system](https://xadupre.github.io/machinelearningext/mlnetdocs/idataviewtypesystem.html).
 
 If the output schema from one transform in the pipeline doesn't match the input schema of the next transform, ML.NET will throw an exception.
 

--- a/docs/machine-learning/resources/index.md
+++ b/docs/machine-learning/resources/index.md
@@ -2,7 +2,7 @@
 title: Machine learning resources 
 description: Explore these ML.NET resources to assist with custom AI solutions creation and integration into your .NET applications.
 ms.custom: seodec18
-ms.date: 03/01/2019
+ms.date: 08/26/2019
 ---
 # Machine learning resources 
 
@@ -11,4 +11,5 @@ The following  [ML.NET](../index.yml) resources may be helpful to build custom A
 - [Machine learning glossary](glossary.md): contains important machine learning term definitions.
 - [Machine learning basics](basics.md): provides links to learning resources to get started with machine learning.
 - [Machine learning tasks](tasks.md): describes various machine learning usage scenarios supported by ML.NET.
+- [IDataView Type System](https://xadupre.github.io/machinelearningext/mlnetdocs/idataviewtypesystem.html): provides an in-depth explanation of the [IDataView](xref:Microsoft.ML.IDataView) interface and its type system.
 - [Data transforms](transforms.md): provides the overview of data transforms supported by ML.NET.

--- a/docs/machine-learning/resources/index.md
+++ b/docs/machine-learning/resources/index.md
@@ -11,5 +11,5 @@ The following  [ML.NET](../index.yml) resources may be helpful to build custom A
 - [Machine learning glossary](glossary.md): contains important machine learning term definitions.
 - [Machine learning basics](basics.md): provides links to learning resources to get started with machine learning.
 - [Machine learning tasks](tasks.md): describes various machine learning usage scenarios supported by ML.NET.
-- [IDataView Type System](https://xadupre.github.io/machinelearningext/mlnetdocs/idataviewtypesystem.html): provides an in-depth explanation of the [IDataView](xref:Microsoft.ML.IDataView) interface and its type system.
+- [IDataView type system](https://xadupre.github.io/machinelearningext/mlnetdocs/idataviewtypesystem.html): provides an in-depth explanation of the [IDataView](xref:Microsoft.ML.IDataView) interface and its type system.
 - [Data transforms](transforms.md): provides the overview of data transforms supported by ML.NET.


### PR DESCRIPTION
Add reference to IDataView Type System [post](https://xadupre.github.io/machinelearningext/mlnetdocs/idataviewtypesystem.html) to overview and resources pages.

[Overview Preview Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/how-does-mldotnet-work?branch=pr-en-us-14031)
[Resources Preview Link](https://review.docs.microsoft.com/en-us/dotnet/machine-learning/resources/index?branch=pr-en-us-14031)

Fixes #13732 
