### PR TITLE
update spec dates

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -222,7 +222,7 @@
         "_csharplang/proposals/csharp-7.1/*.md": "02/16/2018",
         "_csharplang/proposals/csharp-7.2/*.md": "01/19/2019",
         "_csharplang/proposals/csharp-7.3/*.md": "11/25/2018",
-        "_csharplang/proposals/csharp-8.0/*.md": "02/25/2019",
+        "_csharplang/proposals/csharp-8.0/*.md": "09/10/2019",
         "_vblang/spec/*.md": "07/21/2017"
       },
       "ms.technology": {


### PR DESCRIPTION
See #14344
I missed updating the ms-date metadata for the C# 8.0 specifications in that PR.

This PR addresses that omission.

