### PR TITLE
Updated nuget.org's symbol server status

### DIFF
--- a/docs/standard/library-guidance/nuget.md
+++ b/docs/standard/library-guidance/nuget.md
@@ -112,7 +112,7 @@ The downside of embedding symbol files is that they increase the package size by
 
 > Symbol packages (`*.snupkg`) provide developers a good on-demand debugging experience without bloating the main package size and impacting restore performance for those who don't intend to debug the NuGet package.
 >
-> The caveat is that they would need to find and configure the NuGet symbol server in their IDE (as a one-time setup) to get symbol files. Visual Studio 2019 plans to provide the NuGet.org symbol server as one of the options out of the box. 
+> The caveat is that users may need to find and configure the NuGet symbol server in their IDE (as a one-time setup) to get symbol files. Visual Studio 2019 version 16.1 added NuGet.org's symbol server to the list of default symbol servers.
 
 >[!div class="step-by-step"]
 >[Previous](strong-naming.md)


### PR DESCRIPTION
## Summary

Visual Studio 2019 version 16.1 added nuget.org's symbol server as a default symbol server. See https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes-v16.1#debugger