### PR TITLE
Restore XML hierarchy to WCF configuration section (part 2)

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/add-of-claimtyperequirements-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/add-of-claimtyperequirements-element.md
@@ -11,7 +11,7 @@ Specifies the types of required and optional claims expected to appear in the fe
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<claimTypeRequirements>**](claimtyperequirements-for-message.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<add>**

--- a/docs/framework/configure-apps/file-schema/wcf/add-of-claimtyperequirements-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/add-of-claimtyperequirements-element.md
@@ -6,13 +6,15 @@ ms.assetid: 3234cd45-1478-468e-8b19-5c50815c4786
 # \<add> of \<claimTypeRequirements> element
 Specifies the types of required and optional claims expected to appear in the federated credential. For example, services state the requirements on incoming credentials, which must possess a certain set of claim types.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsFederatedBinding>  
-\<binding>  
-\<security>  
-\<message>  
-\<claimTypeRequirements>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<claimTypeRequirements>**](claimtyperequirements-for-message.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<add>**
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/add-of-claimtyperequirements.md
+++ b/docs/framework/configure-apps/file-schema/wcf/add-of-claimtyperequirements.md
@@ -6,13 +6,15 @@ ms.assetid: c68e83c9-39e8-4264-b1ce-b6a9eb5b98aa
 # \<add> of \<claimTypeRequirements>
 Specifies the types of required and optional claims expected to appear in the federated credential. For example, services state the requirements on incoming credentials, which must possess a certain set of claim types.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
-\<issuedTokenParameters>  
-\<claimTypeRequirements>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<issuedTokenParameters>**](issuedtokenparameters.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<claimTypeRequirements>**](claimtyperequirements-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<add>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/basichttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/basichttpbinding.md
@@ -8,9 +8,10 @@ ms.assetid: 85cf1a4f-26c2-48c7-bda6-6c960d5d3fb3
 # \<basicHttpBinding>
 Represents a binding that a Windows Communication Foundation (WCF) service can use to configure and expose endpoints that are able to communicate with ASMX-based Web services and clients and other services that conform to the WS-I Basic Profile 1.1.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<basicHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<basicHttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/basichttpcontextbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/basichttpcontextbinding.md
@@ -6,9 +6,10 @@ ms.assetid: 39b16b82-4ec6-4eff-8031-67e026870961
 # \<basicHttpContextBinding>
 Specifying a binding that provides context for the <xref:System.ServiceModel.BasicHttpBinding> to be exchanged by enabling HTTP cookies as the exchange mechanism.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<basicHttpContextBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<basicHttpContextBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/binarymessageencoding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/binarymessageencoding.md
@@ -6,11 +6,12 @@ ms.assetid: e4ae3cd4-6b67-4ce1-af4b-9400e0a38dba
 # \<binaryMessageEncoding>
 Defines a binary message encoder that encodes Windows Communication Foundation (WCF) messages in binary on the wire.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<binaryMessageEncoding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binaryMessageEncoding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/bytestreammessageencoding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/bytestreammessageencoding.md
@@ -6,11 +6,12 @@ ms.assetid: bbadd8dd-60a2-4007-b959-89373a8a7d60
 # \<byteStreamMessageEncoding>
 Specifies the message encoding as a stream of bytes, with the option to specify the character encoding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<binaryMessageEncoding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<byteStreamMessageEncoding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/channelpoolsettings.md
+++ b/docs/framework/configure-apps/file-schema/wcf/channelpoolsettings.md
@@ -6,12 +6,13 @@ ms.assetid: 4755f3d3-4213-4c68-ae7f-45b67d744459
 # \<channelPoolSettings>
 Specifies the channel pool settings for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<oneWay>  
-\<channelPoolSettings>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<oneWay>**](oneway.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<channelPoolSettings>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/clear-of-claimtyperequirements-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/clear-of-claimtyperequirements-element.md
@@ -6,13 +6,15 @@ ms.assetid: ef42fde7-f292-4610-9111-9fea382c3b5f
 # \<clear> of \<claimTypeRequirements> element
 Specifies that all the claim types to be removed in the federated credential. This ensures that the collection starts empty.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsFederatedBinding>  
-\<binding>  
-\<security>  
-\<message>  
-\<claimTypeRequirements>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<claimTypeRequirements>**](claimtyperequirements-for-message.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<clear>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/compositeduplex.md
+++ b/docs/framework/configure-apps/file-schema/wcf/compositeduplex.md
@@ -6,11 +6,12 @@ ms.assetid: 725004d1-ce88-4405-a220-78e89844f81f
 # \<compositeDuplex>
 Defines the binding element that is used when the client must expose an endpoint for the service to send messages back to the client.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<compositeDuplex>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<compositeDuplex>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/connectionpoolsettings-of-tcptransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/connectionpoolsettings-of-tcptransport.md
@@ -6,12 +6,13 @@ ms.assetid: 2fbc3aa7-fcc9-4193-99a3-85d31d60d3f7
 # \<connectionPoolSettings> of \<tcpTransport>
 Specifies additional connection pool settings for a TCP transport.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<tcpTransport>  
-\<connectionPoolSettings>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<tcpTransport>**](tcptransport.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<connectionPoolSettings>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/connectionpoolsettings.md
+++ b/docs/framework/configure-apps/file-schema/wcf/connectionpoolsettings.md
@@ -6,12 +6,13 @@ ms.assetid: 6fa7fa65-2c6e-4eab-b8cf-7690112c0be5
 # \<connectionPoolSettings>
 Specifies additional connection pool settings for a Named Pipe binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<namePipeTransport>  
-\<connectionPoolSettings>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<namedPipeTransport>**](namedpipetransport.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<connectionPoolSettings>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/custom.md
+++ b/docs/framework/configure-apps/file-schema/wcf/custom.md
@@ -6,12 +6,13 @@ ms.assetid: a6f65a00-bd1a-4d4a-955a-fe009ec02ab8
 # \<custom>
 Specifies settings for a custom peer resolver service.  
   
-\<system.serviceModel>  
-\<bindings>  
-\<netPeerBinding>  
-\<binding>  
-\<resolver>  
-\<custom>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netPeerTcpBinding>**](netpeertcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<resolver>**](resolver.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<custom>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/custombinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/custombinding.md
@@ -8,9 +8,10 @@ ms.assetid: 9da4f960-f64e-4d8a-894d-2b09eba5ce4b
 
 Provides full control over the messaging stack for the user.
 
-\<system.serviceModel>\
-\<bindings>\
-\<customBinding>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<customBinding>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/discoveryclient.md
+++ b/docs/framework/configure-apps/file-schema/wcf/discoveryclient.md
@@ -6,11 +6,12 @@ ms.assetid: a78f74c3-1152-4149-ab29-3f12d316caeb
 # \<discoveryClient>
 A configuration element for creating a custom binding that enables a client application to automatically search for a discoverable service and find its address at runtime.  
   
-\<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<discoveryClient>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<discoveryClient>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/httpstransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/httpstransport.md
@@ -6,11 +6,12 @@ ms.assetid: f6ed4bc0-7e38-4348-9259-30bf61eb9435
 # \<httpsTransport>
 Specifies an HTTP transport for transmitting SOAP messages for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<httpsTransport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<httpsTransport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/httptransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/httptransport.md
@@ -6,11 +6,12 @@ ms.assetid: 8b30c065-b32a-4fa3-8eb4-5537a9c6b897
 # \<httpTransport>
 Specifies an HTTP transport for transmitting SOAP messages for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<httpTransport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<httpTransport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuedtokenparameters.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuedtokenparameters.md
@@ -11,7 +11,7 @@ Specifies the parameters for a security token issued in a Federated security sce
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuedTokenParameters>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/wcf/issuedtokenparameters.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuedtokenparameters.md
@@ -6,12 +6,13 @@ ms.assetid: 120b3f37-7331-4816-b712-d6aab39655a4
 # \<issuedTokenParameters>
 Specifies the parameters for a security token issued in a Federated security scenario.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
-\<issuedTokenParameters>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuedTokenParameters>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuer-of-issuedtokenparameters.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuer-of-issuedtokenparameters.md
@@ -11,7 +11,7 @@ Specifies the Security Token Service (STS) that issues security tokens.
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<issuedTokenParameters>**](issuedtokenparameters.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuer>**  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuer-of-issuedtokenparameters.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuer-of-issuedtokenparameters.md
@@ -6,13 +6,14 @@ ms.assetid: d6a95f32-d58c-40fc-8658-dd92564d3c90
 # \<issuer> of \<issuedTokenParameters>
 Specifies the Security Token Service (STS) that issues security tokens.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
-\<issuedTokenParameters>  
-\<issuer>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<issuedTokenParameters>**](issuedtokenparameters.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuer>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuer.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuer.md
@@ -6,13 +6,14 @@ ms.assetid: 8c49c6ae-fa1a-4179-a84b-613c3216dcde
 # \<issuer>
 Specifies the Security Token Service (STS) that issues security tokens.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<wsFederationHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
-\<issuer>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuer>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuermetadata-of-issuedtokenparameters.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuermetadata-of-issuedtokenparameters.md
@@ -10,7 +10,7 @@ ms.assetid: 1a85ca37-496d-4fa3-8d44-d6c9383d735c
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<issuedTokenParameters>**](issuedtokenparameters.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuerMetadata>**  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuermetadata-of-issuedtokenparameters.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuermetadata-of-issuedtokenparameters.md
@@ -4,13 +4,15 @@ ms.date: "03/30/2017"
 ms.assetid: 1a85ca37-496d-4fa3-8d44-d6c9383d735c
 ---
 # \<issuerMetadata> of \<issuedTokenParameters>
-\<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
-\<issuedTokenParameters>  
-\<issuerMetadata>  
+
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<issuedTokenParameters>**](issuedtokenparameters.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuerMetadata>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/issuermetadata.md
+++ b/docs/framework/configure-apps/file-schema/wcf/issuermetadata.md
@@ -4,13 +4,15 @@ ms.date: "03/30/2017"
 ms.assetid: e7eae2c0-cc17-4281-af59-e4eb8d54f92a
 ---
 # \<issuerMetadata>
-\<system.serviceModel>  
-\<bindings>  
-\<wsFederationHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
-\<issuerMetadata>  
+
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<issuerMetadata>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/localclientsettings-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/localclientsettings-element.md
@@ -6,11 +6,13 @@ ms.assetid: 4680ace5-f4e1-4fcb-b9d8-a4a4af5cd7ae
 # \<localClientSettings> element
 Specifies the security settings of a local client for this binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<localClientSettings>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/localclientsettings-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/localclientsettings-element.md
@@ -11,7 +11,7 @@ Specifies the security settings of a local client for this binding.
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<localClientSettings>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/wcf/localservicesettings-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/localservicesettings-element.md
@@ -11,7 +11,7 @@ Specifies the security settings of a local service for this binding.
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<localServiceSettings>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/wcf/localservicesettings-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/localservicesettings-element.md
@@ -6,11 +6,13 @@ ms.assetid: 0658549c-3f65-46dd-8c5c-9895441ed734
 # \<localServiceSettings> element
 Specifies the security settings of a local service for this binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<localServiceSettings>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-element-of-nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-element-of-nettcpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 1d71edd9-c085-4c2e-b6d3-980c313366f9
 # \<message> element of \<netTcpBinding>
 Defines the type of message-level security requirements for an endpoint configured with the [\<netTcpBinding>](nettcpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netTcpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netTcpBinding>**](nettcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-nettcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-element-of-ws2007federationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-element-of-ws2007federationhttpbinding.md
@@ -11,7 +11,7 @@ Defines settings for the message-level security for the [\<ws2007FederationHttpB
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<ws2007FederationHttpBinding>**](ws2007federationhttpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-ws2007federationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-element-of-ws2007federationhttpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/wcf/message-element-of-ws2007federationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-element-of-ws2007federationhttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 52cd941d-e230-4c82-8b29-333a7d20eca8
 # \<message> element of \<ws2007FederationHttpBinding>
 Defines settings for the message-level security for the [\<ws2007FederationHttpBinding>](ws2007federationhttpbinding.md) element.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<ws2007FederationHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<ws2007FederationHttpBinding>**](ws2007federationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-ws2007federationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-element-of-wsfederationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-element-of-wsfederationhttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 9d710389-d9d8-4454-9bf2-da4ccda31cec
 # \<message> element of \<wsFederationHttpBinding>
 Defines the settings for the message-level security for the [\<wsFederationHttpBinding>](wsfederationhttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsFederatedBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-basichttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-basichttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 51cdd329-6461-471a-8747-56c2299b61e5
 # \<message> of \<basicHttpBinding>
 Defines the settings for message-level security of the [\<basicHttpBinding>](basichttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<basicHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<basicHttpBinding>**](basichttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-basichttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-nethttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-nethttpbinding.md
@@ -4,14 +4,15 @@ ms.date: "03/30/2017"
 ms.assetid: 9def5a35-475d-40d6-b716-ccdbd93863c7
 ---
 # \<message> of \<netHttpBinding>
-Defines the settings for message-level security of the [\<basicHttpBinding>](basichttpbinding.md).  
+Defines the settings for message-level security of the [\<netHttpBinding>](nethttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netHttpBinding>**](nethttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-nethttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-netmsmqbinding.md
@@ -8,14 +8,13 @@ ms.assetid: 6ebf0240-d7be-4493-b0fe-f00fd5989d77
 
 Defines the SOAP message security settings on this `netMsmqBinding` binding.
 
-```xml
-<system.ServiceModel>
-  <bindings>
-    <netMsmqBinding>
-      <binding>
-        <security>
-          <message>
-```
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netMsmqBinding>**](netmsmqbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-netmsmqbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-ws2007httpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-ws2007httpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 9ffd8db6-84a8-4b38-a9fe-2cb1a87a1c97
 # \<message> of \<ws2007HttpBinding>
 Defines settings for message-level security of the [\<ws2007HttpBinding>](ws2007httpbinding.md) element.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<ws2007HttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<ws2007HttpBinding>**](ws2007httpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-ws2007httpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-wsdualhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-wsdualhttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 75101744-eed8-4d61-91f4-5fc4473a21f2
 # \<message> of \<wsDualHttpBinding>
 Defines message-level security for the [\<wsDualHttpBinding>](wsdualhttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsDualHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsDualHttpBinding>**](wsdualhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsdualhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/message-of-wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/message-of-wshttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 621abbde-590b-454d-90ac-68dc3c69c720
 # \<message> of \<wsHttpBinding>
 Defines settings for message-level security of the [\<wsHttpBinding>](wshttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsHttpBinding>  
-\<binding>  
-\<security>  
-\<message>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsHttpBinding>**](wshttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wshttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<message>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/mexhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/mexhttpbinding.md
@@ -6,9 +6,10 @@ ms.assetid: e50b2e1f-9668-41a5-8077-dee7abff9f0f
 # \<mexHttpBinding>
 Specifies the settings for a binding used for the WS-MetadataExchange (WS-MEX) message exchange over HTTP.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<mexHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<mexHttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/mexhttpsbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/mexhttpsbinding.md
@@ -6,9 +6,10 @@ ms.assetid: f2ed3774-78b9-4a15-b79b-655f1ad68b86
 # \<mexHttpsBinding>
 Specifies the settings for a binding used for the WS-MetadataExchange (WS-MEX) message exchange over HTTPS.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<mexHttpsBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<mexHttpsBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/mexnamedpipebinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/mexnamedpipebinding.md
@@ -6,9 +6,10 @@ ms.assetid: 193412fa-3260-414c-92c6-b32ed3b94a34
 # \<mexNamedPipeBinding>
 Specifies the settings for a binding used for the WS-MetadataExchange (WS-MEX) message exchange over named pipe.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<mexNamedPipeBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<mexNamedPipeBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/mextcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/mextcpbinding.md
@@ -6,9 +6,10 @@ ms.assetid: 01baba8d-d784-4255-9ea2-7afff1482bf0
 # \<mexTcpBinding>
 Specifies the settings for a binding used for the WS-MetadataExchange (WS-MEX) message exchange over TCP.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<mexTcpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<mexTcpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/msmqintegration.md
+++ b/docs/framework/configure-apps/file-schema/wcf/msmqintegration.md
@@ -6,11 +6,12 @@ ms.assetid: ab677405-1ffe-457a-803f-00c1770e51e2
 # \<msmqIntegration>
 Specifies a MSMQ transport for custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<msmqIntegration>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<msmqIntegration>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/msmqintegrationbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/msmqintegrationbinding.md
@@ -8,9 +8,12 @@ ms.assetid: edf277f3-e3bf-4ed8-9f55-83b5788430a7
 # \<msmqIntegrationBinding>
 Defines a binding that provides queuing support by routing messages through MSMQ.  
   
- \<system.ServiceModel>  
-\<bindings>  
-msmqIntegrationBinding  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<msmqIntegrationBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/msmqtransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/msmqtransport.md
@@ -6,11 +6,12 @@ ms.assetid: 19d89f35-76ac-49dc-832b-e8bec2d5e33b
 # \<msmqTransport>
 Causes a channel to transfers messages on the MSMQ transport when it is included in a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<msmqIntegration>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<msmqTransport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/msmqtransportsecurity.md
+++ b/docs/framework/configure-apps/file-schema/wcf/msmqtransportsecurity.md
@@ -6,12 +6,13 @@ ms.assetid: 092e911b-ab1b-4069-a26e-6134c3299e06
 # \<msmqTransportSecurity>
 Specifies MSMQ transport security settings for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<msmqIntegration>  
-\<msmqTransportSecurity>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<msmqIntegration>**](msmqintegration.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<msmqTransportSecurity>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/mtommessageencoding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/mtommessageencoding.md
@@ -6,11 +6,12 @@ ms.assetid: 7865d171-cd1e-430a-8421-39cc13541d1b
 # \<mtomMessageEncoding>
 Specifies the encoding and message versioning used for SOAP Message Transmission Optimization Mechanism (MTOM) based messages.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<mtomMessageEncoding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<mtomMessageEncoding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/namedpipetransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/namedpipetransport.md
@@ -6,11 +6,12 @@ ms.assetid: 9fc3f42f-43e2-4ab1-8bc7-3c95a9220df1
 # \<namedPipeTransport>
 Defines a transport that causes a channel to transfer messages using named pipes when it is included in a custom binding.  
   
-\<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<namePipeTransport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<namedPipeTransport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/nethttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/nethttpbinding.md
@@ -6,9 +6,10 @@ ms.assetid: b0d81ca0-87c5-4090-8baa-e390fd3656d2
 # \<netHttpBinding>
 Represents a binding that a Windows Communication Foundation (WCF) service can use to configure and expose endpoints that are able to communicate over HTTP. When used with a duplex contract, Web Sockets will be used, otherwise HTTP will be used.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netHttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/nethttpsbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/nethttpsbinding.md
@@ -6,9 +6,11 @@ ms.assetid: ff122116-6042-4792-9f21-275b4f97a105
 # \<netHttpsBinding>
 Represents a binding that a Windows Communication Foundation (WCF) service can use to configure and expose endpoints that are able to communicate over HTTPS. When used with a duplex contract, Web Sockets will be used, otherwise HTTPS will be used.  
   
- Root Element  
-Next Element  
-  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netHttpsBinding>**  
+
 ## Syntax  
   
 ```xml  

--- a/docs/framework/configure-apps/file-schema/wcf/netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/netmsmqbinding.md
@@ -6,9 +6,10 @@ ms.assetid: a68b44d7-7799-43a3-9e63-f07c782810a6
 # \<netMsmqBinding>
 Defines a queued binding suitable for cross-machine communication.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netMsmqBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netMsmqBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/netnamedpipebinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/netnamedpipebinding.md
@@ -6,9 +6,10 @@ ms.assetid: 00a8580b-face-47a4-838d-b9fed48e72df
 # \<netNamedPipeBinding>
 Defines a binding that is secure, reliable, optimized for on-machine cross process communication. By default, it generates a runtime communication stack with WS-ReliableMessaging for reliability, transport security for transfer security, named pipes for message delivery, and binary message encoding.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netNamedPipeBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netNamedPipeBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/netpeertcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/netpeertcpbinding.md
@@ -8,9 +8,10 @@ ms.assetid: 2dd77ada-a176-47c7-a740-900b279f1aad
 # \<netPeerTcpBinding>
 Defines a binding for peer channel specific TCP messaging.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netPeerTcpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netPeerTcpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/nettcpbinding.md
@@ -9,9 +9,10 @@ ms.assetid: 5c5104a7-8754-4335-8233-46a45322503e
 
 Specifies a secure, reliable, optimized binding suitable for cross-machine communication. By default, it generates a runtime communication stack with Windows Security for message security and authentication, TCP for message delivery, and binary message encoding.
 
-\<system.ServiceModel>  
-\<bindings>  
-\<netTcpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netTcpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/nettcpcontextbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/nettcpcontextbinding.md
@@ -6,9 +6,10 @@ ms.assetid: 1d4715e1-5fff-4c3d-a226-18f21d0b30c4
 # \<netTcpContextBinding>
 Specifies a context for the <xref:System.ServiceModel.NetTcpBinding> that requires that the protection level be signed. The contextExchangeMechanism for NetTcpContextBinding is SOAPHeader.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netTcpContextBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<netTcpContextBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/oneway.md
+++ b/docs/framework/configure-apps/file-schema/wcf/oneway.md
@@ -6,11 +6,12 @@ ms.assetid: 00e67e0e-77c0-4695-9138-c0997b0e5f3c
 # \<oneWay>
 Enables packet routing and the use of one-way methods for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<oneWay>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<oneWay>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/peertransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/peertransport.md
@@ -6,11 +6,12 @@ ms.assetid: c1a5013a-9dd4-4a27-b114-795b8b323177
 # \<peerTransport>
 Defines a peer transport for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<peerTransport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<peerTransport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/pnrppeerresolver.md
+++ b/docs/framework/configure-apps/file-schema/wcf/pnrppeerresolver.md
@@ -6,11 +6,12 @@ ms.assetid: c1b34f3b-68e5-4911-a367-de49fb61dbc6
 # \<pnrpPeerResolver>
 Specifies that the PNRP (Peer Name Resolution Protocol) resolver is to be used as a resolver. This element is optional because PNRP is the default resolver.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<pnrpResolver>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<pnrpResolver>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/privacynoticeat.md
+++ b/docs/framework/configure-apps/file-schema/wcf/privacynoticeat.md
@@ -6,11 +6,12 @@ ms.assetid: 4cc96942-4eb9-4241-b2fd-45aa239915e8
 # \<privacyNoticeAt>
 Represents a configuration element that specifies a privacy notice used in `wsFederationHttp` binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<privacyNotice>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<privacyNotice>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/reliablesession.md
+++ b/docs/framework/configure-apps/file-schema/wcf/reliablesession.md
@@ -6,11 +6,12 @@ ms.assetid: 129b4a59-37f0-4030-b664-03795d257d29
 # \<reliableSession>
 Defines setting for WS-Reliable Messaging. When this element is added to a custom binding, the resulting channel can support exactly-once delivery assurances.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<reliableSession>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<reliableSession>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/remove-of-claimtyperequirements-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/remove-of-claimtyperequirements-element.md
@@ -6,13 +6,15 @@ ms.assetid: 8ef05bc4-1950-4ee4-95c5-1c6a394eff7e
 # \<remove> of \<claimTypeRequirements> element
 Specifies the types of claims to be removed in the federated credential.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsFederatedBinding>  
-\<binding>  
-\<security>  
-\<message>  
-\<claimTypeRequirements>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<claimTypeRequirements>**](claimtyperequirements-for-message.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<remove>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/resolver.md
+++ b/docs/framework/configure-apps/file-schema/wcf/resolver.md
@@ -6,11 +6,12 @@ ms.assetid: 0c00200c-f135-4e5c-a024-76b72bcbc021
 # \<resolver>
 Specifies a peer resolver that is used to resolve a peer mesh ID to a set of peer node addresses that represents several nodes that participate in the mesh.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netPeerBinding>  
-\<binding>  
-\<resolver>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netPeerTcpBinding>**](netpeertcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<resolver>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/secureconversationbootstrap.md
+++ b/docs/framework/configure-apps/file-schema/wcf/secureconversationbootstrap.md
@@ -11,7 +11,7 @@ Specifies the default values used for initiating a secure conversation service.
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-custombinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<secureConversationBootstrap>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/wcf/secureconversationbootstrap.md
+++ b/docs/framework/configure-apps/file-schema/wcf/secureconversationbootstrap.md
@@ -6,12 +6,13 @@ ms.assetid: 66b46f95-fa2d-4b5b-b6ce-0572ab0cdd50
 # \<secureConversationBootstrap>
 Specifies the default values used for initiating a secure conversation service.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
-\<secureConversationBootstrap>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<secureConversationBootstrap>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-element-of-ws2007federationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-element-of-ws2007federationhttpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 826219b4-3a16-45fc-832d-0cd7cbbd3b84
 # \<security> element of \<ws2007FederationHttpBinding>
 Defines the security settings of the [\<ws2007FederationHttpBinding>](ws2007federationhttpbinding.md) element.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<ws2007FederationHttpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<ws2007FederationHttpBinding>**](ws2007federationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-basichttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-basichttpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 6432708d-5465-4bd9-bfc2-466742db99cb
 # \<security> of \<basicHttpBinding>
 Defines the security capabilities of the [\<basicHttpBinding>](basichttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<basicHttpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<basicHttpBinding>**](basichttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-custombinding.md
@@ -6,11 +6,12 @@ ms.assetid: 243a5148-bbd1-447f-a8a5-6e7792c0a3f1
 # \<security> of \<customBinding>
 Specifies the security options for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-msmqintegrationbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-msmqintegrationbinding.md
@@ -6,11 +6,12 @@ ms.assetid: ae5c68a8-14a2-4c6e-b9e0-3e94e3e9135e
 # \<security> of \<msmqIntegrationBinding>
 Defines the transport security settings for the Message Queuing (MSMQ) integration channel.  
   
- \<system.ServiceModel>  
-\<bindings>  
-msmqIntegrationBinding  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<msmqIntegrationBinding>**](msmqintegrationbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-nethttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-nethttpbinding.md
@@ -5,13 +5,14 @@ ms.assetid: dc41f6f7-cabc-4a64-9fa0-ceabf861b348
 ---
 # \<security> of \<netHttpBinding>
 
-Defines the security capabilities of the [\<basicHttpBinding>](basichttpbinding.md).
+Defines the security capabilities of the [\<netHttpBinding>](nethttpbinding.md).
 
-\<system.ServiceModel>\
-\<bindings>\
-\<netHttpBinding>\
-\<binding>\
-\<security>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netHttpBinding>**](nethttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-netmsmqbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 001d11a9-7439-498c-b09d-fca20eaf8cd3
 # \<security> of \<netMsmqBinding>
 Defines the security settings for a MSMQ binding. It specifies whether transport or SOAP security is enabled and, if so, what authentication mode and protection levels are in use.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netMsmqBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netMsmqBinding>**](netmsmqbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-netnamedpipebinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-netnamedpipebinding.md
@@ -6,11 +6,12 @@ ms.assetid: bb3cb022-637e-49fd-92e8-6766038affa7
 # \<security> of \<netNamedPipeBinding>
 Defines the security settings for a binding.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netNamedPipeBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netNamedPipeBinding>**](netnamedpipebinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-netpeerbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-netpeerbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 1ef40d8c-f903-4426-9b08-da81462766d8
 # \<security> of \<netPeerBinding>
 Defines the security settings of the [\<netPeerTcpBinding>](netpeertcpbinding.md), including the type of authentication used and the security used for the message transport.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netPeerBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netPeerTcpBinding>**](netpeertcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-nettcpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 286cd191-4fd5-4c4e-a223-9c71cf7fdead
 # \<security> of \<netTcpBinding>
 Defines the security settings for a binding.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netTcpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netTcpBinding>**](nettcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-peertransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-peertransport.md
@@ -6,12 +6,13 @@ ms.assetid: f73634ed-f896-4968-bf74-5e5ac52d3b6b
 # \<security> of \<peerTransport>
 Contains the security settings associated with a peer channel, including the type of authentication used and the security used for the message transport.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<peerTransport>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<peerTransport>**](peertransport.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-webhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-webhttpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 727cf3d2-6f56-48ad-a59f-ba423edb9c83
 # \<security> of \<webHttpBinding>
 Specifies the security requirements for an endpoint configured with a [\<webHttpBinding>](webhttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<webHttpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<webHttpBinding>**](webhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-ws2007httpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-ws2007httpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: fdda0ff7-b462-4e26-af52-e87ddab71945
 # \<security> of \<ws2007HttpBinding>
 Represents the security settings used with the [\<ws2007HttpBinding>](ws2007httpbinding.md) element.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<ws2007HttpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<ws2007HttpBinding>**](ws2007httpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-wsdualhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-wsdualhttpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 869c05e7-4ebe-467d-95ab-c8f8de4e6b9e
 # \<security> of \<wsDualHttpBinding>
 Defines the security capabilities of the [\<wsDualHttpBinding>](wsdualhttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsDualHttpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsDualHttpBinding>**](wsdualhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-wsfederationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-wsfederationhttpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: a8e5e854-b8dc-4921-843d-34b6a4a6a8ba
 # \<security> of \<wsFederationHttpBinding>
 Defines the security settings of the [\<wsFederationHttpBinding>](wsfederationhttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsFederatedBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/security-of-wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/security-of-wshttpbinding.md
@@ -6,11 +6,12 @@ ms.assetid: 8658b162-2ddf-4162-a869-aa517a42288a
 # \<security> of \<wsHttpBinding>
 Represents the security capabilities of the [\<wsHttpBinding>](wshttpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsHttpBinding>  
-\<binding>  
-\<security>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsHttpBinding>**](wshttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<security>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/sslstreamsecurity.md
+++ b/docs/framework/configure-apps/file-schema/wcf/sslstreamsecurity.md
@@ -6,11 +6,12 @@ ms.assetid: 430a378b-a742-4858-8a12-9f9b235fd627
 # \<sslStreamSecurity>
 Represents a custom binding element that supports channel security using an SSL stream.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<sslStreamSecurity>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<sslStreamSecurity>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/tcptransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/tcptransport.md
@@ -6,11 +6,12 @@ ms.assetid: 8fcd18c1-9958-42e7-b442-7903f7bdb563
 # \<tcpTransport>
 Defines a TCP transport that can be used by a channel to transfers messages for a custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<tcpTransport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<tcpTransport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/textmessageencoding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/textmessageencoding.md
@@ -6,11 +6,12 @@ ms.assetid: e6d834d0-356e-45eb-b530-bbefbb9ec3f0
 # \<textMessageEncoding>
 Specifies the character encoding and message versioning used for text-based XML messages.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<textMessageEncoding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<textMessageEncoding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transactionflow.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transactionflow.md
@@ -6,11 +6,12 @@ ms.assetid: 8c7b4c5b-ace3-4fe3-89ff-7b13c9aacd13
 # \<transactionFlow>
 Specifies transaction flow support for the custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<transactionFlow>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transactionFlow>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-basichttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-basichttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 4c5ba293-3d7e-47a6-b84e-e9022857b7e5
 # \<transport> of \<basicHttpBinding>
 Defines properties that control authentication parameters for the HTTP transport.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<basicHttpBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<basicHttpBinding>**](basichttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-basichttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-msmqintegrationbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-msmqintegrationbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 054579e3-7fdd-47df-99ca-952706ba5c8e
 # \<transport> of \<msmqIntegrationBinding>
 Defines the security settings for the Message Queuing integration transport.  
   
- \<system.ServiceModel>  
-\<bindings>  
-msmqIntegrationBinding  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<msmqIntegrationBinding>**](msmqintegrationbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-msmqintegrationbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-nethttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-nethttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 3b180006-1661-43bf-a699-96fd3da469af
 # \<transport> of \<netHttpBinding>
 Defines properties that control authentication parameters for the HTTP transport.  
   
-\<system.serviceModel>  
-\<bindings>  
-\<netHttpBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netHttpBinding>**](nethttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-nethttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-netmsmqbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-netmsmqbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 72e1b338-39f0-4af1-a5d9-7a2fb79f6a0b
 # \<transport> of \<netMsmqBinding>
 Defines the transport security settings.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netMsmqBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netMsmqBinding>**](netmsmqbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-netmsmqbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-netnamedpipebinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-netnamedpipebinding.md
@@ -6,12 +6,13 @@ ms.assetid: d9eff52d-4bde-4586-b56a-b0ec24611f8d
 # \<transport> of \<netNamedPipeBinding>
 Defines the transport security settings for a named pipe.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netNamedPipeBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netNamedPipeBinding>**](netnamedpipebinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-netnamedpipebinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-netpeertcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-netpeertcpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: c44d86d2-1160-44d7-9c7a-297b12eccc7f
 # \<transport> of \<netPeerTcpBinding>
 Specifies settings for transport level security when using the [\<netPeerTcpBinding>](netpeertcpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netPeerTcpBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netPeerTcpBinding>**](netpeertcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-netpeertcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-netpeertcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-netpeertcpbinding.md
@@ -11,7 +11,7 @@ Specifies settings for transport level security when using the [\<netPeerTcpBind
 &nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netPeerTcpBinding>**](netpeertcpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-netpeertcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-netpeerbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-nettcpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-nettcpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 49462e0a-66e1-463f-b3e1-c83a441673c6
 # \<transport> of \<netTcpBinding>
 Defines the type of message-level security requirements for an endpoint configured with the [\<netTcpBinding>](nettcpbinding.md).  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<netTcpBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netTcpBinding>**](nettcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-nettcpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-peertransport.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-peertransport.md
@@ -6,13 +6,14 @@ ms.assetid: d7116240-845c-4b6f-b203-262de6b597ef
 # \<transport> of \<peerTransport>
 Specifies the transport type for secured messages sent by peers configured with this binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<peerTransport>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<peerTransport>**](peertransport.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-peertransport.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-webhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-webhttpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: f150fb19-7de1-44af-81f4-86cad881cd05
 # \<transport> of \<webHttpBinding>
 Defines the transport-level security settings for a service endpoint configured to receive HTTP requests.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<webHttpBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<webHttpBinding>**](webhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-webhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-ws2007httpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-ws2007httpbinding.md
@@ -6,12 +6,13 @@ ms.assetid: 692befa3-8b0b-4ec5-b601-755874e98eb0
 # \<transport> of \<ws2007HttpBinding>
 Defines authentication settings for the HTTP transport.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<ws2007HttpBinding>  
-\<binding>  
-\<security>  
-\<transport>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<ws2007HttpBinding>**](ws2007httpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-ws2007httpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/transport-of-wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/transport-of-wshttpbinding.md
@@ -8,12 +8,13 @@ ms.assetid: 21e38acf-450a-4bda-82b6-de305e1f7cd8
 
 Defines authentication settings for the HTTP transport.
 
-\<system.serviceModel>\
-\<bindings>\
-\<wsHttpBinding>\
-\<binding>\
-\<security>\
-\<transport>
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsHttpBinding>**](wshttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wshttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<transport>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/udpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/udpbinding.md
@@ -6,9 +6,10 @@ ms.assetid: fa291901-8340-45c6-9c44-5d9281c70bc3
 # \<udpBinding>
 A configuration element used to configure the <xref:System.ServiceModel.UdpBinding> binding.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<udpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<udpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/unrecognizedpolicyassertion.md
+++ b/docs/framework/configure-apps/file-schema/wcf/unrecognizedpolicyassertion.md
@@ -6,11 +6,12 @@ ms.assetid: 043c3c8f-f263-4ac7-a1af-945d03413f0b
 # \<unrecognizedPolicyAssertion>
 Represents a binding element that specifies policy assertion. This element has no attribute and is present as an empty switch.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<unrecognizedPolicyAssertion>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<unrecognizedPolicyAssertion>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/usemanagedpresentation.md
+++ b/docs/framework/configure-apps/file-schema/wcf/usemanagedpresentation.md
@@ -6,11 +6,12 @@ ms.assetid: 17a0dd77-af54-41db-a9d0-4b17ff42878f
 # \<useManagedPresentation>
 A binding element used to communicate with a CardSpace Security Token Service that supports the CardSpace profile of WS-Trust. This element has no attribute and is present as an empty switch.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<useManagedPresentation>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<useManagedPresentation>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/webhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/webhttpbinding.md
@@ -6,9 +6,10 @@ ms.assetid: 84179d77-825d-44b9-895a-ab08e7aa044d
 # \<webHttpBinding>
 Defines a binding element that is used to configure endpoints for Windows Communication Foundation (WCF) Web services that respond to HTTP requests instead of SOAP messages.  
   
-\<system.ServiceModel>  
-\<bindings>  
-\<webHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<webHttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/webmessageencoding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/webmessageencoding.md
@@ -6,11 +6,12 @@ ms.assetid: 892ca485-e21a-4a44-8e40-633161ef6796
 # \<webMessageEncoding>
 Enables plain-text XML, JavaScript Object Notation (JSON) message encodings and "raw" binary content to be read and written when used in a Windows Communication Foundation (WCF) binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<webMessageEncoding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<webMessageEncoding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/websocketsettings.md
+++ b/docs/framework/configure-apps/file-schema/wcf/websocketsettings.md
@@ -6,9 +6,12 @@ ms.assetid: bbf97e02-8dd1-4922-acac-3cd33397b249
 # \<webSocketSettings>
 A configuration element used to specify Web Socket settings.  
   
-\<system.ServiceModel>  
-\<bindings>  
-\<netHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<netHttpBinding>**](nethttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<webSocketSettings>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/windowsstreamsecurity.md
+++ b/docs/framework/configure-apps/file-schema/wcf/windowsstreamsecurity.md
@@ -6,11 +6,12 @@ ms.assetid: 926bea29-90c7-4a26-9cf0-fb4aa44f6f70
 # \<windowsStreamSecurity>
 Specify Windows stream security settings of the custom binding.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<customBinding>  
-\<binding>  
-\<windowsStreamSecurity>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<customBinding>**](custombinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<windowsStreamSecurity>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/ws2007federationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/ws2007federationhttpbinding.md
@@ -8,12 +8,11 @@ ms.assetid: 9af4ec79-cdef-457e-9dca-09d5eb821594
 
 A secure and interoperable binding that derives from [\<wsFederationHttpBinding>](wsfederationhttpbinding.md) and supports federated security.
 
-```xml
-<system.ServiceModel>
-  <bindings>
-    <ws2007FederationHttpBinding>
-```
-
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<ws2007FederationHttpBinding>**  
+  
 ## Syntax
 
 ```xml

--- a/docs/framework/configure-apps/file-schema/wcf/ws2007httpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/ws2007httpbinding.md
@@ -6,9 +6,10 @@ ms.assetid: 8586ecc9-bdaa-44d6-8d4d-7038e4ea1741
 # \<ws2007HttpBinding>
 Defines an interoperable binding that provides support for the correct versions of the <xref:System.ServiceModel.WSHttpBinding.Security%2A>, <xref:System.ServiceModel.ReliableSession>, and <xref:System.ServiceModel.WSHttpBindingBase.TransactionFlow%2A> binding elements.  
   
- \<system.serviceModel>  
-\<bindings>  
-\<ws2007HttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<ws2007HttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/wsdualhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wsdualhttpbinding.md
@@ -8,9 +8,10 @@ ms.assetid: fd8ac4e2-5641-473b-9115-73f14ab1c065
 # \<wsDualHttpBinding>
 Defines a secure, reliable and interoperable binding that is suitable for duplex service contracts or communication through SOAP intermediaries.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsDualHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<wsDualHttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/wsfederationhttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wsfederationhttpbinding.md
@@ -10,9 +10,10 @@ ms.assetid: 9c3312b4-2137-4e71-bf3f-de1cf8e9be79
 
 Defines a binding that supports WS-Federation.
 
-\<system.ServiceModel>\
-\<bindings>\
-wsFederationBinding element
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<wsFederationHttpBinding>**  
 
 ## Syntax
 

--- a/docs/framework/configure-apps/file-schema/wcf/wshttpbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wshttpbinding.md
@@ -8,9 +8,10 @@ ms.assetid: 0eee8ced-ad68-427d-b95a-97260e98deed
 # \<wsHttpBinding>
 Defines a secure, reliable, interoperable binding suitable for non-duplex service contracts. The binding implements the following specifications: WS-Reliable Messaging for reliability, and WS-Security for message security and authentication. The transport is HTTP, and message encoding is Text/XML encoding.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsHttpBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<wsHttpBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/wshttpcontextbinding.md
+++ b/docs/framework/configure-apps/file-schema/wcf/wshttpcontextbinding.md
@@ -6,9 +6,10 @@ ms.assetid: 1e40b5c9-0df2-4d66-afc5-a99d0e4ae7a4
 # \<wsHttpContextBinding>
 Provides a context for the <xref:System.ServiceModel.WSHttpBinding> that requires that the protection level be signed.  
   
-\<system.serviceModel>  
-\<bindings>  
-\<wsHttpContextBinding>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<wsHttpContextBinding>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/xmlelement.md
+++ b/docs/framework/configure-apps/file-schema/wcf/xmlelement.md
@@ -14,7 +14,7 @@ Specifies an XML element that is sent in the message body to the Security Token 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<tokenRequestParameters>**](tokenrequestparameters.md)\
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<xmlElement>**]  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<xmlElement>**  
   
 ## Syntax  
   

--- a/docs/framework/configure-apps/file-schema/wcf/xmlelement.md
+++ b/docs/framework/configure-apps/file-schema/wcf/xmlelement.md
@@ -6,13 +6,15 @@ ms.assetid: 395205c2-d8c0-4a5e-90f3-7ce3c085fccd
 # \<xmlElement>
 Specifies an XML element that is sent in the message body to the Security Token Service when requesting a token.  
   
- \<system.ServiceModel>  
-\<bindings>  
-\<wsFederatedBinding>  
-\<binding>  
-\<security>  
-\<message>  
-\<tokenRequestParameters>  
+[**\<configuration>**](../configuration-element.md)\
+&nbsp;&nbsp;[**\<system.serviceModel>**](system-servicemodel.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;[**\<bindings>**](bindings.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<wsFederationHttpBinding>**](wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<binding>**\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<security>**](security-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<message>**](message-element-of-wsfederationhttpbinding.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[**\<tokenRequestParameters>**](tokenrequestparameters.md)\
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**\<xmlElement>**]  
   
 ## Syntax  
   


### PR DESCRIPTION
Applied XML hierarchy format to WCF configuration section files for:
- `<system.serviceModel.activation><bindings>...</bindings></system.serviceModel.activation>` sub-section

Contributes to #2038 & #2149