### PR TITLE
Improve "virtual" topic

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -166,6 +166,7 @@
       "ms.topic": {
         "_csharplang/**/*.md": "language-reference",
         "_vblang/spec/*.md": "language-reference",
+        "docs/csharp/language-reference/**/**.md": "language-reference",
         "docs/framework/additional-apis/**/**.md": "managed-reference",
         "docs/framework/unmanaged-api/**/**.md": "reference",
         "docs/fsharp/language-reference/**/**.md": "language-reference"

--- a/docs/csharp/language-reference/keywords/virtual.md
+++ b/docs/csharp/language-reference/keywords/virtual.md
@@ -58,10 +58,6 @@ The following program calculates and displays the appropriate area for each figu
 
 ## See also
 
-- [C# Reference](../index.md)
-- [C# Programming Guide](../../programming-guide/index.md)
-- [Modifiers](modifiers.md)
-- [C# Keywords](index.md)
 - [Polymorphism](../../programming-guide/classes-and-structs/polymorphism.md)
 - [abstract](abstract.md)
 - [override](override.md)


### PR DESCRIPTION
See [AB#1591403](https://dev.azure.com/mseng/677da0fb-b067-4f77-b89b-f32c12bb8617/_workitems/edit/1591403)

There are two issues with this topic.

First, the click-through rate is low. Several of the links toward the bottom of the page are redundant, and unlikely to be used.

Secondly, the entire C# language reference was tagged as "conceptual" (the default). The language reference should be "language-reference" which removes the dwell time metric.
