### PR TITLE
Update cs0164.md

### DIFF
--- a/docs/csharp/misc/cs0164.md
+++ b/docs/csharp/misc/cs0164.md
@@ -1,6 +1,6 @@
 ---
 title: "Compiler Warning (level 2) CS0164"
-ms.date: 07/20/2015
+ms.date: 09/07/2019
 f1_keywords: 
   - "CS0164"
 helpviewer_keywords: 
@@ -8,26 +8,25 @@ helpviewer_keywords:
 ms.assetid: c701265b-ea7d-4d56-ae73-f74e039f1005
 ---
 # Compiler Warning (level 2) CS0164
-This label has not been referenced  
-  
- A label was declared but never used.  
-  
- The following sample generates CS0164:  
-  
-```csharp  
-// CS0164.cs  
-// compile with: /W:2  
-public class a  
-{  
-   public int i = 0;  
-  
-   public static void Main()  
-   {  
-      int i = 0;   // CS0164  
-      l1: i++;  
-      // the following lines resolve this error  
-      // if(i < 10)  
-      //    goto l1;  
-   }  
-}  
+This label has not been referenced
+
+ A label was declared but never used.
+
+ The following sample generates CS0164:
+
+```csharp
+// CS0164.cs
+// compile with: /W:2
+public class Program
+{
+    public static void Main()
+    {
+        int i = 0;
+    l1: // CS0164
+        i++;
+        // Uncomment the following lines to resolve this warning.
+        // if (i < 10)
+        //     goto l1;
+    }
+}
 ```


### PR DESCRIPTION
- Removed extra whitespaces.
- Removed unnecessary `public int i` declaration.
- Used 4 spaces instead of 3 for indentation
- Made label indentation one less than the current indentation as recommended by [corefx coding style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md).

    > When using labels (for goto), indent the label one less than the current indentation.

- Put the `// CS0164` comment in the correct line where the warning is generated.
- Updated `the following lines resolve this error` comment to `Uncomment the following lines to resolve this warning.`.