### PR TITLE
Remove redundant use of string interpolation in linq to xml doc

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/linq-to-xml-overview.md
+++ b/docs/csharp/programming-guide/concepts/linq/linq-to-xml-overview.md
@@ -55,7 +55,7 @@ var filename = "PurchaseOrder.xml";
 var currentDirectory = Directory.GetCurrentDirectory();
 var purchaseOrderFilepath = Path.Combine(currentDirectory, filename);
 
-XElement purchaseOrder = XElement.Load($"{purchaseOrderFilepath}");
+XElement purchaseOrder = XElement.Load(purchaseOrderFilepath);
 
 IEnumerable<XElement> pricesByPartNos =  from item in purchaseOrder.Descendants("Item")
                                  where (int) item.Element("Quantity") * (decimal) item.Element("USPrice") > 100

--- a/docs/csharp/programming-guide/concepts/linq/linq-to-xml-overview.md
+++ b/docs/csharp/programming-guide/concepts/linq/linq-to-xml-overview.md
@@ -35,7 +35,7 @@ var filename = "PurchaseOrder.xml";
 var currentDirectory = Directory.GetCurrentDirectory();
 var purchaseOrderFilepath = Path.Combine(currentDirectory, filename);
 
-XElement purchaseOrder = XElement.Load($"{purchaseOrderFilepath}");
+XElement purchaseOrder = XElement.Load(purchaseOrderFilepath);
 
 IEnumerable<string> partNos =  from item in purchaseOrder.Descendants("Item")
                                select (string) item.Attribute("PartNumber");


### PR DESCRIPTION
## Summary

The string interpolation is completely redundant here

