### PR TITLE
Fix the page describing native library loading

### DIFF
--- a/docs/core/dependency-loading/loading-unmanaged.md
+++ b/docs/core/dependency-loading/loading-unmanaged.md
@@ -15,17 +15,15 @@ The following algorithm describes how native libraries are loaded through `PInvo
 
 `PInvoke` uses the following algorithm when attempting to load an unmanaged assembly:
 
-1. Determine the `active` <xref:System.Runtime.Loader.AssemblyLoadContext>. For an unmanaged load library, the `active` AssemblyLoadContext is the caller of the `PInvoke`.
+1. Determine the `active` <xref:System.Runtime.Loader.AssemblyLoadContext>. For an unmanaged load library, the `active` AssemblyLoadContext is the one with the assembly which defines the `PInvoke`.
 
 2. For the `active` <xref:System.Runtime.Loader.AssemblyLoadContext>, try to find the assembly in priority order by:
     * Checking its cache.
 
     * Calling the current <xref:System.Runtime.InteropServices.DllImportResolver?displayProperty=nameWithType> delegate set by the <xref:System.Runtime.InteropServices.NativeLibrary.SetDllImportResolver(System.Reflection.Assembly,System.Runtime.InteropServices.DllImportResolver)?displayProperty=nameWithType> function.
 
-    * Calling the <xref:System.Runtime.Loader.AssemblyLoadContext.LoadUnmanagedDll%2A?displayProperty=nameWithType> function.
+    * Calling the <xref:System.Runtime.Loader.AssemblyLoadContext.LoadUnmanagedDll%2A?displayProperty=nameWithType> function on the `active` AssemblyLoadContext.
 
     * Checking the <xref:System.AppDomain> instance's cache and running the [Unmanaged (native) library probing](default-probing.md#unmanaged-native-library-probing) logic.
 
     * Raising the <xref:System.Runtime.Loader.AssemblyLoadContext.ResolvingUnmanagedDll?displayProperty=nameWithType> event for the `active` AssemblyLoadContext.
-
-3. If the unmanaged library is newly loaded, the <xref:System.AppDomain.AssemblyLoad?displayProperty=nameWithType> event is raised.

--- a/docs/core/dependency-loading/loading-unmanaged.md
+++ b/docs/core/dependency-loading/loading-unmanaged.md
@@ -15,7 +15,7 @@ The following algorithm describes how native libraries are loaded through `PInvo
 
 `PInvoke` uses the following algorithm when attempting to load an unmanaged assembly:
 
-1. Determine the `active` <xref:System.Runtime.Loader.AssemblyLoadContext>. For an unmanaged load library, the `active` AssemblyLoadContext is the one with the assembly which defines the `PInvoke`.
+1. Determine the `active` <xref:System.Runtime.Loader.AssemblyLoadContext>. For an unmanaged load library, the `active` AssemblyLoadContext is the one with the assembly that defines the `PInvoke`.
 
 2. For the `active` <xref:System.Runtime.Loader.AssemblyLoadContext>, try to find the assembly in priority order by:
     * Checking its cache.

--- a/docs/core/dependency-loading/loading-unmanaged.md
+++ b/docs/core/dependency-loading/loading-unmanaged.md
@@ -1,7 +1,7 @@
 ---
 title: Unmanaged library loading algorithm - .NET Core
 description: Description of the details of the unmanaged assembly loading algorithm in .NET Core
-ms.date: 08/09/2019
+ms.date: 10/09/2019
 author: sdmaclea
 ms.author: stmaclea
 ---


### PR DESCRIPTION
This change modifies the docs to match the runtime behavior:
* The ALC used is the one which declares the PInvoke (not the caller)
* There's no event raised when the library is loaded successfully