### PR TITLE
US 1583733 Add missing language IDs - 04

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -34,7 +34,7 @@ dotnet run
 
 You should see the following output:
 
-```console
+```output
 Hello World!
 ```
 

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -66,19 +66,20 @@ Keep in mind that some of the .NET Framework versions used here are no longer in
 
 If you want to reach the maximum number of developers and projects, use the .NET Framework 4.0 as your baseline target. To target the .NET Framework, you will need to begin by using the correct Target Framework Moniker (TFM) that corresponds to the .NET Framework version you wish to support.
 
-| .NET Framework version | TFM    |
-| ---------------------- | ------ |
-| .NET Framework 2.0     | net20  |
-| .NET Framework 3.0     | net30  |
-| .NET Framework 3.5     | net35  |
-| .NET Framework 4.0     | net40  |
-| .NET Framework 4.5     | net45  |
-| .NET Framework 4.5.1   | net451 |
-| .NET Framework 4.5.2   | net452 |
-| .NET Framework 4.6     | net46  |
-| .NET Framework 4.6.1   | net461 |
-| .NET Framework 4.6.2   | net462 |
-| .NET Framework 4.7     | net47  |
+| .NET Framework version | TFM      |
+| ---------------------- | -------- |
+| .NET Framework 2.0     | `net20`  |
+| .NET Framework 3.0     | `net30`  |
+| .NET Framework 3.5     | `net35`  |
+| .NET Framework 4.0     | `net40`  |
+| .NET Framework 4.5     | `net45`  |
+| .NET Framework 4.5.1   | `net451` |
+| .NET Framework 4.5.2   | `net452` |
+| .NET Framework 4.6     | `net46`  |
+| .NET Framework 4.6.1   | `net461` |
+| .NET Framework 4.6.2   | `net462` |
+| .NET Framework 4.7     | `net47`  |
+| .NET Framework 4.8     | `net48`  |
 
 You then insert this TFM into the `TargetFramework` section of your project file. For example, here's how you would write a library which targets the .NET Framework 4.0:
 

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -66,19 +66,19 @@ Keep in mind that some of the .NET Framework versions used here are no longer in
 
 If you want to reach the maximum number of developers and projects, use the .NET Framework 4.0 as your baseline target. To target the .NET Framework, you will need to begin by using the correct Target Framework Moniker (TFM) that corresponds to the .NET Framework version you wish to support.
 
-```
-.NET Framework 2.0   --> net20
-.NET Framework 3.0   --> net30
-.NET Framework 3.5   --> net35
-.NET Framework 4.0   --> net40
-.NET Framework 4.5   --> net45
-.NET Framework 4.5.1 --> net451
-.NET Framework 4.5.2 --> net452
-.NET Framework 4.6   --> net46
-.NET Framework 4.6.1 --> net461
-.NET Framework 4.6.2 --> net462
-.NET Framework 4.7   --> net47
-```
+| .NET Framework version | TFM    |
+| ---------------------- | ------ |
+| .NET Framework 2.0     | net20  |
+| .NET Framework 3.0     | net30  |
+| .NET Framework 3.5     | net35  |
+| .NET Framework 4.0     | net40  |
+| .NET Framework 4.5     | net45  |
+| .NET Framework 4.5.1   | net451 |
+| .NET Framework 4.5.2   | net452 |
+| .NET Framework 4.6     | net46  |
+| .NET Framework 4.6.1   | net461 |
+| .NET Framework 4.6.2   | net462 |
+| .NET Framework 4.7     | net47  |
 
 You then insert this TFM into the `TargetFramework` section of your project file. For example, here's how you would write a library which targets the .NET Framework 4.0:
 

--- a/docs/core/tutorials/testing-with-cli.md
+++ b/docs/core/tutorials/testing-with-cli.md
@@ -102,7 +102,7 @@ Navigate back to the *src* folder and create a *test* folder with a *NewTypesTes
 
 The test project cannot currently test the types in `NewTypes` and requires a project reference to the `NewTypes` project. To add a project reference, use the [`dotnet add reference`](../tools/dotnet-add-reference.md) command:
 
-```
+```console
 dotnet add reference ../../src/NewTypes/NewTypes.csproj
 ```
 
@@ -184,7 +184,7 @@ Start in the *test/NewTypesTests* directory. Restore the test project with the [
 
 As expected, testing fails, and the console displays the following output:
 
-```
+```output
 Test run for c:\Users\ronpet\repos\samples\core\console-apps\NewTypesMsBuild\test\NewTypesTests\bin\Debug\netcoreapp2.1\NewTypesTests.dll(.NETCoreApp,Version=v2.1)
 Microsoft (R) Test Execution Command Line Tool Version 15.8.0
 Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -218,7 +218,7 @@ Change the assertions of your tests from `Assert.NotEqual` to `Assert.Equal`:
 
 Re-run the tests with the `dotnet test` command and obtain the following output:
 
-```
+```output
 Test run for c:\Users\ronpet\repos\samples\core\console-apps\NewTypesMsBuild\test\NewTypesTests\bin\Debug\netcoreapp2.1\NewTypesTests.dll(.NETCoreApp,Version=v2.1)
 Microsoft (R) Test Execution Command Line Tool Version 15.8.0
 Copyright (c) Microsoft Corporation.  All rights reserved.

--- a/docs/csharp/expression-trees-interpreting.md
+++ b/docs/csharp/expression-trees-interpreting.md
@@ -36,7 +36,7 @@ Console.WriteLine($"The value of the constant value is {constant.Value}");
 
 This will print the following:
 
-```
+```output
 This is an Constant expression type
 The type of the constant value is System.Int32
 The value of the constant value is 24
@@ -91,7 +91,7 @@ Console.WriteLine($"\tParameter Type: {right.Type.ToString()}, Name: {right.Name
 
 This sample prints the following output:
 
-```
+```output
 This expression is a/an Lambda expression type
 The name of the lambda is <null>
 The return type is System.Int32
@@ -241,7 +241,7 @@ is encountered. That way, you know to add a new expression type.)
 When you run this visitor on the addition expression shown above, you get the
 following output:
 
-```
+```output
 This expression is a/an Lambda expression type
 The name of the lambda is <null>
 The return type is System.Int32
@@ -311,7 +311,7 @@ Expression<Func<int, int>> sum = (a) => 1 + a + 3 + 4;
 
 Create a visitor for this sum and run the visitor you'll see this output:
 
-```
+```output
 This expression is a/an Lambda expression type
 The name of the lambda is <null>
 The return type is System.Int32
@@ -352,7 +352,7 @@ Expression<Func<int, int, int>> sum3 = (a, b) => (1 + a) + (3 + b);
 
 Here's the output from the visitor:
 
-```
+```output
 This expression is a/an Lambda expression type
 The name of the lambda is <null>
 The return type is System.Int32
@@ -510,7 +510,7 @@ public class MethodCallVisitor : Visitor
 
 And the output for the expression tree would be:
 
-```
+```output
 This expression is a/an Lambda expression type
 The name of the lambda is <null>
 The return type is System.Int32

--- a/docs/csharp/expression-trees-translating.md
+++ b/docs/csharp/expression-trees-translating.md
@@ -161,7 +161,7 @@ private static int Aggregate(Expression exp)
 
 Running it on the same expression yields the following output:
 
-```
+```output
 10
 Found Addition Expression
 Computing Left node
@@ -200,7 +200,7 @@ Expression<Func<int> sum1 = () => 1 + (2 + (3 + 4));
 
 Here's the output from examining this expression:
 
-```
+```output
 Found Addition Expression
 Computing Left node
 Found Constant: 1

--- a/docs/csharp/language-reference/compiler-messages/cs0731.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0731.md
@@ -23,7 +23,7 @@ The type forwarder for type 'type' in assembly 'assembly' causes a cycle
   
  First compile the .IL files as libraries, and then compile the .cs code referencing the two files.  
   
-```  
+```il  
 // Circular.il  
 // compile with: /DLL /out=Circular.dll  
 .assembly extern circular2  
@@ -71,7 +71,7 @@ The type forwarder for type 'type' in assembly 'assembly' causes a cycle
 }   
 ```  
   
-```  
+```il  
 // Circular2.il  
 // compile with: /DLL /out=Circular2.dll  
 .assembly extern mscorlib  

--- a/docs/csharp/language-reference/compiler-options/deterministic-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/deterministic-compiler-option.md
@@ -16,7 +16,7 @@ Causes the compiler to produce an assembly whose byte-for-byte output is identic
 
 ## Syntax
 
-```
+```console
 -deterministic
 ```
 

--- a/docs/csharp/language-reference/compiler-options/response-file-compiler-option.md
+++ b/docs/csharp/language-reference/compiler-options/response-file-compiler-option.md
@@ -13,7 +13,7 @@ The @ option lets you specify a file that contains compiler options and source c
   
 ## Syntax  
   
-```  
+```console  
 @response_file  
 ```  
   
@@ -26,7 +26,7 @@ The @ option lets you specify a file that contains compiler options and source c
   
  To specify more than one response file in a compilation, specify multiple response file options. For example:  
   
-```  
+```console  
 @file1.rsp @file2.rsp  
 ```  
   

--- a/docs/csharp/language-reference/keywords/extern.md
+++ b/docs/csharp/language-reference/keywords/extern.md
@@ -77,7 +77,7 @@ This example illustrates a C# program that calls into a C library (a native DLL)
 
 5. Run `cm.exe`. The `SampleMethod` method passes the value 5 to the DLL file, which returns the value multiplied by 10.  The program produces the following output:
 
-    ```
+    ```output
     SampleMethod() returns 50.
     ```
 

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -28,7 +28,7 @@ To identify a string literal as an interpolated string, prepend it with the `$` 
 
 The structure of an item with an interpolation expression is as follows:
 
-```
+```csharp-interactive
 {<interpolationExpression>[,<alignment>][:<formatString>]}
 ```
 

--- a/docs/csharp/language-reference/tokens/interpolated.md
+++ b/docs/csharp/language-reference/tokens/interpolated.md
@@ -28,7 +28,7 @@ To identify a string literal as an interpolated string, prepend it with the `$` 
 
 The structure of an item with an interpolation expression is as follows:
 
-```csharp-interactive
+```csharp
 {<interpolationExpression>[,<alignment>][:<formatString>]}
 ```
 

--- a/docs/csharp/misc/cs1508.md
+++ b/docs/csharp/misc/cs1508.md
@@ -14,6 +14,6 @@ Resource identifier 'identifier' has already been used in this assembly
   
  For example, the following options would generate CS1508:  
   
-```  
+```console  
 /resource:anyfile.bmp,DuplicatIdent /linkresource:a.bmp,DuplicatIdent  
 ```

--- a/docs/csharp/programming-guide/classes-and-structs/how-to-return-subsets-of-element-properties-in-a-query.md
+++ b/docs/csharp/programming-guide/classes-and-structs/how-to-return-subsets-of-element-properties-in-a-query.md
@@ -15,7 +15,7 @@ Use an anonymous type in a query expression when both of these conditions apply:
   
  If you only want to return one property or field from each source element, then you can just use the dot operator in the `select` clause. For example, to return only the `ID` of each `student`, write the `select` clause as follows:  
   
-```  
+```csharp  
 select student.ID;  
 ```  
   
@@ -26,7 +26,7 @@ select student.ID;
   
  Note that the anonymous type uses the source element's names for its properties if no names are specified. To give new names to the properties in the anonymous type, write the `select` statement as follows:  
   
-```  
+```csharp  
 select new { First = student.FirstName, Last = student.LastName };  
 ```  
   

--- a/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
+++ b/docs/csharp/programming-guide/classes-and-structs/using-constructors.md
@@ -33,14 +33,14 @@ Console.WriteLine(i);
   
  The following code, however, causes a compiler error because it does not use `new`, and because it tries to use an object that has not been initialized:  
   
-```  
+```csharp  
 int i;  
 Console.WriteLine(i);  
 ```  
   
  Alternatively, objects based on `structs` (including all built-in numeric types) can be initialized or assigned and then used as in the following example:  
   
-```  
+```csharp  
 int a = 44;  // Initialize the value type...  
 int b;  
 b = 33;      // Or assign it before using it.  

--- a/docs/csharp/programming-guide/concepts/async/cancel-async-tasks-after-a-period-of-time.md
+++ b/docs/csharp/programming-guide/concepts/async/cancel-async-tasks-after-a-period-of-time.md
@@ -70,7 +70,7 @@ private async void startButton_Click(object sender, RoutedEventArgs e)
 
  Run the program several times to verify that the output might show output for all websites, no websites, or some web sites. The following output is a sample.
 
-```
+```output
 Length of the downloaded string: 35990.
 
 Length of the downloaded string: 407399.


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "il" for il command example. Could have possibly used csharp for better highlighting.
- Used "output" for examples of command output. (This is not a language - obviously - but it is an ID that has been used before.

Contributes to #2192