### PR TITLE
C# 8.0: stackalloc in nested expressions

### DIFF
--- a/docs/csharp/language-reference/operators/stackalloc.md
+++ b/docs/csharp/language-reference/operators/stackalloc.md
@@ -1,7 +1,7 @@
 ---
 title: "stackalloc operator - C# reference"
 ms.custom: seodec18
-ms.date: 06/10/2019
+ms.date: 09/20/2019
 f1_keywords: 
   - "stackalloc_CSharpKeyword"
 helpviewer_keywords: 
@@ -25,6 +25,10 @@ You can assign the result of the `stackalloc` operator to a variable of one of t
 
   [!code-csharp[stackalloc expression](~/samples/csharp/language-reference/operators/StackallocOperator.cs#AsExpression)]
 
+  Starting with C# 8.0, you can use a `stackalloc` expression inside other expressions whenever a <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> variable is allowed, as the following example shows:
+
+  [!code-csharp[stackalloc in nested expressions](~/samples/csharp/language-reference/operators/StackallocOperator.cs#Nested)]
+
   > [!NOTE]
   > We recommend using <xref:System.Span%601> or <xref:System.ReadOnlySpan%601> types to work with stack allocated memory whenever possible.
 
@@ -33,6 +37,8 @@ You can assign the result of the `stackalloc` operator to a variable of one of t
   [!code-csharp[stackalloc pointer](~/samples/csharp/language-reference/operators/StackallocOperator.cs#AssignToPointer)]
 
   As the preceding example shows, you must use an `unsafe` context when you work with pointer types.
+
+  In the case of pointer types, you can use a `stackalloc` expression only in a local variable declaration to initialize the variable.
 
 The content of the newly allocated memory is undefined. Starting with C# 7.3, you can use array initializer syntax to define the content of the newly allocated memory. The following example demonstrates various ways to do that:
 

--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -1,7 +1,7 @@
 ---
 title: What's New in C# 8.0 - C# Guide
 description: Get an overview of the new features available in C# 8.0. This article is up-to-date with preview 5.
-ms.date: 09/10/2019
+ms.date: 09/20/2019
 ---
 # What's new in C# 8.0
 
@@ -22,6 +22,7 @@ There are many enhancements to the C# language that you can try out already.
 - [Indices and ranges](#indices-and-ranges)
 - [Null-coalescing assignment](#null-coalescing-assignment)
 - [Unmanaged constructed types](#unmanaged-constructed-types)
+- [stackalloc in nested expressions](#stackalloc-in-nested-expressions)
 - [Enhancement of interpolated verbatim strings](#enhancement-of-interpolated-verbatim-strings)
 
 > [!NOTE]
@@ -487,6 +488,16 @@ Span<Coords<int>> coordinates = stackalloc[]
 ```
 
 For more information, see [Unmanaged types](../language-reference/builtin-types/unmanaged-types.md).
+
+## stackalloc in nested expressions
+
+Starting with C# 8.0, if the result of a [stackalloc](../language-reference/operators/stackalloc.md) expression is of the <xref:System.Span%601?displayProperty=nameWithType> or <xref:System.ReadOnlySpan%601?displayProperty=nameWithType> type, you can use the `stackalloc` expression in other expressions:
+
+```csharp
+Span<int> numbers = stackalloc[] { 1, 2, 3, 4, 5, 6 };
+var ind = numbers.IndexOfAny(stackalloc[] { 2, 4, 6 ,8 });
+Console.WriteLine(ind);  // output: 1
+```
 
 ## Enhancement of interpolated verbatim strings
 


### PR DESCRIPTION
Fixes #14489
Supported by dotnet/samples#1526
/cc: @gafter 
