### PR TITLE
Fix snippet language

### DIFF
--- a/docs/core/dependency-loading/understanding-assemblyloadcontext.md
+++ b/docs/core/dependency-loading/understanding-assemblyloadcontext.md
@@ -96,7 +96,7 @@ Given a pair of mismatched types it's important to also know:
 
 Given two objects `a` and `b`, evaluating the following in the debugger will be helpful:
 
-```C#
+```csharp
 // In debugger look at each assembly's instance, Location, and FullName
 a.GetType().Assembly
 b.GetType().Assembly


### PR DESCRIPTION
This code snippet isn't highlighted at [live docs](https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext#debugging-type-conversion-issues). Changing identifier from `C#` to `csharp` should fix it.