### PR TITLE
Publish the remaining specifications for C# 8

### DIFF
--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -36,19 +36,19 @@ This section provides reference material about C# keywords, operators, special c
 
 The features that have been implemented in C# versions after 6.0 are represented in language specification proposals. These documents describe the deltas to the language spec in order to add these new features. These are in draft proposal form. These specifications will be refined and submitted to the ECMA standards committee for formal review and incorporation into a future version of the C# Standard.
 
- [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/)  
+ [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/index.md)  
  There are a number of new features implemented in C# 7.0. They include pattern matching, local functions, out variable declarations, throw expressions, binary literals, and digit separators. This folder contains the specifications for each of those features.
   
- [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/)  
+ [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/index.md)  
  There are new features added in C# 7.1. First, you can write a `Main` method that returns `Task` or `Task<int>`. This enables you to add the `async` modifier to `Main`. The `default` expression can be used without a type in locations where the type can be inferred. Also, tuple member names can be inferred. Finally, pattern matching can be used with generics.
 
- [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/)  
+ [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/index.md)  
  C# 7.2 added a number of small features. You can pass arguments by readonly reference using the `in` keyword. There are a number of low-level changes to support compile-time safety for `Span` and related types. You can use named arguments where later arguments are positional, in some situations. The `private protected` access modifier enables you to specify that callers are limited to derived types implemented in the same assembly. The `?:` operator can resolve to a reference to a variable. You can also format hexadecimal and binary numbers using a leading digit separator.
 
- [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/)  
+ [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/index.md)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reasssigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
- [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/)  
+ [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/index.md)  
  C# 8.0 is available with .NET Core 3.0. The features include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
   
 ## Related Sections  

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -48,7 +48,7 @@ The features that have been implemented in C# versions after 6.0 are represented
  [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/blittable.md)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reasssigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
- [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nulable-reference-types.md)  
+ [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md)  
  C# 8.0 is available with .NET Core 3.0. The features include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
   
 ## Related Sections  

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -36,27 +36,27 @@ This section provides reference material about C# keywords, operators, special c
 
 The features that have been implemented in C# versions after 6.0 are represented in language specification proposals. These documents describe the deltas to the language spec in order to add these new features. These are in draft proposal form. These specifications will be refined and submitted to the ECMA standards committee for formal review and incorporation into a future version of the C# Standard.
 
- [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/pattern-matching.md)  
+ [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/)  
  There are a number of new features implemented in C# 7.0. They include pattern matching, local functions, out variable declarations, throw expressions, binary literals, and digit separators. This folder contains the specifications for each of those features.
   
- [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/async-main.md)  
+ [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/)  
  There are new features added in C# 7.1. First, you can write a `Main` method that returns `Task` or `Task<int>`. This enables you to add the `async` modifier to `Main`. The `default` expression can be used without a type in locations where the type can be inferred. Also, tuple member names can be inferred. Finally, pattern matching can be used with generics.
 
- [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/readonly-ref.md)  
+ [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/)  
  C# 7.2 added a number of small features. You can pass arguments by readonly reference using the `in` keyword. There are a number of low-level changes to support compile-time safety for `Span` and related types. You can use named arguments where later arguments are positional, in some situations. The `private protected` access modifier enables you to specify that callers are limited to derived types implemented in the same assembly. The `?:` operator can resolve to a reference to a variable. You can also format hexadecimal and binary numbers using a leading digit separator.
 
- [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/blittable.md)  
+ [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reasssigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
- [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md)  
- C# 8.0 is available with .NET Core 3.0. The following proposals are the current versions of the specifications for those features. Some are more complete; some are still a work in progress. The features that have shipped in previews include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
+ [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/)  
+ C# 8.0 is available with .NET Core 3.0. The features include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
   
 ## Related Sections  
 
  [C# Guide](../index.md)  
  Provides a portal to Visual C# documentation.  
   
- [Using the Visual Studio Development Environment for C#](/visualstudio/csharp-ide/using-the-visual-studio-development-environment-for-csharp)  
+ [Using the Visual Studio Development Environment for C#](/visualstudio/get-started/csharp)  
  Provides links to conceptual and task topics that describe the IDE and Editor.  
   
  [C# Programming Guide](../programming-guide/index.md)  

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -32,7 +32,7 @@ This section provides reference material about C# keywords, operators, special c
  Includes code snippets that demonstrate the cause and correction of C# compiler errors and warnings.  
   
  [C# Language Specification](../../../_csharplang/spec/introduction.md)  
- The C# 6.0 language specification. This is a draft proposal for the C# 6.0 language. Version 5.0 has been released in December 2017 as the [Standard ECMA-334 5th Edition](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-334.pdf) document. This document will be refined through work with the ECMA C# standards committee.
+ The C# 6.0 language specification. This is a draft proposal for the C# 6.0 language. This document will be refined through work with the ECMA C# standards committee. Version 5.0 has been released in December 2017 as the [Standard ECMA-334 5th Edition](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-334.pdf) document.
 
 The features that have been implemented in C# versions after 6.0 are represented in language specification proposals. These documents describe the deltas to the language spec in order to add these new features. These are in draft proposal form. These specifications will be refined and submitted to the ECMA standards committee for formal review and incorporation into a future version of the C# Standard.
 

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -48,7 +48,7 @@ The features that have been implemented in C# versions after 6.0 are represented
  [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/blittable.md)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reasssigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
- [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md)
+ [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md)  
  C# 8.0 is available with .NET Core 3.0. The following proposals are the current versions of the specifications for those features. Some are more complete; some are still a work in progress. The features that have shipped in previews include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
   
 ## Related Sections  

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -32,24 +32,24 @@ This section provides reference material about C# keywords, operators, special c
  Includes code snippets that demonstrate the cause and correction of C# compiler errors and warnings.  
   
  [C# Language Specification](../../../_csharplang/spec/introduction.md)  
- The C# 6.0 language specification. This is a draft proposal for the C# 6.0 language. Version 5.0 has been released in December 2017 as the [Standard ECMA-334 5th Edition](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-334.pdf) document.
+ The C# 6.0 language specification. This is a draft proposal for the C# 6.0 language. Version 5.0 has been released in December 2017 as the [Standard ECMA-334 5th Edition](https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-334.pdf) document. This document will be refined through work with the ECMA C# standards committee.
 
-The features that have been implemented in C# versions after 6.0 are represented in language specification proposals. These documents describe the deltas to the language spec in order to add these new features.
+The features that have been implemented in C# versions after 6.0 are represented in language specification proposals. These documents describe the deltas to the language spec in order to add these new features. These are in draft proposal form. These specifications will be refined and submitted to the ECMA standards committee for formal review and incorporation into a future version of the C# Standard.
 
- [C# 7.0 Language Proposals](../../../_csharplang/proposals/csharp-7.0/pattern-matching.md)  
+ [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/pattern-matching.md)  
  There are a number of new features implemented in C# 7.0. They include pattern matching, local functions, out variable declarations, throw expressions, binary literals, and digit separators. This folder contains the specifications for each of those features.
   
- [C# 7.1 Language Proposals](../../../_csharplang/proposals/csharp-7.1/async-main.md)  
+ [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/async-main.md)  
  There are new features added in C# 7.1. First, you can write a `Main` method that returns `Task` or `Task<int>`. This enables you to add the `async` modifier to `Main`. The `default` expression can be used without a type in locations where the type can be inferred. Also, tuple member names can be inferred. Finally, pattern matching can be used with generics.
 
- [C# 7.2 Language Proposals](../../../_csharplang/proposals/csharp-7.2/readonly-ref.md)  
+ [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/readonly-ref.md)  
  C# 7.2 added a number of small features. You can pass arguments by readonly reference using the `in` keyword. There are a number of low-level changes to support compile-time safety for `Span` and related types. You can use named arguments where later arguments are positional, in some situations. The `private protected` access modifier enables you to specify that callers are limited to derived types implemented in the same assembly. The `?:` operator can resolve to a reference to a variable. You can also format hexadecimal and binary numbers using a leading digit separator.
 
- [C# 7.3 Language Proposals](../../../_csharplang/proposals/csharp-7.3/blittable.md)  
+ [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/blittable.md)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reasssigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
- [C# 8.0 Language Proposals](../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md)
- C# 8.0 is available in preview. The following proposals are the current versions of the specifications for those features. Some are more complete; some are still a work in progress. The features that have shipped in previews include nullable reference types, recursive pattern matching, async streams, ranges and indexes, pattern based using and using declarations, and null coalescing assignment.
+ [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md)
+ C# 8.0 is available with .NET Core 3.0. The following proposals are the current versions of the specifications for those features. Some are more complete; some are still a work in progress. The features that have shipped in previews include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
   
 ## Related Sections  
 

--- a/docs/csharp/language-reference/index.md
+++ b/docs/csharp/language-reference/index.md
@@ -36,19 +36,19 @@ This section provides reference material about C# keywords, operators, special c
 
 The features that have been implemented in C# versions after 6.0 are represented in language specification proposals. These documents describe the deltas to the language spec in order to add these new features. These are in draft proposal form. These specifications will be refined and submitted to the ECMA standards committee for formal review and incorporation into a future version of the C# Standard.
 
- [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/index.md)  
+ [C# 7.0 Specification Proposals](../../../_csharplang/proposals/csharp-7.0/pattern-matching.md)  
  There are a number of new features implemented in C# 7.0. They include pattern matching, local functions, out variable declarations, throw expressions, binary literals, and digit separators. This folder contains the specifications for each of those features.
   
- [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/index.md)  
+ [C# 7.1 Specification Proposals](../../../_csharplang/proposals/csharp-7.1/async-main.md)  
  There are new features added in C# 7.1. First, you can write a `Main` method that returns `Task` or `Task<int>`. This enables you to add the `async` modifier to `Main`. The `default` expression can be used without a type in locations where the type can be inferred. Also, tuple member names can be inferred. Finally, pattern matching can be used with generics.
 
- [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/index.md)  
+ [C# 7.2 Specification Proposals](../../../_csharplang/proposals/csharp-7.2/readonly-ref.md)  
  C# 7.2 added a number of small features. You can pass arguments by readonly reference using the `in` keyword. There are a number of low-level changes to support compile-time safety for `Span` and related types. You can use named arguments where later arguments are positional, in some situations. The `private protected` access modifier enables you to specify that callers are limited to derived types implemented in the same assembly. The `?:` operator can resolve to a reference to a variable. You can also format hexadecimal and binary numbers using a leading digit separator.
 
- [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/index.md)  
+ [C# 7.3 Specification Proposals](../../../_csharplang/proposals/csharp-7.3/blittable.md)  
  C# 7.3 is another point release that includes several small updates. You can use new constraints on generic type parameters. Other changes make it easier to work with `fixed` fields, including using [`stackalloc`](./operators/stackalloc.md) allocations. Local variables declared with the `ref` keyword may be reasssigned to refer to new storage. You can place attributes on auto-implemented properties that target the compiler-generated backing field. Expression variables can be used in initializers. Tuples can be compared for equality (or inequality). There have also been some improvements to overload resolution.
   
- [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/index.md)  
+ [C# 8.0 Specification Proposals](../../../_csharplang/proposals/csharp-8.0/nulable-reference-types.md)  
  C# 8.0 is available with .NET Core 3.0. The features include nullable reference types, recursive pattern matching, default interface members, async streams, ranges and indexes, pattern based using and using declarations, null coalescing assignment, and readonly instance members.
   
 ## Related Sections  

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -555,7 +555,7 @@
     href: ../../../_csharplang/spec/unsafe-code.md
   - name: Documentation comments
     href: ../../../_csharplang/spec/documentation-comments.md
-- name: C# 7.0 language proposals
+- name: C# 7.0 specification proposals
   items:
   - name: Pattern matching
     href: ../../../_csharplang/proposals/csharp-7.0/pattern-matching.md
@@ -569,7 +569,7 @@
     href: ../../../_csharplang/proposals/csharp-7.0/binary-literals.md
   - name: Digit separators
     href: ../../../_csharplang/proposals/csharp-7.0/digit-separators.md
-- name: C# 7.1 language proposals
+- name: C# 7.1 specification proposals
   items:
   - name: Async main method
     href: ../../../_csharplang/proposals/csharp-7.1/async-main.md
@@ -579,7 +579,7 @@
     href: ../../../_csharplang/proposals/csharp-7.1/infer-tuple-names.md
   - name: Pattern matching with generics
     href: ../../../_csharplang/proposals/csharp-7.1/generics-pattern-match.md
-- name: C# 7.2 language proposals
+- name: C# 7.2 specification proposals
   items:
   - name: Readonly references
     href: ../../../_csharplang/proposals/csharp-7.2/readonly-ref.md
@@ -593,7 +593,7 @@
     href: ../../../_csharplang/proposals/csharp-7.2/conditional-ref.md
   - name: Leading digit separator
     href: ../../../_csharplang/proposals/csharp-7.2/leading-separator.md
-- name: C# 7.3 language proposals
+- name: C# 7.3 specfication proposals
   items:
   - name: Unmanaged generic type constraints
     href: ../../../_csharplang/proposals/csharp-7.3/blittable.md
@@ -613,7 +613,7 @@
     href: ../../../_csharplang/proposals/csharp-7.3/tuple-equality.md
   - name: Improved overload candidates
     href: ../../../_csharplang/proposals/csharp-7.3/improved-overload-candidates.md
-- name: C# 8.0 language proposals
+- name: C# 8.0 specification proposal
   items:
   - name: Null reference types - proposal
     href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
@@ -621,6 +621,8 @@
     href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md
   - name: Recursive pattern matching
     href: ../../../_csharplang/proposals/csharp-8.0/patterns.md
+  - name: default interface members
+    href: ../../../_csharplang/proposals/csharp-8.0/default-interface-members.md
   - name: async streams
     href: ../../../_csharplang/proposals/csharp-8.0/async-streams.md
   - name: Ranges
@@ -629,3 +631,5 @@
     href: ../../../_csharplang/proposals/csharp-8.0/using.md
   - name: null coalescing assignment
     href: ../../../_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md
+  - name: readonly instance members
+    href: ../../../_csharplang/proposals/csharp-8.0/readonly-instance-members.md

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -622,7 +622,7 @@
   - name: Recursive pattern matching
     href: ../../../_csharplang/proposals/csharp-8.0/patterns.md
   - name: default interface members
-    href: ../../../_csharplang/proposals/csharp-8.0/default-interface-members.md
+    href: ../../../_csharplang/proposals/csharp-8.0/default-interface-methods.md
   - name: async streams
     href: ../../../_csharplang/proposals/csharp-8.0/async-streams.md
   - name: Ranges

--- a/docs/csharp/language-reference/toc.yml
+++ b/docs/csharp/language-reference/toc.yml
@@ -607,7 +607,7 @@
     href: ../../../_csharplang/proposals/csharp-7.3/stackalloc-array-initializers.md
   - name: Auto-implemented property field-targeted attributes
     href: ../../../_csharplang/proposals/csharp-7.3/auto-prop-field-attrs.md
-  - name: expression variables in initializers
+  - name: Expression variables in initializers
     href: ../../../_csharplang/proposals/csharp-7.3/expression-variables-in-initializers.md
   - name: Tuple equality (==) and inequality (!=)
     href: ../../../_csharplang/proposals/csharp-7.3/tuple-equality.md
@@ -615,21 +615,21 @@
     href: ../../../_csharplang/proposals/csharp-7.3/improved-overload-candidates.md
 - name: C# 8.0 specification proposal
   items:
-  - name: Null reference types - proposal
+  - name: Nullable reference types - proposal
     href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types.md
-  - name: nullable reference types - specification
+  - name: Nullable reference types - specification
     href: ../../../_csharplang/proposals/csharp-8.0/nullable-reference-types-specification.md
   - name: Recursive pattern matching
     href: ../../../_csharplang/proposals/csharp-8.0/patterns.md
-  - name: default interface members
+  - name: Default interface members
     href: ../../../_csharplang/proposals/csharp-8.0/default-interface-methods.md
-  - name: async streams
+  - name: Async streams
     href: ../../../_csharplang/proposals/csharp-8.0/async-streams.md
   - name: Ranges
     href: ../../../_csharplang/proposals/csharp-8.0/ranges.md
   - name: Pattern based using and using declarations
     href: ../../../_csharplang/proposals/csharp-8.0/using.md
-  - name: null coalescing assignment
+  - name: Null coalescing assignment
     href: ../../../_csharplang/proposals/csharp-8.0/null-coalescing-assignment.md
-  - name: readonly instance members
+  - name: Readonly instance members
     href: ../../../_csharplang/proposals/csharp-8.0/readonly-instance-members.md


### PR DESCRIPTION
Fixes #12772

There are three small changes in this PR:

1. add TOC nodes for the remaining C# 8 features.
1. Remove "preview" language from the language reference home page.
1. Change "language proposals" to "specification proposal". Include clarifying language in the home page. The hypothesis is that it removes confusion because these are proposals that will be refined for the standard, not proposals that haven't been implemented.
