### PR TITLE
Fix localization issue

### DIFF
--- a/docs/standard/exceptions/how-to-create-localized-exception-messages.md
+++ b/docs/standard/exceptions/how-to-create-localized-exception-messages.md
@@ -77,12 +77,16 @@ The problem with the previous line is that `"The student cannot be found."` is j
 To create the localized exception messages:
 
 1. Create a new folder named *Resources* to hold the resource files.
-1. Add a new resource file to it. To do that in Visual Studio, right-click the folder in **Solution Explorer**, and select **Add** -> **New Item** -> **Resources File**. Name the file *ExceptionMessages.resx*. This is the default resources file.
+1. Add a new resource file to it. To do that in Visual Studio, right-click the folder in **Solution Explorer**, and select **Add** > **New Item** > **Resources File**. Name the file *ExceptionMessages.resx*. This is the default resources file.
 1. Add a name/value pair for your exception message, like the following image shows:
- ![Add resources to the default culture](media/add-resources-to-default-culture.jpg)
+
+   ![Add resources to the default culture](media/add-resources-to-default-culture.jpg)
+
 1. Add a new resource file for French. Name it *ExceptionMessages.fr-FR.resx*.
 1. Add a name/value pair for the exception message again, but with a French value:
- ![Add resources to the fr-FR culture](media/add-resources-to-fr-culture.jpg)
+
+   ![Add resources to the fr-FR culture](media/add-resources-to-fr-culture.jpg)
+
 1. After you build the project, the build output folder should contain the *fr-FR* folder with a *.dll* file, which is the satellite assembly.
 1. You throw the exception with code like the following:
 

--- a/docs/standard/exceptions/how-to-create-localized-exception-messages.md
+++ b/docs/standard/exceptions/how-to-create-localized-exception-messages.md
@@ -71,7 +71,7 @@ You have created a custom exception, and you can throw it anywhere with code lik
 throw new StudentNotFoundException("The student cannot be found.", "John");
 ```
 
-The problem with the previous line is that "The student cannot be found." is just a constant string. In a localized application, you want to have different messages depending on user culture.
+The problem with the previous line is that `"The student cannot be found."` is just a constant string. In a localized application, you want to have different messages depending on user culture.
 [Satellite Assemblies](../../framework/resources/creating-satellite-assemblies-for-desktop-apps.md) are a good way to do that. A satellite assembly is a .dll that contains resources for a specific language. When you ask for a specific resources at run time, the CLR finds that resource depending on user culture. If no satellite assembly is found for that culture, the resources of the default culture are used.
 
 To create the localized exception messages:


### PR DESCRIPTION
`"The student cannot be found."` this shouldn't be translated, so I put it between back ticks.

Another problem that I don't know how to solve it is the images appear in the English version only.

Screenshots:

English:
![image](https://user-images.githubusercontent.com/31348972/65821247-5e9bf780-e233-11e9-9708-a104ed91b41c.png)

French:
![image](https://user-images.githubusercontent.com/31348972/65821250-6c517d00-e233-11e9-8f70-1236f75fb097.png)
