### PR TITLE
Update cs0041.md

### DIFF
--- a/docs/csharp/misc/cs0041.md
+++ b/docs/csharp/misc/cs0041.md
@@ -1,9 +1,9 @@
 ---
 title: "Compiler Error CS0041"
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "CS0041"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "CS0041"
 ms.assetid: 80dbfe00-8cdb-4275-9574-8a215c7139d6
 ---

--- a/docs/csharp/misc/cs0041.md
+++ b/docs/csharp/misc/cs0041.md
@@ -8,6 +8,5 @@ helpviewer_keywords:
 ms.assetid: 80dbfe00-8cdb-4275-9574-8a215c7139d6
 ---
 # Compiler Error CS0041
-The fully qualified name for 'type' is too long for debug information. Compile without '/debug' option.  
-  
- This error can occur when using the [/debug](../language-reference/compiler-options/debug-compiler-option.md) compiler option. If you encounter this error, try to delete the PDB files in the bin directory and recompiling. If you are still encountering this error, you may have to repair or reinstall Visual Studio.
+
+Unexpected error writing debug information -- '{error}'


### PR DESCRIPTION
The old content of the article was about `CS0811`, not `CS0041`.

The following two files from roslyn repo are much helpful to determine the error codes and the corresponding error message:

https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/CSharpResources.resx
https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs#L50