### PR TITLE
update .net architecture metadata

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -26,14 +26,15 @@
               "(?i)dotnet-spark": ":books: Area - .NET for Apache Spark Guide",
               "(?i)dotnet$": ":books: Area - .NET Guide",
               "(?i)dotnet-ml-api$": ":books: Area - API Reference,:file_folder: Repo - ml-api-docs",
-              "(?i)dotnet-roslyn-api$": ":books: Area - Roslyn API Reference,:file_folder: Repo - roslyn-api-docs"
+              "(?i)dotnet-roslyn-api$": ":books: Area - Roslyn API Reference,:file_folder: Repo - roslyn-api-docs",
+              "(?i)dotnet-architecture$": ":books: Area - .NET Architecture Guide"
             },
             "contentsource": {
-              "(?i).*master\/docs\/architecture\/containerized-lifecycle.*": ":card_file_box: Technology - .NET Architecture,:book: guide - Docker lifecycle",
-              "(?i).*master\/docs\/architecture\/microservices.*": ":card_file_box: Technology - .NET Architecture,:book: guide - .NET Microservices",
-              "(?i).*master\/docs\/architecture\/modern-web-apps-azure.*": ":card_file_box: Technology - .NET Architecture,:book: guide - ASP.NET Core web apps",
-              "(?i).*master\/docs\/architecture\/modernize-with-azure-containers.*": ":card_file_box: Technology - .NET Architecture,:book: guide - Modernizing w/ Windows containers",
-              "(?i).*master\/docs\/architecture\/serverless.*": ":card_file_box: Technology - .NET Architecture,:book: guide - Serverless apps",
+              "(?i).*master\/docs\/architecture\/containerized-lifecycle.*": ":book: guide - Docker lifecycle",
+              "(?i).*master\/docs\/architecture\/microservices.*": ":book: guide - .NET Microservices",
+              "(?i).*master\/docs\/architecture\/modern-web-apps-azure.*": ":book: guide - ASP.NET Core web apps",
+              "(?i).*master\/docs\/architecture\/modernize-with-azure-containers.*": ":book: guide - Modernizing w/ Windows containers",
+              "(?i).*master\/docs\/architecture\/serverless.*": ":book: guide - Serverless apps",
               "(?i).*master\/docs\/core\/tools.*": ":card_file_box: Technology - CLI",
               "(?i).*master\/docs\/core\/docker.*": ":card_file_box: Technology - Docker",
               "(?i).*master\/docs\/framework\/configure-apps\/file-schema\/network.*": ":card_file_box: Technology - NCL",

--- a/docfx.json
+++ b/docfx.json
@@ -151,6 +151,7 @@
       "ms.prod": {
         "_csharplang/**/*.md": "dotnet-csharp",
         "_vblang/spec/*.md": "dotnet-visualbasic",
+        "docs/architecture/**/**.md": "dotnet-architecture",
         "docs/core/**/**.md": "dotnet-core",
         "docs/csharp/**/**.md": "dotnet-csharp",
         "docs/csharp/**/**.yml": "dotnet-csharp",
@@ -227,7 +228,11 @@
       "ms.technology": {
         "_csharplang/**/*.md": "csharp-spec",
         "_vblang/spec/*.md": "vb-spec",
-        "docs/architecture/**/**.md": "dotnet-ebooks",        
+        "docs/architecture/containerized-lifecycle/**/**.md": "containerized-lifecycle",
+        "docs/architecture/microservices/**/**.md": "microservices",
+        "docs/architecture/modernize-with-azure-containers/**/**.md": "modernize-with-azure-containers",
+        "docs/architecture/modern-web-apps-azure/**/**.md": "modern-web-apps-azure",
+        "docs/architecture/serverless/**/**.md": "serverless",
         "docs/csharp/roslyn-sdk/**/**.md": "csharp-roslyn",
         "docs/csharp/language-reference/compiler-messages/**/**.md": "csharp-diagnostics",
         "docs/csharp/misc/**/**.md": "csharp-diagnostics",


### PR DESCRIPTION
Given that we moved the architecture e-books out of the .NET Guide, I also changed the metadata for that content. Now dotnet-architecture is its own product and we have a ms.technology value for each e-book.

/cc @nishanil @Thraka 