### PR TITLE
Replace usage of Resolve with GetHostEntry

### DIFF
--- a/docs/framework/network-programming/listening-with-sockets.md
+++ b/docs/framework/network-programming/listening-with-sockets.md
@@ -24,13 +24,13 @@ Listener or server sockets open a port on the network and then wait for a client
  The following example creates an <xref:System.Net.IPEndPoint> for a server by combining the first IP address returned by **Dns** for the host computer with a port number chosen from the registered port numbers range.  
   
 ```vb  
-Dim ipHostInfo As IPHostEntry = Dns.Resolve(Dns.GetHostName())  
+Dim ipHostInfo As IPHostEntry = Dns.GetHostEntry(Dns.GetHostName())  
 Dim ipAddress As IPAddress = ipHostInfo.AddressList(0)  
 Dim localEndPoint As New IPEndPoint(ipAddress, 11000)  
 ```  
   
 ```csharp  
-IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName());  
+IPHostEntry ipHostInfo = Dns.GetHostEntry(Dns.GetHostName());  
 IPAddress ipAddress = ipHostInfo.AddressList[0];  
 IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 11000);  
 ```  


### PR DESCRIPTION
## Summary

Dns.Resolve is obsolete, the docs advise to use Dns.GetHostEntry instead

Fixes #14745 
