### PR TITLE
Mention the null-forgiving operator in the language reference

### DIFF
--- a/docs/csharp/language-reference/operators/boolean-logical-operators.md
+++ b/docs/csharp/language-reference/operators/boolean-logical-operators.md
@@ -1,7 +1,7 @@
 ---
 title: "Boolean logical operators - C# reference"
 description: "Learn about C# operators that perform logical negation, conjunction (AND), and inclusive and exclusive disjunction (OR) operations with Boolean operands."
-ms.date: 04/08/2019
+ms.date: 09/27/2019
 author: pkulikov
 f1_keywords: 
   - "!_CSharpKeyword"
@@ -48,6 +48,8 @@ For the operands of the [integral](../builtin-types/integral-numeric-types.md) t
 The `!` operator computes logical negation of its operand. That is, it produces `true`, if the operand evaluates to `false`, and `false`, if the operand evaluates to `true`:
 
 [!code-csharp-interactive[logical negation](~/samples/csharp/language-reference/operators/BooleanLogicalOperators.cs#Negation)]
+
+Starting with C# 8.0, the unary postfix `!` operator is a null-forgiving operator. In an enabled nullable annotation context, you use it to declare that expression `x` of a nullable reference type isn't null: `x!`. For more information, see [Nullable reference types](../../nullable-references.md).
 
 ## <a name="logical-and-operator-"></a> Logical AND operator &amp;
 


### PR DESCRIPTION
Contributes to #13420
@BillWagner I'd be glad to fix #13420, but it's not yet clear where to place the update in the reference. I would make it the separate page as it's not only about member access and more about declaration rather than operation (as far as I understand, `x` and `x!` generate the same code at the end?)
