### PR TITLE
C117556: Closing include correctly

### DIFF
--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo8-getdynamicfunctioninfo-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo8-getdynamicfunctioninfo-method.md
@@ -65,7 +65,7 @@ This API can be used to retrieve information about dynamic methods, including a 
 
 **Library:** CorGuids.lib
 
-**.NET Framework Versions:** [!INCLUDE[net_current_v472plus](../../../../includes/net-current-v472plus.md)
+**.NET Framework Versions:** [!INCLUDE[net_current_v472plus](../../../../includes/net-current-v472plus.md)]
 
 ## See also
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Missing closing square bracket is breaking the include syntax. Kindly consider adding it at the end of the reported string.