### PR TITLE
Remove redundant path segments

### DIFF
--- a/docs/visual-basic/language-reference/operators/isnot-operator.md
+++ b/docs/visual-basic/language-reference/operators/isnot-operator.md
@@ -8,42 +8,42 @@ helpviewer_keywords:
 ms.assetid: 8dd2bcdb-0166-48a2-9094-60dfb448f36c
 ---
 # IsNot Operator (Visual Basic)
-Compares two object reference variables.  
-  
-## Syntax  
-  
-```  
-result = object1 IsNot object2  
-```  
-  
-## Parts  
- `result`  
- Required. A `Boolean` value.  
-  
- `object1`  
- Required. Any `Object` variable or expression.  
-  
- `object2`  
- Required. Any `Object` variable or expression.  
-  
-## Remarks  
- The `IsNot` operator determines if two object references refer to different objects. However, it does not perform value comparisons. If `object1` and `object2` both refer to the exact same object instance, `result` is `False`; if they do not, `result` is `True`.  
-  
- `IsNot` is the opposite of the `Is` operator. The advantage of `IsNot` is that you can avoid awkward syntax with `Not` and `Is`, which can be difficult to read.  
-  
- You can use the `Is` and `IsNot` operators to test both early-bound and late-bound objects.  
-  
+Compares two object reference variables.
+
+## Syntax
+
+```vb
+result = object1 IsNot object2
+```
+
+## Parts
+ `result`
+ Required. A `Boolean` value.
+
+ `object1`
+ Required. Any `Object` variable or expression.
+
+ `object2`
+ Required. Any `Object` variable or expression.
+
+## Remarks
+ The `IsNot` operator determines if two object references refer to different objects. However, it does not perform value comparisons. If `object1` and `object2` both refer to the exact same object instance, `result` is `False`; if they do not, `result` is `True`.
+
+ `IsNot` is the opposite of the `Is` operator. The advantage of `IsNot` is that you can avoid awkward syntax with `Not` and `Is`, which can be difficult to read.
+
+ You can use the `Is` and `IsNot` operators to test both early-bound and late-bound objects.
+
 > [!NOTE]
-> The `IsNot` operator cannot be used to compare expressions returned from the `TypeOf` operator. Instead, you must use the `Not` and `Is` operators.  
-  
-## Example  
- The following code example uses both the `Is` operator and the `IsNot` operator to accomplish the same comparison.  
-  
- [!code-vb[VbVbalrOperators#29](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrOperators/VB/Class1.vb#29)]  
-  
+> The `IsNot` operator cannot be used to compare expressions returned from the `TypeOf` operator. Instead, you must use the `Not` and `Is` operators.
+
+## Example
+ The following code example uses both the `Is` operator and the `IsNot` operator to accomplish the same comparison.
+
+ [!code-vb[VbVbalrOperators#29](~/samples/snippets/visualbasic/VS_Snippets_VBCSharp/VbVbalrOperators/VB/Class1.vb#29)]
+
 ## See also
 
-- [Is Operator](../../../visual-basic/language-reference/operators/is-operator.md)
-- [TypeOf Operator](../../../visual-basic/language-reference/operators/typeof-operator.md)
-- [Operator Precedence in Visual Basic](../../../visual-basic/language-reference/operators/operator-precedence.md)
-- [How to: Test Whether Two Objects Are the Same](../../../visual-basic/programming-guide/language-features/operators-and-expressions/how-to-test-whether-two-objects-are-the-same.md)
+- [Is Operator](is-operator.md)
+- [TypeOf Operator](typeof-operator.md)
+- [Operator Precedence in Visual Basic](operator-precedence.md)
+- [How to: Test Whether Two Objects Are the Same](how-to-test-whether-two-objects-are-the-same.md)

--- a/docs/visual-basic/language-reference/operators/isnot-operator.md
+++ b/docs/visual-basic/language-reference/operators/isnot-operator.md
@@ -43,4 +43,4 @@ result = object1 IsNot object2
 - [Is Operator](is-operator.md)
 - [TypeOf Operator](typeof-operator.md)
 - [Operator Precedence in Visual Basic](operator-precedence.md)
-- [How to: Test Whether Two Objects Are the Same](how-to-test-whether-two-objects-are-the-same.md)
+- [How to: Test Whether Two Objects Are the Same](../../programming-guide/language-features/operators-and-expressions/how-to-test-whether-two-objects-are-the-same.md)

--- a/docs/visual-basic/language-reference/operators/isnot-operator.md
+++ b/docs/visual-basic/language-reference/operators/isnot-operator.md
@@ -33,9 +33,6 @@ result = object1 IsNot object2
 
  You can use the `Is` and `IsNot` operators to test both early-bound and late-bound objects.
 
-> [!NOTE]
-> The `IsNot` operator cannot be used to compare expressions returned from the `TypeOf` operator. Instead, you must use the `Not` and `Is` operators.
-
 ## Example
  The following code example uses both the `Is` operator and the `IsNot` operator to accomplish the same comparison.
 


### PR DESCRIPTION
- Removed redundant path segments. (Contributes to: #10653)
- Added language identifier.
- Removed extraspaces.

The article contains the following note:
> The IsNot operator cannot be used to compare expressions returned from the TypeOf operator. Instead, you must use the Not and Is operators.

Is that note really correct ? I think that both of the following are identical regardless the use of TypeOf:

```vb
something IsNot anotherThing
Not something Is anotherThing
```

I've tested using the following example and it seems to be the note not correct,.

![image](https://user-images.githubusercontent.com/31348972/64877123-05d43880-d651-11e9-8b77-7e049d1dcbb4.png)

/cc @rpetrusha 

Fixes: #14540