### PR TITLE
Add reviewers for the new e-books

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,3 +87,9 @@
 /docs/standard/base-types/formatting-types/** @rpetrusha
 # .NET threading
 /docs/standard/threading/** @rpetrusha
+
+################## E-BOOKS ##################
+# Blazor:
+/docs/architecture/blazor-for-web-forms-developers/** @danroth27
+# gRPC:
+/docs/architecture/grpc-for-wcf-developers/** @shirhatti


### PR DESCRIPTION
@nishanil you're already listed as the default one for all the e-books, but then I'm adding specific entries for Blazor and gRPC

@danroth27 and @shirhatti - FYI on being automatically tagged whenever a PR comes for those folders (in the case of gRPC, when that content gets merged of course)