### PR TITLE
Update cs1690.md

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1690.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1690.md
@@ -10,27 +10,30 @@ ms.assetid: bc76efe0-4304-4449-8c11-950667aa8ac9
 # Compiler Warning (level 1) CS1690
 Accessing a member on 'member' may cause a runtime exception because it is a field of a marshal-by-reference class  
   
- This warning occurs when you try to call a method, property, or indexer on a member of a class that derives from <xref:System.MarshalByRefObject>, and the member is a value type. Objects that inherit from `MarshalByRefObject` are typically intended to be marshaled by reference across an application domain. If any code ever attempts to directly access the value-type member of such an object across an application domain, a runtime exception will occur. To resolve the warning, first copy the member into a local variable and call the method on that variable.  
+ This warning occurs when you try to call a method, property, or indexer on a member of a class that derives from <xref:System.MarshalByRefObject>, and the member is a value type. Objects that inherit from `MarshalByRefObject` are typically intended to be marshaled by reference across an application domain. If any code ever attempts to directly access the value-type member of such an object across an application domain, a runtime <xref:System.InvalidOperationException> will occur. To resolve the warning, first copy the member into a local variable and call the method on that variable.
   
  The following sample generates CS1690:  
   
 ```csharp  
 // CS1690.cs  
-using System;  
-  
-class WarningCS1690: MarshalByRefObject  
-{  
-   int i = 5;  
-  
-   public static void Main()   
-   {  
-     WarningCS1690 e = new WarningCS1690();  
-     e.i.ToString();   // CS1690  
-  
-     // OK  
-     int i = e.i;  
-     i.ToString();  
-     e.i = i;  
-   }  
-}  
+using System;
+
+class WarningCS1690 : MarshalByRefObject
+{
+    int i = 5;
+
+    public static void Main()
+    {            
+        AppDomain domain = AppDomain.CreateDomain("MyDomain");                
+        Type t = typeof(WarningCS1690);
+        WarningCS1690 e = (WarningCS1690)domain.CreateInstanceAndUnwrap(t.Assembly.FullName,t.FullName);
+
+        e.i.ToString(); // CS1690    
+
+        // OK  
+        int i = e.i;
+        i.ToString();
+        e.i = i;        
+    }
+}
 ```


### PR DESCRIPTION
## Summary

- Mention the type of thrown exception
- Update example to actually throw exception at runtime

Fixes https://github.com/dotnet/docs/issues/13994

I felt that current example is too simple. While it demonstrates the compiler warning, it does not involve any appdomains and as a result does not throw the mentioned exception, so resolving a warning makes no difference. I suggested to add code that creates `WarningCS1690` instance on the other appdomain, so accessing the field will actually throw exception.
