### PR TITLE
US 1583733 Add missing language IDs - 09

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/intermediate-materialization.md
+++ b/docs/csharp/programming-guide/concepts/linq/intermediate-materialization.md
@@ -60,7 +60,7 @@ class Program
   
  This example produces the following output:  
   
-```  
+```output  
 ToUpper: source >abc<  
 ToUpper: source >def<  
 ToUpper: source >ghi<  

--- a/docs/csharp/programming-guide/concepts/linq/linq-to-xml-events.md
+++ b/docs/csharp/programming-guide/concepts/linq/linq-to-xml-events.md
@@ -72,7 +72,7 @@ Console.WriteLine(root);
 ### Comments  
  This code produces the following output:  
   
-```  
+```output  
 Changed System.Xml.Linq.XElement Add  
 Changed System.Xml.Linq.XElement Add  
 Changed System.Xml.Linq.XText Remove  

--- a/docs/csharp/programming-guide/concepts/linq/performance-of-chained-queries-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/performance-of-chained-queries-linq-to-xml.md
@@ -31,7 +31,7 @@ foreach (var i in query2)
 
 This example produces the following output:
 
-```
+```output
 4
 ```
 

--- a/docs/csharp/programming-guide/concepts/linq/programming-with-nodes.md
+++ b/docs/csharp/programming-guide/concepts/linq/programming-with-nodes.md
@@ -22,7 +22,7 @@ Console.WriteLine(doc.Root.Parent == null);
   
  This example produces the following output:  
   
-```  
+```output  
 True  
 True  
 ```  
@@ -48,7 +48,7 @@ Console.WriteLine(xmlTree.Nodes().OfType<XText>().Count());
   
  This example produces the following output:  
   
-```  
+```output  
 1  
 1  
 2  
@@ -70,7 +70,7 @@ Console.WriteLine(">>{0}<<", textNode2);
   
  This example produces the following output:  
   
-```  
+```output  
 >><<  
 ```  
   
@@ -110,7 +110,7 @@ foreach (XAttribute att in root.Attributes())
   
  This example produces the following output:  
   
-```  
+```output  
 xmlns="http://www.adventure-works.com"  IsNamespaceDeclaration:True  
 xmlns:fc="www.fourthcoffee.com"  IsNamespaceDeclaration:True  
 AnAttribute="abc"  IsNamespaceDeclaration:False  
@@ -138,7 +138,7 @@ Console.WriteLine(((IEnumerable)root.XPathEvaluate("text()")).OfType<XText>().Co
   
  This example produces the following output:  
   
-```  
+```output  
 3  
 0  
 ```  
@@ -160,7 +160,7 @@ Console.WriteLine(doc.Nodes().Count());
   
  This example produces the following output:  
   
-```  
+```output  
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>  
 <Root />  
 1  

--- a/docs/csharp/programming-guide/concepts/linq/querying-an-xdocument-vs-querying-an-xelement.md
+++ b/docs/csharp/programming-guide/concepts/linq/querying-an-xdocument-vs-querying-an-xelement.md
@@ -31,7 +31,7 @@ foreach (XElement e in childList)
   
  As expected, this example produces the following output:  
   
-```  
+```output  
 Querying tree loaded with XElement.Load  
 ----  
 <Child1>1</Child1>  
@@ -61,7 +61,7 @@ foreach (XElement e in childList)
   
  This example produces the following output:  
   
-```  
+```output  
 Querying tree loaded with XDocument.Load  
 ----  
 <Root>  
@@ -95,7 +95,7 @@ foreach (XElement e in childList)
   
  This query now performs in the same way as the query on the tree rooted in <xref:System.Xml.Linq.XElement>. The example produces the following output:  
   
-```  
+```output  
 Querying tree loaded with XDocument.Load  
 ----  
 <Child1>1</Child1>  

--- a/docs/csharp/programming-guide/concepts/linq/refactoring-into-pure-functions.md
+++ b/docs/csharp/programming-guide/concepts/linq/refactoring-into-pure-functions.md
@@ -46,7 +46,7 @@ public class Program
   
  This code produces the following output:  
   
-```  
+```output  
 StringOne-StringTwo  
 ```  
   

--- a/docs/csharp/programming-guide/concepts/linq/refactoring-using-a-pure-function.md
+++ b/docs/csharp/programming-guide/concepts/linq/refactoring-using-a-pure-function.md
@@ -150,7 +150,7 @@ class Program
   
  This example produces the same output as before the refactoring:  
   
-```  
+```output  
 StyleName:Heading1 >Parsing WordprocessingML with LINQ to XML<  
 StyleName:Normal ><  
 StyleName:Normal >The following example prints to the console.<  

--- a/docs/csharp/programming-guide/concepts/linq/refactoring-using-an-extension-method.md
+++ b/docs/csharp/programming-guide/concepts/linq/refactoring-using-an-extension-method.md
@@ -74,7 +74,7 @@ Console.WriteLine("{0}", intNumbers.StringConcatenate(i => i.ToString(), ":"));
   
  This example produces the following output:  
   
-```  
+```output  
 onetwothree  
 one:two:three:  
 123  
@@ -215,7 +215,7 @@ class Program
   
  This example produces the following output when applied to the document described in [Creating the Source Office Open XML Document (C#)](./creating-the-source-office-open-xml-document.md).  
   
-```  
+```output  
 StyleName:Heading1 >Parsing WordprocessingML with LINQ to XML<  
 StyleName:Normal ><  
 StyleName:Normal >The following example prints to the console.<  

--- a/docs/csharp/programming-guide/concepts/linq/retrieving-the-paragraphs-and-their-styles.md
+++ b/docs/csharp/programming-guide/concepts/linq/retrieving-the-paragraphs-and-their-styles.md
@@ -105,7 +105,7 @@ foreach (var p in paragraphs)
   
  This example produces the following output when applied to the document described in [Creating the Source Office Open XML Document (C#)](./creating-the-source-office-open-xml-document.md).  
   
-```  
+```output  
 StyleName:Heading1  
 StyleName:Normal  
 StyleName:Normal  

--- a/docs/csharp/programming-guide/concepts/linq/retrieving-the-text-of-the-paragraphs.md
+++ b/docs/csharp/programming-guide/concepts/linq/retrieving-the-text-of-the-paragraphs.md
@@ -113,7 +113,7 @@ foreach (var p in paraWithText)
   
  This example produces the following output when applied to the document described in [Creating the Source Office Open XML Document (C#)](./creating-the-source-office-open-xml-document.md).  
   
-```  
+```output  
 StyleName:Heading1 >Parsing WordprocessingML with LINQ to XML<  
 StyleName:Normal ><  
 StyleName:Normal >The following example prints to the console.<  

--- a/docs/csharp/programming-guide/concepts/linq/scope-of-default-namespaces.md
+++ b/docs/csharp/programming-guide/concepts/linq/scope-of-default-namespaces.md
@@ -39,7 +39,7 @@ Console.WriteLine("End of result set");
 ### Comments  
  This example produces the following result:  
   
-```  
+```output  
 Result set follows:  
 End of result set  
 ```  
@@ -74,7 +74,7 @@ Console.WriteLine("End of result set");
 ### Comments  
  This example produces the following result:  
   
-```  
+```output  
 Result set follows:  
 1  
 2  

--- a/docs/csharp/programming-guide/concepts/linq/statically-compiled-queries-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/statically-compiled-queries-linq-to-xml.md
@@ -9,7 +9,7 @@ One of the most important performance benefits LINQ to XML, as opposed to <xref:
 ## Statically Compiled Queries vs. XPath  
  The following example shows how to get the descendant elements with a specified name, and with an attribute with a specified value.  
   
- The following is the equivalent XPath expression:  `//Address[@Type='Shipping']`  
+ The following is the equivalent XPath expression: `//Address[@Type='Shipping']`
   
 ```csharp  
 XDocument po = XDocument.Load("PurchaseOrders.xml");  

--- a/docs/csharp/programming-guide/concepts/linq/statically-compiled-queries-linq-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/statically-compiled-queries-linq-to-xml.md
@@ -9,11 +9,7 @@ One of the most important performance benefits LINQ to XML, as opposed to <xref:
 ## Statically Compiled Queries vs. XPath  
  The following example shows how to get the descendant elements with a specified name, and with an attribute with a specified value.  
   
- The following is the equivalent XPath expression:  
-  
-```  
-//Address[@Type='Shipping']  
-```  
+ The following is the equivalent XPath expression:  `//Address[@Type='Shipping']`  
   
 ```csharp  
 XDocument po = XDocument.Load("PurchaseOrders.xml");  
@@ -86,4 +82,3 @@ reader.Close();
 - It iterates through the nodes, appropriately selecting the nodes for the result set based on the evaluation of the expression.  
   
  This is significantly more than the work done by the corresponding LINQ to XML query. The specific performance difference varies for different types of queries, but in general LINQ to XML queries do less work, and therefore perform better, than evaluating XPath expressions using <xref:System.Xml.XmlDocument>.  
-  

--- a/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
+++ b/docs/csharp/programming-guide/indexers/indexers-in-interfaces.md
@@ -29,7 +29,7 @@ Indexers can be declared on an [interface](../../language-reference/keywords/int
   
  In the preceding example, you could use the explicit interface member implementation by using the fully qualified name of the interface member. For example:  
   
-```  
+```csharp  
 string ISomeInterface.this[int index]   
 {   
 }   
@@ -37,7 +37,7 @@ string ISomeInterface.this[int index]
   
  However, the fully qualified name is only needed to avoid ambiguity when the class is implementing more than one interface with the same indexer signature. For example, if an `Employee` class is implementing two interfaces, `ICitizen` and `IEmployee`, and both interfaces have the same indexer signature, the explicit interface member implementation is necessary. That is, the following indexer declaration:  
   
-```  
+```csharp  
 string IEmployee.this[int index]   
 {   
 }   
@@ -45,7 +45,7 @@ string IEmployee.this[int index]
   
  implements the indexer on the `IEmployee` interface, while the following declaration:  
   
-```  
+```csharp  
 string ICitizen.this[int index]
 {   
 }   

--- a/docs/csharp/programming-guide/main-and-command-args/command-line-arguments.md
+++ b/docs/csharp/programming-guide/main-and-command-args/command-line-arguments.md
@@ -22,19 +22,19 @@ You can send arguments to the `Main` method by defining the method in one of the
   
  You can also convert the string arguments to numeric types by using the <xref:System.Convert> class or the `Parse` method. For example, the following statement converts the `string` to a `long` number by using the <xref:System.Int64.Parse%2A> method:  
   
-```  
+```csharp  
 long num = Int64.Parse(args[0]);  
 ```  
   
  It is also possible to use the C# type `long`, which aliases `Int64`:  
   
-```  
+```csharp  
 long num = long.Parse(args[0]);  
 ```  
   
  You can also use the `Convert` class method `ToInt64` to do the same thing:  
   
-```  
+```csharp  
 long num = Convert.ToInt64(s);  
 ```  
   

--- a/docs/csharp/programming-guide/strings/how-to-determine-whether-a-string-represents-a-numeric-value.md
+++ b/docs/csharp/programming-guide/strings/how-to-determine-whether-a-string-represents-a-numeric-value.md
@@ -11,7 +11,7 @@ ms.assetid: a4e84e10-ea0a-489f-a868-503dded9d85f
 # How to: Determine Whether a String Represents a Numeric Value (C# Programming Guide)
 To determine whether a string is a valid representation of a specified numeric type, use the static `TryParse` method that is implemented by all primitive numeric types and also by types such as <xref:System.DateTime> and <xref:System.Net.IPAddress>. The following example shows how to determine whether "108" is a valid [int](../../language-reference/builtin-types/integral-numeric-types.md).  
   
-```  
+```csharp  
 int i = 0;   
 string s = "108";  
 bool result = int.TryParse(s, out i); //i now = 108  

--- a/docs/csharp/programming-guide/strings/index.md
+++ b/docs/csharp/programming-guide/strings/index.md
@@ -101,7 +101,7 @@ For more information on formatting .NET types see [Formatting Types in .NET](../
 ## Null Strings and Empty Strings  
  An empty string is an instance of a <xref:System.String?displayProperty=nameWithType> object that contains zero characters. Empty strings are used often in various programming scenarios to represent a blank text field. You can call methods on empty strings because they are valid <xref:System.String?displayProperty=nameWithType> objects. Empty strings are initialized as follows:  
   
-```  
+```csharp  
 string s = String.Empty;  
 ```  
   

--- a/docs/csharp/programming-guide/types/walkthrough-creating-and-using-dynamic-objects.md
+++ b/docs/csharp/programming-guide/types/walkthrough-creating-and-using-dynamic-objects.md
@@ -91,7 +91,7 @@ The first project that you create in this walkthrough defines a custom dynamic o
   
 2. Copy the following text to the TextFile1.txt file.  
   
-    ```  
+    ```text  
     List of customers and suppliers  
   
     Supplier: Lucerne Publishing (https://www.lucernepublishing.com/)  

--- a/docs/csharp/roslyn-sdk/get-started/semantic-analysis.md
+++ b/docs/csharp/roslyn-sdk/get-started/semantic-analysis.md
@@ -73,7 +73,7 @@ From the <xref:Microsoft.CodeAnalysis.SymbolInfo> object you can obtain the <xre
 
 Run the program and you should see the following output:
 
-```
+```output
 System.Collections
 System.Configuration
 System.Deployment
@@ -130,7 +130,7 @@ You can also build the full query using the LINQ query syntax, and then display 
 
 Build and run the program. You should see the following output:
 
-```
+```output
 Join
 Substring
 Trim


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "output" for program output examples.
- Converted one block to single tick (`).
- Used "text" for text input examples.

Contributes to #2192