### PR TITLE
Fix redirect to WPF styles and templates

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2431,7 +2431,7 @@
         },
         {
             "source_path": "docs/framework/wpf/controls/styling-and-templating.md",
-            "redirect_url": "/dotnet/desktop-wpf/fundamentals/styles-and-templates-overview",
+            "redirect_url": "/dotnet/desktop-wpf/fundamentals/styles-templates-overview",
             "redirect_document_id": true
         },
         {


### PR DESCRIPTION
## Summary

The article actual URL is now https://docs.microsoft.com/dotnet/desktop-wpf/fundamentals/styles-templates-overview (without and)
