### PR TITLE
Add support for pull request files parsing

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -68,5 +68,43 @@
         }
       }
     }
+  },
+  "pullrequest": {
+    "action": {
+      "opened": {
+        "processor-files": {
+          "labels-add": {
+            "defaults": [ ":watch: Not Triaged" ],
+            "path": {
+              "(?i).*docs\/architecture\/blazor-for-web-forms-developers.*": ":book: guide - Blazor",
+              "(?i).*docs\/architecture\/cloud-native.*": ":book: guide - Cloud Native",
+              "(?i).*docs\/architecture\/containerized-lifecycle.*": ":book: guide - Docker lifecycle",
+              "(?i).*docs\/architecture\/grpc-for-wcf-developers.*": ":book: guide - gRPC",
+              "(?i).*docs\/architecture\/microservices.*": ":book: guide - .NET Microservices",
+              "(?i).*docs\/architecture\/modern-web-apps-azure.*": ":book: guide - ASP.NET Core web apps",
+              "(?i).*docs\/architecture\/modernize-with-azure-containers.*": ":book: guide - Modernizing w/ Windows containers",
+              "(?i).*docs\/architecture\/serverless.*": ":book: guide - Serverless apps",
+              "(?i).*docs\/core.*": ":books: Area - .NET Core Guide",
+              "(?i).*docs\/core\/tools.*": ":card_file_box: Technology - CLI",
+              "(?i).*docs\/core\/docker.*": ":card_file_box: Technology - Docker",
+              "(?i).*docs\/framework\/configure-apps\/file-schema\/network.*": ":card_file_box: Technology - NCL",
+              "(?i).*docs\/framework\/configure-apps\/file-schema\/wcf.*": ":card_file_box: Technology - WCF",
+              "(?i).*docs\/framework\/data\/adonet.*": ":card_file_box: Technology - Data Access",
+              "(?i).*docs\/framework\/data\/wcf.*": ":card_file_box: Technology - WCF",
+              "(?i).*docs\/framework\/docker.*": ":card_file_box: Technology - Docker",
+              "(?i).*docs\/framework\/install.*": ":card_file_box: Technology - Installers",
+              "(?i).*docs\/framework\/migration-guide.*": ":card_file_box: Technology - AppCompat",
+              "(?i).*docs\/framework\/network-programming.*": ":card_file_box: Technology - NCL",
+              "(?i).*docs\/framework\/windows-workflow-foundation.*": ":card_file_box: Technology - WF",
+              "(?i).*docs\/framework\/wpf.*": ":card_file_box: Technology - WPF",
+              "(?i).*docs\/framework\/wcf.*": ":card_file_box: Technology - WCF",
+              "(?i).*docs\/framework\/winforms.*": ":card_file_box: Technology - WinForms",
+              "(?i).*docs\/standard\/security.*": ":card_file_box: Technology - Security",
+              "(?i).*docs\/standard\/standard\/design-guidelines\/.*": ":book: guide - Framework Design Guidelines"
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Update has been released to azure functions for the issue label bot that adds support for pull requests.

This duplicates the previous section's logic but it is incomplete. The issue section uses two forms, file path and the product metadata. Metadata isn't provided as part of a PR so the PR logic in this file needs more entries. For example, I added the **core guide** label to the PR logic based on the file path `docs/core`.

I want to get this merged asap test in production, I've already tested in private.