### PR TITLE
Re-apply XML formatting to runtime configuration section

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/add-element-for-namedcaches.md
+++ b/docs/framework/configure-apps/file-schema/runtime/add-element-for-namedcaches.md
@@ -9,10 +9,11 @@ ms.assetid: ce2a63a8-c829-4742-a6ea-72ee5d89f169
 # \<add> Element for \<namedCaches>
 Adds a `namedCache` entry to the `namedCaches` collection for a memory cache.  
   
- \<system.runtime.caching>  
-\<memoryCache>  
-\<namedCaches>  
-\<add>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.runtime.caching>**](system-runtime-caching-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<memoryCache>**](memorycache-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<namedCaches>**](namedcaches-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<add>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/alwaysflowimpersonationpolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/alwaysflowimpersonationpolicy-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<alwaysFlowImpersonationPolicy> Element
 Specifies that the Windows identity always flows across asynchronous points, regardless of how impersonation was performed.  
   
- \<configuration>  
-\<runtime>  
-\<alwaysFlowImpersonationPolicy>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<alwaysFlowImpersonationPolicy>**\  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<AppContextSwitchOverrides> Element
 Defines one or more switches used by the <xref:System.AppContext> class to provide an opt-out mechanism for new functionality.  
   
- \<configuration>  
- \<runtime>  
-\<AppContextSwitchOverrides>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<AppContextSwitchOverrides>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/appdomainmanagerassembly-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appdomainmanagerassembly-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<appDomainManagerAssembly> Element
 Specifies the assembly that provides the application domain manager for the default application domain in the process.  
   
- \<configuration>  
-\<runtime>  
-\<appDomainManagerAssembly>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<appDomainManagerAssembly>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/appdomainmanagertype-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appdomainmanagertype-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<appDomainManagerType> Element
 Specifies the type that serves as the application domain manager for the default application domain.  
   
- \<configuration>  
-\<runtime>  
-\<appDomainManagerType>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<appDomainManagerType>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/appdomainresourcemonitoring-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appdomainresourcemonitoring-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<appDomainResourceMonitoring> Element
 Instructs the runtime to collect statistics on all application domains in the process for the life of the process.  
   
- \<configuration>  
-\<runtime>  
-\<appDomainResourceMonitoring>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<appDomainResourceMonitoring>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/assemblybinding-element-for-runtime.md
+++ b/docs/framework/configure-apps/file-schema/runtime/assemblybinding-element-for-runtime.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<assemblyBinding> Element for \<runtime>
 Contains information about assembly version redirection and the locations of assemblies.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<assemblyBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/assemblyidentity-element-for-runtime.md
+++ b/docs/framework/configure-apps/file-schema/runtime/assemblyidentity-element-for-runtime.md
@@ -13,11 +13,11 @@ ms.assetid: cea4d187-6398-4da4-af09-c1abc6a349c1
 # \<assemblyIdentity> Element for \<runtime>
 Contains identifying information about the assembly.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
-\<dependentAssembly>  
-\<assemblyIdentity>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<dependentAssembly>**](dependentassembly-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<assemblyIdentity>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/bindingredirect-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/bindingredirect-element.md
@@ -13,11 +13,11 @@ ms.assetid: 67784ecd-9663-434e-bd6a-26975e447ac0
 # \<bindingRedirect> Element
 Redirects one assembly version to another.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
-\<dependentAssembly>  
-\<bindingRedirect>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<dependentAssembly>**](dependentassembly-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<bindingRedirect>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/bypasstrustedappstrongnames-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/bypasstrustedappstrongnames-element.md
@@ -13,9 +13,9 @@ ms.author: "ronpet"
 # \<bypassTrustedAppStrongNames> Element
 Specifies whether to bypass the validation of strong names on full-trust assemblies that are loaded into a full-trust <xref:System.AppDomain>.  
   
- \<configuration>  
-\<runtime>  
-\<bypassTrustedAppStrongNames>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<bypassTrustedAppStrongNames>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/clear-element-for-namedcaches.md
+++ b/docs/framework/configure-apps/file-schema/runtime/clear-element-for-namedcaches.md
@@ -9,10 +9,11 @@ ms.assetid: ea01a858-65da-4348-800f-5e3df59d4d79
 # \<clear> Element for \<namedCaches>
 Clears all `namedCache` entries in the `namedCaches` collection for a memory cache.  
   
- \<system.runtime.caching>  
-\<memoryCache>  
-\<namedCaches>  
-\<add>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.runtime.caching>**](system-runtime-caching-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<memoryCache>**](memorycache-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<namedCaches>**](namedcaches-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<clear>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/codebase-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/codebase-element.md
@@ -15,11 +15,11 @@ ms.assetid: d48a3983-2297-43ff-a14d-1f29d3995822
 
 Specifies where the common language runtime can find an assembly.
 
-\<configuration>
-\<runtime>
-\<assemblyBinding>
-\<dependentAssembly>
-\<codeBase>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<dependentAssembly>**](dependentassembly-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\<codeBase>
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/codebase-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/codebase-element.md
@@ -19,7 +19,7 @@ Specifies where the common language runtime can find an assembly.
 &nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<dependentAssembly>**](dependentassembly-element.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\<codeBase>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<codeBase>**
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/compatsortnlsversion-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/compatsortnlsversion-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<CompatSortNLSVersion> Element
 Specifies that the runtime should use legacy sort orders when performing string comparisons.  
   
- \<configuration>  
-\<runtime>  
-\<CompatSortNLSVersion> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<CompatSortNLSVersion>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/crst-disablespinwait-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/crst-disablespinwait-element.md
@@ -12,9 +12,9 @@ ms.author: "ronpet"
 
 Specifies whether to disable spin-waiting for a critical section when contended.  
   
- \<configuration>  
-\<runtime>  
-\<Crst_DisableSpinWait>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<Crst_DisableSpinWait>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/dependentassembly-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/dependentassembly-element.md
@@ -15,10 +15,10 @@ ms.author: "ronpet"
 # \<dependentAssembly> Element
 Encapsulates binding policy and assembly location for each assembly. Use one `dependentAssembly` element for each assembly.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
-\<dependentAssembly>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<dependentAssembly>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/developmentmode-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/developmentmode-element.md
@@ -15,9 +15,9 @@ ms.author: "ronpet"
 # \<developmentMode> Element
 Specifies whether the runtime searches for assemblies in directories specified by the DEVPATH environment variable.  
   
- \<configuration>  
-\<runtime>  
-\<developmentMode>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<developmentMode>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/disablecachingbindingfailures-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/disablecachingbindingfailures-element.md
@@ -16,9 +16,9 @@ ms.author: "ronpet"
 # \<disableCachingBindingFailures> Element
 Specifies whether to disable the caching of binding failures that occur because the assembly was not found by probing.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<disableCachingBindingFailures>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<disableCachingBindingFailures>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/disablecommitthreadstack-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/disablecommitthreadstack-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<disableCommitThreadStack> Element
 Specifies whether the full thread stack is committed when a thread is started.  
   
- \<configuration>  
-\<runtime>  
-\<disableCommitThreadStack>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<disableCommitThreadStack>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/disablefusionupdatesfromadmanager-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/disablefusionupdatesfromadmanager-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<disableFusionUpdatesFromADManager> Element
 Specifies whether the default behavior, which is to allow the runtime host to override configuration settings for an application domain, is disabled.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<disableFusionUpdatesFromADManager>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<disableFusionUpdatesFromADManager>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/enableampmparseadjustment-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/enableampmparseadjustment-element.md
@@ -8,9 +8,9 @@ ms.author: "ronpet"
 # \<EnableAmPmParseAdjustment> Element
 Determines whether date and time parsing methods use an adjusted set of rules to parse date strings that contain a day, month, hour, and AM/PM designator.  
   
- \<configuration>  
- \<runtime>  
-\<EnableAmPmParseAdjustment>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<EnableAmPmParseAdjustment>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/enforcefipspolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/enforcefipspolicy-element.md
@@ -13,9 +13,9 @@ ms.author: "ronpet"
 # \<enforceFIPSPolicy> Element
 Specifies whether to enforce a computer configuration requirement that cryptographic algorithms must comply with the Federal Information Processing Standards (FIPS).  
   
- \<configuration> Element  
-\<runtime> Element  
-\<enforceFIPSPolicy> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<enforceFIPSPolicy>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/etwenable-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/etwenable-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<etwEnable> Element
 Specifies whether to enable event tracing for Windows (ETW) for common language runtime events.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<etwEnabled>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<etwEnabled>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/forceperformancecounteruniquesharedmemoryreads-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/forceperformancecounteruniquesharedmemoryreads-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<forcePerformanceCounterUniqueSharedMemoryReads> Element
 Specifies whether PerfCounter.dll uses the CategoryOptions registry setting in a .NET Framework version 1.1 application to determine whether to load performance counter data from category-specific shared memory or global memory.  
   
- \<configuration>  
-\<runtime>  
-\<forcePerformanceCounterUniqueSharedMemoryReads>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<forcePerformanceCounterUniqueSharedMemoryReads>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<gcAllowVeryLargeObjects> Element
 On 64-bit platforms, enables arrays that are greater than 2 gigabytes (GB) in total size.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<gcAllowVeryLargeObjects> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<gcAllowVeryLargeObjects>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/gcconcurrent-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/gcconcurrent-element.md
@@ -16,9 +16,9 @@ ms.author: "ronpet"
 
 Specifies whether the common language runtime runs garbage collection on a separate thread.
 
-\<configuration>\
-\<runtime>\
-\<gcConcurrent>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<gcConcurrent>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/gccpugroup-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/gccpugroup-element.md
@@ -12,9 +12,9 @@ ms.author: "ronpet"
 
 Specifies whether garbage collection supports multiple CPU groups.
 
-\<configuration>\
-\<runtime>\
-\<GCCpuGroup>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<GCCpuGroup>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/gcserver-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/gcserver-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<gcServer> Element
 Specifies whether the common language runtime runs server garbage collection.  
   
- \<configuration>  
-\<runtime>  
-\<gcServer>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<gcServer>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/generatepublisherevidence-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<generatePublisherEvidence> Element
 Specifies whether the runtime creates <xref:System.Security.Policy.Publisher> evidence for code access security (CAS).  
   
- \<configuration>  
-\<runtime>  
-\<generatePublisherEvidence>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<generatePublisherEvidence>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/index.md
+++ b/docs/framework/configure-apps/file-schema/runtime/index.md
@@ -27,9 +27,10 @@ Runtime settings are used by the common language runtime to configure applicatio
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<assemblyIdentity>](assemblyidentity-element-for-runtime.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<bindingRedirect>](bindingredirect-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<codeBase>](codebase-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<publisherPolicy>](publisherpolicy-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<probing>](probing-element.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<publisherPolicy>](publisherpolicy-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<qualifyAssembly>](qualifyassembly-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<supportPortability>](supportportability-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<bypassTrustedAppStrongNames>](bypasstrustedappstrongnames-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<CompatSortNLSVersion>](compatsortnlsversion-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<developmentMode>](developmentmode-element.md)\
@@ -54,21 +55,18 @@ Runtime settings are used by the common language runtime to configure applicatio
 &nbsp;&nbsp;&nbsp;&nbsp;[\<PreferComInsteadOfManagedRemoting>](prefercominsteadofmanagedremoting-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<relativeBindForResources>](relativebindforresources-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<shadowCopyVerifyByTimeStamp>](shadowcopyverifybytimestamp-element.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;[\<supportPortability>](supportportability-element.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;[\<system.runtime.caching>](system-runtime-caching-element-cache-settings.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<memoryCache>](memorycache-element-cache-settings.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<namedCaches>](namedcaches-element-cache-settings.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<add>](add-element-for-namedcaches.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<clear>](clear-element-for-namedcaches.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<remove>](remove-element-for-namedcaches.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<Thread_UseAllCpuGroups>](thread-useallcpugroups-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<ThrowUnobservedTaskExceptions>](throwunobservedtaskexceptions-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<TimeSpan_LegacyFormatMode>](runtime-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<useLegacyJit>](uselegacyjit-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<UseRandomizedStringHashAlgorithm>](userandomizedstringhashalgorithm-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;[\<UseSmallInternalThreadStacks>](usesmallinternalthreadstacks-element.md)\
-&nbsp;&nbsp;\<\runtime>\
-\<\configuration>
+&nbsp;&nbsp;[\<system.runtime.caching>](system-runtime-caching-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[\<memoryCache>](memorycache-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<namedCaches>](namedcaches-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<add>](add-element-for-namedcaches.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<clear>](clear-element-for-namedcaches.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[\<remove>](remove-element-for-namedcaches.md)  
 
 ## Alphabetical list of \<runtime> elements
 

--- a/docs/framework/configure-apps/file-schema/runtime/legacycorruptedstateexceptionspolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/legacycorruptedstateexceptionspolicy-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<legacyCorruptedStateExceptionsPolicy> Element
 Specifies whether the common language runtime allows managed code to catch access violations and other corrupted state exceptions.  
   
- \<configuration>  
-\<runtime>  
-\<legacyCorruptedStateExceptionsPolicy>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<legacyCorruptedStateExceptionsPolicy>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/legacyimpersonationpolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/legacyimpersonationpolicy-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<legacyImpersonationPolicy> Element
 Specifies that the Windows identity does not flow across asynchronous points, regardless of the flow settings for the execution context on the current thread.  
   
- \<configuration>  
-\<runtime>  
-\<legacyImpersonationPolicy>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<legacyImpersonationPolicy>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/loadfromremotesources-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/loadfromremotesources-element.md
@@ -14,9 +14,9 @@ Specifies whether assemblies loaded from remote sources should be granted full t
 > [!NOTE]
 > If you were directed to this article because of an error message in the Visual Studio project error list or a build error, see [How to: Use an Assembly from the Web in Visual Studio](https://docs.microsoft.com/previous-versions/visualstudio/visual-studio-2010/ee890038(v=vs.100)).  
   
- \<configuration>  
-\<runtime>  
-\<loadFromRemoteSources>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<loadFromRemoteSources>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md
+++ b/docs/framework/configure-apps/file-schema/runtime/memorycache-element-cache-settings.md
@@ -10,9 +10,9 @@ ms.assetid: 182a622f-f7cf-472d-9d0b-451d2fd94525
 # \<memoryCache> Element (Cache Settings)
 Defines an element that is used to configure a cache that is based on the <xref:System.Runtime.Caching.MemoryCache> class. The <xref:System.Runtime.Caching.Configuration.MemoryCacheElement> class defines a [memoryCache](memorycache-element-cache-settings.md) element that you can use to configure the cache. Multiple instances of the <xref:System.Runtime.Caching.MemoryCache> class can be used in a single application. Each `memoryCache` element in the configuration file can contain settings for a named <xref:System.Runtime.Caching.MemoryCache> instance.  
   
- \<configuration>  
-\<system.runtime.caching>  
-\<memoryCache>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.runtime.caching>**](system-runtime-caching-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<memoryCache>**  
   
 ## Syntax  
   
@@ -49,6 +49,7 @@ Defines an element that is used to configure a cache that is based on the <xref:
   
 |Element|Description|  
 |-------------|-----------------|  
+|[\<configuration>](../configuration-element.md)|Specifies the root element in every configuration file that is used by the common language runtime and .NET Framework applications.|  
 |[\<system.runtime.caching>](system-runtime-caching-element-cache-settings.md)|Contains types that let you implement output caching in applications that are built into the .NET Framework.|  
   
 ## Remarks  

--- a/docs/framework/configure-apps/file-schema/runtime/namedcaches-element-cache-settings.md
+++ b/docs/framework/configure-apps/file-schema/runtime/namedcaches-element-cache-settings.md
@@ -10,10 +10,10 @@ ms.assetid: 6bd4fbc5-55a6-4dc4-998b-cdcc7e023330
 # \<namedCaches> Element (Cache Settings)
 Specifies a collection of configuration settings for the named <xref:System.Runtime.Caching.MemoryCache> instances. The <xref:System.Runtime.Caching.Configuration.MemoryCacheSection.NamedCaches%2A> property references the collection of configuration settings from one or more `namedCaches` elements of the configuration file.  
   
- \<configuration>  
-\< system.runtime.caching>  
-\<memoryCache>  
-\<namedCaches>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.runtime.caching>**](system-runtime-caching-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<memoryCache>**](memorycache-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<namedCaches>**  
   
 ## Syntax  
   
@@ -50,7 +50,9 @@ Specifies a collection of configuration settings for the named <xref:System.Runt
   
 |Element|Description|  
 |-------------|-----------------|  
+|[\<configuration>](../configuration-element.md)|Specifies the root element in every configuration file that is used by the common language runtime and .NET Framework applications.|  
 |[\<memoryCache>](memorycache-element-cache-settings.md)|Defines an element that is used to configure a cache that is based on the <xref:System.Runtime.Caching.MemoryCache> class.|  
+|[\<system.runtime.caching>](system-runtime-caching-element-cache-settings.md)|Contains types that let you implement output caching in applications that are built into the .NET Framework.|  
   
 ## Remarks  
  The memory cache configuration section of the Web.config file can contain `add`, `remove`, and `clear` attributes for the `namedCaches` collection. Each `namedCaches` entry is uniquely identified by the `name` attribute.  

--- a/docs/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/netfx40-legacysecuritypolicy-element.md
@@ -12,9 +12,9 @@ ms.author: "ronpet"
 
 Specifies whether the runtime uses legacy code access security (CAS) policy.
 
-\<configuration>\
-\<runtime>\
-\<NetFx40_LegacySecurityPolicy>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<NetFx40_LegacySecurityPolicy>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/netfx40-pinvokestackresilience-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/netfx40-pinvokestackresilience-element.md
@@ -12,9 +12,9 @@ ms.author: "ronpet"
 
 Specifies whether the runtime automatically fixes incorrect platform invoke declarations at run time, at the cost of slower transitions between managed and unmanaged code.
 
-\<configuration>\
-\<runtime>\
-\<NetFx40_PInvokeStackResilience>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<NetFx40_PInvokeStackResilience>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/netfx45-cultureawarecomparergethashcode-longstrings-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/netfx45-cultureawarecomparergethashcode-longstrings-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 
 Specifies whether the runtime uses a fixed amount of memory to calculate hash codes for the <xref:System.StringComparer.GetHashCode%2A?displayProperty=nameWithType> method.
 
-\<configuration>\
-\<runtime>\
-\<NetFx45_CultureAwareComparerGetHashCode_LongStrings>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<NetFx45_CultureAwareComparerGetHashCode_LongStrings>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/prefercominsteadofmanagedremoting-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/prefercominsteadofmanagedremoting-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<PreferComInsteadOfManagedRemoting> Element
 Specifies whether the runtime will use COM interop instead of remoting for all calls across application domain boundaries.  
   
- \<configuration>  
-\<runtime>  
-\<PreferComInsteadOfManagedRemoting>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<PreferComInsteadOfManagedRemoting>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/probing-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/probing-element.md
@@ -15,10 +15,10 @@ ms.author: "ronpet"
 # \<probing> Element
 Specifies application base subdirectories for the common language runtime to search when loading assemblies.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
-\<probing>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<probing>**  
   
 ## Syntax  
   
@@ -36,7 +36,8 @@ Specifies application base subdirectories for the common language runtime to sea
 |`privatePath`|Required attribute.<br /><br /> Specifies subdirectories of the application's base directory that might contain assemblies. Delimit each subdirectory with a semicolon.|  
   
 ### Child Elements  
- None.  
+
+None.  
   
 ### Parent Elements  
   

--- a/docs/framework/configure-apps/file-schema/runtime/publisherpolicy-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/publisherpolicy-element.md
@@ -16,11 +16,11 @@ ms.author: "ronpet"
 # \<publisherPolicy> Element
 Specifies whether the runtime applies publisher policy.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
-\<dependentAssembly>  
-\<publisherPolicy>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<dependentAssembly>**](dependentassembly-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<publisherPolicy>**  
   
 ## Syntax  
   
@@ -45,13 +45,16 @@ Specifies whether the runtime applies publisher policy.
 |`no`|Does not apply publisher policy.|  
   
 ### Child Elements  
- None.  
+
+None.  
   
 ### Parent Elements  
   
 |Element|Description|  
 |-------------|-----------------|  
+|`assemblyBinding`|Contains information about assembly version redirection and the locations of assemblies.|  
 |`configuration`|The root element in every configuration file used by the common language runtime and .NET Framework applications.|  
+|`dependentAssembly`|Encapsulates binding policy and assembly location for each assembly. Use one `<dependentAssembly>` element for each assembly.|  
 |`runtime`|Contains information about assembly binding and garbage collection.|  
   
 ## Remarks  

--- a/docs/framework/configure-apps/file-schema/runtime/qualifyassembly-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/qualifyassembly-element.md
@@ -15,10 +15,10 @@ ms.author: "ronpet"
 # \<qualifyAssembly> Element
 Specifies the full name of the assembly that should be dynamically loaded when a partial name is used.  
   
- \<configuration>  
-\<runtime>  
-\<assemblyBinding>  
-\<qualifyAssembly>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<qualifyAssembly>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/relativebindforresources-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/relativebindforresources-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<relativeBindForResources> Element
 Optimizes the probe for satellite assemblies.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<relativeBindForResources> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<relativeBindForResources>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/remove-element-for-namedcaches.md
+++ b/docs/framework/configure-apps/file-schema/runtime/remove-element-for-namedcaches.md
@@ -9,10 +9,11 @@ ms.assetid: 24211ea5-163e-4fe5-aed8-004d8499760c
 # \<remove> Element for \<namedCaches>
 Removes a named cache entry from the `namedCaches` collection for a memory cache.  
   
- \<system.runtime.caching>  
-\<memoryCache>  
-\<namedCaches>  
-\<remove>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.runtime.caching>**](system-runtime-caching-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<memoryCache>**](memorycache-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<namedCaches>**](namedcaches-element-cache-settings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<remove>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/runtime-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/runtime-element.md
@@ -14,8 +14,8 @@ ms.assetid: 1eb2fae3-de4b-45b6-852f-517c39b751bd
 
 Provides information used by the common language runtime to configure applications.
 
-\<configuration>\
-\<runtime>
+[**\<configuration>**](../configuration-element.md)  
+&nbsp;&nbsp;**\<runtime>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/shadowcopyverifybytimestamp-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/shadowcopyverifybytimestamp-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<shadowCopyVerifyByTimestamp> Element
 Specifies whether shadow copying uses the default startup behavior introduced in the .NET Framework 4, or reverts to the startup behavior of earlier versions of the .NET Framework.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<shadowCopyVerifyByTimestamp> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<shadowCopyVerifyByTimestamp>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/supportportability-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/supportportability-element.md
@@ -11,10 +11,10 @@ ms.author: "ronpet"
 # \<supportPortability> Element
 Specifies that an application can reference the same assembly in two different implementations of the .NET Framework, by disabling the default behavior that treats the assemblies as equivalent for application portability purposes.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<assemblyBinding> Element  
-\<supportPortability> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<assemblyBinding>**](assemblybinding-element-for-runtime.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<supportPortability>**  
   
 ## Syntax  
   
@@ -23,7 +23,8 @@ Specifies that an application can reference the same assembly in two different i
 ```  
   
 ## Attributes and Elements  
- The following sections describe attributes, child elements, and parent elements.  
+
+The following sections describe attributes, child elements, and parent elements.  
   
 ### Attributes  
   
@@ -40,7 +41,8 @@ Specifies that an application can reference the same assembly in two different i
 |false|Disable support for portability between implementations of the specified .NET Framework assembly. This enables the application to have references to multiple implementations of the specified assembly.|  
   
 ### Child Elements  
- None.  
+
+None.  
   
 ### Parent Elements  
   
@@ -51,15 +53,17 @@ Specifies that an application can reference the same assembly in two different i
 |`assemblyBinding`|Contains information about assembly version redirection and the locations of assemblies.|  
   
 ## Remarks  
- Beginning with the .NET Framework 4, support is automatically provided for applications that can use either of two implementations of the .NET Framework, for example either the .NET Framework implementation or the .NET Framework for Silverlight implementation. The two implementations of a particular .NET Framework assembly are seen as equivalent by the assembly binder. In a few scenarios, this application portability feature causes problems. In those scenarios, the `<supportPortability>` element can be used to disable the feature.  
+
+Beginning with the .NET Framework 4, support is automatically provided for applications that can use either of two implementations of the .NET Framework, for example either the .NET Framework implementation or the .NET Framework for Silverlight implementation. The two implementations of a particular .NET Framework assembly are seen as equivalent by the assembly binder. In a few scenarios, this application portability feature causes problems. In those scenarios, the `<supportPortability>` element can be used to disable the feature.  
   
- One such scenario is an assembly that has to reference both the .NET Framework implementation and the .NET Framework for Silverlight implementation of a particular reference assembly. For example, a XAML designer written in Windows Presentation Foundation (WPF) might need to reference both the WPF Desktop implementation, for the designer's user interface, and the subset of WPF that is included in the Silverlight implementation. By default, the separate references cause a compiler error, because assembly binding sees the two assemblies as equivalent. This element disables the default behavior, and allows compilation to succeed.  
+One such scenario is an assembly that has to reference both the .NET Framework implementation and the .NET Framework for Silverlight implementation of a particular reference assembly. For example, a XAML designer written in Windows Presentation Foundation (WPF) might need to reference both the WPF Desktop implementation, for the designer's user interface, and the subset of WPF that is included in the Silverlight implementation. By default, the separate references cause a compiler error, because assembly binding sees the two assemblies as equivalent. This element disables the default behavior, and allows compilation to succeed.  
   
 > [!IMPORTANT]
 > In order for the compiler to pass the information to the common language runtime's assembly-binding logic, you must use the `/appconfig` compiler option to specify the location of the app.config file that contains this element.  
   
 ## Example  
- The following example enables an application to have references to both the .NET Framework implementation and the .NET Framework for Silverlight implementation of any .NET Framework assembly that exists in both implementations. The `/appconfig` compiler option must be used to specify the location of this app.config file.  
+
+The following example enables an application to have references to both the .NET Framework implementation and the .NET Framework for Silverlight implementation of any .NET Framework assembly that exists in both implementations. The `/appconfig` compiler option must be used to specify the location of this app.config file.  
   
 ```xml  
 <configuration>  

--- a/docs/framework/configure-apps/file-schema/runtime/system-runtime-caching-element-cache-settings.md
+++ b/docs/framework/configure-apps/file-schema/runtime/system-runtime-caching-element-cache-settings.md
@@ -13,8 +13,8 @@ ms.author: "ronpet"
 
 Provides configuration for the default in-memory <xref:System.Runtime.Caching.ObjectCache> implementation through the `memoryCache` entry in the configuration file.  
   
- \<configuration>  
-\<system.runtime.caching>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;**\<system.runtime.caching>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/thread-useallcpugroups-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/thread-useallcpugroups-element.md
@@ -9,9 +9,9 @@ ms.author: "ronpet"
 
 Specifies whether the runtime distributes managed threads across all CPU groups.
 
-\<configuration>\
-\<runtime>\
-\<Thread_UseAllCpuGroups>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<Thread_UseAllCpuGroups>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/throwunobservedtaskexceptions-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/throwunobservedtaskexceptions-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<ThrowUnobservedTaskExceptions> Element
 Specifies whether unhandled task exceptions should terminate a running process.  
   
- \<configuration>  
-\<runtime>  
-\<ThrowUnobservedTaskExceptions>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<ThrowUnobservedTaskExceptions>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/timespan-legacyformatmode-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/timespan-legacyformatmode-element.md
@@ -15,9 +15,9 @@ ms.author: "ronpet"
 
 Determines whether the runtime preserves legacy behavior in formatting operations with <xref:System.TimeSpan?displayProperty=nameWithType> values.
 
-\<configuration>\
-\<runtime>\
-\<TimeSpan_LegacyFormatMode>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<TimeSpan_LegacyFormatMode>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/runtime/toc.yml
+++ b/docs/framework/configure-apps/file-schema/runtime/toc.yml
@@ -26,12 +26,14 @@
           href: bindingredirect-element.md
         - name: <codeBase> Element
           href: codebase-element.md
+        - name: <publisherPolicy> Element
+          href: publisherpolicy-element.md
       - name: <probing> Element
         href: probing-element.md
-      - name: <publisherPolicy> Element
-        href: publisherpolicy-element.md
       - name: <qualifyAssembly> Element
         href: qualifyassembly-element.md
+      - name: <supportPortability> Element
+        href: supportportability-element.md
     - name: <bypassTrustedAppStrongNames> Element
       href: bypasstrustedappstrongnames-element.md
     - name: <CompatSortNLSVersion> Element
@@ -82,23 +84,6 @@
       href: relativebindforresources-element.md
     - name: <shadowCopyVerifyByTimestamp> Element
       href: shadowcopyverifybytimestamp-element.md
-    - name: <supportPortability> Element
-      href: supportportability-element.md
-    - name: <system.runtime.caching> Element (Cache Settings)
-      href: system-runtime-caching-element-cache-settings.md
-      items:
-      - name: <memoryCache> Element (Cache Settings)
-        href: memorycache-element-cache-settings.md
-        items:
-        - name: <namedCaches> Element (Cache Settings)
-          href: namedcaches-element-cache-settings.md
-          items:
-          - name: <add> Element for <namedCaches>
-            href: add-element-for-namedcaches.md
-          - name: <clear> Element for <namedCaches>
-            href: clear-element-for-namedcaches.md
-          - name: <remove> Element for <namedCaches>
-            href: remove-element-for-namedcaches.md
     - name: <Thread_UseAllCpuGroups> Element
       href: thread-useallcpugroups-element.md
     - name: <ThrowUnobservedTaskExceptions> Element
@@ -111,3 +96,18 @@
       href: userandomizedstringhashalgorithm-element.md
     - name: <UseSmallInternalThreadStacks> Element
       href: usesmallinternalthreadstacks-element.md
+  - name: <system.runtime.caching> Element (Cache Settings)
+    href: system-runtime-caching-element-cache-settings.md
+    items:
+    - name: <memoryCache> Element (Cache Settings)
+      href: memorycache-element-cache-settings.md
+      items:
+      - name: <namedCaches> Element (Cache Settings)
+        href: namedcaches-element-cache-settings.md
+        items:
+        - name: <add> Element for <namedCaches>
+          href: add-element-for-namedcaches.md
+        - name: <clear> Element for <namedCaches>
+          href: clear-element-for-namedcaches.md
+        - name: <remove> Element for <namedCaches>
+          href: remove-element-for-namedcaches.md

--- a/docs/framework/configure-apps/file-schema/runtime/uselegacyjit-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/uselegacyjit-element.md
@@ -10,9 +10,9 @@ ms.author: "ronpet"
 
 Determines whether the common language runtime uses the legacy 64-bit JIT compiler for just-in-time compilation.  
   
-\<configuration>  
-\<runtime>  
-\<useLegacyJit>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<useLegacyJit>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/userandomizedstringhashalgorithm-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/userandomizedstringhashalgorithm-element.md
@@ -14,9 +14,9 @@ ms.author: "ronpet"
 # \<UseRandomizedStringHashAlgorithm> Element
 Determines whether the common language runtime calculates hash codes for strings on a per application domain basis.  
   
- \<configuration>  
-\<runtime>  
-\<UseRandomizedStringHashAlgorithm>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<UseRandomizedStringHashAlgorithm>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/runtime/usesmallinternalthreadstacks-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/usesmallinternalthreadstacks-element.md
@@ -11,9 +11,9 @@ ms.author: "ronpet"
 # \<UseSmallInternalThreadStacks> Element
 Requests that the common language runtime (CLR) reduce memory use by specifying explicit stack sizes when it creates certain threads that it uses internally, instead of using the default stack size for those threads.  
   
- \<configuration> Element  
-\<runtime> Element  
-\<UseSmallInternalThreadStacks> Element  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<runtime>**](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;**\<UseSmallInternalThreadStacks>**  
   
 ## Syntax  
   


### PR DESCRIPTION
## Summary

- Applied XML formatting to the whole section
- Reordered `index.md` and `toc.yml` to respect XML schema

Contributes to #2038
