### PR TITLE
old marketing site links sweep

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -331,7 +331,7 @@
         },
         {
             "source_path": "docs/core/versions/lts-current.md",
-            "redirect_url": "https://www.microsoft.com/net/Support/Policy"
+            "redirect_url": "https://dotnet.microsoft.com/platform/support/policy"
         },
         {
             "source_path": "docs/core/versions/servicing.md",

--- a/docs/architecture/containerized-lifecycle/design-develop-containerized-apps/build-aspnet-core-applications-linux-containers-aks-kubernetes.md
+++ b/docs/architecture/containerized-lifecycle/design-develop-containerized-apps/build-aspnet-core-applications-linux-containers-aks-kubernetes.md
@@ -37,7 +37,7 @@ Verify that you've selected ASP.NET Core 2.2 as the framework. .NET Core 2.2 is 
 
 **Figure 4-37**. Selecting ASP.NET CORE 2.2 and Web API project type
 
-If you have any previous version of .NET Core, you can download and install the 2.2 version from <https://www.microsoft.com/net/download/core#/sdk>.
+If you have any previous version of .NET Core, you can download and install the 2.2 version from <https://dotnet.microsoft.com/download>.
 
 You can add Docker support when creating the project or afterwards, so you can "Dockerize" your project at any time. To add Docker support after project creation, right-click on the project node in Solution Explorer and select **Add** > **Docker support** on the context menu.
 

--- a/docs/architecture/microservices/index.md
+++ b/docs/architecture/microservices/index.md
@@ -15,7 +15,7 @@ To make it easier to get started, the guide focuses on a reference containerized
 
 ## Action links
 
-- Download this eBook in your format of choice: | [PDF](https://aka.ms/microservicesebook) | [MOBI](https://www.microsoft.com/net/download/thank-you/microservices-architecture-ebook-mobi) | [EPUB](https://www.microsoft.com/net/download/thank-you/microservices-architecture-ebook-epub) |
+- Download this eBook in your format of choice: | [PDF](https://aka.ms/microservicesebook) | [MOBI](https://dotnet.microsoft.com/download/thank-you/microservices-architecture-ebook-mobi) | [EPUB](https://dotnet.microsoft.com/download/thank-you/microservices-architecture-ebook-epub) |
 
 - Clone/Fork the reference application [eShopOnContainers on GitHub](https://github.com/dotnet-architecture/eShopOnContainers)
  

--- a/docs/architecture/microservices/net-core-net-framework-containers/index.md
+++ b/docs/architecture/microservices/net-core-net-framework-containers/index.md
@@ -5,7 +5,7 @@ ms.date: 09/11/2018
 ---
 # Choosing Between .NET Core and .NET Framework for Docker Containers
 
-There are two supported frameworks for building server-side containerized Docker applications with .NET: [.NET Framework and .NET Core](https://www.microsoft.com/net/download). They share many .NET platform components, and you can share code across the two. However, there are fundamental differences between them, and which framework you use will depend on what you want to accomplish. This section provides guidance on when to choose each framework.
+There are two supported frameworks for building server-side containerized Docker applications with .NET: [.NET Framework and .NET Core](https://dotnet.microsoft.com/download). They share many .NET platform components, and you can share code across the two. However, there are fundamental differences between them, and which framework you use will depend on what you want to accomplish. This section provides guidance on when to choose each framework.
 
 >[!div class="step-by-step"]
 >[Previous](../container-docker-introduction/docker-containers-images-registries.md)

--- a/docs/architecture/modern-web-apps-azure/development-process-for-azure.md
+++ b/docs/architecture/modern-web-apps-azure/development-process-for-azure.md
@@ -30,7 +30,7 @@ Whether you prefer a full and powerful IDE or a lightweight and agile editor, Mi
 
 **Visual Studio Code and dotnet CLI** (Cross-Platform Tools for Mac, Linux and Windows). If you prefer a lightweight and cross-platform editor supporting any development language, you can use Microsoft Visual Studio Code and the dotnet CLI. These products provide a simple yet robust experience that streamlines the developer workflow. Additionally, Visual Studio Code supports extensions for C\# and web development, providing intellisense and shortcut-tasks within the editor.
 
-[Download the .NET Core SDK](https://www.microsoft.com/net/download/core)
+[Download the .NET Core SDK](https://dotnet.microsoft.com/download)
 
 [Download Visual Studio Code](https://code.visualstudio.com/download)
 

--- a/docs/core/about.md
+++ b/docs/core/about.md
@@ -14,7 +14,7 @@ ms.date: 08/01/2018
 - **Flexible deployment:** Can be included in your app or installed side-by-side (user-wide or system-wide installations). Can be used with [Docker containers](docker/index.md).
 - **Compatible:** .NET Core is compatible with .NET Framework, Xamarin and Mono, via [.NET Standard](../standard/net-standard.md).
 - **Open source:** The .NET Core platform is open source, using MIT and Apache 2 licenses. .NET Core is a [.NET Foundation](https://dotnetfoundation.org/) project.
-- **Supported by Microsoft:** .NET Core is supported by Microsoft, per [.NET Core Support](https://www.microsoft.com/net/core/support/).
+- **Supported by Microsoft:** .NET Core is supported by Microsoft, per [.NET Core Support](https://dotnet.microsoft.com/platform/support/policy).
 
 ## Languages
 
@@ -51,9 +51,9 @@ Multiple frameworks have been built on top of .NET Core:
 
 These components are distributed in the following ways:
 
-- [.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes the .NET Core runtime and framework libraries.
-- [ASP.NET Core Runtime](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes ASP.NET Core and .NET Core runtime and framework libraries.
-- [.NET Core SDK](https://www.microsoft.com/net/download/dotnet-core/2.1) -- includes the .NET CLI Tools, ASP.NET Core runtime, and .NET Core runtime and framework.
+- [.NET Core Runtime](https://dotnet.microsoft.com/download) -- includes the .NET Core runtime and framework libraries.
+- [ASP.NET Core Runtime](https://dotnet.microsoft.com/download) -- includes ASP.NET Core and .NET Core runtime and framework libraries.
+- [.NET Core SDK](https://dotnet.microsoft.com/download) -- includes the .NET CLI Tools, ASP.NET Core runtime, and .NET Core runtime and framework.
 
 ### Open source
 

--- a/docs/core/additional-tools/dotnet-svcutil.xmlserializer-guide.md
+++ b/docs/core/additional-tools/dotnet-svcutil.xmlserializer-guide.md
@@ -10,7 +10,7 @@ The `dotnet-svcutil.xmlserializer` NuGet package can pre-generate a serializatio
 
 ## Prerequisites
 
-* [.NET Core 2.1 SDK](https://www.microsoft.com/net/download) or later
+* [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download) or later
 * Your favorite code editor
 
 You can use the command `dotnet --info` to check which versions of .NET Core SDK and runtime you already have installed.

--- a/docs/core/additional-tools/xml-serializer-generator.md
+++ b/docs/core/additional-tools/xml-serializer-generator.md
@@ -23,7 +23,7 @@ Like the [Xml Serializer Generator (sgen.exe)](../../standard/serialization/xml-
 
 To complete this tutorial:
 
-* [.NET Core 2.1 SDK](https://www.microsoft.com/net/download) or later
+* [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download) or later
 * Your favorite code editor.
 
 > [!TIP]

--- a/docs/core/get-started.md
+++ b/docs/core/get-started.md
@@ -10,11 +10,11 @@ ms.date: 06/27/2018
 
 This article provides information on getting started with .NET Core. .NET Core can be installed on Windows, Linux, and macOS. You can code in your favorite text editor and produce cross-platform libraries and applications. 
 
-If you're unsure what .NET Core is, or how it relates to other .NET technologies, start with the [What is .NET](https://www.microsoft.com/net/learn/dotnet/what-is-dotnet) overview. Put simply, .NET Core is an open-source, cross-platform implementation of .NET.
+If you're unsure what .NET Core is, or how it relates to other .NET technologies, start with the [What is .NET](https://dotnet.microsoft.com/learn/dotnet/what-is-dotnet) overview. Put simply, .NET Core is an open-source, cross-platform implementation of .NET.
 
 ## Create an application
 
-First, download and install the [.NET Core SDK](https://www.microsoft.com/net/download/) on your computer.
+First, download and install the [.NET Core SDK](https://dotnet.microsoft.com/download) on your computer.
 
 Next, open a terminal such as **PowerShell**, **Command Prompt**, or **bash**. Type the following `dotnet` commands to create and run a C# application.
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -15,9 +15,9 @@ Check out [.NET Core Tutorials](tutorials/index.md) to learn how to create a sim
 
 ## Download .NET Core 2.2
 
-Download the [.NET Core  2.2 SDK](https://www.microsoft.com/net/download) to try .NET Core on your Windows, macOS, or Linux machine. Visit [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) if you prefer to use Docker containers.
+Download the [.NET Core  2.2 SDK](https://dotnet.microsoft.com/download) to try .NET Core on your Windows, macOS, or Linux machine. Visit [dotnet/core](https://hub.docker.com/_/microsoft-dotnet-core/) if you prefer to use Docker containers.
 
-All .NET Core versions are available at [.NET Core Downloads](https://www.microsoft.com/net/download/archives) if you're looking for another .NET Core version.
+All .NET Core versions are available at [.NET Core Downloads](https://dotnet.microsoft.com/download/dotnet-core) if you're looking for another .NET Core version.
 
 ## .NET Core 2.2
 
@@ -40,7 +40,7 @@ Hello World!
 
 ## Support
 
-.NET Core is [supported by Microsoft](https://www.microsoft.com/net/support/policy), on Windows, macOS and Linux. It's updated for security and quality several times a year, typically monthly.
+.NET Core is [supported by Microsoft](https://dotnet.microsoft.com/platform/support/policy), on Windows, macOS and Linux. It's updated for security and quality several times a year, typically monthly.
 
 .NET Core binary distributions are built and tested on Microsoft-maintained servers in Azure and supported just like any Microsoft product.
 

--- a/docs/core/linux-prerequisites.md
+++ b/docs/core/linux-prerequisites.md
@@ -21,7 +21,7 @@ This article shows the dependencies needed to develop .NET Core applications on 
 
 .NET Core 2.x treats Linux as a single operating system. There is a single Linux build (per chip architecture) for supported Linux distributions. 
 
-For download links and more information, see [.NET Core 2.2 downloads](https://www.microsoft.com/net/download/dotnet-core/2.2) or [.NET Core 2.1 downloads](https://www.microsoft.com/net/download/dotnet-core/2.1).
+For download links and more information, see [.NET Core 2.2 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.2) or [.NET Core 2.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.1).
 
 .NET Core 2.x is supported on the following Linux distributions/versions:
 
@@ -40,7 +40,7 @@ See [.NET Core 2.1 Supported OS Versions](https://github.com/dotnet/core/blob/ma
 
 # [.NET Core 1.x](#tab/netcore1x)
 
-For download links and more information, see [.NET Core 1.1 downloads](https://www.microsoft.com/net/download/dotnet-core/1.1) or [.NET Core 1.0 downloads](https://www.microsoft.com/net/download/dotnet-core/1.0).
+For download links and more information, see [.NET Core 1.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/1.1) or [.NET Core 1.0 downloads](https://dotnet.microsoft.com/download/dotnet-core/1.0).
 
 .NET Core 1.x is supported on the following Linux 64-bit (`x86_64` or `amd64`) distributions/versions:
 

--- a/docs/core/macos-prerequisites.md
+++ b/docs/core/macos-prerequisites.md
@@ -20,7 +20,7 @@ This article shows you the supported macOS versions and .NET Core dependencies t
 
 See [.NET Core 2.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md) and [.NET Core 2.2 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2-supported-os.md) for the complete list of .NET Core 2.1 and .NET Core 2.2 supported operating systems, distributions and versions, out of support OS versions, and lifecycle policy links.
 
-For download links and more information, see [.NET Core 2.2 downloads](https://www.microsoft.com/net/download/dotnet-core/2.2) or [.NET Core 2.1 downloads](https://www.microsoft.com/net/download/dotnet-core/2.1).
+For download links and more information, see [.NET Core 2.2 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.2) or [.NET Core 2.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/2.1).
 
 # [.NET Core 1.x](#tab/netcore1x)
 
@@ -31,7 +31,7 @@ For download links and more information, see [.NET Core 2.2 downloads](https://w
 
 See [.NET Core 1.1 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/1.1/1.1.md) and [.NET Core 1.0 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0-supported-os.md) for the complete list of .NET Core 1.1 and .NET Core 1.0 supported operating systems, distributions and versions, out of support OS versions, and lifecycle policy links.
 
-For download links and more information, see [.NET Core 1.1 downloads](https://www.microsoft.com/net/download/dotnet-core/1.1) or [.NET Core 1.0 downloads](https://www.microsoft.com/net/download/dotnet-core/1.0).
+For download links and more information, see [.NET Core 1.1 downloads](https://dotnet.microsoft.com/download/dotnet-core/1.1) or [.NET Core 1.0 downloads](https://dotnet.microsoft.com/download/dotnet-core/1.0).
 
 # [.NET Core 3.0](#tab/netcore30)
 
@@ -41,7 +41,7 @@ For download links and more information, see [.NET Core 1.1 downloads](https://w
 
 See [.NET Core 3.0 Supported OS Versions](https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md) for the complete list of .NET Core 3.0 supported operating systems, distributions and versions, out of support OS versions, and lifecycle policy links.
 
-For download links and more information, see [.NET Core 3.0 downloads](https://www.microsoft.com/net/download/dotnet-core/3.0).
+For download links and more information, see [.NET Core 3.0 downloads](https://dotnet.microsoft.com/download/dotnet-core/3.0).
 
 ---
 
@@ -49,7 +49,7 @@ For download links and more information, see [.NET Core 3.0 downloads](https://w
 
 # [.NET Core 2.x](#tab/netcore2x)
 
-Download and install the .NET Core SDK from [.NET Downloads](https://www.microsoft.com/net/download/core). If you have problems with the installation on macOS, consult the [Known issues](https://github.com/dotnet/core/tree/master/release-notes/2.1) topic for the version you have installed.
+Download and install the .NET Core SDK from the [.NET Downloads](https://dotnet.microsoft.com/download) page. If you have problems with the installation on macOS, consult the [Known issues](https://github.com/dotnet/core/tree/master/release-notes/2.1) topic for the version you have installed.
 
 # [.NET Core 1.x](#tab/netcore1x)
 
@@ -63,11 +63,11 @@ ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
 ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
 ```
 
-Download and install the .NET Core SDK from [.NET Downloads](https://www.microsoft.com/net/download/core). If you have problems with the installation on macOS, consult the [1.0.0 Known Issues](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.0-known-issues.md) and [1.0.1 Known Issues](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-known-issues.md) topics.
+Download and install the .NET Core SDK from the [.NET Downloads](https://dotnet.microsoft.com/download) page. If you have problems with the installation on macOS, consult the [1.0.0 Known Issues](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.0-known-issues.md) and [1.0.1 Known Issues](https://github.com/dotnet/core/blob/master/release-notes/1.0/1.0.1-known-issues.md) topics.
 
 # [.NET Core 3.0](#tab/netcore30)
 
-Download and install the .NET Core SDK from [.NET Downloads](https://www.microsoft.com/net/download/core). If you have problems with the installation on macOS, consult the [Release notes](https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md) topic for the version you have installed.
+Download and install the .NET Core SDK from the [.NET Downloads](https://dotnet.microsoft.com/download) page. If you have problems with the installation on macOS, consult the [Release notes](https://github.com/dotnet/core/blob/master/release-notes/3.0/3.0-supported-os.md) topic for the version you have installed.
 
 ---
 

--- a/docs/core/native-interop/expose-components-to-com.md
+++ b/docs/core/native-interop/expose-components-to-com.md
@@ -20,7 +20,7 @@ In .NET Core, the process for exposing your .NET objects to COM has been signifi
 
 ## Prerequisites
 
-- Install the [.NET Core 3.0 Preview 7 SDK](https://www.microsoft.com/net/core) or a newer version.
+- Install the [.NET Core 3.0 Preview 7 SDK](https://dotnet.microsoft.com/download) or a newer version.
 
 ## Create the library
 

--- a/docs/core/testing/unit-testing-fsharp-with-nunit.md
+++ b/docs/core/testing/unit-testing-fsharp-with-nunit.md
@@ -15,7 +15,7 @@ This tutorial takes you through an interactive experience building a sample solu
 
 ## Prerequisites
 
-- [.NET Core 2.1 SDK](https://www.microsoft.com/net/download) or later versions.
+- [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download) or later versions.
 - A text editor or code editor of your choice.
 
 ## Creating the source project

--- a/docs/core/testing/unit-testing-visual-basic-with-nunit.md
+++ b/docs/core/testing/unit-testing-visual-basic-with-nunit.md
@@ -13,7 +13,7 @@ This tutorial takes you through an interactive experience building a sample solu
 
 ## Prerequisites
 
-- [.NET Core 2.1 SDK](https://www.microsoft.com/net/download) or later versions.
+- [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download) or later versions.
 - A text editor or code editor of your choice.
 
 ## Creating the source project

--- a/docs/core/testing/unit-testing-with-nunit.md
+++ b/docs/core/testing/unit-testing-with-nunit.md
@@ -13,7 +13,7 @@ This tutorial takes you through an interactive experience building a sample solu
 
 ## Prerequisites
 
-- [.NET Core 2.1 SDK](https://www.microsoft.com/net/download) or later versions.
+- [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download) or later versions.
 - A text editor or code editor of your choice.
 
 ## Creating the source project

--- a/docs/core/tools/custom-templates.md
+++ b/docs/core/tools/custom-templates.md
@@ -7,7 +7,7 @@ ms.date: 06/14/2019
 
 # Custom templates for dotnet new
 
-The [.NET Core SDK](https://www.microsoft.com/net/download/core) comes with many templates already installed and ready for you to use. The [`dotnet new` command](dotnet-new.md) isn't only the way to use a template, but also how to install and uninstall templates. Starting with .NET Core 2.0, you can create your own custom templates for any type of project, such as an app, service, tool, or class library. You can even create a template that outputs one or more independent files, such as a configuration file.
+The [.NET Core SDK](https://dotnet.microsoft.com/download) comes with many templates already installed and ready for you to use. The [`dotnet new` command](dotnet-new.md) isn't only the way to use a template, but also how to install and uninstall templates. Starting with .NET Core 2.0, you can create your own custom templates for any type of project, such as an app, service, tool, or class library. You can even create a template that outputs one or more independent files, such as a configuration file.
 
 You can install custom templates from a NuGet package on any NuGet feed, by referencing a NuGet *.nupkg* file directly, or by specifying a file system directory that contains the template. The template engine offers features that allow you to replace values, include and exclude files, and execute custom processing operations when your template is used.
 
@@ -17,7 +17,7 @@ To follow a walkthrough and create a template, see the [Create a custom template
 
 ### .NET default templates
 
-When you install the [.NET Core SDK](https://www.microsoft.com/net/download/core), you receive over a dozen built-in templates for creating projects and files, including console apps, class libraries, unit test projects, ASP.NET Core apps (including [Angular](https://angular.io/) and [React](https://facebook.github.io/react/) projects), and configuration files. To list the built-in templates, run the `dotnet new` command with the `-l|--list` option:
+When you install the [.NET Core SDK](https://dotnet.microsoft.com/download), you receive over a dozen built-in templates for creating projects and files, including console apps, class libraries, unit test projects, ASP.NET Core apps (including [Angular](https://angular.io/) and [React](https://facebook.github.io/react/) projects), and configuration files. To list the built-in templates, run the `dotnet new` command with the `-l|--list` option:
 
 ```console
 dotnet new --list

--- a/docs/core/tools/dotnet-install-script.md
+++ b/docs/core/tools/dotnet-install-script.md
@@ -49,7 +49,7 @@ You can install a specific version using the `--version` argument. The version m
   - Two-part version in X.Y format representing a specific release (for example, `2.0` or `1.0`).
   - Branch name. For example, `release/2.0.0`, `release/2.0.0-preview2`, or `master` (for nightly releases).
 
-  The default value is `LTS`. For more information on .NET support channels, see the [.NET Support Policy](https://www.microsoft.com/net/platform/support-policy#dotnet-core) page.
+  The default value is `LTS`. For more information on .NET support channels, see the [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) page.
 
 - **`-Version <VERSION>`**
 

--- a/docs/core/tools/global-json.md
+++ b/docs/core/tools/global-json.md
@@ -45,13 +45,13 @@ The following example shows the contents of a *global.json* file:
 
 ## global.json and the .NET Core CLI
 
-It's helpful to know which versions are available in order to set one in the *global.json* file. You can find the full list of supported available SDKs at the [.NET Downloads](https://www.microsoft.com/net/download/all) site. Starting with .NET Core 2.1 SDK, you can run the following command to verify which SDK versions are already installed on your machine:
+It's helpful to know which versions are available in order to set one in the *global.json* file. You can find the full list of supported available SDKs at the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page. Starting with .NET Core 2.1 SDK, you can run the following command to verify which SDK versions are already installed on your machine:
 
 ```console
 dotnet --list-sdks
 ```
 
-To install additional .NET Core SDK versions on your machine, visit the [.NET Downloads](https://www.microsoft.com/net/download/all) site.
+To install additional .NET Core SDK versions on your machine, visit the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page.
 
 You can create a new the *global.json* file in the current directory by executing the [dotnet new](dotnet-new.md) command, similar to the following example:
 

--- a/docs/core/tutorials/cli-templates-create-item-template.md
+++ b/docs/core/tutorials/cli-templates-create-item-template.md
@@ -22,7 +22,7 @@ In this part of the series, you'll learn how to:
 
 ## Prerequisites
 
-* [.NET Core 2.2 SDK](https://www.microsoft.com/net/core) or later versions.
+* [.NET Core 2.2 SDK](https://dotnet.microsoft.com/download) or later versions.
 * Read the reference article [Custom templates for dotnet new](../tools/custom-templates.md).
 
   The reference article explains the basics about templates and how they're put together. Some of this information will be reiterated here.

--- a/docs/core/tutorials/creating-app-with-plugin-support.md
+++ b/docs/core/tutorials/creating-app-with-plugin-support.md
@@ -17,7 +17,7 @@ This tutorial shows you how to:
 
 ## Prerequisites
 
-- Install the [.NET Core 3.0 Preview 2 SDK](https://www.microsoft.com/net/core) or a newer version.
+- Install the [.NET Core 3.0 Preview 2 SDK](https://dotnet.microsoft.com/download) or a newer version.
 
 ## Create the application
 

--- a/docs/core/tutorials/libraries.md
+++ b/docs/core/tutorials/libraries.md
@@ -11,7 +11,7 @@ This article covers how to write libraries for .NET using cross-platform CLI too
 
 ## Prerequisites
 
-You need [the .NET Core SDK and CLI](https://www.microsoft.com/net/core) installed on your machine.
+You need [the .NET Core SDK and CLI](https://dotnet.microsoft.com/download) installed on your machine.
 
 For the sections of this document dealing with .NET Framework versions, you need the [.NET Framework](https://dotnet.microsoft.com) installed on a Windows machine.
 

--- a/docs/core/tutorials/netcore-hosting.md
+++ b/docs/core/tutorials/netcore-hosting.md
@@ -17,7 +17,7 @@ This article gives an overview of the steps necessary to start the .NET Core run
 
 Because hosts are native applications, this tutorial will cover constructing a C++ application to host .NET Core. You will need a C++ development environment (such as that provided by [Visual Studio](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs)).
 
-You will also want a simple .NET Core application to test the host with, so you should install the [.NET Core SDK](https://www.microsoft.com/net/core) and [build a small .NET Core test app](with-visual-studio.md) (such as a 'Hello World' app). The 'Hello World' app created by the new .NET Core console project template is sufficient.
+You will also want a simple .NET Core application to test the host with, so you should install the [.NET Core SDK](https://dotnet.microsoft.com/download) and [build a small .NET Core test app](with-visual-studio.md) (such as a 'Hello World' app). The 'Hello World' app created by the new .NET Core console project template is sufficient.
 
 ## Hosting APIs
 There are three different APIs that can be used to host .NET Core. This document (and its associated [samples](https://github.com/dotnet/samples/tree/master/core/hosting)) cover all options.

--- a/docs/core/tutorials/using-on-mac-vs-full-solution.md
+++ b/docs/core/tutorials/using-on-mac-vs-full-solution.md
@@ -19,7 +19,7 @@ This tutorial shows you how to create an application that accepts a search word 
 ## Prerequisites
 
 - OpenSSL (if running .NET Core 1.1): See the [Prerequisites for .NET Core on Mac](../macos-prerequisites.md) topic.
-- [.NET Core SDK 1.1 or later](https://www.microsoft.com/net/core#macos)
+- [.NET Core SDK 1.1 or later](https://dotnet.microsoft.com/download)
 - [Visual Studio 2017 for Mac](https://visualstudio.microsoft.com/vs/mac/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link)
 
 For more information on prerequisites, see the [Prerequisites for .NET Core on Mac](../macos-prerequisites.md). For the full system requirements of Visual Studio 2017 for Mac, see [Visual Studio 2017 for Mac Product Family System Requirements](/visualstudio/productinfo/vs2017-system-requirements-mac).

--- a/docs/core/tutorials/using-on-macos.md
+++ b/docs/core/tutorials/using-on-macos.md
@@ -14,7 +14,7 @@ This document provides the steps and workflow to create a .NET Core solution for
 
 ## Prerequisites
 
-Install the [.NET Core SDK](https://www.microsoft.com/net/core). The .NET Core SDK includes the latest release of the .NET Core framework and runtime.
+Install the [.NET Core SDK](https://dotnet.microsoft.com/download). The .NET Core SDK includes the latest release of the .NET Core framework and runtime.
 
 Install [Visual Studio Code](https://code.visualstudio.com). During the course of this article, you also install Visual Studio Code extensions that improve the .NET Core development experience.
 

--- a/docs/core/tutorials/using-with-xplat-cli.md
+++ b/docs/core/tutorials/using-with-xplat-cli.md
@@ -15,7 +15,7 @@ If you're unfamiliar with the .NET Core CLI toolset, read the [.NET Core SDK ove
 
 ## Prerequisites
 
-- [.NET Core SDK 2.1](https://www.microsoft.com/net/download/core).
+- [.NET Core SDK 2.1](https://dotnet.microsoft.com/download) or later versions.
 - A text editor or code editor of your choice.
 
 ## Hello, Console App!

--- a/docs/core/tutorials/with-visual-studio-code.md
+++ b/docs/core/tutorials/with-visual-studio-code.md
@@ -12,7 +12,7 @@ ms.custom: "seodec18"
 ## Prerequisites
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/).
-2. Install the [.NET Core SDK](https://www.microsoft.com/net/download/core).
+2. Install the [.NET Core SDK](https://dotnet.microsoft.com/download).
 3. Install the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) for Visual Studio Code. For more information about how to install extensions on Visual Studio Code, see [VS Code Extension Marketplace](https://code.visualstudio.com/docs/editor/extension-gallery).
 
 ## Hello World

--- a/docs/core/versions/index.md
+++ b/docs/core/versions/index.md
@@ -103,6 +103,6 @@ Each version of .NET Core implements a version of .NET Standard. Implementing a 
 
 - [Target frameworks](../../standard/frameworks.md)
 - [.NET Core distribution packaging](../build/distribution-packaging.md)
-- [.NET Core Support Lifecycle Fact Sheet](https://www.microsoft.com/net/core/support)
+- [.NET Core Support Lifecycle Fact Sheet](https://dotnet.microsoft.com/platform/support/policy)
 - [.NET Core 2+ Version Binding](https://github.com/dotnet/designs/issues/3)
 - [Docker images for .NET Core](https://hub.docker.com/_/microsoft-dotnet-core/)

--- a/docs/core/whats-new/dotnet-core-2-0.md
+++ b/docs/core/whats-new/dotnet-core-2-0.md
@@ -148,7 +148,7 @@ You can now install the .NET Core SDK independently of Visual Studio. This makes
 
 ### .NET Application Architecture
 
-[.NET Application Architecture](https://www.microsoft.com/net/learn/architecture) gives you access to a set of e-books that provide guidance, best practices, and sample applications when using .NET to build:
+[.NET Application Architecture](https://dotnet.microsoft.com/learn/dotnet/architecture-guides) gives you access to a set of e-books that provide guidance, best practices, and sample applications when using .NET to build:
 
 - [Microservices and Docker containers](../../architecture/microservices/index.md)
 - [Web applications with ASP.NET](../../architecture/modern-web-apps-azure/index.md)

--- a/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
+++ b/docs/csharp/programming-guide/concepts/serialization/walkthrough-persisting-an-object-in-visual-studio.md
@@ -16,7 +16,7 @@ In this walkthrough, you will create a basic `Loan` object and persist its data 
 
 ## Prerequisites
 
-- To build and run, install the [.NET Core SDK](https://www.microsoft.com/net/core).
+- To build and run, install the [.NET Core SDK](https://dotnet.microsoft.com/download).
 
 - Install your favorite code editor, if you haven't already.
 

--- a/docs/csharp/programming-guide/index.md
+++ b/docs/csharp/programming-guide/index.md
@@ -13,7 +13,7 @@ ms.assetid: ac0f23a2-6bf3-4077-be99-538ae5fd3bc5
 # C# programming guide
 This section provides detailed information on key C# language features and features accessible to C# through the .NET Framework.  
   
- Most of this section assumes that you already know something about C# and general programming concepts. If you are a complete beginner with programming or with C#, you might want to visit the [Introduction to C# Tutorials](../tutorials/intro-to-csharp/index.md) or [Getting Started with C#](https://www.microsoft.com/net/tutorials/csharp/getting-started) interactive tutorial, where no prior programming knowledge is required.  
+ Most of this section assumes that you already know something about C# and general programming concepts. If you are a complete beginner with programming or with C#, you might want to visit the [Introduction to C# Tutorials](../tutorials/intro-to-csharp/index.md) or [.NET In-Browser Tutorial](https://dotnet.microsoft.com/learn/dotnet/in-browser-tutorial/1), where no prior programming knowledge is required.  
   
  For information about specific keywords, operators and preprocessor directives, see [C# Reference](../language-reference/index.md). For information about the C# Language Specification, see [C# Language Specification](../language-reference/language-specification/index.md).  
   

--- a/docs/csharp/tutorials/attributes.md
+++ b/docs/csharp/tutorials/attributes.md
@@ -18,7 +18,7 @@ attributes that are built into .NET Core.
 
 ## Prerequisites
 You’ll need to setup your machine to run .NET core. You can find the
-installation instructions on the [.NET Core](https://www.microsoft.com/net/core)
+installation instructions on the [.NET Core Downloads](https://dotnet.microsoft.com/download)
 page.
 You can run this application on Windows, Ubuntu Linux, macOS or in a Docker container. 
 You’ll need to install your favorite code editor. The descriptions below

--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -24,7 +24,7 @@ There are a lot of features in this tutorial. Let’s build them one by one.
 ## Prerequisites
 
 You’ll need to setup your machine to run .NET Core. You can find the
-installation instructions on the [.NET Core](https://www.microsoft.com/net/core)
+installation instructions on the [.NET Core Downloads](https://dotnet.microsoft.com/download)
 page. You can run this
 application on Windows, Linux, macOS or in a Docker container.
 You’ll need to install your favorite code editor.

--- a/docs/csharp/tutorials/console-webapiclient.md
+++ b/docs/csharp/tutorials/console-webapiclient.md
@@ -30,7 +30,7 @@ If you prefer to follow along with the [final sample](https://github.com/dotnet/
 ## Prerequisites
 
 You’ll need to set up your machine to run .NET core. You can find the
-installation instructions on the [.NET Core](https://www.microsoft.com/net/core)
+installation instructions on the [.NET Core Downloads](https://dotnet.microsoft.com/download)
 page. You can run this
 application on Windows, Linux, macOS or in a Docker container.
 You’ll need to install your favorite code editor. The descriptions below

--- a/docs/csharp/tutorials/exploration/interpolated-strings-local.md
+++ b/docs/csharp/tutorials/exploration/interpolated-strings-local.md
@@ -9,7 +9,7 @@ ms.date: 10/23/2018
 
 This tutorial teaches you how to use C# [string interpolation](../../language-reference/tokens/interpolated.md) to insert values into a single result string. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that show you how to insert values into a string and format those values in different ways.
 
-This tutorial expects that you have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. You also can complete the [interactive version](interpolated-strings.yml) of this tutorial in your browser.
+This tutorial expects that you have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Mac, PC or Linux. You also can complete the [interactive version](interpolated-strings.yml) of this tutorial in your browser.
 
 ## Create an interpolated string
 

--- a/docs/csharp/tutorials/exploration/interpolated-strings.yml
+++ b/docs/csharp/tutorials/exploration/interpolated-strings.yml
@@ -114,6 +114,6 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the string interpolation interactive tutorial. You can click the **Collections in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Keep Learning" step brings you back to these tutorials.
+    You've completed the string interpolation interactive tutorial. You can click the **Collections in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     For more information, see [String interpolation](../../language-reference/tokens/interpolated.md).

--- a/docs/csharp/tutorials/inheritance.md
+++ b/docs/csharp/tutorials/inheritance.md
@@ -12,7 +12,7 @@ This tutorial introduces you to inheritance in C#. Inheritance is a feature of o
 
 ## Prerequisites
 
-This tutorial assumes that you've installed .NET Core. For installation instructions, see [.NET Core installation guide](https://www.microsoft.com/net/core). You also need a code editor. This tutorial uses [Visual Studio Code](https://code.visualstudio.com), although you can use any code editor of your choice.
+This tutorial assumes that you've installed the .NET Core SDK. Visit the [.NET Core Downloads](https://dotnet.microsoft.com/download) page to download it. You also need a code editor. This tutorial uses [Visual Studio Code](https://code.visualstudio.com), although you can use any code editor of your choice.
 
 ## Running the examples
 

--- a/docs/csharp/tutorials/intro-to-csharp/arrays-and-collections.md
+++ b/docs/csharp/tutorials/intro-to-csharp/arrays-and-collections.md
@@ -9,7 +9,7 @@ ms.custom: mvc
 This introductory tutorial provides an introduction to the C# language and the basics of the <xref:System.Collections.Generic.List%601>
 class.
 
-This tutorial expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in [Become familiar with the development tools](local-environment.md), with links to more details.
+This tutorial expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in [Become familiar with the development tools](local-environment.md), with links to more details.
 
 ## A basic list example
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops-local.md
@@ -9,7 +9,7 @@ ms.custom: mvc
 
 This tutorial teaches you how to write code that examines variables and changes the execution path based on those variables. You write C# code and see the results of compiling and running it. The tutorial contains a series of lessons that explore branching and looping constructs in C#. These lessons teach you the fundamentals of the C# language.
 
-This tutorial expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
+This tutorial expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
 
 ## Make decisions using the `if` statement
 

--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -274,7 +274,7 @@ items:
 
 - title: Congratulations!
   content: |
-    You've completed the "branches and loops" interactive tutorial. You can click the **list collection** link below to start the next interactive tutorial, or you can visit the [.NET site](https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Keep Learning" step brings you back to these tutorials.
+    You've completed the "branches and loops" interactive tutorial. You can click the **list collection** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     You can learn more about these concepts in these topics:
 

--- a/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
@@ -221,7 +221,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the "Hello C#" introduction to C# tutorial. You can click the **Numbers in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Keep Learning" step brings you back to these tutorials.
+    You've completed the "Hello C#" introduction to C# tutorial. You can click the **Numbers in C#** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     For further reading on the `string` type:
     - [C# Programming Guide](../../programming-guide/index.md) topic on [strings](../../programming-guide/strings/index.md).

--- a/docs/csharp/tutorials/intro-to-csharp/index.md
+++ b/docs/csharp/tutorials/intro-to-csharp/index.md
@@ -61,4 +61,4 @@ This tutorial assumes that you have finished the lessons listed above.
 This final tutorial is only available to run on your machine, using your own local development environment and .NET Core.
 You'll build a console application and see the basic object-oriented features that are part of the C# language.
 
-This tutorial assumes you've finished the online introductory tutorials, and you've installed [.NET Core SDK](https://www.microsoft.com/net/download) and [Visual Studio Code](https://code.visualstudio.com/).
+This tutorial assumes you've finished the online introductory tutorials, and you've installed [.NET Core SDK](https://dotnet.microsoft.com/download) and [Visual Studio Code](https://code.visualstudio.com/).

--- a/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
+++ b/docs/csharp/tutorials/intro-to-csharp/introduction-to-classes.md
@@ -6,7 +6,7 @@ ms.custom: mvc
 ---
 # Explore object oriented programming with classes and objects
 
-This tutorial expects that you have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
+This tutorial expects that you have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
 
 ## Create your application
 

--- a/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
@@ -162,7 +162,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the list interactive tutorial. That's the final introduction to C# interactive tutorial. You can visit the [.NET site](https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Keep Learning" step brings you back to these tutorials to build projects on your machine.
+    You've completed the list interactive tutorial. That's the final introduction to C# interactive tutorial. You can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     You can learn more about [.NET collections](../../../standard/collections/index.md) in the following articles:
     - [Selecting a collection type](../../../standard/collections/selecting-a-collection-class.md)

--- a/docs/csharp/tutorials/intro-to-csharp/local-environment.md
+++ b/docs/csharp/tutorials/intro-to-csharp/local-environment.md
@@ -6,10 +6,10 @@ ms.date: 10/23/2018
 # Become familiar with the .NET development tools
 
 The first step in running a tutorial on your machine is to set up a development environment.
-The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting
+The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting
 up your local development environment on Mac, PC or Linux.
 
-Alternatively, you can install the [.NET Core SDK](https://www.microsoft.com/net/download) and
+Alternatively, you can install the [.NET Core SDK](https://dotnet.microsoft.com/download) and
 [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Basic application development flow

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp-local.md
@@ -9,7 +9,7 @@ ms.custom: mvc
 
 This tutorial teaches you about the numeric types in C# interactively. You'll write small amounts of code, then you'll compile and run that code. The tutorial contains a series of lessons that explore numbers and math operations in C#. These lessons teach you the fundamentals of the C# language.
 
-This tutorial expects you to have a machine you can use for development. The .NET topic [Get Started in 10 minutes](https://www.microsoft.com/net/core) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
+This tutorial expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on Mac, PC or Linux. A quick overview of the commands you'll use is in the [Become familiar with the development tools](local-environment.md) with links to more details.
 
 ## Explore integer math
 

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
@@ -293,7 +293,7 @@ items:
     > This online coding experience is in preview mode. If you encounter problems, please report them [on the dotnet/try repo](https://github.com/dotnet/try/issues).
 
 - content: |
-    You've completed the "Numbers in C#" interactive tutorial. You can click the **Branches and Loops** link below to start the next interactive tutorial, or you can visit the [.NET site](https://www.microsoft.com/net/learn/dotnet/hello-world-tutorial) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Keep Learning" step brings you back to these tutorials.
+    You've completed the "Numbers in C#" interactive tutorial. You can click the **Branches and Loops** link below to start the next interactive tutorial, or you can visit the [.NET site](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) to download the .NET Core SDK, create a project on your machine, and keep coding. The "Next steps" section brings you back to these tutorials.
 
     You can learn more about numbers in C# in the following topics:
 

--- a/docs/framework/get-started/net-core-and-open-source.md
+++ b/docs/framework/get-started/net-core-and-open-source.md
@@ -12,7 +12,7 @@ This topic provides a brief overview  of what .NET Core is and shows how you can
 ## What is .NET Core?  
  .NET Core is a general purpose, modular, cross-platform and open source implementation of the .NET Standard. It contains many of the same APIs as the .NET Framework (but .NET Core is a smaller set) and includes runtime, framework, compiler and tools components that support a variety of operating systems and chip targets. The .NET Core implementation was primarily driven by the ASP.NET Core workloads but also by the need and desire to have a more modern implementation. It can be used in device, cloud and embedded/IoT scenarios.  
   
- To get started with .NET Core, please visit the [.NET Core homepage](https://www.microsoft.com/net/core).  
+ To get started with .NET Core, visit the .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro).  
   
  Here are the main characteristics of .NET Core:  
   
@@ -41,6 +41,6 @@ This topic provides a brief overview  of what .NET Core is and shows how you can
   
 ## See also
 
-- [.NET Core homepage](https://www.microsoft.com/net/core)
+- [.NET Tutorial - Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro)
 - [.NET Core Guide](../../core/index.md)
 - [ASP.NET Core Documentation](/aspnet/core/)

--- a/docs/framework/install/index.md
+++ b/docs/framework/install/index.md
@@ -23,7 +23,7 @@ You can install .NET Framework on various Windows versions.
 
 ## See also
 
-- [Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)
+- [Download the .NET Framework](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)
 - [Deploy the .NET Framework for developers](../deployment/deployment-guide-for-developers.md)

--- a/docs/framework/install/on-windows-10.md
+++ b/docs/framework/install/on-windows-10.md
@@ -66,7 +66,7 @@ The .NET Framework 3.5 supports apps built for the .NET Framework 1.0 through 3.
 
 - 4.x versions of the .NET Framework can be used to run applications built for the .NET Framework 4.0 through that version. For example, .NET Framework 4.7 can be used to run applications built for the .NET Framework 4.0 through 4.7. The latest version (the .NET Framework 4.8) can be used to run applications built with all versions of the .NET Framework starting with 4.0.
 
-For a list of all the versions of the .NET Framework available to download, see the [.NET Downloads](https://www.microsoft.com/net/download?utm_source=ms-docs&utm_medium=referral) page.
+For a list of all the versions of the .NET Framework available to download, see the [.NET Downloads](https://dotnet.microsoft.com/download) page.
 
 ## Help
 
@@ -74,6 +74,6 @@ If you cannot get the correct version of the .NET Framework installed, you can [
 
 ## See also
 
-- [.NET Downloads](https://www.microsoft.com/net/download?utm_source=ms-docs&utm_medium=referral)
+- [.NET Downloads](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)

--- a/docs/framework/install/on-windows-7.md
+++ b/docs/framework/install/on-windows-7.md
@@ -34,6 +34,6 @@ You can [contact Microsoft for help](mailto:dotnet-install-help@service.microsof
 
 ## See also
 
-- [Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)
+- [Download the .NET Framework](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)

--- a/docs/framework/install/on-windows-8-1.md
+++ b/docs/framework/install/on-windows-8-1.md
@@ -34,6 +34,6 @@ You can [contact Microsoft for help](mailto:dotnet-install-help@service.microsof
 
 ## See also
 
-- [Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)
+- [Download the .NET Framework](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)

--- a/docs/framework/install/on-windows-8.md
+++ b/docs/framework/install/on-windows-8.md
@@ -42,6 +42,6 @@ You can [contact Microsoft for help](mailto:dotnet-install-help@service.microsof
 
 ## See also
 
-- [Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)
+- [Download the .NET Framework](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)

--- a/docs/framework/install/on-windows-vista.md
+++ b/docs/framework/install/on-windows-vista.md
@@ -29,6 +29,6 @@ The .NET Framework 3.5 supports apps built for .NET Framework 1.0 through 3.5.
 
 ## See also
 
-- [Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)
+- [Download the .NET Framework](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)

--- a/docs/framework/install/on-windows-xp.md
+++ b/docs/framework/install/on-windows-xp.md
@@ -34,6 +34,6 @@ The .NET Framework 3.5 can be used to run applications built for .NET Framework 
 
 ## See also
 
-- [Download the .NET Framework](https://www.microsoft.com/net/download/framework?utm_source=ms-docs&utm_medium=referral)
+- [Download the .NET Framework](https://dotnet.microsoft.com/download)
 - [Troubleshoot blocked .NET Framework installations and uninstallations](troubleshoot-blocked-installations-and-uninstallations.md)
 - [Install the .NET Framework for developers](guide-for-developers.md)

--- a/docs/fsharp/get-started/get-started-command-line.md
+++ b/docs/fsharp/get-started/get-started-command-line.md
@@ -9,7 +9,7 @@ This article covers how you can get started with F# on any operating system (Win
 
 ## Prerequisites
 
-To begin, you must install the latest [.NET Core SDK](https://www.microsoft.com/net/download/).
+To begin, you must install the latest [.NET Core SDK](https://dotnet.microsoft.com/download).
 
 This article assumes that you know how to use a command line and have a preferred text editor. If you don't already use it, [Visual Studio Code](get-started-vscode.md) is a great option as a text editor for F#.
 

--- a/docs/fsharp/get-started/install-fsharp.md
+++ b/docs/fsharp/get-started/install-fsharp.md
@@ -34,7 +34,7 @@ You must have [git installed](https://git-scm.com/download) and available on you
 brew install mono
 ```
 
-Also install the [.NET Core SDK](https://www.microsoft.com/net/download).
+Also install the [.NET Core SDK](https://dotnet.microsoft.com/download).
 
 ### [Linux](#tab/linux)
 
@@ -45,13 +45,13 @@ sudo apt-get update
 sudo apt-get install mono-complete fsharp
 ```
 
-Also install the [.NET Core SDK](https://www.microsoft.com/net/download).
+Also install the [.NET Core SDK](https://dotnet.microsoft.com/download).
 
 ### [Windows](#tab/windows)
 
 Install [Visual Studio with F# support](#install-f-with-visual-studio). This installs all the necessary components to write, compile, and execute F# code.
 
-Also install the [.NET Core SDK](https://www.microsoft.com/net/download/).
+Also install the [.NET Core SDK](https://dotnet.microsoft.com/download).
 
 ---
 

--- a/docs/machine-learning/how-to-guides/matchup-app-infer-net.md
+++ b/docs/machine-learning/how-to-guides/matchup-app-infer-net.md
@@ -18,7 +18,7 @@ Probabilistic programming allows you to create statistical models of real-world 
 
 - Local development environment setup
 
-  This how-to guide expects you to have a machine you can use for development. The .NET [Get Started in 10 minutes](https://www.microsoft.com/net/core) tutorial has instructions for setting up your local development environment on Mac, PC, or Linux.
+  This how-to guide expects you to have a machine you can use for development. The .NET tutorial [Hello World in 10 minutes](https://dotnet.microsoft.com/learn/dotnet/hello-world-tutorial/intro) has instructions for setting up your local development environment on macOS, Windows, or Linux.
 
 ## Create your app
 

--- a/docs/machine-learning/how-to-guides/use-gams-for-model-explainability.md
+++ b/docs/machine-learning/how-to-guides/use-gams-for-model-explainability.md
@@ -8,7 +8,7 @@ ms.custom: mvc,how-to
 # Use Generalized Additive Models and shape functions for model explainability in ML.NET
 
 > [!NOTE]
-> This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit [the ML.NET introduction](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet).
+> This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit the [ML.NET](https://dotnet.microsoft.com/apps/machinelearning-ai/ml-dotnet) page.
 
 This how-to and related sample are currently using **ML.NET version 0.10**. For more information, see the release notes at the [dotnet/machinelearning GitHub repo](https://github.com/dotnet/machinelearning/tree/master/docs/release-notes).
 

--- a/docs/machine-learning/how-to-guides/verify-model-quality-ml-net.md
+++ b/docs/machine-learning/how-to-guides/verify-model-quality-ml-net.md
@@ -8,7 +8,7 @@ ms.custom: mvc,how-to
 # Calculate metrics to evaluate machine learning model quality 
 
 > [!NOTE]
-> This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit [the ML.NET introduction](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet).
+> This topic refers to ML.NET, which is currently in Preview, and material may be subject to change. For more information, visit the [ML.NET](https://dotnet.microsoft.com/apps/machinelearning-ai/ml-dotnet) page.
 
 This how-to and related sample are currently using **ML.NET version 0.10**. For more information, see the release notes at the [dotnet/machinelearning GitHub repo](https://github.com/dotnet/machinelearning/tree/master/docs/release-notes).
 

--- a/docs/machine-learning/tutorials/mlnet-cli.md
+++ b/docs/machine-learning/tutorials/mlnet-cli.md
@@ -22,7 +22,7 @@ In this tutorial, you will do the following steps:
 > - Explore the generated C# code that was used to train the model
 
 > [!NOTE]
-> This topic refers to the ML.NET CLI tool, which is currently in Preview, and material may be subject to change. For more information, visit [the ML.NET introduction](https://www.microsoft.com/net/learn/apps/machine-learning-and-ai/ml-dotnet).
+> This topic refers to the ML.NET CLI tool, which is currently in Preview, and material may be subject to change. For more information, visit the [ML.NET](https://dotnet.microsoft.com/apps/machinelearning-ai/ml-dotnet) page.
 
 The ML.NET CLI is part of ML.NET and its main goal is to "democratize" ML.NET for .NET developers when learning ML.NET so you don't need to code from scratch to get started.
 

--- a/docs/samples-and-tutorials/index.md
+++ b/docs/samples-and-tutorials/index.md
@@ -8,7 +8,7 @@ ms.date: 04/11/2017
 
 # .NET samples and tutorials
 
-The .NET documentation contains a set of samples and tutorials that teach you about .NET. This topic describes how to find, view, and download .NET Core, ASP.NET Core, and C# samples and tutorials. Find resources to learn the F# programming language on the [F# Foundation's site](https://fsharp.org/learn.html). If you're interested in exploring C# using an online code editor, start with [this interactive tutorial](https://www.microsoft.com/net/learn/in-browser-tutorial/1) and continue with [C# interactive tutorial](../csharp/tutorials/intro-to-csharp/index.md). For instructions on how to view and download sample code, see the [Viewing and downloading samples](#viewing-and-downloading-samples) section.
+The .NET documentation contains a set of samples and tutorials that teach you about .NET. This topic describes how to find, view, and download .NET Core, ASP.NET Core, and C# samples and tutorials. Find resources to learn the F# programming language on the [F# Foundation's site](https://fsharp.org/learn.html). If you're interested in exploring C# using an online code editor, start with [this interactive tutorial](https://dotnet.microsoft.com/learn/dotnet/in-browser-tutorial/1) and continue with [C# interactive tutorial](../csharp/tutorials/intro-to-csharp/index.md). For instructions on how to view and download sample code, see the [Viewing and downloading samples](#viewing-and-downloading-samples) section.
 
 ## .NET Core
 

--- a/docs/standard/index.md
+++ b/docs/standard/index.md
@@ -13,7 +13,7 @@ The .NET Guide provides a large amount of information about .NET.  Depending on 
 
 ## New to .NET
 
-If you want a high-level overview about .NET, check out [What is .NET?](https://www.microsoft.com/net/learn/what-is-dotnet).
+If you want a high-level overview about .NET, check out [What is .NET?](https://dotnet.microsoft.com/learn/dotnet/what-is-dotnet).
 
 If you're new to .NET, check out the [Get Started](get-started.md) article.
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -62,4 +62,4 @@ This documentation is completely [open source](https://github.com/dotnet/docs). 
 - [Windows Forms](https://github.com/dotnet/winforms)
 - [WPF](https://github.com/dotnet/wpf)
 
-You can join other people who are already active in the [.NET community](https://www.microsoft.com/net/community) to find out what's new or ask for help.
+You can join other people who are already active in the [.NET community](https://dotnet.microsoft.com/platform/community) to find out what's new or ask for help.


### PR DESCRIPTION
Related to #13626 

That issue made me realize that we never updated the links since we migrated to the new site at https://dotnet.microsoft.com/. This PR only accounts for link updates, even though some content might be outdated.

/cc @rowanmiller 