### PR TITLE
Add explanation for using await over Result

### DIFF
--- a/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
+++ b/docs/csharp/programming-guide/concepts/async/start-multiple-async-tasks-and-process-them-as-they-complete.md
@@ -65,7 +65,7 @@ In the MainWindow.xaml.cs file of the project, make the following changes to the
         downloadTasks.Remove(firstFinishedTask);
         ```
 
-    3. Awaits `firstFinishedTask`, which is returned by a call to `ProcessURLAsync`. The `firstFinishedTask` variable is a <xref:System.Threading.Tasks.Task%601> where `TReturn` is an integer. The task is already complete, but you await it to retrieve the length of the downloaded website, as the following example shows.
+    3. Awaits `firstFinishedTask`, which is returned by a call to `ProcessURLAsync`. The `firstFinishedTask` variable is a <xref:System.Threading.Tasks.Task%601> where `TReturn` is an integer. The task is already complete, but you await it to retrieve the length of the downloaded website, as the following example shows. If the task is faulted, `await` will throw the first child exception stored in the `AggregateException`, unlike reading the `Result` property which would throw the `AggregateException`.
 
         ```csharp
         int length = await firstFinishedTask;


### PR DESCRIPTION
## Summary

Add explanation for using await over Result when reading the value of a completed task.

Fixes #12071
