### PR TITLE
Update cs0019.md

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0019.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0019.md
@@ -1,72 +1,73 @@
 ---
 title: "Compiler Error CS0019"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0019"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0019"
 ms.assetid: 5a25be41-535b-4850-a230-9a385e01fd20
 ---
 # Compiler Error CS0019
 
-Operator 'operator' cannot be applied to operands of type 'type' and 'type'  
-  
- A binary operator is applied to data types that do not support it. For example, you cannot use the [&#124;&#124;](../operators/boolean-logical-operators.md#conditional-logical-or-operator-) operator on strings, you cannot use [+](../operators/addition-operator.md), [-](../operators/subtraction-operator.md), [\<](../operators/comparison-operators.md#less-than-operator-), or [>](../operators/comparison-operators.md#greater-than-operator-) operators on [bool](../keywords/bool.md) variables, and you cannot use the [==](../operators/equality-operators.md#equality-operator-) operator with a `struct` type unless the type explicitly overloads that operator.  
-  
+Operator 'operator' cannot be applied to operands of type 'type' and 'type'
+
+ A binary operator is applied to data types that do not support it. For example, you cannot use the [&#124;&#124;](../operators/boolean-logical-operators.md#conditional-logical-or-operator-) operator on strings, you cannot use [+](../operators/addition-operator.md), [-](../operators/subtraction-operator.md), [\<](../operators/comparison-operators.md#less-than-operator-), or [>](../operators/comparison-operators.md#greater-than-operator-) operators on [bool](../keywords/bool.md) variables, and you cannot use the [==](../operators/equality-operators.md#equality-operator-) operator with a `struct` type unless the type explicitly overloads that operator.
+
  You can overload an operator to make it support operands of certain types. For more information, see [Operator overloading](../operators/operator-overloading.md).
-  
+
 ## Example
 
- In the following example, CS0019 is generated in two places because [bool](../keywords/bool.md) in C# is not convertible to [int](../builtin-types/integral-numeric-types.md). CS0019 also is generated when the subtraction operator is applied to a string. The addition operator (+) can be used with string operands because that operator is overloaded by the `String` class to perform string concatenation.  
+ In the following example, CS0019 is generated in two places because [bool](../keywords/bool.md) in C# is not convertible to [int](../builtin-types/integral-numeric-types.md). CS0019 also is generated when the subtraction operator is applied to a string. The addition operator (+) can be used with string operands because that operator is overloaded by the `String` class to perform string concatenation.
 
 ```csharp
-static void Main()  
-{  
-    bool result = true;  
-    if (result > 0) //CS0019  
-    {  
-        // Do something.  
-    }  
-  
-    int i = 1;  
-    // You cannot compare an integer and a boolean value.  
-    if (i == true) //CS0019  
-    {  
-        //Do something...  
-    }  
-  
+static void Main()
+{
+    bool result = true;
+    if (result > 0) //CS0019
+    {
+        // Do something.
+    }
+
+    int i = 1;
+    // You cannot compare an integer and a boolean value.
+    if (i == true) //CS0019
+    {
+        //Do something...
+    }
+
     // The following use of == causes no error. It is the comparison of
     // an integer and a boolean value that causes the error in the
-    // previous if statement.  
-    if (result == true)  
-    {  
-        //Do something...  
-    }  
-  
-    string s = "Just try to subtract me.";  
-    float f = 100 - s; // CS0019  
-}  
+    // previous if statement.
+    if (result == true)
+    {
+        //Do something...
+    }
+
+    string s = "Just try to subtract me.";
+    float f = 100 - s; // CS0019
+}
 ```
 
 ## Example
 
- In the following example, conditional logic must be specified outside the <xref:System.Diagnostics.ConditionalAttribute>. You can pass only one predefined symbol to the <xref:System.Diagnostics.ConditionalAttribute>.  
-  
- The following sample generates CS0019.  
+ In the following example, conditional logic must be specified outside the <xref:System.Diagnostics.ConditionalAttribute>. You can pass only one predefined symbol to the <xref:System.Diagnostics.ConditionalAttribute>.
+
+ The following sample generates CS0019:
 
 ```csharp
-// CS0019_a.cs  
-// compile with: /target:library  
-using System.Diagnostics;  
-public class MyClass  
-{  
-   [ConditionalAttribute("DEBUG" || "TRACE")]   // CS0019  
-   public void TestMethod() {}  
-  
-   // OK  
-   [ConditionalAttribute("DEBUG"), ConditionalAttribute("TRACE")]  
-   public void TestMethod2() {}  
-}  
+// CS0019_a.cs
+// compile with: /target:library
+using System.Diagnostics;
+
+public class MyClass
+{
+   [ConditionalAttribute("DEBUG" || "TRACE")]   // CS0019
+   public void TestMethod() {}
+
+   // OK
+   [ConditionalAttribute("DEBUG"), ConditionalAttribute("TRACE")]
+   public void TestMethod2() {}
+}
 ```
 
 ## See also

--- a/docs/csharp/language-reference/compiler-messages/cs0019.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0019.md
@@ -34,15 +34,7 @@ static void Main()
     {
         //Do something...
     }
-
-    // The following use of == causes no error. It is the comparison of
-    // an integer and a boolean value that causes the error in the
-    // previous if statement.
-    if (result == true)
-    {
-        //Do something...
-    }
-
+    
     string s = "Just try to subtract me.";
     float f = 100 - s; // CS0019
 }


### PR DESCRIPTION
- Fixed punctuation: `The following sample generates CS0019.` => `The following sample generates CS0019:`
- Added blank line after the `using` statement.
- Removed extra spaces.