### PR TITLE
fix: MD045/no-alt-text

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -39,7 +39,6 @@
     "MD036": false,
     "MD040": false,
     "MD041": false,
-    "MD045": false,
     "MD046": {
         "style": "fenced"
     }

--- a/docs/architecture/modern-web-apps-azure/azure-hosting-recommendations-for-asp-net-web-apps.md
+++ b/docs/architecture/modern-web-apps-azure/azure-hosting-recommendations-for-asp-net-web-apps.md
@@ -121,7 +121,7 @@ Your application's requirements should dictate its architecture. There are many 
 
 Figure 11-2 shows an example reference architecture. This diagram describes a recommended architecture approach for a Sitecore content management system website optimized for marketing.
 
-![](./media/image11-2.png)
+![Figure 11-2](./media/image11-2.png)
 
 **Figure 11-1.** Sitecore marketing website reference architecture.
 

--- a/docs/architecture/modern-web-apps-azure/azure-hosting-recommendations-for-asp-net-web-apps.md
+++ b/docs/architecture/modern-web-apps-azure/azure-hosting-recommendations-for-asp-net-web-apps.md
@@ -119,9 +119,9 @@ Transient command- or event-based data used to orchestrate application behavior 
 
 Your application's requirements should dictate its architecture. There are many different Azure services available. Choosing the right one is an important decision. Microsoft offers a gallery of reference architectures to help identify typical architectures optimized for common scenarios. You may find a reference architecture that maps closely to your application's requirements, or at least offers a starting point.
 
-Figure 11-2 shows an example reference architecture. This diagram describes a recommended architecture approach for a Sitecore content management system website optimized for marketing.
+Figure 11-1 shows an example reference architecture. This diagram describes a recommended architecture approach for a Sitecore content management system website optimized for marketing.
 
-![Figure 11-2](./media/image11-2.png)
+![Figure 11-1](./media/image11-2.png)
 
 **Figure 11-1.** Sitecore marketing website reference architecture.
 

--- a/docs/architecture/modern-web-apps-azure/common-web-application-architectures.md
+++ b/docs/architecture/modern-web-apps-azure/common-web-application-architectures.md
@@ -180,7 +180,7 @@ You can build a single and monolithic-deployment based Web Application or Servic
 
 To manage this model, you deploy a single container to represent the application. To scale, just add additional copies with a load balancer in front. The simplicity comes from managing a single deployment in a single container or VM.
 
-![](./media/image5-13.png)
+![Figure 5-13](./media/image5-13.png)
 
 You can include multiple components/libraries or internal layers within each container, as illustrated in Figure 5-13. But, following the container principle of _"a container does one thing, and does it in one process_", the monolithic pattern might be a conflict.
 
@@ -192,7 +192,7 @@ In addition to the "scale everything" problem, changes to a single component req
 
 The monolithic approach is common, and many organizations are developing with this architectural approach. Many are having good enough results, while others are hitting limits. Many designed their applications in this model, because the tools and infrastructure were too difficult to build service-oriented architectures (SOA), and they didn't see the need until the app grew. If you find you're hitting the limits of the monolithic approach, breaking up the app to enable it to better leverage containers and microservices may be the next logical step.
 
-![](./media/image5-14.png)
+![Figure 5-14](./media/image5-14.png)
 
 Deploying monolithic applications in Microsoft Azure can be achieved using dedicated VMs for each instance. Using [Azure Virtual Machine Scale Sets](https://docs.microsoft.com/azure/virtual-machine-scale-sets/), you can easily scale the VMs. [Azure App Services](https://azure.microsoft.com/services/app-service/) can run monolithic applications and easily scale instances without having to manage the VMs. Azure App Services can run single instances of Docker containers as well, simplifying the deployment. Using Docker, you can deploy a single VM as a Docker host, and run multiple instances. Using the Azure balancer, as shown in the Figure 5-14, you can manage scaling.
 

--- a/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/choosing-azure-compute-options-for-container-based-applications.md
+++ b/docs/architecture/modernize-with-azure-containers/modernize-existing-apps-to-cloud-optimized/choosing-azure-compute-options-for-container-based-applications.md
@@ -19,9 +19,9 @@ However, this recommendation should be taken with a pinch of salt, as the produc
 
 After a deeper analysis of the application’s needs, the product selected could be different. But, as a starting point, it is good to have initial guidance from where you can start evaluating and testing based on certain priority.
 
-In the next figure, you can see a breakdown of different kinds of apps and their ideal Azure hosting scenarios.
+In Figure 1, you can see a breakdown of different kinds of apps and their ideal Azure hosting scenarios.
 
-![](./media/image8.5.png)
+![Figure 1](./media/image8.5.png)
 
 > [!div class="step-by-step"]
 > [Previous](when-to-deploy-windows-containers-to-azure-container-service-kubernetes.md)

--- a/docs/framework/wpf/controls/walkthrough-create-a-button-by-using-xaml.md
+++ b/docs/framework/wpf/controls/walkthrough-create-a-button-by-using-xaml.md
@@ -163,7 +163,7 @@ So far, the control of how buttons look in the application has been confined to 
 
      Press F5 to run the application. It should look like the following.
 
-     ![](./media/custom-button-animatedbutton-4.gif "custom_button_AnimatedButton_4")
+     ![Window with 3 buttons](./media/custom-button-animatedbutton-4.gif)
 
 3. **Add a glasseffect to the template:** Next you will add the glass. First you create some resources that create a glass gradient effect. Add these gradient resources anywhere within the `Application.Resources` block:
 

--- a/docs/machine-learning/tutorials/object-detection-onnx.md
+++ b/docs/machine-learning/tutorials/object-detection-onnx.md
@@ -41,7 +41,7 @@ This sample creates a .NET core console application that detects objects within 
 
 Object detection is a computer vision problem. While closely related to image classification, object detection performs image classification at a more granular scale. Object detection both locates _and_ categorizes entities within images. Use object detection when images contain multiple objects of different types.
 
-![](./media/object-detection-onnx/img-classification-obj-detection.PNG)
+![Side-by-side images showing Image Classification of a dog on the left, and Object Classification of a group at a dog show on the right](./media/object-detection-onnx/img-classification-obj-detection.PNG)
 
 Some use cases for object detection include:
 
@@ -62,7 +62,7 @@ There are different types of neural networks, the most common being Multi-Layere
 
 Object detection is an image processing task. Therefore, most deep learning models trained to solve this problem are CNNs. The model used in this tutorial is the Tiny YOLOv2 model, a more compact version of the YOLOv2 model described in the paper: ["YOLO9000: Better, Faster, Stronger" by Redmon and Fadhari](https://arxiv.org/pdf/1612.08242.pdf). Tiny YOLOv2 is trained on the Pascal VOC dataset and is made up of 15 layers that can predict 20 different classes of objects. Because Tiny YOLOv2 is a condensed version of the original YOLOv2 model, a tradeoff is made between speed and accuracy. The different layers that make up the model can be visualized using tools like Netron. Inspecting the model would yield a mapping of the connections between all the layers that make up the neural network, where each layer would contain the name of the layer along with the dimensions of the respective input / output. The data structures used to describe the inputs and outputs of the model are known as tensors. Tensors can be thought of as containers that store data in N-dimensions. In the case of Tiny YOLOv2, the name of the input layer is `image` and it expects a tensor of dimensions `3 x 416 x 416`. The name of the output layer is `grid` and generates an output tensor of dimensions `125 x 13 x 13`.
 
-![](./media/object-detection-onnx/netron-model-map.png)
+![Input layer being split into hidden layers, then output layer](./media/object-detection-onnx/netron-model-map.png)
 
 The YOLO model takes an image `3(RGB) x 416px x 416px`. The model takes this input and passes it through the different layers to produce an output. The output divides the input image into a `13 x 13` grid, with each cell in the grid consisting of `125` values.
 
@@ -70,11 +70,11 @@ The YOLO model takes an image `3(RGB) x 416px x 416px`. The model takes this inp
 
 The Open Neural Network Exchange (ONNX) is an open source format for AI models. ONNX supports interoperability between frameworks. This means you can train a model in one of the many popular machine learning frameworks like PyTorch, convert it into ONNX format and consume the ONNX model in a different framework like ML.NET. To learn more, visit the [ONNX website](https://onnx.ai/).
 
-![](./media/object-detection-onnx/onnx-frameworks.png)
+![ONNX supported formats being imported to ONNX, then used by other ONNX supported formats](./media/object-detection-onnx/onnx-frameworks.png)
 
 The pre-trained Tiny YOLOv2 model is stored in ONNX format, a serialized representation of the layers and learned patterns of those layers. In ML.NET, interoperability with ONNX is achieved with the [`ImageAnalytics`](xref:Microsoft.ML.Transforms.Image) and [`OnnxTransformer`](xref:Microsoft.ML.Transforms.Onnx.OnnxTransformer) NuGet packages. The [`ImageAnalytics`](xref:Microsoft.ML.Transforms.Image) package contains a series of transforms that take an image and encode it into numerical values that can be used as input into a prediction or training pipeline. The [`OnnxTransformer`](xref:Microsoft.ML.Transforms.Onnx.OnnxTransformer) package leverages the ONNX Runtime to load an ONNX model and use it to make predictions based on input provided.
 
-![](./media/object-detection-onnx/onnx-ml-net-integration.png)
+![Data flow of ONNX file into the ONNX Runtime, and finally to the C# application](./media/object-detection-onnx/onnx-ml-net-integration.png)
 
 ## Set up the .NET Core project
 
@@ -179,7 +179,7 @@ Initialize the `mlContext` variable with a new instance of `MLContext` by adding
 
 The model segments an image into a `13 x 13` grid, where each grid cell is `32px x 32px`. Each grid cell contains 5 potential object bounding boxes. A bounding box has  25 elements:
 
-![](./media/object-detection-onnx/model-output-description.png)
+![Grid sample on the left, and Bounding Box sample on the right](./media/object-detection-onnx/model-output-description.png)
 
 - `x` the x position of the bounding box center relative to the grid cell it's associated with.
 - `y` the y position of the bounding box center relative to the grid cell it's associated with.
@@ -699,7 +699,7 @@ person and its Confidence score: 0.5551759
 
 To see the images with bounding boxes, navigate to the `assets/images/output/` directory. Below is a sample from one of the processed images.
 
-![](./media/object-detection-onnx/image3.jpg)
+![Sample processed image of a dinning room](./media/object-detection-onnx/image3.jpg)
 
 Congratulations! You've now successfully built a machine learning model for object detection by reusing a pre-trained `ONNX` model in ML.NET.
 

--- a/docs/machine-learning/tutorials/sentiment-analysis-model-builder.md
+++ b/docs/machine-learning/tutorials/sentiment-analysis-model-builder.md
@@ -62,7 +62,7 @@ Each row in the *wikipedia-detox-250-line-data.tsv* dataset represents a differe
 
 ## Choose a scenario
 
-![](./media/sentiment-analysis-model-builder/model-builder-screen.png)
+![Model Builder wizard in Visual Studio](./media/sentiment-analysis-model-builder/model-builder-screen.png)
 
 To train your model, you need to select from the list of available machine learning scenarios provided by Model Builder.
 
@@ -246,7 +246,7 @@ Now that your application is set up, run the application which should launch in 
 
 When the application launches, enter *Model Builder is cool!* into the text area. The predicted sentiment displayed should be *Not Toxic*.
 
-![](./media/sentiment-analysis-model-builder/web-app.png)
+![Running window with the predicted sentiment window](./media/sentiment-analysis-model-builder/web-app.png)
 
 If you need to reference the Model Builder generated projects at a later time inside of another solution, you can find them inside the `C:\Users\%USERNAME%\AppData\Local\Temp\MLVSTools` directory.
 


### PR DESCRIPTION
Used the "Figure" number when it was being described by the preceeding text.
Looked at the content for the few when there wasn't directly preceeding descriptions