### PR TITLE
Update cs0071.md

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs0071.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0071.md
@@ -1,49 +1,51 @@
 ---
 title: "Compiler Error CS0071"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0071"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0071"
 ms.assetid: 787cbeae-fb2b-455a-ba10-811b956ed170
 ---
 # Compiler Error CS0071
-An explicit interface implementation of an event must use event accessor syntax  
+
+An explicit interface implementation of an event must use event accessor syntax
+
+ When explicitly implementing an [event](../keywords/event.md) that was declared in an interface, you must use manually provide the `add` and `remove` event accessors that are typically provided by the compiler. The accessor code can connect the interface event to another event in your class (shown later in this topic), or to its own delegate type. For more information, see [How to: Implement Interface Events](../../programming-guide/events/how-to-implement-interface-events.md).
   
- When explicitly implementing an [event](../keywords/event.md) that was declared in an interface, you must use manually provide the `add` and `remove` event accessors that are typically provided by the compiler. The accessor code can connect the interface event to another event in your class (shown later in this topic), or to its own delegate type. For more information, see [How to:  Implement Interface Events](../../programming-guide/events/how-to-implement-interface-events.md).  
-  
-## Example  
- The following sample generates CS0071.  
-  
-```csharp  
-// CS0071.cs  
-public delegate void MyEvent(object sender);  
-  
-interface ITest  
-{  
-    event MyEvent Clicked;  
-}  
-  
-class Test : Itest  
-{  
-    event MyEvent ITest.Clicked;  // CS0071  
-  
-    // try the following code instead  
-/*  
-private MyEvent clicked;  
-  
-    event MyEvent Itest.Clicked  
-    {  
-        add  
-        {  
-            clicked += value;  
-        }  
-        remove  
-        {  
-            clicked -= value;  
-        }  
-    }  
-*/  
-    public static void Main() { }  
-}  
+## Example
+
+ The following sample generates CS0071.
+
+```csharp
+// CS0071.cs
+public delegate void MyEvent(object sender);
+
+interface ITest
+{
+    event MyEvent Clicked;
+}
+
+class Test : ITest
+{
+    event MyEvent ITest.Clicked;  // CS0071
+
+    // Try the following code instead.
+/*
+private MyEvent clicked;
+
+    event MyEvent Itest.Clicked
+    {
+        add
+        {
+            clicked += value;
+        }
+        remove
+        {
+            clicked -= value;
+        }
+    }
+*/
+    public static void Main() { }
+}
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs0071.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0071.md
@@ -31,8 +31,8 @@ class Test : ITest
     event MyEvent ITest.Clicked;  // CS0071
 
     // Try the following code instead.
-/*
-private MyEvent clicked;
+    /*
+    private MyEvent clicked;
 
     event MyEvent ITest.Clicked
     {
@@ -45,7 +45,7 @@ private MyEvent clicked;
             clicked -= value;
         }
     }
-*/
+    */
     public static void Main() { }
 }
 ```

--- a/docs/csharp/language-reference/compiler-messages/cs0071.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0071.md
@@ -34,7 +34,7 @@ class Test : ITest
 /*
 private MyEvent clicked;
 
-    event MyEvent Itest.Clicked
+    event MyEvent ITest.Clicked
     {
         add
         {

--- a/docs/csharp/language-reference/compiler-messages/cs0071.md
+++ b/docs/csharp/language-reference/compiler-messages/cs0071.md
@@ -11,7 +11,7 @@ ms.assetid: 787cbeae-fb2b-455a-ba10-811b956ed170
 
 An explicit interface implementation of an event must use event accessor syntax
 
- When explicitly implementing an [event](../keywords/event.md) that was declared in an interface, you must use manually provide the `add` and `remove` event accessors that are typically provided by the compiler. The accessor code can connect the interface event to another event in your class (shown later in this topic), or to its own delegate type. For more information, see [How to: Implement Interface Events](../../programming-guide/events/how-to-implement-interface-events.md).
+ When explicitly implementing an [event](../keywords/event.md) that was declared in an interface, you must manually provide the `add` and `remove` event accessors that are typically provided by the compiler. The accessor code can connect the interface event to another event in your class (shown later in this topic) or to its own delegate type. For more information, see [How to: Implement Interface Events](../../programming-guide/events/how-to-implement-interface-events.md).
   
 ## Example
 


### PR DESCRIPTION
- Removed extra spaces.
- Fixed typo: `Itest` => `ITest`.