### PR TITLE
Match docs text with code

### DIFF
--- a/docs/csharp/language-reference/keywords/char.md
+++ b/docs/csharp/language-reference/keywords/char.md
@@ -2,10 +2,10 @@
 title: "char keyword - C# Reference"
 ms.custom: seodec18
 ms.date: 07/20/2015
-f1_keywords: 
+f1_keywords:
   - "char"
   - "char_CSharpKeyword"
-helpviewer_keywords: 
+helpviewer_keywords:
   - "char data type [C#]"
 ms.assetid: b51cf4fb-124c-4067-af48-afbac122b228
 ---
@@ -21,7 +21,7 @@ The `char` keyword is used to declare an instance of the <xref:System.Char?displ
 
 ## Literals
 
-Constants of the `char` type can be written as character literals, hexadecimal escape sequence, or Unicode representation. You can also cast the integral character codes. In the following example four `char` variables are initialized with the same character `X`:
+Constants of the `char` type can be written as character literals, hexadecimal escape sequence, or Unicode representation. You can also cast the integral character codes. In the following example, the four elements of an array of `char` are initialized with the same character `X`:
 
 [!code-csharp[csrefKeywordsTypes#19](~/samples/snippets/csharp/VS_Snippets_VBCSharp/csrefKeywordsTypes/CS/keywordsTypes.cs#19)]
 


### PR DESCRIPTION
The docs text was inaccurate and mismatching the code snippet.