### PR TITLE
Remove incorrect info about calling AppDomain.AssemblyLoad

### DIFF
--- a/docs/core/dependency-loading/loading-unmanaged.md
+++ b/docs/core/dependency-loading/loading-unmanaged.md
@@ -27,5 +27,3 @@ The following algorithm describes how native libraries are loaded through `PInvo
     * Checking the <xref:System.AppDomain> instance's cache and running the [Unmanaged (native) library probing](default-probing.md#unmanaged-native-library-probing) logic.
 
     * Raising the <xref:System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll?displayProperty=nameWithType> event for the `active` AssemblyLoadContext.
-
-3. If the unmanaged library is newly loaded, the <xref:System.AppDomain.AssemblyLoad?displayProperty=nameWithType> event is raised.


### PR DESCRIPTION
Unmanaged libraries do not call this - it's only for managed assemblies.

cc: @swaroop-sridhar 