### PR TITLE
Allocation and ownership of rgILMapEntries

### DIFF
--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo-setilinstrumentedcodemap-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo-setilinstrumentedcodemap-method.md
@@ -79,7 +79,7 @@ The debugger will assume that each old offset refers to an MSIL offset within th
 
   - A new offset of 20 or higher will be mapped to old offset 9.
 
-Before .NET Framework 4.0, `rgILMapEntries` array should have been allocated using the [CoTaskMemAlloc](/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc) method and the profiler shouldn't have attempt to free this memory.
+In the .NET Framework 3.5 and previous versions, you allocate the `rgILMapEntries` array by calling the [CoTaskMemAlloc](/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc) method. Because the runtime takes ownership of this memory, the profiler should not attempt to free it.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/profiling/icorprofilerinfo-setilinstrumentedcodemap-method.md
+++ b/docs/framework/unmanaged-api/profiling/icorprofilerinfo-setilinstrumentedcodemap-method.md
@@ -79,6 +79,8 @@ The debugger will assume that each old offset refers to an MSIL offset within th
 
   - A new offset of 20 or higher will be mapped to old offset 9.
 
+Before .NET Framework 4.0, `rgILMapEntries` array should have been allocated using the [CoTaskMemAlloc](/windows/desktop/api/combaseapi/nf-combaseapi-cotaskmemalloc) method and the profiler shouldn't have attempt to free this memory.
+
 ## Requirements
 
 **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).


### PR DESCRIPTION
Add extra information about required allocator and transferring of ownership for `rgILMapEntries` argument in `ProfToEEInterfaceImpl::SetILInstrumentedCodeMap` before .NET Framework 4.0.

Fixes https://github.com/dotnet/coreclr/issues/22851