### PR TITLE
Update override.md

### DIFF
--- a/docs/csharp/language-reference/keywords/override.md
+++ b/docs/csharp/language-reference/keywords/override.md
@@ -15,7 +15,7 @@ The `override` modifier is required to extend or modify the abstract or virtual 
 
 ## Example
 
-In this example, the `Square` class must provide an overridden implementation of `Area` because `Area` is inherited from the abstract `ShapesClass`:
+In this example, the `Square` class must provide an overridden implementation of `GetArea` because `GetArea` is inherited from the abstract `Shape` class:
 
 [!code-csharp[csrefKeywordsModifiers#1](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsModifiers/CS/csrefKeywordsModifiers.cs#1)]
 


### PR DESCRIPTION
## Summary

Fixed example explanation text that did not match the method and class names in the example code.  The example code was modified in samples PR 885 (https://github.com/dotnet/samples/pull/885) but the docs did not get updated to match.