### PR TITLE
C# 6 tutorial - add missing namespace

### DIFF
--- a/docs/csharp/tutorials/exploration/csharp-6.yml
+++ b/docs/csharp/tutorials/exploration/csharp-6.yml
@@ -188,6 +188,7 @@ items:
 
     ```csharp
     using System;
+    using System.Collections.Generic;
 
     public class Program
     {


### PR DESCRIPTION
fixes #14226 