### PR TITLE
WCF configuration - update syntax with correct element name

### DIFF
--- a/docs/framework/configure-apps/file-schema/wcf/httpdigest-element.md
+++ b/docs/framework/configure-apps/file-schema/wcf/httpdigest-element.md
@@ -17,7 +17,7 @@ Specifies a digest type credential used when authenticating the client to a serv
 ## Syntax  
   
 ```xml  
-<digest impersonationLevel="Identification/Impersonation/Delegation/Anonymous/None" />
+<httpDigest impersonationLevel="Identification/Impersonation/Delegation/Anonymous/None" />
 ```  
   
 ## Attributes and Elements  


### PR DESCRIPTION
Fix syntax according to VS xml schema for clientCredentials element:
`<digest>` to `<httpDigest>`

Fixes #14251 