### PR TITLE
Use bullet list in see also section

### DIFF
--- a/docs/core/compatibility/categories.md
+++ b/docs/core/compatibility/categories.md
@@ -43,4 +43,4 @@ Maintaining forward compatibility is not a goal of .NET Core.
 
 ## See also
 
-[Evaluate breaking changes in .NET Core](index.md)
+- [Evaluate breaking changes in .NET Core](index.md)

--- a/docs/core/porting/project-structure.md
+++ b/docs/core/porting/project-structure.md
@@ -63,4 +63,4 @@ Changes to note are:
 
 ## See also
 
-Please see the [.NET Core porting documentation](index.md) for more guidance on migrating to .NET Core.
+- [.NET Core porting documentation](index.md)

--- a/docs/framework/data/adonet/ef/aggregate-functions-sqlclient-for-entity-framework.md
+++ b/docs/framework/data/adonet/ef/aggregate-functions-sqlclient-for-entity-framework.md
@@ -217,10 +217,7 @@ A `Double`.
   
 ## See also
 
-For more information about the aggregate functions that SqlClient supports, see the documentation for the SQL Server version that you specified in the SqlClient provider manifest:
-
 - **SQL Server 2005:** [Aggregate Functions (Transact-SQL)](https://docs.microsoft.com/previous-versions/sql/sql-server-2005/ms173454(v=sql.90))
 - **SQL Server 2008 and later:** [Aggregate Functions (Transact-SQL)](/sql/t-sql/functions/aggregate-functions-transact-sql)
-
 - [Entity SQL Language](./language-reference/entity-sql-language.md)
 - [Aggregate Canonical Functions](./language-reference/aggregate-canonical-functions.md)

--- a/docs/framework/data/adonet/ef/aggregate-functions-sqlclient-for-entity-framework.md
+++ b/docs/framework/data/adonet/ef/aggregate-functions-sqlclient-for-entity-framework.md
@@ -217,7 +217,6 @@ A `Double`.
   
 ## See also
 
-- **SQL Server 2005:** [Aggregate Functions (Transact-SQL)](https://docs.microsoft.com/previous-versions/sql/sql-server-2005/ms173454(v=sql.90))
-- **SQL Server 2008 and later:** [Aggregate Functions (Transact-SQL)](/sql/t-sql/functions/aggregate-functions-transact-sql)
+- [Aggregate Functions (Transact-SQL)](/sql/t-sql/functions/aggregate-functions-transact-sql)
 - [Entity SQL Language](./language-reference/entity-sql-language.md)
 - [Aggregate Canonical Functions](./language-reference/aggregate-canonical-functions.md)

--- a/docs/framework/data/adonet/ef/mathematical-functions.md
+++ b/docs/framework/data/adonet/ef/mathematical-functions.md
@@ -376,7 +376,5 @@ Calculates the tangent of a specified expression.
   
 ## See also
 
-- **SQL Server 2005:** [Mathematical Functions (Transact-SQL)](https://docs.microsoft.com/previous-versions/sql/sql-server-2005/ms177516(v=sql.90))
-- **SQL Server 2008:** [Mathematical Functions (Transact-SQL)](https://docs.microsoft.com/previous-versions/sql/sql-server-2008/ms177516(v=sql.100))
-- **SQL Server 2012 and later:** [Mathematical Functions (Transact-SQL)](/sql/t-sql/functions/mathematical-functions-transact-sql)
+- [Mathematical Functions (Transact-SQL)](/sql/t-sql/functions/mathematical-functions-transact-sql)
 - [SqlClient for Entity Framework Functions](sqlclient-for-ef-functions.md)

--- a/docs/framework/data/adonet/ef/mathematical-functions.md
+++ b/docs/framework/data/adonet/ef/mathematical-functions.md
@@ -376,10 +376,7 @@ Calculates the tangent of a specified expression.
   
 ## See also
 
-For more information about the mathematical functions that SqlClient supports, see the documentation for the SQL Server version that you specified in the SqlClient provider manifest:
-
 - **SQL Server 2005:** [Mathematical Functions (Transact-SQL)](https://docs.microsoft.com/previous-versions/sql/sql-server-2005/ms177516(v=sql.90))
 - **SQL Server 2008:** [Mathematical Functions (Transact-SQL)](https://docs.microsoft.com/previous-versions/sql/sql-server-2008/ms177516(v=sql.100))
 - **SQL Server 2012 and later:** [Mathematical Functions (Transact-SQL)](/sql/t-sql/functions/mathematical-functions-transact-sql)
-
 - [SqlClient for Entity Framework Functions](sqlclient-for-ef-functions.md)

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -58,4 +58,4 @@ Provides documentation for private .NET Framework APIs used by Microsoft tools.
 
 ## See also
 
-* [.NET Framework Class Library](/dotnet/api/?view=netframework-4.8)
+- [.NET Framework Class Library](/dotnet/api/?view=netframework-4.8)

--- a/docs/framework/migration-guide/net-framework-4-migration-issues.md
+++ b/docs/framework/migration-guide/net-framework-4-migration-issues.md
@@ -310,17 +310,9 @@ Namespaces: <xref:System.Xml.Linq>; <xref:System.Xml.Schema>, <xref:System.Xml.X
 
 ## See also
 
-### Reference
-
 - [New Types and Members in the .NET Framework 4](https://docs.microsoft.com/previous-versions/dotnet/netframework-4.0/ff641764%28v=vs.100%29)
-
-### Concepts
-
 - [Migration Guide to the .NET Framework 4](https://docs.microsoft.com/previous-versions/dotnet/netframework-4.0/ff657133%28v=vs.100%29)
 - [What's New in the .NET Framework 4](https://docs.microsoft.com/previous-versions/dotnet/netframework-4.0/ms171868%28v=vs.100%29)
 - [Version Compatibility in the .NET Framework](version-compatibility.md)
 - [Migrating Office Solutions to the .NET Framework 4](/visualstudio/vsto/migrating-office-solutions-to-the-dotnet-framework-4-or-later)
-
-### Other resources
-
 - [What's Obsolete in the .NET Framework Class Library](../whats-new/whats-obsolete.md)

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-createbreakpoint-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-createbreakpoint-method.md
@@ -49,6 +49,4 @@ HRESULT CreateBreakpoint (
   
  **Library:** CorGuids.lib  
   
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-getaddress-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-getaddress-method.md
@@ -40,6 +40,4 @@ HRESULT GetAddress (
   
  **Library:** CorGuids.lib  
   
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-getencremapsequencepoints-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-getencremapsequencepoints-method.md
@@ -1,35 +1,34 @@
 ---
 title: "ICorDebugCode::GetEnCRemapSequencePoints Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugCode.GetEnCRemapSequencePoints"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugCode::GetEnCRemapSequencePoints"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetEnCRemapSequencePoints method [.NET Framework debugging]"
   - "ICorDebugCode::GetEnCRemapSequencePoints method [.NET Framework debugging]"
 ms.assetid: 8463a98a-de4a-418e-beb0-9611885ae6b0
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCode::GetEnCRemapSequencePoints Method
-This method is not implemented in the current version of the .NET Framework.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetEnCRemapSequencePoints(  
-    [in] ULONG32 cMap,  
-    [out] ULONG32 *pcMap,  
-    [out, size_is(cMap), length_is(*pcMap)]  
-        ULONG32 offsets[]  
-);  
-```  
-  
-## See also
+
+This method is not implemented in the current version of the .NET Framework.
+
+## Syntax
+
+```cpp
+HRESULT GetEnCRemapSequencePoints(
+    [in] ULONG32 cMap,
+    [out] ULONG32 *pcMap,
+    [out, size_is(cMap), length_is(*pcMap)]
+        ULONG32 offsets[]
+);
+```

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-getfunction-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-getfunction-method.md
@@ -43,6 +43,4 @@ HRESULT GetFunction (
   
  **Library:** CorGuids.lib  
   
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-getsize-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-getsize-method.md
@@ -19,27 +19,29 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCode::GetSize Method
-Gets the size, in bytes, of the binary code represented by this "ICorDebugCode".  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetSize (  
-    [out] ULONG32    *pcBytes  
-);  
-```  
-  
-## Parameters  
- `pcBytes`  
- [out] A pointer to the size, in bytes, of the binary code that this `ICorDebugCode` object represents.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** CorDebug.idl, CorDebug.h  
-  
- **Library:** CorGuids.lib  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+
+Gets the size, in bytes, of the binary code represented by this "ICorDebugCode".
+
+## Syntax
+
+```cpp
+HRESULT GetSize (
+    [out] ULONG32    *pcBytes
+);
+```
+
+## Parameters
+
+ `pcBytes`
+ [out] A pointer to the size, in bytes, of the binary code that this `ICorDebugCode` object represents.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../get-started/system-requirements.md).
+
+ **Header:** CorDebug.idl, CorDebug.h
+
+ **Library:** CorGuids.lib
+
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]
+ 

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-getsize-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-getsize-method.md
@@ -32,7 +32,7 @@ HRESULT GetSize (
 
 ## Parameters
 
- `pcBytes`
+ `pcBytes`  
  [out] A pointer to the size, in bytes, of the binary code that this `ICorDebugCode` object represents.
 
 ## Requirements

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-getversionnumber-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-getversionnumber-method.md
@@ -19,30 +19,32 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCode::GetVersionNumber Method
-Gets the one-based number that identifies the version of the code that this "ICorDebugCode" represents.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetVersionNumber (  
-    [out] ULONG32    *nVersion  
-);  
-```  
-  
-## Parameters  
+
+Gets the one-based number that identifies the version of the code that this "ICorDebugCode" represents.
+
+## Syntax
+
+```cpp
+HRESULT GetVersionNumber (
+    [out] ULONG32    *nVersion
+);
+```
+
+## Parameters
+
  `nVersion`  
- [out] A pointer to the version number of the code.  
-  
-## Remarks  
- The version number is incremented each time an edit-and-continue (EnC) operation is performed on the code.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
+ [out] A pointer to the version number of the code.
+
+## Remarks
+
+ The version number is incremented each time an edit-and-continue (EnC) operation is performed on the code.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
   
  **Header:** CorDebug.idl, CorDebug.h  
   
  **Library:** CorGuids.lib  
   
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]

--- a/docs/framework/unmanaged-api/debugging/icordebugcode-isil-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode-isil-method.md
@@ -19,27 +19,28 @@ author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCode::IsIL Method
-Gets a value that indicates whether this "ICorDebugCode" represents code that was compiled in Microsoft intermediate language (MSIL).  
-  
-## Syntax  
-  
-```cpp  
-HRESULT IsIL (  
-    [out] BOOL       *pbIL  
-);  
-```  
-  
-## Parameters  
+
+Gets a value that indicates whether this "ICorDebugCode" represents code that was compiled in Microsoft intermediate language (MSIL).
+
+## Syntax
+
+```cpp
+HRESULT IsIL (
+    [out] BOOL       *pbIL
+);
+```
+
+## Parameters
  `pbIL`  
- [out] `true` if this `ICorDebugCode` represents code that was compiled in MSIL; otherwise, `false`.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
+ [out] `true` if this `ICorDebugCode` represents code that was compiled in MSIL; otherwise, `false`.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../get-started/system-requirements.md).  
+
  **Header:** CorDebug.idl, CorDebug.h  
-  
+
  **Library:** CorGuids.lib  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]
+ 

--- a/docs/framework/unmanaged-api/debugging/icordebugcode2-getcodechunks-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode2-getcodechunks-method.md
@@ -1,57 +1,60 @@
 ---
 title: "ICorDebugCode2::GetCodeChunks Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugCode2.GetCodeChunks"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugCode2::GetCodeChunks"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetCodeChunks method [.NET Framework debugging]"
   - "ICorDebugCode2::GetCodeChunks method [.NET Framework debugging]"
 ms.assetid: 210a2f02-2678-4555-bc4a-78a0408764c8
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCode2::GetCodeChunks Method
-Gets the chunks of code that this code object is composed of.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetCodeChunks (  
-    [in]  ULONG32     cbufSize,  
-    [out] ULONG32     *pcnumChunks,  
-    [out, size_is(cbufSize), length_is(*pcnumChunks)]   
-        CodeChunkInfo chunks[]  
-);  
-```  
-  
-## Parameters  
+
+Gets the chunks of code that this code object is composed of.
+
+## Syntax
+
+```cpp
+HRESULT GetCodeChunks (
+    [in]  ULONG32     cbufSize,
+    [out] ULONG32     *pcnumChunks,
+    [out, size_is(cbufSize), length_is(*pcnumChunks)]
+        CodeChunkInfo chunks[]
+);
+```
+
+## Parameters
+
  `cbufSize`  
- [in] Size of the `chunks` array.  
-  
+ [in] Size of the `chunks` array.
+
  `pcnumChunks`  
- [out] The number of chunks returned in the `chunks` array.  
-  
+ [out] The number of chunks returned in the `chunks` array.
+
  `chunks`  
- [out] An array of "CodeChunkInfo" structures, each of which represents a single chunk of code. If the value of `cbufSize` is 0, this parameter can be null.  
-  
-## Remarks  
- The code chunks will never overlap, and they will follow the order in which they would have been concatenated by [ICorDebugCode::GetCode](../../../../docs/framework/unmanaged-api/debugging/icordebugcode-getcode-method.md). A Microsoft intermediate language (MSIL) code object in the .NET Framework version 2.0 will comprise a single code chunk.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** CorDebug.idl, CorDebug.h  
-  
- **Library:** CorGuids.lib  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]  
-  
-## See also
+ [out] An array of "CodeChunkInfo" structures, each of which represents a single chunk of code. If the value of `cbufSize` is 0, this parameter can be null.
+
+## Remarks
+
+ The code chunks will never overlap, and they will follow the order in which they would have been concatenated by [ICorDebugCode::GetCode](icordebugcode-getcode-method.md). A Microsoft intermediate language (MSIL) code object in the .NET Framework version 2.0 will comprise a single code chunk.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../get-started/system-requirements.md).
+
+ **Header:** CorDebug.idl, CorDebug.h
+
+ **Library:** CorGuids.lib
+
+ **.NET Framework Versions:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]
+ 

--- a/docs/framework/unmanaged-api/debugging/icordebugcode2-getcompilerflags-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcode2-getcompilerflags-method.md
@@ -1,45 +1,47 @@
 ---
 title: "ICorDebugCode2::GetCompilerFlags Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugCode2.GetCompilerFlags"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugCode2::GetCompilerFlags"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "GetCompilerFlags method [.NET Framework debugging]"
   - "ICorDebugCode2::GetCompilerFlags method [.NET Framework debugging]"
 ms.assetid: 532e9dfd-d114-4c75-b952-1accce102643
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCode2::GetCompilerFlags Method
-Gets the flags that specify the conditions under which this code object was either just-in-time (JIT) compiled or generated using the native image generator (Ngen.exe).  
-  
-## Syntax  
-  
-```cpp  
-HRESULT GetCompilerFlags (  
-    [out] DWORD *pdwFlags  
-);  
-```  
-  
-## Parameters  
+
+Gets the flags that specify the conditions under which this code object was either just-in-time (JIT) compiled or generated using the native image generator (Ngen.exe).
+
+## Syntax
+
+```cpp
+HRESULT GetCompilerFlags (
+    [out] DWORD *pdwFlags
+);
+```
+
+## Parameters
+
  `pdwFlags`  
- [out] A pointer to a value of the [CorDebugJITCompilerFlags](../../../../docs/framework/unmanaged-api/debugging/cordebugjitcompilerflags-enumeration.md) enumeration that specifies the behavior of the JIT compiler or the native image generator.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** CorDebug.idl, CorDebug.h  
-  
- **Library:** CorGuids.lib  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]  
-  
-## See also
+ [out] A pointer to a value of the [CorDebugJITCompilerFlags](../../../../docs/framework/unmanaged-api/debugging/cordebugjitcompilerflags-enumeration.md) enumeration that specifies the behavior of the JIT compiler or the native image generator.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+
+ **Header:** CorDebug.idl, CorDebug.h
+
+ **Library:** CorGuids.lib
+
+ **.NET Framework Versions:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]
+ 

--- a/docs/framework/unmanaged-api/debugging/icordebugcodeenum-next-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcodeenum-next-method.md
@@ -1,54 +1,56 @@
 ---
 title: "ICorDebugCodeEnum::Next Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugCodeEnum.Next"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugCodeEnum::Next"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ICorDebugCodeEnum::Next method [.NET Framework debugging]"
   - "Next method, ICorDebugEnum interface [.NET Framework debugging]"
 ms.assetid: 644ece86-384d-4c63-9fba-52c789616ff7
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugCodeEnum::Next Method
-Gets the specified number of "ICorDebugCode" instances from the enumeration, starting at the current position.  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Next (  
-    [in] ULONG  celt,  
-    [out, size_is(celt), length_is(*pceltFetched)]  
-        ICorDebugCode *values[],  
-    [out] ULONG *pceltFetched  
-);  
-```  
-  
-## Parameters  
+
+Gets the specified number of "ICorDebugCode" instances from the enumeration, starting at the current position.
+
+## Syntax
+
+```cpp
+HRESULT Next (
+    [in] ULONG  celt,
+    [out, size_is(celt), length_is(*pceltFetched)]
+        ICorDebugCode *values[],
+    [out] ULONG *pceltFetched
+);
+```
+
+## Parameters
+
  `celt`  
- [in] The number of `ICorDebugCode` instances to be retrieved.  
-  
+ [in] The number of `ICorDebugCode` instances to be retrieved.
+
  `values`  
- [out] An array of pointers, each of which points to an `ICorDebugCode` object.  
-  
+ [out] An array of pointers, each of which points to an `ICorDebugCode` object.
+
  `pceltFetched`  
- [out] A pointer to the number of `ICorDebugCode` instances actually returned. This value may be null if `celt` is one.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** CorDebug.idl, CorDebug.h  
-  
- **Library:** CorGuids.lib  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]  
-  
-## See also
+ [out] A pointer to the number of `ICorDebugCode` instances actually returned. This value may be null if `celt` is one.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../get-started/system-requirements.md).
+
+ **Header:** CorDebug.idl, CorDebug.h
+
+ **Library:** CorGuids.lib
+
+ **.NET Framework Versions:** [!INCLUDE[net_current_v20plus](../../../../includes/net-current-v20plus-md.md)]
+ 

--- a/docs/framework/unmanaged-api/debugging/icordebugcontroller-cancommitchanges-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcontroller-cancommitchanges-method.md
@@ -1,24 +1,23 @@
 ---
 title: "ICorDebugController::CanCommitChanges Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugController.CanCommitChanges"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugController::CanCommitChanges"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ICorDebugController::CanCommitChanges method [.NET Framework debugging]"
   - "CanCommitChanges method [.NET Framework debugging]"
 ms.assetid: 7050e94b-f197-4ffd-88fa-ed2ecdf19663
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugController::CanCommitChanges Method
-`CanCommitChanges` is obsolete. Do not call this method.  
-  
-## See also
+
+`CanCommitChanges` is obsolete. Do not call this method.

--- a/docs/framework/unmanaged-api/debugging/icordebugcontroller-commitchanges-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcontroller-commitchanges-method.md
@@ -1,24 +1,23 @@
 ---
 title: "ICorDebugController::CommitChanges Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugController.CommitChanges"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugController::CommitChanges"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "ICorDebugController::CommitChanges method [.NET Framework debugging]"
   - "CommitChanges method [.NET Framework debugging]"
 ms.assetid: f8e38bf6-0312-4517-bed5-42031ed86331
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugController::CommitChanges Method
-`CommitChanges` is obsolete. Do not call this method.  
-  
-## See also
+
+`CommitChanges` is obsolete. Do not call this method.

--- a/docs/framework/unmanaged-api/debugging/icordebugcontroller-continue-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcontroller-continue-method.md
@@ -37,13 +37,13 @@ HRESULT Continue (
 
 ## Remarks
 
- `Continue` continues the process after a call to the `ICorDebugController::Stop` method.
+`Continue` continues the process after a call to the `ICorDebugController::Stop` method.
 
- When doing mixed-mode debugging, do not call `Continue` on the Win32 event thread unless you are continuing from an out-of-band event.
+When doing mixed-mode debugging, do not call `Continue` on the Win32 event thread unless you are continuing from an out-of-band event.
 
- An *in-band event* is either a managed event or a normal unmanaged event during which the debugger supports interaction with the managed state of the process. In this case, the debugger receives the [ICorDebugUnmanagedCallback::DebugEvent](icordebugunmanagedcallback-debugevent-method.md) callback with its `fOutOfBand` parameter set to `false`.
+An *in-band event* is either a managed event or a normal unmanaged event during which the debugger supports interaction with the managed state of the process. In this case, the debugger receives the [ICorDebugUnmanagedCallback::DebugEvent](icordebugunmanagedcallback-debugevent-method.md) callback with its `fOutOfBand` parameter set to `false`.
   
- An *out-of-band event* is an unmanaged event during which interaction with the managed state of the process is impossible while the process is stopped due to the event. In this case, the debugger receives the `ICorDebugUnmanagedCallback::DebugEvent` callback with its `fOutOfBand` parameter set to `true`.
+An *out-of-band event* is an unmanaged event during which interaction with the managed state of the process is impossible while the process is stopped due to the event. In this case, the debugger receives the `ICorDebugUnmanagedCallback::DebugEvent` callback with its `fOutOfBand` parameter set to `true`.
 
 ## Requirements
 

--- a/docs/framework/unmanaged-api/debugging/icordebugcontroller-continue-method.md
+++ b/docs/framework/unmanaged-api/debugging/icordebugcontroller-continue-method.md
@@ -1,54 +1,57 @@
 ---
 title: "ICorDebugController::Continue Method"
 ms.date: "03/30/2017"
-api_name: 
+api_name:
   - "ICorDebugController.Continue"
-api_location: 
+api_location:
   - "mscordbi.dll"
-api_type: 
+api_type:
   - "COM"
-f1_keywords: 
+f1_keywords:
   - "ICorDebugController::Continue"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "Continue method [.NET Framework debugging]"
   - "ICorDebugController::Continue method [.NET Framework debugging]"
 ms.assetid: 8684cd06-ad3e-48ef-832e-15320e1f43a2
-topic_type: 
+topic_type:
   - "apiref"
 author: "rpetrusha"
 ms.author: "ronpet"
 ---
 # ICorDebugController::Continue Method
-Resumes execution of managed threads after a call to [Stop Method](../../../../docs/framework/unmanaged-api/debugging/icordebugcontroller-stop-method.md).  
-  
-## Syntax  
-  
-```cpp  
-HRESULT Continue (  
-    [in] BOOL fIsOutOfBand  
-);  
-```  
-  
-## Parameters  
+
+Resumes execution of managed threads after a call to [Stop Method](icordebugcontroller-stop-method.md).
+
+## Syntax
+
+```cpp
+HRESULT Continue (
+    [in] BOOL fIsOutOfBand
+);
+```
+
+## Parameters
+
  `fIsOutOfBand`  
- [in] Set to `true` if continuing from an out-of-band event; otherwise, set to `false`.  
+ [in] Set to `true` if continuing from an out-of-band event; otherwise, set to `false`.
+
+## Remarks
+
+ `Continue` continues the process after a call to the `ICorDebugController::Stop` method.
+
+ When doing mixed-mode debugging, do not call `Continue` on the Win32 event thread unless you are continuing from an out-of-band event.
+
+ An *in-band event* is either a managed event or a normal unmanaged event during which the debugger supports interaction with the managed state of the process. In this case, the debugger receives the [ICorDebugUnmanagedCallback::DebugEvent](icordebugunmanagedcallback-debugevent-method.md) callback with its `fOutOfBand` parameter set to `false`.
   
-## Remarks  
- `Continue` continues the process after a call to the `ICorDebugController::Stop` method.  
-  
- When doing mixed-mode debugging, do not call `Continue` on the Win32 event thread unless you are continuing from an out-of-band event.  
-  
- An *in-band event* is either a managed event or a normal unmanaged event during which the debugger supports interaction with the managed state of the process. In this case, the debugger receives the [ICorDebugUnmanagedCallback::DebugEvent](../../../../docs/framework/unmanaged-api/debugging/icordebugunmanagedcallback-debugevent-method.md) callback with its `fOutOfBand` parameter set to `false`.  
-  
- An *out-of-band event* is an unmanaged event during which interaction with the managed state of the process is impossible while the process is stopped due to the event. In this case, the debugger receives the `ICorDebugUnmanagedCallback::DebugEvent` callback with its `fOutOfBand` parameter set to `true`.  
-  
-## Requirements  
- **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).  
-  
- **Header:** CorDebug.idl, CorDebug.h  
-  
- **Library:** CorGuids.lib  
-  
- **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]  
-  
-## See also
+ An *out-of-band event* is an unmanaged event during which interaction with the managed state of the process is impossible while the process is stopped due to the event. In this case, the debugger receives the `ICorDebugUnmanagedCallback::DebugEvent` callback with its `fOutOfBand` parameter set to `true`.
+
+## Requirements
+
+ **Platforms:** See [System Requirements](../../../../docs/framework/get-started/system-requirements.md).
+
+ **Header:** CorDebug.idl, CorDebug.h
+
+ **Library:** CorGuids.lib
+
+ **.NET Framework Versions:** [!INCLUDE[net_current_v10plus](../../../../includes/net-current-v10plus-md.md)]
+ 

--- a/docs/standard/exceptions/how-to-use-the-try-catch-block-to-catch-exceptions.md
+++ b/docs/standard/exceptions/how-to-use-the-try-catch-block-to-catch-exceptions.md
@@ -21,7 +21,7 @@ Place any code statements that might raise or throw an exception in a `try` bloc
 In the following example, a <xref:System.IO.StreamReader> opens a file called *data.txt* and retrieves a line from the file. Since the code might throw any of three exceptions, it's placed in a `try` block. Three `catch` blocks catch the exceptions and handle them by displaying the results to the console.
 
 [!code-csharp[CatchException#3](~/samples/snippets/csharp/VS_Snippets_CLR/CatchException/CS/catchexception2.cs#3)]
-[!code-vb[CatchException#3](~/samples/snippets/visualbasic/VS_Snippets_CLR/CatchException/VB/catchexception2.vb#3)]  
+[!code-vb[CatchException#3](~/samples/snippets/visualbasic/VS_Snippets_CLR/CatchException/VB/catchexception2.vb#3)]
 
 The Common Language Runtime (CLR) catches exceptions not handled by `catch` blocks. If an exception is caught by the CLR, one of the following results may occur depending on your CLR configuration:
 
@@ -34,5 +34,5 @@ The Common Language Runtime (CLR) catches exceptions not handled by `catch` bloc
 
 ## See also
 
-[Exceptions](index.md)  
-[Handling I/O errors in .NET](../io/handling-io-errors.md)
+- [Exceptions](index.md)
+- [Handling I/O errors in .NET](../io/handling-io-errors.md)


### PR DESCRIPTION
I've gone through the files that matched this regex: `# see also(?!\s*-)` and manually updated the see also section depending on the situation. I've also removed some redundant path segments (Contributes to: #10653) and extra spaces.

* This PR doesn't include all files matching the mentioned regex, I only went through 20 files to make it easier for review. and will do the other files in about 2 other PRs