### PR TITLE
Fixed OS name typo

### DIFF
--- a/docs/core/whats-new/dotnet-core-2-1.md
+++ b/docs/core/whats-new/dotnet-core-2-1.md
@@ -207,7 +207,7 @@ The <xref:System.IO.Compression.BrotliStream> behavior is the same as <xref:Syst
 
 - The static <xref:System.Security.Cryptography.RandomNumberGenerator.Fill%2A?displayProperty=nameWithType> method fills a <xref:System.Span%601> with random values.
 
-- The <xref:System.Security.Cryptography.Pkcs.EnvelopedCms?displayProperty=nameWithType> is now supported on Linux and maxOS.
+- The <xref:System.Security.Cryptography.Pkcs.EnvelopedCms?displayProperty=nameWithType> is now supported on Linux and macOS.
 
 - Elliptic-Curve Diffie-Hellman (ECDH) is now available in the <xref:System.Security.Cryptography.ECDiffieHellman?displayProperty=nameWithType> class family. The surface area is the same as in the .NET Framework.
 


### PR DESCRIPTION
## Summary

Describe your changes here.

macOS name typo fixed.
