### PR TITLE
L125217: Changing italic underscore by italic asterisks

### DIFF
--- a/docs/csharp/whats-new/csharp-7-2.md
+++ b/docs/csharp/whats-new/csharp-7-2.md
@@ -69,7 +69,7 @@ For example:
 int binaryValue = 0b_0101_0101;
 ```
 
-## _private protected_ access modifier
+## *private protected* access modifier
 
 A new compound access modifier: `private protected` indicates that a member may be
 accessed by containing class or derived classes that are declared in the same assembly. While `protected internal`


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: The usage of _ character in header of this file is causing tooling issues when generating the corresponding bookmark (\<a name="_private-protected_-access-modifier"\> instead of \<a name="private-protected-access-modifier"\>). Please replace \#\# \_private protected\_ access modifier by \#\# \*private protected\* access modifier