### PR TITLE
US 1583733 Add missing language IDs - 05

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/control-flow-in-async-programs.md
+++ b/docs/csharp/programming-guide/concepts/async/control-flow-in-async-programs.md
@@ -54,7 +54,7 @@ public partial class MainWindow : Window
 
 Each of the labeled locations, "ONE" through "SIX," displays information about the current state of the program. The following output is produced:
 
-```text
+```output
 ONE:   Entering startButton_Click.
            Calling AccessTheWebAsync.
 
@@ -234,7 +234,7 @@ To run the project, perform the following steps:
 
     The following output appears:
 
-    ```text
+    ```output
     ONE:   Entering startButton_Click.
                Calling AccessTheWebAsync.
 
@@ -286,7 +286,7 @@ Task<string> getStringTask = client.GetStringAsync("https://msdn.microsoft.com")
 
  You can think of the task as a promise by `client.GetStringAsync` to produce an actual string eventually. In the meantime, if `AccessTheWebAsync` has work to do that doesn't depend on the promised string from `client.GetStringAsync`, that work can continue while  `client.GetStringAsync` waits. In the example, the following lines of output, which are labeled "THREE," represent the opportunity to do independent work
 
-```
+```output
 THREE: Back in AccessTheWebAsync.
            Task getStringTask is started.
            About to await getStringTask & return a Task<int> to startButton_Click.
@@ -321,7 +321,7 @@ Task<int> getLengthTask = AccessTheWebAsync();
 
  As in `AccessTheWebAsync`, `startButton_Click` can continue with work that doesn’t depend on the results of the asynchronous task (`getLengthTask`) until the task is awaited. The following output lines represent that work.
 
-```
+```output
 FOUR:  Back in startButton_Click.
            Task getLengthTask is started.
            About to await getLengthTask -- no caller to return to.
@@ -341,7 +341,7 @@ int contentLength = await getLengthTask;
 
 When `client.GetStringAsync` signals that it’s complete, processing in `AccessTheWebAsync` is released from suspension and can continue past the await statement. The following lines of output represent the resumption of processing.
 
-```
+```output
 FIVE:  Back in AccessTheWebAsync.
            Task getStringTask is complete.
            Processing the return statement.
@@ -362,7 +362,7 @@ When `AccessTheWebAsync` signals that it’s complete, processing can continue p
 
 The following lines of output represent the resumption of processing in `startButton_Async`:
 
-```
+```output
 SIX:   Back in startButton_Click.
            Task getLengthTask is finished.
            Result from AccessTheWebAsync is stored in contentLength.

--- a/docs/csharp/programming-guide/concepts/async/handling-reentrancy-in-async-apps.md
+++ b/docs/csharp/programming-guide/concepts/async/handling-reentrancy-in-async-apps.md
@@ -30,7 +30,7 @@ In the example in this topic, users choose a **Start** button to initiate an asy
 
 The following example shows the expected output if the user chooses the **Start** button only once. A list of the downloaded websites appears with the size, in bytes, of each site. The total number of bytes appears at the end.
 
-```
+```output
 1. msdn.microsoft.com/library/hh191443.aspx                83732
 2. msdn.microsoft.com/library/aa578028.aspx               205273
 3. msdn.microsoft.com/library/jj155761.aspx                29019
@@ -45,7 +45,7 @@ TOTAL bytes returned:  890591
 
 However, if the user chooses the button more than once, the event handler is invoked repeatedly, and the download process is reentered each time. As a result, several asynchronous operations are running at the same time, the output interleaves the results, and the total number of bytes is confusing.
 
-```
+```output
 1. msdn.microsoft.com/library/hh191443.aspx                83732
 2. msdn.microsoft.com/library/aa578028.aspx               205273
 3. msdn.microsoft.com/library/jj155761.aspx                29019
@@ -264,7 +264,7 @@ async Task AccessTheWebAsync(CancellationToken ct)
 
 If you choose the **Start** button several times while this app is running, it should produce results that resemble the following output.
 
-```
+```output
 1. msdn.microsoft.com/library/hh191443.aspx                83732
 2. msdn.microsoft.com/library/aa578028.aspx               205273
 3. msdn.microsoft.com/library/jj155761.aspx                29019
@@ -302,7 +302,7 @@ To set up this scenario, make the following changes to the basic code that is pr
 
 The following output shows the result if the user chooses the **Start** button only once. The letter label, A, indicates that the result is from the first time the **Start** button is chosen. The numbers show the order of the URLs in the list of download targets.
 
-```
+```output
 #Starting group A.
 #Task assigned for group A.
 
@@ -322,7 +322,7 @@ TOTAL bytes returned:  918876
 
 If the user chooses the **Start** button three times, the app produces output that resembles the following lines. The information lines that start with a pound sign (#) trace the progress of the application.
 
-```
+```output
 #Starting group A.
 #Task assigned for group A.
 
@@ -493,7 +493,7 @@ The output shows the following patterns.
 
 - A group can be started while a previous group is displaying its output, but the display of the previous group's output isn't interrupted.
 
-    ```
+    ```output
     #Starting group A.
     #Task assigned for group A. Download tasks are active.
 
@@ -531,7 +531,7 @@ The output shows the following patterns.
 
 - The following two lines always appear together in the output. The code is never interrupted between starting a group's operation in `StartButton_Click` and assigning a task for the group to `pendingWork`.
 
-    ```
+    ```output
     #Starting group B.
     #Task assigned for group B. Download tasks are active.
     ```

--- a/docs/csharp/programming-guide/concepts/linq/atomized-xname-and-xnamespace-objects-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/atomized-xname-and-xnamespace-objects-linq-to-xml.md
@@ -35,7 +35,7 @@ else
   
  This example produces the following output:  
   
-```  
+```output  
 r1 and r2 have names that refer to the same instance.  
 The name of r1 and the name in 'n' refer to the same instance.  
 ```  

--- a/docs/csharp/programming-guide/concepts/linq/chaining-queries-example.md
+++ b/docs/csharp/programming-guide/concepts/linq/chaining-queries-example.md
@@ -58,7 +58,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 ToUpper: source >abc<  
 AppendString: source >ABC<  
 Main: str >ABC!!!<  

--- a/docs/csharp/programming-guide/concepts/linq/chaining-standard-query-operators-together.md
+++ b/docs/csharp/programming-guide/concepts/linq/chaining-standard-query-operators-together.md
@@ -69,7 +69,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 ToUpper: source >abc<  
 ToUpper: source >def<  
 AppendString: source >DEF<  
@@ -79,4 +79,3 @@ ToUpper: source >ghi<
 AppendString: source >GHI<  
 Main: str >GHI!!!<  
 ```  
-  

--- a/docs/csharp/programming-guide/concepts/linq/creating-the-source-office-open-xml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/creating-the-source-office-open-xml-document.md
@@ -19,7 +19,7 @@ To create the document that this tutorial uses, you must either have Microsoft O
 
 2. Paste the following text into the new document:
 
-    ```
+    ```text
     Parsing WordprocessingML with LINQ to XML
 
     The following example prints to the console.

--- a/docs/csharp/programming-guide/concepts/linq/deferred-execution-example.md
+++ b/docs/csharp/programming-guide/concepts/linq/deferred-execution-example.md
@@ -40,7 +40,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 ToUpper: source abc  
 Main: str ABC  
 ToUpper: source def  

--- a/docs/csharp/programming-guide/concepts/linq/finding-text-in-word-documents.md
+++ b/docs/csharp/programming-guide/concepts/linq/finding-text-in-word-documents.md
@@ -161,7 +161,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 StyleName:Code >        Console.WriteLine("Hello World");<  
 StyleName:Code >Hello World<  
 ```  
@@ -308,7 +308,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 StyleName:Code ><  
 ```  
   

--- a/docs/csharp/programming-guide/concepts/linq/finding-the-default-paragraph-style.md
+++ b/docs/csharp/programming-guide/concepts/linq/finding-the-default-paragraph-style.md
@@ -73,7 +73,7 @@ Console.WriteLine("The default style is: {0}", defaultStyle);
 ### Comments  
  This example produces the following output:  
   
-```  
+```output  
 The default style is: Normal  
 ```  
   
@@ -81,4 +81,3 @@ The default style is: Normal
  In the next example, you'll create a similar query that finds all the paragraphs in a document and their styles:  
   
 - [Retrieving the Paragraphs and Their Styles (C#)](./retrieving-the-paragraphs-and-their-styles.md)  
-  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-calculate-intermediate-values.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-calculate-intermediate-values.md
@@ -25,7 +25,7 @@ foreach (decimal ex in extensions)
   
  This code produces the following output:  
   
-```  
+```output  
 55.92  
 73.50  
 89.99  
@@ -53,7 +53,7 @@ foreach (decimal ex in extensions)
   
  This code produces the following output:  
   
-```  
+```output  
 55.92  
 73.50  
 89.99  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-catch-parsing-errors.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-catch-parsing-errors.md
@@ -30,7 +30,7 @@ catch (System.Xml.XmlException e)
   
  When you run this code, it throws the following exception:  
   
-```  
+```console  
 The 'Contacts' start tag on line 1 does not match the end tag of 'Contcts'. Line 5, position 13.  
 ```  
   

--- a/docs/csharp/programming-guide/concepts/linq/how-to-combine-and-compare-string-collections-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-combine-and-compare-string-collections-linq.md
@@ -10,7 +10,7 @@ This example shows how to merge files that contain lines of text and then sort t
   
 1. Copy these names into a text file that is named names1.txt and save it in your project folder:  
   
-    ```  
+    ```text  
     Bankov, Peter  
     Holm, Michael  
     Garcia, Hugo  
@@ -25,7 +25,7 @@ This example shows how to merge files that contain lines of text and then sort t
   
 2. Copy these names into a text file that is named names2.txt and save it in your project folder. Note that the two files have some names in common.  
   
-    ```  
+    ```text  
     Liu, Jinghao  
     Bankov, Peter  
     Holm, Michael  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-control-the-type-of-a-projection.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-control-the-type-of-a-projection.md
@@ -56,7 +56,7 @@ class Program
   
  This code produces the following output:  
   
-```  
+```output  
 GREAL:Great Lakes Food Market:Howard Snyder  
 HUNGC:Hungry Coyote Import Store:Yoshi Latimer  
 LAZYK:Lazy K Kountry Store:John Steel  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-debug-empty-query-results-sets.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-debug-empty-query-results-sets.md
@@ -36,7 +36,7 @@ Console.WriteLine("End of result set");
   
  This example produces the following result:  
   
-```  
+```output  
 Result set follows:  
 End of result set  
 ```  
@@ -68,7 +68,7 @@ Console.WriteLine("End of result set");
   
  This example produces the following result:  
   
-```  
+```output  
 Result set follows:  
 1  
 2  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-filter-on-an-attribute-xpath-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-filter-on-an-attribute-xpath-linq-to-xml.md
@@ -38,7 +38,7 @@ foreach (XElement el in list1)
   
  This example produces the following output:  
   
-```  
+```output  
 Results are identical  
 <Address Type="Shipping">  
   <Name>Ellen Adams</Name>  


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.

- Used the tag "output" for code blocks with program output examples. 
- Used the tag "text" for code blocks with text content.

Contributes to #2192