### PR TITLE
Add identifier to template.md

### DIFF
--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -319,8 +319,8 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |SQL|sql|
 |Swift|swift|
 |TypeScript|typescript|
-|VB|vb|
-|vbscript|vbscript|
+|Visual Basic|vb|
+|VBScript|vbscript|
 |XAML|xaml|
 |XML|xml|
 

--- a/styleguide/template.md
+++ b/styleguide/template.md
@@ -320,6 +320,7 @@ Use three backticks (\`\`\`) + a language ID to apply language-specific color co
 |Swift|swift|
 |TypeScript|typescript|
 |VB|vb|
+|vbscript|vbscript|
 |XAML|xaml|
 |XML|xml|
 


### PR DESCRIPTION
I noticed that `vbscript` is a valid identifier and is used [here](https://docs.microsoft.com/en-us/dotnet/framework/wcf/samples/using-the-wcf-moniker-with-com-clients), so added it to `template.md`.