### PR TITLE
Fixed formatting errors in compat documentation

### DIFF
--- a/includes/core-changes/corefx/jsonelement-api-changes.md
+++ b/includes/core-changes/corefx/jsonelement-api-changes.md
@@ -25,14 +25,13 @@ In .NET Core 3.0 Preview 7, <xref:System.Text.Json.JsonElement> APIs have change
 
 1. `WriteValue` was renamed as <xref:System.Text.Json.JsonElement.WriteTo%2A>. This affects code such as the following:
 
-```csharp
-using (JsonDocument doc = JsonDocument.Parse(jsonString))
-{
-    JsonElement root = doc.RootElement;
-    root.WriteValue(writer);
-}
-
-```
+   ```csharp
+    using (JsonDocument doc = JsonDocument.Parse(jsonString))
+    {
+        JsonElement root = doc.RootElement;
+        root.WriteValue(writer);
+    }
+    ```
 
 1. <xref:System.Text.Json.JsonElement.WriteTo%2A> now throws an <xref:System.ArgumentNullException> when its method parameter is `null`.
 

--- a/includes/core-changes/visualbasic/vbnewline-is-obsolete.md
+++ b/includes/core-changes/visualbasic/vbnewline-is-obsolete.md
@@ -32,5 +32,4 @@ Visual Basic
 
 - `F:Microsoft.VisualBasic.Constants.vbNewLine`
 
--- >
-
+-->


### PR DESCRIPTION
## Fixed formatting errors in compat documentation

This PR addresses two formatting issues:

- Indented a code block that was causing the numbering of a numbered list to restart.

- Removed an embedded space from a close comment tag. It caused two Visual Basic-related issues to not appear in the documentation.
