### PR TITLE
Direct people on their local machine

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/branches-and-loops.yml
@@ -27,6 +27,8 @@ items:
         Console.WriteLine("The answer is greater than 10.");
     ```
 
+    If you are running this on your environment, you should follow the instructions for the [local version](branches-and-loops-local.md) instead.
+
     Modify the declaration of `b` so that the sum is less than 10:
 
     ```csharp

--- a/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/list-collection.yml
@@ -26,6 +26,8 @@ items:
     }
     ```
 
+    If you are running this on your environment, you should follow the instructions for the [local version](arrays-and-collections.md) instead.
+
     You've created a list of strings, added three names to that list, and printed out the names in all CAPS. You're using concepts
     that you've learned in earlier tutorials to loop through the list.
 

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
@@ -26,6 +26,7 @@ items:
     int c = a + b;
     Console.WriteLine(c);
     ```
+
     If you are running this on your environment, you should follow the instructions for the [local version](numbers-in-csharp-local.md) instead.
 
     You've just seen one of the fundamental math operations with integers. The `int` type represents an **integer**, a positive or negative whole number. You use the `+` symbol for addition. Other common mathematical operations for integers include:

--- a/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/numbers-in-csharp.yml
@@ -26,6 +26,7 @@ items:
     int c = a + b;
     Console.WriteLine(c);
     ```
+    If you are running this on your environment, you should follow the instructions for the [local version](numbers-in-csharp-local.md) instead.
 
     You've just seen one of the fundamental math operations with integers. The `int` type represents an **integer**, a positive or negative whole number. You use the `+` symbol for addition. Other common mathematical operations for integers include:
 


### PR DESCRIPTION
The snippets in the online tutorials assume scaffolding. If a reader is working locally, they need different instructions because they won't have the scaffolding in place.

Fixes #13939

The issue mentions not having the instructions for the `using` directive needed. I didn't want to add that instruction to the online tutorial, where it would be confusing for online readers. Instead, I suggest reading the local versions instead.