### PR TITLE
Increase heading level

### DIFF
--- a/docs/csharp/nullable-references.md
+++ b/docs/csharp/nullable-references.md
@@ -77,7 +77,7 @@ You can also use directives to set these same contexts anywhere in your project:
 
 The default nullable annotation and warning contexts are `disabled`. That decision means that your existing code compiles without changes and without generating any new warnings.
 
-### Nullable annotation context
+## Nullable annotation context
 
 The compiler uses the following rules in a disabled nullable annotation context:
 


### PR DESCRIPTION
I don't think _Nullable annotation context_ was supposed to have a lower heading level than _Nullable warning context_. They seem like siblings, and it's useful to have them both in the TOC.
