### PR TITLE
Add missing supported identifiers in template.md

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -313,6 +313,8 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |PowerApps (comma decimal separator)|powerapps-comma|
 |PowerShell|powershell|
 |Python|python|
+|Q#|qsharp|
+|R|r|
 |Ruby|ruby|
 |SQL|sql|
 |Swift|swift|

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -281,8 +281,8 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |Name|Markdown label|
 |-----|-------|
 |.NET Console|dotnetcli|
-|ASP.NET with C#|aspx-csharp|
-|ASP.NET with VB|aspx-vb|
+|ASP.NET (C#)|aspx-csharp|
+|ASP.NET (VB)|aspx-vb|
 |Azure CLI|azurecli|
 |AzCopy|azcopy|
 |Azure PowerShell|azurepowershell|

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -295,7 +295,7 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |Console|console|
 |CSHTML|cshtml|
 |DAX|dax|
-|Docker|dockerfile|
+|Dockerfile|Dockerfile|
 |F#|fsharp|
 |Go|go|
 |HTML|html|

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -295,7 +295,7 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |Console|console|
 |CSHTML|cshtml|
 |DAX|dax|
-|Dockerfile|Dockerfile|
+|Dockerfile|dockerfile|
 |F#|fsharp|
 |Go|go|
 |HTML|html|

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -280,26 +280,43 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 
 |Name|Markdown label|
 |-----|-------|
+|.NET Console|dotnetcli|
 |ASP.NET with C#|aspx-csharp|
 |ASP.NET with VB|aspx-vb|
 |Azure CLI|azurecli|
 |AzCopy|azcopy|
+|Azure PowerShell|azurepowershell|
+|Bash|bash|
 |C++|cpp|
+|C++/CX|cppcx|
+|C++/WinRT|cppwinrt|
 |C#|csharp|
 |C# in browser|csharp-interactive|
 |Console|console|
+|CSHTML|cshtml|
+|DAX|dax|
+|Docker|dockerfile|
 |F#|fsharp|
+|Go|go|
+|HTML|html|
+|HTTP|http|
 |Java|java|
 |JavaScript|javascript|
 |JSON|json|
+|Kusto Query Language|kusto|
+|Markdown|md|
 |NodeJS|nodejs|
 |Objective-C|objc|
+|OData|odata|
 |PHP|php|
+|PowerApps (dot decimal separator)|powerapps-dot|
+|PowerApps (comma decimal separator)|powerapps-comma|
 |PowerShell|powershell|
 |Python|python|
 |Ruby|ruby|
 |SQL|sql|
 |Swift|swift|
+|TypeScript|typescript|
 |VB|vb|
 |XAML|xaml|
 |XML|xml|


### PR DESCRIPTION
- Added some identifiers that are mentioned [here](https://docs.microsoft.com/en-us/contribute/how-to-write-use-markdown#code-snippets) but not in `template.md`
- Replaced `ASP.NET with C#` with `ASP.NET (C#)` and `ASP.NET with VB` with `ASP.NET (VB)` because that is how it's rendered in live docs.

![image](https://user-images.githubusercontent.com/31348972/64266251-95346a00-cf34-11e9-912f-9956851deacd.png)
