### PR TITLE
Reference new jitter in resilient-applications/retry

### DIFF
--- a/docs/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
+++ b/docs/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md
@@ -50,17 +50,20 @@ so it will try six times and the seconds between each retry will be exponential,
 
 ## Add a jitter strategy to the retry policy
 
-A regular Retry policy can impact your system in cases of high concurrency and scalability and under high contention. To overcome peaks of similar retries coming from many clients in case of partial outages, a good workaround is to add a jitter strategy to the retry algorithm/policy. This can improve the overall performance of the end-to-end system by adding randomness to the exponential backoff. This spreads out the spikes when issues arise. When you use a plain Polly policy, code to implement jitter could look like the following example:
+A regular Retry policy can impact your system in cases of high concurrency and scalability and under high contention. To overcome peaks of similar retries coming from many clients in case of partial outages, a good workaround is to add a jitter strategy to the retry algorithm/policy. This can improve the overall performance of the end-to-end system by adding randomness to the exponential backoff. This spreads out the spikes when issues arise. The principle is illustrated by the following example:
 
 ```csharp
 Random jitterer = new Random(); 
-Policy
-  .Handle<HttpResponseException>() // etc
-  .WaitAndRetry(5,    // exponential back-off plus some jitter
-      retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))  
-                    + TimeSpan.FromMilliseconds(jitterer.Next(0, 100)) 
-  );
+var retryWithJitterPolicy = HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+    .WaitAndRetryAsync(6,    // exponential back-off plus some jitter
+        retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))  
+                      + TimeSpan.FromMilliseconds(jitterer.Next(0, 100)) 
+    );
 ```
+
+Polly provides production-ready jitter algorithms via the project website.
 
 ## Additional resources
 
@@ -72,6 +75,9 @@ Policy
 
 - **Polly (.NET resilience and transient-fault-handling library)**  
   <https://github.com/App-vNext/Polly>
+
+- **Polly: Retry with Jitter**  
+  <https://github.com/App-vNext/Polly/wiki/Retry-with-jitter>
 
 - **Marc Brooker. Jitter: Making Things Better With Randomness**  
   <https://brooker.co.za/blog/2015/03/21/backoff.html>


### PR DESCRIPTION
## Summary

The Polly team and contributors have published [easy code helpers for new jitter algorithms](https://github.com/Polly-Contrib/Polly.Contrib.WaitAndRetry#new-jitter-recommendation) offering a very smooth jittered distribution of retries while still observing the exponential backoff characteristic.  

This PR avoids adding more detail on jitter to the published docs text, but:

+ Tidies the retry-with-jitter simple code example to align more closely with preceding code example on the same page
+ Directs readers to the Polly website for production-ready jitter algorithms
+ Adds an **Additional resource** linking directly to Polly's jitter page

---

Section: `architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly.md`

(Contributor reference: I'm the lead Polly maintainer, and worked with contributors to make these new jitter algorithms available.)