### PR TITLE
Updated .Net Core versions

### DIFF
--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -12,7 +12,7 @@ This topic provides a step-by-step introduction to building, debugging, and publ
 
 ## Prerequisites
 
-[Visual Studio 2017](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs) with the ".NET Core cross-platform development" workload installed. You can develop your app with either .NET Core 1.1 or .NET Core 2.0.
+[Visual Studio 2017](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs) with the ".NET Core cross-platform development" workload installed. You can develop your app with .NET Core 1.1 or any higher version.
 
 For more information, see the [Prerequisites for .NET Core on Windows](../windows-prerequisites.md) topic.
 

--- a/docs/core/tutorials/with-visual-studio.md
+++ b/docs/core/tutorials/with-visual-studio.md
@@ -12,7 +12,7 @@ This topic provides a step-by-step introduction to building, debugging, and publ
 
 ## Prerequisites
 
-[Visual Studio 2017](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs) with the ".NET Core cross-platform development" workload installed. You can develop your app with .NET Core 1.1 or any higher version.
+[Visual Studio 2017](https://aka.ms/vsdownload?utm_source=mscom&utm_campaign=msdocs) with the ".NET Core cross-platform development" workload installed. You can develop your app with .NET Core 2.1 or later versions.
 
 For more information, see the [Prerequisites for .NET Core on Windows](../windows-prerequisites.md) topic.
 


### PR DESCRIPTION
Statement "either .NET Core 1.1 or .NET Core 2.0" is giving a reflection that user must use either version 1.1 or 2.0. 
So replaced text "either .NET Core 1.1 or .NET Core 2.0." with ".NET Core 1.1 or any higher version" as we have other versions available too.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
