### PR TITLE
US 1583733 Add missing language IDs - 38

### DIFF
--- a/docs/framework/wpf/advanced/globalization-for-wpf.md
+++ b/docs/framework/wpf/advanced/globalization-for-wpf.md
@@ -45,7 +45,7 @@ The following example shows a hexadecimal character reference. Notice that it ha
 
  The following [!INCLUDE[TLA#tla_xaml](../../../../includes/tlasharptla-xaml-md.md)] example uses the `fr-CA` language attribute to specify Canadian French.
 
-```xml
+```xaml
 <TextBlock xml:lang="fr-CA">Découvrir la France</TextBlock>
 ```
 

--- a/docs/framework/wpf/advanced/globalization-for-wpf.md
+++ b/docs/framework/wpf/advanced/globalization-for-wpf.md
@@ -19,13 +19,13 @@ This topic introduces issues that you should be aware of when writing [!INCLUDE[
 ### Character References
 A character reference gives the UTF16 code unit of the particular [!INCLUDE[TLA#tla_unicode](../../../../includes/tlasharptla-unicode-md.md)] character it represents, in either decimal or hexadecimal. The following example shows a decimal character reference for the COPTIC CAPITAL LETTER HORI, or 'Ϩ':
 
-```
+```xaml
 &#1000;
 ```
 
 The following example shows a hexadecimal character reference. Notice that it has an **x** in front of the hexadecimal number.
 
-```
+```xaml
 &#x3E8;
 ```
 
@@ -33,7 +33,7 @@ The following example shows a hexadecimal character reference. Notice that it ha
 ### Encoding
  The encoding supported by [!INCLUDE[TLA2#tla_xaml](../../../../includes/tla2sharptla-xaml-md.md)] are ASCII, [!INCLUDE[TLA2#tla_unicode](../../../../includes/tla2sharptla-unicode-md.md)] UTF-16, and UTF-8. The encoding statement is at the beginning of [!INCLUDE[TLA2#tla_xaml](../../../../includes/tla2sharptla-xaml-md.md)] document. If no encoding attribute exists and there is no byte-order, the parser defaults to UTF-8. UTF-8 and UTF-16 are the preferred encodings. UTF-7 is not supported. The following example demonstrates how to specify a UTF-8 encoding in a [!INCLUDE[TLA2#tla_xaml](../../../../includes/tla2sharptla-xaml-md.md)] file.
 
-```
+```xaml
 ?xml encoding="UTF-8"?
 ```
 
@@ -167,7 +167,7 @@ The following example shows a hexadecimal character reference. Notice that it ha
 
  The solution to this problem is setting the neutral language fallback attribute. An application developer can optionally remove resources from the main assembly and specify that the resources can be found in a satellite assembly corresponding to a specific culture. To control this process use the <xref:System.Resources.NeutralResourcesLanguageAttribute>. The constructor of the <xref:System.Resources.NeutralResourcesLanguageAttribute> class has two signatures, one that takes an <xref:System.Resources.UltimateResourceFallbackLocation> parameter to specify the location where the <xref:System.Resources.ResourceManager> should extract the fallback resources: main assembly or satellite assembly. The following example shows how to use the attribute. For the ultimate fallback location, the code causes the <xref:System.Resources.ResourceManager> to look for the resources in the "de" subdirectory of the directory of the currently executing assembly.
 
-```
+```csharp
 [assembly: NeutralResourcesLanguageAttribute(
     "de" , UltimateResourceFallbackLocation.Satellite)]
 ```

--- a/docs/framework/wpf/advanced/globalization-for-wpf.md
+++ b/docs/framework/wpf/advanced/globalization-for-wpf.md
@@ -19,11 +19,13 @@ This topic introduces issues that you should be aware of when writing [!INCLUDE[
 ### Character References
 A character reference gives the UTF16 code unit of the particular [!INCLUDE[TLA#tla_unicode](../../../../includes/tlasharptla-unicode-md.md)] character it represents, in either decimal or hexadecimal. The following example shows a decimal character reference for the COPTIC CAPITAL LETTER HORI, or 'Ϩ':
 
+```
 &#1000;
 ```
 
 The following example shows a hexadecimal character reference. Notice that it has an **x** in front of the hexadecimal number.
 
+```
 &#x3E8;
 ```
 

--- a/docs/framework/wpf/advanced/globalization-for-wpf.md
+++ b/docs/framework/wpf/advanced/globalization-for-wpf.md
@@ -19,13 +19,11 @@ This topic introduces issues that you should be aware of when writing [!INCLUDE[
 ### Character References
 A character reference gives the UTF16 code unit of the particular [!INCLUDE[TLA#tla_unicode](../../../../includes/tlasharptla-unicode-md.md)] character it represents, in either decimal or hexadecimal. The following example shows a decimal character reference for the COPTIC CAPITAL LETTER HORI, or 'Ϩ':
 
-```xaml
 &#1000;
 ```
 
 The following example shows a hexadecimal character reference. Notice that it has an **x** in front of the hexadecimal number.
 
-```xaml
 &#x3E8;
 ```
 

--- a/docs/framework/wpf/advanced/hosting-win32-content-in-wpf.md
+++ b/docs/framework/wpf/advanced/hosting-win32-content-in-wpf.md
@@ -65,14 +65,14 @@ Next, introduce the dialog into the larger [!INCLUDE[TLA2#tla_winclient](../../.
 
 You can turn a dialog box into a child HWND using the WS_CHILD and DS_CONTROL styles. Go into the resource file (.rc) where the dialog is defined, and find the beginning of the definition of the dialog:
 
-```
+```text
 IDD_DIALOG1 DIALOGEX 0, 0, 303, 121
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
 ```
 
 Change the second line to:
 
-```
+```text
 STYLE DS_SETFONT | WS_CHILD | WS_BORDER | DS_CONTROL
 ```
 

--- a/docs/framework/wpf/advanced/markup-extensions-and-wpf-xaml.md
+++ b/docs/framework/wpf/advanced/markup-extensions-and-wpf-xaml.md
@@ -98,7 +98,7 @@ This topic introduces the concept of markup extensions for XAML, including their
 ## Nesting Markup Extensions in XAML Usage  
  Nesting of multiple markup extensions is supported, and each markup extension will be evaluated deepest first. For example, consider the following usage:  
   
-```  
+```xaml  
 <Setter Property="Background"  
   Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />  
 ```  

--- a/docs/framework/wpf/advanced/mc-ignorable-attribute.md
+++ b/docs/framework/wpf/advanced/mc-ignorable-attribute.md
@@ -15,7 +15,7 @@ Specifies which [!INCLUDE[TLA2#tla_xml](../../../../includes/tla2sharptla-xml-md
   
 ## XAML Attribute Usage (Single Prefix)  
   
-```  
+```xaml  
 <object  
   xmlns:ignorablePrefix="ignorableUri"  
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"  
@@ -26,7 +26,7 @@ Specifies which [!INCLUDE[TLA2#tla_xml](../../../../includes/tla2sharptla-xml-md
   
 ## XAML Attribute Usage (Two Prefixes)  
   
-```  
+```xaml  
 <object  
   xmlns:ignorablePrefix1="ignorableUri"  
   xmlns:ignorablePrefix2="ignorableUri2"  

--- a/docs/framework/wpf/advanced/mc-processcontent-attribute.md
+++ b/docs/framework/wpf/advanced/mc-processcontent-attribute.md
@@ -11,7 +11,7 @@ Specifies which [!INCLUDE[TLA2#tla_xaml](../../../../includes/tla2sharptla-xaml-
   
 ## XAML Attribute Usage  
   
-```  
+```xaml  
 <object  
   xmlns:ignorablePrefix="ignorableUri"  
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"  

--- a/docs/framework/wpf/advanced/presentationoptions-freeze-attribute.md
+++ b/docs/framework/wpf/advanced/presentationoptions-freeze-attribute.md
@@ -12,7 +12,7 @@ Sets the <xref:System.Windows.Freezable.IsFrozen%2A> state to `true` on the cont
   
 ## XAML Attribute Usage  
   
-```  
+```xaml  
 <object  
   xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"  
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"  

--- a/docs/framework/wpf/advanced/safe-constructor-patterns-for-dependencyobjects.md
+++ b/docs/framework/wpf/advanced/safe-constructor-patterns-for-dependencyobjects.md
@@ -29,7 +29,7 @@ Generally, class constructors should not call callbacks such as virtual methods 
   
  The following example code (and subsequent examples) is a pseudo-C# example that violates this rule and explains the problem:  
   
-```  
+```csharp  
 public class MyClass : DependencyObject  
 {  
     public MyClass() {}  
@@ -65,7 +65,7 @@ public class MyClass : DependencyObject
 #### Parameterless constructors calling base initialization  
  Implement these constructors calling the base default:  
   
-```  
+```csharp  
 public MyClass : SomeBaseClass {  
     public MyClass() : base() {  
         // ALL class initialization, including initial defaults for   
@@ -77,7 +77,7 @@ public MyClass : SomeBaseClass {
 #### Non-default (convenience) constructors, not matching any base signatures  
  If these constructors use the parameters to set dependency properties in the initialization, first call your own class parameterless constructor for initialization, and then use the parameters to set dependency properties. These could either be dependency properties defined by your class, or dependency properties inherited from base classes, but in either case use the following pattern:  
   
-```  
+```csharp  
 public MyClass : SomeBaseClass {  
     public MyClass(object toSetProperty1) : this() {  
         // Class initialization NOT done by default.  

--- a/docs/framework/wpf/advanced/walkthrough-creating-direct3d9-content-for-hosting-in-wpf.md
+++ b/docs/framework/wpf/advanced/walkthrough-creating-direct3d9-content-for-hosting-in-wpf.md
@@ -112,7 +112,7 @@ This walkthrough shows how to create Direct3D9 content that is suitable for host
 
 11. Replace the automatically generated code with the following code.
 
-    ```
+    ```cpp
     LIBRARY "D3DContent"
 
     EXPORTS

--- a/docs/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
+++ b/docs/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
@@ -74,7 +74,7 @@ You need Visual Studio to complete this walkthrough.
 
 2. Add the following XAML to the opening <xref:System.Windows.Window> tag to create an XML namespace reference to the current application.
 
-    ```
+    ```xaml
     xmlns:local="clr-namespace:DragDropExample"
     ```
 

--- a/docs/framework/wpf/advanced/walkthrough-hosting-a-windows-forms-composite-control-in-wpf.md
+++ b/docs/framework/wpf/advanced/walkthrough-hosting-a-windows-forms-composite-control-in-wpf.md
@@ -112,7 +112,7 @@ You need Visual Studio to complete this walkthrough.
 
 3. Generate a key file named MyControls.snk by running the following command.
 
-    ```
+    ```console
     Sn.exe -k MyControls.snk
     ```
 

--- a/docs/framework/wpf/advanced/walkthrough-hosting-a-wpf-composite-control-in-windows-forms.md
+++ b/docs/framework/wpf/advanced/walkthrough-hosting-a-wpf-composite-control-in-windows-forms.md
@@ -110,7 +110,7 @@ You need Visual Studio to complete this walkthrough.
 #### The Basic Structure of the Code-Behind File  
  The code-behind file consists of a single namespace, `MyControls`, which will contain two classes, `MyControl1` and `MyControlEventArgs`.  
   
-```  
+```csharp  
 namespace MyControls  
 {  
   public partial class MyControl1 : Grid  

--- a/docs/framework/wpf/advanced/walkthrough-localizing-a-hybrid-application.md
+++ b/docs/framework/wpf/advanced/walkthrough-localizing-a-hybrid-application.md
@@ -116,7 +116,7 @@ You can map your localizable content to resource assemblies by using resource id
 
 2. Use the following command to assign resource identifiers to your localizable content.
 
-    ```
+    ```console
     msbuild -t:updateuid LocalizingWpfInWf.csproj
     ```
 
@@ -136,7 +136,7 @@ Your localized content is stored in a resource-only *satellite assembly*. Use th
 
 2. In the Command Prompt window, use the following command to extract resource strings into a temporary file.
 
-    ```
+    ```console
     LocBaml /parse LocalizingWpfInWf.g.en-US.resources /out:temp.csv
     ```
 
@@ -146,7 +146,7 @@ Your localized content is stored in a resource-only *satellite assembly*. Use th
 
 5. Use the following command to generate the localized resource file.
 
-    ```
+    ```console
     LocBaml /generate /trans:temp.csv LocalizingWpfInWf.g.en-US.resources /out:. /cul:es-ES
     ```
 
@@ -154,7 +154,7 @@ Your localized content is stored in a resource-only *satellite assembly*. Use th
 
 6. Use the following command to build the localized satellite assembly.
 
-    ```
+    ```console
     Al.exe /out:LocalizingWpfInWf.resources.dll /culture:es-ES /embed:LocalizingWpfInWf.Form1.es-ES.resources /embed:LocalizingWpfInWf.g.es-ES.resources
     ```
 

--- a/docs/framework/wpf/advanced/weak-event-patterns.md
+++ b/docs/framework/wpf/advanced/weak-event-patterns.md
@@ -52,25 +52,25 @@ In applications, it is possible that handlers that are attached to event sources
   
      For example, if your code uses the following pattern to subscribe to an event:  
   
-    ```  
+    ```csharp  
     source.SomeEvent += new SomeEventEventHandler(OnSomeEvent);  
     ```  
   
      Change it to the following pattern:  
   
-    ```  
+    ```csharp  
     SomeEventWeakEventManager.AddHandler(source, OnSomeEvent);  
     ```  
   
      Similarly, if your code uses the following pattern to unsubscribe from an event:  
   
-    ```  
+    ```csharp  
     source.SomeEvent -= new SomeEventEventHandler(OnSomeEvent);  
     ```  
   
      Change it to the following pattern:  
   
-    ```  
+    ```csharp  
     SomeEventWeakEventManager.RemoveHandler(source, OnSomeEvent);  
     ```  
   
@@ -80,7 +80,7 @@ In applications, it is possible that handlers that are attached to event sources
   
      When you use <xref:System.Windows.WeakEventManager%602> to register event listeners, you supply the event source and <xref:System.EventArgs> type as the type parameters to the class and call <xref:System.Windows.WeakEventManager%602.AddHandler%2A> as shown in the following code:  
   
-    ```  
+    ```csharp  
     WeakEventManager<EventSource, SomeEventEventArgs>.AddHandler(source, "SomeEvent", source_SomeEvent);  
     ```  
   
@@ -102,25 +102,25 @@ In applications, it is possible that handlers that are attached to event sources
   
      For example, if your code uses the following pattern to subscribe to an event:  
   
-    ```  
+    ```csharp  
     source.SomeEvent += new SomeEventEventHandler(OnSomeEvent);  
     ```  
   
      Change it to the following pattern:  
   
-    ```  
+    ```csharp  
     SomeEventWeakEventManager.AddHandler(source, OnSomeEvent);  
     ```  
   
      Similarly, if your code uses the following pattern to unsubscribe to an event:  
   
-    ```  
+    ```csharp  
     source.SomeEvent -= new SomeEventEventHandler(OnSome);  
     ```  
   
      Change it to the following pattern:  
   
-    ```  
+    ```csharp  
     SomeEventWeakEventManager.RemoveHandler(source, OnSomeEvent);  
     ```  
   

--- a/docs/framework/wpf/advanced/xaml-syntax-in-detail.md
+++ b/docs/framework/wpf/advanced/xaml-syntax-in-detail.md
@@ -106,7 +106,7 @@ This topic defines the terms that are used to describe the elements of XAML synt
   
  For flagwise enumerations, the behavior is based on the <xref:System.Enum.Parse%2A?displayProperty=nameWithType> method. You can specify multiple values for a flagwise enumeration by separating each value with a comma. However, you cannot combine enumeration values that are not flagwise. For instance, you cannot use the comma syntax to attempt to create a <xref:System.Windows.Trigger> that acts on multiple conditions of a nonflag enumeration:  
   
-```  
+```xaml  
 <!--This will not compile, because Visibility is not a flagwise enumeration.-->  
 ...  
 <Trigger Property="Visibility" Value="Collapsed,Hidden">  
@@ -191,7 +191,7 @@ This topic defines the terms that are used to describe the elements of XAML synt
 ### XAML Content Property Values Must Be Contiguous  
  The value of a XAML content property must be given either entirely before or entirely after any other property elements on that object element. This is true whether the value of a XAML content property is specified as a string, or as one or more objects. For example, the following markup does not parse:  
   
-```  
+```xaml  
 <Button>I am a   
   <Button.Background>Blue</Button.Background>  
   blue button</Button>  
@@ -199,7 +199,7 @@ This topic defines the terms that are used to describe the elements of XAML synt
   
  This is illegal essentially because if this syntax were made explicit by using property element syntax for the content property, then the content property would be set twice:  
   
-```xml  
+```xaml  
 <Button>  
   <Button.Content>I am a </Button.Content>  
   <Button.Background>Blue</Button.Background>  
@@ -209,7 +209,7 @@ This topic defines the terms that are used to describe the elements of XAML synt
   
  A similarly illegal example is if the content property is a collection, and child elements are interspersed with property elements:  
   
-```xml  
+```xaml  
 <StackPanel>  
   <Button>This example</Button>  
   <StackPanel.Resources>  

--- a/docs/framework/wpf/app-development/filterinputmessage.md
+++ b/docs/framework/wpf/app-development/filterinputmessage.md
@@ -11,7 +11,7 @@ Called by PresentationHost.exe whenever a message is received unless E_NOTIMPL i
   
 ## Syntax  
   
-```  
+```cpp  
 HRESULT FilterInputMessage( [in] MSG* pMsg ) ;  
 ```  
   

--- a/docs/framework/wpf/app-development/getcustomui.md
+++ b/docs/framework/wpf/app-development/getcustomui.md
@@ -10,7 +10,7 @@ Called by PresentationHost.exe to get custom progress and error messages from th
   
 ## Syntax  
   
-```  
+```cpp  
 HRESULT GetCustomUI( [out] BSTR* pwzProgressAssemblyName, [out] BSTR* pwzProgressClassName, [out] BSTR* pwzErrorAssemblyName, [out] BSTR* pwzErrorClassName );  
 ```  
   

--- a/docs/framework/wpf/app-development/getrawinputdevices.md
+++ b/docs/framework/wpf/app-development/getrawinputdevices.md
@@ -10,7 +10,7 @@ Allows PresentationHost.exe to discover the raw input devices (Human Interface D
   
 ## Syntax  
   
-```  
+```cpp  
 HRESULT GetRawInputDevices( [out] IEnumRAWINPUTDEVICE **ppEnum );  
 ```  
   


### PR DESCRIPTION
US 1583733 - Fix CATS P1 issues by adding missing language IDs to code blocks.
- Used "xaml" for examples of character references supported by XAML.
- Used "text" for .rc resource file examples.
- Used "console" for command-line tool and syntax examples.

Contributes to #2192
