### PR TITLE
US 1583733 Add missing language IDs - 24

### DIFF
--- a/docs/framework/wcf/extending/extending-hosting-using-servicehostfactory.md
+++ b/docs/framework/wcf/extending/extending-hosting-using-servicehostfactory.md
@@ -8,7 +8,7 @@ The standard <xref:System.ServiceModel.ServiceHost> API for hosting services in 
   
  In the self-host environment, you do not have to create a custom <xref:System.ServiceModel.ServiceHost> because you write the code that instantiates the host and then call <xref:System.ServiceModel.ICommunicationObject.Open> on it after you instantiate it. Between those two steps you can do whatever you want. You could, for example, add a new <xref:System.ServiceModel.Description.IServiceBehavior>:  
   
-```  
+```csharp
 public static void Main()  
 {  
    ServiceHost host = new ServiceHost( typeof( MyService ) );  
@@ -23,7 +23,7 @@ public static void Main()
   
  However, a slight variation of the example can also be used to solve this problem. One approach is to move the code that adds the ServiceBehavior out of `Main()` and into the <xref:System.ServiceModel.Channels.CommunicationObject.OnOpening%2A> method of a custom derivative of <xref:System.ServiceModel.ServiceHost>:  
   
-```  
+```csharp
 public class DerivedHost : ServiceHost  
 {  
    public DerivedHost( Type t, params Uri baseAddresses ) :  
@@ -38,7 +38,7 @@ public class DerivedHost : ServiceHost
   
  Then, inside of `Main()` you can use:  
   
-```  
+```csharp
 public static void Main()  
 {  
    ServiceHost host = new DerivedHost( typeof( MyService ) );  
@@ -56,7 +56,7 @@ public static void Main()
   
  The intent is that for basic cases, implementing your own factory should be a straight forward exercise. For example, here is a custom <xref:System.ServiceModel.Activation.ServiceHostFactory> that returns a derived <xref:System.ServiceModel.ServiceHost>:  
   
-```  
+```csharp
 public class DerivedFactory : ServiceHostFactory  
 {  
    public override ServiceHost CreateServiceHost( Type t, Uri[] baseAddresses )  
@@ -68,10 +68,8 @@ public class DerivedFactory : ServiceHostFactory
   
  To use this factory instead of the default factory, provide the type name in the @ServiceHost directive as follows:  
   
-```  
-<% @ServiceHost Factory="DerivedFactory" Service="MyService" %>  
-```  
+`<% @ServiceHost Factory="DerivedFactory" Service="MyService" %>`  
   
- While there is no technical limit on doing what you want to the <xref:System.ServiceModel.ServiceHost> you return from <xref:System.ServiceModel.Activation.ServiceHostFactory.CreateServiceHost%2A>, we suggest that you keep your factory implementations as simple as possible. If you have lots of custom logic, it is better to put that logic inside of you host instead of inside the factory so that it can be reusable.  
+ While there is no technical limit on doing what you want to the <xref:System.ServiceModel.ServiceHost> you return from <xref:System.ServiceModel.Activation.ServiceHostFactory.CreateServiceHost%2A>, we suggest that you keep your factory implementations as simple as possible. If you have lots of custom logic, it is better to put that logic inside of your host instead of inside the factory so that it can be reusable.  
   
  There is one more layer to the hosting API that should be mentioned here. WCF also has <xref:System.ServiceModel.ServiceHostBase> and <xref:System.ServiceModel.Activation.ServiceHostFactoryBase>, from which <xref:System.ServiceModel.ServiceHost> and <xref:System.ServiceModel.Activation.ServiceHostFactory> respectively derive. Those exist for more advanced scenarios where you must swap out large parts of the metadata system with your own customized creations.

--- a/docs/framework/wcf/extending/handling-exceptions-and-faults.md
+++ b/docs/framework/wcf/extending/handling-exceptions-and-faults.md
@@ -42,7 +42,7 @@ SOAP 1.2 Fault (left) and SOAP 1.1 Fault (right). Note that in SOAP 1.1 only the
   
  SOAP defines a fault message as a message that contains only a fault element (an element whose name is `<env:Fault>`) as a child of `<env:Body>`. The contents of the fault element differ slightly between SOAP 1.1 and SOAP 1.2 as shown in figure 1. However, the <xref:System.ServiceModel.Channels.MessageFault?displayProperty=nameWithType> class normalizes these differences into one object model:  
   
-```  
+```csharp
 public abstract class MessageFault  
 {  
     protected MessageFault();  
@@ -68,7 +68,7 @@ public abstract class MessageFault
   
  You should create new fault subcodes (or new fault codes if using SOAP 1.1) if it is interesting to programmatically distinguish a fault. This is analogous to creating a new exception type. You should avoid using the dot notation with SOAP 1.1 fault codes. (The [WS-I Basic Profile](https://go.microsoft.com/fwlink/?LinkId=95177) also discourages the use of the fault code dot notation.)  
   
-```  
+```csharp  
 public class FaultCode  
 {  
     public FaultCode(string name);  
@@ -90,7 +90,7 @@ public class FaultCode
   
  The `Reason` property corresponds to the `env:Reason` (or `faultString` in SOAP 1.1) a human-readable description of the error condition analogous to an exception’s message. The `FaultReason` class (and SOAP `env:Reason/faultString`) has built-in support for having multiple translations in the interest of globalization.  
   
-```  
+```csharp  
 public class FaultReason  
 {  
     public FaultReason(FaultReasonText translation);  
@@ -112,7 +112,7 @@ public class FaultReason
   
  When generating a fault, the custom channel should not send the fault directly, rather, it should throw an exception and let the layer above decide whether to convert that exception to a fault and how to send it. To aid in this conversion, the channel should provide a `FaultConverter` implementation that can convert the exception thrown by the custom channel to the appropriate fault. `FaultConverter` is defined as:  
   
-```  
+```csharp  
 public class FaultConverter  
 {  
     public static FaultConverter GetDefaultFaultConverter(  
@@ -128,7 +128,7 @@ public class FaultConverter
   
  Each channel that generates custom faults must implement `FaultConverter` and return it from a call to `GetProperty<FaultConverter>`. The custom `OnTryCreateFaultMessage` implementation must either convert the exception to a fault or delegate to the inner channel’s `FaultConverter`. If the channel is a transport it must either convert the exception or delegate to the encoder’s `FaultConverter` or the default `FaultConverter` provided in WCF . The default `FaultConverter` converts errors corresponding to fault messages specified by WS-Addressing and SOAP. Here is an example `OnTryCreateFaultMessage` implementation.  
   
-```  
+```csharp  
 public override bool OnTryCreateFaultMessage(Exception exception,   
                                              out Message message)  
 {  
@@ -198,7 +198,7 @@ public override bool OnTryCreateFaultMessage(Exception exception,
   
  The following object model supports converting messages to exceptions:  
   
-```  
+```csharp  
 public class FaultConverter  
 {  
     public static FaultConverter GetDefaultFaultConverter(  
@@ -218,7 +218,7 @@ public class FaultConverter
   
  A typical implementation looks like this:  
   
-```  
+```csharp  
 public override bool OnTryCreateException(  
                             Message message,   
                             MessageFault fault,   
@@ -284,7 +284,7 @@ public override bool OnTryCreateException(
   
  If your protocol channel sends a custom header with MustUnderstand=true and receives a `mustUnderstand` fault, it must figure out whether that fault is due to the header it sent. There are two members on the `MessageFault` class that are useful for this:  
   
-```  
+```csharp  
 public class MessageFault  
 {  
     ...  
@@ -316,7 +316,7 @@ public class MessageFault
   
  Once you have a trace source, you call its <xref:System.Diagnostics.TraceSource.TraceData%2A>, <xref:System.Diagnostics.TraceSource.TraceEvent%2A>, or <xref:System.Diagnostics.TraceSource.TraceInformation%2A> methods to write trace entries to the trace listeners. For each trace entry you write, you need to classify the type of event as one of the event types defined in <xref:System.Diagnostics.TraceEventType>. This classification and the trace level setting in configuration determine whether the trace entry is output to the listener. For example, setting the trace level in configuration to `Warning` allows `Warning`, `Error` and `Critical` trace entries to be written but blocks Information and Verbose entries. Here is an example of instantiating a trace source and writing out an entry at Information level:  
   
-```  
+```csharp
 using System.Diagnostics;  
 //...  
 TraceSource udpSource=new TraceSource("Microsoft.Samples.Udp");  

--- a/docs/framework/wcf/extending/how-to-configure-a-custom-ws-metadata-exchange-binding.md
+++ b/docs/framework/wcf/extending/how-to-configure-a-custom-ws-metadata-exchange-binding.md
@@ -48,7 +48,7 @@ This topic will explain how to configure a custom WS-Metadata exchange binding. 
   
 5. In the client's Main() method, create a new <xref:System.ServiceModel.Description.MetadataExchangeClient> instance, set its <xref:System.ServiceModel.Description.MetadataExchangeClient.ResolveMetadataReferences%2A> property to `true`, call <xref:System.ServiceModel.Description.MetadataExchangeClient.GetMetadata%2A> and then iterate through the collection of metadata returned:  
   
-    ```  
+    ```csharp
     string mexAddress = "http://localhost:8000/servicemodelsamples/service/mex";  
   
     MetadataExchangeClient mexClient = new MetadataExchangeClient("MyMexEndpoint");  
@@ -62,19 +62,19 @@ This topic will explain how to configure a custom WS-Metadata exchange binding. 
   
 1. Create a <xref:System.ServiceModel.WSHttpBinding> binding instance:  
   
-    ```  
+    ```csharp  
     WSHttpBinding binding = new WSHttpBinding();  
     ```  
   
 2. Create a <xref:System.ServiceModel.ServiceHost> instance:  
   
-    ```  
+    ```csharp  
     ServiceHost serviceHost = new ServiceHost(typeof(CalculatorService), baseAddress);  
     ```  
   
 3. Add a service endpoint and add a <xref:System.ServiceModel.Description.ServiceMetadataBehavior> instance:  
   
-    ```  
+    ```csharp  
     serviceHost.AddServiceEndpoint(typeof(ICalculator), binding, baseAddress);  
     ServiceMetadataBehavior smb = new ServiceMetadataBehavior();  
     smb.HttpGetEnabled = true;  
@@ -83,7 +83,7 @@ This topic will explain how to configure a custom WS-Metadata exchange binding. 
   
 4. Add a metadata exchange endpoint, specifying the <xref:System.ServiceModel.WSHttpBinding> created earlier:  
   
-    ```  
+    ```csharp  
     serviceHost.AddServiceEndpoint(typeof(IMetadataExchange), binding, mexAddress);  
     ```  
   
@@ -97,7 +97,7 @@ This topic will explain how to configure a custom WS-Metadata exchange binding. 
   
 6. In the client's Main() method, create a new <xref:System.ServiceModel.Description.MetadataExchangeClient> instance, set the <xref:System.ServiceModel.Description.MetadataExchangeClient.ResolveMetadataReferences%2A> property to `true`, call <xref:System.ServiceModel.Description.MetadataExchangeClient.GetMetadata%2A> and then iterate through the collection of metadata returned:  
   
-    ```  
+    ```csharp  
     string mexAddress = "http://localhost:8000/servicemodelsamples/service/mex";  
   
     MetadataExchangeClient mexClient = new MetadataExchangeClient("MyMexEndpoint");  

--- a/docs/framework/wcf/extending/how-to-retrieve-metadata-over-a-non-mex-binding.md
+++ b/docs/framework/wcf/extending/how-to-retrieve-metadata-over-a-non-mex-binding.md
@@ -79,7 +79,7 @@ This topic describes how to retrieve metadata from a MEX endpoint over a non-MEX
   
 3. Create a `MetadataExchangeClient` and call `GetMetadata`. There are two ways to do this: you can specify the custom binding in configuration, or you can specify the custom binding in code, as shown in the following example.  
   
-    ```  
+    ```csharp
     // The custom binding is specified in configuration.  
     EndpointAddress mexAddress = new EndpointAddress("http://localhost:8000/ServiceModelSamples/Service/mex");  
   
@@ -110,7 +110,7 @@ This topic describes how to retrieve metadata from a MEX endpoint over a non-MEX
   
 4. Create a `WsdlImporter` and call `ImportAllEndpoints`, as shown in the following code.  
   
-    ```  
+    ```csharp
     WsdlImporter importer = new WsdlImporter(mexSet);  
     ServiceEndpointCollection endpoints = importer.ImportAllEndpoints();  
     ```  

--- a/docs/framework/wcf/extending/how-to-write-an-extension-for-the-servicecontractgenerator.md
+++ b/docs/framework/wcf/extending/how-to-write-an-extension-for-the-servicecontractgenerator.md
@@ -12,7 +12,7 @@ This topic describes how to write an extension for the <xref:System.ServiceModel
   
 1. Implement <xref:System.ServiceModel.Description.IServiceContractGenerationExtension>. To modify the generated service contract, use the <xref:System.ServiceModel.Description.ServiceContractGenerationContext> instance passed into the <xref:System.ServiceModel.Description.IServiceContractGenerationExtension.GenerateContract%28System.ServiceModel.Description.ServiceContractGenerationContext%29> method.  
   
-    ```  
+    ```csharp
     public void GenerateContract(ServiceContractGenerationContext context)  
     {  
         Console.WriteLine("In generate contract.");  
@@ -22,7 +22,7 @@ This topic describes how to write an extension for the <xref:System.ServiceModel
   
 2. Implement <xref:System.ServiceModel.Description.IWsdlImportExtension> on the same class. The <xref:System.ServiceModel.Description.IWsdlImportExtension.ImportContract%28System.ServiceModel.Description.WsdlImporter%2CSystem.ServiceModel.Description.WsdlContractConversionContext%29> method can process a specific WSDL extension (WSDL annotations in this case) by adding a code generation extension to the imported <xref:System.ServiceModel.Description.ContractDescription> instance.  
   
-    ```  
+    ```csharp
     public void ImportContract(WsdlImporter importer, WsdlContractConversionContext context)  
        {  
                 // Contract documentation  
@@ -66,7 +66,7 @@ This topic describes how to write an extension for the <xref:System.ServiceModel
   
 4. In the client code, create a `MetadataExchangeClient` and call `GetMetadata`.  
   
-    ```  
+    ```csharp  
     MetadataExchangeClient mexClient = new MetadataExchangeClient(metadataAddress);  
     mexClient.ResolveMetadataReferences = true;  
     MetadataSet metaDocs = mexClient.GetMetadata();  
@@ -74,13 +74,13 @@ This topic describes how to write an extension for the <xref:System.ServiceModel
   
 5. Create a `WsdlImporter` and call `ImportAllContracts`.  
   
-    ```  
+    ```csharp  
     WsdlImporter importer = new WsdlImporter(metaDocs);            System.Collections.ObjectModel.Collection<ContractDescription> contracts = importer.ImportAllContracts();  
     ```  
   
 6. Create a `ServiceContractGenerator` and call `GenerateServiceContractType` for each contract.  
   
-    ```  
+    ```csharp  
     ServiceContractGenerator generator = new ServiceContractGenerator();  
     foreach (ContractDescription contract in contracts)  
     {  

--- a/docs/framework/wcf/extending/specifying-a-custom-crypto-algorithm.md
+++ b/docs/framework/wcf/extending/specifying-a-custom-crypto-algorithm.md
@@ -103,7 +103,7 @@ public class MyCustomAlgorithmSuite : SecurityAlgorithmSuite
   
  To register the custom algorithm in code use the <xref:System.Security.Cryptography.CryptoConfig.AddAlgorithm(System.Type,System.String[])> method. This method creates both mappings. The following example shows how to call this method:  
   
-```  
+```csharp
 // Register the custom URI string defined for the hashAlgorithm in MyCustomAlgorithmSuite class to create the   
 // SHA256CryptoServiceProvider hash algorithm object.  
 CryptoConfig.AddAlgorithm(typeof(SHA256CryptoServiceProvider), "http://constoso.com/CustomAlgorithms/CustomHashAlgorithm");  

--- a/docs/framework/wcf/feature-details/comparing-aspnet-web-services-to-wcf-based-on-development.md
+++ b/docs/framework/wcf/feature-details/comparing-aspnet-web-services-to-wcf-based-on-development.md
@@ -319,9 +319,7 @@ In programming service types, frequent use is made of the <xref:System.ServiceMo
 
 ASP.NET Web services are compiled into a class library assembly. A file called the service file is provided that has the extension .asmx and contains an `@ WebService` directive that identifies the class that contains the code for the service and the assembly in which it is located.
 
-```
-<%@ WebService Language="C#" Class="Service,ServiceAssembly" %>
-```
+`<%@ WebService Language="C#" Class="Service,ServiceAssembly" %>`
 
 The service file is copied into an ASP.NET application root in Internet Information Services (IIS), and the assembly is copied into the \bin subdirectory of that application root. The application is then accessible by using the uniform resource locator (URL) of the service file in the application root.
 
@@ -333,9 +331,7 @@ To host a service within IIS 5.1, 6.0 or within WAS, use the follows steps:
 
 2. Create a service file with a .svc extension with an `@ ServiceHost` directive to identify the service type:
 
-    ```
-    <%@ServiceHost language="c#" Service="MyService" %>
-    ```
+    `<%@ServiceHost language="c#" Service="MyService" %>`
 
 3. Copy the service file into a virtual directory, and the assembly into the \bin subdirectory of that virtual directory.
 

--- a/docs/framework/wcf/feature-details/creating-a-custom-header-that-is-signed-and-or-encrypted.md
+++ b/docs/framework/wcf/feature-details/creating-a-custom-header-that-is-signed-and-or-encrypted.md
@@ -9,7 +9,7 @@ When calling a non-WCF service using a WCF client it is sometimes necessary to u
 ## Defining the custom header  
  Custom headers are defined by defining a message contract and marking the members you want to be sent as headers with a <xref:System.ServiceModel.MessageHeaderAttribute> attribute. To work around the canonicalization bug you must ensure that the XML serializer declares the namespace for the custom header with a prefix instead of a default namespace declaration. The following code shows how to define the data type that will be used as a message header with the correct namespace declaration.  
   
-```  
+```csharp
 [System.CodeDom.Compiler.GeneratedCodeAttribute("svcutil", "3.0.4506.648")]  
 [System.SerializableAttribute()]  
 [System.Diagnostics.DebuggerStepThroughAttribute()]  
@@ -39,7 +39,7 @@ public partial class msgHeaderElement
   
  This code declares a new type called `msgHeaderElement` that will be serialized with the XML Serializer. When an instance of this type is serialized, it will define a namespace with an ‘h’ prefix, thus working around the canonicalization bug.  The message contract would then define an instance of `msgHeaderElement` and mark it with the <xref:System.ServiceModel.MessageHeaderAttribute> attribute as shown in the following example.  
   
-```  
+```csharp
 [MessageContract]  
 public  class MyMessageContract  
 {  

--- a/docs/framework/wcf/feature-details/creating-a-long-running-workflow-service.md
+++ b/docs/framework/wcf/feature-details/creating-a-long-running-workflow-service.md
@@ -185,7 +185,7 @@ You must have the following software installed to use this walkthrough:
 
 5. Build the solution and run the `OrderClient` application. The client will display the following text:
 
-    ```Output
+    ```output
     Sending start messageWorkflow service is idle...Press [ENTER] to send an add item message to reactivate the workflow service...
     ```
 
@@ -195,7 +195,7 @@ You must have the following software installed to use this walkthrough:
 
 7. Press enter to send the add item message to the workflow service. The client will display the following text:
 
-    ```Output
+    ```output
     Sending add item messageService returned: Item added to orderPress any key to continue . . .
     ```
 

--- a/docs/framework/wcf/feature-details/creating-wcf-ajax-services-without-aspnet.md
+++ b/docs/framework/wcf/feature-details/creating-wcf-ajax-services-without-aspnet.md
@@ -19,7 +19,7 @@ Windows Communication Foundation (WCF) AJAX services can be accessed from any Ja
 ## Creating an AJAX Endpoint  
  The most basic way to enable AJAX support in a WCF service is to use the <xref:System.ServiceModel.Activation.WebServiceHostFactory> in the .svc file associated with the service, as in the following example.  
   
-```  
+```svc
 <%ServiceHost   
     language=c#  
     Debug="true"  
@@ -58,7 +58,7 @@ Windows Communication Foundation (WCF) AJAX services can be accessed from any Ja
 ## Creating an AJAX-Compatible Service Contract  
  By default, service contracts exposed over an AJAX endpoint return data in the XML format. Also, by default service operations are accessible through HTTP POST requests to URLs that include the endpoint address followed by the operation name, as shown in the following example.  
   
-```  
+```csharp
 [OperationContract]  
 string[] GetCities(string firstLetters);  
 ```  
@@ -71,13 +71,13 @@ string[] GetCities(string firstLetters);
   
  Normally, JSON requests and responses consist of just one item. For the preceding `GetCities` operation, the request resembles the following statement.  
   
-```  
+```json
 "na"  
 ```  
   
  The response to that request resembles the following statement.  
   
-```  
+```json
 ["Nairobi", "Naples", "Nashville"]  
 ```  
   
@@ -89,7 +89,7 @@ string[] GetCities(string firstLetters);
   
  The following contract accepts this message.  
   
-```  
+```csharp
 [WebInvoke(BodyStyle=WebMessageBodyStyle.WrappedRequest, ResponseFormat=WebMessageFormat.Json)]  
 [OperationContract]  
 string[] GetCities(string firstLetters, int maxNumber);  

--- a/docs/framework/wcf/feature-details/delegation-and-impersonation-with-wcf.md
+++ b/docs/framework/wcf/feature-details/delegation-and-impersonation-with-wcf.md
@@ -152,7 +152,7 @@ ms.assetid: 110e60f7-5b03-4b69-b667-31721b8e3152
   
  The following code shows how to configure the service.  
   
-```  
+```csharp
 // Create a binding that sets a certificate as the client credential type.  
 WSHttpBinding b = new WSHttpBinding();  
 b.Security.Message.ClientCredentialType = MessageCredentialType.Certificate;  

--- a/docs/framework/wcf/feature-details/deploying-an-internet-information-services-hosted-wcf-service.md
+++ b/docs/framework/wcf/feature-details/deploying-an-internet-information-services-hosted-wcf-service.md
@@ -43,7 +43,7 @@ Note that IIS 6.0 and later versions periodically restart an isolated object-ori
 
 WCF services hosted in IIS are represented as special content files (.svc files) inside the IIS application. This model is similar to the way ASMX pages are represented inside of an IIS application as .asmx files. A .svc file contains a WCF-specific processing directive ([\@ServiceHost](../../../../docs/framework/configure-apps/file-schema/wcf-directive/servicehost.md)) that allows the WCF hosting infrastructure to activate hosted services in response to incoming messages. The most common syntax for a .svc file is in the following statement.
 
-```
+```svc
 <% @ServiceHost Service="MyNamespace.MyServiceImplementationTypeName" %>
 ```
 


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "svc" for examples of statements in .svc files.

Contributes to #2192

