### PR TITLE
US 1583733 Add missing language IDs - 07

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-find-sibling-nodes-xpath-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-find-sibling-nodes-xpath-linq-to-xml.md
@@ -45,7 +45,7 @@ foreach (XElement el in list1)
   
  This example produces the following output:  
   
-```  
+```output  
 Results are identical  
 <Book id="bk101">  
   <Author>Garghentini, Davide</Author>  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-find-the-immediate-preceding-sibling-xpath-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-find-the-immediate-preceding-sibling-xpath-linq-to-xml.md
@@ -41,7 +41,7 @@ Console.WriteLine(el1);
   
  This example produces the following output:  
   
-```  
+```output  
 Results are identical  
 <Child3 />  
 ```  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-find-the-root-element-xpath-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-find-the-root-element-xpath-linq-to-xml.md
@@ -33,7 +33,7 @@ Console.WriteLine(el1.Name);
   
  This example produces the following output:  
   
-```  
+```output  
 Results are identical  
 PurchaseOrders  
 ```  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-generate-text-files-from-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-generate-text-files-from-xml.md
@@ -40,7 +40,7 @@ Console.WriteLine(csv);
   
  This code produces the following output:  
   
-```  
+```output  
 GREAL,Great Lakes Food Market,Howard Snyder,Marketing Manager,(503) 555-7555,2732 Baker Blvd.,Eugene,OR,97403,USA  
 HUNGC,Hungry Coyote Import Store,Yoshi Latimer,Sales Representative,(503) 555-6874,City Center Plaza 516 Main St.,Elgin,OR,97827,USA  
 LAZYK,Lazy K Kountry Store,John Steel,Marketing Manager,(509) 555-7969,12 Orchestra Terrace,Walla Walla,WA,99362,USA  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-join-content-from-dissimilar-files-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-join-content-from-dissimilar-files-linq.md
@@ -11,7 +11,7 @@ This example shows how to join data from two comma-delimited files that share a 
   
 1. Copy the following lines into a file that is named *scores.csv* and save it to your project folder. The file represents spreadsheet data. Column 1 is the student's ID, and columns 2 through 5 are test scores.  
   
-    ```  
+    ```csv  
     111, 97, 92, 81, 60  
     112, 75, 84, 91, 39  
     113, 88, 94, 65, 91  
@@ -28,7 +28,7 @@ This example shows how to join data from two comma-delimited files that share a 
   
 2. Copy the following lines into a file that is named *names.csv* and save it to your project folder. The file represents a spreadsheet that contains the student's last name, first name, and student ID.  
   
-    ```  
+    ```csv  
     Omelchenko,Svetlana,111  
     O'Donnell,Claire,112  
     Mortensen,Sven,113  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-join-two-collections-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-join-two-collections-linq-to-xml.md
@@ -70,7 +70,7 @@ if (!errors)
   
  This code produces the following output:  
   
-```  
+```output  
 Attempting to validate, custOrdDoc validated  
 <Root>  
   <Order>  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-list-all-nodes-in-a-tree.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-list-all-nodes-in-a-tree.md
@@ -33,7 +33,7 @@ Sometimes it is helpful to list all nodes in a tree. This can be useful when lea
   
  The following is the list of nodes in the above XML tree, expressed as XPath expressions:  
   
-```  
+```text  
 /processing-instruction()  
 /Root  
 /Root/@AttName  
@@ -311,7 +311,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>  
 <?target data?>  
 <Root AttName="An Attribute" xmlns:aw="http://www.adventure-works.com">  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-modify-an-office-open-xml-document.md
@@ -137,7 +137,6 @@ class Program
   
  When run with the sample Open XML document described in [Creating the Source Office Open XML Document (C#)](./creating-the-source-office-open-xml-document.md), this example produces the following output:  
   
-```  
+```output  
 New first paragraph: >PARSING WORDPROCESSINGML WITH LINQ TO XML<  
 ```  
-  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-perform-streaming-transformations-of-text-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-perform-streaming-transformations-of-text-to-xml.md
@@ -11,7 +11,7 @@ One approach to processing a text file is to write an extension method that stre
 ## Example  
  The following text file, People.txt, is the source for this example.  
   
-```  
+```text  
 #This is a comment  
 1,Tai,Yee,Writer  
 2,Nikolay,Grachev,Programmer  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-project-a-new-type-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-project-a-new-type-linq-to-xml.md
@@ -47,7 +47,7 @@ This example uses the <xref:System.Xml.Linq.XContainer.Element%2A> method that w
 
 This example produces the following output:
 
-```console
+```output
 Lawnmower:1
 Baby Monitor:2
 ```

--- a/docs/csharp/programming-guide/concepts/linq/how-to-project-an-anonymous-type.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-project-an-anonymous-type.md
@@ -8,7 +8,7 @@ In some cases you might want to project a query to a new type, even though you k
   
  Anonymous types are the C# implementation of the mathematical concept of a *tuple*. The mathematical term tuple originated from the sequence single, double, triple, quadruple, quintuple, n-tuple. It refers to a finite sequence of objects, each of a specific type. Sometimes this is called a list of name/value pairs. For example, the contents of an address in the [Sample XML File: Typical Purchase Order (LINQ to XML)](./sample-xml-file-typical-purchase-order-linq-to-xml-1.md) XML document could be expressed as follows:  
   
-```  
+```text  
 Name: Ellen Adams  
 Street: 123 Maple Street  
 City: Mill Valley  
@@ -39,7 +39,7 @@ foreach (var cust in custList)
   
  This code produces the following output:  
   
-```  
+```output  
 GREAL:Great Lakes Food Market:Howard Snyder  
 HUNGC:Hungry Coyote Import Store:Yoshi Latimer  
 LAZYK:Lazy K Kountry Store:John Steel  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-project-an-object-graph.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-project-an-object-graph.md
@@ -212,7 +212,7 @@ class Program {
   
  The example produces the following output:  
   
-```  
+```output  
 PurchaseOrderNumber: 99503  
 OrderDate: 10/20/1999  
   

--- a/docs/csharp/programming-guide/concepts/linq/how-to-query-an-arraylist-with-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-query-an-arraylist-with-linq.md
@@ -8,7 +8,7 @@ When using LINQ to query non-generic <xref:System.Collections.IEnumerable> colle
   
 ```csharp  
 var query = from Student s in arrList  
-...  
+//...
 ```  
   
  By specifying the type of the range variable, you are casting each item in the <xref:System.Collections.ArrayList> to a `Student`.  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-query-an-arraylist-with-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-query-an-arraylist-with-linq.md
@@ -6,7 +6,7 @@ ms.assetid: 2bfb471c-6e9a-4e60-bd83-4a1778abde11
 # How to: Query an ArrayList with LINQ (C#)
 When using LINQ to query non-generic <xref:System.Collections.IEnumerable> collections such as <xref:System.Collections.ArrayList>, you must explicitly declare the type of the range variable to reflect the specific type of the objects in the collection. For example, if you have an <xref:System.Collections.ArrayList> of `Student` objects, your [from clause](../../../language-reference/keywords/from-clause.md) should look like this:  
   
-```  
+```csharp  
 var query = from Student s in arrList  
 ...  
 ```  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-read-and-write-an-encoded-document.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-read-and-write-an-encoded-document.md
@@ -50,7 +50,7 @@ Console.WriteLine("Encoding of loaded document is:{0}", newDoc16.Declaration.Enc
   
  This example produces the following output:  
   
-```  
+```output  
 Creating a document with utf-8 encoding  
 Encoding is:utf-8  
   

--- a/docs/csharp/programming-guide/concepts/linq/how-to-reorder-the-fields-of-a-delimited-file-linq.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-reorder-the-fields-of-a-delimited-file-linq.md
@@ -12,7 +12,7 @@ A comma-separated value (CSV) file is a text file that is often used to store sp
   
 1. Copy the following lines into a plain text file that is named spreadsheet1.csv. Save the file in your project folder.  
   
-    ```  
+    ```csv  
     Adams,Terry,120  
     Fakhouri,Fadi,116  
     Feng,Hanying,117  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-a-collection-of-attributes-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-a-collection-of-attributes-linq-to-xml.md
@@ -24,7 +24,7 @@ foreach (XAttribute a in listOfAttributes)
   
  This code produces the following output:  
   
-```  
+```output  
 ID="1243"  
 Type="int"  
 ConvertableTo="double"  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-a-collection-of-elements-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-a-collection-of-elements-linq-to-xml.md
@@ -22,7 +22,7 @@ foreach (XElement el in childElements)
   
  This example produces the following output.  
   
-```  
+```output  
 Name: Address  
 Name: Address  
 Name: DeliveryNotes  

--- a/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-a-single-attribute-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-retrieve-a-single-attribute-linq-to-xml.md
@@ -31,7 +31,7 @@ foreach (XElement el in elList)
   
  This code produces the following output:  
   
-```  
+```output  
 home  
 work  
 ```  
@@ -57,7 +57,7 @@ foreach (XElement el in elList)
   
  This code produces the following output:  
   
-```  
+```output  
 home  
 work  
 ```  
@@ -86,7 +86,7 @@ foreach (XElement el in elList)
   
  This code produces the following output:  
   
-```  
+```output  
 home  
 work  
 ```  


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "output" for program output examples.
- Used "csv" for .csv input.
- Used "text" for text input.

Contributes to #2192