### PR TITLE
Restore config file hierarchy and links

### DIFF
--- a/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
@@ -15,10 +15,10 @@ ms.assetid: 7a151659-b803-4c27-b5ce-1c4aa0d5a823
 
 Specifies the compiler configuration attributes for a language provider.
 
-\<configuration Element>
-\<system.codedom Element>
-\<compilers Element>
-\<compiler> Element
+[**\<configuration>**](../configuration-element.md)   
+&nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<compilers>**](compilers-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<compiler>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/compiler-element.md
@@ -15,7 +15,7 @@ ms.assetid: 7a151659-b803-4c27-b5ce-1c4aa0d5a823
 
 Specifies the compiler configuration attributes for a language provider.
 
-[**\<configuration>**](../configuration-element.md)   
+[**\<configuration>**](../configuration-element.md)  
 &nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<compilers>**](compilers-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<compiler>**  

--- a/docs/framework/configure-apps/file-schema/compiler/compilers-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/compilers-element.md
@@ -13,7 +13,7 @@ ms.assetid: d40fba59-98f9-4783-ae0c-2ebea27ce77b
 # \<compilers> Element
 Container for compiler configuration elements; contains zero or more [\<compiler>](compiler-element.md) elements.  
   
-[**\<configuration>**](../configuration-element.md)   
+[**\<configuration>**](../configuration-element.md)  
 &nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;**\<compilers>**  
   

--- a/docs/framework/configure-apps/file-schema/compiler/compilers-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/compilers-element.md
@@ -13,9 +13,9 @@ ms.assetid: d40fba59-98f9-4783-ae0c-2ebea27ce77b
 # \<compilers> Element
 Container for compiler configuration elements; contains zero or more [\<compiler>](compiler-element.md) elements.  
   
- \<configuration>  
-\<system.codedom>  
-\<compilers> Element  
+[**\<configuration>**](../configuration-element.md)   
+&nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;**\<compilers>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/compiler/index.md
+++ b/docs/framework/configure-apps/file-schema/compiler/index.md
@@ -17,7 +17,7 @@ Compiler and language provider settings specify compiler configuration elements 
   
 The .NET Framework defines the initial compiler settings in the machine configuration file (Machine.config). Developers and compiler vendors can add configuration settings for a new <xref:System.CodeDom.Compiler.CodeDomProvider> implementation. Use the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo%2A?displayProperty=nameWithType> method to programmatically enumerate language provider and compiler configuration settings on a computer.  
   
-[**\<configuration>**](../configuration-element.md)   
+[**\<configuration>**](../configuration-element.md)  
 &nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<compilers>**](compilers-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<compiler>**](compiler-element.md)  

--- a/docs/framework/configure-apps/file-schema/compiler/index.md
+++ b/docs/framework/configure-apps/file-schema/compiler/index.md
@@ -15,15 +15,12 @@ ms.assetid: c020b139-8699-4f0d-9ac9-70d0c5b2a8c8
 # Compiler and Language Provider Settings Schema
 Compiler and language provider settings specify compiler configuration elements for available language providers. Each compiler configuration element specifies the code provider type name, compiler parameters, supported language names, and supported file extensions.  
   
- The .NET Framework defines the initial compiler settings in the machine configuration file (Machine.config). Developers and compiler vendors can add configuration settings for a new <xref:System.CodeDom.Compiler.CodeDomProvider> implementation. Use the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo%2A?displayProperty=nameWithType> method to programmatically enumerate language provider and compiler configuration settings on a computer.  
+The .NET Framework defines the initial compiler settings in the machine configuration file (Machine.config). Developers and compiler vendors can add configuration settings for a new <xref:System.CodeDom.Compiler.CodeDomProvider> implementation. Use the <xref:System.CodeDom.Compiler.CodeDomProvider.GetAllCompilerInfo%2A?displayProperty=nameWithType> method to programmatically enumerate language provider and compiler configuration settings on a computer.  
   
- [\<configuration> Element](../configuration-element.md)  
-  
- [\<system.codedom>](system-codedom-element.md)  
-  
- [\<compilers>](compilers-element.md)  
-  
- [\<compiler>](compiler-element.md)  
+[**\<configuration>**](../configuration-element.md)   
+&nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<compilers>**](compilers-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<compiler>**](compiler-element.md)  
   
 |Element|Description|  
 |-------------|-----------------|  

--- a/docs/framework/configure-apps/file-schema/compiler/provideroption-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/provideroption-element.md
@@ -12,11 +12,11 @@ ms.assetid: 014f2e0b-c0b5-4fc4-92d3-73f02978b2a1
 # \<providerOption> Element
 Specifies the compiler version attributes for a language provider.  
   
- \<configuration Element>  
-\<system.codedom Element>  
-\<compilers Element>  
-\<compiler> Element  
-\<providerOption> Element  
+[**\<configuration>**](../configuration-element.md)   
+&nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<compilers>**](compilers-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<compiler>**](compiler-element.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\<providerOption>  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/compiler/provideroption-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/provideroption-element.md
@@ -12,11 +12,11 @@ ms.assetid: 014f2e0b-c0b5-4fc4-92d3-73f02978b2a1
 # \<providerOption> Element
 Specifies the compiler version attributes for a language provider.  
   
-[**\<configuration>**](../configuration-element.md)   
+[**\<configuration>**](../configuration-element.md)  
 &nbsp;&nbsp;[**\<system.codedom>**](system-codedom-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<compilers>**](compilers-element.md)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<compiler>**](compiler-element.md)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\<providerOption>  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<providerOption>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/compiler/system-codedom-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/system-codedom-element.md
@@ -13,7 +13,7 @@ ms.assetid: 672a68f7-e69f-4479-ac30-e980085ec4fe
 # \<system.codedom> Element
 Specifies compiler configuration settings for available language providers.  
   
-[**\<configuration>**](../configuration-element.md)   
+[**\<configuration>**](../configuration-element.md)  
 &nbsp;&nbsp;**\<system.codedom>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/compiler/system-codedom-element.md
+++ b/docs/framework/configure-apps/file-schema/compiler/system-codedom-element.md
@@ -13,8 +13,8 @@ ms.assetid: 672a68f7-e69f-4479-ac30-e980085ec4fe
 # \<system.codedom> Element
 Specifies compiler configuration settings for available language providers.  
   
- \<configuration> Element  
-\<system.codedom> Element  
+[**\<configuration>**](../configuration-element.md)   
+&nbsp;&nbsp;**\<system.codedom>**  
   
 ## Syntax  
   


### PR DESCRIPTION
Used the formatting used in root folder and applied it to the `/framework/configure-apps/file-schema/compiler/` one

Contributes to #2038

