### PR TITLE
Update some errors that are not used by roslyn

### DIFF
--- a/docs/csharp/language-reference/compiler-messages/cs1933.md
+++ b/docs/csharp/language-reference/compiler-messages/cs1933.md
@@ -9,32 +9,35 @@ ms.assetid: 80d719d3-1b39-44ec-90fd-039ae5570f01
 ---
 # Compiler Error CS1933
 
-Expression cannot contain query expressions  
-  
- Some variables cannot be initialized with a query expression. Constants cannot be initialized with query expressions because constants may only be initialized with some combination of literals, named constants, and mathematical operators.  
-  
+Expression cannot contain query expressions
+
+ Some variables cannot be initialized with a query expression. Constants cannot be initialized with query expressions because constants may only be initialized with some combination of literals, named constants, and mathematical operators.
+
 ## To correct this error  
-  
-1. Remove the modifier from the query variable.  
-  
+
+1. Remove the modifier from the query variable.
+
 ## Example
 
- The following example generates CS1933:  
+ The following example generates CS1933:
 
 ```csharp
-// cs1933.cs  
-using System.Linq;  
-using System.Collections;  
-  
-class P  
-{  
-    const IEnumerable e = from x in new[] { 1, 2, 3 } select x; // CS1933  
-    static int Main()  
-    {  
-        return 1;  
-    }  
-}  
+// cs1933.cs
+using System.Linq;
+using System.Collections;
+
+class Program
+{
+    const IEnumerable e = from x in new[] { 1, 2, 3 } select x; // CS1933
+    static int Main()
+    {
+        return 1;
+    }
+}
 ```
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn. The previous example generates CS0133 when compiled with Roslyn.
 
 ## See also
 

--- a/docs/csharp/misc/cs0043.md
+++ b/docs/csharp/misc/cs0043.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Error CS0043"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0043"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0043"
 ms.assetid: 471e2cf8-4275-4618-ad20-408f829d2119
 ---
 # Compiler Error CS0043
-PDB file 'file' has an incorrect or out-of-date format. Delete it and rebuild.  
-  
+
+PDB file 'file' has an incorrect or out-of-date format. Delete it and rebuild.
+
  Delete the .pdb file for this compilation and recompile.
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0410.md
+++ b/docs/csharp/misc/cs0410.md
@@ -8,25 +8,31 @@ helpviewer_keywords:
 ms.assetid: a8b11042-9119-465e-abf6-235cbc7b8db5
 ---
 # Compiler Error CS0410
-No overload for 'method' has the correct parameter and return types  
-  
- This error occurs if you try to instantiate a delegate with a function that has the wrong parameter types. The parameter types of the delegate must match the function that you are assigning to the delegate.  
-  
-## Example  
- The following example generates CS0410:  
-  
-```csharp  
-// CS0410.cs  
-// compile with: /langversion:ISO-1  
-  
-class Test  
-{  
-    delegate void D(double d );  
-    static void F(int i) { }  
-  
-    static void Main()  
-    {  
-        D d = new D(F);  // CS0410  
-    }  
-}  
+
+No overload for 'method' has the correct parameter and return types
+
+ This error occurs if you try to instantiate a delegate with a function that has the wrong parameter types. The parameter types of the delegate must match the function that you are assigning to the delegate.
+
+## Example
+
+ The following example generates CS0410:
+
+```csharp
+// CS0410.cs
+// compile with: /langversion:ISO-1
+
+class Test
+{
+    delegate void D(double d );
+    static void F(int i) { }
+
+    static void Main()
+    {
+        D d = new D(F);  // CS0410
+    }
+}
 ```
+
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn. The previous example generates CS0123 when compiled with Roslyn.

--- a/docs/csharp/misc/cs0422.md
+++ b/docs/csharp/misc/cs0422.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Warning (level 4) CS0422"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0422"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0422"
 ms.assetid: 5021e260-c0ff-46af-95ba-e9abbd9a086e
 ---
 # Compiler Warning (level 4) CS0422
-The /incremental option is no longer supported  
-  
+
+The /incremental option is no longer supported
+
  Incremental compilation (**/incr** or **/incremental**) is not supported in C# 2.0.
+ 
+> [!NOTE]
+> This compiler warning is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0444.md
+++ b/docs/csharp/misc/cs0444.md
@@ -8,10 +8,14 @@ helpviewer_keywords:
 ms.assetid: 5beb8c06-39d3-4b59-a7c3-5590200bd43d
 ---
 # Compiler Warning (level 2) CS0444
-Predefined type 'type name 1' was not found in 'System namespace 1' but was found in 'System namespace 2'  
-  
- A predefined object such as <xref:System.Int32> was not found where the compiler expected to find it, but instead found it in 'System namespace 2'.  
-  
- The error could indicate that the .NET Framework is installed incorrectly. To fix this, reinstall the .NET Framework.  
-  
+
+Predefined type 'type name 1' was not found in 'System namespace 1' but was found in 'System namespace 2'
+
+ A predefined object such as <xref:System.Int32> was not found where the compiler expected to find it, but instead found it in 'System namespace 2'.
+
+ The error could indicate that the .NET Framework is installed incorrectly. To fix this, reinstall the .NET Framework.
+
  If you are writing your own base class libraries, you might also encounter this error. In this case, to resolve the error, rebuild mscorlib.
+ 
+> [!NOTE]
+> This compiler warning is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0447.md
+++ b/docs/csharp/misc/cs0447.md
@@ -1,42 +1,49 @@
 ---
 title: "Compiler Error CS0447"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0447"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0447"
 ms.assetid: a25486c5-e9bf-4528-8533-c1aaab22ace0
 ---
 # Compiler Error CS0447
-Attributes cannot be used on type arguments, only on type parameters  
-  
- This error occurs when you apply an attribute to a type argument that occurs in an invocation statement. It is acceptable to apply an attribute to a type parameter in a class or method declaration statement such as the following:  
-  
-```csharp  
-class C<[some attribute] T> {…}  
-```  
-  
- The following line of code will generate this error. It is assumed that the class `C`, defined in the previous line of code, has a static method called `MyStaticMethod`.  
-  
-```csharp  
-C<[some attribute] T>.MyStaticMethod();  
-```  
-  
-## Example  
- The following code generates error CS0447.  
-  
-```csharp  
-// CS0447.cs  
-using System;  
-namespace Test41  
-{  
-    public interface I<A>   
-    {  
-        void Meth<B>();  
-    }  
-    public class B : I<int>   
-    {  
-        void I<[Test] int>.Meth<X>() { }  // CS0447  
-    }  
-}  
+
+Attributes cannot be used on type arguments, only on type parameters
+
+ This error occurs when you apply an attribute to a type argument that occurs in an invocation statement. It is acceptable to apply an attribute to a type parameter in a class or method declaration statement such as the following:
+
+```csharp
+class C<[some attribute] T> {…}
 ```
+
+ The following line of code will generate this error. It is assumed that the class `C`, defined in the previous line of code, has a static method called `MyStaticMethod`.
+
+```csharp
+C<[some attribute] T>.MyStaticMethod();
+```
+
+## Example
+
+ The following code generates error CS0447:
+
+```csharp
+// CS0447.cs
+using System;
+
+namespace Test41
+{
+    public interface I<A>
+    {
+        void Meth<B>();
+    }
+    public class B : I<int>
+    {
+        void I<[Test] int>.Meth<X>() { }  // CS0447
+    }
+}
+```
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.
+

--- a/docs/csharp/misc/cs0459.md
+++ b/docs/csharp/misc/cs0459.md
@@ -1,40 +1,45 @@
 ---
 title: "Compiler Error CS0459"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0459"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0459"
 ms.assetid: 01b058dd-8d65-4e9d-9de1-d47f9488d22a
 ---
 # Compiler Error CS0459
-Cannot take the address of a read-only local variable  
-  
- There are three common scenarios in the C# language that generate read-only local variables: `foreach`, `using`, and `fixed`. In each of these cases, you are not allowed to write to the read-only local variable, or to take its address. This error is generated when the compiler realizes you are trying to take the address of a read-only local variable.  
-  
-## Example  
- The following example generates CS0459 when an attempt is made to take the address of a read-only local variable in a `foreach` loop and in a `fixed` statement block.  
-  
-```csharp  
-// CS0459.cs  
-// compile with: /unsafe  
-  
-class A  
-{  
-    public unsafe void M1()  
-    {  
-        int[] ints = new int[] { 1, 2, 3 };  
-        foreach (int i in ints)  
-        {  
-            int *j = &i;  // CS0459  
-        }  
-  
-        fixed (int *i = &_i)  
-        {  
-            int **j = &i;  // CS0459  
-        }  
-    }  
-  
-    private int _i = 0;  
-}  
+
+Cannot take the address of a read-only local variable
+
+ There are three common scenarios in the C# language that generate read-only local variables: `foreach`, `using`, and `fixed`. In each of these cases, you are not allowed to write to the read-only local variable, or to take its address. This error is generated when the compiler realizes you are trying to take the address of a read-only local variable.
+
+## Example
+
+ The following example generates CS0459 when an attempt is made to take the address of a read-only local variable in a `foreach` loop and in a `fixed` statement block:
+
+```csharp
+// CS0459.cs
+// compile with: /unsafe
+
+class Program
+{
+    public unsafe void M1()
+    {
+        int[] ints = new int[] { 1, 2, 3 };
+        foreach (int i in ints)
+        {
+            int *j = &i;  // CS0459
+        }
+
+        fixed (int *i = &_i)
+        {
+            int **j = &i;  // CS0459
+        }
+    }
+
+    private int _i = 0;
+}
 ```
+
+> [!NOTE]
+> Roslyn compiler was updated and this compiler error was removed starting with Visual Studio 2017 15.5, so the previous code would compile successfully with this version and later.

--- a/docs/csharp/misc/cs0468.md
+++ b/docs/csharp/misc/cs0468.md
@@ -1,13 +1,17 @@
 ---
-title: "Compiler Error CS0468"
+title: "Compiler Warning CS0468"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0468"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0468"
 ms.assetid: 1ec4f8af-0b32-4ea9-8bc0-bb9e52b9457b
 ---
-# Compiler Error CS0468
-Ambiguity between type 'type1' and type 'type2'  
-  
+# Compiler Warning CS0468
+
+Ambiguity between type 'type1' and type 'type2'
+
  This error is generated when there are two types in the assembly being compiled that have the same fully qualified name. This could occur if they are both in added modules or one is in an added module and one in source.
+ 
+> [!NOTE]
+> This compiler warning is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0468.md
+++ b/docs/csharp/misc/cs0468.md
@@ -1,5 +1,5 @@
 ---
-title: "Compiler Warning CS0468"
+title: "Compiler Error CS0468"
 ms.date: 07/20/2015
 f1_keywords:
   - "CS0468"
@@ -7,11 +7,11 @@ helpviewer_keywords:
   - "CS0468"
 ms.assetid: 1ec4f8af-0b32-4ea9-8bc0-bb9e52b9457b
 ---
-# Compiler Warning CS0468
+# Compiler Error CS0468
 
 Ambiguity between type 'type1' and type 'type2'
 
  This error is generated when there are two types in the assembly being compiled that have the same fully qualified name. This could occur if they are both in added modules or one is in an added module and one in source.
  
 > [!NOTE]
-> This compiler warning is no longer used in Roslyn.
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0471.md
+++ b/docs/csharp/misc/cs0471.md
@@ -1,32 +1,36 @@
 ---
 title: "Compiler Error CS0471"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0471"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0471"
 ms.assetid: 3b666461-c57b-45f4-83d3-a23786e29ae9
 ---
 # Compiler Error CS0471
-The method 'name' is not a generic method. If you intended an expression list, use parentheses around the < expression.  
-  
- This error is generated when your code contains an expression list without parentheses.  
-  
-## Example  
- The following example generates CS0471.  
-  
-```csharp  
-// CS0471.cs  
-// compile with: /t:library  
-class Test  
-{  
-    public void F(bool x, bool y) {}  
-    public void F1()  
-    {  
-        int a = 1, b = 2, c = 3;  
-        F(a<b, c>(3));    // CS0471  
-        // To resolve, try the following instead:  
-        // F((a<b), c>(3));  
-    }  
-}  
+
+The method 'name' is not a generic method. If you intended an expression list, use parentheses around the < expression.
+
+ This error is generated when your code contains an expression list without parentheses.
+
+## Example
+ The following example generates CS0471:
+
+```csharp
+// CS0471.cs
+// compile with: /t:library
+class Test
+{
+    public void F(bool x, bool y) {}
+    public void F1()
+    {
+        int a = 1, b = 2, c = 3;
+        F(a<b, c>(3));    // CS0471
+        // To resolve, try the following instead:
+        // F((a<b), c>(3));
+    }
+}
 ```
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn. The previous example should compile successfully.

--- a/docs/csharp/misc/cs0583.md
+++ b/docs/csharp/misc/cs0583.md
@@ -1,15 +1,19 @@
 ---
 title: "Compiler Error CS0583"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0583"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0583"
 ms.assetid: 67a9b339-af79-42a3-afe7-b1732bd43f8f
 ---
 # Compiler Error CS0583
-Internal Compiler Error. An internal error has occurred in the compiler. To work around this problem, try simplifying or changing the program near the locations listed below. Locations at the top of the list are closer to the point at which the internal error occurred. Errors such as this can be reported to Microsoft by using the /errorreport option.  
-  
- Please create a bug report file with the '/bugreport' option, and submit the report to your assigned problem reporting contact.  
-  
+
+Internal Compiler Error. An internal error has occurred in the compiler. To work around this problem, try simplifying or changing the program near the locations listed below. Locations at the top of the list are closer to the point at which the internal error occurred. Errors such as this can be reported to Microsoft by using the /errorreport option.
+
+ Please create a bug report file with the '/bugreport' option, and submit the report to your assigned problem reporting contact.
+
  Use the [/bugreport](../language-reference/compiler-options/bugreport-compiler-option.md) compiler option to capture the problem.
+ 
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0584.md
+++ b/docs/csharp/misc/cs0584.md
@@ -8,6 +8,10 @@ helpviewer_keywords:
 ms.assetid: f9af5795-ffd0-4dc3-b4c9-0a24b8a0076a
 ---
 # Compiler Error CS0584
-Internal Compiler Error: stage 'stage' symbol 'symbol'  
+
+Internal Compiler Error: stage 'stage' symbol 'symbol'
   
  Try to determine whether the compiler is failing because of its inability to parse unexpected syntax. If that is not the case, try [Talk to Us](/visualstudio/ide/talk-to-us).
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0585.md
+++ b/docs/csharp/misc/cs0585.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Error CS0585"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0585"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0585"
 ms.assetid: e2e23a07-ea37-4dd9-aca6-5714fdbc4ef4
 ---
 # Compiler Error CS0585
-Internal Compiler Error: stage 'stage'  
-  
+
+Internal Compiler Error: stage 'stage'
+
  Try to determine if the compiler is failing due to its inability to parse unexpected syntax. If that is not the case, try [Talk to Us](/visualstudio/ide/talk-to-us).
+ 
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0586.md
+++ b/docs/csharp/misc/cs0586.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Error CS0586"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0586"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0586"
 ms.assetid: cda1f0ea-8118-4da1-b37f-51be7da71cb8
 ---
 # Compiler Error CS0586
-Internal Compiler Error: stage 'stage'  
-  
+
+Internal Compiler Error: stage 'stage'
+
  Try to determine if the compiler is failing due to its inability to parse unexpected syntax. If that is not the case, try [Talk to Us](/visualstudio/ide/talk-to-us).
+ 
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0587.md
+++ b/docs/csharp/misc/cs0587.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Error CS0587"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0587"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0587"
 ms.assetid: a19c329a-9240-4ccf-bf4a-2d3c070ee68b
 ---
 # Compiler Error CS0587
-Internal Compiler Error: stage 'stage'  
-  
+
+Internal Compiler Error: stage 'stage'
+
  Try to determine if the compiler is failing due to its inability to parse unexpected syntax. If this is not the case, try [Talk to Us](/visualstudio/ide/talk-to-us).
+ 
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0588.md
+++ b/docs/csharp/misc/cs0588.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Error CS0588"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0588"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0588"
 ms.assetid: 5dea3fbc-c9ca-47c9-aa83-c9af43fd155b
 ---
 # Compiler Error CS0588
-Internal Compiler Error: stage 'LEX'  
-  
+
+Internal Compiler Error: stage 'LEX'
+
  Try to determine whether the compiler is failing because of its inability to parse unexpected syntax. If this is not the case, try [Talk to Us](/visualstudio/ide/talk-to-us).
+ 
+> [!NOTE]
+> This compiler error is no longer used in Roslyn. 

--- a/docs/csharp/misc/cs0589.md
+++ b/docs/csharp/misc/cs0589.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Error CS0589"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0589"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0589"
 ms.assetid: dbe1aa49-d793-4096-ae77-141c724a5813
 ---
 # Compiler Error CS0589
-Internal Compiler Error: stage 'PARSE'  
-  
+
+Internal Compiler Error: stage 'PARSE'
+
  Try to determine if the compiler is failing due to its inability to parse unexpected syntax. If that is not the case, try [Talk to Us](/visualstudio/ide/talk-to-us).
+ 
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0602.md
+++ b/docs/csharp/misc/cs0602.md
@@ -1,13 +1,17 @@
 ---
 title: "Compiler Warning (level 1) CS0602"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0602"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0602"
 ms.assetid: 18d95dca-1560-445b-892b-fa3b8d288d71
 ---
 # Compiler Warning (level 1) CS0602
-The feature 'old_feature' is deprecated. Please use 'new_feature' instead  
-  
+
+The feature 'old_feature' is deprecated. Please use 'new_feature' instead
+
  A language feature used in your code (*old_feature*) is still supported, but that support may be removed in a future release. Instead, you should use the recommended syntax (*new_feature*).
+ 
+> [!NOTE]
+> This compiler warning is no longer used in Roslyn.

--- a/docs/csharp/misc/cs0609.md
+++ b/docs/csharp/misc/cs0609.md
@@ -1,57 +1,61 @@
 ---
 title: "Compiler Error CS0609"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0609"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0609"
 ms.assetid: f3ff07a6-1190-4a1c-86a5-f607e1a32b78
 ---
 # Compiler Error CS0609
-Cannot set the IndexerName attribute on an indexer marked override  
-  
- The name attribute (**IndexerNameAttribute**) cannot be applied to an indexed property that is an override. For more information, see [Indexers](../programming-guide/indexers/index.md).  
-  
- The following sample generates CS0609:  
-  
-```csharp  
-// CS0609.cs  
-using System;  
-using System.Runtime.CompilerServices;  
-  
-public class idx  
-{  
-   public virtual int this[int iPropIndex]  
-   {  
-      get  
-      {  
-         return 0;  
-      }  
-      set  
-      {  
-      }  
-   }  
-}  
-  
-public class MonthDays : idx  
-{  
-   [IndexerName("MonthInfoIndexer")]   // CS0609, delete to resolve this CS0609  
-   public override int this[int iPropIndex]  
-   {  
-      get  
-      {  
-         return 0;  
-      }  
-      set  
-      {  
-      }  
-   }  
-}  
-  
-public class test  
-{  
-   public static void Main( string[] args )  
-   {  
-   }  
-}  
+
+Cannot set the IndexerName attribute on an indexer marked override
+
+ The name attribute (**IndexerNameAttribute**) cannot be applied to an indexed property that is an override. For more information, see [Indexers](../programming-guide/indexers/index.md).
+
+ The following sample generates CS0609:
+
+```csharp
+// CS0609.cs
+using System;
+using System.Runtime.CompilerServices;
+
+public class idx
+{
+   public virtual int this[int iPropIndex]
+   {
+      get
+      {
+         return 0;
+      }
+      set
+      {
+      }
+   }
+}
+
+public class MonthDays : idx
+{
+   [IndexerName("MonthInfoIndexer")]   // CS0609, delete to resolve this CS0609
+   public override int this[int iPropIndex]
+   {
+      get
+      {
+         return 0;
+      }
+      set
+      {
+      }
+   }
+}
+
+public class test
+{
+   public static void Main(string[] args)
+   {
+   }
+}
 ```
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn. The previous code should compile successfully.

--- a/docs/csharp/misc/cs5000.md
+++ b/docs/csharp/misc/cs5000.md
@@ -8,6 +8,10 @@ helpviewer_keywords:
 ms.assetid: 8751c338-8cf4-41b3-9565-f65ffda4744a
 ---
 # Compiler Warning (level 1) CS5000
-Unknown compiler option '/option'  
-  
+
+Unknown compiler option '/option'
+
  An invalid [compiler option](../language-reference/compiler-options/index.md) was specified.
+
+> [!NOTE]
+> This compiler error is no longer used in Roslyn.


### PR DESCRIPTION
I'm not sure if the note addition is correct or these pages should be just deleted ?

* See [ErrorCode.cs Line 50](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs#L50), [ErrorCode.cs Line 1142](https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs#L1142) and https://github.com/dotnet/roslyn/pull/22400

There are much more pages than I've changed that require an attention.