### PR TITLE
US 1583733 Add missing language IDs - 14

### DIFF
--- a/docs/framework/data/adonet/ef/modification-sql-generation.md
+++ b/docs/framework/data/adonet/ef/modification-sql-generation.md
@@ -57,9 +57,7 @@ The Returning value specifies a projection of results to be returned based on th
 
 SetClauses specifies the list of insert or update set clauses that define the insert or update operation.
 
-```
 The elements of the list are specified as type DbModificationClause, which specifies a single clause in an insert or update modification operation. DbSetClause inherits from DbModificationClause and specifies the clause in a modification operation that sets the value of a property. Beginning in version 3.5 of the .NET Framework, all elements in SetClauses are of type SetClause.
-```
 
 Property specifies the property that should be updated. It is always a DbPropertyExpression over a DbVariableReferenceExpression, which represents a reference to the Target of the corresponding DbModificationCommandTree.
 
@@ -155,7 +153,7 @@ using (NorthwindEntities northwindContext = new NorthwindEntities()) {
 
 This code produces the following command tree, which is passed to the provider:
 
-```
+```output
 DbInsertCommandTree
 |_Parameters
 |_Target : 'target'
@@ -225,7 +223,7 @@ using (NorthwindEntities northwindContext = new NorthwindEntities()) {
 
 This user code produces the following command tree, which is passed to the provider:
 
-```
+```output
 DbUpdateCommandTree
 |_Parameters
 |_Target : 'target'
@@ -276,7 +274,7 @@ using (NorthwindEntities northwindContext = new NorthwindEntities()) {
 
 This user code produces the following command tree, which is passed to the provider.
 
-```
+```output
 DbDeleteCommandTree
 |_Parameters
 |_Target : 'target'

--- a/docs/framework/data/adonet/ef/performance-considerations.md
+++ b/docs/framework/data/adonet/ef/performance-considerations.md
@@ -58,7 +58,7 @@ This topic describes performance characteristics of the ADO.NET Entity Framework
   
      The following is an example of a nested query in a projection clause:  
   
-    ```  
+    ```sql  
     SELECT c, (SELECT c, (SELECT c FROM AdventureWorksModel.Vendor AS c  ) As Inner2   
         FROM AdventureWorksModel.JobCandidate AS c  ) As Inner1   
         FROM AdventureWorksModel.EmployeeDepartmentHistory AS c  

--- a/docs/framework/data/adonet/ef/provider-manifest-specification.md
+++ b/docs/framework/data/adonet/ef/provider-manifest-specification.md
@@ -87,7 +87,7 @@ public DbProviderManifest GetProviderManifest(string manifestToken);
 #### Using a Provider Manifest Token  
  For the offline scenario, the token is picked from SSDL representation. The SSDL allows you to specify a ProviderManifestToken (see [Schema Element (SSDL)](/ef/ef6/modeling/designer/advanced/edmx/ssdl-spec#schema-element-ssdl) for more information). For example, if a connection cannot be opened, the SSDL has a provider manifest token that specifies information about the manifest.  
   
-```  
+```csharp  
 public DbProviderManifest GetProviderManifest(string manifestToken);  
 ```  
   

--- a/docs/framework/data/adonet/ef/security-considerations.md
+++ b/docs/framework/data/adonet/ef/security-considerations.md
@@ -114,11 +114,11 @@ This topic describes security considerations that are specific to developing, de
   
 - A consumer of a query that exposes an <xref:System.Linq.IQueryable%601> type could call methods on the result that expose secure data or increase the size of the result set. For example, consider the following method signature:  
   
-    ```  
+    ```csharp  
     public IQueryable<Customer> GetCustomer(int customerId)  
     ```  
   
-     A consumer of this query could call `.Include("Orders")` on the returned `IQueryable<Customer>` to retrieve data that the query did not intend to expose. This can be avoided by changing the return type of the method to <xref:System.Collections.Generic.IEnumerable%601> and calling a method (such as `.ToList()`) that materializes the results.  
+    A consumer of this query could call `.Include("Orders")` on the returned `IQueryable<Customer>` to retrieve data that the query did not intend to expose. This can be avoided by changing the return type of the method to <xref:System.Collections.Generic.IEnumerable%601> and calling a method (such as `.ToList()`) that materializes the results.  
   
 - Because <xref:System.Linq.IQueryable%601> queries are executed when the results are iterated over, a consumer of a query that exposes an <xref:System.Linq.IQueryable%601> type could catch exceptions that are thrown. Exceptions could contain information not intended for the consumer.  
   

--- a/docs/framework/data/adonet/ef/walkthrough-sql-generation.md
+++ b/docs/framework/data/adonet/ef/walkthrough-sql-generation.md
@@ -18,7 +18,7 @@ INNER JOIN (SELECT OD.ProductId, OD.Order.ShipCountry as ShipCountry
 
 The query produces the following output command tree that is passed to the provider:
 
-```
+```output
 DbQueryCommandTree
 |_Parameters
 |_Query : Collection{Record['C1'=Edm.Int32, 'ProductID'=Edm.Int32, 'ProductName'=Edm.String, 'CategoryName'=Edm.String, 'ShipCountry'=Edm.String, 'ProductID1'=Edm.Int32]}
@@ -154,7 +154,7 @@ The join condition of Join4 is similarly processed. The control returns to the V
 
 Finally, the following SqlSelectStatement is produced:
 
-```
+```sql
 SELECT:
   "1", " AS ", "[C1]",
   <symbol_Extent1>, ".", "[ProductID]", " AS ", "[ProductID]",

--- a/docs/framework/data/adonet/ole-db-odbc-and-oracle-connection-pooling.md
+++ b/docs/framework/data/adonet/ole-db-odbc-and-oracle-connection-pooling.md
@@ -9,7 +9,7 @@ Pooling connections can significantly enhance the performance and scalability of
 ## Connection Pooling for OleDb  
  The .NET Framework Data Provider for OLE DB automatically pools connections using OLE DB session pooling. Connection string arguments can be used to enable or disable OLE DB services including pooling. For example, the following connection string disables OLE DB session pooling and automatic transaction enlistment.  
   
-```  
+```csharp
 Provider=SQLOLEDB;OLE DB Services=-4;Data Source=localhost;Integrated Security=SSPI;  
 ```  
   

--- a/docs/framework/data/adonet/optimistic-concurrency.md
+++ b/docs/framework/data/adonet/optimistic-concurrency.md
@@ -61,13 +61,13 @@ In a multiuser environment, there are two models for updating data in a database
   
  Another technique for testing for an optimistic concurrency violation is to verify that all the original column values in a row still match those found in the database. For example, consider the following query:  
   
-```csharp
+```sql
 SELECT Col1, Col2, Col3 FROM Table1  
 ```  
   
  To test for an optimistic concurrency violation when updating a row in **Table1**, you would issue the following UPDATE statement:  
   
-```csharp
+```sql
 UPDATE Table1 Set Col1 = @NewCol1Value,  
               Set Col2 = @NewCol2Value,  
               Set Col3 = @NewCol3Value  
@@ -82,7 +82,7 @@ WHERE Col1 = @OldCol1Value AND
   
  If a column at your data source allows nulls, you may need to extend your WHERE clause to check for a matching null reference in your local table and at the data source. For example, the following UPDATE statement verifies that a null reference in the local row still matches a null reference at the data source, or that the value in the local row still matches the value at the data source.  
   
-```csharp
+```sql
 UPDATE Table1 Set Col1 = @NewVal1  
   WHERE (@OldVal1 IS NULL AND Col1 IS NULL) OR Col1 = @OldVal1  
 ```  

--- a/docs/framework/data/adonet/optimistic-concurrency.md
+++ b/docs/framework/data/adonet/optimistic-concurrency.md
@@ -61,13 +61,13 @@ In a multiuser environment, there are two models for updating data in a database
   
  Another technique for testing for an optimistic concurrency violation is to verify that all the original column values in a row still match those found in the database. For example, consider the following query:  
   
-```  
+```csharp
 SELECT Col1, Col2, Col3 FROM Table1  
 ```  
   
  To test for an optimistic concurrency violation when updating a row in **Table1**, you would issue the following UPDATE statement:  
   
-```  
+```csharp
 UPDATE Table1 Set Col1 = @NewCol1Value,  
               Set Col2 = @NewCol2Value,  
               Set Col3 = @NewCol3Value  
@@ -82,7 +82,7 @@ WHERE Col1 = @OldCol1Value AND
   
  If a column at your data source allows nulls, you may need to extend your WHERE clause to check for a matching null reference in your local table and at the data source. For example, the following UPDATE statement verifies that a null reference in the local row still matches a null reference at the data source, or that the value in the local row still matches the value at the data source.  
   
-```  
+```csharp
 UPDATE Table1 Set Col1 = @NewVal1  
   WHERE (@OldVal1 IS NULL AND Col1 IS NULL) OR Col1 = @OldVal1  
 ```  

--- a/docs/framework/data/adonet/oracle-and-adonet.md
+++ b/docs/framework/data/adonet/oracle-and-adonet.md
@@ -26,7 +26,7 @@ using System.Data.OracleClient;
   
  You also must include a reference to the DLL when you compile your code. For example, if you are compiling a C# program, your command line should include:  
   
-```  
+```console
 csc /r:System.Data.OracleClient.dll  
 ```  
   

--- a/docs/framework/data/adonet/oracle-distributed-transactions.md
+++ b/docs/framework/data/adonet/oracle-distributed-transactions.md
@@ -6,7 +6,7 @@ ms.assetid: c340ca81-ef79-402f-b204-c5156b890fe5
 # Oracle Distributed Transactions
 The <xref:System.Data.OracleClient.OracleConnection> object automatically enlists in an existing distributed transaction if it determines that a transaction is active. Automatic transaction enlistment occurs when the connection is opened or retrieved from the connection pool. You can disable auto-enlistment in existing transactions by specifying  
   
-```  
+```csharp  
 Enlist=false  
 ```  
   

--- a/docs/framework/data/adonet/sql/authentication-in-sql-server.md
+++ b/docs/framework/data/adonet/sql/authentication-in-sql-server.md
@@ -15,7 +15,7 @@ SQL Server supports two authentication modes, Windows authentication mode and mi
   
  With Windows authentication, users are already logged onto Windows and do not have to log on separately to SQL Server. The following `SqlConnection.ConnectionString` specifies Windows authentication without requiring users to provide a user name or password.  
   
-```  
+```csharp  
 "Server=MSSQL1;Database=AdventureWorks;Integrated Security=true;  
 ```  
   

--- a/docs/framework/data/adonet/sql/authentication-in-sql-server.md
+++ b/docs/framework/data/adonet/sql/authentication-in-sql-server.md
@@ -16,7 +16,7 @@ SQL Server supports two authentication modes, Windows authentication mode and mi
  With Windows authentication, users are already logged onto Windows and do not have to log on separately to SQL Server. The following `SqlConnection.ConnectionString` specifies Windows authentication without requiring users to provide a user name or password.  
   
 ```csharp  
-"Server=MSSQL1;Database=AdventureWorks;Integrated Security=true;  
+"Server=MSSQL1;Database=AdventureWorks;Integrated Security=true;"
 ```  
   
 > [!NOTE]

--- a/docs/framework/data/adonet/sql/bulk-copy-example-setup.md
+++ b/docs/framework/data/adonet/sql/bulk-copy-example-setup.md
@@ -16,7 +16,7 @@ The <xref:System.Data.SqlClient.SqlBulkCopy> class can be used to write data onl
 ## Table Setup  
  To create the tables necessary for the code samples to run correctly, you must run the following Transact-SQL statements in a SQL Server database.  
   
-```  
+```sql
 USE AdventureWorks  
   
 IF EXISTS (SELECT * FROM dbo.sysobjects   

--- a/docs/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values.md
+++ b/docs/framework/data/adonet/sql/comparing-guid-and-uniqueidentifier-values.md
@@ -22,7 +22,7 @@ The globally unique identifier (GUID) data type in SQL Server is represented by 
   
  This example produces the following results.  
   
-```  
+```output  
 Unsorted Guids:  
 3aaaaaaa-bbbb-cccc-dddd-2eeeeeeeeeee  
 2aaaaaaa-bbbb-cccc-dddd-1eeeeeeeeeee  

--- a/docs/framework/data/adonet/sql/customizing-permissions-with-impersonation-in-sql-server.md
+++ b/docs/framework/data/adonet/sql/customizing-permissions-with-impersonation-in-sql-server.md
@@ -11,7 +11,7 @@ Many applications use stored procedures to access data, relying on ownership cha
 ## Context Switching with the EXECUTE AS Statement  
  The Transact-SQL EXECUTE AS statement allows you to switch the execution context of a statement by impersonating another login or database user. This is a useful technique for testing queries and procedures as another user.  
   
-```  
+```sql  
 EXECUTE AS LOGIN = 'loginName';  
 EXECUTE AS USER = 'userName';  
 ```  
@@ -30,7 +30,7 @@ EXECUTE AS USER = 'userName';
   
 1. Create a proxy user in the database that is not mapped to a login. This is not required, but it helps when managing permissions.  
   
-```  
+```sql
 CREATE USER proxyUser WITHOUT LOGIN  
 ```  
   
@@ -38,7 +38,7 @@ CREATE USER proxyUser WITHOUT LOGIN
   
 2. Add the EXECUTE AS clause to the stored procedure or user-defined function.  
   
-```  
+```sql
 CREATE PROCEDURE [procName] WITH EXECUTE AS 'proxyUser' AS ...  
 ```  
   

--- a/docs/framework/data/adonet/sql/database-mirroring-in-sql-server.md
+++ b/docs/framework/data/adonet/sql/database-mirroring-in-sql-server.md
@@ -20,7 +20,7 @@ Database mirroring in SQL Server allows you to keep a copy, or mirror, of a SQL 
 ## Specifying the Failover Partner in the Connection String  
  If you supply the name of a failover partner server in the connection string, the client will transparently attempt a connection with the failover partner if the principal database is unavailable when the client application first connects.  
   
-```  
+```csharp
 ";Failover Partner=PartnerServerName"  
 ```  
   

--- a/docs/framework/data/adonet/sql/enabling-cross-database-access-in-sql-server.md
+++ b/docs/framework/data/adonet/sql/enabling-cross-database-access-in-sql-server.md
@@ -20,7 +20,7 @@ Cross-database ownership chaining occurs when a procedure in one database depend
   
  The following sample turns on cross-database ownership chaining for all databases:  
   
-```  
+```sql
 EXECUTE sp_configure 'show advanced', 1;  
 RECONFIGURE;  
 EXECUTE sp_configure 'cross db ownership chaining', 1;  
@@ -29,7 +29,7 @@ RECONFIGURE;
   
  The following sample turns on cross-database ownership chaining for specific databases:  
   
-```  
+```sql
 ALTER DATABASE Database1 SET DB_CHAINING ON;  
 ALTER DATABASE Database2 SET DB_CHAINING ON;  
 ```  

--- a/docs/framework/data/adonet/sql/enabling-query-notifications.md
+++ b/docs/framework/data/adonet/sql/enabling-query-notifications.md
@@ -49,7 +49,7 @@ Applications that consume query notifications have a common set of requirements.
   
  For the query notification samples to run correctly, the following Transact-SQL statements must be executed on the database server.  
   
-```  
+```sql
 CREATE QUEUE ContactChangeMessages;  
   
 CREATE SERVICE ContactChangeNotifications  

--- a/docs/framework/data/adonet/sql/handling-null-values.md
+++ b/docs/framework/data/adonet/sql/handling-null-values.md
@@ -33,19 +33,19 @@ A null value in a relational database is used when the value in a column is unkn
   
  The ANSI SQL-92 standard does not support *columnName* = NULL in a WHERE clause. In SQL Server, the ANSI_NULLS option controls both default nullability in the database and evaluation of comparisons against null values. If ANSI_NULLS is turned on (the default), the IS NULL operator must be used in expressions when testing for null values. For example, the following comparison always yields unknown when ANSI_NULLS is on:  
   
-```  
+```sql
 colname > NULL  
 ```  
   
  Comparison to a variable containing a null value also yields unknown:  
   
-```  
+```sql
 colname > @MyVariable  
 ```  
   
  Use the IS NULL or IS NOT NULL predicate to test for a null value. This can add complexity to the WHERE clause. For example, the TerritoryID column in the AdventureWorks Customer table allows null values. If a SELECT statement is to test for null values in addition to others, it must include an IS NULL predicate:  
   
-```  
+```sql
 SELECT CustomerID, AccountNumber, TerritoryID  
 FROM AdventureWorks.Sales.Customer  
 WHERE TerritoryID IN (1, 2, 3)  
@@ -106,7 +106,7 @@ WHERE TerritoryID IN (1, 2, 3)
   
  This example displays the following results:  
   
-```  
+```output
 isColumnNull=False, ID=123, Description=Side Mirror  
 isColumnNull=True, ID=Null, Description=Null  
 ```  
@@ -121,7 +121,7 @@ isColumnNull=True, ID=Null, Description=Null
   
  The code produces the following output:  
   
-```  
+```output
 SqlString.Equals shared/static method:  
   Two nulls=Null  
   


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "output" for command tree examples.
- Used "sql" for examples of SQL statements, and "csharp" for .NET Framework APIs that consume them.

Contributes to #2192