### PR TITLE
Update cs0161.md

### DIFF
--- a/docs/csharp/misc/cs0161.md
+++ b/docs/csharp/misc/cs0161.md
@@ -1,35 +1,38 @@
 ---
 title: "Compiler Error CS0161"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0161"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0161"
 ms.assetid: c2731a6c-0285-4558-9e62-a7fd480ab0cf
 ---
 # Compiler Error CS0161
-'method': not all code paths return a value  
-  
- A method that returns a value must have a `return` statement in all code paths. For more information, see [Methods](../programming-guide/classes-and-structs/methods.md).  
-  
- The following sample generates CS0161:  
-  
-```csharp  
-// CS0161.cs  
-public class Test  
-{  
-   public static int Main() // CS0161  
-   {  
-      int i = 10;  
-      if (i < 10)  
-      {  
-         return i;  
-      }  
-      else  
-      {  
-         // uncomment the following line to resolve  
-         // return 1;  
-      }  
-   }  
-}  
+
+'method': not all code paths return a value
+
+ A method that returns a value must have a `return` statement in all code paths. For more information, see [Methods](../programming-guide/classes-and-structs/methods.md).
+
+## Example
+
+ The following sample generates CS0161:
+
+```csharp
+// CS0161.cs
+public class Test
+{
+    public static int Main() // CS0161
+    {
+        int i = 5;
+        if (i < 10)
+        {
+            return i;
+        }
+        else
+        {
+            // Uncomment the following line to resolve.
+            // return 1;  
+        }
+    }
+}
 ```


### PR DESCRIPTION
- Markdown improvements.
- Fix indentation.
- Changed variable value to make the condition goes to the branch that HAS a return value. The reason is to make the reader understand that even if the method will always return a value by logic but a code path doesn't have a return statement, the error will be generated.