### PR TITLE
C117640Escaping backslah to avoid localization content

### DIFF
--- a/docs/visual-basic/language-reference/operators/data-types-of-operator-results.md
+++ b/docs/visual-basic/language-reference/operators/data-types-of-operator-results.md
@@ -108,7 +108,7 @@ Visual Basic determines the result data type of an operation based on the data t
 |`Long`|Long|Long|Long|Long|Long|Long|Long|Long|Decimal|  
 |`ULong`|Decimal|Decimal|ULong|Decimal|ULong|Decimal|ULong|Decimal|ULong|  
   
-### \ Operator  
+### \\ Operator  
  The following table shows the result data types for the `\` operator. Note that this table is symmetric; for a given combination of operand data types, the result data type is the same regardless of the order of the operands.  
   
 |||||||||||  

--- a/docs/visual-basic/language-reference/operators/data-types-of-operator-results.md
+++ b/docs/visual-basic/language-reference/operators/data-types-of-operator-results.md
@@ -92,7 +92,7 @@ Visual Basic determines the result data type of an operation based on the data t
   
  If the left operand is `Decimal`, `Single`, `Double`, or `String`, Visual Basic attempts to convert it to `Long` before the operation, and the result data type is `Long`. The right operand (the number of bit positions to shift) must be `Integer` or a type that widens to `Integer`.  
   
-### Binary +, –, *, and Mod Operators  
+### Binary +, –, \*, and Mod Operators  
  The following table shows the result data types for the binary `+` and `–` operators and the `*` and `Mod` operators. Note that this table is symmetric; for a given combination of operand data types, the result data type is the same regardless of the order of the operands.  
   
 |||||||||||  


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Backslash"\\" in section name is breaking formatting causing English strings to render on LOC pages.