### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/docs/framework/tools/signtool-exe.md
+++ b/docs/framework/tools/signtool-exe.md
@@ -164,7 +164,7 @@ signtool sign /f MyCert.pfx /p MyPassword MyFile.exe
  The following command digitally signs and time-stamps a file. The certificate used to sign the file is stored in a PFX file.  
   
 ```  
-signtool sign /f MyCert.pfx /t http://timestamp.verisign.com/scripts/timstamp.dll MyFile.exe  
+signtool sign /f MyCert.pfx /t http://timestamp.digicert.com MyFile.exe  
 ```  
   
  The following command signs a file by using a certificate located in the `My` store that has a subject name of `My Company Certificate`.  
@@ -182,7 +182,7 @@ Signtool sign /f MyCert.pfx /d: "MyControl" /du http://www.example.com/MyControl
  The following command time-stamps a file that has already been digitally signed.  
   
 ```  
-signtool timestamp /t http://timestamp.verisign.com/scripts/timstamp.dll MyFile.exe  
+signtool timestamp /t http://timestamp.digicert.com MyFile.exe  
 ```  
   
  The following command verifies that a file has been signed.  


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
