### PR TITLE
Fix index for getting started in wpf desktop

### DIFF
--- a/docs/desktop-wpf/getting-started/index.md
+++ b/docs/desktop-wpf/getting-started/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_url: how-to-create-an-application
+redirect_url: https://docs.microsoft.com/visualstudio/get-started/csharp/tutorial-wpf?toc=/dotnet/desktop-wpf/toc.json&bc=/dotnet/breadcrumb/toc.json
 ---


### PR DESCRIPTION
## Summary

Change redirect link for index

Fixes #14850

[Internal Review Link](https://review.docs.microsoft.com/en-us/dotnet/desktop-wpf/getting-started/?branch=pr-en-us-14938) -- This link pops you out of the review system due to the way redirects work, if URL works though, it's good. Compare with the [public link](https://docs.microsoft.com/en-us/dotnet/desktop-wpf/getting-started/) that doesn't work.
