### PR TITLE
US 1583733 Add missing language IDs - 20

### DIFF
--- a/docs/framework/resources/creating-resource-files-for-desktop-apps.md
+++ b/docs/framework/resources/creating-resource-files-for-desktop-apps.md
@@ -68,7 +68,7 @@ HelpMenuName=Help
 
  Empty strings (that is, a resource whose value is <xref:System.String.Empty?displayProperty=nameWithType>) are permitted in text files. For example:
 
-```
+```text
 EmptyString=
 ```
 
@@ -125,7 +125,7 @@ vbc greeting.vb -resource:GreetingResources.resources
 
  If you are using C#, and the source code file is named Greeting.cs, the following command creates an executable file that includes the embedded .resources file:
 
- ```console
+```console
 csc greeting.cs -resource:GreetingResources.resources
 ```
 

--- a/docs/framework/resources/packaging-and-deploying-resources-in-desktop-apps.md
+++ b/docs/framework/resources/packaging-and-deploying-resources-in-desktop-apps.md
@@ -171,13 +171,13 @@ You can optionally remove resources from the main assembly and specify that the 
 
 The following .NET Framework example uses the <xref:System.Resources.NeutralResourcesLanguageAttribute> attribute to store an application's fallback resources in a satellite assembly for the French (`fr`) language. The example has two text-based resource files that define a single string resource named `Greeting`. The first, resources.fr.txt, contains a French language resource.
 
-```
+```text
 Greeting=Bon jour!
 ```
 
 The second, resources,ru.txt, contains a Russian language resource.
 
-```
+```text
 Greeting=Добрый день
 ```
 
@@ -218,7 +218,7 @@ Because there are no resources embedded in the main assembly, you do not have to
 
 When you run the example from a system whose language is anything other than Russian, it displays the following output:
 
-```
+```output
 Bon jour!
 ```
 

--- a/docs/framework/resources/retrieving-resources-in-desktop-apps.md
+++ b/docs/framework/resources/retrieving-resources-in-desktop-apps.md
@@ -37,19 +37,19 @@ When you work with localized resources in .NET Framework desktop apps, you shoul
 ### Retrieving String Data: An Example  
  The following example calls the <xref:System.Resources.ResourceManager.GetString%28System.String%29> method to retrieve the string resources of the current UI culture. It includes a neutral string resource for the English (United States) culture and localized resources for the French (France) and Russian (Russia) cultures. The following English (United States) resource is in a file named Strings.txt:  
   
-```  
+```text
 TimeHeader=The current time is  
 ```  
   
  The French (France) resource is in a file named Strings.fr-FR.txt:  
   
-```  
+```text
 TimeHeader=L'heure actuelle est  
 ```  
   
  The Russian (Russia) resource is in a file named Strings.ru-RU-txt:  
   
-```  
+```text
 TimeHeader=Текущее время —  
 ```  
   
@@ -60,7 +60,7 @@ TimeHeader=Текущее время —
   
  The following batch (.bat) file compiles the example and generates satellite assemblies in the appropriate directories. The commands are provided for the C# language and compiler. For Visual Basic, change `csc` to `vbc`, and change `GetString.cs` to `GetString.vb`.  
   
-```  
+```console
 resgen strings.txt  
 csc GetString.cs -resource:strings.resources  
   
@@ -90,7 +90,7 @@ al -embed:strings.ru-RU.resources -culture:ru-RU -out:ru-RU\GetString.resources.
   
  You can use the following batch file to build the C# example. For Visual Basic, change `csc` to `vbc`, and change the extension of the source code file from `.cs` to `.vb`.  
   
-```  
+```console
 csc CreateResources.cs  
 CreateResources  
   
@@ -116,7 +116,7 @@ csc GetStream.cs -resource:AppResources.resources
   
  You can build the necessary resource file and assemblies and run the app by executing the following batch file. You must use the `/r` option to supply Resgen.exe with a reference to UIElements.dll so that it can access information about the `PersonTable` structure. If you're using C#, replace the `vbc` compiler name with `csc`, and replace the `.vb` extension with `.cs`.  
   
-```  
+```console
 vbc -t:library UIElements.vb  
 vbc CreateResources.vb -r:UIElements.dll  
 CreateResources  
@@ -160,21 +160,21 @@ GetObject.exe
 ### An Example  
  The following example illustrates how the resource manager retrieves resources directly from .resources files. The example consists of three text-based resource files for the English (United States), French (France), and Russian (Russia) cultures. English (United States) is the example's default culture. Its resources are stored in the following file named Strings.txt:  
   
-```  
+```text
 Greeting=Hello  
 Prompt=What is your name?  
 ```  
   
  Resources for the French (France) culture are stored in the following file, which is named Strings.fr-FR.txt:  
   
-```  
+```text 
 Greeting=Bon jour  
 Prompt=Comment vous appelez-vous?  
 ```  
   
  Resources for the Russian (Russia) culture are stored in the following file, which is named Strings.ru-RU.txt:  
   
-```  
+```text
 Greeting=Здравствуйте  
 Prompt=Как вас зовут?  
 ```  
@@ -186,7 +186,7 @@ Prompt=Как вас зовут?
   
  You can compile the C# version of the example by running the following batch file. If you're using Visual Basic, replace `csc` with `vbc`, and replace the `.cs` extension with `.vb`.  
   
-```  
+```console
 Md Resources  
 Resgen Strings.txt Resources\Strings.resources  
 Resgen Strings.fr-FR.txt Resources\Strings.fr-FR.resources  

--- a/docs/framework/security/how-to-build-claims-aware-aspnet-web-forms-app-using-wif.md
+++ b/docs/framework/security/how-to-build-claims-aware-aspnet-web-forms-app-using-wif.md
@@ -132,8 +132,8 @@ author: "BrucePerlerMS"
   
 1. Open the **Default.aspx** file under the **TestApp** project and replace its existing markup with the following markup:  
   
-    ```  
-    %@ Page Language="C#" AutoEventWireup="true" CodeFile="Default.aspx.cs" Inherits="_Default" %>  
+    ```aspx-csharp
+    <%@ Page Language="C#" AutoEventWireup="true" CodeFile="Default.aspx.cs" Inherits="_Default" %>  
   
     <!DOCTYPE html>  
   

--- a/docs/framework/security/how-to-display-signed-in-status-using-wif.md
+++ b/docs/framework/security/how-to-display-signed-in-status-using-wif.md
@@ -93,7 +93,7 @@ author: "BrucePerlerMS"
   
 2. Replace the existing markup in the **Default.aspx** file with the following markup:  
   
-    ```  
+    ```aspx-csharp  
     <%@ Page Language="C#" AutoEventWireup="true" CodeFile="Default.aspx.cs" Inherits="_Default" %>  
   
     <!DOCTYPE html>  

--- a/docs/framework/security/how-to-enable-wif-for-a-wcf-web-service-application.md
+++ b/docs/framework/security/how-to-enable-wif-for-a-wcf-web-service-application.md
@@ -239,7 +239,7 @@ In this step you will test your WIF-enabled WCF application and verify that clai
 
 2. Press **Enter**, and the following claims information should appear in the console:
 
-    ```
+    ```output
     Computed by Service1
     Input received from client: Hello World
     Client Name: Terry

--- a/docs/framework/security/wif-and-web-farms.md
+++ b/docs/framework/security/wif-and-web-farms.md
@@ -58,7 +58,7 @@ When you use Windows Identity Foundation (WIF) to secure the resources of a rely
 ## The WCF Caching Service  
  The following interface defines the contract between the WCF caching service and the WCF client used by the relying party application to communicate with it. It essentially exposes the methods of the <xref:System.IdentityModel.Tokens.SessionSecurityTokenCache> class as service operations.  
   
-```  
+```csharp
 [ServiceContract()]  
 public interface ISessionSecurityTokenCacheService  
 {  
@@ -84,7 +84,7 @@ public interface ISessionSecurityTokenCacheService
   
  The following code shows the implementation of the WCF caching service. In this example, the default, in-memory session token cache implemented by WIF is used. Alternatively, you could implement a durable cache backed by a database. `ISessionSecurityTokenCacheService` defines the interface shown above. In this example, not all of the methods required to implement the interface are shown for brevity.  
   
-```  
+```csharp
 using System;  
 using System.Collections.Generic;  
 using System.IdentityModel.Configuration;  
@@ -144,7 +144,7 @@ namespace WcfSessionSecurityTokenCacheService
   
  The class overrides the <xref:System.IdentityModel.Tokens.SessionSecurityTokenCache.LoadCustomConfiguration%2A> method to get the service endpoint from the custom `<cacheServiceAddress>` child element of the `<sessionSecurityTokenCache>` element. It uses this endpoint to initialize an `ISessionSecurityTokenCacheService` channel over which it can communicate with the service.  In this example, not all of the methods required to implement the <xref:System.IdentityModel.Tokens.SessionSecurityTokenCache> class are shown for brevity.  
   
-```  
+```csharp
 using System;  
 using System.Configuration;  
 using System.IdentityModel.Configuration;  

--- a/docs/framework/security/wif-configuration-schema-conventions.md
+++ b/docs/framework/security/wif-configuration-schema-conventions.md
@@ -15,9 +15,7 @@ This topic discusses conventions used throughout the Windows Identity Foundation
 ## Timespan Values  
  Where <xref:System.TimeSpan> is used as the type of an attribute, see the <xref:System.TimeSpan.Parse%28System.String%29> method to see the allowed format. This format conforms to the following specification.  
   
-```  
-[ws][-]{ d | [d.]hh:mm[:ss[.ff]] }[ws]  
-```  
+`[ws][-]{ d | [d.]hh:mm[:ss[.ff]] }[ws]`  
   
  For example, "30", "30.00:00", "30.00:00:00" all mean 30 days; and "00:05", "00:05:00", "0.00:05:00.00" all mean 5 minutes.  
   

--- a/docs/framework/security/wsfederation-authentication-module-overview.md
+++ b/docs/framework/security/wsfederation-authentication-module-overview.md
@@ -61,7 +61,7 @@ Windows Identity Foundation (WIF) includes support for federated authentication 
   
 - The <xref:System.IdentityModel.Services.FederatedAuthentication.FederationConfigurationCreated?displayProperty=nameWithType> event is raised when the ASP.NET infrastructure invokes the <xref:System.IdentityModel.Services.HttpModuleBase.Init%2A> method for the first time on one of the application’s modules that derive from <xref:System.IdentityModel.Services.HttpModuleBase>. This method accesses the static <xref:System.IdentityModel.Services.FederatedAuthentication.FederationConfiguration%2A?displayProperty=nameWithType> property, which causes configuration to be loaded from the Web.config file. This event is only raised the first time this property is accessed. The <xref:System.IdentityModel.Services.Configuration.FederationConfiguration> object that is initialized from configuration can be accessed through the <xref:System.IdentityModel.Services.Configuration.FederationConfigurationCreatedEventArgs.FederationConfiguration%2A?displayProperty=nameWithType> property in an event handler. You can use this event to modify the configuration before it is applied to any modules. You can add a handler for this event in the Application_Start method:  
   
-    ```  
+    ```csharp
     void Application_Start(object sender, EventArgs e)  
     {  
         FederatedAuthentication.FederationConfigurationCreated += new EventHandler<FederationConfigurationCreatedEventArgs>(FederatedAuthentication_FederationConfigurationCreated);  

--- a/docs/framework/tools/aximp-exe-windows-forms-activex-control-importer.md
+++ b/docs/framework/tools/aximp-exe-windows-forms-activex-control-importer.md
@@ -24,7 +24,7 @@ The ActiveX Control Importer converts type definitions in a COM type library for
   
 ## Syntax  
   
-```  
+```console  
 aximp [options]{file.dll | file.ocx}  
 ```  
   
@@ -69,7 +69,7 @@ aximp [options]{file.dll | file.ocx}
 ## Example  
  The following command generates MediaPlayer.dll and AxMediaPlayer.dll for the Media Player control `msdxm.ocx`.  
   
-```  
+```console 
 aximp c:\systemroot\system32\msdxm.ocx  
 ```  
   

--- a/docs/framework/tools/caspol-exe-code-access-security-policy-tool.md
+++ b/docs/framework/tools/caspol-exe-code-access-security-policy-tool.md
@@ -33,7 +33,7 @@ The Code Access Security (CAS) Policy tool (Caspol.exe) enables users and admini
   
 ## Syntax  
   
-```  
+```console
 caspol [options]  
 ```  
   

--- a/docs/framework/tools/cert2spc-exe-software-publisher-certificate-test-tool.md
+++ b/docs/framework/tools/cert2spc-exe-software-publisher-certificate-test-tool.md
@@ -20,7 +20,7 @@ The Software Publisher Certificate Test tool creates a Software Publisher's Cert
   
 ## Syntax  
   
-```  
+```console  
 cert2spc cert1.cer | crl1.crl [... certN.cer | crlN.crl] outputSPCfile.spc  
 ```  
   
@@ -39,13 +39,13 @@ cert2spc cert1.cer | crl1.crl [... certN.cer | crlN.crl] outputSPCfile.spc
 ## Examples  
  The following command creates an SPC from `myCertificate.cer` and places it in `mySPCFile.spc`.  
   
-```  
+```console
 cert2spc myCertificate.cer mySPCFile.spc  
 ```  
   
  The following command creates an SPC from `oneCertificate.cer` and `twoCertificate.cer`, and places it in `mySPCFile.spc`.  
   
-```  
+```console
 cert2spc oneCertificate.cer twoCertificate.cer mySPCFile.spc  
 ```  
   

--- a/docs/framework/tools/certmgr-exe-certificate-manager-tool.md
+++ b/docs/framework/tools/certmgr-exe-certificate-manager-tool.md
@@ -32,7 +32,7 @@ The Certificate Manager tool (Certmgr.exe) manages certificates, certificate tru
   
 ## Syntax  
   
-```  
+```console  
       certmgr [/add | /del | /put] [options]  
 [/s[/r registryLocation]] [sourceStorename]  
 [/s[/r registryLocation]] [destinationStorename]  
@@ -91,43 +91,43 @@ The Certificate Manager tool (Certmgr.exe) manages certificates, certificate tru
 ## Examples  
  The following command displays a default system store called `my` with verbose output.  
   
-```  
+```console  
 certmgr /v /s my  
 ```  
   
  The following command adds all the certificates in a file called `myFile.ext` to a new file called `newFile.ext`.  
   
-```  
+```console  
 certmgr /add /all /c myFile.ext newFile.ext  
 ```  
   
  The following command adds the certificate in a file named `testcert.cer` to the `my` system store.  
   
-```  
+```console  
 certmgr /add /c testcert.cer /s my  
 ```  
   
  The following command adds the certificate in a file named `TrustedCert.cer` to the root certificate store.  
   
-```  
+```console  
 certmgr /c /add TrustedCert.cer /s root  
 ```  
   
  The following command saves a certificate with the common name `myCert` in the `my` system store to a file called `newCert.cer`.  
   
-```  
+```console  
 certmgr /add /c /n myCert /s my newCert.cer  
 ```  
   
  The following command deletes all CTLs in the `my` system store and saves the resulting store to a file called `newStore.str`.  
   
-```  
+```console  
 certmgr /del /all /ctl /s my newStore.str  
 ```  
   
  The following command saves a certificate in the `my` system store in the file `newFile`. You will be prompted to enter the certificate number from `my` to put in `newFile`.  
   
-```  
+```console  
 certmgr /put /c /s my newFile  
 ```  
   

--- a/docs/framework/tools/clrver-exe-clr-version-tool.md
+++ b/docs/framework/tools/clrver-exe-clr-version-tool.md
@@ -17,7 +17,7 @@ The CLR Version tool (Clrver.exe) reports all the installed versions of the comm
   
 ## Syntax  
   
-```  
+```console  
 clrver [option]  
 ```  
   

--- a/docs/framework/tools/corflags-exe-corflags-conversion-tool.md
+++ b/docs/framework/tools/corflags-exe-corflags-conversion-tool.md
@@ -18,7 +18,7 @@ The CorFlags Conversion tool allows you to configure the CorFlags section of the
   
 ## Syntax  
   
-```  
+```console  
 CorFlags.exe assembly [options]  
 ```  
   

--- a/docs/framework/tools/fuslogvw-exe-assembly-binding-log-viewer.md
+++ b/docs/framework/tools/fuslogvw-exe-assembly-binding-log-viewer.md
@@ -23,7 +23,7 @@ This tool is automatically installed with Visual Studio. To run the tool, use th
 
 At the command prompt, type the following:
 
-```
+```console
 fuslogvw
 ```
 
@@ -60,7 +60,7 @@ The viewer displays an entry for each failed assembly bind. For each failure, th
 
 The following sample log entry shows detailed information about a failed assembly bind.
 
-```
+```output
 *** Assembly Binder Log Entry  (3/5/2007 @ 12:54:20 PM) ***
 
 The operation failed.
@@ -124,7 +124,7 @@ By default, Fuslogvw.exe logs normal assembly bind requests. Alternatively, you 
 
 The following log shows a failure caused by a dependency that did not exist when the native image was created for the application. If the dependencies at run time differ from the dependencies when Ngen.exe is run, binding to a native image is not allowed.
 
-```
+```output
 *** Assembly Binder Log Entry  (12/8/2006 @ 5:22:07 PM) ***
 
 The operation failed.
@@ -148,7 +148,7 @@ LOG: Bind to native image assembly did not succeed. Use IL image.
 
 The following log shows a native image binding failure that occurred because the security settings on the computer when the application was run were different from the security settings at the time the native image was created.
 
-```
+```output
 *** Assembly Binder Log Entry  (12/8/2006 @ 5:29:09 PM) ***
 
 The operation failed.

--- a/docs/framework/tools/gacutil-exe-gac-tool.md
+++ b/docs/framework/tools/gacutil-exe-gac-tool.md
@@ -30,7 +30,7 @@ At the command prompt, type the following:
 
 ## Syntax
 
-```
+```console
 gacutil [options] [assemblyName | assemblyPath | assemblyListFile]
 ```
 
@@ -75,7 +75,7 @@ Gacutil.exe provides options that support reference counting similar to the refe
 
 Use the **/il** or **/ul** options to install or uninstall a list of assemblies stored in an ANSI text file. The contents of the text file must be formatted correctly. To use a text file to install assemblies, specify the path to each assembly on a separate line in the file. The following example demonstrates the contents of a file containing assemblies to install.
 
-```
+```text
 myAssembly1.dll
 myAssembly2.dll
 myAssembly3.dll
@@ -83,7 +83,7 @@ myAssembly3.dll
 
 To use a text file to uninstall assemblies, specify the fully qualified assembly name for each assembly on a separate line in the file. The following example demonstrates the contents of a file containing assemblies to uninstall.
 
-```
+```text
 myAssembly1,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
 myAssembly2,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
 myAssembly3,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
@@ -92,7 +92,7 @@ myAssembly3,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
 > [!NOTE]
 > Attempting to install an assembly with a filename longer than between 79 and 91 characters (excluding the file extension) can result in the following error:
 >
-> ```
+> ```output
 > Failure adding assembly to the cache:   The file name is too long.
 > ```
 >
@@ -111,13 +111,13 @@ myAssembly3,Version=1.1.0.0,Culture=en,PublicKeyToken=874e23ab874e23ab
 
 The following command installs the assembly `mydll.dll` into the global assembly cache.
 
-```
+```console
 gacutil /i mydll.dll
 ```
 
 The following command removes the assembly `hello` from the global assembly cache as long as no reference counts exist for the assembly.
 
-```
+```console
 gacutil /u hello
 ```
 
@@ -125,49 +125,49 @@ Note that the previous command might remove more than one assembly from the asse
 
 Use the following example to avoid removing more than one assembly. This command removes only the `hello` assembly that matches the fully specified version number, culture, and public key.
 
-```
+```console
 gacutil /u hello, Version=1.0.0.1, Culture="de",PublicKeyToken=45e343aae32233ca
 ```
 
 The following command installs the assemblies specified in the file `assemblyList.txt` into the global assembly cache.
 
-```
+```console
 gacutil /il assemblyList.txt
 ```
 
 The following command removes the assemblies specified in the file `assemblyList.txt` from the global assembly cache.
 
-```
+```console
 gacutil /ul assemblyList.txt
 ```
 
 The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The assembly `myDll.dll` is used by the application `MyApp`. The `UNINSTALL_KEY MyApp` parameter specifies the registry key that adds `MyApp` to Add/Remove Programs in Windows. The description parameter is specified as `My Application Description`.
 
-```
+```console
 gacutil /i /r myDll.dll UNINSTALL_KEY MyApp "My Application Description"
 ```
 
 The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The scheme parameter, `FILEPATH`, and the id parameter, `c:\applications\myApp\myApp.exe`, specify the path to the application that is installing `myDll.dll.` The description parameter is specified as `MyApp`.
 
-```
+```console
 gacutil /i /r myDll.dll FILEPATH c:\applications\myApp\myApp.exe MyApp
 ```
 
 The following command installs `myDll.dll` into the global assembly cache and adds a reference to count it. The scheme parameter, `OPAQUE`, allows you to customize the id and description parameters.
 
-```
+```console
 gacutil /i /r mydll.dll OPAQUE "Insert custom application details here" "Insert Custom description information here"
 ```
 
 The following command removes the reference to `myDll.dll` by the application `myApp`. If this is the last reference to the assembly, it will also remove the assembly from the global assembly cache.
 
-```
+```console
 gacutil /u /r myDll.dll FILEPATH c:\applications\myApp\myApp.exe MyApp
 ```
 
 The following command lists the contents of the global assembly cache.
 
-```
+```console
 gacutil /l
 ```
 


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "console" for all Framework tool syntax and command examples.
- Used "output" for Framework tool log examples, and error messages.
