### PR TITLE
remove RequireQualifiedAccess attribute

### DIFF
--- a/docs/fsharp/what-is-fsharp.md
+++ b/docs/fsharp/what-is-fsharp.md
@@ -104,7 +104,6 @@ type Set<'T when 'T: comparison>(elements: seq<'T>) =
     interface IEnumerable<‘T>
     interface IReadOnlyCollection<‘T>
 
-[<RequireQualifiedAccess>]
 module Set =
     let isEmpty (set: Set<'T>) = set.IsEmpty
 


### PR DESCRIPTION
## Summary

Removing RequireQualifiedAccess attribute from F# code sample in the interest of simplicity.
