### PR TITLE
Update how-to-perform-streaming-transformations-of-text-to-xml.md

### DIFF
--- a/docs/csharp/programming-guide/concepts/linq/how-to-perform-streaming-transformations-of-text-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-perform-streaming-transformations-of-text-to-xml.md
@@ -4,11 +4,13 @@ ms.date: 07/20/2015
 ms.assetid: 9b3bd941-d0ff-4f2d-ae41-7c3b81d8fae6
 ---
 # How to: Perform Streaming Transformations of Text to XML (C#)
+
 One approach to processing a text file is to write an extension method that streams the text file a line at a time using the `yield return` construct. You then can write a LINQ query that processes the text file in a lazy deferred fashion. If you then use <xref:System.Xml.Linq.XStreamingElement> to stream output, you then can create a transformation from the text file to XML that uses a minimal amount of memory, regardless of the size of the source text file.  
   
  There are some caveats regarding streaming transformations. A streaming transformation is best applied in situations where you can process the entire file once, and if you can process the lines in the order that they occur in the source document. If you have to process the file more than once, or if you have to sort the lines before you can process them, you will lose many of the benefits of using a streaming technique.  
   
 ## Example  
+
  The following text file, People.txt, is the source for this example.  
   
 ```text  
@@ -20,43 +22,43 @@ One approach to processing a text file is to write an extension method that stre
   
  The following code contains an extension method that streams the lines of the text file in a deferred fashion.  
   
-```csharp  
-public static class StreamReaderSequence  
-{  
-    public static IEnumerable<string> Lines(this StreamReader source)  
-    {  
-        String line;  
-  
-        if (source == null)  
-            throw new ArgumentNullException("source");  
-        while ((line = source.ReadLine()) != null)  
-        {  
-            yield return line;  
-        }  
-    }  
-}  
-  
-class Program  
-{  
-    static void Main(string[] args)  
-    {  
-        StreamReader sr = new StreamReader("People.txt");  
-        XStreamingElement xmlTree = new XStreamingElement("Root",  
-            from line in sr.Lines()  
-            let items = line.Split(',')  
-            where !line.StartsWith("#")  
-            select new XElement("Person",  
-                       new XAttribute("ID", items[0]),  
-                       new XElement("First", items[1]),  
-                       new XElement("Last", items[2]),  
-                       new XElement("Occupation", items[3])  
-                   )  
-        );  
-        Console.WriteLine(xmlTree);  
-        sr.Close();  
-    }  
-}  
-```  
+```csharp
+public static class StreamReaderSequence
+{
+    public static IEnumerable<string> Lines(this StreamReader source)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        string line;
+        while ((line = source.ReadLine()) != null)
+        {
+            yield return line;
+        }
+    }
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        var sr = new StreamReader("People.txt");
+        var xmlTree = new XStreamingElement("Root",
+            from line in sr.Lines()
+            let items = line.Split(',')
+            where !line.StartsWith("#")
+            select new XElement("Person",
+                       new XAttribute("ID", items[0]),
+                       new XElement("First", items[1]),
+                       new XElement("Last", items[2]),
+                       new XElement("Occupation", items[3])
+                   )
+        );
+        Console.WriteLine(xmlTree);
+        sr.Close();
+    }
+}
+```
   
  This example produces the following output:  
   

--- a/docs/csharp/programming-guide/concepts/linq/how-to-perform-streaming-transformations-of-text-to-xml.md
+++ b/docs/csharp/programming-guide/concepts/linq/how-to-perform-streaming-transformations-of-text-to-xml.md
@@ -5,23 +5,23 @@ ms.assetid: 9b3bd941-d0ff-4f2d-ae41-7c3b81d8fae6
 ---
 # How to: Perform Streaming Transformations of Text to XML (C#)
 
-One approach to processing a text file is to write an extension method that streams the text file a line at a time using the `yield return` construct. You then can write a LINQ query that processes the text file in a lazy deferred fashion. If you then use <xref:System.Xml.Linq.XStreamingElement> to stream output, you then can create a transformation from the text file to XML that uses a minimal amount of memory, regardless of the size of the source text file.  
-  
- There are some caveats regarding streaming transformations. A streaming transformation is best applied in situations where you can process the entire file once, and if you can process the lines in the order that they occur in the source document. If you have to process the file more than once, or if you have to sort the lines before you can process them, you will lose many of the benefits of using a streaming technique.  
-  
-## Example  
+One approach to processing a text file is to write an extension method that streams the text file a line at a time using the `yield return` construct. You then can write a LINQ query that processes the text file in a lazy deferred fashion. If you then use <xref:System.Xml.Linq.XStreamingElement> to stream output, you then can create a transformation from the text file to XML that uses a minimal amount of memory, regardless of the size of the source text file.
 
- The following text file, People.txt, is the source for this example.  
-  
-```text  
-#This is a comment  
-1,Tai,Yee,Writer  
-2,Nikolay,Grachev,Programmer  
-3,David,Wright,Inventor  
-```  
-  
- The following code contains an extension method that streams the lines of the text file in a deferred fashion.  
-  
+ There are some caveats regarding streaming transformations. A streaming transformation is best applied in situations where you can process the entire file once, and if you can process the lines in the order that they occur in the source document. If you have to process the file more than once, or if you have to sort the lines before you can process them, you will lose many of the benefits of using a streaming technique.
+
+## Example
+
+ The following text file, People.txt, is the source for this example.
+
+```text
+#This is a comment
+1,Tai,Yee,Writer
+2,Nikolay,Grachev,Programmer
+3,David,Wright,Inventor
+```
+
+ The following code contains an extension method that streams the lines of the text file in a deferred fashion.
+
 ```csharp
 public static class StreamReaderSequence
 {
@@ -59,29 +59,29 @@ class Program
     }
 }
 ```
-  
- This example produces the following output:  
-  
-```xml  
-<Root>  
-  <Person ID="1">  
-    <First>Tai</First>  
-    <Last>Yee</Last>  
-    <Occupation>Writer</Occupation>  
-  </Person>  
-  <Person ID="2">  
-    <First>Nikolay</First>  
-    <Last>Grachev</Last>  
-    <Occupation>Programmer</Occupation>  
-  </Person>  
-  <Person ID="3">  
-    <First>David</First>  
-    <Last>Wright</Last>  
-    <Occupation>Inventor</Occupation>  
-  </Person>  
-</Root>  
-```  
-  
+
+ This example produces the following output:
+
+```xml
+<Root>
+  <Person ID="1">
+    <First>Tai</First>
+    <Last>Yee</Last>
+    <Occupation>Writer</Occupation>
+  </Person>
+  <Person ID="2">
+    <First>Nikolay</First>
+    <Last>Grachev</Last>
+    <Occupation>Programmer</Occupation>
+  </Person>
+  <Person ID="3">
+    <First>David</First>
+    <Last>Wright</Last>
+    <Occupation>Inventor</Occupation>
+  </Person>
+</Root>
+```
+
 ## See also
 
 - <xref:System.Xml.Linq.XStreamingElement>


### PR DESCRIPTION
- Use `nameof` instead of magic string.
- Leave blank line after headings.
- Improving code.