### PR TITLE
Replace wrong with proper quotes in string.Join()

### DIFF
--- a/docs/csharp/whats-new/csharp-8.md
+++ b/docs/csharp/whats-new/csharp-8.md
@@ -455,7 +455,7 @@ numbers ??= new List<int>();
 numbers.Add(i ??= 17);
 numbers.Add(i ??= 20);
 
-Console.WriteLine(string.Join(' ', numbers));  // output: 17 17
+Console.WriteLine(string.Join(" ", numbers));  // output: 17 17
 Console.WriteLine(i);  // output: 17
 ```
 


### PR DESCRIPTION
## Summary
The example does not compile.

With single quotes, the example will not compile since single quotes are for char and not for string as the method [string.Join()](https://docs.microsoft.com/en-us/dotnet/api/system.string.join?view=netframework-4.8) requires in its documentation.
