### PR TITLE
Add Thraka as code owner of docs/desktop-wpf

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,9 @@
 # The Desktop Guide:
 /docs/desktop/** @Thraka
 
+# The Desktop WPF Guide:
+/docs/desktop-wpf/** @Thraka
+
 ############### .NET Core ########################
 # What's New
 /docs/core/whats-new/** @rpetrusha

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,9 +42,6 @@
 # The .NET Architecture Guide:
 /docs/architecture/** @nishanil
 
-# The Desktop Guide:
-/docs/desktop/** @Thraka
-
 # The Desktop WPF Guide:
 /docs/desktop-wpf/** @Thraka
 


### PR DESCRIPTION
When I opened #14643, I noticed that no code review was requested. I think `docs/desktop-wpf` should be added in the `CODEOWNERS` file.