### PR TITLE
Fix ms.prod value

### DIFF
--- a/docs/spark/index.yml
+++ b/docs/spark/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: .NET for Apache Spark documentation
   description: Learn how to use .NET for Apache Spark to process batches of data, real-time streams, machine learning, and ad-hoc queries with Apache Spark anywhere you write .NET code.
   services: service
-  ms.service: dotnet-spark
+  ms.prod: dotnet-spark
   ms.topic: landing-page
   ms.collection: collection
   author: mamccrea


### PR DESCRIPTION
@mamccrea I don't know what the other values mean but dotnet-spark is a ms.prod value, not a ms.service and it's being flagged by the metadata health report. Other values such as services: service not sure if should be removed or not.
